### PR TITLE
Add TypeScript 7-native static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,7 @@ jobs:
         working-directory: prototypes/inspect-web
         run: |
           npm ci
+          npm run analyze
           npm run build
           grep -q '<script type="importmap"></script>' dist/index.html
           grep -Eq '<link rel="preload" id="webassembly"[[:space:]]*/?>' dist/index.html

--- a/prototypes/inspect-web/.oxlintrc.json
+++ b/prototypes/inspect-web/.oxlintrc.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error",
+    "suspicious": "error"
+  },
+  "env": {
+    "browser": true,
+    "es2022": true
+  },
+  "ignorePatterns": [
+    "src/inspect-web-engine.d.ts"
+  ],
+  "options": {
+    "denyWarnings": true,
+    "reportUnusedDisableDirectives": "error",
+    "typeAware": true
+  },
+  "overrides": [
+    {
+      "files": [
+        "scripts/*.js",
+        "test/**/*.{js,ts}",
+        "vite.config.js"
+      ],
+      "env": {
+        "browser": false,
+        "node": true
+      }
+    },
+    {
+      "files": [
+        "**/*.js"
+      ],
+      "rules": {
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off"
+      }
+    }
+  ],
+  "rules": {
+    "eslint/no-underscore-dangle": "off",
+    "typescript/no-floating-promises": [
+      "error",
+      {
+        "allowForKnownSafeCalls": [
+          {
+            "from": "package",
+            "name": "test",
+            "package": "node:test"
+          }
+        ]
+      }
+    ],
+    "typescript/no-misused-promises": "error",
+    "typescript/no-unsafe-argument": "error",
+    "typescript/no-unsafe-assignment": "error",
+    "typescript/no-unsafe-call": "error",
+    "typescript/no-unsafe-member-access": "error",
+    "typescript/no-unsafe-return": "error",
+    "typescript/only-throw-error": "error",
+    "typescript/prefer-promise-reject-errors": "error",
+    "typescript/restrict-plus-operands": "error",
+    "typescript/use-unknown-in-catch-callback-variable": "error",
+    "unicorn/consistent-function-scoping": "off",
+    "unicorn/no-array-sort": "off",
+    "unicorn/prefer-add-event-listener": "off"
+  }
+}

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -468,11 +468,58 @@ that contains whitespace. If that applies to the local SDK installation, pass
 `EmscriptenSdkToolsPath` pointing to a no-whitespace link to the installed
 Emscripten `tools` directory.
 
+## Static analysis
+
+Run both frontend analysis gates locally with:
+
+```bash
+cd prototypes/inspect-web
+npm run typecheck
+npm run analyze
+```
+
+The TypeScript gate checks product and test projects with `strict`,
+`exactOptionalPropertyTypes`, and `noImplicitReturns`. `npm run analyze` then
+runs Oxlint with its tsgolint backend against the same TypeScript 7.0.2
+toolchain used to build the product. Correctness and suspicious diagnostics,
+type-aware promise and unsafe-operation checks, warnings, and unused
+suppression directives all fail the gate. Browser/background promises must
+either preserve sequencing or surface unexpected rejection visibly. The exact
+`node:test` `test` call is the only configured safe promise-returning call
+because the test runner owns and observes that returned promise.
+
+Oxlint excludes only the generated `src/inspect-web-engine.d.ts` surface, which
+remains covered by TypeScript and the generated-surface drift check. The
+configuration disables four non-correctness rules: underscore spelling,
+function relocation, listener API preference, and `Array.prototype.sort`.
+Those rules prescribe naming/layout churn or, for sorting, the ES2023
+`toSorted` API while this project targets ES2022.
+
+Existing JavaScript tests and verification scripts remain covered by Oxlint's
+correctness and suspicious rules, but not by its unsafe-operation type rules:
+adding a shadow type model or migrating those files to TypeScript is outside
+this analysis change. Their dependency and reachability graph remains covered
+by Knip.
+
+Knip checks authored source, every TypeScript and JavaScript test, and
+build/verification scripts for unused files, exports, and dependencies.
+`knip.json` excludes only `engine/wwwroot/inspect-web-engine.js`: that generated
+publish artifact imports `./_framework/dotnet.js`, which exists only after Wasm
+publish.
+
+`noUncheckedIndexedAccess` is not enabled yet. A TypeScript 7.0.2 migration
+probe reports 77 findings across 15 files: 65 in nine product files and 12 in
+six test files. [Issue #4549](https://github.com/richlander/dotnet-inspect/issues/4549)
+records the probe commands, file distribution, and migration discipline; the
+set should be migrated with close negative tests for indexing behavior rather
+than hidden behind assertions.
+
 ## Test
 
 ```bash
 cd prototypes/inspect-web
 npm ci
+npm run analyze
 npm run build
 npm test
 cd ../..
@@ -514,9 +561,9 @@ above on every browser-engine CI run.
 Pull requests that change the browser prototype, its shared annotated-source
 viewer, product dependencies, or repository build inputs run the `inspect-web`
 CI job. That job installs the locked Node dependencies, checks and bundles the
-TypeScript/JavaScript frontend, compiles the platform-index generator, publishes
-the Release Wasm bundle, runs the browser-engine tests, and runs both frontend
-test suites.
+TypeScript/JavaScript frontend, rejects unused authored files, exports, and
+dependencies, compiles the platform-index generator, publishes the Release Wasm
+bundle, runs the browser-engine tests, and runs both frontend test suites.
 The `eng/CiChangeDetection` gate, invoked through
 `eng/test-ci-change-detection.cs`, gates the path classification, and
 `ci-required` includes the job's result.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -508,15 +508,16 @@ publish artifact imports `./_framework/dotnet.js`, which exists only after Wasm
 publish.
 
 The tsgolint semantic backend publishes native binaries for x64 and arm64 hosts
-running macOS, Linux, or Windows. Those are the supported
+running macOS, Linux (glibc or musl), or Windows. Those are the supported
 development-analysis hosts; `npm run lint` fails before launching the analyzer
 on other operating-system or architecture combinations, including Linux
 ppc64le and s390x. Oxlint itself supports additional hosts, but type-aware
 analysis is the limiting capability. This approved development-tool exception
 does not affect the browser/Wasm product runtime or artifact. The host-matrix
 unit test derives the supported intersection from the locked Oxlint and
-tsgolint package metadata and pins the npm preflight wiring; `npm run analyze`
-on macOS arm64 and the Linux x64 CI host gates the supported paths.
+tsgolint package metadata, requires both Linux libc variants, and pins the npm
+preflight wiring; `npm run analyze` on macOS arm64 and the Linux x64 CI host
+gates the supported paths.
 
 `noUncheckedIndexedAccess` is not enabled yet. A TypeScript 7.0.2 migration
 probe reports 77 findings across 15 files: 65 in nine product files and 12 in

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -507,14 +507,16 @@ build/verification scripts for unused files, exports, and dependencies.
 publish artifact imports `./_framework/dotnet.js`, which exists only after Wasm
 publish.
 
-The Oxlint and tsgolint npm packages publish native analysis binaries for x64
-and arm64 hosts running macOS, Linux, or Windows. Those are the supported
+The tsgolint semantic backend publishes native binaries for x64 and arm64 hosts
+running macOS, Linux, or Windows. Those are the supported
 development-analysis hosts; `npm run lint` fails before launching the analyzer
 on other operating-system or architecture combinations, including Linux
-ppc64le and s390x. This approved development-tool exception does not affect the
-browser/Wasm product runtime or artifact. The host-matrix unit test and
-`npm run analyze` on macOS arm64 and the Linux x64 CI host gate the supported
-paths.
+ppc64le and s390x. Oxlint itself supports additional hosts, but type-aware
+analysis is the limiting capability. This approved development-tool exception
+does not affect the browser/Wasm product runtime or artifact. The host-matrix
+unit test derives the supported intersection from the locked Oxlint and
+tsgolint package metadata and pins the npm preflight wiring; `npm run analyze`
+on macOS arm64 and the Linux x64 CI host gates the supported paths.
 
 `noUncheckedIndexedAccess` is not enabled yet. A TypeScript 7.0.2 migration
 probe reports 77 findings across 15 files: 65 in nine product files and 12 in

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -507,6 +507,15 @@ build/verification scripts for unused files, exports, and dependencies.
 publish artifact imports `./_framework/dotnet.js`, which exists only after Wasm
 publish.
 
+The Oxlint and tsgolint npm packages publish native analysis binaries for x64
+and arm64 hosts running macOS, Linux, or Windows. Those are the supported
+development-analysis hosts; `npm run lint` fails before launching the analyzer
+on other operating-system or architecture combinations, including Linux
+ppc64le and s390x. This approved development-tool exception does not affect the
+browser/Wasm product runtime or artifact. The host-matrix unit test and
+`npm run analyze` on macOS arm64 and the Linux x64 CI host gate the supported
+paths.
+
 `noUncheckedIndexedAccess` is not enabled yet. A TypeScript 7.0.2 migration
 probe reports 77 findings across 15 files: 65 in nine product files and 12 in
 six test files. [Issue #4549](https://github.com/richlander/dotnet-inspect/issues/4549)

--- a/prototypes/inspect-web/knip.json
+++ b/prototypes/inspect-web/knip.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": [
+    "test/**/*.test.ts",
+    "test/*.test.js",
+    "scripts/*.js"
+  ],
+  "project": [
+    "src/**/*.ts",
+    "test/**/*.{ts,js}",
+    "scripts/*.js"
+  ],
+  "ignore": ["engine/wwwroot/inspect-web-engine.js"]
+}

--- a/prototypes/inspect-web/package-lock.json
+++ b/prototypes/inspect-web/package-lock.json
@@ -9,11 +9,48 @@
       "version": "0.0.1",
       "devDependencies": {
         "@types/node": "^24.13.3",
+        "knip": "^6.32.2",
+        "oxlint": "^1.79.0",
+        "oxlint-tsgolint": "7.0.2001",
         "typescript": "7.0.2",
         "vite": "^7.0.6"
       },
       "engines": {
         "node": ">=24"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -478,6 +515,1111 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+      "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+      "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+      "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+      "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+      "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+      "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+      "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+      "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+      "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+      "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+      "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+      "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+      "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+      "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+      "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+      "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+      "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+      "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+      "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/darwin-arm64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-7.0.2001.tgz",
+      "integrity": "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/darwin-x64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-7.0.2001.tgz",
+      "integrity": "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-arm64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-7.0.2001.tgz",
+      "integrity": "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/linux-x64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-7.0.2001.tgz",
+      "integrity": "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-arm64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-7.0.2001.tgz",
+      "integrity": "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint-tsgolint/win32-x64": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-7.0.2001.tgz",
+      "integrity": "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz",
+      "integrity": "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz",
+      "integrity": "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz",
+      "integrity": "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz",
+      "integrity": "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz",
+      "integrity": "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz",
+      "integrity": "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz",
+      "integrity": "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz",
+      "integrity": "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz",
+      "integrity": "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz",
+      "integrity": "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz",
+      "integrity": "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz",
+      "integrity": "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz",
+      "integrity": "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz",
+      "integrity": "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz",
+      "integrity": "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz",
+      "integrity": "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz",
+      "integrity": "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz",
+      "integrity": "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz",
+      "integrity": "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
@@ -866,6 +2008,17 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -1266,6 +2419,16 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1284,6 +2447,22 @@
         }
       }
     },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1297,6 +2476,68 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/knip": {
+      "version": "6.32.2",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.32.2.tgz",
+      "integrity": "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.1",
+        "jiti": "^2.7.0",
+        "oxc-parser": "^0.143.0",
+        "oxc-resolver": "11.24.2",
+        "picomatch": "^4.0.5",
+        "smol-toml": "^1.7.1",
+        "strip-json-comments": "5.0.3",
+        "tinyglobby": "^0.2.17",
+        "unbash": "^4.0.9",
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/nanoid": {
@@ -1316,6 +2557,141 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+      "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.143.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+        "@oxc-parser/binding-android-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-x64": "0.143.0",
+        "@oxc-parser/binding-freebsd-x64": "0.143.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz",
+      "integrity": "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.79.0",
+        "@oxlint/binding-android-arm64": "1.79.0",
+        "@oxlint/binding-darwin-arm64": "1.79.0",
+        "@oxlint/binding-darwin-x64": "1.79.0",
+        "@oxlint/binding-freebsd-x64": "1.79.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.79.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.79.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.79.0",
+        "@oxlint/binding-linux-arm64-musl": "1.79.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.79.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.79.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.79.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.79.0",
+        "@oxlint/binding-linux-x64-gnu": "1.79.0",
+        "@oxlint/binding-linux-x64-musl": "1.79.0",
+        "@oxlint/binding-openharmony-arm64": "1.79.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.79.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.79.0",
+        "@oxlint/binding-win32-x64-msvc": "1.79.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=7.0.2001",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint-tsgolint": {
+      "version": "7.0.2001",
+      "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-7.0.2001.tgz",
+      "integrity": "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsgolint": "bin/tsgolint.js"
+      },
+      "optionalDependencies": {
+        "@oxlint-tsgolint/darwin-arm64": "7.0.2001",
+        "@oxlint-tsgolint/darwin-x64": "7.0.2001",
+        "@oxlint-tsgolint/linux-arm64": "7.0.2001",
+        "@oxlint-tsgolint/linux-x64": "7.0.2001",
+        "@oxlint-tsgolint/win32-arm64": "7.0.2001",
+        "@oxlint-tsgolint/win32-x64": "7.0.2001"
       }
     },
     "node_modules/picocolors": {
@@ -1367,6 +2743,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -1413,6 +2799,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1421,6 +2820,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -1439,6 +2851,14 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "7.0.2",
@@ -1473,6 +2893,16 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/unbash": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.10.tgz",
+      "integrity": "sha512-b7zoBQvpWp0vuN5q2vK2RRBR2SvuruQAs50DApdDveBSn3eSYd84IaHodFqQIMlvY9K2VnyBUEXgwOBuGU9GBg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/undici-types": {
@@ -1555,6 +2985,42 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "npm run typecheck && node --test",
     "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
-    "lint": "oxlint src test scripts vite.config.js",
+    "lint": "node scripts/verify-analysis-host.js && oxlint src test scripts vite.config.js",
     "analyze": "npm run lint && knip"
   },
   "devDependencies": {

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -11,10 +11,15 @@
     "build": "npm run typecheck && vite build && node scripts/verify-site-artifact.js dist",
     "preview": "vite preview",
     "test": "npm run typecheck && node --test",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+    "lint": "oxlint src test scripts vite.config.js",
+    "analyze": "npm run lint && knip"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",
+    "knip": "^6.32.2",
+    "oxlint": "^1.79.0",
+    "oxlint-tsgolint": "7.0.2001",
     "typescript": "7.0.2",
     "vite": "^7.0.6"
   }

--- a/prototypes/inspect-web/scripts/verify-analysis-host.js
+++ b/prototypes/inspect-web/scripts/verify-analysis-host.js
@@ -1,0 +1,21 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const supportedPlatforms = new Set(["darwin", "linux", "win32"]);
+const supportedArchitectures = new Set(["arm64", "x64"]);
+
+export function verifyAnalysisHost(platform, architecture) {
+  if (
+    !supportedPlatforms.has(platform)
+    || !supportedArchitectures.has(architecture)
+  ) {
+    throw new Error(
+      "inspect-web analysis requires an x64 or arm64 host running macOS, Linux, "
+      + `or Windows; the current host is ${platform}-${architecture}.`,
+    );
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  verifyAnalysisHost(process.platform, process.arch);
+}

--- a/prototypes/inspect-web/scripts/verify-analysis-host.js
+++ b/prototypes/inspect-web/scripts/verify-analysis-host.js
@@ -1,14 +1,19 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const supportedPlatforms = new Set(["darwin", "linux", "win32"]);
-const supportedArchitectures = new Set(["arm64", "x64"]);
+export const supportedAnalysisHosts = Object.freeze([
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64",
+  "linux-x64",
+  "win32-arm64",
+  "win32-x64",
+]);
+
+const supportedAnalysisHostSet = new Set(supportedAnalysisHosts);
 
 export function verifyAnalysisHost(platform, architecture) {
-  if (
-    !supportedPlatforms.has(platform)
-    || !supportedArchitectures.has(architecture)
-  ) {
+  if (!supportedAnalysisHostSet.has(`${platform}-${architecture}`)) {
     throw new Error(
       "inspect-web analysis requires an x64 or arm64 host running macOS, Linux, "
       + `or Windows; the current host is ${platform}-${architecture}.`,

--- a/prototypes/inspect-web/src/annotated-source-view.ts
+++ b/prototypes/inspect-web/src/annotated-source-view.ts
@@ -20,7 +20,6 @@ export type {
   AnnotatedSourceFact,
   AnnotatedSourceNode,
   SourceMedium,
-  TextSpan,
 } from "./document-model.ts";
 
 // The document model owns validation, coordinates, line derivation, segmentation, and
@@ -39,11 +38,11 @@ export interface AnnotatedViewState {
   selectedNodeIds?: readonly number[];
 }
 
-export interface AnnotatedViewSegment extends SourceSegment {
+interface AnnotatedViewSegment extends SourceSegment {
   selected: boolean;
 }
 
-export interface AnnotatedViewLine {
+interface AnnotatedViewLine {
   number: number;
   medium: LineMedium;
   start: number;
@@ -51,7 +50,7 @@ export interface AnnotatedViewLine {
   segments: AnnotatedViewSegment[];
 }
 
-export interface AnnotatedViewFact {
+interface AnnotatedViewFact {
   id: number;
   descriptor: string;
   category: string;
@@ -166,11 +165,6 @@ export function factsForNode(
     document.targets.filter(target => target.node_id === nodeId).map(target => target.fact_id),
   );
   return document.facts.filter(fact => factIds.has(fact.id));
-}
-
-export function factLabel(fact: AnnotatedSourceFact): string {
-  const detail = fact.detail ? ` ${fact.detail}` : "";
-  return `${fact.descriptor}${detail}`;
 }
 
 function isVisible(

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -31,11 +31,11 @@ export function renderAnnotatedSource(options: RenderAnnotatedSourceOptions): st
   const { result, media, selectedFactId, selectedNodeIds, escapeHtml } = options;
   let view;
   try {
-    view = buildAnnotatedView(result.document, {
-      media,
-      selectedFactId,
-      selectedNodeIds,
-    });
+    const viewState: AnnotatedViewState = {};
+    if (media !== undefined) viewState.media = media;
+    if (selectedFactId !== undefined) viewState.selectedFactId = selectedFactId;
+    if (selectedNodeIds !== undefined) viewState.selectedNodeIds = selectedNodeIds;
+    view = buildAnnotatedView(result.document, viewState);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return `<section class="document-section empty-member-section"><h2>Annotated source document rejected</h2><p>${escapeHtml(message)}</p></section>`;

--- a/prototypes/inspect-web/src/call-graph-inspection.ts
+++ b/prototypes/inspect-web/src/call-graph-inspection.ts
@@ -82,7 +82,7 @@ export interface CallGraphInspectionDependencies {
 export interface CallGraphInspectionCoordinator {
   load(request: MemberCallGraphRequest): Promise<void>;
   drill(request: PlatformDrillRequest): Promise<void>;
-  popDrill(): void;
+  popDrill(): Promise<void>;
 }
 
 export function createCallGraphInspectionCoordinator(
@@ -133,7 +133,7 @@ export function createCallGraphInspectionCoordinator(
       if (state.memberCallGraphKey === request.signature
         && (state.memberCallGraph || state.memberCallGraphError)) {
         dependencies.render();
-        dependencies.renderCallGraph();
+        await dependencies.renderCallGraph();
         return;
       }
       state.memberCallGraphKey = request.signature;
@@ -218,12 +218,12 @@ export function createCallGraphInspectionCoordinator(
       }
     },
 
-    popDrill() {
+    async popDrill() {
       if (state.platformStack.length === 0) return;
       state.platformStack.pop();
       state.platformDrillError = "";
       dependencies.render();
-      dependencies.renderCallGraph();
+      await dependencies.renderCallGraph();
     },
   };
 }

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -33,7 +33,7 @@ export interface PackageIdentity {
 export function packageIdentityKey(pkg: PackageIdentity | null | undefined): string {
   if (!pkg) return "";
   return [pkg.id, pkg.version, pkg.activeFramework]
-    .map(value => encodeURIComponent(String(value || "").toLowerCase()))
+    .map(value => encodeURIComponent(value.toLowerCase()))
     .join("|");
 }
 
@@ -140,7 +140,7 @@ export function dependencyGraphRenderSignature(graph: DependencyGraphResult | nu
   ]);
   return JSON.stringify([
     graph.definition,
-    Boolean(graph.truncated),
+    graph.truncated,
     graph.nodeLimit,
     navigation
   ]);
@@ -236,13 +236,22 @@ export function normalizeShareTabs(list: unknown): NormalizedShareTabs {
   const tabs: WorkspaceTab[] = [];
   const sourceIndexes: number[] = [];
   const identityIndexes = new Map<string, number>();
-  for (let sourceIndex = 0; sourceIndex < list.length; sourceIndex++) {
-    const tuple: unknown = list[sourceIndex];
-    if (!Array.isArray(tuple)
-      || tuple.length < 1
-      || tuple.length > 3
-      || tuple.some(value => typeof value !== "string")
-      || !tuple[0].trim()) {
+  const entries: unknown[] = list;
+  for (let sourceIndex = 0; sourceIndex < entries.length; sourceIndex++) {
+    const tuple: unknown = entries[sourceIndex];
+    if (!Array.isArray(tuple) || tuple.length < 1 || tuple.length > 3) {
+      return {
+        tabs: [],
+        sourceIndexes: [],
+        error: "The shared workspace state is invalid and was ignored."
+      };
+    }
+    const values: unknown[] = tuple;
+    const [idValue, versionValue, frameworkValue] = values;
+    if (typeof idValue !== "string"
+      || !idValue.trim()
+      || (versionValue !== undefined && typeof versionValue !== "string")
+      || (frameworkValue !== undefined && typeof frameworkValue !== "string")) {
       return {
         tabs: [],
         sourceIndexes: [],
@@ -250,9 +259,9 @@ export function normalizeShareTabs(list: unknown): NormalizedShareTabs {
       };
     }
     const tab: WorkspaceTab = {
-      id: tuple[0],
-      version: tuple[1] || "latest",
-      framework: tuple[2] || ""
+      id: idValue,
+      version: versionValue || "latest",
+      framework: frameworkValue || ""
     };
     const identity = packageIdentityKey({
       id: tab.id,
@@ -268,8 +277,8 @@ export function normalizeShareTabs(list: unknown): NormalizedShareTabs {
   return { tabs, sourceIndexes, error: "" };
 }
 
-export function shareStateLengthError(value: unknown): string {
-  return String(value || "").length > MAX_SHARE_STATE_CHARACTERS
+export function shareStateLengthError(value: string): string {
+  return value.length > MAX_SHARE_STATE_CHARACTERS
     ? `The shared workspace state exceeds the ${MAX_SHARE_STATE_CHARACTERS}-character limit and was ignored.`
     : "";
 }
@@ -343,7 +352,7 @@ export interface DependencyGroup {
   dependencies?: readonly DependencyGroupDependency[];
 }
 
-export interface DependencyGroupDependency {
+interface DependencyGroupDependency {
   id: string;
   versionRange?: string;
 }
@@ -424,16 +433,16 @@ export function packageCoordinateMatchesLocation(
   location: PackageCoordinateLocation | null | undefined,
 ): boolean {
   if (!pkg || !location?.package || !location.version || !location.framework) return false;
-  return String(pkg.id).toLowerCase() === String(location.package).toLowerCase()
-    && String(pkg.version).toLowerCase() === String(location.version).toLowerCase()
-    && String(pkg.activeFramework).toLowerCase() === String(location.framework).toLowerCase();
+  return pkg.id.toLowerCase() === location.package.toLowerCase()
+    && pkg.version.toLowerCase() === location.version.toLowerCase()
+    && pkg.activeFramework.toLowerCase() === location.framework.toLowerCase();
 }
 
 export function workspaceCoordinatesMatch(
   packages: readonly PackageIdentity[] | null | undefined,
   tabs: readonly WorkspaceTab[] | null | undefined,
 ): boolean {
-  if (!Array.isArray(packages) || !Array.isArray(tabs) || packages.length !== tabs.length)
+  if (!packages || !tabs || packages.length !== tabs.length)
     return false;
   return tabs.every((tab, index) =>
     packageIdentityKey(packages[index]) === packageIdentityKey({
@@ -450,7 +459,7 @@ export function removeAppendedNotice(current: string, previous: string, appended
   return [previous, laterNotice].filter(Boolean).join(" ");
 }
 
-export interface NavigationEntry {
+interface NavigationEntry {
   sig: string;
   view: unknown;
 }
@@ -529,16 +538,16 @@ export function callGraphAssemblyIdentityMatches(
   if (!hasVersion) return true;
   if (!target?.assemblyVersion) return false;
   if (!assembly) return false;
-  const normalizeCulture = (value: unknown) => {
-    const normalized = String(value ?? "").toLowerCase();
+  const normalizeCulture = (value: string | null | undefined) => {
+    const normalized = value?.toLowerCase() ?? "";
     return normalized === "neutral" ? "" : normalized;
   };
-  return String(assembly.name ?? "").toLowerCase()
-      === String(target.assembly ?? "").toLowerCase()
-    && String(assembly.version ?? "") === String(target.assemblyVersion)
+  return (assembly.name ?? "").toLowerCase()
+      === (target.assembly ?? "").toLowerCase()
+    && (assembly.version ?? "") === target.assemblyVersion
     && normalizeCulture(assembly.culture) === normalizeCulture(target.assemblyCulture)
-    && String(assembly.publicKeyToken ?? "").toLowerCase()
-      === String(target.assemblyPublicKeyToken ?? "").toLowerCase();
+    && (assembly.publicKeyToken ?? "").toLowerCase()
+      === (target.assemblyPublicKeyToken ?? "").toLowerCase();
 }
 
 export interface ResolvableGraphType extends CallGraphMatchableType {
@@ -547,10 +556,10 @@ export interface ResolvableGraphType extends CallGraphMatchableType {
   assemblyId?: string;
 }
 
-export interface ResolvableGraphPackage {
+export interface ResolvableGraphPackage<TType extends ResolvableGraphType = ResolvableGraphType> {
   isRuntimePack?: boolean;
   assembly?: string;
-  types?: readonly ResolvableGraphType[];
+  types?: readonly TType[];
   assemblies?: readonly AssemblyDescriptor[];
 }
 
@@ -560,7 +569,7 @@ export type GraphTargetCandidate<TPackage, TType> =
   | { status: "unique"; pkg: TPackage; type: TType };
 
 export function resolveLoadedGraphTargetCandidate<
-  TPackage extends ResolvableGraphPackage,
+  TPackage extends ResolvableGraphPackage<TType>,
   TType extends ResolvableGraphType,
 >(
   packages: readonly TPackage[],
@@ -571,15 +580,14 @@ export function resolveLoadedGraphTargetCandidate<
   const matches: { pkg: TPackage; type: TType }[] = [];
   for (const pkg of packages) {
     if (!pkg || pkg.isRuntimePack) continue;
-    for (const type of (pkg.types ?? []) as readonly TType[]) {
-      const assembly = String(
-        type.assemblyName ?? type.assembly ?? pkg.assembly ?? "")
+    for (const type of pkg.types ?? []) {
+      const assembly = (type.assemblyName ?? type.assembly ?? pkg.assembly ?? "")
         .replace(/\.dll$/i, "");
       const descriptors = pkg.assemblies ?? [];
       const descriptor = type.assemblyId
         ? descriptors.find(candidate => candidate.id === type.assemblyId)
         : descriptors.find(candidate =>
-            String(candidate.name ?? "").replace(/\.dll$/i, "").toLowerCase()
+            (candidate.name ?? "").replace(/\.dll$/i, "").toLowerCase()
               === assembly.toLowerCase());
       if (assembly.toLowerCase() === target.assembly.toLowerCase()
           && callGraphAssemblyIdentityMatches(target, descriptor)
@@ -666,13 +674,13 @@ export const MARKDOWN_SANITIZE_OPTIONS = Object.freeze({
   ALLOW_DATA_ATTR: false
 });
 
-export interface GraphMemberBodySelector {
+interface GraphMemberBodySelector {
   memberName: string;
   selectorKey: string;
   token?: number;
 }
 
-export interface GraphMemberOverload {
+interface GraphMemberOverload {
   bodySelectors?: readonly GraphMemberBodySelector[];
   graphSelectorKey?: string;
 }
@@ -874,9 +882,9 @@ export function memberSectionIdsFor(member: SectionableMember | null | undefined
 
 const FORMAT_CHARACTER = /^\p{Cf}$/u;
 
-export function mermaidLabel(value: unknown): string {
+export function mermaidLabel(value: string): string {
   let encoded = "";
-  for (const character of String(value ?? "")) {
+  for (const character of value) {
     const scalar = character.codePointAt(0)!;
     if (character === "&") encoded += "&amp;";
     else if (character === "<") encoded += "&lt;";

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -1,6 +1,6 @@
 import type { BrowserPackageDocument } from "./inspect-web-engine.d.ts";
 
-export type DocViewerDocument = Pick<BrowserPackageDocument, "name" | "path">;
+type DocViewerDocument = Pick<BrowserPackageDocument, "name" | "path">;
 
 export interface DocViewerMeta {
   name: string;
@@ -19,7 +19,7 @@ export interface RenderDocViewerOptions {
 
 export function renderDocViewer(options: RenderDocViewerOptions): string {
   const { doc, meta, loading, error, html, escapeHtml } = options;
-  const title = doc ? `${doc.name}` : "Document";
+  const title = doc ? doc.name : "Document";
   const subtitle = doc ? doc.path : "";
   const metaCard = meta
     ? `<div class="doc-frontmatter">

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -24,8 +24,8 @@ export interface DocumentInspectionDependencies {
   state: DocumentInspectionState;
   queryDocument:
     (request: PackageDocumentRequest) => Promise<BrowserPackageDocumentContent>;
-  renderMarkdown: (text: unknown) => Promise<string>;
-  renderMarkdownInline: (text: unknown) => Promise<string>;
+  renderMarkdown: (text: string) => Promise<string>;
+  renderMarkdownInline: (text: string) => Promise<string>;
   describeError: (error: unknown) => string;
   render: () => void;
 }
@@ -39,8 +39,8 @@ interface DocumentFrontmatter {
 
 // Skill files carry YAML frontmatter whose folded/literal descriptions need
 // projecting separately before the remaining body is rendered as Markdown.
-function splitFrontmatter(text: unknown) {
-  const source = String(text ?? "");
+function splitFrontmatter(text: string) {
+  const source = text;
   const match = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source);
   if (!match) return { meta: null, body: source };
   const meta: DocumentFrontmatter = {};
@@ -81,6 +81,8 @@ export function createDocumentInspectionCoordinator(
       try {
         const content = await dependencies.queryDocument(request);
         if (sequence !== state.docViewerSeq) return;
+        if (typeof content.text !== "string")
+          throw new TypeError("The document content did not contain text.");
         const { meta, body } = splitFrontmatter(content.text);
         const html = await dependencies.renderMarkdown(body);
         if (sequence !== state.docViewerSeq) return;
@@ -101,9 +103,10 @@ export function createDocumentInspectionCoordinator(
         if (sequence !== state.docViewerSeq) return;
         state.docViewerError = dependencies.describeError(error);
       } finally {
-        if (sequence !== state.docViewerSeq) return;
-        state.docViewerLoading = false;
-        dependencies.render();
+        if (sequence === state.docViewerSeq) {
+          state.docViewerLoading = false;
+          dependencies.render();
+        }
       }
     },
 

--- a/prototypes/inspect-web/src/document-model.ts
+++ b/prototypes/inspect-web/src/document-model.ts
@@ -3,7 +3,7 @@ import * as model from "../../annotated-source-viewer/src/document-model.js";
 export type SourceMedium = "CSharp" | "Il";
 export type LineMedium = SourceMedium | "Mixed";
 
-export interface TextSpan {
+interface TextSpan {
   start: number;
   length: number;
 }
@@ -16,7 +16,7 @@ export interface AnnotatedSourceNode {
   il_offset?: number | null;
 }
 
-export interface AnnotatedSourceRegion {
+interface AnnotatedSourceRegion {
   role: string;
   spans: readonly TextSpan[];
 }
@@ -31,7 +31,7 @@ export interface AnnotatedSourceFact {
   source_offset: number;
 }
 
-export interface AnnotatedSourceTarget {
+interface AnnotatedSourceTarget {
   fact_id: number;
   node_id: number;
 }
@@ -76,7 +76,6 @@ type SegmentsForLine = (
 
 // The portable implementation remains owned by annotated-source-viewer. These typed aliases let
 // inspect-web consume that one implementation without copying its validation or projection logic.
-export const parseDocument: (json: string) => AnnotatedSourceDocument = model.parseDocument;
 export const validateDocument: ValidateDocument = model.validateDocument;
 export const buildLines: (text: string) => SourceLine[] = model.buildLines;
 export const lineMedium: (
@@ -87,13 +86,11 @@ export const nodeIdsForFact: (
   document: AnnotatedSourceDocument,
   factId: number,
 ) => number[] = model.nodeIdsForFact;
-export const nodeKinds: (document: AnnotatedSourceDocument) => string[] = model.nodeKinds;
-export const nodeIdsForKind: (
-  document: AnnotatedSourceDocument,
-  kind: string,
-) => number[] = model.nodeIdsForKind;
 export const unanchoredFacts: (
   document: AnnotatedSourceDocument,
 ) => AnnotatedSourceFact[] = model.unanchoredFacts;
+// The portable JavaScript owner is runtime-validated but does not publish TypeScript declarations.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 export const nodesAtOffset = model.nodesAtOffset as NodesAtOffset;
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 export const segmentsForLine = model.segmentsForLine as SegmentsForLine;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -8,7 +8,6 @@ import {
   createDependencyGraphRenderSequence,
   dependencyCoordinateCandidates,
   dependencyGroupSelectionMessage,
-  dependencyGraphGroupSelectionIndex,
   dependencyGraphRenderSignature,
   graphTargetNavigationDisposition,
   graphMemberSelection,
@@ -17,7 +16,6 @@ import {
   MAX_WORKSPACE_PACKAGES,
   memberRequestKey,
   memberSectionIdsFor,
-  mermaidLabel,
   packageCoordinateMatchesLocation,
   packageForView,
   packageIdentityKey,
@@ -30,7 +28,6 @@ import {
   scopedRequestState,
   sourceReloadKind,
   sourceRequestNeedsLoad,
-  selectedDependencyGroup,
   spotlightCandidateKey,
   spotlightCandidateSignature,
   type DependencyGroupData,
@@ -51,7 +48,6 @@ import {
   restoreLibraryScope,
   restoreMemberHistoryState,
   type BodyTarget,
-  type FilterableMemberGroup,
 } from "./member-filtering.ts";
 import {
   createNavigationHistory,
@@ -82,7 +78,6 @@ import {
 } from "./metadata-inspection.ts";
 import {
   createMemberDetailInspectionCoordinator,
-  type MemberFactRow,
   type MemberFacts,
 } from "./member-detail-inspection.ts";
 import {
@@ -162,8 +157,6 @@ import {
 } from "./catalog-requests.ts";
 import { fmtBytes, statusBarHtml } from "./status-bar.ts";
 import type {
-  BrowserAnnotatedSource,
-  BrowserAssemblyReference,
   BrowserBuildIdentity,
   BrowserCallGraph,
   BrowserCallGraphTarget,
@@ -300,8 +293,10 @@ interface AppMemberSurface extends BrowserMemberSurface {
 
 function loadStoredTaste() {
   try {
-    const value = JSON.parse(localStorage.getItem("inspect-taste") || "[]");
-    return Array.isArray(value) ? value.filter(item => typeof item === "string") : [];
+    const value: unknown = JSON.parse(localStorage.getItem("inspect-taste") || "[]");
+    if (!Array.isArray(value)) return [];
+    const entries: unknown[] = value;
+    return entries.filter((item): item is string => typeof item === "string");
   } catch {
     return [];
   }
@@ -317,10 +312,13 @@ const RECENT_PACKAGES_MAX = 12;
 // browser HTTP cache when still present).
 function loadRecentPackages() {
   try {
-    const value = JSON.parse(localStorage.getItem("inspect-recent-packages") || "[]");
+    const value: unknown = JSON.parse(
+      localStorage.getItem("inspect-recent-packages") || "[]");
     if (!Array.isArray(value)) return [];
-    return value
-      .filter(entry => entry && typeof entry.id === "string" && entry.id)
+    const entries: unknown[] = value;
+    return entries
+      .filter((entry): entry is Record<string, unknown> & { id: string } =>
+        isRecord(entry) && typeof entry.id === "string" && entry.id.length > 0)
       .map(entry => ({
         id: entry.id,
         version: typeof entry.version === "string" && entry.version ? entry.version : "latest",
@@ -339,10 +337,13 @@ function loadRecentPackages() {
 // remembered ASP.NET Core library re-materialises from the right shared framework.
 function loadPlatformRecent() {
   try {
-    const value = JSON.parse(localStorage.getItem("inspect-platform-recent") || "[]");
+    const value: unknown = JSON.parse(
+      localStorage.getItem("inspect-platform-recent") || "[]");
     if (!Array.isArray(value)) return [];
-    return value
-      .filter(entry => entry && typeof entry.assembly === "string")
+    const entries: unknown[] = value;
+    return entries
+      .filter((entry): entry is Record<string, unknown> & { assembly: string } =>
+        isRecord(entry) && typeof entry.assembly === "string")
       .map(entry => ({
         assembly: entry.assembly.replace(/\.dll$/i, ""),
         pack: entry.pack === "aspnetcore.app" ? "aspnetcore.app" : "netcore.app",
@@ -353,7 +354,7 @@ function loadPlatformRecent() {
   }
 }
 
-type RetryAction = (() => unknown) | null;
+type RetryAction = (() => void | Promise<unknown>) | null;
 
 interface SpotlightCache {
   signature: string;
@@ -401,7 +402,11 @@ interface Diagnostics {
 type MemberSection = "overview" | "source" | "annotated" | "call-graph" | "facts";
 
 function isMemberSection(value: string): value is MemberSection {
-  return memberSections.includes(value as MemberSection);
+  return memberSections.some(section => section === value);
+}
+
+function isAnnotatedMedium(value: string): value is (typeof MEDIA)[number] {
+  return MEDIA.some(medium => medium === value);
 }
 
 let spotlightCache: SpotlightCache | null = null;
@@ -421,7 +426,7 @@ const initialState = {
   selectedMemberKey: "",
   memberBrowseTypeId: "",
   selectedOverloadIndex: null,
-  memberSection: "overview",
+  memberSection: "overview" as const,
   memberKindFilter: "all",
   memberAccessibilityFilter: "all",
   memberTraitFilter: "",
@@ -504,7 +509,7 @@ const initialState = {
   spotlightQuery: "",
   spotlightIndex: 0,
   spotlightScope: "all",
-  spotlightFocus: "input",
+  spotlightFocus: "input" as const,
   spotlightChipIndex: 0,
   spotlightPkgHits: [],
   spotlightPkgLoading: false,
@@ -602,7 +607,7 @@ interface StateOverrides {
 
 type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides;
 
-const state = initialState as AppState;
+const state: AppState = initialState;
 const sourceInspection = createSourceInspectionCoordinator({
   state,
   queryMemberSource: request => inspectMemberSource(
@@ -832,11 +837,16 @@ function applyView(view: WorkspaceView) {
   state.selectedBodyTarget = memberHistory.selectedBodyTarget;
   navigationHistory.normalizeCurrent();
   if (!state.atPackageRoot && state.lens === "api" && state.selectedMemberKey && member) {
-    if (state.memberSection === "source") loadSelectedMemberSource();
-    else if (state.memberSection === "annotated") loadSelectedMemberAnnotatedSource();
-    else if (state.memberSection === "call-graph") loadSelectedMemberCallGraph();
-    else if (state.memberSection === "facts") loadSelectedMemberFacts();
-    else loadSelectedMemberDocumentation();
+    if (state.memberSection === "source")
+      observeAsync(loadSelectedMemberSource(), "Loading member source");
+    else if (state.memberSection === "annotated")
+      observeAsync(loadSelectedMemberAnnotatedSource(), "Loading annotated member source");
+    else if (state.memberSection === "call-graph")
+      observeAsync(loadSelectedMemberCallGraph(), "Loading the member call graph");
+    else if (state.memberSection === "facts")
+      observeAsync(loadSelectedMemberFacts(), "Loading member facts");
+    else
+      observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
   } else {
     render();
   }
@@ -935,15 +945,18 @@ const initialDeepLink = {
   memberTraitFilter: initialLocation.memberTraitFilter
 };
 
-function requireElement<T extends Element>(selector: string): T {
-  const element = document.querySelector<T>(selector);
+function requireElement(selector: string): HTMLElement {
+  const element = document.querySelector<HTMLElement>(selector);
   if (!element) throw new Error(`Required element '${selector}' is missing.`);
   return element;
 }
 
-const app = requireElement<HTMLElement>("#app");
-let mermaidModule;
-let markdownModule;
+const app = requireElement("#app");
+type MermaidModule = typeof import("https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs");
+type MarkedModule = typeof import("https://cdn.jsdelivr.net/npm/marked@15.0.7/lib/marked.esm.js");
+type DomPurifyModule = typeof import("https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.es.mjs");
+let mermaidModule: Promise<MermaidModule> | undefined;
+let markdownModule: Promise<[MarkedModule, DomPurifyModule]> | undefined;
 const depGraphRenderSequence = createDependencyGraphRenderSequence();
 let callGraphRenderSeq = 0;
 let spotlightFocusGeneration = 0;
@@ -958,11 +971,49 @@ function escapeHtml(value: unknown) {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error ?? "");
+  if (error instanceof Error) return error.message;
+  if (isRecord(error) && typeof error.message === "string") return error.message;
+  if (typeof error === "string") return error;
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint")
+    return String(error);
+  return "";
 }
 
+function reportAsyncFailure(description: string, error: unknown): void {
+  console.error(`${description} failed.`, error);
+  appendQueryNotice(
+    `${description} failed: ${errorMessage(error) || "Unknown error."}`);
+  render();
+}
+
+function observeAsync(
+  operation: Promise<unknown> | undefined,
+  description: string,
+): void {
+  if (!operation) return;
+  operation.catch((error: unknown) => {
+    reportAsyncFailure(description, error);
+  });
+}
+
+function observeAction(
+  action: () => void | Promise<unknown>,
+  description: string,
+): void {
+  try {
+    observeAsync(Promise.resolve(action()), description);
+  } catch (error) {
+    reportAsyncFailure(description, error);
+  }
+}
+
+// The Wasm engine is an in-process producer whose DTO surface is generated by tsbindgen.
+// Runtime validators are not generated yet, so this is the one trusted JSON/type boundary.
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters
 function parseEngineJson<T>(json: string): T {
-  return JSON.parse(json) as T;
+  const parsed: unknown = JSON.parse(json);
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return parsed as T;
 }
 
 function currentPackage(): AppPackage {
@@ -993,11 +1044,13 @@ const spotlight = createSpotlight({
   searchResults: spotlightResults,
   pickResult: pickSpotlightResult,
   executeCommand,
+  reportCommandError: error =>
+    reportAsyncFailure("Running a Spotlight command", error),
   commandContext: () => !state.home && state.package
     ? { command: state.spotlightQuery, package: state.package }
     : null,
-  schedulePackageFetch: spotlightPackageSearch.schedule,
-  resetPackageSearch: spotlightPackageSearch.reset,
+  schedulePackageFetch: () => spotlightPackageSearch.schedule(),
+  resetPackageSearch: () => spotlightPackageSearch.reset(),
   packageSearchLoading: () => state.spotlightPkgLoading,
   packageCount: () => state.packages.length,
   activeFramework: () => state.package?.activeFramework || "",
@@ -1037,11 +1090,11 @@ function focusTypeList(generation = spotlightFocusGeneration) {
   });
 }
 
-function openSpotlight(seed = "", scope = "all") {
+function openSpotlight(seed = "", spotlightScope = "all") {
   if (state.loading || state.error) return;
   state.tasteOpen = false;
   beginSpotlightNavigation();
-  spotlight.open(seed, scope);
+  spotlight.open(seed, spotlightScope);
 }
 
 function closeSpotlight() {
@@ -1055,8 +1108,10 @@ const packageBar = createPackageBar({
   runtimePackPackage,
   selectPackageTab,
   closePackageTab,
-  openRuntimePack: openRuntimePackFromHome,
-  openPackage: (packageId, version) => loadPackage(packageId, version, ""),
+  openRuntimePack: () =>
+    observeAsync(openRuntimePackFromHome(), "Opening the .NET Platform"),
+  openPackage: (packageId, version) =>
+    observeAsync(loadPackage(packageId, version, ""), "Opening a package"),
   showToast,
 });
 
@@ -1649,7 +1704,7 @@ function openMemberGroup(key: string) {
   state.selectedMemberKey = key;
   state.selectedOverloadIndex = null;
   resetMemberSectionState();
-  loadSelectedMemberDocumentation();
+  observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
 }
 
 function enterMemberScope() {
@@ -1691,7 +1746,7 @@ function normalizeMemberSelection() {
 function openOverload(index: number) {
   state.selectedOverloadIndex = index;
   resetMemberSectionState();
-  loadSelectedMemberDocumentation();
+  observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
 }
 
 // Switch the open member's section (Overview / Call graph / Facts / Source / Annotated) and
@@ -1707,11 +1762,16 @@ function applyMemberSection(id: MemberSection) {
     invalidateMemberCallGraphWork(state);
   }
   state.memberSection = id;
-  if (id === "source") loadSelectedMemberSource();
-  else if (id === "annotated") loadSelectedMemberAnnotatedSource();
-  else if (id === "call-graph") loadSelectedMemberCallGraph();
-  else if (id === "facts") loadSelectedMemberFacts();
-  else if (id === "overview") loadSelectedMemberDocumentation();
+  if (id === "source")
+    observeAsync(loadSelectedMemberSource(), "Loading member source");
+  else if (id === "annotated")
+    observeAsync(loadSelectedMemberAnnotatedSource(), "Loading annotated member source");
+  else if (id === "call-graph")
+    observeAsync(loadSelectedMemberCallGraph(), "Loading the member call graph");
+  else if (id === "facts")
+    observeAsync(loadSelectedMemberFacts(), "Loading member facts");
+  else if (id === "overview")
+    observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
   else render();
 }
 
@@ -2029,7 +2089,7 @@ function render() {
   if (scope() === "member"
     && state.memberSection === "call-graph"
     && currentCallGraph()?.mermaid) {
-    renderMermaidCallGraph();
+    observeAsync(renderMermaidCallGraph(), "Rendering the member call graph");
   }
 }
 
@@ -2042,9 +2102,11 @@ function maybeAutoLoadVisibleSource() {
         state.graphSourceLoading,
         state.graphSource,
         state.graphSourceError)) {
-      openGraphSource(
-        state.graphSourceRequest.request,
-        state.graphSourceRequest.title);
+      observeAsync(
+        openGraphSource(
+          state.graphSourceRequest.request,
+          state.graphSourceRequest.title),
+        "Loading graph source");
     }
     return;
   }
@@ -2058,7 +2120,7 @@ function maybeAutoLoadVisibleSource() {
         state.typeSourceLoading,
         state.typeSource,
         state.typeSourceError)) {
-      loadSelectedTypeSource();
+      observeAsync(loadSelectedTypeSource(), "Loading type source");
     }
     return;
   }
@@ -2072,7 +2134,7 @@ function maybeAutoLoadVisibleSource() {
         state.memberSourceLoading,
         state.memberSource,
         state.memberSourceError)) {
-      loadSelectedMemberSource();
+      observeAsync(loadSelectedMemberSource(), "Loading member source");
     }
   }
 }
@@ -2083,10 +2145,11 @@ function maybeAutoLoadTypeMetadata() {
   if (!type) return;
   const signature = typeMetadataSignature(type, currentPackage());
   if (state.typeMetadataKey === signature) {
-    if (state.typeMetadata && state.typeMetadata.graphNodes.length > 1) renderTypeGraph();
+    if (state.typeMetadata && state.typeMetadata.graphNodes.length > 1)
+      observeAsync(renderTypeGraph(), "Rendering the type graph");
     return;
   }
-  loadSelectedTypeMetadata();
+  observeAsync(loadSelectedTypeMetadata(), "Loading type metadata");
 }
 
 function renderNavPane(
@@ -2103,7 +2166,7 @@ function renderTypeNavPane(
   visible: readonly BrowserTypeSurface[],
 ) {
   return renderTypeNav({
-    current,
+    current: current ?? null,
     visible,
     typeGroups: typeGroups(),
     typeFilter: state.typeFilter,
@@ -2345,7 +2408,7 @@ function patchDependenciesGroup() {
       Number(button.dataset.depGroup) === selectedGroupIndex));
   listSection.outerHTML = dependencyListSectionHtml(groups, selectedGroupIndex);
   bindDependencyListHandlers();
-  renderDependencyGraph();
+  observeAsync(renderDependencyGraph(), "Rendering the dependency graph");
 }
 
 function bindDependencyListHandlers() {
@@ -2358,7 +2421,10 @@ function bindDependencyListHandlers() {
   document.querySelectorAll<HTMLElement>("[data-dep-load]").forEach(button => {
     button.onclick = () => {
       const id = button.dataset.depLoad;
-      if (id) openDependencyPackage(id, button.dataset.depVersion || "");
+      if (id)
+        observeAsync(
+          openDependencyPackage(id, button.dataset.depVersion || ""),
+          "Opening a dependency package");
     };
   });
 }
@@ -2441,12 +2507,12 @@ function maybeAutoLoadPackageDependencies() {
   if (!state.atPackageRoot || state.packageLens !== "dependencies") return;
   if (state.packageDependenciesKey === packageDependenciesSignature()) {
     if (state.packageDependencies) {
-      renderDependencyGraph();
-      ensureWorkspaceDependencies();
+      observeAsync(renderDependencyGraph(), "Rendering the dependency graph");
+      observeAsync(ensureWorkspaceDependencies(), "Loading workspace dependencies");
     }
     return;
   }
-  loadPackageDependencies();
+  observeAsync(loadPackageDependencies(), "Loading package dependencies");
 }
 
 // Fetches dependency manifests for every other open package so the dependency graph can
@@ -2511,7 +2577,7 @@ function renderPackageIntegrations() {
     : "";
 
   if (!categories.length) {
-    return `${platformPicker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No ecosystem integrations detected</h2><p>The public surface of ${isPlatform ? `${escapeHtml(scopedLib)}` : escapeHtml(pkg.activeFramework)} shows no known DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting signals.</p></section>`;
+    return `${platformPicker}${warning}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No ecosystem integrations detected</h2><p>The public surface of ${isPlatform ? escapeHtml(scopedLib) : escapeHtml(pkg.activeFramework)} shows no known DI, logging, OpenTelemetry, ASP.NET Core, AI, or hosting signals.</p></section>`;
   }
 
   const summary = `
@@ -2559,7 +2625,7 @@ async function loadPackageIntegrations() {
 function maybeAutoLoadPackageIntegrations() {
   if (!state.atPackageRoot || state.packageLens !== "integrations") return;
   if (state.packageIntegrationsKey === packageIntegrationsSignature()) return;
-  loadPackageIntegrations();
+  observeAsync(loadPackageIntegrations(), "Loading package integrations");
 }
 
 function packageScopeSignature() {
@@ -2608,7 +2674,7 @@ function maybeAutoLoadPackageOpportunities() {
   if (!state.atPackageRoot || state.packageLens !== "opportunities") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
   if (state.packageOpportunitiesKey === packageScopeSignature()) return;
-  loadPackageOpportunities();
+  observeAsync(loadPackageOpportunities(), "Loading package opportunities");
 }
 
 function renderPackagePerformance() {
@@ -2681,7 +2747,7 @@ function maybeAutoLoadPackagePerformance() {
   if (!state.atPackageRoot || state.packageLens !== "analysis") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
   if (state.packagePerformanceKey === packageScopeSignature()) return;
-  loadPackagePerformance();
+  observeAsync(loadPackagePerformance(), "Loading package analysis");
 }
 
 // The Metadata lens: the image-level "container" view of each assembly — metadata format
@@ -2690,7 +2756,7 @@ function maybeAutoLoadPackagePerformance() {
 // it scopes to one runtime-pack assembly (the shared framework is ~160 assemblies); for a
 // NuGet package it describes every active-framework lib/ assembly.
 function renderPackageMetadata() {
-  const isPlatform = Boolean(state.package?.isRuntimePack);
+  const isPlatform = state.package?.isRuntimePack === true;
   const fresh = state.packageMetadataKey === packageScopeSignature();
   return renderPackageMetadataHtml({
     isPlatform,
@@ -2698,7 +2764,7 @@ function renderPackageMetadata() {
     activeFramework: state.package?.activeFramework || "",
     pickerHtml: isPlatform ? platformLensPicker("data-platform-metadata-library") : "",
     fresh,
-    loading: Boolean(state.packageMetadataLoading),
+    loading: state.packageMetadataLoading,
     error: state.packageMetadataError || "",
     metadata: state.packageMetadata || null,
     escapeHtml,
@@ -2719,7 +2785,7 @@ function maybeAutoLoadPackageMetadata() {
   if (!state.atPackageRoot || state.packageLens !== "metadata") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
   if (state.packageMetadataKey === packageScopeSignature()) return;
-  loadPackageMetadata();
+  observeAsync(loadPackageMetadata(), "Loading package metadata");
 }
 
 // ─── Metadata Explorer ─────────────────────────────────────────────────────────
@@ -2740,7 +2806,7 @@ function explorerPageSize() {
 function openExplorer(assemblyFileName: string, tableIndex: number, rowId = 0) {
   const ex = buildBaseExplorer(assemblyFileName);
   if (!ex) return;
-  ex.history = [{ index: Number(tableIndex), rowId: Number(rowId) || 0 }];
+  ex.history = [{ index: tableIndex, rowId: rowId || 0 }];
   ex.historyPos = 0;
   state.explorer = ex;
   applyExplorerFocus();
@@ -2879,7 +2945,8 @@ function applyExplorerFocus() {
     ex.focusHeap = entry.heap;
     ex.highlight = null;
     ex.detail = null;
-    if (!ex.heapWindows[entry.heap]) loadExplorerHeap(entry.heap);
+    if (!ex.heapWindows[entry.heap])
+      observeAsync(loadExplorerHeap(entry.heap), "Loading metadata heap rows");
     else render();
   } else {
     if (entry.index == null) return;
@@ -2892,7 +2959,7 @@ function applyExplorerFocus() {
     const onScreen = win?.data && (!entry.rowId
       || (entry.rowId >= win.data.startRowId && entry.rowId < win.data.startRowId + (win.data.rows?.length || 0)));
     if (onScreen) render();
-    else loadExplorerWindow(entry.index, start);
+    else observeAsync(loadExplorerWindow(entry.index, start), "Loading metadata table rows");
   }
   ex.pendingScroll = true;
   explorerScrollToFocus();
@@ -2943,7 +3010,9 @@ function syncExplorerPageSize() {
   const win = ex.windows[ex.focusIndex];
   const rows = win?.data?.rows ?? [];
   if (win?.data && rows.length < fit && rows.length < win.data.rowCount) {
-    loadExplorerWindow(ex.focusIndex, win.data.startRowId, fit);
+    observeAsync(
+      loadExplorerWindow(ex.focusIndex, win.data.startRowId, fit),
+      "Loading metadata table rows");
   }
 }
 
@@ -2981,10 +3050,13 @@ function bindMetadataExplorerEvents() {
   document.querySelectorAll<HTMLElement>("[data-mde-page]").forEach(btn =>
     btn.addEventListener("click", () => {
       const [index, start] = (btn.dataset.mdePage ?? "").split(":").map(Number);
-      loadExplorerWindow(index, start);
+      observeAsync(loadExplorerWindow(index, start), "Loading metadata table rows");
     }));
   document.querySelectorAll<HTMLElement>("[data-mde-heap-chip]").forEach(chip =>
-    chip.addEventListener("click", () => pushExplorerFocus({ heap: chip.dataset.mdeHeapChip })));
+    chip.addEventListener("click", () => {
+      const heap = chip.dataset.mdeHeapChip;
+      if (heap !== undefined) pushExplorerFocus({ heap });
+    }));
 
   if (ex?.overview) {
     // All-tables view: clicking a card head, a ref, or a row focuses that table.
@@ -2996,7 +3068,8 @@ function bindMetadataExplorerEvents() {
     document.querySelectorAll<HTMLElement>(".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head").forEach(head =>
       head.addEventListener("click", () => {
         const card = head.closest<HTMLElement>(".mde-heap-card");
-        if (card) pushExplorerFocus({ heap: card.dataset.mdeHeap });
+        const heap = card?.dataset.mdeHeap;
+        if (heap !== undefined) pushExplorerFocus({ heap });
       }));
     document.querySelectorAll<HTMLElement>(".mde-wall .mde-row[data-mde-row]").forEach(tr =>
       tr.addEventListener("click", () => {
@@ -3027,9 +3100,13 @@ function bindMetadataExplorerEvents() {
       if (entry.isIntersecting) {
         if (!(entry.target instanceof HTMLElement)) continue;
         if (entry.target.dataset.mdeHeapNeedsLoad != null) {
-          loadExplorerHeap(entry.target.dataset.mdeHeapNeedsLoad);
+          observeAsync(
+            loadExplorerHeap(entry.target.dataset.mdeHeapNeedsLoad),
+            "Loading metadata heap rows");
         } else {
-          loadExplorerWindow(Number(entry.target.dataset.mdeNeedsLoad));
+          observeAsync(
+            loadExplorerWindow(Number(entry.target.dataset.mdeNeedsLoad)),
+            "Loading metadata table rows");
         }
       }
     }
@@ -3041,9 +3118,13 @@ function bindMetadataExplorerEvents() {
   // Always ensure the focused table or heap is loaded (its window backs the focus panel).
   if (state.explorer) {
     if (state.explorer.focusHeap && !state.explorer.heapWindows[state.explorer.focusHeap]) {
-      loadExplorerHeap(state.explorer.focusHeap);
+      observeAsync(
+        loadExplorerHeap(state.explorer.focusHeap),
+        "Loading metadata heap rows");
     } else if (!state.explorer.focusHeap && !state.explorer.windows[state.explorer.focusIndex]) {
-      loadExplorerWindow(state.explorer.focusIndex);
+      observeAsync(
+        loadExplorerWindow(state.explorer.focusIndex),
+        "Loading metadata table rows");
     }
     // Once the focus panel is laid out, size the row window to its actual height.
     if (!state.explorer.overview && !state.explorer.focusHeap) {
@@ -3098,7 +3179,7 @@ function drillToPerfMember(token: string, assembly: string, typeId: string) {
   resetMemberSectionState();
   state.memberSection = "facts";
   state.typeCursor = filteredTypes().findIndex(candidate => candidate.id === targetType.id);
-  loadSelectedMemberFacts();
+  observeAsync(loadSelectedMemberFacts(), "Loading member facts");
 }
 
 function renderPackageOverview() {
@@ -3190,7 +3271,7 @@ function renderPackageOverview() {
     const ns = type.namespace || "global";
     nsCounts.set(ns, (nsCounts.get(ns) || 0) + 1);
   }
-  const namespaces = [...nsCounts.entries()]
+  const namespaceChips = [...nsCounts.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, 12)
     .map(([ns, count]) => `<button class="type-chip" data-namespace-jump="${escapeHtml(ns)}"><span class="ns-count">${count}</span>${escapeHtml(ns)}</button>`)
@@ -3229,7 +3310,7 @@ function renderPackageOverview() {
     </section>
     <section class="document-section">
       <div class="section-title"><h2>Namespaces</h2><span>${nsCounts.size} — click to filter</span></div>
-      <div class="type-chip-list">${namespaces}${nsOverflow}</div>
+      <div class="type-chip-list">${namespaceChips}${nsOverflow}</div>
     </section>${documentsSection}`;
 }
 
@@ -3403,7 +3484,7 @@ function renderMember(type: BrowserTypeSurface, member: AppMemberGroup) {
     const platformView = drilled || Boolean(state.package?.isRuntimePack);
     const callers = active?.callers?.children ?? [];
     const callees = active?.callees?.children ?? [];
-    const scope = active?.scope;
+    const graphScope = active?.scope;
     const otherWorkspaceLibraries = Math.max(
       0,
       state.packages.filter(packageItem => !packageItem.isRuntimePack).length - 1);
@@ -3413,11 +3494,11 @@ function renderMember(type: BrowserTypeSurface, member: AppMemberGroup) {
           <span class="graph-crumbs">${escapeHtml(platformCrumbTrail())}</span>
         </div>`
       : "";
-    const scopeLine = !scope
+    const scopeLine = !graphScope
       ? ""
       : platformView
-      ? `<div class="graph-scope"><strong>Platform${drilled ? " descent" : ""}</strong><span>${escapeHtml(scope.calleeScope)} · runtime pack</span><strong>Callees</strong><span>depth 2</span></div>`
-      : `<div class="graph-scope"><strong>Workspace callers</strong><span>${scope.packages} loaded packages · ${scope.callerAssemblies} scanned assemblies</span><strong>Callees</strong><span>${escapeHtml(scope.calleeScope)} · depth 2</span></div>`;
+      ? `<div class="graph-scope"><strong>Platform${drilled ? " descent" : ""}</strong><span>${escapeHtml(graphScope.calleeScope)} · runtime pack</span><strong>Callees</strong><span>depth 2</span></div>`
+      : `<div class="graph-scope"><strong>Workspace callers</strong><span>${graphScope.packages} loaded packages · ${graphScope.callerAssemblies} scanned assemblies</span><strong>Callees</strong><span>${escapeHtml(graphScope.calleeScope)} · depth 2</span></div>`;
     const diagnostics = active?.diagnostics;
     const diagnosticsMessage = callGraphDiagnosticsMessage(diagnostics);
     const incompleteGraph = diagnosticsMessage
@@ -3530,7 +3611,9 @@ function renderMemberFacts(
     ${renderFactTable("Allocation facts", facts.allocations, [
       ["IL", "offset"], ["Kind", "kind"], ["Type", "type"], ["Multiplicity", "multiplicity"],
       ["Path", "path"], ["Escape", "escape"], ["Loop", row => row.inLoop ? "yes" : ""],
-      ["Size", row => row.estimatedSizeBytes == null ? "" : `${row.estimatedSizeBytes} B`]
+      ["Size", row => typeof row.estimatedSizeBytes === "number"
+        ? `${row.estimatedSizeBytes} B`
+        : ""]
     ], "No heap-allocation occurrences were found in this method.")}
     ${renderFactTable("Calls", facts.calls, [
       ["IL", "offset"], ["Opcode", "opcode"], ["Callee", "callee"],
@@ -3641,8 +3724,8 @@ function highlight(value: string) {
     .replace(/\b(string|object|void|Type|Stream|Task|ValueTask|CancellationToken|TValue)\b/g, '<span class="primitive">$1</span>');
 }
 
-function highlightCSharp(value: unknown) {
-  const source = String(value ?? "");
+function highlightCSharp(value: string) {
+  const source = value;
   if (window.Prism?.languages?.csharp) {
     return window.Prism.highlight(
       source,
@@ -3687,7 +3770,9 @@ function bindEvents() {
     render();
   }));
   document.querySelectorAll<HTMLElement>("[data-framework-chip]").forEach(button => button.addEventListener("click", () => {
-    switchPackageFramework(button.dataset.frameworkChip ?? "");
+    observeAsync(
+      switchPackageFramework(button.dataset.frameworkChip ?? ""),
+      "Switching the package framework");
   }));
   document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => button.addEventListener("click", () => {
     const index = Number(button.dataset.depGroup);
@@ -3772,7 +3857,9 @@ function bindEvents() {
     navigateToTypeByName(id);
   }));
   document.querySelectorAll<HTMLElement>("[data-opp-package]").forEach(button => button.addEventListener("click", () => {
-    openDependencyPackage(button.dataset.oppPackage ?? "", "");
+    observeAsync(
+      openDependencyPackage(button.dataset.oppPackage ?? "", ""),
+      "Opening an opportunity package");
   }));
   document.querySelectorAll<HTMLElement>("[data-opp-lookfor]").forEach(button => button.addEventListener("click", () => {
     openSpotlight(button.dataset.oppLookfor ?? "");
@@ -3804,7 +3891,7 @@ function bindEvents() {
     renderMemberFilterAndRestoreFocus();
   }));
   const memberFilter = document.querySelector<HTMLInputElement>("#member-filter");
-  memberFilter?.addEventListener("input", event => {
+  memberFilter?.addEventListener("input", () => {
     state.memberTextFilter = memberFilter.value;
     normalizeMemberSelection();
     renderPreservingMemberFocus();
@@ -3883,21 +3970,21 @@ function bindEvents() {
   document.querySelector("#member-back")?.addEventListener("click", () => {
     drillOut();
   });
-  document.querySelector("#copy-name")?.addEventListener("click", async () => {
+  document.querySelector("#copy-name")?.addEventListener("click", () => {
     const type = selectedType();
     if (!type) return;
     const typeName = `${type.namespace ? `${type.namespace}.` : ""}${type.name}`;
     const member = selectedMember(type);
     const fullName = member ? `${typeName}.${member.name}` : typeName;
-    await copyText(fullName, "name copied");
+    void copyText(fullName, "name copied");
   });
-  document.querySelector("#copy-signature")?.addEventListener("click", async () => {
+  document.querySelector("#copy-signature")?.addEventListener("click", () => {
     const type = selectedType();
     const member = selectedMember(type);
     const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
-    if (overload) await copyText(overload.signature, "signature copied");
+    if (overload) void copyText(overload.signature, "signature copied");
   });
-  document.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button => button.addEventListener("click", async () => {
+  document.querySelectorAll<HTMLElement>("[data-copy-anchor]").forEach(button => button.addEventListener("click", () => {
     const type = selectedType();
     const member = selectedMember(type);
     const overload = member?.overloads[state.selectedOverloadIndex ?? 0];
@@ -3906,20 +3993,23 @@ function bindEvents() {
       digest: overload?.anchorDigest,
       canonical: overload?.canonicalSignature
     };
-    const anchor = button.dataset.copyAnchor as keyof typeof values | undefined;
-    const value = anchor ? values[anchor] : undefined;
-    if (value) await copyText(value, `${anchor} copied`);
+    const anchor = button.dataset.copyAnchor;
+    const value = anchor === "selector" || anchor === "digest" || anchor === "canonical"
+      ? values[anchor]
+      : undefined;
+    if (value) void copyText(value, `${anchor} copied`);
   }));
-  document.querySelector("#copy-source")?.addEventListener("click", async () => {
-    if (state.memberSource) await copyText(state.memberSource.text, "source copied");
+  document.querySelector("#copy-source")?.addEventListener("click", () => {
+    if (state.memberSource) void copyText(state.memberSource.text, "source copied");
   });
-  document.querySelector("#copy-annotated")?.addEventListener("click", async () => {
-    if (state.memberAnnotated) await copyText(state.memberAnnotated.document.text, "annotated source copied");
+  document.querySelector("#copy-annotated")?.addEventListener("click", () => {
+    if (state.memberAnnotated)
+      void copyText(state.memberAnnotated.document.text, "annotated source copied");
   });
   document.querySelectorAll<HTMLElement>("[data-annotated-medium]").forEach(button => button.addEventListener("click", () => {
     const medium = button.dataset.annotatedMedium;
-    if (!medium || !MEDIA.includes(medium as (typeof MEDIA)[number])) return;
-    const typedMedium = medium as (typeof MEDIA)[number];
+    if (!medium || !isAnnotatedMedium(medium)) return;
+    const typedMedium = medium;
     const next = {
       ...state.memberAnnotatedMedia,
       [typedMedium]: !state.memberAnnotatedMedia[typedMedium],
@@ -3950,8 +4040,8 @@ function bindEvents() {
     state.memberAnnotatedNodeIds = [];
     render();
   });
-  document.querySelector("#copy-type-source")?.addEventListener("click", async () => {
-    if (state.typeSource) await copyText(state.typeSource.text, "source copied");
+  document.querySelector("#copy-type-source")?.addEventListener("click", () => {
+    if (state.typeSource) void copyText(state.typeSource.text, "source copied");
   });
   document.querySelectorAll<HTMLElement>("[data-namespace]").forEach(button => button.addEventListener("click", () => {
     state.namespaceFilter = button.dataset.namespace ?? "";
@@ -4001,7 +4091,7 @@ function bindEvents() {
     const name = select.value;
     if (!name) return;
     const pack = select.selectedOptions[0]?.dataset.pack || "netcore.app";
-    openPlatformLibrary(name, pack);
+    observeAsync(openPlatformLibrary(name, pack), "Opening a platform library");
   }));
   // The lens-scoped library pickers (Integrations, Opportunities, Analysis) scope the scan
   // without leaving the lens: unlike the main platform selector they keep package (platform)
@@ -4015,7 +4105,7 @@ function bindEvents() {
   const bindPlatformLensPicker = (
     dataAttr: string,
     lens: string,
-    loader: () => unknown,
+    loader: () => Promise<void>,
   ) => {
     const openLibrary = async (
       name: string,
@@ -4083,14 +4173,14 @@ function bindEvents() {
       state.typeFilter = "";
       state.kindFilter = "";
       normalizeLibrarySelection();
-      loader();
+      await loader();
     };
     document.querySelectorAll<HTMLSelectElement>(`[${dataAttr}]`).forEach(select => select.addEventListener("change", () => {
       const name = select.value;
       if (!name) return;
       const key = name.replace(/\.dll$/i, "");
       const pack = select.selectedOptions[0]?.dataset.pack || platformPackForAssembly(key);
-      openLibrary(name, pack);
+      observeAsync(openLibrary(name, pack), "Opening a platform library");
     }));
   };
   bindPlatformLensPicker("data-platform-integrations-library", "integrations", loadPackageIntegrations);
@@ -4111,17 +4201,25 @@ function bindEvents() {
     }));
   const frameworkSelect = document.querySelector<HTMLSelectElement>("#framework");
   frameworkSelect?.addEventListener("change", () => {
-    switchPackageFramework(frameworkSelect.value);
+    observeAsync(
+      switchPackageFramework(frameworkSelect.value),
+      "Switching the package framework");
   });
   const packageVersionSelect =
     document.querySelector<HTMLSelectElement>("#package-version");
   packageVersionSelect?.addEventListener("change", () => {
     if (state.package?.isRuntimePack)
-      switchPlatformVersion(packageVersionSelect.value);
-    else switchPackageVersion(packageVersionSelect.value);
+      observeAsync(
+        switchPlatformVersion(packageVersionSelect.value),
+        "Switching the platform version");
+    else
+      observeAsync(
+        switchPackageVersion(packageVersionSelect.value),
+        "Switching the package version");
   });
-  ensurePackageVersions(state.package);
-  if (state.package?.isRuntimePack) ensureDotnetReleases();
+  observeAsync(ensurePackageVersions(state.package), "Loading package versions");
+  if (state.package?.isRuntimePack)
+    observeAsync(ensureDotnetReleases(), "Loading .NET release information");
   const filter = document.querySelector<HTMLInputElement>("#type-filter");
   filter?.addEventListener("input", () => {
     state.typeFilter = filter.value;
@@ -4154,7 +4252,9 @@ function bindEvents() {
   document.querySelectorAll<HTMLElement>("[data-doc-path]").forEach(button =>
     button.addEventListener(
       "click",
-      () => openPackageDocument(button.dataset.docPath ?? "")));
+      () => observeAsync(
+        openPackageDocument(button.dataset.docPath ?? ""),
+        "Opening a package document")));
   document.querySelector("#doc-viewer-backdrop")?.addEventListener("mousedown", event => {
     if (event.target instanceof HTMLElement
         && event.target.id === "doc-viewer-backdrop") closeDocViewer();
@@ -4180,15 +4280,19 @@ function bindEvents() {
     focusFilter();
   });
 
-  document.querySelector("#share")?.addEventListener("click", share);
-  document.querySelector("[data-graph-back]")?.addEventListener("click", popPlatformDrill);
+  document.querySelector("#share")?.addEventListener("click", () => void share());
+  document.querySelector("[data-graph-back]")?.addEventListener(
+    "click",
+    popPlatformDrill);
   document.querySelector("#dismiss-notice")?.addEventListener("click", () => {
     state.queryNotice = "";
     state.queryNoticeRetryAction = null;
     render();
   });
-  document.querySelector("#retry-notice")?.addEventListener("click", () =>
-    state.queryNoticeRetryAction?.());
+  document.querySelector("#retry-notice")?.addEventListener("click", () => {
+    const retryAction = state.queryNoticeRetryAction;
+    if (retryAction) observeAction(retryAction, "Retrying the inspection");
+  });
   document.querySelector("#dismiss-package-notice")?.addEventListener("click", () => {
     currentPackage().inspectionError = "";
     render();
@@ -4211,9 +4315,13 @@ function setTheme(theme: "light" | "dark") {
   localStorage.setItem("inspect-theme", state.theme);
   document.documentElement.dataset.theme = state.theme;
   render();
-  if (state.memberCallGraph) renderMermaidCallGraph();
+  if (state.memberCallGraph)
+    observeAsync(renderMermaidCallGraph(), "Rendering the member call graph");
   const depGraph = document.querySelector<HTMLElement>("#dependency-graph-diagram");
-  if (depGraph) { depGraph.dataset.graphDef = ""; renderDependencyGraph(); }
+  if (depGraph) {
+    depGraph.dataset.graphDef = "";
+    observeAsync(renderDependencyGraph(), "Rendering the dependency graph");
+  }
 }
 
 function handleTypeKeys(event: KeyboardEvent) {
@@ -4606,11 +4714,11 @@ function mostRecentAvailableLibrary() {
 // exclude anything already open.
 function spotlightResults(): SpotlightResult[] {
   const query = state.spotlightQuery.trim();
-  const scope = state.spotlightScope;
-  const all = scope === "all";
+  const spotlightScope = state.spotlightScope;
+  const all = spotlightScope === "all";
   const results: SpotlightResult[] = [];
 
-  if (scope === "runtime") {
+  if (spotlightScope === "runtime") {
     if (state.runtimePackLoading) {
       results.push({ kind: "rtpack-status", loading: true });
       return results;
@@ -4646,7 +4754,7 @@ function spotlightResults(): SpotlightResult[] {
     return results;
   }
 
-  if (all || scope === "packages") {
+  if (all || spotlightScope === "packages") {
     const loaded = spotlightLoadedPackageMatches(query).slice(0, all ? 3 : 20);
     for (const match of loaded) results.push({ kind: "pkg-loaded", pkg: match.pkg, ranges: match.ranges });
     const openIds = new Set(state.packages.map(pkg => pkg.id.toLowerCase()));
@@ -4675,17 +4783,17 @@ function spotlightResults(): SpotlightResult[] {
       if (all && ++added >= 4) break;
     }
   }
-  if ((all || scope === "types") && query) {
+  if ((all || spotlightScope === "types") && query) {
     for (const match of spotlightTypeMatches(query).slice(0, all ? 6 : 50)) results.push({ ...match, kind: "type" });
-  } else if (scope === "types" && !query) {
+  } else if (spotlightScope === "types" && !query) {
     for (const match of spotlightTypeMatches("").slice(0, 40)) results.push({ ...match, kind: "type" });
   }
-  if ((all || scope === "members") && query) {
+  if ((all || spotlightScope === "members") && query) {
     for (const match of spotlightMemberMatches(query).slice(0, all ? 6 : 50)) results.push({ ...match, kind: "member" });
   }
   // Offer the runtime pack when the user is clearly hunting a platform type but it isn't
   // loaded yet — one gesture makes BCL types (TextWriter, String…) searchable session-wide.
-  if ((all || scope === "types") && query.length >= 2 && !runtimePackLoaded() && !state.runtimePackLoading) {
+  if ((all || spotlightScope === "types") && query.length >= 2 && !runtimePackLoaded() && !state.runtimePackLoading) {
     results.push({ kind: "rtpack-suggest" });
   }
   return results;
@@ -4701,12 +4809,38 @@ interface NugetSearchResponse {
   data?: NugetSearchResult[];
 }
 
+interface DotnetReleaseIndexEntry {
+  "channel-version": string;
+  "latest-release": string;
+}
+
+function isNugetSearchResult(value: unknown): value is NugetSearchResult {
+  return isRecord(value)
+    && typeof value.id === "string"
+    && typeof value.version === "string"
+    && (value.description === undefined || typeof value.description === "string");
+}
+
+function isDotnetReleaseIndexEntry(
+  value: unknown,
+): value is DotnetReleaseIndexEntry {
+  return isRecord(value)
+    && typeof value["channel-version"] === "string"
+    && typeof value["latest-release"] === "string";
+}
+
 async function querySpotlightPackages(query: string): Promise<SpotlightPackageHit[]> {
   const url = `https://azuresearch-usnc.nuget.org/query?q=${encodeURIComponent(query)}&take=8&prerelease=true&semVerLevel=2.0.0`;
   const response = await fetch(url);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const payload = await response.json() as NugetSearchResponse;
-  return (payload.data || []).map(item => ({
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)
+      || (payload.data !== undefined
+        && (!Array.isArray(payload.data) || !payload.data.every(isNugetSearchResult)))) {
+    throw new TypeError("NuGet search returned an invalid response.");
+  }
+  const typedPayload: NugetSearchResponse = payload;
+  return (typedPayload.data || []).map(item => ({
     id: item.id,
     version: item.version,
     description: item.description || "",
@@ -4751,13 +4885,16 @@ async function queryDotnetReleases(): Promise<DotnetRelease[]> {
   const url = "https://raw.githubusercontent.com/dotnet/core/refs/heads/main/release-notes/releases-index.json";
   const response = await fetch(url);
   if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const payload = await response.json() as {
-    "releases-index"?: Array<{
-      "channel-version": string;
-      "latest-release": string;
-    }>;
-  };
-  return (payload["releases-index"] || [])
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) throw new TypeError("The .NET release index was invalid.");
+  const releases = payload["releases-index"];
+  if (releases !== undefined
+      && (!Array.isArray(releases)
+        || !releases.every(isDotnetReleaseIndexEntry))) {
+    throw new TypeError("The .NET release index contained an invalid release.");
+  }
+  const typedReleases: DotnetReleaseIndexEntry[] = releases || [];
+  return typedReleases
     .map(entry => {
       const major = parseInt(entry["channel-version"], 10);
       return {
@@ -4835,7 +4972,7 @@ async function switchPlatformVersion(
   state.memberBrowseTypeId = "";
   state.selectedOverloadIndex = null;
   render();
-  loadSelectionData();
+  observeAsync(loadSelectionData(), "Loading selection data");
 }
 
 function ensurePackageVersions(pkg: AppPackage | null) {
@@ -4881,14 +5018,35 @@ function pickSpotlightResult(result: SpotlightResult) {
   if (!result) { closeSpotlight(); return; }
   switch (result.kind) {
     case "pkg-loaded": pickSpotlightLoadedPackage(result.pkg); break;
-    case "pkg-nuget": loadPackageFromSpotlight(result.hit.id, result.hit.version); break;
-    case "pkg-recent": loadPackageFromSpotlight(result.entry.id, result.entry.version, result.entry.framework); break;
-    case "member": pickSpotlightMember(result); break;
+    case "pkg-nuget":
+      observeAsync(
+        loadPackageFromSpotlight(result.hit.id, result.hit.version),
+        "Loading a Spotlight package");
+      break;
+    case "pkg-recent":
+      observeAsync(
+        loadPackageFromSpotlight(
+          result.entry.id,
+          result.entry.version,
+          result.entry.framework),
+        "Loading a recent package");
+      break;
+    case "member":
+      observeAsync(pickSpotlightMember(result), "Opening a Spotlight member");
+      break;
     case "rtpack-suggest": state.spotlightScope = "runtime"; state.spotlightIndex = 0; activateRuntimePack(); break;
-    case "platform-lib": openPlatformLibrary(result.assembly, result.pack); break;
+    case "platform-lib":
+      observeAsync(
+        openPlatformLibrary(result.assembly, result.pack),
+        "Opening a platform library");
+      break;
     case "rtpack-status": break;
-    case "type": pickSpotlight(result.pkg, result.type.id); break;
-    default: executeCommand(result.value, result); break;
+    case "type":
+      observeAsync(pickSpotlight(result.pkg, result.type.id), "Opening a Spotlight type");
+      break;
+    default:
+      observeAsync(executeCommand(result.value, result), "Running a Spotlight command");
+      break;
   }
 }
 
@@ -4917,10 +5075,12 @@ function activateRuntimePack() {
     framework,
     () => navigationSequence.isCurrent(navigationSeq)); // sets runtimePackLoading synchronously
   spotlight.refresh();
-  pending.then(() => {
-    if (!state.spotlightOpen && !state.home) return;
-    spotlight.refresh();
-  });
+  observeAsync(
+    pending.then(() => {
+      if (!state.spotlightOpen && !state.home) return;
+      spotlight.refresh();
+    }),
+    "Loading the runtime pack");
 }
 
 // Drill into one platform library from the index-first Platform scope: lazily fetch just
@@ -4942,7 +5102,7 @@ async function openPlatformLibrary(
   const scopeOnly = options.scopeOnly === true;
   const focusGeneration = scopeOnly ? null : beginSpotlightNavigation();
   const navigationSeq = options.navigationSeq ?? navigationSequence.begin();
-  if (!navigationSequence.isCurrent(navigationSeq)) return;
+  if (!navigationSequence.isCurrent(navigationSeq)) return undefined;
   spotlight.reset();
   const key = (assembly || "").replace(/\.dll$/i, "");
   const fileName = key ? `${key}.dll` : "";
@@ -4962,7 +5122,7 @@ async function openPlatformLibrary(
       pack,
       () => navigationSequence.isCurrent(navigationSeq));
     const loaded = runtimeResult.packageModel;
-    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    if (!navigationSequence.isCurrent(navigationSeq)) return undefined;
     if (!loaded) {
       state.loading = false;
       const failureMessage =
@@ -4974,11 +5134,11 @@ async function openPlatformLibrary(
       state.retryAction = options.retryAction
         ?? (() => openPlatformLibrary(assembly, pack));
       render();
-      return;
+      return undefined;
     }
   }
   const pkg = runtimePackPackage();
-  if (!pkg) { render(); return; }
+  if (!pkg) { render(); return undefined; }
   activatePackage(pkg, { resetAccessibility: true });
   state.home = false;
   const hasLib = pkg.types.some(type => libraryKey(type) === key);
@@ -5001,6 +5161,7 @@ async function openPlatformLibrary(
   render();
   await selectionData;
   if (focusGeneration != null) focusTypeList(focusGeneration);
+  return undefined;
 }
 
 function pickSpotlightLoadedPackage(pkg: {
@@ -5149,7 +5310,7 @@ function executeCommand(
   } else if (verb === "find" || verb === "types") {
     state.typeFilter = argument.replace(/^public\s*/, "");
   } else if (verb === "share") {
-    share();
+    operation = share();
   }
   state.history = [value, ...state.history.filter(item => item !== value)].slice(0, 5);
   return operation;
@@ -5365,17 +5526,17 @@ function applyDeepLink(deep: DeepLink | null | undefined) {
 // Kick off the async data load implied by the current lens/section so a restored or
 // history-navigated view fills in its content.
 function loadSelectionData() {
-  if (state.atPackageRoot) return;
+  if (state.atPackageRoot) return undefined;
   if (state.lens === "source") {
     return loadSelectedTypeSource();
   }
   if (state.lens === "metadata") {
     return loadSelectedTypeMetadata();
   }
-  if (state.lens !== "api" || !state.selectedMemberKey) return;
+  if (state.lens !== "api" || !state.selectedMemberKey) return undefined;
   const member = selectedMember(selectedType());
-  if (!member) return;
-  if (member.overloads.length > 1 && state.selectedOverloadIndex == null) return;
+  if (!member) return undefined;
+  if (member.overloads.length > 1 && state.selectedOverloadIndex == null) return undefined;
   if (state.memberSection === "source") return loadSelectedMemberSource();
   if (state.memberSection === "annotated") return loadSelectedMemberAnnotatedSource();
   if (state.memberSection === "call-graph") return loadSelectedMemberCallGraph();
@@ -5544,12 +5705,15 @@ const HOME_DEMO_LINKS = {
 
 function runHomeDemo(kind: keyof typeof HOME_DEMO_LINKS | "callgraph") {
   state.home = false;
-  if (kind === "callgraph") { runCallGraphDemo(); return; }
+  if (kind === "callgraph") {
+    observeAsync(runCallGraphDemo(), "Loading the call graph demo");
+    return;
+  }
   const link = HOME_DEMO_LINKS[kind];
   if (!link) return;
   workspaceLocation.push(link);
   const loc = parseLocation();
-  restoreWorkspaceFromLocation(loc, loc);
+  observeAsync(restoreWorkspaceFromLocation(loc, loc), "Loading the demo workspace");
 }
 
 // Return to the intro/home page without tearing down the warm engine or the loaded packages.
@@ -5608,7 +5772,7 @@ async function openRuntimePackFromHome() {
   state.memberBrowseTypeId = "";
   state.selectedOverloadIndex = null;
   render();
-  loadSelectionData();
+  observeAsync(loadSelectionData(), "Loading selection data");
 }
 
 // The inspector-bot mascot series shown on interstitial (loading) screens. Each entry is a
@@ -5643,7 +5807,7 @@ function openPackageFromError(packageId: string, version: string) {
     window.location.assign(url);
     return;
   }
-  loadPackage(packageId, version, "");
+  observeAsync(loadPackage(packageId, version, ""), "Loading a package");
 }
 
 function renderLoading() {
@@ -5668,7 +5832,9 @@ function renderLoading() {
     </div>`;
   document.querySelector("#retry-load")?.addEventListener(
     "click",
-    () => (state.retryAction ?? bootstrap)());
+    () => observeAction(
+      state.retryAction ?? bootstrap,
+      "Retrying the inspection"));
   document.querySelector("#error-package-query")?.addEventListener("submit", event => {
     event.preventDefault();
     const input =
@@ -5788,7 +5954,7 @@ function memberRequestSignature(
     type?.queryId ?? type?.id,
     type?.definitionId ?? type?.id,
     overload?.stableSelector ?? overload?.canonicalSignature ?? overload?.signature
-  ].map(value => String(value ?? ""));
+  ].map(value => value ?? "");
   if (includeBody) {
     parts.push(
       String(state.selectedBodyTarget?.metadataToken ?? ""),
@@ -5893,7 +6059,8 @@ async function renderTypeGraph() {
     const rootStyle = getComputedStyle(document.documentElement);
     const resolved = definition.replace(
       /var\((--[\w-]+)\)/g,
-      (whole, name) => rootStyle.getPropertyValue(name).trim() || whole
+      (whole: string, name: string) =>
+        rootStyle.getPropertyValue(name).trim() || whole
     );
     const { svg } = await mermaid.render(id, resolved);
     if (document.querySelector("#type-graph-diagram") !== container) return;
@@ -6004,9 +6171,13 @@ async function renderDependencyGraph() {
   if (!pkg) return;
   const built = buildDependencyGraphMermaid(
     {
-      ...state,
       package: pkg,
-      packageDependencies: state.packageDependencies ?? undefined,
+      packages: state.packages,
+      dependenciesGroupIndex: state.dependenciesGroupIndex,
+      workspaceDependencies: state.workspaceDependencies,
+      ...(state.packageDependencies
+        ? { packageDependencies: state.packageDependencies }
+        : {}),
     },
     (_packages, packageId, versionRange) =>
       uniqueCompatiblePackage(state.packages, packageId, versionRange));
@@ -6042,7 +6213,8 @@ async function renderDependencyGraph() {
     const rootStyle = getComputedStyle(document.documentElement);
     const resolved = built.definition.replace(
       /var\((--[\w-]+)\)/g,
-      (whole, name) => rootStyle.getPropertyValue(name).trim() || whole
+      (whole: string, name: string) =>
+        rootStyle.getPropertyValue(name).trim() || whole
     );
     const { svg } = await mermaid.render(id, resolved);
     // A newer render superseded this one, or the container was swapped out — bail without touching the DOM.
@@ -6076,7 +6248,9 @@ async function renderDependencyGraph() {
         if (info.kind === "open" && info.packageKey)
           switchToPackageForDependencies(info.packageKey);
         else if (info.id)
-          openDependencyPackage(info.id, info.versionRange);
+          observeAsync(
+            openDependencyPackage(info.id, info.versionRange),
+            "Opening a dependency package");
       });
     });
   } catch (error) {
@@ -6209,7 +6383,7 @@ function patchCallGraphSection(previousMermaid: string | undefined) {
   const graph = state.memberCallGraph;
   const callers = graph?.callers?.children ?? [];
   const callees = graph?.callees?.children ?? [];
-  const scope = graph?.scope;
+  const graphScope = graph?.scope;
   const countSpan = section.querySelector(".section-title span");
   if (countSpan) {
     countSpan.textContent =
@@ -6225,13 +6399,14 @@ function patchCallGraphSection(previousMermaid: string | undefined) {
     warning.textContent = diagnosticsMessage;
     scopeEl?.before(warning);
   }
-  if (scopeEl && scope) {
+  if (scopeEl && graphScope) {
     scopeEl.innerHTML =
-      `<strong>Workspace callers</strong><span>${scope.packages} loaded packages · ${scope.callerAssemblies} scanned assemblies</span><strong>Callees</strong><span>${escapeHtml(scope.calleeScope)} · depth 2</span>`;
+      `<strong>Workspace callers</strong><span>${graphScope.packages} loaded packages · ${graphScope.callerAssemblies} scanned assemblies</span><strong>Callees</strong><span>${escapeHtml(graphScope.calleeScope)} · depth 2</span>`;
   }
   const sourceCode = section.querySelector(".graph-mermaid pre code");
   if (sourceCode) sourceCode.textContent = graph?.mermaid ?? "";
-  if (graph?.mermaid && graph.mermaid !== previousMermaid) renderMermaidCallGraph();
+  if (graph?.mermaid && graph.mermaid !== previousMermaid)
+    observeAsync(renderMermaidCallGraph(), "Rendering the member call graph");
 }
 
 async function renderMermaidCallGraph() {
@@ -6259,7 +6434,8 @@ async function renderMermaidCallGraph() {
     const rootStyle = getComputedStyle(document.documentElement);
     const definition = active.mermaid.replace(
       /var\((--[\w-]+)\)/g,
-      (whole, name) => rootStyle.getPropertyValue(name).trim() || whole
+      (whole: string, name: string) =>
+        rootStyle.getPropertyValue(name).trim() || whole
     );
     const { svg } = await mermaid.render(id, definition);
     if (seq === callGraphRenderSeq
@@ -6434,7 +6610,9 @@ function attachGraphPanZoom(
         node.style.cursor = "pointer";
         node.addEventListener("click", () => {
           if (moved) return;
-          navigateOrDrillPlatform(target);
+          observeAsync(
+            navigateOrDrillPlatform(target),
+            "Opening a platform call-graph target");
         });
         return;
       }
@@ -6466,9 +6644,13 @@ function attachGraphPanZoom(
             loaded.overloadIndex,
             target);
         } else if (loaded) {
-          openGraphSource(loaded.request, loaded.title);
+          observeAsync(
+            openGraphSource(loaded.request, loaded.title),
+            "Loading graph source");
         } else if (platform) {
-          navigateOrDrillPlatform(target);
+          observeAsync(
+            navigateOrDrillPlatform(target),
+            "Opening a platform call-graph target");
         }
       });
     });
@@ -6561,7 +6743,9 @@ async function drillPlatformNode(node: BrowserCallGraphTarget) {
 }
 
 function popPlatformDrill() {
-  callGraphInspection.popDrill();
+  observeAsync(
+    callGraphInspection.popDrill(),
+    "Returning to the previous platform call graph");
 }
 
 // A clicked platform (BCL) call-graph node should land the user *inside* the resident
@@ -6657,7 +6841,7 @@ function navigateToRuntimeMember(
   state.memberAnnotatedError = "";
   state.selectedBodyTarget = bodyTarget;
   state.typeCursor = Math.max(0, filteredTypes().findIndex(item => item.id === type.id));
-  loadSelectedMemberCallGraph();
+  observeAsync(loadSelectedMemberCallGraph(), "Loading the member call graph");
 }
 
 // Resolve a platform call-graph node's structured identity to a concrete type, member
@@ -6722,22 +6906,22 @@ async function markdownLibs() {
   return { marked, DOMPurify };
 }
 
-async function renderMarkdown(text: unknown) {
+async function renderMarkdown(text: string) {
   const { marked, DOMPurify } = await markdownLibs();
-  const html = marked.parse(String(text ?? ""), { gfm: true, breaks: false });
+  const html = marked.parse(text, { gfm: true, breaks: false });
   return DOMPurify.sanitize(html, MARKDOWN_SANITIZE_OPTIONS);
 }
 
-async function renderMarkdownInline(text: unknown) {
+async function renderMarkdownInline(text: string) {
   const { marked, DOMPurify } = await markdownLibs();
-  const html = marked.parseInline(String(text ?? ""), { gfm: true });
+  const html = marked.parseInline(text, { gfm: true });
   return DOMPurify.sanitize(html, MARKDOWN_SANITIZE_OPTIONS);
 }
 
 function openPackageDocument(path: string) {
   const pkg = state.package;
   const doc = (pkg?.documents || []).find(candidate => candidate.path === path);
-  if (!pkg || !doc) return;
+  if (!pkg || !doc) return undefined;
   return documentInspection.open({
     packageId: pkg.id,
     version: pkg.version,
@@ -6792,19 +6976,23 @@ function reloadVisibleSource() {
   switch (sourceReloadKind(state)) {
     case "graph":
       if (state.graphSourceRequest) {
-        openGraphSource(
-          state.graphSourceRequest.request,
-          state.graphSourceRequest.title);
+        observeAsync(
+          openGraphSource(
+            state.graphSourceRequest.request,
+            state.graphSourceRequest.title),
+          "Reloading graph source");
       }
       break;
     case "type":
-      loadSelectedTypeSource();
+      observeAsync(loadSelectedTypeSource(), "Reloading type source");
       break;
     case "member":
-      loadSelectedMemberSource();
+      observeAsync(loadSelectedMemberSource(), "Reloading member source");
       break;
     case "annotated":
-      loadSelectedMemberAnnotatedSource();
+      observeAsync(
+        loadSelectedMemberAnnotatedSource(),
+        "Reloading annotated member source");
       break;
   }
 }
@@ -6921,7 +7109,7 @@ function navigateToMember(
   state.memberAnnotated = null;
   state.memberAnnotatedError = "";
   state.selectedBodyTarget = bodyTarget;
-  loadSelectedMemberDocumentation();
+  observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
 }
 
 async function loadSelectedMemberFacts() {
@@ -6996,10 +7184,12 @@ async function loadPackage(
       packageId,
       version,
       framework,
-      replacePackage: options.replacePackage,
-      isCurrent: navigationSeq == null
-        ? undefined
-        : () => navigationSequence.isCurrent(navigationSeq),
+      ...(options.replacePackage !== undefined
+        ? { replacePackage: options.replacePackage }
+        : {}),
+      ...(navigationSeq == null
+        ? {}
+        : { isCurrent: () => navigationSequence.isCurrent(navigationSeq) }),
     });
     if (!packageModel) return null;
     if (background) return packageModel;
@@ -7039,6 +7229,8 @@ async function loadPackage(
       return null;
     }
     state.loading = false;
+    const retryOptions: LoadPackageOptions = { ...options };
+    delete retryOptions.navigationSeq;
     if (prevPackage) {
       // A failed *new* query must not blow away an already-open workbench and trap the user
       // on a full-screen error. Keep them in their current package and restore the requested
@@ -7056,7 +7248,7 @@ async function loadPackage(
           packageId,
           version,
           framework,
-          { ...options, navigationSeq: undefined })));
+          retryOptions)));
       render();
     } else {
       state.error = state.queryNotice
@@ -7070,7 +7262,7 @@ async function loadPackage(
         packageId,
         version,
         framework,
-        { ...options, navigationSeq: undefined });
+        retryOptions);
       render();
     }
     return null;
@@ -7115,7 +7307,7 @@ function platformLibrarySelectHtml(
   if (!roster.length) return "";
   const byAssembly = new Map(roster.map(lib => [lib.assembly, lib]));
   const scoped = selectedKey !== undefined
-    ? String(selectedKey || "")
+    ? selectedKey ?? ""
     : (state.libraryScope && state.libraryScope.size === 1 ? [...state.libraryScope][0] : "");
   // Recent = the loaded/most-recently-accessed libraries: the explicit MRU first
   // (persisted across sessions), then any other currently-loaded libraries such as
@@ -7159,7 +7351,7 @@ function platformLibrarySelectHtml(
 // re-running LoadRuntimePack (per TFM), not GetPackageBytesAsync. This id test lets the
 // restore path route it correctly instead of 404-ing on a nupkg fetch.
 function isRuntimePackId(id: string | null | undefined) {
-  return String(id || "").toLowerCase() === "microsoft.netcore.app";
+  return (id ?? "").toLowerCase() === "microsoft.netcore.app";
 }
 
 const packageAcquisition = createPackageAcquisition({
@@ -7324,13 +7516,13 @@ async function restoreWorkspaceFromLocation(
   };
   const matchesFramework = (tab: RestorableCoordinate) =>
     !target.framework
-    || String(tab.framework || tab.activeFramework || "").toLowerCase()
-      === String(target.framework).toLowerCase();
+    || (tab.framework || tab.activeFramework || "").toLowerCase()
+      === target.framework.toLowerCase();
   const matchesTarget = (tab: RestorableCoordinate) =>
     isRuntimePackId(tab.id)
       ? isRuntimePackId(target.id) && matchesFramework(tab)
       : (tab.id.toLowerCase() === target.id.toLowerCase()
-        && String(tab.version).toLowerCase() === String(target.version).toLowerCase()
+        && tab.version.toLowerCase() === target.version.toLowerCase()
         && matchesFramework(tab));
   if (!tabs.some(matchesTarget)) {
     if (tabs.length === MAX_WORKSPACE_PACKAGES) {
@@ -7396,7 +7588,7 @@ async function restoreWorkspaceFromLocation(
     applyDeepLink(deep);
     state.loading = false;
     render();
-    loadSelectionData();
+    await loadSelectionData();
   } else if (!isRuntimePackId(target.id)) {
     // The focused NuGet target failed to load during the silent background pass; re-run it in
     // the foreground so its error (e.g. a 404) surfaces properly instead of a blank workbench.
@@ -7475,7 +7667,7 @@ async function bootstrap() {
     state.buildIdentity = inspectBuildIdentity();
     const tEngine = performance.now();
     try {
-      const vocabulary = await inspectVocabulary();
+      const vocabulary = inspectVocabulary();
       const sections = vocabulary?.sections || [];
       state.styleTiers = (
         sections.find(section => section.id === "csharp.style-tiers")?.values
@@ -7725,18 +7917,24 @@ window.addEventListener("popstate", () => {
   resetLocationFilters();
   const deep = loc;
   if (!state.package) {
-    restoreWorkspaceFromLocation(loc, deep, navigationSeq);
+    observeAsync(
+      restoreWorkspaceFromLocation(loc, deep, navigationSeq),
+      "Restoring workspace history");
     return;
   }
   if (loc.tabs?.length && !workspaceCoordinatesMatch(state.packages, loc.tabs)) {
-    restoreWorkspaceFromLocation(loc, deep, navigationSeq);
+    observeAsync(
+      restoreWorkspaceFromLocation(loc, deep, navigationSeq),
+      "Restoring workspace history");
     return;
   }
   if (loc.tabs?.length) {
     const target = state.packages.find(candidate =>
       packageCoordinateMatchesLocation(candidate, loc));
     if (!target) {
-      restoreWorkspaceFromLocation(loc, deep, navigationSeq);
+      observeAsync(
+        restoreWorkspaceFromLocation(loc, deep, navigationSeq),
+        "Restoring workspace history");
       return;
     }
     activatePackage(target, { resetAccessibility: true });
@@ -7748,22 +7946,28 @@ window.addEventListener("popstate", () => {
     if (isRuntimePackId(state.package.id)) {
       // Back/forward within the platform: re-scope to the target library (or the
       // aggregate) before restoring selection, since scope is part of the view.
-      restorePlatformScopeThenDeepLink(loc, navigationSeq);
+      observeAsync(
+        restorePlatformScopeThenDeepLink(loc, navigationSeq),
+        "Restoring platform history");
     } else {
       applyDeepLink(loc);
       render();
-      loadSelectionData();
+      observeAsync(loadSelectionData(), "Loading selection data");
     }
   } else if (isRuntimePackId(loc.package)) {
     // The runtime pack has no nupkg; rebuild it from its TFM instead of 404-ing
     // on a NuGet fetch when back/forward lands on a platform state.
-    restoreRuntimePackFromHistory(loc, deep, navigationSeq);
+    observeAsync(
+      restoreRuntimePackFromHistory(loc, deep, navigationSeq),
+      "Restoring runtime-pack history");
   } else {
-    loadPackage(loc.package, loc.version || "latest", loc.framework || "", {
-      deepLink: deep,
-      navigationSeq,
-      queryNotice: loc.workspaceNotice
-    });
+    observeAsync(
+      loadPackage(loc.package, loc.version || "latest", loc.framework || "", {
+        deepLink: deep,
+        navigationSeq,
+        queryNotice: loc.workspaceNotice
+      }),
+      "Restoring package history");
   }
 });
 
@@ -7786,19 +7990,19 @@ async function restorePlatformScopeThenDeepLink(
   applyDeepLink(loc);
   state.loading = false;
   render();
-  loadSelectionData();
+  await loadSelectionData();
 }
 
 // Load and scope to a single platform library key (or clear the scope when null). Reuses
 // openPlatformLibrary so a restored view matches clicking the library in the selector.
 async function applyPlatformLibraryScope(
-  libraryKey: string | null,
+  requestedLibraryKey: string | null,
   navigationSeq: number | null = null,
   retryAction: RetryAction = null,
 ) {
   if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
-    return;
-  const key = String(libraryKey || "").replace(/\.dll$/i, "");
+    return undefined;
+  const key = (requestedLibraryKey ?? "").replace(/\.dll$/i, "");
   if (!key) { state.libraryScope = null; return true; }
   // The pack (CoreCLR vs ASP.NET Core) is resolved from the static index roster; ensure it
   // is loaded on a cold shared/refreshed link so the right assembly is fetched.
@@ -7806,12 +8010,12 @@ async function applyPlatformLibraryScope(
     try { state.platformIndex = await loadPlatformIndex(); } catch { /* best effort; defaults to CoreCLR */ }
   }
   if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
-    return;
+    return undefined;
   return Boolean(await openPlatformLibrary(
     key,
     platformPackForAssembly(key),
     {
-      navigationSeq: navigationSeq ?? undefined,
+      ...(navigationSeq === null ? {} : { navigationSeq }),
       retryAction,
       scopeOnly: true,
     }));
@@ -7855,14 +8059,18 @@ async function restoreRuntimePackFromHistory(
         || "runtime pack acquisition failed."}`);
   }
   render();
-  loadSelectionData();
+  await loadSelectionData();
 }
 
-bootstrap();
+observeAsync(bootstrap(), "Starting dotnet-inspect");
 
 // Warm the static platform-assembly/facade index in the background. It is a
 // hint layer (facade badges, per-library overview roster, library-scope
 // selector) built on top of the app; prefetching keeps it ready without
 // blocking boot. Cached on state once resolved; exposed for verification.
 window.__platformIndex = loadPlatformIndex();
-window.__platformIndex.then(index => { if (index) state.platformIndex = index; });
+observeAsync(
+  window.__platformIndex.then(index => {
+    if (index) state.platformIndex = index;
+  }),
+  "Loading the platform index");

--- a/prototypes/inspect-web/src/graph-mermaid.ts
+++ b/prototypes/inspect-web/src/graph-mermaid.ts
@@ -183,7 +183,8 @@ export function buildDependencyGraphMermaid(
 
   let downFrontier = [model.package];
   const downVisited = new Set([packageIdentityKey(model.package)]);
-  for (let depth = 0; depth < MAX_DEPTH && downFrontier.length && !truncated; depth++) {
+  for (let depth = 0; depth < MAX_DEPTH && downFrontier.length; depth++) {
+    if (truncated) break;
     const next: DependencyGraphPackage[] = [];
     for (const pkg of downFrontier) {
       const group = groupFor(pkg);
@@ -212,7 +213,8 @@ export function buildDependencyGraphMermaid(
 
   let upFrontier = [model.package];
   const upVisited = new Set([packageIdentityKey(model.package)]);
-  for (let depth = 0; depth < MAX_DEPTH && upFrontier.length && !truncated; depth++) {
+  for (let depth = 0; depth < MAX_DEPTH && upFrontier.length; depth++) {
+    if (truncated) break;
     const next: DependencyGraphPackage[] = [];
     for (const targetPackage of upFrontier) {
       const target = openPackageNode(
@@ -262,8 +264,12 @@ export function buildDependencyGraphMermaid(
   lines.push("classDef self fill:var(--accent-soft),stroke:var(--accent),color:var(--text),stroke-width:2px;");
   lines.push("classDef open fill:var(--panel-active),stroke:var(--blue),color:var(--text);");
   lines.push("classDef external fill:transparent,stroke:var(--line-strong),color:var(--dim);");
-  const nodeInfoById = new Map(
-    keys.map(key => [idOf.get(key), nodeInfo.get(key)])) as Map<string, DependencyGraphNodeInfo>;
+  const nodeInfoById = new Map<string, DependencyGraphNodeInfo>();
+  for (const key of keys) {
+    const id = idOf.get(key);
+    const info = nodeInfo.get(key);
+    if (id && info) nodeInfoById.set(id, info);
+  }
   return {
     definition: lines.join("\n"),
     nodeInfoById,

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -1,6 +1,6 @@
 import type { BrowserSource } from "./inspect-web-engine.d.ts";
 
-export type GraphSourceResult = BrowserSource;
+type GraphSourceResult = BrowserSource;
 
 export interface RenderGraphSourceOptions {
   title: string;
@@ -8,7 +8,7 @@ export interface RenderGraphSourceOptions {
   source: GraphSourceResult | null;
   error: string;
   escapeHtml: (value: unknown) => string;
-  highlightCSharp: (value: unknown) => string;
+  highlightCSharp: (value: string) => string;
 }
 
 export function renderGraphSource(options: RenderGraphSourceOptions): string {

--- a/prototypes/inspect-web/src/member-filtering.ts
+++ b/prototypes/inspect-web/src/member-filtering.ts
@@ -18,7 +18,7 @@ export interface MemberGroupFilters {
 }
 
 /** The overload fields the filter predicates and body-target matching read. */
-export interface FilterableMemberOverload extends MemberOverloadSummary {
+interface FilterableMemberOverload extends MemberOverloadSummary {
   accessibility?: string;
   isStatic?: boolean;
   isUnsafe?: boolean;
@@ -37,7 +37,7 @@ export function memberGroupMatches(
   group: FilterableMemberGroup,
   filters: MemberGroupFilters,
 ): boolean {
-  const query = String(filters.query || "").trim().toLowerCase();
+  const query = (filters.query ?? "").trim().toLowerCase();
   if (filters.kind && filters.kind !== "all" && group.kind !== filters.kind) {
     return false;
   }
@@ -55,7 +55,7 @@ export function memberGroupMatches(
     }
     return !query
       || group.name.toLowerCase().includes(query)
-      || String(overload.signature || "").toLowerCase().includes(query);
+      || overload.signature.toLowerCase().includes(query);
   });
 }
 
@@ -137,7 +137,7 @@ export interface BodyTarget {
   metadataToken: number | null;
 }
 
-export interface BodySelectorLike {
+interface BodySelectorLike {
   memberName: string;
   selectorKey: string;
   token: number;
@@ -154,7 +154,7 @@ export interface BodyTargetMember {
 }
 
 export function bodyTargetMatchesOverload(
-  target: BodyTarget | null | undefined,
+  target: Partial<BodyTarget> | null | undefined,
   member: BodyTargetMember | null | undefined,
   overload: BodyTargetOverload | null | undefined,
 ): boolean {
@@ -190,16 +190,19 @@ export function encodeBodyTarget(target: BodyTarget | null | undefined): Encoded
 
 export function decodeBodyTarget(value: unknown): BodyTarget | null {
   if (!Array.isArray(value) || value.length !== 3) return null;
-  const [memberNameValue, selectorKeyValue, metadataTokenValue] = value;
+  const values: unknown[] = value;
+  const [memberNameValue, selectorKeyValue, metadataTokenValue] = values;
   if ((memberNameValue != null && typeof memberNameValue !== "string")
     || (selectorKeyValue != null && typeof selectorKeyValue !== "string")
-    || (metadataTokenValue != null && !Number.isInteger(metadataTokenValue))) {
+    || (metadataTokenValue != null
+      && (typeof metadataTokenValue !== "number"
+        || !Number.isInteger(metadataTokenValue)))) {
     return null;
   }
   const target: BodyTarget = {
     memberName: memberNameValue || null,
     selectorKey: selectorKeyValue || null,
-    metadataToken: metadataTokenValue,
+    metadataToken: metadataTokenValue ?? null,
   };
   return target.memberName || target.selectorKey || target.metadataToken != null
     ? target

--- a/prototypes/inspect-web/src/member-focus.ts
+++ b/prototypes/inspect-web/src/member-focus.ts
@@ -28,22 +28,32 @@ export interface MemberFocusRestorer {
   ): void;
 }
 
+function isHtmlElement(value: Element | null): value is HTMLElement {
+  return value !== null && "dataset" in value && "focus" in value;
+}
+
+function isTextInput(value: HTMLElement): value is HTMLInputElement {
+  return "selectionStart" in value && "setSelectionRange" in value;
+}
+
 export function captureMemberFocus(
   document: Document,
 ): MemberFocusSnapshot {
-  const active = document.activeElement as HTMLElement | null;
+  const active = isHtmlElement(document.activeElement) ? document.activeElement : null;
   const navigationList = document.querySelector<HTMLElement>("#type-list");
   let selector = "";
   let dataTarget: MemberFocusSnapshot["dataTarget"] = null;
   let selection: MemberFocusSnapshot["selection"] = null;
   if (active?.id === "member-filter" || active?.id === "type-filter") {
-    const input = active as HTMLInputElement;
+    const input = isTextInput(active) ? active : null;
     selector = `#${active.id}`;
-    selection = {
-      start: input.selectionStart,
-      end: input.selectionEnd,
-      direction: input.selectionDirection,
-    };
+    selection = input
+      ? {
+          start: input.selectionStart,
+          end: input.selectionEnd,
+          direction: input.selectionDirection,
+        }
+      : null;
   } else if (active?.id === "clear-member-filter") {
     selector = "#clear-member-filter";
   } else if (active?.dataset.memberKindFilter !== undefined) {
@@ -122,7 +132,7 @@ export function captureMemberFocus(
     focusLost:
       active === null
       || active === document.body
-      || active.isConnected === false,
+      || ! active.isConnected,
   };
 }
 
@@ -162,19 +172,18 @@ export function restoreMemberFocus(
       : snapshot.selector
         ? document.querySelector<HTMLElement>(snapshot.selector)
         : null;
-    const active = document.activeElement as HTMLElement | null;
+    const active = isHtmlElement(document.activeElement) ? document.activeElement : null;
     const canRestoreFocus =
       active === null
       || active === document.body
-      || active.isConnected === false
+      || ! active.isConnected
       || active === replacement;
     if (!replacement || !canRestoreFocus)
       return;
 
     replacement.focus();
-    const input = replacement as HTMLInputElement | null;
-    if (snapshot.selection && typeof input?.setSelectionRange === "function") {
-      input.setSelectionRange(
+    if (snapshot.selection && isTextInput(replacement)) {
+      replacement.setSelectionRange(
         snapshot.selection.start,
         snapshot.selection.end,
         snapshot.selection.direction ?? undefined,

--- a/prototypes/inspect-web/src/package-acquisition.ts
+++ b/prototypes/inspect-web/src/package-acquisition.ts
@@ -179,7 +179,7 @@ export interface NuGetPackageRequest {
 
 export interface RuntimeAcquisitionResult {
   packageModel: AppPackage | null;
-  error: unknown | null;
+  error: unknown;
 }
 
 export interface PackageAcquisition {
@@ -202,8 +202,9 @@ export function createPackageAcquisition(
   let runtimeOperation: Promise<AppPackage | null> | null = null;
 
   const waitForRuntimeOperation = async () => {
-    while (runtimeOperation) {
+    for (;;) {
       const pending = runtimeOperation;
+      if (!pending) return;
       try {
         await pending;
       } catch {
@@ -291,7 +292,7 @@ export function createPackageAcquisition(
             === requestedFramework.toLowerCase())
         && resident.assemblies.some(assembly =>
           assembly.name.toLowerCase()
-            === String(assemblyFileName).toLowerCase())) {
+            === assemblyFileName.toLowerCase())) {
         return { packageModel: resident, error: null };
       }
 

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -97,7 +97,7 @@ export interface PackageInspectionDependencies {
   describeError(error: unknown): string;
   refreshPackageStats(): void;
   render(): void;
-  renderDependencyGraph(): void;
+  renderDependencyGraph(): Promise<void>;
 }
 
 export interface PackageInspectionCoordinator {
@@ -167,7 +167,7 @@ export function createPackageInspectionCoordinator(
       && !state.workspaceDependencyLoads.has(
         workspaceDependencyKey(packageModel)));
     if (!missing.length) {
-      dependencies.renderDependencyGraph();
+      await dependencies.renderDependencyGraph();
       return;
     }
     for (const packageModel of missing) {
@@ -253,7 +253,7 @@ export function createPackageInspectionCoordinator(
         }
         dependencies.refreshPackageStats();
         dependencies.render();
-        void ensureWorkspaceDependencies();
+        await ensureWorkspaceDependencies();
       }
     },
 

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -1,12 +1,10 @@
 import type {
-  BrowserOpportunityCategory,
   BrowserOpportunityItem,
   BrowserPackageOpportunities,
 } from "./inspect-web-engine.d.ts";
 
-export type OpportunityItem = BrowserOpportunityItem;
-export type OpportunityCategory = BrowserOpportunityCategory;
-export type PackageOpportunities = Pick<
+type OpportunityItem = BrowserOpportunityItem;
+type PackageOpportunities = Pick<
   BrowserPackageOpportunities,
   "categories" | "totalOpportunities" | "inspectionError"
 >;
@@ -44,15 +42,15 @@ function splitApiName(fullName: string): { short: string; qualifier: string } {
 // front of an integration-kind phrase so it can render as a load-on-demand package chip. Kinds
 // with no dotted prefix (e.g. "IServiceCollection registration") stay as plain muted text.
 function splitOpportunityKind(integrationType: string): { package: string | null; text: string } {
-  const match = String(integrationType || "").match(/^([A-Z][A-Za-z0-9]+(?:\.[A-Z][A-Za-z0-9]+)+)\b\s*(.*)$/);
-  return match ? { package: match[1], text: match[2].trim() } : { package: null, text: String(integrationType || "") };
+  const match = integrationType.match(/^([A-Z][A-Za-z0-9]+(?:\.[A-Z][A-Za-z0-9]+)+)\b\s*(.*)$/);
+  return match ? { package: match[1], text: match[2].trim() } : { package: null, text: integrationType };
 }
 
 // Turns the comma-separated "look for" hint into chips. Concrete identifiers open a spotlight
 // search (seeded on the base name, generics stripped); wildcard patterns like "Add*" render as
 // muted, non-interactive hints because they are naming shapes rather than resolvable types.
 function renderLookForChips(lookFor: string, escapeHtml: (value: unknown) => string): string {
-  const tokens = String(lookFor || "").split(",").map(token => token.trim()).filter(Boolean);
+  const tokens = lookFor.split(",").map(token => token.trim()).filter(Boolean);
   if (!tokens.length) return `<span class="opp-pattern">any registration surface</span>`;
   return tokens.map(token => {
     if (token.includes("*")) return `<span class="opp-pattern" title="Naming pattern">${escapeHtml(token)}</span>`;

--- a/prototypes/inspect-web/src/platform-index.ts
+++ b/prototypes/inspect-web/src/platform-index.ts
@@ -12,10 +12,10 @@
 
 const INDEX_URL = "/assets/platform-index.tsv";
 
-export type PlatformPack = "netcore.app" | "aspnetcore.app" | "netstandard";
-export type PlatformAssemblyKind = "impl" | "facade" | "ref";
+type PlatformPack = "netcore.app" | "aspnetcore.app" | "netstandard";
+type PlatformAssemblyKind = "impl" | "facade" | "ref";
 
-export interface PlatformAssemblyRow {
+interface PlatformAssemblyRow {
   tfm: string;
   pack: PlatformPack;
   assembly: string;
@@ -58,12 +58,18 @@ function parseTsv(text: string): ParsedIndex {
     if (!line) continue;
     const parts = line.split("\t");
     if (parts.length < 8) continue;
+    const pack = parts[1];
+    const kind = parts[4];
+    if (pack !== "netcore.app" && pack !== "aspnetcore.app" && pack !== "netstandard")
+      throw new Error(`Invalid platform pack '${pack}' on index line ${i + 1}.`);
+    if (kind !== "impl" && kind !== "facade" && kind !== "ref")
+      throw new Error(`Invalid platform assembly kind '${kind}' on index line ${i + 1}.`);
     const row: PlatformAssemblyRow = {
       tfm: parts[0],
-      pack: parts[1] as PlatformPack,
+      pack,
       assembly: parts[2],
       file: parts[3],
-      kind: parts[4] as PlatformAssemblyKind,
+      kind,
       forwardsTo: parts[5] || null,
       version: parts[6],
       publicTypes: Number(parts[7]) || 0
@@ -115,7 +121,7 @@ export function loadPlatformIndex(): Promise<PlatformIndex | null> {
       return response.text();
     })
     .then(text => makeIndex(parseTsv(text)))
-    .catch(error => {
+    .catch((error: unknown) => {
       indexPromise = null; // allow retry
       console.warn("platform index load failed", error);
       return null;

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -1,6 +1,6 @@
 type LensDefinition = readonly [id: string, label: string];
 
-export type Scope = "package" | "type" | "member";
+type Scope = "package" | "type" | "member";
 
 export interface RenderScopeBarOptions {
   scope: Scope;

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -208,9 +208,10 @@ export function createSourceInspectionCoordinator(
           state.graphSourceError = dependencies.describeError(error);
         }
       } finally {
-        if (!isCurrent()) return;
-        state.graphSourceLoading = false;
-        dependencies.render();
+        if (isCurrent()) {
+          state.graphSourceLoading = false;
+          dependencies.render();
+        }
       }
     },
 

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -115,7 +115,8 @@ interface SpotlightOptions {
   executeCommand: (
     command: string,
     result: CommandPaletteResult,
-  ) => unknown;
+  ) => Promise<unknown> | undefined;
+  reportCommandError: (error: unknown) => void;
   commandContext: () => CommandContext | null;
   schedulePackageFetch: () => void;
   resetPackageSearch: () => void;
@@ -227,6 +228,17 @@ export function spotlightResultIdentity(result: SpotlightResult): string {
     default:
       return result.kind;
   }
+}
+
+function isTextInputTarget(value: EventTarget | null): value is HTMLInputElement {
+  return value !== null
+    && "selectionStart" in value
+    && "selectionEnd" in value
+    && "value" in value;
+}
+
+function hasElementId(value: EventTarget | null): value is EventTarget & { id: string } {
+  return value !== null && "id" in value && typeof value.id === "string";
 }
 
 export function createSpotlight(options: SpotlightOptions) {
@@ -581,11 +593,15 @@ export function createSpotlight(options: SpotlightOptions) {
     reset();
     const execution = options.executeCommand(result.command, result);
     options.render();
-    void Promise.resolve(execution).then(() => {
-      if (generation === interactionGeneration) {
-        options.focusAfterDismiss?.();
-      }
-    });
+    const focusAfterExecution = () => {
+      if (generation === interactionGeneration) options.focusAfterDismiss?.();
+    };
+    Promise.resolve(execution).then(
+      focusAfterExecution,
+      (error: unknown) => {
+        options.reportCommandError(error);
+        focusAfterExecution();
+      });
   }
 
   function highlightSelection(): number {
@@ -679,7 +695,8 @@ export function createSpotlight(options: SpotlightOptions) {
     }
 
     if (event.key === "ArrowRight") {
-      const input = event.currentTarget as HTMLInputElement;
+      const input = event.currentTarget;
+      if (!isTextInputTarget(input)) return;
       const atEnd = input.selectionStart === input.selectionEnd
         && input.selectionStart === input.value.length;
       if (atEnd) {
@@ -755,8 +772,8 @@ export function createSpotlight(options: SpotlightOptions) {
       root.querySelector("#spotlight-backdrop")?.addEventListener(
         "mousedown",
         event => {
-          const target = event.target as HTMLElement;
-          if (target.id === "spotlight-backdrop") close();
+          const target = event.target;
+          if (hasElementId(target) && target.id === "spotlight-backdrop") close();
         },
       );
       focus();

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -78,7 +78,7 @@ export function createNavigationSequence(): NavigationSequence {
   };
 }
 
-export interface NavigationHistory<TView> {
+export interface NavigationHistory {
   record(): void;
   normalizeCurrent(): void;
   canBack(): boolean;
@@ -101,7 +101,7 @@ interface NavigationEntry<TView> {
 
 export function createNavigationHistory<TView>(
   dependencies: NavigationHistoryDependencies<TView>,
-): NavigationHistory<TView> {
+): NavigationHistory {
   const navigation = {
     stack: [] as NavigationEntry<TView>[],
     index: -1,
@@ -266,7 +266,10 @@ export function encodeWorkspaceShareState(state: WorkspaceUrlState): string {
     if (state.selectedOverloadIndex != null) packet.o = state.selectedOverloadIndex;
     if (state.memberSection && state.memberSection !== "overview")
       packet.c = state.memberSection;
-    if (state.selectedBodyTarget) packet.d = encodeBodyTarget(state.selectedBodyTarget) ?? undefined;
+    if (state.selectedBodyTarget) {
+      const encodedBodyTarget = encodeBodyTarget(state.selectedBodyTarget);
+      if (encodedBodyTarget) packet.d = encodedBodyTarget;
+    }
     if (state.memberBrowse) packet.b = 1;
     if (state.memberTextFilter) packet.q = state.memberTextFilter;
     if (state.memberKindFilter !== "all") packet.k = state.memberKindFilter;
@@ -314,17 +317,19 @@ function decodeWorkspaceShareState(value: string | null): ShareStateResult {
           : 0,
         view: typeof raw.v === "string" ? raw.v : "",
         rich: true,
-        type: raw.y != null ? String(raw.y) : null,
-        member: raw.m != null ? String(raw.m) : null,
-        overload: raw.o != null ? String(raw.o) : null,
-        section: raw.c != null ? String(raw.c) : null,
+        type: typeof raw.y === "string" ? raw.y : null,
+        member: typeof raw.m === "string" ? raw.m : null,
+        overload: typeof raw.o === "string" || typeof raw.o === "number"
+          ? String(raw.o)
+          : null,
+        section: typeof raw.c === "string" ? raw.c : null,
         bodyTarget: decodeBodyTarget(raw.d),
-        library: raw.l != null ? String(raw.l) : null,
+        library: typeof raw.l === "string" ? raw.l : null,
         memberBrowse: raw.b === 1,
-        memberTextFilter: raw.q != null ? String(raw.q) : "",
-        memberKindFilter: raw.k != null ? String(raw.k) : "all",
-        memberAccessibilityFilter: raw.e != null ? String(raw.e) : "all",
-        memberTraitFilter: raw.r != null ? String(raw.r) : "",
+        memberTextFilter: typeof raw.q === "string" ? raw.q : "",
+        memberKindFilter: typeof raw.k === "string" ? raw.k : "all",
+        memberAccessibilityFilter: typeof raw.e === "string" ? raw.e : "all",
+        memberTraitFilter: typeof raw.r === "string" ? raw.r : "",
       };
     }
     return { error: "The shared workspace state is invalid and was ignored." };

--- a/prototypes/inspect-web/test/call-graph-inspection.test.ts
+++ b/prototypes/inspect-web/test/call-graph-inspection.test.ts
@@ -579,7 +579,7 @@ test("platform drill publishes current graphs and pop restores the parent", asyn
   }]);
   assert.deepEqual(events, ["focus:capture", "focus:restore", "graph"]);
 
-  coordinator.popDrill();
+  await coordinator.popDrill();
   assert.deepEqual(state.platformStack, []);
   assert.deepEqual(events, [
     "focus:capture",

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -55,8 +55,8 @@ function inspectionDependencies(
   return {
     state,
     queryDocument: async () => content("# Read me"),
-    renderMarkdown: async text => `<p>${String(text)}</p>`,
-    renderMarkdownInline: async text => `<span>${String(text)}</span>`,
+    renderMarkdown: async text => `<p>${text}</p>`,
+    renderMarkdownInline: async text => `<span>${text}</span>`,
     describeError: error =>
       error instanceof Error ? error.message : String(error),
     render: () => {},
@@ -236,7 +236,7 @@ test("a newer document remains published after an older request completes", asyn
         request.document === document
           ? first.promise
           : content("current"),
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
     }));
 
   const firstOpen = coordinator.open({
@@ -268,7 +268,7 @@ test("replacement during acquisition does not enter stale rendering", async () =
         request.document === document ? first.promise : second.promise,
       renderMarkdown: async text => {
         if (text === "stale") staleBodyRenders++;
-        return `<p>${String(text)}</p>`;
+        return `<p>${text}</p>`;
       },
     }));
 
@@ -308,7 +308,7 @@ test("reopening the same document during acquisition rejects stale identity", as
       queryDocument: () => ++queries === 1 ? first.promise : second.promise,
       renderMarkdown: async text => {
         if (text === "stale") staleBodyRenders++;
-        return `<p>${String(text)}</p>`;
+        return `<p>${text}</p>`;
       },
     }));
 
@@ -356,7 +356,7 @@ test("replacement during body rendering suppresses stale description work", asyn
           bodyEntered.resolve();
           return body.promise;
         }
-        return `<p>${String(text)}</p>`;
+        return `<p>${text}</p>`;
       },
       renderMarkdownInline: async () => {
         inlineRenders++;
@@ -407,7 +407,7 @@ test("reopening the same document during body rendering suppresses stale work", 
           bodyEntered.resolve();
           return body.promise;
         }
-        return `<p>${String(text)}</p>`;
+        return `<p>${text}</p>`;
       },
       renderMarkdownInline: async () => {
         inlineRenders++;
@@ -451,7 +451,7 @@ test("replacement during description rendering suppresses stale publication", as
         request.document === document
           ? content("---\ndescription: Summary\n---\nBody")
           : second.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
       renderMarkdownInline: async () => {
         descriptionEntered.resolve();
         return description.promise;
@@ -494,7 +494,7 @@ test("reopening the same document during description rendering suppresses stale 
       queryDocument: () => ++queries === 1
         ? Promise.resolve(content("---\ndescription: Summary\n---\nBody"))
         : second.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
       renderMarkdownInline: async () => {
         descriptionEntered.resolve();
         return description.promise;
@@ -534,7 +534,7 @@ test("rejected replaced documents cannot settle the current request", async () =
     inspectionDependencies(state, {
       queryDocument: async request =>
         request.document === document ? first.promise : second.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
       render: () => renders++,
     }));
 
@@ -573,7 +573,7 @@ test("reopening the same document suppresses a stale rejection", async () => {
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
       queryDocument: () => ++queries === 1 ? first.promise : second.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
     }));
 
   const firstOpen = coordinator.open({
@@ -725,7 +725,7 @@ test("opening another document clears a prior visible failure", async () => {
         }
         return replacement.promise;
       },
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
     }));
 
   await coordinator.open({
@@ -762,7 +762,7 @@ test("opening another document clears prior published surfaces immediately", asy
         request.document === document
           ? content("---\nname: Old\n---\nold body")
           : replacement.promise,
-      renderMarkdown: async text => `<p>${String(text)}</p>`,
+      renderMarkdown: async text => `<p>${text}</p>`,
     }));
 
   await coordinator.open({

--- a/prototypes/inspect-web/test/member-filtering.test.ts
+++ b/prototypes/inspect-web/test/member-filtering.test.ts
@@ -13,7 +13,6 @@ import {
   restoreLibraryScope,
   restoreMemberHistoryState,
 } from "../src/member-filtering.ts";
-import type { BodyTarget } from "../src/member-filtering.ts";
 
 test("body targets must identify the selected overload or one of its accessor bodies", () => {
   const member = { name: "Value" };
@@ -44,7 +43,7 @@ test("body targets must identify the selected overload or one of its accessor bo
       member,
       overload),
     false);
-  assert.equal(bodyTargetMatchesOverload({} as BodyTarget, member, overload), false);
+  assert.equal(bodyTargetMatchesOverload({}, member, overload), false);
 });
 
 test("body targets round-trip through the compact rich-packet tuple", () => {

--- a/prototypes/inspect-web/test/member-focus.test.ts
+++ b/prototypes/inspect-web/test/member-focus.test.ts
@@ -32,6 +32,8 @@ interface MockDocument {
 }
 
 function captureMemberFocus(document: MockDocument): MemberFocusSnapshot {
+  // The harness supplies the exact DOM subset the product reads.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   return captureMemberFocusImpl(document as unknown as Document);
 }
 
@@ -41,6 +43,7 @@ function restoreMemberFocus(
   requestFrame: (callback: FrameRequestCallback) => number,
   isCurrent?: () => boolean,
 ): void {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   restoreMemberFocusImpl(document as unknown as Document, snapshot, requestFrame, isCurrent);
 }
 
@@ -54,6 +57,7 @@ function createMemberFocusRestorer() {
       snapshot: MemberFocusSnapshot,
       requestFrame: (callback: FrameRequestCallback) => number,
     ) {
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       restorer.schedule(document as unknown as Document, snapshot, requestFrame);
     },
   };
@@ -70,7 +74,9 @@ function createDocument() {
     },
     querySelectorAll(selector: string) {
       const key = selector.match(/^\[data-([a-z-]+)\]$/)?.[1]
-        ?.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+        ?.replace(
+          /-([a-z])/g,
+          (_match: string, letter: string) => letter.toUpperCase());
       return key
         ? [...elements.values()].filter(value =>
           value.isConnected && value.dataset[key] !== undefined)
@@ -196,6 +202,7 @@ test("member-filter selection survives a replacement render", () => {
     selectionStart: 2,
     selectionEnd: 5,
     selectionDirection: "backward",
+    setSelectionRange() {},
   });
   document.activeElement = initialInput;
   const snapshot = captureMemberFocus(document);
@@ -203,6 +210,9 @@ test("member-filter selection survives a replacement render", () => {
   let restoredSelection = null;
   const replacementInput = element("#member-filter", {
     id: "member-filter",
+    selectionStart: null,
+    selectionEnd: null,
+    selectionDirection: null,
     setSelectionRange(start, end, direction) {
       restoredSelection = { start, end, direction };
     },
@@ -227,6 +237,7 @@ test("type-filter selection survives a replacement render", () => {
     selectionStart: 2,
     selectionEnd: 5,
     selectionDirection: "backward",
+    setSelectionRange() {},
   });
   document.activeElement = initialInput;
   const snapshot = captureMemberFocus(document);
@@ -234,6 +245,9 @@ test("type-filter selection survives a replacement render", () => {
   let restoredSelection = null;
   const replacementInput = element("#type-filter", {
     id: "type-filter",
+    selectionStart: null,
+    selectionEnd: null,
+    selectionDirection: null,
     setSelectionRange(start, end, direction) {
       restoredSelection = { start, end, direction };
     },
@@ -312,24 +326,24 @@ test("member and overload rows survive activation renders", () => {
     });
 
     test("taste controls survive source completion renders", () => {
-      const { document, element } = createDocument();
-      const selector = "[data-taste=\"prefer-var\"]";
-      const initialCheckbox = element(selector, {
+      const { document: tasteDocument, element: tasteElement } = createDocument();
+      const tasteSelector = "[data-taste=\"prefer-var\"]";
+      const initialCheckbox = tasteElement(tasteSelector, {
         dataset: { taste: "prefer-var" },
       });
-      document.activeElement = initialCheckbox;
-      const snapshot = captureMemberFocus(document);
+      tasteDocument.activeElement = initialCheckbox;
+      const tasteSnapshot = captureMemberFocus(tasteDocument);
 
-      const replacementCheckbox = element(selector, {
+      const replacementCheckbox = tasteElement(tasteSelector, {
         dataset: { taste: "prefer-var" },
       });
-      document.activeElement = document.body;
-      restoreMemberFocus(document, snapshot, callback => {
+      tasteDocument.activeElement = tasteDocument.body;
+      restoreMemberFocus(tasteDocument, tasteSnapshot, callback => {
         callback(0);
         return 1;
       });
 
-      assert.equal(document.activeElement, replacementCheckbox);
+      assert.equal(tasteDocument.activeElement, replacementCheckbox);
     });
 
     assert.equal(document.activeElement, replacementButton);

--- a/prototypes/inspect-web/test/package-acquisition.test.ts
+++ b/prototypes/inspect-web/test/package-acquisition.test.ts
@@ -116,7 +116,12 @@ function acquisitionDependencies(
       runtimeSurface("corelib", "System.Private.CoreLib", "System.Object")),
     loadRuntimePackAssembly: async () => JSON.stringify(
       runtimeSurface("json", "System.Text.Json", "System.Text.Json.JsonDocument")),
-    parseRuntimeSurface: json => JSON.parse(json),
+    parseRuntimeSurface: json => {
+      const parsed: unknown = JSON.parse(json);
+      // The test parses JSON emitted from the typed fixture immediately above.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      return parsed as BrowserPackageSurface;
+    },
     runtimePackage: () => null,
     retainPackage: () => {},
     recordRecentPackage: () => {},

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -18,8 +18,8 @@ function escapeHtml(value: unknown) {
     .replaceAll('"', "&quot;");
 }
 
-function packageIdentityKey(pkg: PackageBarPackage) {
-  return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
+function packageIdentityKey(packageModel: PackageBarPackage) {
+  return `${packageModel.id}@${packageModel.version}::${packageModel.activeFramework}`;
 }
 
 function pkg(

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -150,7 +150,7 @@ function inspectionDependencies(
       error instanceof Error ? error.message : String(error),
     refreshPackageStats: () => {},
     render: () => {},
-    renderDependencyGraph: () => {},
+    renderDependencyGraph: async () => {},
     ...overrides,
   };
 }
@@ -323,7 +323,9 @@ test("dependency results cache for a resident package after the foreground lens 
       queryDependencies: async () => request.promise,
       refreshPackageStats: () => events.push("stats"),
       render: () => events.push("render"),
-      renderDependencyGraph: () => events.push("graph"),
+      renderDependencyGraph: async () => {
+        events.push("graph");
+      },
     }));
 
   const load = coordinator.loadDependencies(packageItem, "first");
@@ -682,7 +684,9 @@ test("workspace dependency loading skips keys already in flight", async () => {
         queries++;
         return dependencyResult();
       },
-      renderDependencyGraph: () => graphRenders++,
+      renderDependencyGraph: async () => {
+        graphRenders++;
+      },
     }));
 
   await coordinator.ensureWorkspaceDependencies();

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -96,7 +96,7 @@ test("an inspection error renders a warning banner alongside categories", () => 
   assert.match(html, /&lt;bad&gt; assembly/);
 });
 
-test("categories render a summary with area\/suggestion counts and a chip per category", () => {
+test("categories render a summary with area/suggestion counts and a chip per category", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
     data: {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -407,7 +407,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /state\.spotlightOpen[\s\S]*event\.key === "Escape"[\s\S]*closeSpotlight\(\)/);
   assert.match(
     appSource,
-    /function openSpotlight\(seed = "", scope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
+    /function openSpotlight\(seed = "", spotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
   assert.match(
     spotlightSource,
     /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(\);/);
@@ -448,7 +448,7 @@ test("Spotlight navigation waits for selection data before restoring focus", () 
     /let spotlightFocusGeneration = 0[\s\S]*function focusTypeList\(generation = spotlightFocusGeneration\)[\s\S]*generation !== spotlightFocusGeneration[\s\S]*isTextEntry\(\)/);
   assert.match(
     spotlightSource,
-    /const generation = interactionGeneration;[\s\S]*Promise\.resolve\(execution\)\.then\(\(\) => \{\s*if \(generation === interactionGeneration\)/);
+    /const generation = interactionGeneration;[\s\S]*const focusAfterExecution = \(\) => \{[\s\S]*generation === interactionGeneration[\s\S]*Promise\.resolve\(execution\)\.then\(\s*focusAfterExecution,\s*\(error: unknown\) => \{\s*options\.reportCommandError\(error\);\s*focusAfterExecution\(\)/);
 });
 
 test("dependency graph render identity includes truncation and navigation", () => {
@@ -536,7 +536,7 @@ test("bare home paints before wasm engine download", () => {
     /state\.retryAction = \(\) => window\.location\.reload\(\)/);
   assert.match(
     errorPackageRecovery,
-    /if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*loadPackage\(packageId, version, ""\)/);
+    /if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*observeAsync\(loadPackage\(packageId, version, ""\)/);
   assert.match(
     loadingView,
     /#error-package-query[\s\S]*openPackageFromError\(packageId, version\)/);
@@ -631,7 +631,9 @@ test("shared member views retain scope and filter state", () => {
   assert.match(encoder, /packet\.k = state\.memberKindFilter/);
   assert.match(encoder, /packet\.e = state\.memberAccessibilityFilter/);
   assert.match(encoder, /packet\.r = state\.memberTraitFilter/);
-  assert.match(encoder, /packet\.d = encodeBodyTarget\(state\.selectedBodyTarget\)/);
+  assert.match(
+    encoder,
+    /const encodedBodyTarget = encodeBodyTarget\(state\.selectedBodyTarget\);[\s\S]*if \(encodedBodyTarget\) packet\.d = encodedBodyTarget/);
   assert.match(decoder, /memberBrowse: raw\.b === 1/);
   assert.match(decoder, /bodyTarget: decodeBodyTarget\(raw\.d\)/);
   assert.match(capture, /selectedBodyTarget: state\.selectedBodyTarget/);
@@ -698,7 +700,7 @@ test("home demos restore the complete parsed location", () => {
   assert.match(runHomeDemo, /restoreWorkspaceFromLocation\(loc, loc\)/);
   assert.doesNotMatch(runHomeDemo, /type: loc\.type/);
   const restoreWorkspace =
-    appSource.match(/async function restoreWorkspaceFromLocation\([\s\S]*?\n}\n\n\/\/ Restores the full open-tab/)?.[0]
+    appSource.match(/async function restoreWorkspaceFromLocation\([\s\S]*?\n}\n\nfunction applyLocationView/)?.[0]
     ?? "";
   assert.match(
     restoreWorkspace,
@@ -719,7 +721,7 @@ test("home demos restore the complete parsed location", () => {
     platformHistory,
     /await applyPlatformLibraryScope\([\s\S]*applyLocationView\(loc\);\s*applyDeepLink\(loc\)/);
   const runtimeHistory =
-    appSource.match(/async function restoreRuntimePackFromHistory\([\s\S]*?\n}\n\nbootstrap\(\);/)?.[0]
+    appSource.match(/async function restoreRuntimePackFromHistory\([\s\S]*?\n}\n\nobserveAsync\(bootstrap\(\)/)?.[0]
     ?? "";
   assert.match(
     runtimeHistory,
@@ -764,7 +766,7 @@ test("authoritative location restore clears filters and applies aggregate Platfo
     ?? "";
   assert.match(popstate, /if \(bareHome\)[\s\S]*resetLocationFilters\(\);\s*const deep = loc/);
   const runtimeHistory =
-    appSource.match(/async function restoreRuntimePackFromHistory\([\s\S]*?\n}\n\nbootstrap\(\);/)?.[0]
+    appSource.match(/async function restoreRuntimePackFromHistory\([\s\S]*?\n}\n\nobserveAsync\(bootstrap\(\)/)?.[0]
     ?? "";
   assert.match(
     runtimeHistory,
@@ -1017,7 +1019,7 @@ test("stale dependency graph cleanup preserves a replacement with the same signa
 test("dependency graph binds navigation to generated node identities", () => {
   assert.match(
     graphSource,
-    /const nodeInfoById = new Map\(\s+keys\.map\(key => \[idOf\.get\(key\), nodeInfo\.get\(key\)\]\)\)/);
+    /const nodeInfoById = new Map<string, DependencyGraphNodeInfo>\(\);[\s\S]*for \(const key of keys\)[\s\S]*if \(id && info\) nodeInfoById\.set\(id, info\)/);
   assert.match(
     appSource,
     /const nodeId = dataId \|\| idMatch\?\.\[1\];\s*const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null/);
@@ -1836,7 +1838,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /clearWorkspacePackages\(\);\s+render\(\);/);
   assert.match(
     appSource,
-    /if \(loc\.tabs\?\.length && !workspaceCoordinatesMatch\(state\.packages, loc\.tabs\)\) \{\s+restoreWorkspaceFromLocation/);
+    /if \(loc\.tabs\?\.length && !workspaceCoordinatesMatch\(state\.packages, loc\.tabs\)\) \{\s+observeAsync\(\s*restoreWorkspaceFromLocation/);
   assert.match(
     appSource,
     /for \(const packageModel of discarded\)\s+releasePackageModelCaches\(packageModel\);/);
@@ -1851,7 +1853,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /state\.error = "";\s+state\.errorTitle = "";\s+state\.errorDetail = "";\s+state\.retryAction = null;\s+state\.home = true;/);
   assert.match(
     appSource,
-    /\(\) => \(state\.retryAction \?\? bootstrap\)\(\)/);
+    /\(\) => observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
   assert.match(
     appSource,
     /state\.retryAction = openRuntimePackFromHome/);

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -80,7 +80,8 @@ function createHarness({
     kindIcon: () => "C",
     searchResults,
     pickResult: () => {},
-    executeCommand: () => {},
+    executeCommand: () => undefined,
+    reportCommandError: () => {},
     commandContext: () => commandContext,
     schedulePackageFetch: () => {},
     resetPackageSearch: () => {},
@@ -182,7 +183,7 @@ test("modal arrow navigation reuses rendered results", () => {
     selectionStart: 7,
     selectionEnd: 7,
     addEventListener: (name, listener) => {
-      listeners.set(name, listener as (event: MockKeyboardEvent) => void);
+      listeners.set(name, listener);
     },
     focus: () => {},
     setAttribute: () => {},
@@ -201,12 +202,15 @@ test("modal arrow navigation reuses rendered results", () => {
     querySelector: selector => selector === "#spotlight-input" ? input : null,
     querySelectorAll: () => [],
   };
+  // The harness temporarily installs its minimal DOM globals and restores them below.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const globals = globalThis as unknown as {
     document?: Document;
     requestAnimationFrame?: (callback: FrameRequestCallback) => number;
   };
   const previousDocument = globals.document;
   const previousRequestAnimationFrame = globals.requestAnimationFrame;
+  // oxlint-disable typescript/no-unsafe-type-assertion
   globals.document = {
     querySelector: (selector: string) => {
       if (selector === "#spotlight-input") return input;
@@ -214,12 +218,15 @@ test("modal arrow navigation reuses rendered results", () => {
       return null;
     },
   } as unknown as Document;
+  // oxlint-enable typescript/no-unsafe-type-assertion
   globals.requestAnimationFrame = (callback: FrameRequestCallback) => {
     callback(0);
     return 0;
   };
 
   try {
+    // The root implements the exact ParentNode query surface Spotlight consumes.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     spotlight.bind(root as unknown as ParentNode, "modal");
     for (let index = 0; index < 4; index++) {
       listeners.get("keydown")!({
@@ -300,4 +307,3 @@ test("command queries and command metadata are escaped in Spotlight markup", () 
   assert.doesNotMatch(html, /<script/);
   assert.match(html, /find &lt;script class=&quot;x&quot;&gt;/);
 });
-

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -10,7 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { verifyAnalysisHost } from "../scripts/verify-analysis-host.js";
+import {
+  supportedAnalysisHosts,
+  verifyAnalysisHost,
+} from "../scripts/verify-analysis-host.js";
 import { verifySiteArtifact } from "../scripts/verify-site-artifact.js";
 
 const packageLock = JSON.parse(
@@ -49,24 +52,54 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   );
 });
 
-test("the analysis host check matches the native analyzer packages", () => {
-  for (const platform of ["darwin", "linux", "win32"]) {
-    for (const architecture of ["arm64", "x64"]) {
-      assert.doesNotThrow(() => verifyAnalysisHost(platform, architecture));
+function optionalNativeHosts(packagePath, dependencyPrefix) {
+  const packageEntry = packageLock.packages[packagePath];
+  assert.ok(packageEntry);
+  const dependencies = Object.keys(packageEntry.optionalDependencies ?? {})
+    .filter(dependency => dependency.startsWith(dependencyPrefix));
+  assert.notEqual(dependencies.length, 0);
+
+  return new Set(dependencies.map(dependency => {
+    const nativeEntry = packageLock.packages[`node_modules/${dependency}`];
+    assert.ok(nativeEntry);
+    assert.equal(nativeEntry.os?.length, 1);
+    assert.equal(nativeEntry.cpu?.length, 1);
+    return `${nativeEntry.os[0]}-${nativeEntry.cpu[0]}`;
+  }));
+}
+
+test("the analysis host check matches locked native packages and lint wiring", () => {
+  const oxlintHosts = optionalNativeHosts(
+    "node_modules/oxlint",
+    "@oxlint/binding-",
+  );
+  const tsgolintHosts = optionalNativeHosts(
+    "node_modules/oxlint-tsgolint",
+    "@oxlint-tsgolint/",
+  );
+  const expectedHosts = new Set(
+    [...tsgolintHosts].filter(host => oxlintHosts.has(host)),
+  );
+
+  assert.deepEqual(
+    [...supportedAnalysisHosts].sort(),
+    [...expectedHosts].sort(),
+  );
+  for (const host of new Set([...oxlintHosts, ...tsgolintHosts])) {
+    const separator = host.indexOf("-");
+    const platform = host.slice(0, separator);
+    const architecture = host.slice(separator + 1);
+    const verify = () => verifyAnalysisHost(platform, architecture);
+    if (expectedHosts.has(host)) {
+      assert.doesNotThrow(verify);
+    } else {
+      assert.throws(verify, new RegExp(`current host is ${host}`));
     }
   }
 
-  assert.throws(
-    () => verifyAnalysisHost("linux", "ppc64"),
-    /current host is linux-ppc64/,
-  );
-  assert.throws(
-    () => verifyAnalysisHost("linux", "s390x"),
-    /current host is linux-s390x/,
-  );
-  assert.throws(
-    () => verifyAnalysisHost("freebsd", "x64"),
-    /current host is freebsd-x64/,
+  assert.equal(
+    packageJson.scripts.lint,
+    "node scripts/verify-analysis-host.js && oxlint src test scripts vite.config.js",
   );
 });
 

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { verifyAnalysisHost } from "../scripts/verify-analysis-host.js";
 import { verifySiteArtifact } from "../scripts/verify-site-artifact.js";
 
 const packageLock = JSON.parse(
@@ -45,6 +46,27 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   assert.equal(
     packageJson.scripts.typecheck,
     "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+  );
+});
+
+test("the analysis host check matches the native analyzer packages", () => {
+  for (const platform of ["darwin", "linux", "win32"]) {
+    for (const architecture of ["arm64", "x64"]) {
+      assert.doesNotThrow(() => verifyAnalysisHost(platform, architecture));
+    }
+  }
+
+  assert.throws(
+    () => verifyAnalysisHost("linux", "ppc64"),
+    /current host is linux-ppc64/,
+  );
+  assert.throws(
+    () => verifyAnalysisHost("linux", "s390x"),
+    /current host is linux-s390x/,
+  );
+  assert.throws(
+    () => verifyAnalysisHost("freebsd", "x64"),
+    /current host is freebsd-x64/,
   );
 });
 

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -52,40 +52,65 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   );
 });
 
-function optionalNativeHosts(packagePath, dependencyPrefix) {
+const linuxLibcs = ["glibc", "musl"];
+
+function optionalNativeVariants(packagePath, dependencyPrefix) {
   const packageEntry = packageLock.packages[packagePath];
   assert.ok(packageEntry);
   const dependencies = Object.keys(packageEntry.optionalDependencies ?? {})
     .filter(dependency => dependency.startsWith(dependencyPrefix));
   assert.notEqual(dependencies.length, 0);
 
-  return new Set(dependencies.map(dependency => {
+  const variants = new Set();
+  for (const dependency of dependencies) {
     const nativeEntry = packageLock.packages[`node_modules/${dependency}`];
     assert.ok(nativeEntry);
     assert.equal(nativeEntry.os?.length, 1);
     assert.equal(nativeEntry.cpu?.length, 1);
-    return `${nativeEntry.os[0]}-${nativeEntry.cpu[0]}`;
+    assert.ok(nativeEntry.libc === undefined || nativeEntry.libc.length === 1);
+
+    const host = `${nativeEntry.os[0]}-${nativeEntry.cpu[0]}`;
+    const libcs = nativeEntry.libc
+      ?? (nativeEntry.os[0] === "linux" ? linuxLibcs : ["none"]);
+    for (const libc of libcs) {
+      variants.add(`${host}/${libc}`);
+    }
+  }
+  return variants;
+}
+
+function completeAnalyzerHosts(oxlintVariants, tsgolintVariants) {
+  const sharedVariants = new Set(
+    [...tsgolintVariants].filter(variant => oxlintVariants.has(variant)),
+  );
+  const hosts = new Set(
+    [...oxlintVariants, ...tsgolintVariants]
+      .map(variant => variant.slice(0, variant.indexOf("/"))),
+  );
+
+  return new Set([...hosts].filter(host => {
+    const requiredLibcs = host.startsWith("linux-") ? linuxLibcs : ["none"];
+    return requiredLibcs.every(libc => sharedVariants.has(`${host}/${libc}`));
   }));
 }
 
 test("the analysis host check matches locked native packages and lint wiring", () => {
-  const oxlintHosts = optionalNativeHosts(
+  const oxlintVariants = optionalNativeVariants(
     "node_modules/oxlint",
     "@oxlint/binding-",
   );
-  const tsgolintHosts = optionalNativeHosts(
+  const tsgolintVariants = optionalNativeVariants(
     "node_modules/oxlint-tsgolint",
     "@oxlint-tsgolint/",
   );
-  const expectedHosts = new Set(
-    [...tsgolintHosts].filter(host => oxlintHosts.has(host)),
-  );
+  const expectedHosts = completeAnalyzerHosts(oxlintVariants, tsgolintVariants);
 
-  assert.deepEqual(
-    [...supportedAnalysisHosts].sort(),
-    [...expectedHosts].sort(),
+  assert.deepEqual(new Set(supportedAnalysisHosts), expectedHosts);
+  const availableHosts = new Set(
+    [...oxlintVariants, ...tsgolintVariants]
+      .map(variant => variant.slice(0, variant.indexOf("/"))),
   );
-  for (const host of new Set([...oxlintHosts, ...tsgolintHosts])) {
+  for (const host of availableHosts) {
     const separator = host.indexOf("-");
     const platform = host.slice(0, separator);
     const architecture = host.slice(separator + 1);

--- a/prototypes/inspect-web/tsconfig.json
+++ b/prototypes/inspect-web/tsconfig.json
@@ -7,7 +7,9 @@
     "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "exactOptionalPropertyTypes": true,
     "noEmit": true,
+    "noImplicitReturns": true,
     "paths": {
       "/inspect-web-engine.js": ["./src/inspect-web-engine.d.ts"]
     },


### PR DESCRIPTION
## Summary

Adds a TypeScript 7-native correctness gate for `inspect-web`: Oxlint with its
tsgolint semantic backend, Knip, stricter compiler checks, and CI enforcement.
The analyzer found and drove fixes for dropped promises, promise-returning DOM
callbacks, unsafe `any` flow, unchecked external data, and unnecessary type
assertions.

This intentionally supersedes the issue's initial ESLint choice. The current
`typescript-eslint` parser does not support the project's TypeScript 7.0.2
toolchain; tsgolint targets that exact compiler generation instead of analyzing
against a shadow TypeScript 6 installation.

## Changes

- Enables Oxlint correctness/suspicious diagnostics and type-aware promise,
  unsafe-operation, rejection, and throw checks; warnings and stale
  suppressions fail the gate.
- Preserves browser/background sequencing or observes failures visibly,
  including async contracts previously erased behind `void` interfaces.
- Enables `exactOptionalPropertyTypes` and `noImplicitReturns`.
- Adds Knip coverage for authored product, test, and build-script entry points.
- Runs `npm run analyze` in the existing `inspect-web` CI job and documents the
  local contract and narrow exclusions.

## Boundaries

- The native Oxlint/tsgolint analysis host is explicitly limited to x64 and
  arm64 on macOS, Linux, and Windows—the architectures supported by the .NET
  SDK used here. Other hosts fail a checked preflight; the browser/Wasm runtime
  and artifact remain cross-platform.
- `noUncheckedIndexedAccess` remains staged as #4549, with its 77-finding
  migration inventory and close-negative-test requirement.
- Existing JavaScript tests/scripts remain syntax-linted and Knip-covered; this
  PR does not create a shadow type model or broadly migrate them to TypeScript.
- No formatting or subjective style gate is introduced.

## Validation

- `npm ci --no-audit --no-fund`
- `npm run analyze`
- `npm test` (420 passed)
- `node --test test/toolchain.test.js` (4 passed after the host-matrix fix)
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `dotnet run eng/test-ci-change-detection.cs`

Closes #4541.
