### PR TITLE
Target the caller's own window when renaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,19 @@ them.
 
 ### Name the window for identity
 
-`tmux rename-window pr<number>` — not the session. A tmux session is shared by
-every window on that host, so renaming it identifies nothing; `rename-window`
-sets the same per-window name that `C-b ,` sets. Without a PR yet, use the
-issue: `i<number>`.
+```sh
+tmux rename-window -t "$TMUX_PANE" pr<number>
+```
+
+**The `-t "$TMUX_PANE"` is required, not decoration.** Bare `tmux rename-window`
+resolves to the session's *current* window, not the window you are running in —
+so without it you rename whichever window the operator happens to be viewing,
+and every agent overwrites every other agent's name. Verified: a rename issued
+from window 2 renamed window 0.
+
+Rename the window, never the session. A session is shared by every window on
+that host, so renaming it identifies nothing. Without a PR yet, use the issue:
+`i<number>`.
 
 Keep the name short and stable. The status bar truncates, and a truncated name
 reads as a corrupted one. Do not encode changing state in it — your terminal


### PR DESCRIPTION
## The bug

`tmux rename-window <name>` with no target resolves to the **session's current window**, not the window the command is running in. The convention added in #4553 told agents to run exactly that, so every agent renaming itself has been stamping its PR number onto whichever window the operator was viewing — and overwriting every other agent's name.

## Evidence

Reproduced directly. Three windows, `first` active, rename issued from `third`:

```
before:            0:first*  1:second  2:third
after rename in 2: 0:renamed*  1:second  2:third      <- wrong window
```

With the fix:

```
after rename in 2: 0:first*  1:second  2:correct-target   <- right window
```

Measured on the live 19-window fleet before the fix: 12 windows carried a name unrelated to their own work, and two PR numbers were each claimed by two different windows. That looked like agents failing to keep names current; it was actually agents renaming each other.

## The fix

```sh
tmux rename-window -t "$TMUX_PANE" pr<number>
```

`$TMUX_PANE` is set by tmux in every pane and resolves to that pane's window, so the rename lands on the caller regardless of what the operator is looking at.

The doc now states *why* the flag is required. Without that, it reads as boilerplate and gets dropped — and the failure is silent, produces plausible-looking names, and is invisible until you compare a window's name against its own content.

## Verification

`markdownlint-cli2 AGENTS.md` — 0 issues. No unqualified `rename-window` remains in the file.

Docs-only.
