### PR TITLE
Model opportunity requests as a discriminated union

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1064,9 +1064,14 @@ rendered DOM bindings, opportunity-row API-name splitting, package-chip
 detection, and "look for" chip rendering. `dotnet-inspect.ts` still owns
 `state`, target resolution, navigation effects, and the platform library
 picker, `package-inspection.ts` owns the scan-scope-keyed async load lifecycle,
-and the root supplies behavior through typed callbacks.
+and the root supplies behavior through typed callbacks. The Opportunities
+request is one `AsyncResource` state: idle, loading, ready, or failed. Loading
+owns its request object, so a stale completion cannot publish into a newer
+state, and data/error fields exist only on their applicable variants.
+`test/package-inspection.test.ts` gates those transitions, same-request reuse,
+and stale-result suppression.
 `test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
-the scanning/loading/error states (fresh versus stale scope), the
+the idle/loading/ready/failed states (fresh versus stale scope), the
 no-opportunities and inspection-error banners, the category summary counts,
 API name splitting, package-chip versus plain-text kind rendering, look-for
 chip/wildcard/empty rendering, binding dispatch and empty-value behavior, and

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1069,7 +1069,12 @@ request is one `AsyncResource` state: idle, loading, ready, or failed. Loading
 owns its request object, so a stale completion cannot publish into a newer
 state, and data/error fields exist only on their applicable variants.
 `test/package-inspection.test.ts` gates those transitions, same-request reuse,
-and stale-result suppression.
+and stale-result suppression. A second caller of an in-flight request joins it
+rather than returning early, so it reports completion only once the request has
+actually settled -- including when that request rejects.
+`test/async-resource-state.test.ts` derives the converted lenses from their
+declared type and fails if one regains a parallel `…Loading`/`…Error`/`…Key`
+field on either the coordinator state or the initial state.
 `test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
 the idle/loading/ready/failed states (fresh versus stale scope), the
 no-opportunities and inspection-error banners, the category summary counts,

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -1406,6 +1406,22 @@ export interface ScopedRequestState {
   error: string;
 }
 
+export type AsyncResource<T> =
+  | { status: "idle" }
+  | { status: "loading"; key: string }
+  | { status: "ready"; key: string; data: T }
+  | { status: "failed"; key: string; error: string };
+
+export function idleAsyncResource<T>(): AsyncResource<T> {
+  return { status: "idle" };
+}
+
+export function asyncResourceKey<T>(
+  resource: AsyncResource<T>,
+): string | null {
+  return resource.status === "idle" ? null : resource.key;
+}
+
 export function scopedRequestState(
   activeKey: string,
   requestKey: string,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1,6 +1,7 @@
 import {
   accessibilityFilterIncludingType,
   activeSourceOperationKind,
+  asyncResourceKey,
   assemblyDescriptorForType,
   assertNever,
   pdbSourceLimitationHtml,
@@ -19,6 +20,7 @@ import {
   graphMemberSelection,
   graphMemberTargetFromShare,
   graphOnlyBodyTarget,
+  idleAsyncResource,
   MARKDOWN_SANITIZE_OPTIONS,
   MAX_WORKSPACE_PACKAGES,
   memberRequestKey,
@@ -584,10 +586,7 @@ const initialState = {
   packageIntegrationsLoading: false,
   packageIntegrationsError: "",
   packageIntegrationsKey: "",
-  packageOpportunities: null,
-  packageOpportunitiesLoading: false,
-  packageOpportunitiesError: "",
-  packageOpportunitiesKey: "",
+  packageOpportunities: idleAsyncResource<BrowserPackageOpportunities>(),
   packagePerformance: null,
   packagePerformanceLoading: false,
   packagePerformanceError: "",
@@ -699,7 +698,6 @@ interface StateOverrides {
   workspaceDependencyErrors: Record<string, string>;
   workspaceDependencyLoads: Set<string>;
   packageIntegrations: BrowserPackageIntegrations | null;
-  packageOpportunities: BrowserPackageOpportunities | null;
   packagePerformance: PackagePerformance | null;
   packageMetadata: PackageMetadata | null;
   explorer: AppExplorerState | null;
@@ -2986,10 +2984,8 @@ function renderPackageOpportunities() {
     scopedLibrary: scopedLib,
     activeFramework: pkg.activeFramework,
     picker,
-    fresh: state.packageOpportunitiesKey === current,
-    loading: state.packageOpportunitiesLoading,
-    error: state.packageOpportunitiesError,
-    data: state.packageOpportunities,
+    signature: current,
+    resource: state.packageOpportunities,
     escapeHtml,
   });
 }
@@ -3006,7 +3002,9 @@ async function loadPackageOpportunities() {
 function maybeAutoLoadPackageOpportunities() {
   if (!state.atPackageRoot || state.packageLens !== "opportunities") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
-  if (state.packageOpportunitiesKey === packageScopeSignature()) return;
+  if (asyncResourceKey(state.packageOpportunities) === packageScopeSignature()) {
+    return;
+  }
   observeAsync(loadPackageOpportunities(), "Loading package opportunities");
 }
 

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -148,6 +148,50 @@ export function createPackageInspectionCoordinator(
 ): PackageInspectionCoordinator {
   const { state } = dependencies;
 
+  // The completion of the opportunity request that owns the live `loading` resource. A
+  // duplicate caller has to await this rather than returning: a `loading` resource means the
+  // work is still running, and returning told the caller it had finished. Joining is keyed
+  // on the *identity* of that resource as well as the signature -- the signature alone could
+  // join a request that was already abandoned and will publish nothing.
+  let opportunitiesInFlight: {
+    readonly resource: AsyncResource<BrowserPackageOpportunities>;
+    readonly completion: Promise<void>;
+  } | null = null;
+
+  // Never rejects: every outcome is published as a resource state, so a joining caller
+  // awaits a promise that always settles.
+  const publishOpportunities = async (
+    packageModel: AppPackage,
+    signature: string,
+    scopedLibrary: string | null | undefined,
+    pending: AsyncResource<BrowserPackageOpportunities>,
+  ): Promise<void> => {
+    try {
+      const coordinates = packageModel.isRuntimePack
+        ? platformCoordinates(packageModel, scopedLibrary ?? "")
+        : null;
+      const result = coordinates
+        ? await dependencies.queryPlatformOpportunities(
+            coordinates.framework,
+            coordinates.assemblyFileName,
+            coordinates.pack)
+        : await dependencies.queryPackageOpportunities(packageModel);
+      if (state.packageOpportunities === pending) {
+        state.packageOpportunities = { status: "ready", key: signature, data: result };
+      }
+    } catch (error) {
+      if (state.packageOpportunities === pending) {
+        state.packageOpportunities = {
+          status: "failed",
+          key: signature,
+          error: dependencies.describeError(error),
+        };
+      }
+    } finally {
+      dependencies.render();
+    }
+  };
+
   const platformCoordinates = (
     packageModel: AppPackage,
     scopedLibrary: string,
@@ -297,41 +341,30 @@ export function createPackageInspectionCoordinator(
 
     async loadOpportunities(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      if (state.packageOpportunities.status !== "idle"
-        && state.packageOpportunities.key === signature) {
+      const current = state.packageOpportunities;
+      if (current.status !== "idle" && current.key === signature) {
+        // A settled resource is the finished answer, so returning is correct. A `loading`
+        // one is not finished, and returning reported a completion that had not happened.
+        const joined = current.status === "loading"
+          && opportunitiesInFlight?.resource === current
+          ? opportunitiesInFlight.completion
+          : null;
         dependencies.render();
+        if (joined) await joined;
         return;
       }
       const pending = { status: "loading", key: signature } as const;
       state.packageOpportunities = pending;
-      dependencies.render();
+      const completion = publishOpportunities(
+        packageModel, signature, scopedLibrary, pending);
+      opportunitiesInFlight = { resource: pending, completion };
       try {
-        const coordinates = packageModel.isRuntimePack
-          ? platformCoordinates(packageModel, scopedLibrary ?? "")
-          : null;
-        const result = coordinates
-          ? await dependencies.queryPlatformOpportunities(
-              coordinates.framework,
-              coordinates.assemblyFileName,
-              coordinates.pack)
-          : await dependencies.queryPackageOpportunities(packageModel);
-        if (state.packageOpportunities === pending) {
-          state.packageOpportunities = {
-            status: "ready",
-            key: signature,
-            data: result,
-          };
-        }
-      } catch (error) {
-        if (state.packageOpportunities === pending) {
-          state.packageOpportunities = {
-            status: "failed",
-            key: signature,
-            error: dependencies.describeError(error),
-          };
-        }
-      } finally {
+        // `render()` is inside the `try`, so a throwing render cannot strand the in-flight
+        // record and leave later same-signature callers awaiting a request nobody clears.
         dependencies.render();
+        await completion;
+      } finally {
+        if (opportunitiesInFlight?.resource === pending) opportunitiesInFlight = null;
       }
     },
 

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -1,5 +1,6 @@
 import {
   packageIdentityKey,
+  type AsyncResource,
   type DependencyGroupData,
   type PackageLens,
   type PackageIdentity,
@@ -45,10 +46,7 @@ export interface PackageInspectionState {
   packageIntegrationsLoading: boolean;
   packageIntegrationsError: string;
   packageIntegrationsKey: string;
-  packageOpportunities: BrowserPackageOpportunities | null;
-  packageOpportunitiesLoading: boolean;
-  packageOpportunitiesError: string;
-  packageOpportunitiesKey: string;
+  packageOpportunities: AsyncResource<BrowserPackageOpportunities>;
   packagePerformance: PackagePerformance | null;
   packagePerformanceLoading: boolean;
   packagePerformanceError: string;
@@ -299,15 +297,13 @@ export function createPackageInspectionCoordinator(
 
     async loadOpportunities(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      if (state.packageOpportunitiesKey === signature
-        && (state.packageOpportunities || state.packageOpportunitiesError)) {
+      if (state.packageOpportunities.status !== "idle"
+        && state.packageOpportunities.key === signature) {
         dependencies.render();
         return;
       }
-      state.packageOpportunitiesKey = signature;
-      state.packageOpportunities = null;
-      state.packageOpportunitiesError = "";
-      state.packageOpportunitiesLoading = true;
+      const pending = { status: "loading", key: signature } as const;
+      state.packageOpportunities = pending;
       dependencies.render();
       try {
         const coordinates = packageModel.isRuntimePack
@@ -319,17 +315,22 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackageOpportunities(packageModel);
-        if (state.packageOpportunitiesKey === signature) {
-          state.packageOpportunities = result;
+        if (state.packageOpportunities === pending) {
+          state.packageOpportunities = {
+            status: "ready",
+            key: signature,
+            data: result,
+          };
         }
       } catch (error) {
-        if (state.packageOpportunitiesKey === signature) {
-          state.packageOpportunitiesError = dependencies.describeError(error);
+        if (state.packageOpportunities === pending) {
+          state.packageOpportunities = {
+            status: "failed",
+            key: signature,
+            error: dependencies.describeError(error),
+          };
         }
       } finally {
-        if (state.packageOpportunitiesKey === signature) {
-          state.packageOpportunitiesLoading = false;
-        }
         dependencies.render();
       }
     },

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -158,8 +158,8 @@ export function createPackageInspectionCoordinator(
     readonly completion: Promise<void>;
   } | null = null;
 
-  // Never rejects: every outcome is published as a resource state, so a joining caller
-  // awaits a promise that always settles.
+  // Query failures are published as resource state. Rendering can still reject, so the
+  // in-flight record observes completion even if the starting caller's render throws.
   const publishOpportunities = async (
     packageModel: AppPackage,
     signature: string,
@@ -358,14 +358,13 @@ export function createPackageInspectionCoordinator(
       const completion = publishOpportunities(
         packageModel, signature, scopedLibrary, pending);
       opportunitiesInFlight = { resource: pending, completion };
-      try {
-        // `render()` is inside the `try`, so a throwing render cannot strand the in-flight
-        // record and leave later same-signature callers awaiting a request nobody clears.
-        dependencies.render();
-        await completion;
-      } finally {
+      void completion.then(() => {
         if (opportunitiesInFlight?.resource === pending) opportunitiesInFlight = null;
-      }
+      }, () => {
+        if (opportunitiesInFlight?.resource === pending) opportunitiesInFlight = null;
+      });
+      dependencies.render();
+      await completion;
     },
 
     async loadPerformance(packageModel, signature, scopedLibrary) {

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -2,6 +2,7 @@ import type {
   BrowserOpportunityItem,
   BrowserPackageOpportunities,
 } from "./inspect-web-engine.d.ts";
+import type { AsyncResource } from "./data.ts";
 
 export type OpportunityItem = BrowserOpportunityItem;
 type PackageOpportunities = Pick<
@@ -14,10 +15,8 @@ export interface RenderPackageOpportunitiesOptions {
   scopedLibrary: string | null;
   activeFramework: string;
   picker: string;
-  fresh: boolean;
-  loading: boolean;
-  error: string;
-  data: PackageOpportunities | null;
+  signature: string;
+  resource: AsyncResource<PackageOpportunities>;
   escapeHtml: (value: unknown) => string;
 }
 
@@ -142,19 +141,30 @@ function renderOpportunityRow(item: OpportunityItem, escapeHtml: (value: unknown
 }
 
 export function renderPackageOpportunities(options: RenderPackageOpportunitiesOptions): string {
-  const { isPlatform, scopedLibrary, activeFramework, picker, fresh, loading, error, data, escapeHtml } = options;
+  const {
+    isPlatform,
+    scopedLibrary,
+    activeFramework,
+    picker,
+    signature,
+    resource,
+    escapeHtml,
+  } = options;
 
   if (isPlatform && !scopedLibrary) {
     return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to compare its public surface against ecosystem integration patterns.</p></section>`;
   }
   const scanScope = isPlatform ? `${escapeHtml(scopedLibrary)} · ${escapeHtml(activeFramework)}` : escapeHtml(activeFramework);
-  if (loading && fresh) {
+  const fresh = resource.status !== "idle" && resource.key === signature;
+  if (fresh && resource.status === "loading") {
     return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning opportunities…</h2><p>Comparing the public surface against ecosystem integration patterns.</p></section>`;
   }
-  if (fresh && error) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(error)}</p></section>`;
+  if (fresh && resource.status === "failed") {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
   }
-  const resolved = fresh ? data : null;
+  const resolved = fresh && resource.status === "ready"
+    ? resource.data
+    : null;
   if (!resolved) {
     return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
   }

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -2,7 +2,7 @@ import type {
   BrowserOpportunityItem,
   BrowserPackageOpportunities,
 } from "./inspect-web-engine.d.ts";
-import type { AsyncResource } from "./data.ts";
+import { assertNever, type AsyncResource } from "./data.ts";
 
 export type OpportunityItem = BrowserOpportunityItem;
 type PackageOpportunities = Pick<
@@ -155,18 +155,28 @@ export function renderPackageOpportunities(options: RenderPackageOpportunitiesOp
     return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Pick a library to scan</h2><p>Choose a .NET platform library above to compare its public surface against ecosystem integration patterns.</p></section>`;
   }
   const scanScope = isPlatform ? `${escapeHtml(scopedLibrary)} · ${escapeHtml(activeFramework)}` : escapeHtml(activeFramework);
-  const fresh = resource.status !== "idle" && resource.key === signature;
-  if (fresh && resource.status === "loading") {
-    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning opportunities…</h2><p>Comparing the public surface against ecosystem integration patterns.</p></section>`;
-  }
-  if (fresh && resource.status === "failed") {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
-  }
-  const resolved = fresh && resource.status === "ready"
-    ? resource.data
-    : null;
-  if (!resolved) {
-    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+  const pending = `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+
+  // "Nothing has been requested" and "what we have describes a different scan" are the two
+  // cases where the placeholder is the honest answer, and neither is a question about which
+  // state a live resource is in. Settling both first is what leaves a plain dispatch below
+  // that has to be exhaustive. Mixing them in was how the old form acquired a trailing
+  // catch-all: `fresh && status === ...` tests left every other combination to a final
+  // `if (!resolved)`, so an added member rendered as an indefinite "Loading…" spinner with
+  // no compile error.
+  if (resource.status === "idle" || resource.key !== signature) return pending;
+
+  let resolved: PackageOpportunities;
+  switch (resource.status) {
+    case "loading":
+      return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning opportunities…</h2><p>Comparing the public surface against ecosystem integration patterns.</p></section>`;
+    case "failed":
+      return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Opportunity scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
+    case "ready":
+      resolved = resource.data;
+      break;
+    default:
+      return assertNever(resource, "AsyncResource");
   }
 
   const categories = resolved.categories || [];

--- a/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
+++ b/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { idleAsyncResource, type AsyncResource } from "../src/data.ts";
+
+// `AsyncResource` claims that a result, an error, and a request key exist only on the
+// variants entitled to them -- that is the whole reason for replacing the four parallel
+// fields (`data`, `loading`, `error`, `key`) with a union. Nothing enforced that claim.
+//
+// Adversarial review demonstrated it by widening each variant independently -- adding
+// `data?` and `error?` to `loading`, `error?` to `ready`, `data?` to `failed` -- and
+// running the full suite. All 500 tests passed for each. Every contradictory combination
+// the slice says it eliminated could come back with the suite still green, because a
+// runtime test can only observe states the code actually constructs, and a weakened type
+// is a statement about states it *permits*.
+//
+// So the gate has to be the compiler. Each `@ts-expect-error` below asserts that the
+// combination on the next line is rejected. TypeScript reports an unused
+// `@ts-expect-error` directive as an error in its own right, so weakening a variant to
+// admit one of these does not silently satisfy the assertion -- it fails typechecking
+// from the other direction. That is what makes these two-way.
+
+type Payload = { value: number };
+
+// A loading resource has no result yet. Carrying one is the state that lets a stale render
+// show data while a newer request is in flight.
+const loadingWithData: AsyncResource<Payload> = {
+  status: "loading",
+  key: "k",
+  // @ts-expect-error -- `loading` must not carry `data`
+  data: { value: 1 },
+};
+
+// A loading resource has not failed. Carrying an error is what lets a spinner and a failure
+// message describe the same request.
+const loadingWithError: AsyncResource<Payload> = {
+  status: "loading",
+  key: "k",
+  // @ts-expect-error -- `loading` must not carry `error`
+  error: "boom",
+};
+
+// A ready resource succeeded. An error beside the result is the combination that lets a
+// consumer suppress a failure by preferring the data, or blank a good result by preferring
+// the error.
+const readyWithError: AsyncResource<Payload> = {
+  status: "ready",
+  key: "k",
+  data: { value: 1 },
+  // @ts-expect-error -- `ready` must not carry `error`
+  error: "boom",
+};
+
+// A failed resource has no result. Carrying one is how a failure renders as success-shaped
+// output, which this repository's rules forbid outright.
+const failedWithData: AsyncResource<Payload> = {
+  status: "failed",
+  key: "k",
+  error: "boom",
+  // @ts-expect-error -- `failed` must not carry `data`
+  data: { value: 1 },
+};
+
+// An idle resource has never been requested, so it owns no request key: a key on `idle` is
+// what would let a stale-scope check believe a scan had been requested for that scope.
+const idleWithKey: AsyncResource<Payload> = {
+  status: "idle",
+  // @ts-expect-error -- `idle` must not carry `key`
+  key: "k",
+};
+
+// Reading each binding keeps `noUnusedLocals` from removing the assertions above, and
+// keeps the file honest about being compiled rather than merely parsed.
+const forbidden = [
+  loadingWithData,
+  loadingWithError,
+  readyWithError,
+  failedWithData,
+  idleWithKey,
+];
+
+test("the forbidden AsyncResource combinations are rejected by the compiler", () => {
+  // The compile-time directives above are the actual gate; `npm test` typechecks this
+  // file through `test/tsconfig.json` before it runs. This asserts the file was not
+  // quietly excluded from that typecheck -- if it were, the directives would prove
+  // nothing and this suite would still be green.
+  assert.equal(forbidden.length, 5);
+  assert.deepEqual(idleAsyncResource<Payload>(), { status: "idle" });
+});

--- a/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
+++ b/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
@@ -91,8 +91,8 @@ const idleWithError: AsyncResource<Payload> = {
   error: "boom",
 };
 
-// Reading each binding keeps `noUnusedLocals` from removing the assertions above, and
-// keeps the file honest about being compiled rather than merely parsed.
+// Reading each binding also gives the runtime gate the exact compiled specimen rather
+// than requiring it to rediscover the roster from comment prose.
 const forbidden = [
   loadingWithData,
   loadingWithError,
@@ -134,13 +134,17 @@ function requiredCombinations(): Set<string> {
   return required;
 }
 
-// Each directive names its combination in prose, which is also how a reader checks it, so
-// the enumeration is read from the same place rather than maintained beside it.
 function enumeratedCombinations(): Set<string> {
-  const source = readFileSync(fileURLToPath(import.meta.url), "utf8");
-  return new Set(
-    [...source.matchAll(/@ts-expect-error -- `(\w+)` must not carry `(\w+)`/g)]
-      .map(match => `${match[1]}.${match[2]}`));
+  const required = requiredCombinations();
+  const combinations = forbidden.flatMap(resource =>
+    Object.keys(resource)
+      .map(field => `${resource.status}.${field}`)
+      .filter(combination => required.has(combination)));
+  assert.equal(
+    combinations.length,
+    forbidden.length,
+    "each compiled specimen must exercise exactly one forbidden combination");
+  return new Set(combinations);
 }
 
 test("the forbidden AsyncResource combinations are rejected by the compiler", () => {

--- a/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
+++ b/prototypes/inspect-web/test/async-resource-exclusivity.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { idleAsyncResource, type AsyncResource } from "../src/data.ts";
+
+const sourceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
 
 // `AsyncResource` claims that a result, an error, and a request key exist only on the
 // variants entitled to them -- that is the whole reason for replacing the four parallel
@@ -69,6 +75,22 @@ const idleWithKey: AsyncResource<Payload> = {
   key: "k",
 };
 
+// `idle` is the variant the renderer short-circuits to the placeholder, so a widened `idle`
+// is precisely the shape that could smuggle a previous scan's payload or failure past that
+// short-circuit. Both combinations were missing from this roster, and adding them to
+// `AsyncResource` left the suite green.
+const idleWithData: AsyncResource<Payload> = {
+  status: "idle",
+  // @ts-expect-error -- `idle` must not carry `data`
+  data: { value: 1 },
+};
+
+const idleWithError: AsyncResource<Payload> = {
+  status: "idle",
+  // @ts-expect-error -- `idle` must not carry `error`
+  error: "boom",
+};
+
 // Reading each binding keeps `noUnusedLocals` from removing the assertions above, and
 // keeps the file honest about being compiled rather than merely parsed.
 const forbidden = [
@@ -77,13 +99,63 @@ const forbidden = [
   readyWithError,
   failedWithData,
   idleWithKey,
+  idleWithData,
+  idleWithError,
 ];
+
+// The declaration drives the enforcement set. `forbidden.length === 5` was a pinned literal:
+// adding a sixth variant to `AsyncResource`, or a fifth field, required no change here and
+// produced no failure, so the roster restated one moment's truth. Reading the union instead
+// means a new variant or field is unenforced *until* its combinations are enumerated.
+function requiredCombinations(): Set<string> {
+  const source = readFileSync(join(sourceRoot, "data.ts"), "utf8");
+  const declaration =
+    /export type AsyncResource<T> =([\s\S]*?);\n/.exec(source)?.[1] ?? "";
+  const variants = [...declaration.matchAll(/\{([^}]*)\}/g)].map(match => {
+    const body = match[1] ?? "";
+    const fields = [...body.matchAll(/(\w+)\s*:/g)]
+      .map(field => field[1])
+      .filter((field): field is string => field !== undefined && field !== "status");
+    const status = /status\s*:\s*"([^"]+)"/.exec(body)?.[1] ?? "";
+    return { status, fields: new Set(fields) };
+  });
+
+  assert.ok(
+    variants.length >= 4 && variants.every(variant => variant.status !== ""),
+    "the AsyncResource anchor stopped matching, so this gate derives nothing");
+
+  const everyField = new Set(variants.flatMap(variant => [...variant.fields]));
+  const required = new Set<string>();
+  for (const variant of variants) {
+    for (const field of everyField) {
+      if (!variant.fields.has(field)) required.add(`${variant.status}.${field}`);
+    }
+  }
+  return required;
+}
+
+// Each directive names its combination in prose, which is also how a reader checks it, so
+// the enumeration is read from the same place rather than maintained beside it.
+function enumeratedCombinations(): Set<string> {
+  const source = readFileSync(fileURLToPath(import.meta.url), "utf8");
+  return new Set(
+    [...source.matchAll(/@ts-expect-error -- `(\w+)` must not carry `(\w+)`/g)]
+      .map(match => `${match[1]}.${match[2]}`));
+}
 
 test("the forbidden AsyncResource combinations are rejected by the compiler", () => {
   // The compile-time directives above are the actual gate; `npm test` typechecks this
   // file through `test/tsconfig.json` before it runs. This asserts the file was not
   // quietly excluded from that typecheck -- if it were, the directives would prove
   // nothing and this suite would still be green.
-  assert.equal(forbidden.length, 5);
+  const enumerated = enumeratedCombinations();
+  assert.equal(forbidden.length, enumerated.size);
+
+  assert.deepEqual(
+    [...enumerated].sort((a, b) => a.localeCompare(b)),
+    [...requiredCombinations()].sort((a, b) => a.localeCompare(b)),
+    "the exclusivity roster no longer matches the AsyncResource union. A missing entry is a "
+    + "variant/field combination nothing rejects; an extra one no longer exists.");
+
   assert.deepEqual(idleAsyncResource<Payload>(), { status: "idle" });
 });

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -1,0 +1,108 @@
+// A lens converted to `AsyncResource` holds its whole request lifecycle in one state field.
+// The parallel `…Loading`/`…Error`/`…Key` fields it replaces are gone -- but nothing proved
+// they were gone, and adversarial review (GPT-5.6 Sol, Claude Opus 5) resurrected them two
+// ways with the suite and the analyzer silent:
+//
+//   * adding optional legacy fields to `PackageInspectionState`, and
+//   * adding all three concrete fields beside the resource in `initialState`.
+//
+// Neither is caught by the type system. `AppState` is derived *from* the `initialState`
+// literal, so extra properties simply join the type, and `state` reaches the coordinator as
+// a non-fresh value, so no excess-property check applies. Neither oxlint nor knip sees an
+// object property as unused.
+//
+// A literal search for the three old names would restate today's roster. This derives the
+// converted lenses from the state type instead, so converting the next lens extends the
+// check automatically and a resurrected parallel field is red on either surface.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const sourceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
+
+function read(file: string): string {
+  return readFileSync(join(sourceRoot, file), "utf8");
+}
+
+function block(source: string, anchor: RegExp): string {
+  const start = source.search(anchor);
+  assert.ok(
+    start >= 0, `the anchor ${anchor} no longer matches, so this gate derives nothing`);
+  let depth = 0;
+  let end = -1;
+  for (let cursor = start; cursor < source.length && end < 0; cursor += 1) {
+    const character = source[cursor];
+    if (character === "{") depth += 1;
+    else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) end = cursor + 1;
+    }
+  }
+  assert.ok(end >= 0, `the block at ${anchor} is unterminated`);
+  return source.slice(start, end);
+}
+
+// The converted lenses, discovered from their declared type rather than named here.
+function resourceFields(declaration: string): string[] {
+  return [...declaration.matchAll(/(\w+)\s*:\s*AsyncResource</g)]
+    .map(match => match[1])
+    .filter((name): name is string => name !== undefined);
+}
+
+function propertyNames(literalOrInterface: string): string[] {
+  return [...literalOrInterface.matchAll(/^\s{2}(\w+)\s*[:?]/gm)]
+    .map(match => match[1])
+    .filter((name): name is string => name !== undefined);
+}
+
+test("a lens converted to AsyncResource keeps exactly one state field", () => {
+  const coordinatorState = block(
+    read("package-inspection.ts"), /export interface PackageInspectionState \{/);
+  const initialState = block(read("dotnet-inspect.ts"), /^const initialState = \{/m);
+
+  const converted = resourceFields(coordinatorState);
+  assert.ok(
+    converted.length > 0,
+    "no AsyncResource state field was found, so the anchor has stopped resolving");
+
+  const surfaces: readonly (readonly [string, readonly string[]])[] = [
+    ["PackageInspectionState", propertyNames(coordinatorState)],
+    ["initialState", propertyNames(initialState)],
+  ];
+
+  const survivors: string[] = [];
+  for (const [surface, names] of surfaces) {
+    for (const name of names) {
+      for (const lens of converted) {
+        // `packageOpportunitiesKey` beside `packageOpportunities` is a parallel field;
+        // `packageOpportunities` itself is the resource.
+        if (name !== lens && name.startsWith(lens)) survivors.push(`${surface}.${name}`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    survivors.sort((left, right) => left.localeCompare(right)),
+    [],
+    "a lens holding its lifecycle in an AsyncResource also has a parallel state field. "
+    + "The resource is the single source of truth for that request; a second field beside "
+    + "it can disagree with it.");
+});
+
+test("the parallel-field gate sees both surfaces", () => {
+  // Non-vacuity, and the specific shape of the two mutations that were silent: a gate that
+  // reads only one surface, or whose property scan stops matching, would pass above while
+  // proving nothing.
+  const coordinatorState = block(
+    read("package-inspection.ts"), /export interface PackageInspectionState \{/);
+  const initialState = block(read("dotnet-inspect.ts"), /^const initialState = \{/m);
+
+  assert.ok(
+    propertyNames(coordinatorState).includes("packageOpportunities"),
+    "the coordinator-state property scan no longer sees the converted lens");
+  assert.ok(
+    propertyNames(initialState).includes("packageOpportunities"),
+    "the initial-state property scan no longer sees the converted lens");
+});

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -588,12 +588,24 @@ test("opportunity requests occupy one explicit lifecycle state", async () => {
     key: "current",
   });
 
-  await coordinator.loadOpportunities(packageItem, "current", null);
+  // The duplicate must *join* the live request, not report a completion that has not
+  // happened. Awaiting it here used to pass only because the coordinator returned early
+  // while the request was still running.
+  let duplicateSettled = false;
+  const duplicate = coordinator
+    .loadOpportunities(packageItem, "current", null)
+    .then(() => { duplicateSettled = true; });
   assert.equal(queries, 1);
+  await Promise.resolve();
+  assert.equal(
+    duplicateSettled,
+    false,
+    "a duplicate caller completed before the request it deduplicated");
 
   const result = opportunitiesResult();
   request.resolve(result);
-  await load;
+  await Promise.all([load, duplicate]);
+  assert.equal(duplicateSettled, true);
   assert.deepEqual(state.packageOpportunities, {
     status: "ready",
     key: "current",
@@ -691,6 +703,49 @@ test("a re-requested scope keeps the newest result when the abandoned one lands 
     data: { ...opportunitiesResult(), totalOpportunities: 99 },
   });
 });
+
+test("a re-requested scope keeps the newest result when the abandoned one fails late",
+  async () => {
+    // The reject path is a separate guard from the resolve path, and round 1 fixed only the
+    // resolve one. The existing failure test changes the key between requests, so key
+    // equality and identity give the same answer there and it cannot tell them apart. This
+    // is the A->B->A shape, where the abandoned request carries the *same* key as the live
+    // one: without identity ownership, a good current opportunity table is replaced by an
+    // error banner from a scan the user already navigated away from -- and, because a
+    // `failed` resource short-circuits the loader's dedupe, it never retries.
+    const packageItem = packageModel();
+    const first = deferred<BrowserPackageOpportunities>();
+    const second = deferred<BrowserPackageOpportunities>();
+    const other = deferred<BrowserPackageOpportunities>();
+    const pending = [first, second];
+    const state = inspectionState();
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryPackageOpportunities: async ({ id }) =>
+          id === packageItem.id
+            ? (pending.shift() ?? first).promise
+            : other.promise,
+      }));
+
+    const abandoned = coordinator.loadOpportunities(packageItem, "scope-a", null);
+
+    const otherPackage = packageModel({ id: "Example.Other" });
+    const otherLoad = coordinator.loadOpportunities(otherPackage, "scope-b", null);
+    other.resolve(opportunitiesResult());
+    await otherLoad;
+
+    const reloaded = coordinator.loadOpportunities(packageItem, "scope-a", null);
+    second.resolve({ ...opportunitiesResult(), totalOpportunities: 99 });
+    await reloaded;
+
+    first.reject(new Error("abandoned scan failed"));
+    await abandoned;
+    assert.deepEqual(state.packageOpportunities, {
+      status: "ready",
+      key: "scope-a",
+      data: { ...opportunitiesResult(), totalOpportunities: 99 },
+    });
+  });
 
 test("stale package lens rejection cannot overwrite newer state", async () => {
   const packageItem = packageModel();

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -620,6 +620,49 @@ test("opportunity requests occupy one explicit lifecycle state", async () => {
   });
 });
 
+test("opportunity ownership survives initial and completion render failures", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageOpportunities>();
+  const state = inspectionState();
+  let renders = 0;
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageOpportunities: async () => request.promise,
+      render: () => {
+        renders++;
+        if (renders === 1) throw new Error("initial render failed");
+        if (renders === 3) throw new Error("completion render failed");
+      },
+    }));
+
+  await assert.rejects(
+    coordinator.loadOpportunities(packageItem, "current", null),
+    /initial render failed/);
+
+  let duplicateSettled = false;
+  const duplicate = coordinator
+    .loadOpportunities(packageItem, "current", null)
+    .then(
+      () => { duplicateSettled = true; },
+      (error: unknown) => {
+        duplicateSettled = true;
+        throw error;
+      });
+  await Promise.resolve();
+  assert.equal(
+    duplicateSettled,
+    false,
+    "a duplicate caller completed after the owner render failed but before the request");
+
+  request.resolve(opportunitiesResult());
+  await assert.rejects(duplicate, /completion render failed/);
+  assert.deepEqual(state.packageOpportunities, {
+    status: "ready",
+    key: "current",
+    data: opportunitiesResult(),
+  });
+});
+
 test("opportunity failures and stale results preserve request ownership", async () => {
   const packageItem = packageModel();
   const request = deferred<BrowserPackageOpportunities>();

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -57,10 +57,7 @@ function inspectionState(
     packageIntegrationsLoading: false,
     packageIntegrationsError: "",
     packageIntegrationsKey: "",
-    packageOpportunities: null,
-    packageOpportunitiesLoading: false,
-    packageOpportunitiesError: "",
-    packageOpportunitiesKey: "",
+    packageOpportunities: { status: "idle" },
     packagePerformance: null,
     packagePerformanceLoading: false,
     packagePerformanceError: "",
@@ -402,10 +399,16 @@ test("package lens loaders reuse cached results without querying or clearing the
       name: "opportunities",
       cached: opportunities,
       state: inspectionState({
-        packageOpportunitiesKey: "cached",
-        packageOpportunities: opportunities,
+        packageOpportunities: {
+          status: "ready",
+          key: "cached",
+          data: opportunities,
+        },
       }),
-      read: (state: PackageInspectionState) => state.packageOpportunities,
+      read: (state: PackageInspectionState) =>
+        state.packageOpportunities.status === "ready"
+          ? state.packageOpportunities.data
+          : null,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadOpportunities(packageItem, "cached", null),
     },
@@ -531,23 +534,6 @@ test("every package lens preserves its complete request lifecycle", async () => 
     setError: (state, error) => { state.packageIntegrationsError = error; },
   });
   await verifyPackageLensLifecycle({
-    name: "opportunities",
-    result: opportunitiesResult(),
-    createCoordinator: (state, query, render = () => {}) =>
-      createPackageInspectionCoordinator(
-        inspectionDependencies(state, {
-          queryPackageOpportunities: async () => query(),
-          render,
-        })),
-    load: (coordinator, signature) =>
-      coordinator.loadOpportunities(packageItem, signature, null),
-    readResult: state => state.packageOpportunities,
-    readLoading: state => state.packageOpportunitiesLoading,
-    readError: state => state.packageOpportunitiesError,
-    setKey: (state, key) => { state.packageOpportunitiesKey = key; },
-    setError: (state, error) => { state.packageOpportunitiesError = error; },
-  });
-  await verifyPackageLensLifecycle({
     name: "performance",
     result: performanceResult(),
     createCoordinator: (state, query, render = () => {}) =>
@@ -580,6 +566,76 @@ test("every package lens preserves its complete request lifecycle", async () => 
     readError: state => state.packageMetadataError,
     setKey: (state, key) => { state.packageMetadataKey = key; },
     setError: (state, error) => { state.packageMetadataError = error; },
+  });
+});
+
+test("opportunity requests occupy one explicit lifecycle state", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageOpportunities>();
+  let queries = 0;
+  const state = inspectionState();
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageOpportunities: async () => {
+        queries++;
+        return request.promise;
+      },
+    }));
+
+  const load = coordinator.loadOpportunities(packageItem, "current", null);
+  assert.deepEqual(state.packageOpportunities, {
+    status: "loading",
+    key: "current",
+  });
+
+  await coordinator.loadOpportunities(packageItem, "current", null);
+  assert.equal(queries, 1);
+
+  const result = opportunitiesResult();
+  request.resolve(result);
+  await load;
+  assert.deepEqual(state.packageOpportunities, {
+    status: "ready",
+    key: "current",
+    data: result,
+  });
+
+  await coordinator.loadOpportunities(packageItem, "next", null);
+  assert.deepEqual(state.packageOpportunities, {
+    status: "ready",
+    key: "next",
+    data: result,
+  });
+});
+
+test("opportunity failures and stale results preserve request ownership", async () => {
+  const packageItem = packageModel();
+  const request = deferred<BrowserPackageOpportunities>();
+  const state = inspectionState();
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageOpportunities: async ({ id }) => {
+        if (id === packageItem.id) return request.promise;
+        throw new Error("newer failure");
+      },
+    }));
+
+  const staleLoad =
+    coordinator.loadOpportunities(packageItem, "first", null);
+  const newerPackage = packageModel({ id: "Example.Newer" });
+  await coordinator.loadOpportunities(newerPackage, "second", null);
+  assert.deepEqual(state.packageOpportunities, {
+    status: "failed",
+    key: "second",
+    error: "newer failure",
+  });
+
+  request.resolve(opportunitiesResult());
+  await staleLoad;
+  assert.deepEqual(state.packageOpportunities, {
+    status: "failed",
+    key: "second",
+    error: "newer failure",
   });
 });
 
@@ -905,7 +961,7 @@ test("scoped package lenses route platform coordinates and suppress stale result
     "metadata:Example.Package",
   ]);
   assert.ok(state.packageIntegrations);
-  assert.ok(state.packageOpportunities);
+  assert.equal(state.packageOpportunities.status, "ready");
   assert.equal(state.packagePerformance, null);
   assert.equal(state.packagePerformanceError, "analysis unavailable");
   assert.equal(state.packagePerformanceLoading, false);
@@ -994,16 +1050,21 @@ test("package lens results clear before a different request completes", async ()
   {
     const query = deferred<BrowserPackageOpportunities>();
     const state = inspectionState({
-      packageOpportunitiesKey: "old",
-      packageOpportunities: opportunitiesResult(),
+      packageOpportunities: {
+        status: "ready",
+        key: "old",
+        data: opportunitiesResult(),
+      },
     });
     const coordinator = createPackageInspectionCoordinator(
       inspectionDependencies(state, {
         queryPackageOpportunities: async () => query.promise,
       }));
     const load = coordinator.loadOpportunities(packageItem, "new", null);
-    assert.equal(state.packageOpportunities, null);
-    assert.equal(state.packageOpportunitiesLoading, true);
+      assert.deepEqual(state.packageOpportunities, {
+        status: "loading",
+        key: "new",
+      });
     query.resolve(opportunitiesResult());
     await load;
   }
@@ -1069,11 +1130,16 @@ test("package lens results require their current request key", async () => {
         queryPackageOpportunities: async () => query.promise,
       }));
     const load = coordinator.loadOpportunities(packageItem, "first", null);
-    state.packageOpportunitiesKey = "second";
-    query.resolve(opportunitiesResult());
-    await load;
-    assert.equal(state.packageOpportunities, null);
-    assert.equal(state.packageOpportunitiesLoading, true);
+      state.packageOpportunities = {
+        status: "loading",
+        key: "second",
+      };
+      query.resolve(opportunitiesResult());
+      await load;
+      assert.deepEqual(state.packageOpportunities, {
+        status: "loading",
+        key: "second",
+      });
   }
 
   {
@@ -1130,7 +1196,7 @@ test("runtime package lenses wait for an explicit library scope", async () => {
   assert.equal(queries, 0);
   assert.equal(renders, 0);
   assert.equal(state.packageIntegrationsKey, "");
-  assert.equal(state.packageOpportunitiesKey, "");
+  assert.equal(state.packageOpportunities.status, "idle");
   assert.equal(state.packagePerformanceKey, "");
   assert.equal(state.packageMetadataKey, "");
 });

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -639,6 +639,59 @@ test("opportunity failures and stale results preserve request ownership", async 
   });
 });
 
+// The staleness test above changes the key between the two requests, so key equality and
+// object identity give the same answer and it cannot tell them apart. Adversarial review
+// used exactly that gap: replacing both ownership checks with `status !== "idle" && key
+// === signature` left all 23 tests green, even though a late completion could then publish
+// into a newer request that happens to share its key.
+//
+// This is the interleaving that separates them. Scope A is requested, abandoned for B, and
+// then requested again -- one user navigating away and back. Both A requests carry the same
+// key, so only object identity can tell the first from the second.
+test("a re-requested scope keeps the newest result when the abandoned one lands late", async () => {
+  const packageItem = packageModel();
+  const first = deferred<BrowserPackageOpportunities>();
+  const second = deferred<BrowserPackageOpportunities>();
+  const other = deferred<BrowserPackageOpportunities>();
+  const pending = [first, second];
+  const state = inspectionState();
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryPackageOpportunities: async ({ id }) =>
+        id === packageItem.id
+          ? (pending.shift() ?? first).promise
+          : other.promise,
+    }));
+
+  const abandoned = coordinator.loadOpportunities(packageItem, "scope-a", null);
+
+  // Navigating to B releases A's ownership, so the re-request below is a genuinely new
+  // request object rather than a reuse of the in-flight one.
+  const otherPackage = packageModel({ id: "Example.Other" });
+  const otherLoad = coordinator.loadOpportunities(otherPackage, "scope-b", null);
+  other.resolve(opportunitiesResult());
+  await otherLoad;
+
+  const reloaded = coordinator.loadOpportunities(packageItem, "scope-a", null);
+  second.resolve({ ...opportunitiesResult(), totalOpportunities: 99 });
+  await reloaded;
+  assert.deepEqual(state.packageOpportunities, {
+    status: "ready",
+    key: "scope-a",
+    data: { ...opportunitiesResult(), totalOpportunities: 99 },
+  });
+
+  // The abandoned request now lands, carrying the same key as the live one. Identity
+  // ownership rejects it; key equality would accept it and show the stale count.
+  first.resolve({ ...opportunitiesResult(), totalOpportunities: 1 });
+  await abandoned;
+  assert.deepEqual(state.packageOpportunities, {
+    status: "ready",
+    key: "scope-a",
+    data: { ...opportunitiesResult(), totalOpportunities: 99 },
+  });
+});
+
 test("stale package lens rejection cannot overwrite newer state", async () => {
   const packageItem = packageModel();
   const request = deferred<PackagePerformance>();

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -6,6 +6,7 @@ import {
   type OpportunityItem,
   type PackageOpportunitiesBindingActions,
   type PackageOpportunityTarget,
+  type RenderPackageOpportunitiesOptions,
 } from "../src/package-opportunities.ts";
 import { fakeDom } from "./fake-dom.ts";
 
@@ -179,15 +180,21 @@ function escapeHtml(value: unknown) {
     .replaceAll('"', "&quot;");
 }
 
-const baseOptions = {
+type OpportunityResource = RenderPackageOpportunitiesOptions["resource"];
+type OpportunityData =
+  Extract<OpportunityResource, { status: "ready" }>["data"];
+
+function ready(data: OpportunityData): OpportunityResource {
+  return { status: "ready", key: "current", data };
+}
+
+const baseOptions: RenderPackageOpportunitiesOptions = {
   isPlatform: false,
   scopedLibrary: null,
   activeFramework: "net10.0",
   picker: "",
-  fresh: true,
-  loading: false,
-  error: "",
-  data: null,
+  signature: "current",
+  resource: { status: "idle" },
   escapeHtml,
 };
 
@@ -211,7 +218,6 @@ test("a platform package with no scoped library prompts to pick one, before any 
     isPlatform: true,
     scopedLibrary: null,
     picker: "<PICKER>",
-    fresh: false,
   });
 
   assert.match(html, /^<PICKER>/);
@@ -219,26 +225,39 @@ test("a platform package with no scoped library prompts to pick one, before any 
 });
 
 test("a fresh scan in progress shows the scanning status", () => {
-  const html = renderPackageOpportunities({ ...baseOptions, loading: true });
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    resource: { status: "loading", key: "current" },
+  });
 
   assert.match(html, /Scanning opportunities…/);
 });
 
-test("a loading flag from a stale (non-fresh) scope does not show the scanning status", () => {
-  const html = renderPackageOpportunities({ ...baseOptions, loading: true, fresh: false });
+test("a stale loading request does not show the scanning status", () => {
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    resource: { status: "loading", key: "stale" },
+  });
 
   assert.doesNotMatch(html, /Scanning opportunities…/);
   assert.match(html, /Loading…/);
 });
 
 test("a fresh scan error shows the failure message, escaped", () => {
-  const html = renderPackageOpportunities({ ...baseOptions, error: "<boom> failed to load" });
+  const html = renderPackageOpportunities({
+    ...baseOptions,
+    resource: {
+      status: "failed",
+      key: "current",
+      error: "<boom> failed to load",
+    },
+  });
 
   assert.match(html, /Opportunity scan failed/);
   assert.match(html, /&lt;boom&gt; failed to load/);
 });
 
-test("no data yet (fresh, no error, no data) shows a generic loading placeholder", () => {
+test("an idle request shows a generic loading placeholder", () => {
   const html = renderPackageOpportunities(baseOptions);
 
   assert.match(html, /Loading…/);
@@ -247,7 +266,11 @@ test("no data yet (fresh, no error, no data) shows a generic loading placeholder
 test("empty categories render the no-opportunities message with the scan scope", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: { categories: [], totalOpportunities: 0, inspectionError: null },
+    resource: ready({
+      categories: [],
+      totalOpportunities: 0,
+      inspectionError: null,
+    }),
   });
 
   assert.match(html, /No integration opportunities/);
@@ -259,7 +282,11 @@ test("a platform scan scope names the scoped library and framework", () => {
     ...baseOptions,
     isPlatform: true,
     scopedLibrary: "System.Text.Json",
-    data: { categories: [], totalOpportunities: 0, inspectionError: null },
+    resource: ready({
+      categories: [],
+      totalOpportunities: 0,
+      inspectionError: null,
+    }),
   });
 
   assert.match(html, /System\.Text\.Json · net10\.0/);
@@ -268,11 +295,11 @@ test("a platform scan scope names the scoped library and framework", () => {
 test("an inspection error renders a warning banner alongside categories", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{ integration: "Auth", items: [] }],
       totalOpportunities: 0,
       inspectionError: "<bad> assembly",
-    },
+    }),
   });
 
   assert.match(html, /Some assemblies could not be scanned/);
@@ -282,14 +309,14 @@ test("an inspection error renders a warning banner alongside categories", () => 
 test("categories render a summary with area/suggestion counts and a chip per category", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [
         { integration: "Auth", items: [opportunity({ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" })] },
         { integration: "Database", items: [] },
       ],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /2 areas · 1 suggestion · net10\.0/);
@@ -300,7 +327,7 @@ test("categories render a summary with area/suggestion counts and a chip per cat
 test("an opportunity row splits the API into short name and qualifier", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "AI",
         items: [{
@@ -316,7 +343,7 @@ test("an opportunity row splits the API into short name and qualifier", () => {
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /<span class="opp-type-name">PipelineMessage<\/span><span class="opp-type-ns">System\.ClientModel\.Primitives<\/span>/);
@@ -376,14 +403,14 @@ test("an explicitly unknown source identity remains distinct from a legacy row",
 test("an integration kind with a leading dotted namespace renders a load-on-demand package chip", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "AI",
         items: [opportunity({ api: "Widget", integrationType: "Microsoft.Extensions.AI IChatClient extension", lookFor: "" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /<button class="opp-package-chip" data-opp-package="Microsoft\.Extensions\.AI"/);
@@ -393,14 +420,14 @@ test("an integration kind with a leading dotted namespace renders a load-on-dema
 test("an integration kind with no dotted namespace renders as plain muted text", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "Config",
         items: [opportunity({ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.doesNotMatch(html, /opp-package-chip/);
@@ -410,14 +437,14 @@ test("an integration kind with no dotted namespace renders as plain muted text",
 test("look-for tokens render as spotlight-seeded chips, one per comma-separated identifier", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "AI",
         items: [opportunity({ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "AddChatClient, AddEmbeddingGenerator" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /<button class="opp-chip" data-opp-lookfor="AddChatClient"[^>]*>AddChatClient<\/button>/);
@@ -427,14 +454,14 @@ test("look-for tokens render as spotlight-seeded chips, one per comma-separated 
 test("a wildcard look-for pattern renders as a muted, non-interactive hint", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "Config",
         items: [opportunity({ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "Add*" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /<span class="opp-pattern" title="Naming pattern">Add\*<\/span>/);
@@ -444,14 +471,14 @@ test("a wildcard look-for pattern renders as a muted, non-interactive hint", () 
 test("an empty look-for hint renders a generic any-registration-surface hint", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "Config",
         items: [opportunity({ api: "Widget", integrationType: "IServiceCollection registration", lookFor: "" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /<span class="opp-pattern">any registration surface<\/span>/);
@@ -460,14 +487,14 @@ test("an empty look-for hint renders a generic any-registration-surface hint", (
 test("API and integration-type text is escaped", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "<Cat>",
         items: [opportunity({ api: "<Widget>", integrationType: "<bad> kind", lookFor: "<bad>" })],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(html, /&lt;Widget&gt;/);

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -243,6 +243,43 @@ test("a stale loading request does not show the scanning status", () => {
   assert.match(html, /Loading…/);
 });
 
+test("a stale result belonging to another scan scope is not rendered as current", () => {
+  // One guard carries staleness for all three live variants, but only the `loading` case
+  // was tested. Narrowing it to `status === "loading" && key !== signature` left the whole
+  // suite green while another scope's opportunity table rendered under this scope's heading.
+  const stale = renderPackageOpportunities({
+    ...baseOptions,
+    resource: {
+      status: "ready",
+      key: "stale",
+      data: {
+        categories: [],
+        totalOpportunities: 41,
+        inspectionError: null,
+      },
+    },
+  });
+
+  assert.doesNotMatch(stale, /No integration opportunities/);
+  assert.doesNotMatch(stale, /41/);
+  assert.match(stale, /Loading…/);
+});
+
+test("a stale failure belonging to another scan scope is not rendered as current", () => {
+  const stale = renderPackageOpportunities({
+    ...baseOptions,
+    resource: {
+      status: "failed",
+      key: "stale",
+      error: "another scope failed",
+    },
+  });
+
+  assert.doesNotMatch(stale, /Opportunity scan failed/);
+  assert.doesNotMatch(stale, /another scope failed/);
+  assert.match(stale, /Loading…/);
+});
+
 test("a fresh scan error shows the failure message, escaped", () => {
   const html = renderPackageOpportunities({
     ...baseOptions,

--- a/prototypes/inspect-web/test/package-opportunities.test.ts
+++ b/prototypes/inspect-web/test/package-opportunities.test.ts
@@ -396,7 +396,7 @@ test("an opportunity row splits the API into short name and qualifier", () => {
 test("an explicitly unknown source identity remains distinct from a legacy row", () => {
   const currentHtml = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "AI",
         items: [{
@@ -412,7 +412,7 @@ test("an explicitly unknown source identity remains distinct from a legacy row",
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
   const legacyItem = opportunity({
     api: "Example.Legacy",
@@ -422,14 +422,14 @@ test("an explicitly unknown source identity remains distinct from a legacy row",
   Reflect.deleteProperty(legacyItem, "sourceDefinitionId");
   const legacyHtml = renderPackageOpportunities({
     ...baseOptions,
-    data: {
+    resource: ready({
       categories: [{
         integration: "AI",
         items: [legacyItem],
       }],
       totalOpportunities: 1,
       inspectionError: null,
-    },
+    }),
   });
 
   assert.match(currentHtml, /data-opp-source-identity="unknown"/);


### PR DESCRIPTION
Part of #4570

The Opportunities lens now represents its asynchronous lifecycle as one `AsyncResource` discriminated union instead of independent result, loading, error, and key fields. Each loading value is also the request-ownership token, so same-key work is reused and a stale completion cannot overwrite a newer state. Rendering consumes the union directly and only reads data or errors from the applicable variant.

This is intentionally the first state-family slice. Dependencies, Integrations, Performance, Metadata, source, selection, and top-level view states remain as explicit residual work under #4570.

## Stack

- Slice 4 of the semantic TypeScript conversion stack.
- Parent: #4581 (`type/4571-dom-payloads`).
- Residual: the remaining state families in #4570 plus #4572-#4575.

## Validation

- `npm test` (612 tests)
- `npm run analyze`
- `npm run build`
- `node --test test/package-inspection.test.ts test/package-opportunities.test.ts` (49 tests)
- `npx --yes markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

## Latest-main restack

Restacked onto #4581 head `470786cd7`; current head is `e7d8a16e0`.
Latest-main source-provenance cases now exercise the union-backed opportunity
renderer rather than its removed parallel `data` field.

- Full suite: 612/612.
- Focused package-inspection and opportunity tests after the second parent
  refresh: 49/49.
- Analyzer and production build: clean.
