### PR TITLE
Lint generated tsbindgen output

### DIFF
--- a/prototypes/inspect-web/.oxlintrc.json
+++ b/prototypes/inspect-web/.oxlintrc.json
@@ -8,9 +8,6 @@
     "browser": true,
     "es2022": true
   },
-  "ignorePatterns": [
-    "src/inspect-web-engine.d.ts"
-  ],
   "options": {
     "denyWarnings": true,
     "reportUnusedDisableDirectives": "error",

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -488,12 +488,16 @@ either preserve sequencing or surface unexpected rejection visibly. The exact
 `node:test` `test` call is the only configured safe promise-returning call
 because the test runner owns and observes that returned promise.
 
-Oxlint excludes only the generated `src/inspect-web-engine.d.ts` surface, which
-remains covered by TypeScript and the generated-surface drift check. The
-configuration disables four non-correctness rules: underscore spelling,
-function relocation, listener API preference, and `Array.prototype.sort`.
-Those rules prescribe naming/layout churn or, for sorting, the ES2023
-`toSorted` API while this project targets ES2022.
+Oxlint checks both checked-in tsbindgen outputs as consumer contracts:
+`src/inspect-web-engine.d.ts` receives the TypeScript rules, while
+`engine/wwwroot/inspect-web-engine.js` receives the JavaScript correctness and
+suspicious rules described below. TypeScript compilation and the generated
+surface drift gate provide independent declaration coverage. The toolchain
+test pins both generated lint inputs so a generator change cannot silently
+leave analysis coverage. The configuration disables four non-correctness
+rules: underscore spelling, function relocation, listener API preference, and
+`Array.prototype.sort`. Those rules prescribe naming/layout churn or, for
+sorting, the ES2023 `toSorted` API while this project targets ES2022.
 
 Existing JavaScript tests and verification scripts remain covered by Oxlint's
 correctness and suspicious rules, but not by its unsafe-operation type rules:
@@ -505,7 +509,8 @@ Knip checks authored source, every TypeScript and JavaScript test, and
 build/verification scripts for unused files, exports, and dependencies.
 `knip.json` excludes only `engine/wwwroot/inspect-web-engine.js`: that generated
 publish artifact imports `./_framework/dotnet.js`, which exists only after Wasm
-publish.
+publish. The exclusion is specific to Knip reachability; Oxlint still checks
+the generated module.
 
 The tsgolint semantic backend publishes native binaries for x64 and arm64 hosts
 running macOS, Linux (glibc or musl), or Windows. Those are the supported

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "npm run typecheck && node --test",
     "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
-    "lint": "node scripts/verify-analysis-host.js && oxlint src test scripts vite.config.js",
+    "lint": "node scripts/verify-analysis-host.js && oxlint src test scripts engine/wwwroot/inspect-web-engine.js vite.config.js",
     "analyze": "npm run lint && knip"
   },
   "devDependencies": {

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -22,6 +22,9 @@ const packageLock = JSON.parse(
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
+const oxlintConfig = JSON.parse(
+  readFileSync(new URL("../.oxlintrc.json", import.meta.url), "utf8"),
+);
 const browserTsconfig = JSON.parse(
   readFileSync(new URL("../tsconfig.json", import.meta.url), "utf8"),
 );
@@ -124,7 +127,19 @@ test("the analysis host check matches locked native packages and lint wiring", (
 
   assert.equal(
     packageJson.scripts.lint,
-    "node scripts/verify-analysis-host.js && oxlint src test scripts vite.config.js",
+    "node scripts/verify-analysis-host.js && oxlint src test scripts "
+      + "engine/wwwroot/inspect-web-engine.js vite.config.js",
+  );
+});
+
+test("the lint gate includes both generated tsbindgen outputs", () => {
+  assert.ok(
+    !(oxlintConfig.ignorePatterns ?? []).includes("src/inspect-web-engine.d.ts"),
+  );
+  assert.match(packageJson.scripts.lint, /(?:^| )src(?: |$)/);
+  assert.match(
+    packageJson.scripts.lint,
+    /(?:^| )engine\/wwwroot\/inspect-web-engine\.js(?: |$)/,
   );
 });
 


### PR DESCRIPTION
## Summary

Makes both checked-in tsbindgen outputs part of inspect-web's permanent analyzer
gate. A future generator change that introduces an Oxlint diagnostic now fails
the same `npm run analyze` command used by CI.

## Changes

- Removes the generated declaration from Oxlint's ignore list, so
  `src/inspect-web-engine.d.ts` receives the TypeScript rule set.
- Adds `engine/wwwroot/inspect-web-engine.js` as an explicit lint input for
  JavaScript correctness and suspicious diagnostics.
- Pins both generated inputs in the toolchain test so configuration drift
  cannot silently remove this consumer coverage.
- Clarifies that the runtime module's Knip exclusion is reachability-specific;
  the framework import exists only after Wasm publish and does not exclude it
  from linting.

No runtime behavior or generated artifact changes.

## Validation

- `npm ci --no-audit --no-fund`
- `npm run analyze`
- `npm run typecheck`
- `node --test test/toolchain.test.js` (5 passed)
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`
