### PR TITLE
Type inspect-web UI navigation vocabularies

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -664,8 +664,10 @@ paths. Close-negative tests cover those boundaries rather than relying on
 non-null assertions.
 
 The scope, lens, and member-section vocabularies are closed union types derived
-from the catalogs that render them, so `data.ts` and `spotlight.ts` are the only
-places those spellings exist. Values arriving from `dataset` attributes, URL
+from the catalogs that render them. `data.ts` and `spotlight.ts` own those
+catalogs; narrower typed subsets such as the platform library picker may repeat
+only the values that surface exposes, with assignment back to catalog-derived
+state checked by TypeScript. Values arriving from `dataset` attributes, URL
 query parameters, hashes, and share packets are admitted through `isTypeLens`,
 `isPackageLens`, `isMemberSection`, `isWorkspaceScope`, and `availableScope`;
 an unrecognized value is rejected at that boundary rather than cast into typed

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -615,6 +615,11 @@ either preserve sequencing or surface unexpected rejection visibly. The exact
 `node:test` `test` call is the only configured safe promise-returning call
 because the test runner owns and observes that returned promise.
 
+Closed workspace scopes, type and package lenses, member sections, and
+Spotlight scopes are literal unions derived from their UI catalogs. DOM and URL
+tokens are decoded before they reach typed state or actions; the scope-bar and
+workspace-navigation tests gate rejection of unknown values.
+
 Oxlint checks both checked-in tsbindgen outputs as consumer contracts:
 `src/inspect-web-engine.d.ts` receives the TypeScript rules, while
 `engine/wwwroot/inspect-web-engine.js` receives the JavaScript correctness and

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -672,19 +672,23 @@ an unrecognized value is rejected at that boundary rather than cast into typed
 state.
 
 Because those catalogs also render the choices a user can pick, adding an entry
-widens the union *and* immediately offers the new value. Every consumer that
-branches on one therefore ends in `assertNever`, so adding a catalog entry fails
-compilation until each consumer says what the new value does. Nothing at runtime
-can observe that property — an unhandled value would simply take whichever
-branch the consumer fell through to — so the gate is the compiler, and
+widens the union *and* immediately offers the new value. Every dispatch named by
+the exhaustiveness gate therefore ends in `assertNever`, so adding a catalog
+entry fails compilation until each such dispatch says what the new value does.
+The gate derives its vocabulary roster from every exported type alias in
+`data.ts` and `spotlight.ts` that queries a catalog; it is not tied to one
+formatting or indexing shape.
+
+Nothing at runtime can observe that property — an unhandled value would simply
+take whichever branch the consumer fell through to — so the gate is the compiler, and
 `widening a UI vocabulary catalog fails compilation until every consumer handles it`
 in `test/vocabulary-exhaustiveness.test.ts` is that gate. It widens each catalog
-in a throwaway copy of `src/` and asserts `tsc` reports exactly the expected
-number of `assertNever` rejections, so deleting any one exhaustive dispatch
-turns it red. `renderPackageView` is deliberately not exhaustive: an unwired
-package lens renders a visible "not wired yet" panel rather than another lens's
-content, which is already the failure-visible outcome exhaustiveness exists to
-force.
+in a throwaway copy of the real TypeScript source graph and asserts `tsc`
+reports the expected `assertNever` location in every named dispatch, with no
+unrelated diagnostic. Deleting any one exhaustive dispatch turns it red.
+`packageLensBody` is exhaustive too: an unwired package lens used to render a
+placeholder that was indistinguishable from an empty lens, but now fails
+compilation until its behavior is explicit.
 
 ## Test
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -663,6 +663,29 @@ decoded assembly descriptors reported through the existing visible failure
 paths. Close-negative tests cover those boundaries rather than relying on
 non-null assertions.
 
+The scope, lens, and member-section vocabularies are closed union types derived
+from the catalogs that render them, so `data.ts` and `spotlight.ts` are the only
+places those spellings exist. Values arriving from `dataset` attributes, URL
+query parameters, hashes, and share packets are admitted through `isTypeLens`,
+`isPackageLens`, `isMemberSection`, `isWorkspaceScope`, and `availableScope`;
+an unrecognized value is rejected at that boundary rather than cast into typed
+state.
+
+Because those catalogs also render the choices a user can pick, adding an entry
+widens the union *and* immediately offers the new value. Every consumer that
+branches on one therefore ends in `assertNever`, so adding a catalog entry fails
+compilation until each consumer says what the new value does. Nothing at runtime
+can observe that property — an unhandled value would simply take whichever
+branch the consumer fell through to — so the gate is the compiler, and
+`widening a UI vocabulary catalog fails compilation until every consumer handles it`
+in `test/vocabulary-exhaustiveness.test.ts` is that gate. It widens each catalog
+in a throwaway copy of `src/` and asserts `tsc` reports exactly the expected
+number of `assertNever` rejections, so deleting any one exhaustive dispatch
+turns it red. `renderPackageView` is deliberately not exhaustive: an unwired
+package lens renders a visible "not wired yet" panel rather than another lens's
+content, which is already the failure-visible outcome exhaustiveness exists to
+force.
+
 ## Test
 
 ```bash

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -5,20 +5,68 @@
 // wiring; these functions are pure transforms over explicit inputs/outputs so they can be
 // unit-tested and reused (e.g. by `graph-mermaid.ts`) without the render/event-wiring layer.
 
-export const lenses: readonly (readonly [string, string])[] = [
+// Not exported: every consumer now goes through `typeLensesFor`, which applies the
+// runtime-pack filter. A direct export would be a way to skip it.
+const lenses = [
   ["api", "API"],
   ["metadata", "Metadata"],
   ["source", "Source"]
-];
+] as const;
 
-export const packageLenses: readonly (readonly [string, string])[] = [
+export type TypeLens = (typeof lenses)[number][0];
+
+export function isTypeLens(
+  value: string | null | undefined,
+): value is TypeLens {
+  return typeof value === "string"
+    && lenses.some(([id]) => id === value);
+}
+
+export const packageLenses = [
   ["overview", "Overview"],
   ["dependencies", "Dependencies"],
   ["integrations", "Integrations"],
   ["opportunities", "Opportunities"],
   ["analysis", "Analysis"],
   ["metadata", "Metadata"]
-];
+] as const;
+
+export type PackageLens = (typeof packageLenses)[number][0];
+
+export function isPackageLens(
+  value: string | null | undefined,
+): value is PackageLens {
+  return typeof value === "string"
+    && packageLenses.some(([id]) => id === value);
+}
+
+export const memberSectionDefinitions = [
+  ["overview", "Overview"],
+  ["call-graph", "Call graph"],
+  ["facts", "Facts"],
+  ["source", "Source"],
+  ["annotated", "Annotated source"],
+] as const;
+
+export type MemberSection = (typeof memberSectionDefinitions)[number][0];
+
+export function isMemberSection(
+  value: string | null | undefined,
+): value is MemberSection {
+  return typeof value === "string"
+    && memberSectionDefinitions.some(([id]) => id === value);
+}
+
+const workspaceScopes = ["package", "type", "member"] as const;
+
+export type WorkspaceScope = (typeof workspaceScopes)[number];
+
+export function isWorkspaceScope(
+  value: string | null | undefined,
+): value is WorkspaceScope {
+  return typeof value === "string"
+    && workspaceScopes.some(scope => scope === value);
+}
 
 export const MAX_WORKSPACE_PACKAGES = 12;
 export const MAX_SHARE_STATE_CHARACTERS = 65536;
@@ -1374,9 +1422,9 @@ export interface SourceWorkbenchState {
   package?: unknown;
   graphSourceOpen?: boolean;
   atPackageRoot?: boolean;
-  lens?: string;
+  lens?: TypeLens;
   selectedMemberKey?: string;
-  memberSection?: string;
+  memberSection?: MemberSection;
 }
 
 function sourceWorkbenchIsVisible(state: SourceWorkbenchState): boolean {
@@ -1493,7 +1541,7 @@ export function memberSectionIdsFor(
   member: SectionableMember | null | undefined,
   isRuntimePack = false,
   hasSelectedBody = false,
-): string[] {
+): MemberSection[] {
   if (["property", "field", "event", "constant"].includes(member?.kind ?? "")
     && !hasSelectedBody) {
     return ["overview"];
@@ -1509,7 +1557,7 @@ export function memberSectionIdsFor(
 
 export function typeLensesFor(
   pkg: { isRuntimePack?: boolean } | null | undefined,
-): readonly (readonly [string, string])[] {
+): readonly (readonly [TypeLens, string])[] {
   return pkg?.isRuntimePack
     ? lenses.filter(([id]) => id === "api")
     : lenses;

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -5,6 +5,15 @@
 // wiring; these functions are pure transforms over explicit inputs/outputs so they can be
 // unit-tested and reused (e.g. by `graph-mermaid.ts`) without the render/event-wiring layer.
 
+// Exhaustiveness guard for the closed vocabularies below. The unions in this module are
+// derived from catalogs that also drive visible UI choices, so adding a catalog entry both
+// widens the union and offers the new value to users. Passing the switched value here makes
+// the compiler reject that addition until every consumer states what the new value does; the
+// throw is the residual runtime signal if a value ever reaches a consumer past its validator.
+export function assertNever(value: never, vocabulary: string): never {
+  throw new Error(`Unhandled ${vocabulary}: ${JSON.stringify(value)}`);
+}
+
 // Not exported: every consumer now goes through `typeLensesFor`, which applies the
 // runtime-pack filter. A direct export would be a way to skip it.
 const lenses = [
@@ -1537,6 +1546,16 @@ export interface SectionableMember {
   kind?: string;
 }
 
+// The full roster is derived from the catalog rather than restated, so a new section is
+// offered as soon as it is defined. Restating it was the durable defect: the compiler
+// rejects a *removal* from the catalog, because the literal would stop being assignable,
+// but nothing caught an *addition*, which silently never reached the UI at all.
+const allMemberSections: readonly MemberSection[] =
+  memberSectionDefinitions.map(([id]) => id);
+
+const sourceBackedMemberSections: ReadonlySet<MemberSection> =
+  new Set<MemberSection>(["source", "annotated"]);
+
 export function memberSectionIdsFor(
   member: SectionableMember | null | undefined,
   isRuntimePack = false,
@@ -1547,8 +1566,8 @@ export function memberSectionIdsFor(
     return ["overview"];
   }
   const sections = isRuntimePack
-    ? ["overview", "call-graph", "facts"]
-    : ["overview", "call-graph", "facts", "source", "annotated"];
+    ? allMemberSections.filter(section => !sourceBackedMemberSections.has(section))
+    : [...allMemberSections];
   return hasSelectedBody
     && ["property", "event"].includes(member?.kind ?? "")
     ? sections.filter(id => id !== "source")

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2547,14 +2547,20 @@ function renderScopeBar() {
       escapeHtml,
     });
   }
-  return renderScopeBarPure({
-    scope: sc,
-    strip: typeLensesFor(state.package),
-    activeStripId: state.lens,
-    stripAttribute: "data-lens",
-    showMemberScope,
-    escapeHtml,
-  });
+  if (sc === "type") {
+    return renderScopeBarPure({
+      scope: sc,
+      // `typeLensesFor` rather than the raw catalog: a runtime pack offers only the API
+      // lens, and reading the catalog directly here would skip that restriction.
+      strip: typeLensesFor(state.package),
+      activeStripId: state.lens,
+      stripAttribute: "data-lens",
+      showMemberScope,
+      escapeHtml,
+    });
+  }
+  // A new scope used to render silently as the type strip.
+  return assertNever(sc, "workspace scope");
 }
 
 function packageHeading() {
@@ -2574,22 +2580,24 @@ function packageHeading() {
   </header>`;
 }
 
-function packageLensPlaceholder(lensId: PackageLens) {
-  const copy = ({
-    dependencies: ["⌘", "Dependencies", "Package NuGet dependencies and assembly references. Wiring the engine export in a follow-up pass."]
-  } as Record<string, string[]>)[lensId]
-    || ["△", "Not available", "This package lens is not wired yet."];
-  return `<section class="document-section empty-document"><span class="large-glyph">${copy[0]}</span><h2>${escapeHtml(copy[1])}</h2><p>${escapeHtml(copy[2])}</p></section>`;
+function renderPackageView() {
+  const body = packageLensBody();
+  return `${packageHeading()}${body}`;
 }
 
-function renderPackageView() {
-  if (state.packageLens === "overview") return `${packageHeading()}${renderPackageOverview()}`;
-  if (state.packageLens === "dependencies") return `${packageHeading()}${renderPackageDependencies()}`;
-  if (state.packageLens === "integrations") return `${packageHeading()}${renderPackageIntegrations()}`;
-  if (state.packageLens === "opportunities") return `${packageHeading()}${renderPackageOpportunities()}`;
-  if (state.packageLens === "analysis") return `${packageHeading()}${renderPackagePerformance()}`;
-  if (state.packageLens === "metadata") return `${packageHeading()}${renderPackageMetadata()}`;
-  return `${packageHeading()}${packageLensPlaceholder(state.packageLens)}`;
+function packageLensBody() {
+  switch (state.packageLens) {
+    case "overview": return renderPackageOverview();
+    case "dependencies": return renderPackageDependencies();
+    case "integrations": return renderPackageIntegrations();
+    case "opportunities": return renderPackageOpportunities();
+    case "analysis": return renderPackagePerformance();
+    case "metadata": return renderPackageMetadata();
+  }
+  // `packageLenses` drives the rendered strip directly, so a new catalog entry is offered
+  // to users the moment it is added. It used to fall through to a "not available"
+  // placeholder here, which is indistinguishable from a lens that is wired but empty.
+  return assertNever(state.packageLens, "package lens");
 }
 
 function packageDependenciesSignature() {
@@ -4466,6 +4474,9 @@ function bindScopeBarEvents() {
         state.selectedOverloadIndex = null;
       } else if (target === "member") {
         enterMemberScope();
+      } else {
+        // A new scope used to be accepted here and then do nothing at all.
+        assertNever(target, "workspace scope");
       }
       render();
     },
@@ -6028,6 +6039,18 @@ function applyDeepLink(deep: DeepLink | null | undefined) {
 
 // Kick off the async data load implied by the current lens/section so a restored or
 // history-navigated view fills in its content.
+// Returns the loader for a type-level lens, or the sentinel `"member"` when the lens
+// defers to the member-section loaders below. A new type lens used to fall through the
+// `state.lens !== "api"` test and silently fetch nothing.
+function loadSelectedTypeLensData(): Promise<void> | undefined | "member" {
+  switch (state.lens) {
+    case "source": return loadSelectedTypeSource();
+    case "metadata": return loadSelectedTypeMetadata();
+    case "api": return "member";
+  }
+  return assertNever(state.lens, "type lens");
+}
+
 function loadSelectionData() {
   if (state.pendingGraphMemberDeepLink
     && !graphMemberPendingMatchesView(
@@ -6040,13 +6063,9 @@ function loadSelectionData() {
     return restorePendingGraphMember();
   }
   if (state.atPackageRoot) return undefined;
-  if (state.lens === "source") {
-    return loadSelectedTypeSource();
-  }
-  if (state.lens === "metadata") {
-    return loadSelectedTypeMetadata();
-  }
-  if (state.lens !== "api" || !state.selectedMemberKey) return undefined;
+  const typeLensLoad = loadSelectedTypeLensData();
+  if (typeLensLoad !== "member") return typeLensLoad;
+  if (!state.selectedMemberKey) return undefined;
   const member = selectedMember(selectedType());
   if (!member) return undefined;
   if (member.overloads.length > 1 && state.selectedOverloadIndex == null) return undefined;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1066,16 +1066,19 @@ function applyView(view: WorkspaceView) {
   }
   navigationHistory.normalizeCurrent();
   if (!state.atPackageRoot && state.lens === "api" && state.selectedMemberKey && member) {
-    if (state.memberSection === "source")
+    const section = state.memberSection;
+    if (section === "source")
       observeAsync(loadSelectedMemberSource(), "Loading member source");
-    else if (state.memberSection === "annotated")
+    else if (section === "annotated")
       observeAsync(loadSelectedMemberAnnotatedSource(), "Loading annotated member source");
-    else if (state.memberSection === "call-graph")
+    else if (section === "call-graph")
       observeAsync(loadSelectedMemberCallGraph(), "Loading the member call graph");
-    else if (state.memberSection === "facts")
+    else if (section === "facts")
       observeAsync(loadSelectedMemberFacts(), "Loading member facts");
-    else
+    else if (section === "overview")
       observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
+    else
+      assertNever(section, "member section");
   } else {
     render();
   }
@@ -1930,6 +1933,28 @@ function scope(): WorkspaceScope {
   return memberScopeIsActive(state, selectedType()?.id) ? "member" : "type";
 }
 
+function selectScopeLensByIndex(index: number, workspaceScope: WorkspaceScope): void {
+  if (workspaceScope === "package") {
+    const selected = packageLensesFor(state.package)[index];
+    if (selected) {
+      state.packageLens = selected[0];
+      render();
+    }
+  } else if (workspaceScope === "type") {
+    const selected = typeLensesFor(state.package)[index];
+    if (selected) {
+      state.lens = selected[0];
+      render();
+    }
+  } else if (workspaceScope === "member") {
+    const member = selectedMember(selectedType());
+    const selected = member ? memberSectionsFor(member)[index] : undefined;
+    if (selected) applyMemberSection(selected[0]);
+  } else {
+    assertNever(workspaceScope, "workspace scope");
+  }
+}
+
 // The resident runtime pseudo-package (Microsoft.NETCore.App) has no NuGet nupkg, so the
 // package lenses that fetch one would 404. Integrations and Opportunities scan a
 // selected library through the content-backed platform workspace; dependencies remain
@@ -2056,7 +2081,8 @@ function applyMemberSection(id: MemberSection) {
     observeAsync(loadSelectedMemberFacts(), "Loading member facts");
   else if (id === "overview")
     observeAsync(loadSelectedMemberDocumentation(), "Loading member documentation");
-  else render();
+  else
+    assertNever(id, "member section");
 }
 
 // Flattened, ordered nav rows for member mode: filtered public groups plus the selected
@@ -8961,25 +8987,7 @@ keybindings.register({
     && !event.metaKey
     && !event.ctrlKey,
   run: event => {
-    const index = Number(event.key) - 1;
-    const sc = scope();
-    if (sc === "package") {
-      const selected = packageLensesFor(state.package)[index];
-      if (selected) {
-        state.packageLens = selected[0];
-        render();
-      }
-    } else if (sc === "member") {
-      const member = selectedMember(selectedType());
-      const selected = member ? memberSectionsFor(member)[index] : undefined;
-      if (selected) applyMemberSection(selected[0]);
-    } else {
-      const selected = typeLensesFor(state.package)[index];
-      if (selected) {
-        state.lens = selected[0];
-        render();
-      }
-    }
+    selectScopeLensByIndex(Number(event.key) - 1, scope());
     return true;
   },
 });

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -3655,7 +3655,7 @@ function renderLens(item: AppTypeSurface | null | undefined) {
   }
 }
 
-function renderApiLens(item: BrowserTypeSurface) {
+function renderApiLens(item: AppTypeSurface) {
   const pending = state.pendingGraphMemberDeepLink;
   if (pending
     && graphMemberPendingMatchesView(
@@ -5842,7 +5842,9 @@ function captureWorkspaceUrlState(): WorkspaceUrlState | null {
     selectedTypeId: pending?.type ?? state.selectedTypeId,
     selectedMemberKey: pending?.member ?? state.selectedMemberKey,
     selectedOverloadIndex,
-    memberSection: pending?.section ?? state.memberSection,
+    memberSection: pending && isMemberSection(pending.section)
+      ? pending.section
+      : state.memberSection,
     selectedBodyTarget: pending ? null : state.selectedBodyTarget,
     graphTarget,
     memberBrowse: memberScopeIsActive(state, selectedType()?.id),

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -21,6 +21,8 @@ import {
   MARKDOWN_SANITIZE_OPTIONS,
   MAX_WORKSPACE_PACKAGES,
   memberRequestKey,
+  isMemberSection,
+  memberSectionDefinitions,
   memberSectionIdsFor,
   packageCoordinateMatchesLocation,
   packageForView,
@@ -56,6 +58,12 @@ import {
   type WorkspaceTab,
   uniqueTypeByQueryId,
   workspaceCoordinatesMatch
+} from "./data.ts";
+import type {
+  MemberSection,
+  PackageLens,
+  TypeLens,
+  WorkspaceScope,
 } from "./data.ts";
 import type { CommandPaletteResult } from "./command-bar.ts";
 import {
@@ -231,6 +239,7 @@ import {
   createSpotlight,
   type SpotlightPackageHit,
   type SpotlightResult,
+  type SpotlightScope,
   visibleSpotlightPackageHits,
 } from "./spotlight.ts";
 import { createSpotlightPackageSearch } from "./spotlight-package-search.ts";
@@ -513,12 +522,6 @@ interface Diagnostics {
   assets: number;
 }
 
-type MemberSection = "overview" | "source" | "annotated" | "call-graph" | "facts";
-
-function isMemberSection(value: string): value is MemberSection {
-  return memberSections.some(section => section === value);
-}
-
 function isAnnotatedMedium(value: string): value is (typeof MEDIA)[number] {
   return MEDIA.some(medium => medium === value);
 }
@@ -617,8 +620,8 @@ const initialState = {
   memberDocumentationLoading: false,
   memberDocumentationError: "",
   memberDocumentationKey: "",
-  lens: "api",
-  packageLens: "overview",
+  lens: "api" as const,
+  packageLens: "overview" as const,
   atPackageRoot: false,
   typeFilter: "",
   namespaceFilter: "",
@@ -630,7 +633,7 @@ const initialState = {
   spotlightOpen: false,
   spotlightQuery: "",
   spotlightIndex: 0,
-  spotlightScope: "all",
+  spotlightScope: "all" as const,
   spotlightFocus: "input" as const,
   spotlightChipIndex: 0,
   spotlightPkgHits: [],
@@ -710,7 +713,10 @@ interface StateOverrides {
   accessibilityFilter: Set<string>;
   spotlightPkgHits: SpotlightPackageHit[];
   spotlightFocus: "input" | "chips";
+  spotlightScope: SpotlightScope;
   memberSection: MemberSection;
+  lens: TypeLens;
+  packageLens: PackageLens;
   packageVersions: Record<string, string[]>;
   packageVersionsLoading: Record<string, boolean>;
   platformRecent: PlatformRecent[];
@@ -995,9 +1001,7 @@ function applyView(view: WorkspaceView) {
   state.memberTraitFilter = memberHistory.memberTraitFilter;
   state.memberTextFilter = memberHistory.memberTextFilter;
   state.selectedOverloadIndex = memberHistory.selectedOverloadIndex;
-  state.memberSection = isMemberSection(memberHistory.memberSection)
-    ? memberHistory.memberSection
-    : "overview";
+  state.memberSection = memberHistory.memberSection;
   state.atPackageRoot = view.atPackageRoot ?? false;
   state.packageLens = view.packageLens ?? "overview";
   state.memberSource = null;
@@ -1097,20 +1101,6 @@ function navForward() {
   navigationHistory.forward();
 }
 
-const memberSections: readonly MemberSection[] =
-  ["overview", "source", "annotated", "call-graph", "facts"];
-
-// Member-mode strip: the sections shown for an open member, in display order. Lives at
-// module scope because both the scope/lens strip (in render) and the member detail view
-// read it. Order here is the visual left-to-right order in the strip.
-const memberSectionDefs = [
-  ["overview", "Overview"],
-  ["call-graph", "Call graph"],
-  ["facts", "Facts"],
-  ["source", "Source"],
-  ["annotated", "Annotated source"]
-] as const;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -1121,7 +1111,7 @@ function memberSectionsFor(member: AppMemberGroup) {
       member,
       state.package?.isRuntimePack,
       memberHasSelectedBody(member)));
-  return memberSectionDefs.filter(([id]) => allowed.has(id));
+  return memberSectionDefinitions.filter(([id]) => allowed.has(id));
 }
 
 function memberHasSelectedBody(member: AppMemberGroup) {
@@ -1326,7 +1316,7 @@ function focusTypeList(generation = spotlightFocusGeneration) {
   });
 }
 
-function openSpotlight(seed = "", spotlightScope = "all") {
+function openSpotlight(seed = "", spotlightScope: SpotlightScope = "all") {
   if (state.loading || state.error) return;
   state.tasteOpen = false;
   beginSpotlightNavigation();
@@ -1934,7 +1924,7 @@ function selectedMember(type: BrowserTypeSurface | null | undefined) {
 // Selection sits on a scope ladder: package (a whole NuGet package / its assemblies),
 // type (one public type), or member (a member + its overloads under the API lens). The
 // lens strip, detail pane, and arrow keys all react to the active scope.
-function scope() {
+function scope(): WorkspaceScope {
   if (state.atPackageRoot) return "package";
   return memberScopeIsActive(state, selectedType()?.id) ? "member" : "type";
 }
@@ -1957,16 +1947,6 @@ function scopedPlatformLibrary() {
   if (state.libraryScope && state.libraryScope.size === 1)
     return state.libraryScope.values().next().value ?? null;
   return null;
-}
-
-function activeLenses() {
-  const sc = scope();
-  if (sc === "package") return packageLensesFor(state.package);
-  if (sc === "member") {
-    const member = selectedMember(selectedType());
-    return member ? memberSectionsFor(member) : [];
-  }
-  return typeLensesFor(state.package);
 }
 
 // The nav pane reacts to context: types at the top level, or the current type's
@@ -2593,7 +2573,7 @@ function packageHeading() {
   </header>`;
 }
 
-function packageLensPlaceholder(lensId: string) {
+function packageLensPlaceholder(lensId: PackageLens) {
   const copy = ({
     dependencies: ["⌘", "Dependencies", "Package NuGet dependencies and assembly references. Wiring the engine export in a follow-up pass."]
   } as Record<string, string[]>)[lensId]
@@ -4455,7 +4435,7 @@ function bindTypePanelEvents() {
 function bindScopeBarEvents() {
   bindScopeBar(document, {
     onMemberSectionSelect: section => {
-      if (section && isMemberSection(section)) applyMemberSection(section);
+      applyMemberSection(section);
     },
     onPackageLensSelect: lens => {
       state.packageLens = lens;
@@ -8928,16 +8908,24 @@ keybindings.register({
     && !event.metaKey
     && !event.ctrlKey,
   run: event => {
-    const set = activeLenses();
     const index = Number(event.key) - 1;
-    const selected = set[index];
-    if (selected) {
-      const [id] = selected;
-      const sc = scope();
-      if (sc === "package") { state.packageLens = id; render(); }
-      else if (sc === "member" && isMemberSection(id))
-        applyMemberSection(id);
-      else { state.lens = id; render(); }
+    const sc = scope();
+    if (sc === "package") {
+      const selected = packageLensesFor(state.package)[index];
+      if (selected) {
+        state.packageLens = selected[0];
+        render();
+      }
+    } else if (sc === "member") {
+      const member = selectedMember(selectedType());
+      const selected = member ? memberSectionsFor(member)[index] : undefined;
+      if (selected) applyMemberSection(selected[0]);
+    } else {
+      const selected = typeLensesFor(state.package)[index];
+      if (selected) {
+        state.lens = selected[0];
+        render();
+      }
     }
     return true;
   },

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2,6 +2,7 @@ import {
   accessibilityFilterIncludingType,
   activeSourceOperationKind,
   assemblyDescriptorForType,
+  assertNever,
   pdbSourceLimitationHtml,
   callGraphDiagnosticsMessage,
   callGraphTargetTypeId,
@@ -3606,9 +3607,23 @@ function renderTypeSourceHtml(item: BrowserTypeSurface) {
 function renderLens(item: AppTypeSurface | null | undefined) {
   if (state.atPackageRoot) return renderPackageView();
   if (!item) return "";
+  switch (state.lens) {
+    case "source":
+      return `
+      ${typeHeadingHtml(item)}
+      ${renderTypeSourceHtml(item)}`;
+    case "metadata":
+      return `${typeHeadingHtml(item)}${renderTypeMetadataHtml(item)}`;
+    case "api":
+      return renderApiLens(item);
+    default:
+      return assertNever(state.lens, "type lens");
+  }
+}
+
+function renderApiLens(item: BrowserTypeSurface) {
   const pending = state.pendingGraphMemberDeepLink;
-  if (state.lens === "api"
-    && pending
+  if (pending
     && graphMemberPendingMatchesView(
       pending,
       packageIdentityKey(state.package),
@@ -3619,8 +3634,8 @@ function renderLens(item: AppTypeSurface | null | undefined) {
     return renderGraphMemberPendingHtml(item, title);
   }
   const member = selectedMember(item);
-  if (state.lens === "api" && member) return renderMember(item, member);
-  if (state.lens === "api" && state.memberBrowseTypeId === item.id) {
+  if (member) return renderMember(item, member);
+  if (state.memberBrowseTypeId === item.id) {
     return `
       ${typeHeadingHtml(item)}
       <section class="document-section empty-document">
@@ -3628,14 +3643,6 @@ function renderLens(item: AppTypeSurface | null | undefined) {
         <h2>No member selected</h2>
         <p>Adjust the member filters or choose a member from the list.</p>
       </section>`;
-  }
-  if (state.lens === "source") {
-    return `
-      ${typeHeadingHtml(item)}
-      ${renderTypeSourceHtml(item)}`;
-  }
-  if (state.lens === "metadata") {
-    return `${typeHeadingHtml(item)}${renderTypeMetadataHtml(item)}`;
   }
   const { publicMembers, graphMembers } =
     partitionGraphMembers(item.api);
@@ -3856,7 +3863,7 @@ function renderMember(type: BrowserTypeSurface, member: AppMemberGroup) {
       : state.memberAnnotated
         ? renderAnnotatedSource(state.memberAnnotated)
         : `<section class="document-section empty-member-section"><h2>Annotated source query failed</h2><p>${escapeHtml(state.memberAnnotatedError || "No annotated source result was returned.")}</p></section>`;
-  } else {
+  } else if (state.memberSection === "source") {
     content = state.memberSourceLoading
       ? `<section class="document-section source-progress"><span class="loader"></span><h2>Resolving source…</h2><p>Trying PDB-checksum-verified source through SourceLink, then dotnet-inspect decompilation.</p></section>`
       : state.memberSource
@@ -3865,6 +3872,8 @@ function renderMember(type: BrowserTypeSurface, member: AppMemberGroup) {
             <pre class="language-csharp"><code class="language-csharp">${highlightCSharp(state.memberSource.text)}</code></pre>
           </section>`
         : `<section class="document-section empty-member-section"><h2>Source query failed</h2><p>${escapeHtml(state.memberSourceError || "No source result was returned.")}</p></section>`;
+  } else {
+    assertNever(state.memberSection, "member section");
   }
   // The member-mode strip (Overview / Call graph / Facts / Source / Annotated) now lives in
   // the top scope+lens bar, so the detail view renders only the section content itself.
@@ -5059,47 +5068,69 @@ function mostRecentAvailableLibrary() {
 // In "all" each group is capped so every target stays visible; a focused scope shows a
 // deeper single-target list. Loaded packages rank ahead of NuGet discovery hits, which
 // exclude anything already open.
+function runtimeSpotlightResults(query: string): SpotlightResult[] {
+  const results: SpotlightResult[] = [];
+  if (state.runtimePackLoading) {
+    results.push({ kind: "rtpack-status", loading: true });
+    return results;
+  }
+  if (state.runtimePackError && !runtimePackLoaded()) {
+    results.push({ kind: "rtpack-status", error: state.runtimePackError });
+  }
+  // Index-first: the platform library roster needs no pack download. Selecting
+  // "Platform" instantly lists the CoreCLR + ASP.NET Core libraries the static
+  // index knows for the active framework, filterable by name.
+  const roster = platformLibraryRoster(query);
+  for (const lib of roster.slice(0, 200)) {
+    results.push({ ...lib, kind: "platform-lib" });
+  }
+  // Once a pack is resident, blend its type/member matches so drilled-in
+  // platform content stays searchable alongside the library roster.
+  if (platformSurfaceLoaded()) {
+    const typeSource = query ? spotlightTypeMatches(query) : [];
+    for (const match of typeSource.filter(item => item.pkg?.isRuntimePack).slice(0, 50)) {
+      results.push({ ...match, kind: "type" });
+    }
+    if (query) {
+      for (const match of spotlightMemberMatches(query).filter(item => item.pkg?.isRuntimePack).slice(0, 50)) {
+        results.push({ ...match, kind: "member" });
+      }
+    }
+  }
+  // Only when the static index is unavailable do we fall back to the old
+  // download-first prompt, so the scope is never empty and inert.
+  if (!roster.length && !runtimePackLoaded()) {
+    results.push({ kind: "rtpack-suggest" });
+  }
+  return results;
+}
+
 function spotlightResults(): SpotlightResult[] {
   const query = state.spotlightQuery.trim();
   const spotlightScope = state.spotlightScope;
+  // Exhaustive scope dispatch. "all" blends the package, type and member scopes, so those four
+  // arms share the composed body below instead of each owning a renderer. Adding an entry to the
+  // spotlight scope catalog offers it to users immediately, so it must fail compilation here
+  // until it declares which of these shapes it is.
+  switch (spotlightScope) {
+    case "runtime":
+      return runtimeSpotlightResults(query);
+    case "commands":
+      // `spotlight.ts` answers the command scope from the command palette and never delegates
+      // here. Reaching this arm means that interception was removed, which is a wiring failure
+      // and not an empty result set.
+      throw new Error("Spotlight delegated the command scope to the workspace search results.");
+    case "all":
+    case "packages":
+    case "types":
+    case "members":
+      break;
+    default:
+      return assertNever(spotlightScope, "spotlight scope");
+  }
+
   const all = spotlightScope === "all";
   const results: SpotlightResult[] = [];
-
-  if (spotlightScope === "runtime") {
-    if (state.runtimePackLoading) {
-      results.push({ kind: "rtpack-status", loading: true });
-      return results;
-    }
-    if (state.runtimePackError && !runtimePackLoaded()) {
-      results.push({ kind: "rtpack-status", error: state.runtimePackError });
-    }
-    // Index-first: the platform library roster needs no pack download. Selecting
-    // "Platform" instantly lists the CoreCLR + ASP.NET Core libraries the static
-    // index knows for the active framework, filterable by name.
-    const roster = platformLibraryRoster(query);
-    for (const lib of roster.slice(0, 200)) {
-      results.push({ ...lib, kind: "platform-lib" });
-    }
-    // Once a pack is resident, blend its type/member matches so drilled-in
-    // platform content stays searchable alongside the library roster.
-    if (platformSurfaceLoaded()) {
-      const typeSource = query ? spotlightTypeMatches(query) : [];
-      for (const match of typeSource.filter(item => item.pkg?.isRuntimePack).slice(0, 50)) {
-        results.push({ ...match, kind: "type" });
-      }
-      if (query) {
-        for (const match of spotlightMemberMatches(query).filter(item => item.pkg?.isRuntimePack).slice(0, 50)) {
-          results.push({ ...match, kind: "member" });
-        }
-      }
-    }
-    // Only when the static index is unavailable do we fall back to the old
-    // download-first prompt, so the scope is never empty and inert.
-    if (!roster.length && !runtimePackLoaded()) {
-      results.push({ kind: "rtpack-suggest" });
-    }
-    return results;
-  }
 
   if (all || spotlightScope === "packages") {
     const loaded = spotlightLoadedPackageMatches(query).slice(0, all ? 3 : 20);
@@ -6019,11 +6050,14 @@ function loadSelectionData() {
   const member = selectedMember(selectedType());
   if (!member) return undefined;
   if (member.overloads.length > 1 && state.selectedOverloadIndex == null) return undefined;
-  if (state.memberSection === "source") return loadSelectedMemberSource();
-  if (state.memberSection === "annotated") return loadSelectedMemberAnnotatedSource();
-  if (state.memberSection === "call-graph") return loadSelectedMemberCallGraph();
-  if (state.memberSection === "facts") return loadSelectedMemberFacts();
-  return loadSelectedMemberDocumentation();
+  switch (state.memberSection) {
+    case "source": return loadSelectedMemberSource();
+    case "annotated": return loadSelectedMemberAnnotatedSource();
+    case "call-graph": return loadSelectedMemberCallGraph();
+    case "facts": return loadSelectedMemberFacts();
+    case "overview": return loadSelectedMemberDocumentation();
+    default: return assertNever(state.memberSection, "member section");
+  }
 }
 
 async function share() {

--- a/prototypes/inspect-web/src/member-filtering.ts
+++ b/prototypes/inspect-web/src/member-filtering.ts
@@ -1,3 +1,4 @@
+import type { MemberSection, TypeLens } from "./data.ts";
 import type { MemberGroup, MemberOverloadSummary } from "./type-panel.ts";
 
 export const MEMBER_TRAITS = [
@@ -68,7 +69,7 @@ export function filterMemberGroups(
 
 export interface MemberScopeState {
   atPackageRoot: boolean;
-  lens: string;
+  lens: TypeLens;
   selectedMemberKey: string;
   memberBrowseTypeId: string;
 }
@@ -218,7 +219,7 @@ export interface MemberHistoryView {
   memberTraitFilter?: string;
   memberTextFilter?: string;
   selectedOverloadIndex?: number | null;
-  memberSection?: string;
+  memberSection?: MemberSection;
   bodyTarget?: BodyTarget | null;
 }
 
@@ -239,7 +240,7 @@ export interface RestoredMemberHistoryState {
   memberTraitFilter: string;
   memberTextFilter: string;
   selectedOverloadIndex: number | null;
-  memberSection: string;
+  memberSection: MemberSection;
   selectedBodyTarget: BodyTarget | null;
 }
 
@@ -247,7 +248,7 @@ export function restoreMemberHistoryState(
   view: MemberHistoryView,
   type: MemberHistoryType | null | undefined,
   member: MemberHistoryMember | null | undefined,
-  memberSectionIds: readonly string[] = [],
+  memberSectionIds: readonly MemberSection[] = [],
 ): RestoredMemberHistoryState {
   const restoreMemberScope = Boolean(type)
     && view.memberBrowseTypeId === type!.id

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -1,6 +1,7 @@
 import {
   packageIdentityKey,
   type DependencyGroupData,
+  type PackageLens,
   type PackageIdentity,
 } from "./data.ts";
 import type {
@@ -32,7 +33,7 @@ export interface PackagePerformance {
 export interface PackageInspectionState {
   packages: AppPackage[];
   atPackageRoot: boolean;
-  packageLens: string;
+  packageLens: PackageLens;
   packageDependencies: BrowserPackageDependencies | null;
   packageDependenciesLoading: boolean;
   packageDependenciesError: string;

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -1,9 +1,18 @@
+import {
+  isMemberSection,
+  isPackageLens,
+  isTypeLens,
+  isWorkspaceScope,
+  type MemberSection,
+  type PackageLens,
+  type TypeLens,
+  type WorkspaceScope,
+} from "./data.ts";
+
 type LensDefinition = readonly [id: string, label: string];
 
-type Scope = "package" | "type" | "member";
-
 export interface RenderScopeBarOptions {
-  scope: Scope;
+  scope: WorkspaceScope;
   strip: readonly LensDefinition[];
   activeStripId: string | null;
   stripAttribute: string;
@@ -13,10 +22,10 @@ export interface RenderScopeBarOptions {
 }
 
 export interface ScopeBarBindingActions {
-  onMemberSectionSelect: (section: string | undefined) => void;
-  onPackageLensSelect: (lens: string) => void;
-  onScopeSelect: (scope: string | undefined) => void;
-  onTypeLensSelect: (lens: string) => void;
+  onMemberSectionSelect: (section: MemberSection) => void;
+  onPackageLensSelect: (lens: PackageLens) => void;
+  onScopeSelect: (scope: WorkspaceScope) => void;
+  onTypeLensSelect: (lens: TypeLens) => void;
 }
 
 export function bindScopeBar(
@@ -24,22 +33,25 @@ export function bindScopeBar(
   actions: ScopeBarBindingActions,
 ) {
   root.querySelectorAll<HTMLElement>("[data-scope]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => actions.onScopeSelect(button.dataset.scope)));
+    button.addEventListener("click", () => {
+      const scope = button.dataset.scope;
+      if (isWorkspaceScope(scope)) actions.onScopeSelect(scope);
+    }));
   root.querySelectorAll<HTMLElement>("[data-package-lens]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => actions.onPackageLensSelect(
-        button.dataset.packageLens ?? "overview")));
+    button.addEventListener("click", () => {
+      const lens = button.dataset.packageLens;
+      if (isPackageLens(lens)) actions.onPackageLensSelect(lens);
+    }));
   root.querySelectorAll<HTMLElement>("[data-lens]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => actions.onTypeLensSelect(button.dataset.lens ?? "api")));
+    button.addEventListener("click", () => {
+      const lens = button.dataset.lens;
+      if (isTypeLens(lens)) actions.onTypeLensSelect(lens);
+    }));
   root.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button =>
-    button.addEventListener(
-      "click",
-      () => actions.onMemberSectionSelect(button.dataset.memberSection)));
+    button.addEventListener("click", () => {
+      const section = button.dataset.memberSection;
+      if (isMemberSection(section)) actions.onMemberSectionSelect(section);
+    }));
 }
 
 function lensButton(

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -9,12 +9,17 @@ import {
   type WorkspaceScope,
 } from "./data.ts";
 
-type LensDefinition = readonly [id: string, label: string];
+type LensDefinition<TId extends string = string> = readonly [id: TId, label: string];
 
-export interface RenderScopeBarOptions {
+// `TId` is inferred from the strip catalog, so the active id has to be a member of the
+// strip being rendered. A `string` there let a caller pass an id no button carries, which
+// renders a strip with nothing active and no failure anywhere. `NoInfer` keeps the strip
+// as the sole inference site; without it TypeScript infers the union of both and a
+// mismatched pair type-checks.
+export interface RenderScopeBarOptions<TId extends string = string> {
   scope: WorkspaceScope;
-  strip: readonly LensDefinition[];
-  activeStripId: string | null;
+  strip: readonly LensDefinition<TId>[];
+  activeStripId: NoInfer<TId> | null;
   stripAttribute: string;
   showMemberScope?: boolean;
   emptyStripLabel?: string;
@@ -75,7 +80,9 @@ function scopeSegment(id: string, label: string, active: boolean): string {
 //   package → package lenses   type → type lenses   member → member sections
 // Keeping all three families of buttons on one strip means the member modes (Overview,
 // Call graph, …) live here too instead of inside the detail pane.
-export function renderScopeBar(options: RenderScopeBarOptions): string {
+export function renderScopeBar<TId extends string>(
+  options: RenderScopeBarOptions<TId>,
+): string {
   const {
     scope,
     strip,

--- a/prototypes/inspect-web/src/spotlight-package-search.ts
+++ b/prototypes/inspect-web/src/spotlight-package-search.ts
@@ -1,8 +1,11 @@
-import type { SpotlightPackageHit } from "./spotlight.ts";
+import type {
+  SpotlightPackageHit,
+  SpotlightScope,
+} from "./spotlight.ts";
 
 export interface SpotlightPackageSearchState {
   spotlightQuery: string;
-  spotlightScope: string;
+  spotlightScope: SpotlightScope;
   spotlightPkgHits: SpotlightPackageHit[];
   spotlightPkgQuery: string;
   spotlightPkgLoading: boolean;

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -98,7 +98,7 @@ export interface SpotlightState {
   spotlightOpen: boolean;
   spotlightQuery: string;
   spotlightIndex: number;
-  spotlightScope: string;
+  spotlightScope: SpotlightScope;
   spotlightFocus: SpotlightFocus;
   spotlightChipIndex: number;
 }
@@ -139,6 +139,10 @@ const BASE_SCOPES = [
 ] as const;
 
 const COMMAND_SCOPE = { id: "commands", label: "Commands" } as const;
+
+export type SpotlightScope =
+  | (typeof BASE_SCOPES)[number]["id"]
+  | typeof COMMAND_SCOPE.id;
 const PLATFORM_PACK_LABEL: Readonly<Record<string, string>> = {
   "netcore.app": ".NET",
   "aspnetcore.app": "ASP.NET Core",
@@ -483,8 +487,8 @@ export function createSpotlight(options: SpotlightOptions) {
   function bindChipClicks(root: ParentNode): void {
     root.querySelectorAll<HTMLElement>("[data-sl-scope]").forEach(button => {
       button.addEventListener("click", () => {
-        const scope = button.dataset.slScope;
-        if (scope !== undefined) setScope(scope);
+        const scope = availableScope(button.dataset.slScope);
+        if (scope !== null) setScope(scope);
       });
     });
   }
@@ -531,7 +535,11 @@ export function createSpotlight(options: SpotlightOptions) {
     updateResults();
   }
 
-  function setScope(scope: string): void {
+  function availableScope(scope: string | undefined): SpotlightScope | null {
+    return scopes().find(item => item.id === scope)?.id ?? null;
+  }
+
+  function setScope(scope: SpotlightScope): void {
     const available = scopes();
     if (!available.some(item => item.id === scope)) return;
     state.spotlightScope = scope;
@@ -565,9 +573,7 @@ export function createSpotlight(options: SpotlightOptions) {
     options.resetPackageSearch();
     state.spotlightOpen = true;
     state.spotlightQuery = seed;
-    state.spotlightScope = scopes().some(item => item.id === scope)
-      ? scope
-      : "all";
+    state.spotlightScope = availableScope(scope) ?? "all";
     state.spotlightFocus = "input";
     state.spotlightChipIndex = 0;
     state.spotlightIndex = 0;

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -568,7 +568,7 @@ export function createSpotlight(options: SpotlightOptions) {
     options.focusAfterDismiss?.();
   }
 
-  function open(seed = "", scope = "all"): void {
+  function open(seed = "", scope: SpotlightScope = "all"): void {
     interactionGeneration++;
     options.resetPackageSearch();
     state.spotlightOpen = true;

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -1,15 +1,19 @@
 import {
   graphMemberShareTarget,
   graphMemberTargetFromPacket,
-  lenses,
+  isMemberSection,
+  isPackageLens,
+  isTypeLens,
   normalizeShareTabs,
-  packageLenses,
   platformPackToken,
   replaceCurrentNavigationEntry,
   shareStateLengthError,
+  type MemberSection,
+  type PackageLens,
   type PlatformPack,
   type GraphMemberShareIdentity,
   type GraphMemberShareTarget,
+  type TypeLens,
   type WorkspaceTab,
 } from "./data.ts";
 import {
@@ -24,7 +28,7 @@ import {
 export interface WorkspaceView {
   package: string;
   packageKey: string;
-  lens: string;
+  lens: TypeLens;
   selectedTypeId: string;
   selectedMemberKey: string;
   memberBrowseTypeId: string;
@@ -34,9 +38,9 @@ export interface WorkspaceView {
   memberTextFilter: string;
   selectedOverloadIndex: number | null;
   bodyTarget: BodyTarget | null;
-  memberSection: string;
+  memberSection: MemberSection;
   atPackageRoot: boolean;
-  packageLens: string;
+  packageLens: PackageLens;
   libraryScope: string[] | null;
 }
 
@@ -253,7 +257,7 @@ export interface WorkspaceDeepLink {
   type?: string | null;
   member?: string | null;
   overload?: string | null;
-  section?: string | null;
+  section?: MemberSection | null;
   bodyTarget?: BodyTarget | null;
   memberBrowse?: boolean;
   memberTextFilter?: string;
@@ -267,15 +271,15 @@ export interface WorkspaceUrlState {
   package: string;
   tabs: WorkspaceTab[];
   active: number;
-  lens: string;
+  lens: TypeLens;
   atPackageRoot: boolean;
-  packageLens: string;
+  packageLens: PackageLens;
   library: string | null;
   libraryPack: PlatformPack | null;
   selectedTypeId: string;
   selectedMemberKey: string;
   selectedOverloadIndex: number | null;
-  memberSection: string;
+  memberSection: MemberSection;
   selectedBodyTarget: BodyTarget | null;
   graphTarget: GraphMemberShareIdentity | null;
   memberBrowse: boolean;
@@ -312,7 +316,7 @@ interface DecodedShareState {
   type: string | null;
   member: string | null;
   overload: string | null;
-  section: string | null;
+  section: MemberSection | null;
   bodyTarget: BodyTarget | null;
   library: string | null;
   libraryPack: PlatformPack | null;
@@ -467,7 +471,9 @@ function decodeWorkspaceShareState(value: string | null): ShareStateResult {
         overload: typeof raw.o === "string" || typeof raw.o === "number"
           ? String(raw.o)
           : null,
-        section: typeof raw.c === "string" ? raw.c : null,
+        section: typeof raw.c === "string" && isMemberSection(raw.c)
+          ? raw.c
+          : null,
         bodyTarget: decodeBodyTarget(raw.d),
         library: typeof raw.l === "string" ? raw.l : null,
         libraryPack: platformPackToken(raw.p),
@@ -485,14 +491,19 @@ function decodeWorkspaceShareState(value: string | null): ShareStateResult {
   }
 }
 
-function resolveView(token: string) {
+function resolveView(token: string): {
+  lens: TypeLens | null;
+  atPackageRoot: boolean;
+  packageLens: PackageLens | null;
+} {
   const atPackageRoot = token === "pkg" || token.startsWith("pkg:");
+  const packageLensToken = atPackageRoot ? token.split(":")[1] : undefined;
   return {
-    lens: lenses.some(([id]) => id === token) ? token : null,
+    lens: isTypeLens(token) ? token : null,
     atPackageRoot,
     packageLens: atPackageRoot
-      ? (packageLenses.some(([id]) => id === token.split(":")[1])
-        ? token.split(":")[1]
+      ? (isPackageLens(packageLensToken)
+        ? packageLensToken
         : "overview")
       : null,
   };
@@ -521,7 +532,10 @@ export function parseWorkspaceLocation(location: WorkspaceLocationSnapshot) {
   let type = params.get("type");
   let member = params.get("member");
   let overload = params.get("overload");
-  let section = params.get("section");
+  const sectionToken = params.get("section");
+  let section: MemberSection | null = isMemberSection(sectionToken)
+    ? sectionToken
+    : null;
   let bodyTarget: BodyTarget | null = null;
   let viewToken = location.hash.slice(1);
   let tabs: WorkspaceTab[] = [];

--- a/prototypes/inspect-web/test/member-filtering.test.ts
+++ b/prototypes/inspect-web/test/member-filtering.test.ts
@@ -103,7 +103,7 @@ test("history rejects a missing member and stale overload body", () => {
     memberTraitFilter: "",
     memberTextFilter: "",
     selectedOverloadIndex: 4,
-    memberSection: "source",
+    memberSection: "source" as const,
     bodyTarget: {
       metadataToken: 99,
       memberName: "Build",
@@ -207,7 +207,7 @@ test("member search covers names and signatures", () => {
 test("member scope follows the resolved type identity", () => {
   const state = {
     atPackageRoot: false,
-    lens: "api",
+    lens: "api" as const,
     selectedMemberKey: "",
     memberBrowseTypeId: "Type0",
     selectedTypeId: null,

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -128,6 +128,43 @@ test("scope bar binding tolerates an empty strip", () => {
     recordingActions([])));
 });
 
+test("scope bar bindings ignore missing and unknown dataset values", () => {
+  const root = new FakeRoot();
+  root.add(
+    "[data-scope]",
+    new FakeElement(),
+    new FakeElement({ scope: "assembly" }));
+  root.add(
+    "[data-package-lens]",
+    new FakeElement(),
+    new FakeElement({ packageLens: "files" }));
+  root.add(
+    "[data-lens]",
+    new FakeElement(),
+    new FakeElement({ lens: "implementation" }));
+  root.add(
+    "[data-member-section]",
+    new FakeElement(),
+    new FakeElement({ memberSection: "history" }));
+  const calls: string[] = [];
+  bindScopeBar(
+    fakeDom.parentNode(root),
+    recordingActions(calls));
+
+  for (const selector of [
+    "[data-scope]",
+    "[data-package-lens]",
+    "[data-lens]",
+    "[data-member-section]",
+  ]) {
+    for (const element of root.querySelectorAll(selector)) {
+      element.dispatch("click");
+    }
+  }
+
+  assert.deepEqual(calls, []);
+});
+
 test("package scope marks only the package segment and the active package lens", () => {
   const html = renderScopeBar({
     scope: "package",

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1892,15 +1892,17 @@ test("global workbench shortcuts respect the topmost modal", () => {
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {
-  // The type-lens arm of this dispatch lives in `loadSelectedTypeLensData`, which
-  // `loadSelectionData` delegates to; take both bodies so the claim is about the whole
-  // dispatch rather than one function's text.
+  const typeLensLoader =
+    appSource.match(/function loadSelectedTypeLensData\([\s\S]*?\n}/)?.[0];
   const selectionLoader =
-    (appSource.match(/function loadSelectedTypeLensData\([\s\S]*?\n}/)?.[0] ?? "")
-    + (appSource.match(/function loadSelectionData\(\)[\s\S]*?\n}/)?.[0] ?? "");
-  assert.match(selectionLoader, /return loadSelectedTypeSource\(\)/);
-  assert.match(selectionLoader, /return loadSelectedTypeMetadata\(\)/);
-  assert.match(selectionLoader, /loadSelectedTypeLensData\(\)/);
+    appSource.match(/function loadSelectionData\(\)[\s\S]*?\n}/)?.[0];
+  assert.ok(typeLensLoader);
+  assert.ok(selectionLoader);
+  assert.match(typeLensLoader, /return loadSelectedTypeSource\(\)/);
+  assert.match(typeLensLoader, /return loadSelectedTypeMetadata\(\)/);
+  assert.match(
+    selectionLoader,
+    /const typeLensLoad = loadSelectedTypeLensData\(\);\s*if \(typeLensLoad !== "member"\) return typeLensLoad;/);
   assert.match(
     appSource,
     /async function loadPackageFromSpotlight[\s\S]*await loadPackage\([\s\S]*focusTypeList\(focusGeneration\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -42,6 +42,7 @@ import {
   MAX_SHARE_STATE_CHARACTERS,
   MAX_WORKSPACE_PACKAGES,
   memberRequestKey,
+  memberSectionDefinitions,
   memberSectionIdsFor,
   mergeInspectionErrors,
   mermaidLabel,
@@ -2243,9 +2244,13 @@ test("lens-scoped Platform library changes reset type-specific member state", ()
 });
 
 test("Platform Spotlight distinguishes resident content from core readiness", () => {
+  // The runtime scope moved out of `spotlightResults` into its own renderer when the
+  // scope dispatch became exhaustive, so this scans the function that now owns the two
+  // predicates rather than the one that used to.
   const results =
-    appSource.match(/function spotlightResults\(\): SpotlightResult\[\] \{[\s\S]*?\n}\n\ninterface NugetSearchResult/)?.[0]
+    appSource.match(/function runtimeSpotlightResults\(query: string\): SpotlightResult\[\] \{[\s\S]*?\n}\n/)?.[0]
     ?? "";
+  assert.ok(results, "runtimeSpotlightResults was not found");
   assert.match(
     results,
     /if \(platformSurfaceLoaded\(\)\) \{[\s\S]*spotlightTypeMatches\(query\)/);
@@ -2932,6 +2937,17 @@ test("MethodDef-only member sections are hidden for bodiless APIs", () => {
   assert.deepEqual(
     memberSectionIdsFor({ kind: "method" }),
     ["overview", "call-graph", "facts", "source", "annotated"]);
+});
+
+// `memberSectionIdsFor` is the admission set for the member strip, for the URL `?section=`
+// token, and for the share packet's `c` token, so a section the catalog defines but this
+// function omits is defined and never reachable. It used to restate the roster, which the
+// compiler could not check in that direction. This is the gate for it deriving instead:
+// restoring a hand-written list makes a catalog addition stop appearing here.
+test("the full member-section roster is derived from the catalog, not restated", () => {
+  assert.deepEqual(
+    memberSectionIdsFor({ kind: "method" }),
+    memberSectionDefinitions.map(([id]) => id));
 });
 
 test("source requests carry exact type and member identities", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -3948,7 +3948,7 @@ test("restored views reconcile normalization before rendering", () => {
     /graphSelection\?\.group\.key !== view\.selectedMemberKey\) \{[\s\S]*?navigationHistory\.normalizeCurrent\(\);[\s\S]*?restorePendingGraphMember\(\)/);
   assert.match(
     apply,
-    /state\.memberSection = isMemberSection\(memberHistory\.memberSection\)[\s\S]*?memberHistory\.memberSection[\s\S]*?navigationHistory\.normalizeCurrent\(\);/);
+    /state\.memberSection = memberHistory\.memberSection;[\s\S]*?navigationHistory\.normalizeCurrent\(\);/);
 });
 
 test("ambiguous call graph targets expose a visible refusal", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1282,13 +1282,7 @@ test("typed scope bar owns its rendered control bindings", () => {
   const memberSection = callbackProperty(actions, "onMemberSectionSelect");
   assert.deepEqual(
     statementSignatures(memberSection.body.body),
-    [
-      {
-        if: "section && isMemberSection(section)",
-        whenTrue: ["call:applyMemberSection(section)"],
-        whenFalse: [],
-      },
-    ]);
+    ["call:applyMemberSection(section)"]);
 
   const packageLens = callbackProperty(actions, "onPackageLensSelect");
   assert.deepEqual(
@@ -1857,7 +1851,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /id: "taste\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.popover[\s\S]*state\.tasteOpen = false/);
   assert.match(
     appSource,
-    /function openSpotlight\(seed = "", spotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
+    /function openSpotlight\(seed = "", spotlightScope: SpotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
   assert.match(
     spotlightSource,
     /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(\);/);
@@ -2373,7 +2367,7 @@ test("history validates saved type and member identity before restoring Member s
     /state\.selectedTypeId = type\?\.id \?\? pkg\.types\[0\]\?\.id \?\? "";[\s\S]*state\.selectedMemberKey = memberHistory\.selectedMemberKey;[\s\S]*state\.memberBrowseTypeId = memberHistory\.memberBrowseTypeId;[\s\S]*state\.memberKindFilter = memberHistory\.memberKindFilter;[\s\S]*state\.memberAccessibilityFilter = memberHistory\.memberAccessibilityFilter;[\s\S]*state\.memberTraitFilter = memberHistory\.memberTraitFilter;[\s\S]*state\.memberTextFilter = memberHistory\.memberTextFilter/);
   assert.match(
     applyView,
-    /state\.selectedOverloadIndex = memberHistory\.selectedOverloadIndex;[\s\S]*state\.memberSection = isMemberSection\(memberHistory\.memberSection\)[\s\S]*\? memberHistory\.memberSection[\s\S]*state\.selectedBodyTarget = memberHistory\.selectedBodyTarget/);
+    /state\.selectedOverloadIndex = memberHistory\.selectedOverloadIndex;[\s\S]*state\.memberSection = memberHistory\.memberSection;[\s\S]*state\.selectedBodyTarget = memberHistory\.selectedBodyTarget/);
   assert.match(
     applyView,
     /navigationHistory\.normalizeCurrent\(\);[\s\S]*loadSelectedMemberSource\(\)[\s\S]*else \{\s*render\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1325,7 +1325,9 @@ test("typed scope bar owns its rendered control bindings", () => {
               {
                 if: 'target === "member"',
                 whenTrue: ["call:enterMemberScope()"],
-                whenFalse: [],
+                // A scope this dispatch does not handle is now a compile error rather
+                // than a silently ignored click.
+                whenFalse: ['call:assertNever(target, "workspace scope")'],
               },
             ],
           },
@@ -1890,11 +1892,15 @@ test("global workbench shortcuts respect the topmost modal", () => {
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {
+  // The type-lens arm of this dispatch lives in `loadSelectedTypeLensData`, which
+  // `loadSelectionData` delegates to; take both bodies so the claim is about the whole
+  // dispatch rather than one function's text.
   const selectionLoader =
-    appSource.match(/function loadSelectionData\(\)[\s\S]*?\n}/)?.[0]
-    ?? "";
+    (appSource.match(/function loadSelectedTypeLensData\([\s\S]*?\n}/)?.[0] ?? "")
+    + (appSource.match(/function loadSelectionData\(\)[\s\S]*?\n}/)?.[0] ?? "");
   assert.match(selectionLoader, /return loadSelectedTypeSource\(\)/);
   assert.match(selectionLoader, /return loadSelectedTypeMetadata\(\)/);
+  assert.match(selectionLoader, /loadSelectedTypeLensData\(\)/);
   assert.match(
     appSource,
     /async function loadPackageFromSpotlight[\s\S]*await loadPackage\([\s\S]*focusTypeList\(focusGeneration\)/);

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -7,7 +7,11 @@ import {
   nextSpotlightSelection,
   visibleSpotlightPackageHits,
 } from "../src/spotlight.ts";
-import type { SpotlightResult, SpotlightState } from "../src/spotlight.ts";
+import type {
+  SpotlightResult,
+  SpotlightScope,
+  SpotlightState,
+} from "../src/spotlight.ts";
 import type { CommandContext } from "../src/command-bar.ts";
 import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import { fakeDom } from "./fake-dom.ts";
@@ -21,7 +25,7 @@ function escapeHtml(value: unknown) {
 }
 
 interface HarnessOptions {
-  scope?: string;
+  scope?: SpotlightScope;
   query?: string;
   commandContext?: CommandContext | null;
   focusAfterDismiss?: () => void;

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -15,6 +15,7 @@ import type {
 import type { CommandContext } from "../src/command-bar.ts";
 import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import { fakeDom } from "./fake-dom.ts";
+import type { TypeLens } from "../src/data.ts";
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -102,6 +103,35 @@ function createHarness({
     focusAfterDismiss,
   });
   return { keybindings, spotlight, state };
+}
+
+// open() ends by scheduling input focus through the real DOM. These tests are about
+// scope admission, so they install the minimal focus target and restore it after.
+function withStubbedFocusTarget(body: () => void): void {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const globals = globalThis as unknown as {
+    document?: Document;
+    requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  };
+  const previousDocument = globals.document;
+  const previousRequestAnimationFrame = globals.requestAnimationFrame;
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  globals.document = { querySelector: () => null } as unknown as Document;
+  globals.requestAnimationFrame = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  };
+  try {
+    body();
+  } finally {
+    if (previousDocument === undefined) delete globals.document;
+    else globals.document = previousDocument;
+    if (previousRequestAnimationFrame === undefined) {
+      delete globals.requestAnimationFrame;
+    } else {
+      globals.requestAnimationFrame = previousRequestAnimationFrame;
+    }
+  }
 }
 
 const packageContext: CommandContext["package"] = {
@@ -299,7 +329,7 @@ test("workspace Spotlight exposes commands as a dedicated scope", () => {
 });
 
 test("workspace command lenses are resolved from the current package", () => {
-  let lenses: readonly (readonly [string, string])[] =
+  let lenses: readonly (readonly [TypeLens, string])[] =
     [["api", "API"], ["metadata", "Metadata"]];
   const harness = createHarness({
     scope: "commands",
@@ -312,6 +342,28 @@ test("workspace command lenses are resolved from the current package", () => {
   lenses = [["api", "API"]];
   assert.doesNotMatch(harness.spotlight.modalHtml(), />show metadata</);
   assert.match(harness.spotlight.modalHtml(), />show api</);
+});
+
+test("Spotlight rejects a scope the current context does not offer", () => {
+  const { spotlight, state } = createHarness();
+
+  // "commands" is a well-typed SpotlightScope, but scopes() only offers it when a
+  // command context exists. Without one, open() must fall back rather than seat a
+  // scope whose results() branch can only ever return an empty list.
+  withStubbedFocusTarget(() => spotlight.open("", "commands"));
+
+  assert.equal(state.spotlightScope, "all");
+  assert.doesNotMatch(spotlight.modalHtml(), /data-sl-scope="commands"/);
+});
+
+test("Spotlight accepts a scope the current context does offer", () => {
+  const { spotlight, state } = createHarness({
+    commandContext: { command: "", package: packageContext },
+  });
+
+  withStubbedFocusTarget(() => spotlight.open("", "commands"));
+
+  assert.equal(state.spotlightScope, "commands");
 });
 
 test("home Spotlight keeps the shared typed UI without workspace commands", () => {

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -20,6 +20,9 @@ const tscBin = join(projectRoot, "node_modules", "typescript", "bin", "tsc");
 // Each entry widens one catalog and names the token the widened union gains. `src/` imports
 // nothing outside itself and the project sets `"types": []`, so a copy of `src/` plus
 // `tsconfig.json` compiles standalone without `node_modules` present beside it.
+// `dispatches` names every function the widened member must be rejected in. It is a set of
+// locations, not a count: adversarial review broke one dispatch and added an unrelated
+// consumer receiving the same `never`, which a count cannot tell apart from the original.
 const widenings = [
   {
     vocabulary: "TypeLens",
@@ -27,8 +30,15 @@ const widenings = [
     find: '  ["source", "Source"]\n] as const;\n\nexport type TypeLens',
     replace: '  ["source", "Source"],\n  ["probe-type-lens", "Probe"]\n] as const;\n\nexport type TypeLens',
     token: "probe-type-lens",
-    // `renderLens`.
-    exhaustiveConsumers: 1,
+    dispatches: ["renderLens", "loadSelectedTypeLensData"],
+  },
+  {
+    vocabulary: "PackageLens",
+    file: "data.ts",
+    find: '  ["metadata", "Metadata"]\n] as const;',
+    replace: '  ["metadata", "Metadata"],\n  ["probe-package-lens", "Probe"]\n] as const;',
+    token: "probe-package-lens",
+    dispatches: ["packageLensBody"],
   },
   {
     vocabulary: "MemberSection",
@@ -36,8 +46,15 @@ const widenings = [
     find: '  ["annotated", "Annotated source"],\n] as const;',
     replace: '  ["annotated", "Annotated source"],\n  ["probe-member-section", "Probe"],\n] as const;',
     token: "probe-member-section",
-    // The member-section render dispatch and the member-section loader dispatch.
-    exhaustiveConsumers: 2,
+    dispatches: ["renderMember", "loadSelectionData"],
+  },
+  {
+    vocabulary: "WorkspaceScope",
+    file: "data.ts",
+    find: 'const workspaceScopes = ["package", "type", "member"] as const;',
+    replace: 'const workspaceScopes = ["package", "type", "member", "probe-workspace-scope"] as const;',
+    token: "probe-workspace-scope",
+    dispatches: ["renderScopeBar", "onScopeSelect"],
   },
   {
     vocabulary: "SpotlightScope",
@@ -45,12 +62,18 @@ const widenings = [
     find: '  { id: "runtime", label: "Platform" },\n] as const;',
     replace: '  { id: "runtime", label: "Platform" },\n  { id: "probe-spotlight-scope", label: "Probe" },\n] as const;',
     token: "probe-spotlight-scope",
-    // `spotlightResults`.
-    exhaustiveConsumers: 1,
+    dispatches: ["spotlightResults"],
   },
 ] as const;
 
-function compileWidenedSource(): string {
+interface WidenedCompilation {
+  diagnostics: string;
+  // Diagnostics point into the scratch copy, which is deleted on the way out, so the
+  // sources have to be captured while it still exists.
+  sources: Map<string, string>;
+}
+
+function compileWidenedSource(): WidenedCompilation {
   const scratch = mkdtempSync(join(tmpdir(), "inspect-web-exhaustiveness-"));
   try {
     cpSync(join(projectRoot, "src"), join(scratch, "src"), { recursive: true });
@@ -68,33 +91,98 @@ function compileWidenedSource(): string {
       encoding: "utf8",
       cwd: scratch,
     });
-    return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    const diagnostics = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    const sources = new Map<string, string>();
+    for (const match of diagnostics.matchAll(/^(\S+)\(\d+,\d+\): error TS/gm)) {
+      const file = match[1];
+      if (!file || sources.has(file)) continue;
+      const absolute = file.startsWith("/") ? file : join(scratch, file);
+      sources.set(file, readFileSync(absolute, "utf8"));
+    }
+    return { diagnostics, sources };
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }
 }
 
+// Map a diagnostic location back to the function that contains it, so the gate can name
+// *which* dispatch rejected the widened member.
+//
+// Counting diagnostics is not enough. Adversarial review (Claude Opus 5) broke `renderLens`
+// and added an unrelated but reachable guard receiving the same `never`, which held the
+// count at 1 and kept the suite green while an unhandled lens rendered blank. A location is
+// what a count cannot fake.
+function enclosingFunction(source: string, line: number): string {
+  const lines = source.split("\n");
+  for (let index = Math.min(line, lines.length) - 1; index >= 0; index -= 1) {
+    const text = lines[index] ?? "";
+    const declaration = /^(?:async )?function ([A-Za-z_$][\w$]*)\s*[(<]/.exec(text);
+    if (declaration?.[1]) return declaration[1];
+    // Object-literal callbacks such as `onScopeSelect: target => {` are dispatch sites too.
+    const property = /^\s{0,8}([A-Za-z_$][\w$]*): (?:async )?(?:\([^)]*\)|[A-Za-z_$][\w$]*) =>/
+      .exec(text);
+    if (property?.[1]) return property[1];
+  }
+  return "<unknown>";
+}
+
+test("every closed UI vocabulary is covered by this gate", () => {
+  // Derive the roster instead of restating it. Every union declared from an `as const`
+  // catalog is a closed vocabulary whose members reach a dispatch, so a new one that nobody
+  // adds here fails immediately rather than sitting silently uncovered -- which is exactly
+  // how `PackageLens` and `WorkspaceScope` went ungated through three rounds.
+  const declared = new Set<string>();
+  for (const file of ["data.ts", "spotlight.ts"]) {
+    const source = readFileSync(join(projectRoot, "src", file), "utf8");
+    for (const match of source.matchAll(
+      /export type ([A-Za-z_$][\w$]*) =\s*\|?\s*\(typeof [A-Za-z_$][\w$]*\)\[number\]/g)) {
+      if (match[1]) declared.add(match[1]);
+    }
+  }
+
+  // Non-vacuity: an anchor that stopped matching would otherwise turn this into a test that
+  // derives an empty roster and passes.
+  assert.deepEqual(
+    [...declared].sort((a, b) => a.localeCompare(b)),
+    ["MemberSection", "PackageLens", "SpotlightScope", "TypeLens", "WorkspaceScope"],
+    "the catalog-union anchor stopped matching the vocabularies it is meant to discover");
+
+  const covered = new Set<string>(widenings.map(widening => widening.vocabulary));
+  assert.deepEqual(
+    [...declared].filter(name => !covered.has(name)).sort((a, b) => a.localeCompare(b)),
+    [],
+    "a closed vocabulary is declared in src/ but has no case in this gate");
+});
+
 test("widening a UI vocabulary catalog fails compilation until every consumer handles it", () => {
-  const diagnostics = compileWidenedSource();
+  const { diagnostics, sources } = compileWidenedSource();
   assert.ok(
     diagnostics.trim().length > 0,
     "Widening every vocabulary catalog compiled cleanly, so no consumer is exhaustive.");
+
   for (const widening of widenings) {
-    // `assertNever` takes `never`, so an unhandled member is reported as the new string literal
-    // being unassignable, and it is the only parameter in the prototype with that type. Counting
-    // those diagnostics therefore counts the vocabulary's exhaustive consumers exactly, which is
-    // what a per-vocabulary match cannot do: with two dispatches over `MemberSection`, deleting
-    // either one still leaves the other reporting.
+    // `assertNever` takes `never`, so an unhandled member is reported as the new string
+    // literal being unassignable, and it is the only parameter in the prototype with that
+    // type. Collect the *functions* those diagnostics land in.
     const pattern = new RegExp(
-      `Argument of type '"${widening.token}"' is not assignable to parameter of type 'never'`,
-      "g");
-    const reported = diagnostics.match(pattern)?.length ?? 0;
-    assert.equal(
-      reported,
-      widening.exhaustiveConsumers,
-      `${widening.vocabulary}: expected ${widening.exhaustiveConsumers} exhaustive consumer(s) to reject a new `
-      + `catalog entry, but ${reported} did. Fewer means a consumer accepts an unknown `
-      + `${widening.vocabulary} and silently gives it another member's behavior; more means a new `
-      + "exhaustive consumer was added and this count needs raising.");
+      `^(\\S+)\\((\\d+),\\d+\\): error TS2345: Argument of type '"${widening.token}"' `
+      + "is not assignable to parameter of type 'never'",
+      "gm");
+    const reported = new Set<string>();
+    for (const match of diagnostics.matchAll(pattern)) {
+      const file = match[1];
+      const line = Number(match[2]);
+      const source = file === undefined ? undefined : sources.get(file);
+      if (source === undefined || !Number.isFinite(line)) continue;
+      reported.add(enclosingFunction(source, line));
+    }
+
+    assert.deepEqual(
+      [...reported].sort((a, b) => a.localeCompare(b)),
+      [...widening.dispatches].sort((a, b) => a.localeCompare(b)),
+      `${widening.vocabulary}: the dispatches that reject a new catalog entry are not the `
+      + "ones this gate expects. A missing name means that dispatch silently gives an "
+      + "unknown member another member's behavior; an unexpected name means a new "
+      + "exhaustive dispatch appeared and belongs in this list.");
   }
 });

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -1,0 +1,100 @@
+// The closed vocabularies in `src/data.ts` and `src/spotlight.ts` are derived from catalogs
+// that also drive visible UI choices, so adding a catalog entry both widens the union and
+// immediately offers the new value to users. Nothing at runtime can observe that: the value
+// simply takes whichever branch the consumer falls through to. The gate for that property is
+// therefore the compiler, and this test is that gate — it widens each catalog in a throwaway
+// copy of `src/` and asserts `tsc` rejects the result at the `assertNever` call in every
+// consumer. Deleting an exhaustive dispatch makes the corresponding case below go green,
+// which fails the assertion.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const tscBin = join(projectRoot, "node_modules", "typescript", "bin", "tsc");
+
+// Each entry widens one catalog and names the token the widened union gains. `src/` imports
+// nothing outside itself and the project sets `"types": []`, so a copy of `src/` plus
+// `tsconfig.json` compiles standalone without `node_modules` present beside it.
+const widenings = [
+  {
+    vocabulary: "TypeLens",
+    file: "data.ts",
+    find: '  ["source", "Source"]\n] as const;\n\nexport type TypeLens',
+    replace: '  ["source", "Source"],\n  ["probe-type-lens", "Probe"]\n] as const;\n\nexport type TypeLens',
+    token: "probe-type-lens",
+    // `renderLens`.
+    exhaustiveConsumers: 1,
+  },
+  {
+    vocabulary: "MemberSection",
+    file: "data.ts",
+    find: '  ["annotated", "Annotated source"],\n] as const;',
+    replace: '  ["annotated", "Annotated source"],\n  ["probe-member-section", "Probe"],\n] as const;',
+    token: "probe-member-section",
+    // The member-section render dispatch and the member-section loader dispatch.
+    exhaustiveConsumers: 2,
+  },
+  {
+    vocabulary: "SpotlightScope",
+    file: "spotlight.ts",
+    find: '  { id: "runtime", label: "Platform" },\n] as const;',
+    replace: '  { id: "runtime", label: "Platform" },\n  { id: "probe-spotlight-scope", label: "Probe" },\n] as const;',
+    token: "probe-spotlight-scope",
+    // `spotlightResults`.
+    exhaustiveConsumers: 1,
+  },
+] as const;
+
+function compileWidenedSource(): string {
+  const scratch = mkdtempSync(join(tmpdir(), "inspect-web-exhaustiveness-"));
+  try {
+    cpSync(join(projectRoot, "src"), join(scratch, "src"), { recursive: true });
+    cpSync(join(projectRoot, "tsconfig.json"), join(scratch, "tsconfig.json"));
+    for (const widening of widenings) {
+      const path = join(scratch, "src", widening.file);
+      const original = readFileSync(path, "utf8");
+      assert.ok(
+        original.includes(widening.find),
+        `${widening.vocabulary}: catalog anchor not found in src/${widening.file}. `
+        + "The catalog moved; update this gate's anchor rather than deleting the case.");
+      writeFileSync(path, original.replace(widening.find, widening.replace));
+    }
+    const result = spawnSync(process.execPath, [tscBin, "--noEmit", "-p", join(scratch, "tsconfig.json")], {
+      encoding: "utf8",
+      cwd: scratch,
+    });
+    return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+test("widening a UI vocabulary catalog fails compilation until every consumer handles it", () => {
+  const diagnostics = compileWidenedSource();
+  assert.ok(
+    diagnostics.trim().length > 0,
+    "Widening every vocabulary catalog compiled cleanly, so no consumer is exhaustive.");
+  for (const widening of widenings) {
+    // `assertNever` takes `never`, so an unhandled member is reported as the new string literal
+    // being unassignable, and it is the only parameter in the prototype with that type. Counting
+    // those diagnostics therefore counts the vocabulary's exhaustive consumers exactly, which is
+    // what a per-vocabulary match cannot do: with two dispatches over `MemberSection`, deleting
+    // either one still leaves the other reporting.
+    const pattern = new RegExp(
+      `Argument of type '"${widening.token}"' is not assignable to parameter of type 'never'`,
+      "g");
+    const reported = diagnostics.match(pattern)?.length ?? 0;
+    assert.equal(
+      reported,
+      widening.exhaustiveConsumers,
+      `${widening.vocabulary}: expected ${widening.exhaustiveConsumers} exhaustive consumer(s) to reject a new `
+      + `catalog entry, but ${reported} did. Fewer means a consumer accepts an unknown `
+      + `${widening.vocabulary} and silently gives it another member's behavior; more means a new `
+      + "exhaustive consumer was added and this count needs raising.");
+  }
+});

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -14,6 +14,14 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  parseSync,
+  visitorKeys,
+  type Node,
+  type Program,
+  type TSTypeAliasDeclaration,
+} from "oxc-parser";
+
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const tscBin = join(projectRoot, "node_modules", "typescript", "bin", "tsc");
 
@@ -46,7 +54,7 @@ const widenings = [
     find: '  ["annotated", "Annotated source"],\n] as const;',
     replace: '  ["annotated", "Annotated source"],\n  ["probe-member-section", "Probe"],\n] as const;',
     token: "probe-member-section",
-    dispatches: ["renderMember", "loadSelectionData"],
+    dispatches: ["applyMemberSection", "applyView", "renderMember", "loadSelectionData"],
   },
   {
     vocabulary: "WorkspaceScope",
@@ -54,7 +62,7 @@ const widenings = [
     find: 'const workspaceScopes = ["package", "type", "member"] as const;',
     replace: 'const workspaceScopes = ["package", "type", "member", "probe-workspace-scope"] as const;',
     token: "probe-workspace-scope",
-    dispatches: ["renderScopeBar", "onScopeSelect"],
+    dispatches: ["onScopeSelect", "renderScopeBar", "selectScopeLensByIndex"],
   },
   {
     vocabulary: "SpotlightScope",
@@ -75,11 +83,16 @@ interface WidenedCompilation {
 
 function compileWidenedSource(): WidenedCompilation {
   const scratch = mkdtempSync(join(tmpdir(), "inspect-web-exhaustiveness-"));
+  const compilationRoot = join(scratch, "inspect-web");
   try {
-    cpSync(join(projectRoot, "src"), join(scratch, "src"), { recursive: true });
-    cpSync(join(projectRoot, "tsconfig.json"), join(scratch, "tsconfig.json"));
+    cpSync(join(projectRoot, "src"), join(compilationRoot, "src"), { recursive: true });
+    cpSync(join(projectRoot, "tsconfig.json"), join(compilationRoot, "tsconfig.json"));
+    cpSync(
+      join(projectRoot, "..", "annotated-source-viewer", "src"),
+      join(scratch, "annotated-source-viewer", "src"),
+      { recursive: true });
     for (const widening of widenings) {
-      const path = join(scratch, "src", widening.file);
+      const path = join(compilationRoot, "src", widening.file);
       const original = readFileSync(path, "utf8");
       assert.ok(
         original.includes(widening.find),
@@ -87,16 +100,21 @@ function compileWidenedSource(): WidenedCompilation {
         + "The catalog moved; update this gate's anchor rather than deleting the case.");
       writeFileSync(path, original.replace(widening.find, widening.replace));
     }
-    const result = spawnSync(process.execPath, [tscBin, "--noEmit", "-p", join(scratch, "tsconfig.json")], {
+    const result = spawnSync(process.execPath, [
+      tscBin,
+      "--noEmit",
+      "-p",
+      join(compilationRoot, "tsconfig.json"),
+    ], {
       encoding: "utf8",
-      cwd: scratch,
+      cwd: compilationRoot,
     });
     const diagnostics = `${result.stdout ?? ""}${result.stderr ?? ""}`;
     const sources = new Map<string, string>();
     for (const match of diagnostics.matchAll(/^(\S+)\(\d+,\d+\): error TS/gm)) {
       const file = match[1];
       if (!file || sources.has(file)) continue;
-      const absolute = file.startsWith("/") ? file : join(scratch, file);
+      const absolute = file.startsWith("/") ? file : join(compilationRoot, file);
       sources.set(file, readFileSync(absolute, "utf8"));
     }
     return { diagnostics, sources };
@@ -126,19 +144,57 @@ function enclosingFunction(source: string, line: number): string {
   return "<unknown>";
 }
 
-test("every closed UI vocabulary is covered by this gate", () => {
-  // Derive the roster instead of restating it. Every union declared from an `as const`
-  // catalog is a closed vocabulary whose members reach a dispatch, so a new one that nobody
-  // adds here fails immediately rather than sitting silently uncovered -- which is exactly
-  // how `PackageLens` and `WorkspaceScope` went ungated through three rounds.
-  const declared = new Set<string>();
-  for (const file of ["data.ts", "spotlight.ts"]) {
-    const source = readFileSync(join(projectRoot, "src", file), "utf8");
-    for (const match of source.matchAll(
-      /export type ([A-Za-z_$][\w$]*) =\s*\|?\s*\(typeof [A-Za-z_$][\w$]*\)\[number\]/g)) {
-      if (match[1]) declared.add(match[1]);
+function parse(file: string): Program {
+  const source = readFileSync(join(projectRoot, "src", file), "utf8");
+  const parsed = parseSync(file, source);
+  assert.deepEqual(
+    parsed.errors,
+    [],
+    `${file} must parse before its vocabulary declarations can be inspected`);
+  return parsed.program;
+}
+
+function isNode(value: unknown): value is Node {
+  return typeof value === "object"
+    && value !== null
+    && typeof Reflect.get(value, "type") === "string";
+}
+
+function containsTypeQuery(node: Node): boolean {
+  if (node.type === "TSTypeQuery") return true;
+  for (const key of visitorKeys[node.type] ?? []) {
+    const child = Reflect.get(node, key) as unknown;
+    if (Array.isArray(child)) {
+      if (child.some(candidate => isNode(candidate) && containsTypeQuery(candidate)))
+        return true;
+    } else if (isNode(child) && containsTypeQuery(child)) {
+      return true;
     }
   }
+  return false;
+}
+
+function catalogTypeAliases(program: Program): TSTypeAliasDeclaration[] {
+  return program.body.flatMap(node => {
+    const declaration = node.type === "ExportNamedDeclaration"
+      ? node.declaration
+      : null;
+    return declaration?.type === "TSTypeAliasDeclaration"
+      && containsTypeQuery(declaration.typeAnnotation)
+      ? [declaration]
+      : [];
+  });
+}
+
+test("every closed UI vocabulary is covered by this gate", () => {
+  // Derive the roster from every exported type alias that queries a catalog, independent of
+  // formatting, tuple indexing, or union shape. A new catalog-derived vocabulary that nobody
+  // adds here fails rather than sitting silently uncovered -- which is exactly how
+  // `PackageLens` and `WorkspaceScope` went ungated through three rounds.
+  const declared = new Set(
+    ["data.ts", "spotlight.ts"]
+      .flatMap(file => catalogTypeAliases(parse(file)))
+      .map(declaration => declaration.id.name));
 
   // Non-vacuity: an anchor that stopped matching would otherwise turn this into a test that
   // derives an empty roster and passes.
@@ -159,6 +215,13 @@ test("widening a UI vocabulary catalog fails compilation until every consumer ha
   assert.ok(
     diagnostics.trim().length > 0,
     "Widening every vocabulary catalog compiled cleanly, so no consumer is exhaustive.");
+  assert.deepEqual(
+    [...diagnostics.matchAll(/error TS(\d+):/g)]
+      .map(match => match[1])
+      .filter(code => code !== undefined)
+      .filter((code, index, codes) => codes.indexOf(code) === index),
+    ["2345"],
+    "The widened compile has an unrelated diagnostic, so its exhaustiveness evidence is invalid.");
 
   for (const widening of widenings) {
     // `assertNever` takes `never`, so an unhandled member is reported as the new string

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -449,6 +449,36 @@ test("invalid and oversized workspace packets stay visible", () => {
   assert.match(oversized.workspaceNotice, /65536-character limit/);
 });
 
+test("rich workspace packets keep valid member sections and drop invalid ones", () => {
+  function richPacket(section: unknown) {
+    return Buffer.from(JSON.stringify({
+      t: [["Example.Package", "1.0.0", "net10.0"]],
+      a: 0,
+      y: "Example.Widget",
+      m: "method:Serialize",
+      c: section,
+    })).toString("base64url");
+  }
+
+  const valid = parseWorkspaceLocation(locationSnapshot(
+    `https://inspect.example/?w=${richPacket("call-graph")}`));
+  assert.equal(valid.section, "call-graph");
+  assert.equal(valid.workspaceNotice, "");
+
+  // The share packet is untrusted input, so an unknown token must not reach the
+  // MemberSection-typed field just because it is a string.
+  for (const hostile of ["history", "", "Overview", "call-graph "]) {
+    const parsed = parseWorkspaceLocation(locationSnapshot(
+      `https://inspect.example/?w=${richPacket(hostile)}`));
+    assert.equal(parsed.section, null, hostile);
+    assert.equal(parsed.type, "Example.Widget", hostile);
+  }
+
+  const nonString = parseWorkspaceLocation(locationSnapshot(
+    `https://inspect.example/?w=${richPacket(7)}`));
+  assert.equal(nonString.section, null);
+});
+
 test("malformed rich packet fields cannot override the visible package", () => {
   const base = {
     t: [["Hidden.Package", "1.0.0", "net10.0"]],

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -414,6 +414,21 @@ test("legacy workspace packets retain visible-location authority", () => {
   assert.equal(parsed.active, 1);
 });
 
+test("unknown workspace view and member-section tokens are ignored", () => {
+  const unknownLens = parseWorkspaceLocation(locationSnapshot(
+    "https://inspect.example/?package=Example.Package"
+      + "&section=history#implementation"));
+  assert.equal(unknownLens.lens, null);
+  assert.equal(unknownLens.atPackageRoot, false);
+  assert.equal(unknownLens.packageLens, null);
+  assert.equal(unknownLens.section, null);
+
+  const unknownPackageLens = parseWorkspaceLocation(locationSnapshot(
+    "https://inspect.example/?package=Example.Package#pkg:files"));
+  assert.equal(unknownPackageLens.atPackageRoot, true);
+  assert.equal(unknownPackageLens.packageLens, "overview");
+});
+
 test("invalid and oversized workspace packets stay visible", () => {
   const invalid = parseWorkspaceLocation(locationSnapshot(
     "https://inspect.example/?package=Example.Package&w=not-base64"));


### PR DESCRIPTION
Part of #4571

## Summary

- derive workspace scope, type/package lens, member-section, and Spotlight
  scope unions from their authoritative UI catalogs
- thread those closed types through application state, navigation snapshots,
  package/member coordinators, and Spotlight package search
- decode DOM dataset and workspace URL/share tokens before invoking typed
  actions or restoring state; unknown values are ignored
- derive the exhaustiveness roster from the catalog-referencing type aliases
  and require every named dispatch to reject a widened vocabulary

## Stack

- Semantic TypeScript typeification, slice 2
- Parent: #4577
- Base branch: `type/4549-unchecked-index-access`
- Residual: decode numeric and structured DOM payloads in a subsequent #4571
  slice; state/request modelling remains tracked by #4570, #4573, and #4575

## Compatibility

Valid scope, lens, section, Spotlight, and workspace-link behavior is unchanged.
This slice intentionally stops missing or unknown DOM/URL vocabulary tokens
from falling through to default or arbitrary string state.

## Validation

- `npm test` — 588 passed
- `npm run analyze`
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
- widened-catalog mutation: removing `applyMemberSection` exhaustiveness makes
  the named-dispatch gate fail
- `git diff --check`

## Latest-main restack

Restacked onto #4577 head `238affec0`; current head is `3ae03660e`.
Conflict resolution preserves main's selected-accessor member sections and
graph-only API projection while retaining the catalog-derived unions and
exhaustive lens dispatch.

- Full suite: 588/588.
- Focused vocabulary, workspace, and root-composition tests after the second
  parent refresh: 165/165.
- Analyzer and production build: clean.
