### PR TITLE
Define agent behavior on session resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,24 +126,28 @@ Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a
 window nobody can identify.
 
-### Asking for help is best effort
+### Signal when you need a person
 
-When you are blocked on a person, you may send one transient notification:
+Whenever you stop and wait on a human decision, say so out of band as well as on
+screen. This is the standing convention during normal work, not an option:
 
 ```sh
 tmux display-message -d 10000 'PR #4405 needs a decision'
 ```
 
-**It is best effort and probably will not be seen.** Nobody may be attached; the
-person may be in another window, on another machine, or asleep. The message is
-transient and takes over the status line while it shows, so keep it rare and
-short.
+Send it once, when you become blocked — not on a timer, and not again while
+waiting on the same question. Keep it to one short line naming the PR and what
+is needed; the message takes over the status line for as long as it shows.
 
-It is a nudge, never a handoff. A sent notification is not a delivered
-question and never an answered one. You must still stop at your prompt and
-wait, and restate the request in full when resumed. Do not use it for progress,
-for completion, or to announce a resume — only for something you are blocked
-on. One per block, not one per reminder.
+**It is best effort and will often go unseen.** Nobody may be attached; the
+person may be in another window, on another machine, or asleep. So it is a
+nudge, never a handoff: a sent notification is not a delivered question and
+never an answered one. Stop at your prompt and wait exactly as you would have
+without it, and restate the request in full when resumed.
+
+Signal only for being blocked. Progress, completion, and resuming are not
+signals — they belong in your output, where they can be read whenever someone
+looks.
 
 ## User-directed workflow adjustments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,9 @@ formed before you stopped can describe a world that no longer exists.
   you were gone. Do not pull or rebase a pushed branch to "catch up"; reconcile
   it the way this file already requires.
 - **Re-check PR state** per [Canonical round flow](#canonical-round-flow).
-- **Name your window — not the session.** `tmux rename-window pr-<number>`, or
-  an equally short issue-scoped name when no PR exists yet, so the work can be
-  found from outside. A tmux session is shared by every window on that host, so
-  renaming it identifies nothing; `rename-window` is the same per-window name
-  `C-b ,` sets. Keep it short — the status bar truncates long names, and a
-  truncated name reads as a corrupted one.
+- **Re-announce yourself.** A resumed window has lost whatever it had on
+  screen, so nothing identifies it. Rename it and restate your PR per
+  [Making your work findable](#making-your-work-findable).
 
 ### Then act on where you stopped
 
@@ -75,6 +72,78 @@ else.
 If you cannot tell which of the three applies, that is the fourth case: say so,
 summarize what the transcript claims and what git shows, and wait rather than
 guessing.
+
+## Making your work findable
+
+Work runs in many concurrent agent windows across several machines. Whoever is
+watching must be able to tell, without attaching to any of them, which PR each
+window is on and which one needs a person. Three conventions carry that. Use
+them.
+
+### Name the window for identity
+
+`tmux rename-window pr<number>` — not the session. A tmux session is shared by
+every window on that host, so renaming it identifies nothing; `rename-window`
+sets the same per-window name that `C-b ,` sets. Without a PR yet, use the
+issue: `i<number>`.
+
+Keep the name short and stable. The status bar truncates, and a truncated name
+reads as a corrupted one. Do not encode changing state in it — your terminal
+title already carries that, updates itself, and costs nothing.
+
+The one exception is a state a person must act on. Append a single token then,
+and remove it when it clears:
+
+| suffix | means |
+| --- | --- |
+| `-blocked` | waiting on a human decision |
+| `-conflict` | in conflict recovery |
+
+`pr4405-conflict` is worth the eight characters. `pr4405-round-6-of-adversarial-review` is not.
+
+### Announce PR identity in your output
+
+State which PR you are on, in your visible output, in a form a reader and a
+script can both parse. Either pattern below is sufficient and both is fine; what
+matters is that the literal token `PR #<number>` or `PR <number>` appears, and
+the branch name where it is relevant.
+
+Beginning or continuing work:
+
+> Continue PR #4405 readiness for frozen expected head `595e5d4b…` on branch
+> `browser-platform-workspace` after conflict recovery.
+
+Completing a round:
+
+> Round 6 is complete for PR 4463.
+> - Review models GPT-5.6 Sol and Claude Opus 5 were used for adversarial review.
+> - Review feedback is: converging.
+> - Round start / end / duration.
+>
+> Fix description: …
+
+Restate it after every resume and at the start of every round, not once at the
+beginning. A window that has scrolled past its only mention of the PR is a
+window nobody can identify.
+
+### Asking for help is best effort
+
+When you are blocked on a person, you may send one transient notification:
+
+```sh
+tmux display-message -d 10000 'PR #4405 needs a decision'
+```
+
+**It is best effort and probably will not be seen.** Nobody may be attached; the
+person may be in another window, on another machine, or asleep. The message is
+transient and takes over the status line while it shows, so keep it rare and
+short.
+
+It is a nudge, never a handoff. A sent notification is not a delivered
+question and never an answered one. You must still stop at your prompt and
+wait, and restate the request in full when resumed. Do not use it for progress,
+for completion, or to announce a resume — only for something you are blocked
+on. One per block, not one per reminder.
 
 ## User-directed workflow adjustments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,11 @@ reboot, a lost terminal, a session resumed from disk. This section covers that.
 It is distinct from a round restart, which
 [Canonical round flow](#canonical-round-flow) governs.
 
-A resume restores your transcript and nothing else. Time has passed: the base may
-have moved and CI has run, so your restored plan may describe a state that no
-longer exists. Treat the transcript as
-history, not as current fact.
+Your transcript comes back intact, and no conversation was missed: nothing
+happened between your last turn and this one, so there is nothing to catch up on
+and no new direction waiting to be found. What may have moved is machine state
+outside your process — CI runs asynchronously and other work merges — so a plan
+formed before you stopped can describe a world that no longer exists.
 
 ### First, re-establish the world
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,54 @@ Keep the peer-checkout `ProjectReference` edits local and unpushed. After
 Markout lands and releases, restore `PackageReference` and only then raise the
 dotnet-inspect PR.
 
+## Session resume
+
+Your process can be replaced without your work being finished — a machine
+reboot, a lost terminal, a session resumed from disk. This section covers that.
+It is distinct from a round restart, which
+[Canonical round flow](#canonical-round-flow) governs.
+
+A resume restores your transcript and nothing else. Time has passed: the base
+has moved, CI has run, reviewers or the user may have posted, and your restored
+plan may describe a state that no longer exists. Treat the transcript as
+history, not as current fact.
+
+### First, re-establish the world
+
+- **Position comes from git, not from the transcript.** Confirm the worktree,
+  branch, and head. Fetch, and determine whether the effective base moved while
+  you were gone. Do not pull or rebase a pushed branch to "catch up"; reconcile
+  it the way this file already requires.
+- **Re-read the PR conversation** from where you stopped. Anything posted while
+  you were gone is current and outranks your restored plan.
+- **Re-check PR state** per [Canonical round flow](#canonical-round-flow).
+- **Name your window** so the session can be found from outside:
+  `tmux rename-window pr-<number>`, or the issue number when no PR exists yet.
+
+### Then act on where you stopped
+
+Exactly one of these applies. Say which, in one line, before doing anything
+else.
+
+- **Mid-stream — continue.** Pick the work back up. The re-check above takes
+  precedence: a conflict, a failed gate, or a moved base supersedes your
+  restored plan and is handled first. Conflict recovery remains the first
+  priority. If nothing changed, do not re-litigate decisions already made in
+  the transcript; carry on from them.
+- **Waiting on the user — restate the request.** Never assume the question was
+  seen or answered while you were gone. Restate it in full, including the
+  context needed to answer it and the options you were choosing between; a
+  pointer to an earlier message is not a restatement, because the user may be
+  looking at a fresh window with none of that history on screen. Then wait.
+- **Task complete — report and propose.** State what landed and what proves it.
+  Then either propose the next piece of work, with a reason it is the right
+  next thing, or ask for a task. Propose; do not start. Inventing scope after a
+  resume is how a finished PR grows changes nobody asked for.
+
+If you cannot tell which of the three applies, that is the fourth case: say so,
+summarize what the transcript claims and what git shows, and wait rather than
+guessing.
+
 ## User-directed workflow adjustments
 
 The workflow gates in this file establish the default safe sequencing. A user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,12 @@ formed before you stopped can describe a world that no longer exists.
   you were gone. Do not pull or rebase a pushed branch to "catch up"; reconcile
   it the way this file already requires.
 - **Re-check PR state** per [Canonical round flow](#canonical-round-flow).
-- **Name your window** so the session can be found from outside:
-  `tmux rename-window pr-<number>`, or the issue number when no PR exists yet.
+- **Name your window — not the session.** `tmux rename-window pr-<number>`, or
+  an equally short issue-scoped name when no PR exists yet, so the work can be
+  found from outside. A tmux session is shared by every window on that host, so
+  renaming it identifies nothing; `rename-window` is the same per-window name
+  `C-b ,` sets. Keep it short — the status bar truncates long names, and a
+  truncated name reads as a corrupted one.
 
 ### Then act on where you stopped
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ reboot, a lost terminal, a session resumed from disk. This section covers that.
 It is distinct from a round restart, which
 [Canonical round flow](#canonical-round-flow) governs.
 
-A resume restores your transcript and nothing else. Time has passed: the base
-has moved, CI has run, reviewers or the user may have posted, and your restored
-plan may describe a state that no longer exists. Treat the transcript as
+A resume restores your transcript and nothing else. Time has passed: the base may
+have moved and CI has run, so your restored plan may describe a state that no
+longer exists. Treat the transcript as
 history, not as current fact.
 
 ### First, re-establish the world
@@ -43,8 +43,6 @@ history, not as current fact.
   branch, and head. Fetch, and determine whether the effective base moved while
   you were gone. Do not pull or rebase a pushed branch to "catch up"; reconcile
   it the way this file already requires.
-- **Re-read the PR conversation** from where you stopped. Anything posted while
-  you were gone is current and outranks your restored plan.
 - **Re-check PR state** per [Canonical round flow](#canonical-round-flow).
 - **Name your window** so the session can be found from outside:
   `tmux rename-window pr-<number>`, or the issue number when no PR exists yet.


### PR DESCRIPTION
## What

Adds a `## Session resume` section to AGENTS.md, placed after **Start here** since it is an entry condition.

An agent's process can be replaced without its work being finished — a machine reboot, a lost terminal, a session resumed from disk. Nothing currently tells a resumed agent what to do.

## The three states

Exactly one applies, and the agent must say which before doing anything else:

| state | what it owes |
| --- | --- |
| **Mid-stream** | continue — but the re-check takes precedence; a conflict, failed gate, or moved base supersedes the restored plan |
| **Waiting on the user** | restate the request *in full*, with the context and options needed to answer — a pointer to an earlier message is not a restatement, because the user may be looking at a fresh window with no history on screen |
| **Task complete** | report what landed and what proves it, then propose the next work or ask for a task — propose, do not start |

There is a fourth case for "cannot tell", which resolves to: say so and wait.

## Why "resume" and not "restart"

This file already contains eight occurrences of "restart", every one of them a **round** restart owned by [Canonical round flow](../blob/main/AGENTS.md#canonical-round-flow) — "failed-gate restart", "restart the same numbered round". A second meaning for the same word would invite agents to conflate a process resume with a round restart. "resume" appeared zero times before this change, and it matches the `--resume` flag agents are literally invoked with.

## Precedence is explicit

"Continue if mid-stream" could be read as overriding conflict-first recovery, so the section states the ordering outright rather than leaving two rules to collide. Conflict, CI, and round mechanics are delegated to Canonical round flow rather than restated, per this file's single-source-of-truth rule.

## Verification

`markdownlint-cli2 AGENTS.md` — 0 issues. The `#canonical-round-flow` fragment resolves to the existing heading.

Docs-only; no code paths touched.
