### PR TITLE
match: add --implementation flag for decompiled C#/IL side-by-side view (#4304 Slice 4)

### DIFF
--- a/src/dotnet-inspect.Tests/MatchCommandTests.cs
+++ b/src/dotnet-inspect.Tests/MatchCommandTests.cs
@@ -134,6 +134,130 @@ public sealed class MatchCommandTests
         Assert.Empty(error);
         Assert.Contains("\"relation\": \"Exact\"", output);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ImplementationOnDifferentBodies_RendersCSharpAndIlEvidence()
+    {
+        // Issue #4304 Slice 4: --implementation independently decompiles both selectors and
+        // renders a Research-owned side-by-side C#/IL implementation-diff view, even though
+        // these two methods are not structurally clone-related (a genuine content diff, not an
+        // identity assumption).
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.Greet",
+            RightSelector = $"{typeof(MatchSampleA).FullName}.GreetFormal",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            IncludeImplementation = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => MatchCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("# Implementation Diff:", output);
+        Assert.Contains("| Mechanism | Difference | Change | Evidence |", output);
+        Assert.Contains("Good day", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ImplementationOnIdenticalBodies_ReportsNoDifferences()
+    {
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.AddOne",
+            RightSelector = $"{typeof(MatchSampleB).FullName}.AddOneToo",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            IncludeImplementation = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => MatchCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("No implementation differences detected.", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ImplementationJson_EmitsMatchAndImplementationEnvelope()
+    {
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.Greet",
+            RightSelector = $"{typeof(MatchSampleA).FullName}.GreetFormal",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            IncludeImplementation = true,
+            JsonOutput = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => MatchCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.Contains("\"match\": {", output);
+        Assert.Contains("\"implementation\": {", output);
+        Assert.Contains("\"disposition\": \"Completed\"", output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultJson_IsUnaffectedByImplementationFlagAbsence()
+    {
+        // The default (non --implementation) --json output must stay byte-identical to what
+        // Slice 3 shipped: the flat StructuralCloneComparisonDocument, no wrapping envelope.
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.AddOne",
+            RightSelector = $"{typeof(MatchSampleA).FullName}.Greet",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            JsonOutput = true,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => MatchCommand.ExecuteAsync(options));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.DoesNotContain("\"match\": {", output);
+        Assert.DoesNotContain("\"implementation\": {", output);
+        Assert.Contains("\"disposition\":", output);
+    }
+
+    [Theory]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    public async Task ExecuteAsync_ImplementationWithTabularFormat_RejectsCombination(bool tabular, bool tsv, bool jsonl)
+    {
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.Greet",
+            RightSelector = $"{typeof(MatchSampleA).FullName}.GreetFormal",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            IncludeImplementation = true,
+            Tabular = tabular,
+            Tsv = tsv,
+            Jsonl = jsonl,
+        };
+
+        var (exitCode, output, error) =
+            await ConsoleCapture.RunAsync(
+                () => MatchCommand.ExecuteAsync(options));
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(output);
+        Assert.Contains("--implementation cannot be combined with", error);
+    }
 }
 
 public static class MatchSampleA
@@ -141,6 +265,8 @@ public static class MatchSampleA
     public static int AddOne(int x) => x + 1;
 
     public static string Greet(string name) => $"Hello, {name}!";
+
+    public static string GreetFormal(string name) => $"Good day, {name}.";
 
     public static int Overloaded(int x) => x;
 

--- a/src/dotnet-inspect/CommandLine/Commands/MatchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/MatchCommandDefinitions.cs
@@ -37,6 +37,10 @@ public static class MatchCommandDefinitions
         var tfmOption = new Option<string?>("--tfm") { Description = "Source: select by TFM (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include non-public members when resolving selectors" };
         var compactOption = new Option<bool>("--compact") { Description = "Output as minified JSON (use with --json)" };
+        var implementationOption = new Option<bool>("--implementation")
+        {
+            Description = "Also decompile both members and render a side-by-side C#/IL implementation-diff view",
+        };
 
         matchCommand.Arguments.Add(leftArg);
         matchCommand.Arguments.Add(rightArg);
@@ -49,6 +53,7 @@ public static class MatchCommandDefinitions
         matchCommand.Options.Add(allOption);
         matchCommand.Options.Add(opts.Json);
         matchCommand.Options.Add(compactOption);
+        matchCommand.Options.Add(implementationOption);
         opts.AddTableOptionsTo(matchCommand);
         opts.AddOutputOptionsTo(matchCommand);
         opts.AddNuGetOptionsTo(matchCommand);
@@ -78,6 +83,7 @@ public static class MatchCommandDefinitions
                 IncludeAll = parseResult.GetValue(allOption),
                 JsonOutput = opts.ResolveFormat(parseResult) == OutputFormat.Json,
                 CompactJson = parseResult.GetValue(compactOption),
+                IncludeImplementation = parseResult.GetValue(implementationOption),
                 Tabular = opts.ResolveTabular(parseResult),
                 Tsv = opts.ResolveTsv(parseResult),
                 Jsonl = opts.ResolveJsonl(parseResult),

--- a/src/dotnet-inspect/Commands/MatchCommand.cs
+++ b/src/dotnet-inspect/Commands/MatchCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using DotnetInspector.Inspectors;
@@ -6,6 +7,7 @@ using DotnetInspector.Output;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using ILInspector.Analysis;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 using ILInspector.Research;
 using Markout;
@@ -32,6 +34,17 @@ public static class MatchCommand
         {
             CommandError.Write("match requires two method selectors (Type.Member).");
             CommandError.WriteLine("Usage: dotnet-inspect match <Type.MemberA> <Type.MemberB> --package <pkg>");
+            return 1;
+        }
+
+        // The Implementation Diff section renders one C#/IL side-by-side row set, the same
+        // "one section at a time" restriction diff already enforces for tabular/TSV/JSONL output
+        // (issue #4304 Slice 4).
+        if (options.IncludeImplementation && (options.Tabular || options.Tsv || options.Jsonl))
+        {
+            CommandError.Write(
+                "--implementation cannot be combined with --table, --tsv, or --jsonl; "
+                    + "render Markdown (the default) or --json instead.");
             return 1;
         }
 
@@ -85,17 +98,33 @@ public static class MatchCommand
                 MetadataTokens.MethodDefinitionHandle(left.Token!.Value),
                 MetadataTokens.MethodDefinitionHandle(right.Token!.Value));
 
+            ImplementationDiffView? implementationView = options.IncludeImplementation
+                ? BuildImplementationDiffView(left, right)
+                : null;
+
             if (options.JsonOutput)
             {
-                JsonOutputHelper.Write(
-                    result.Document,
-                    StructuralCloneComparisonDocumentJsonContext.Default.StructuralCloneComparisonDocument,
-                    StructuralCloneComparisonDocumentCompactJsonContext.Default.StructuralCloneComparisonDocument,
-                    options.CompactJson);
+                if (implementationView is null)
+                {
+                    JsonOutputHelper.Write(
+                        result.Document,
+                        StructuralCloneComparisonDocumentJsonContext.Default.StructuralCloneComparisonDocument,
+                        StructuralCloneComparisonDocumentCompactJsonContext.Default.StructuralCloneComparisonDocument,
+                        options.CompactJson);
+                }
+                else
+                {
+                    var envelope = new MatchImplementationDocument(result.Document, implementationView);
+                    JsonOutputHelper.Write(
+                        envelope,
+                        MatchImplementationDocumentJsonContext.Default.MatchImplementationDocument,
+                        MatchImplementationDocumentCompactJsonContext.Default.MatchImplementationDocument,
+                        options.CompactJson);
+                }
             }
             else
             {
-                WriteMarkoutOutput(left.Display!, right.Display!, result, options);
+                WriteMarkoutOutput(left.Display!, right.Display!, result, implementationView, options);
             }
 
             return 0;
@@ -204,7 +233,46 @@ public static class MatchCommand
         return new ResolvedSelector(MethodToken(candidates[0]), $"{apiType.FullName}.{memberName}", originAssemblyPath, null);
     }
 
-    static void WriteMarkoutOutput(string leftDisplay, string rightDisplay, ResearchMatchResult result, MatchOptions options)
+    /// <summary>
+    /// Independently decompiles both selectors' method bodies and projects a C#/IL side-by-side
+    /// implementation-diff view, reusing <see cref="ImplementationDiff.CompareMembers"/> and
+    /// <see cref="DiffOutputFormatter.BuildImplementationDiffView"/> exactly as <c>diff</c>'s
+    /// Implementation Diff section does (issue #4304 Slice 4). <c>CompareMembers</c> makes no
+    /// identity assumption about its two handles, so it applies unchanged to match's
+    /// non-identity-matched pair.
+    /// </summary>
+    static ImplementationDiffView BuildImplementationDiffView(ResolvedSelector left, ResolvedSelector right)
+    {
+        using var source = MetadataSource.Open(left.OriginAssemblyPath!);
+        var memberDiff = ImplementationDiff.CompareMembers(
+            source,
+            MetadataTokens.MethodDefinitionHandle(left.Token!.Value),
+            source,
+            MetadataTokens.MethodDefinitionHandle(right.Token!.Value));
+
+        var member = new ImplementationDiffMember(memberDiff.Subject, memberDiff.Changes)
+        {
+            SourceComparison = memberDiff.SourceComparison,
+        };
+        // BuildImplementationDiffView only reads diff.Members; this ResearchComparison is a
+        // type-satisfying formality, not a second, independently meaningful comparison result.
+        var diff = new ImplementationDiffResult(
+            [member],
+            new ResearchComparison(memberDiff.Changes.ToImmutableArray()));
+
+        return DiffOutputFormatter.BuildImplementationDiffView(
+            $"{left.Display} vs {right.Display}",
+            diff,
+            left.Display!,
+            right.Display!);
+    }
+
+    static void WriteMarkoutOutput(
+        string leftDisplay,
+        string rightDisplay,
+        ResearchMatchResult result,
+        ImplementationDiffView? implementationView,
+        MatchOptions options)
     {
         var view = MatchOutputFormatter.BuildView(leftDisplay, rightDisplay, result);
 
@@ -219,7 +287,17 @@ public static class MatchCommand
         else
         {
             OutputFormatter.WriteWindowedMarkdown(Console.Out, options.Rows,
-                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
+                opts =>
+                {
+                    var text = MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts);
+                    if (implementationView is not null)
+                    {
+                        var implementationText = DiffOutputFormatter.RenderImplementationDiffView(implementationView, opts);
+                        text = $"{text}\n\n{implementationText}";
+                    }
+
+                    return text;
+                });
         }
     }
 }

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -81,6 +81,33 @@ internal partial class DiffJsonContext : JsonSerializerContext
 {
 }
 
+/// <summary>
+/// Serialization contract for <c>match --implementation --json</c>
+/// (<see cref="MatchImplementationDocument"/>): snake-case names, omitted nulls, and string enums
+/// to match <see cref="ILInspector.Analysis.StructuralCloneComparisonDocumentJsonContext"/>'s
+/// contract for the nested <see cref="ILInspector.Analysis.StructuralCloneComparisonDocument"/>.
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(MatchImplementationDocument))]
+internal partial class MatchImplementationDocumentJsonContext : JsonSerializerContext
+{
+}
+
+/// <inheritdoc cref="MatchImplementationDocumentJsonContext"/>
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(MatchImplementationDocument))]
+internal partial class MatchImplementationDocumentCompactJsonContext : JsonSerializerContext
+{
+}
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(PackageFileJsonRow))]
 internal partial class PackageFileJsonRowContext : JsonSerializerContext

--- a/src/dotnet-inspect/Options/MatchOptions.cs
+++ b/src/dotnet-inspect/Options/MatchOptions.cs
@@ -14,6 +14,13 @@ public record MatchOptions : ApiOptions
     public string? RightSelector { get; init; }
 
     /// <summary>
+    /// Additionally decompile both members and render a Research-owned side-by-side C#/IL
+    /// implementation-diff view alongside the verified structural clone relation (issue #4304
+    /// Slice 4). Decompilation is CPU-expensive, so this stays out of the default view.
+    /// </summary>
+    public bool IncludeImplementation { get; init; }
+
+    /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
     public override bool IsRawOutput => Bare || JsonOutput || Tabular || Jsonl || NoHeader || Count;

--- a/src/dotnet-inspect/Views/MatchViews.cs
+++ b/src/dotnet-inspect/Views/MatchViews.cs
@@ -73,3 +73,15 @@ public static class MatchOutputFormatter
         return view;
     }
 }
+
+/// <summary>
+/// JSON envelope for <c>match --implementation --json</c>: composes the structural clone
+/// comparison with a decompiled C#/IL implementation-diff view, reusing the same
+/// <see cref="DotnetInspector.Views.ImplementationDiffView"/>/<see cref="ImplementationDiffRow"/>
+/// types the <c>diff</c> command's Implementation Diff section serializes (issue #4304 Slice 4).
+/// Plain <c>match --json</c> (without <c>--implementation</c>) is unaffected: it stays the flat
+/// <see cref="StructuralCloneComparisonDocument"/> shape shipped in Slice 3.
+/// </summary>
+public sealed record MatchImplementationDocument(
+    StructuralCloneComparisonDocument Match,
+    ImplementationDiffView Implementation);


### PR DESCRIPTION
Slice 4 of #4304 — adds an opt-in `--implementation` flag to `match`,
completing the issue's "Initial demo" steps: independently decompile both
selectors and render a Research-owned side-by-side C#/IL implementation-diff
view alongside the verified structural clone relation Slices 1–3 already
produce.

## What changed

- Reuses `ImplementationDiff.CompareMembers` unchanged — it makes no identity
  assumption about its two method handles, so it applies directly to match's
  non-identity-matched pair.
- Reuses `DiffOutputFormatter.BuildImplementationDiffView`/
  `RenderImplementationDiffView` and the existing `ImplementationDiffView`/
  `ImplementationDiffRow` types `diff`'s Implementation Diff section already
  renders and serializes, rather than duplicating them.
- Markdown (default) output appends the rendered Implementation Diff section
  after the existing Match section.
- `--json --implementation` switches to a new `MatchImplementationDocument`
  envelope (`{ match, implementation }`) via a new dedicated
  `JsonSerializerContext`. Plain `match --json` (without `--implementation`)
  is byte-shape-unchanged: the flat `StructuralCloneComparisonDocument` Slice
  3 shipped.
- `--implementation` combined with `--table`/`--tsv`/`--jsonl` is rejected,
  mirroring `diff`'s existing "one section at a time" restriction for tabular
  formats.
- Opens the origin assembly via `MetadataSource.Open` (path-based, no raw
  `PEReader`), consistent with the Slice 3 layering fix and
  `LayeringTests.Cli_DoesNotReferenceRawMetadataReaders`.

## Non-action / residual

No README changes: `match` itself has no README section yet (Slice 3 added
none either), so this flag is documented only via `--help` and code comments,
consistent with that precedent.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`: 0 errors, 0 warnings.
- `dotnet run --project src/dotnet-inspect.Tests -c Release`: 4315 total, 0
  failed, 15 pre-existing skips (no `ilasm`/`ildasm` on this machine).
- 6 new `MatchCommandTests`: a genuine C#/IL content diff, the
  no-differences case, the JSON envelope shape, the unaffected default JSON
  shape, and the tabular-restriction error (3 format variants).
- Manually verified Markdown, `--json`, exact/no-diff, and tabular-restriction
  behavior against a throwaway compiled fixture assembly.
