### PR TITLE
Model package lens requests as discriminated unions

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1064,13 +1064,14 @@ rendered DOM bindings, opportunity-row API-name splitting, package-chip
 detection, and "look for" chip rendering. `dotnet-inspect.ts` still owns
 `state`, target resolution, navigation effects, and the platform library
 picker, `package-inspection.ts` owns the scan-scope-keyed async load lifecycle,
-and the root supplies behavior through typed callbacks. The Opportunities
+and the root supplies behavior through typed callbacks. Each package-lens
 request is one `AsyncResource` state: idle, loading, ready, or failed. Loading
 owns its request object, so a stale completion cannot publish into a newer
 state, and data/error fields exist only on their applicable variants.
 `test/package-inspection.test.ts` gates those transitions, same-request reuse,
-and stale-result suppression. A second caller of an in-flight request joins it
-rather than returning early, so it reports completion only once the request has
+and stale-result suppression for Dependencies, Integrations, Opportunities,
+Analysis, and Metadata. A second caller of an in-flight request joins it rather
+than returning early, so it reports completion only once the request has
 actually settled -- including when that request rejects.
 `test/async-resource-state.test.ts` derives the converted lenses from their
 declared type and fails if one regains a parallel `…Loading`/`…Error`/`…Key`

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1079,8 +1079,10 @@ it would not want. Registration owns the settlement: the loader body runs
 inside `runInFlight`, so no exit path -- including a throwing `render()` -- can
 leave a joined caller awaiting a request nobody will resolve.
 `test/package-inspection.test.ts` also drives every lens with a render that
-throws on the nth call, for every n, and projects every `AsyncResource` variant
-through `packageMetadataView`, deriving both rosters from the union declaration.
+throws on the nth call, for every n, and requires a later same-key call to reach
+a settled resource rather than returning from ownerless loading state. It also
+projects every `AsyncResource` variant through `packageMetadataView`, deriving
+both rosters from the union declaration.
 `test/async-resource-state.test.ts` derives the converted lenses from their
 declared type and fails if one regains any parallel state field -- named,
 quoted, or carried in by a spread -- on either the coordinator state or the

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1072,10 +1072,19 @@ state, and data/error fields exist only on their applicable variants.
 and stale-result suppression for Dependencies, Integrations, Opportunities,
 Analysis, and Metadata. A second caller of an in-flight request joins it rather
 than returning early, so it reports completion only once the request has
-actually settled -- including when that request rejects.
+actually settled -- including when that request rejects. Joining requires both
+the same scope signature and the live request object, so a caller for a
+different scope starts its own request instead of waiting on one whose result
+it would not want. Registration owns the settlement: the loader body runs
+inside `runInFlight`, so no exit path -- including a throwing `render()` -- can
+leave a joined caller awaiting a request nobody will resolve.
+`test/package-inspection.test.ts` also drives every lens with a render that
+throws on the nth call, for every n, and projects every `AsyncResource` variant
+through `packageMetadataView`, deriving both rosters from the union declaration.
 `test/async-resource-state.test.ts` derives the converted lenses from their
-declared type and fails if one regains a parallel `…Loading`/`…Error`/`…Key`
-field on either the coordinator state or the initial state.
+declared type and fails if one regains any parallel state field -- named,
+quoted, or carried in by a spread -- on either the coordinator state or the
+initial state.
 `test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
 the idle/loading/ready/failed states (fresh versus stale scope), the
 no-opportunities and inspection-error banners, the category summary counts,

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "build": "npm run typecheck && vite build && node scripts/verify-site-artifact.js dist",
     "preview": "vite preview",
-    "test": "npm run typecheck && node --test",
+    "test": "npm run typecheck && node --test --test-timeout 120000",
     "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "lint": "node scripts/verify-analysis-host.js && oxlint src test scripts engine/wwwroot/inspect-web-engine.js vite.config.js",
     "analyze": "npm run lint && knip"

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -1422,6 +1422,12 @@ export function asyncResourceKey<T>(
   return resource.status === "idle" ? null : resource.key;
 }
 
+export function asyncResourceData<T>(
+  resource: AsyncResource<T>,
+): T | null {
+  return resource.status === "ready" ? resource.data : null;
+}
+
 export function scopedRequestState(
   activeKey: string,
   requestKey: string,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -107,6 +107,7 @@ import {
 } from "./package-acquisition.ts";
 import {
   createPackageInspectionCoordinator,
+  packageMetadataView,
   workspaceDependencyKey,
   type PackagePerformance,
 } from "./package-inspection.ts";
@@ -2625,19 +2626,27 @@ function packageDependenciesSignature() {
 function renderPackageDependencies() {
   const current = packageDependenciesSignature();
   const resource = state.packageDependencies;
-  const fresh = resource.status !== "idle" && resource.key === current;
-  if (fresh && resource.status === "loading") {
-    return `<section class="document-section source-progress"><span class="loader"></span><h2>Reading dependencies…</h2><p>Parsing the package manifest and assembly references.</p></section>`;
+  const pending = `<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+
+  // Settle staleness first, so the switch below dispatches only on a resource that
+  // describes the scope being rendered. Splitting it that way lets the `default` arm
+  // reach `assertNever`, which is what makes a new `AsyncResource` status a compile
+  // error here instead of a silent fall-through to the pending placeholder.
+  if (resource.status === "idle" || resource.key !== current) return pending;
+
+  let data: BrowserPackageDependencies;
+  switch (resource.status) {
+    case "loading":
+      return `<section class="document-section source-progress"><span class="loader"></span><h2>Reading dependencies…</h2><p>Parsing the package manifest and assembly references.</p></section>`;
+    case "failed":
+      return `<section class="document-section empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
+    case "ready":
+      data = resource.data;
+      break;
+    default:
+      assertNever(resource, "package dependency resource status");
   }
-  if (fresh && resource.status === "failed") {
-    return `<section class="document-section empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
-  }
-  const data = fresh && resource.status === "ready"
-    ? resource.data
-    : null;
-  if (!data) {
-    return `<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
+  if (!data) return pending;
 
   const groups = data.dependencyGroups || [];
   const assemblyReferences = assemblyReferencesSectionHtml(data);
@@ -2881,19 +2890,25 @@ function renderPackageIntegrations() {
     : escapeHtml(pkg.activeFramework);
   const current = packageIntegrationsSignature();
   const resource = state.packageIntegrations;
-  const fresh = resource.status !== "idle" && resource.key === current;
-  if (fresh && resource.status === "loading") {
-    return `${platformPicker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning integrations…</h2><p>Reading the public surface of ${isPlatform ? escapeHtml(scopedLib) : "each assembly"} for ecosystem signals.</p></section>`;
+  const pending = `${platformPicker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+
+  // Staleness first, so the switch dispatches only on a resource describing the scope
+  // being rendered and its `default` arm can reach `assertNever`.
+  if (resource.status === "idle" || resource.key !== current) return pending;
+
+  let data: BrowserPackageIntegrations;
+  switch (resource.status) {
+    case "loading":
+      return `${platformPicker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning integrations…</h2><p>Reading the public surface of ${isPlatform ? escapeHtml(scopedLib) : "each assembly"} for ecosystem signals.</p></section>`;
+    case "failed":
+      return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Integration scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
+    case "ready":
+      data = resource.data;
+      break;
+    default:
+      assertNever(resource, "package integration resource status");
   }
-  if (fresh && resource.status === "failed") {
-    return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Integration scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
-  }
-  const data = fresh && resource.status === "ready"
-    ? resource.data
-    : null;
-  if (!data) {
-    return `${platformPicker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
+  if (!data) return pending;
 
   const categories = data.categories || [];
   const warning = data.inspectionError
@@ -3017,19 +3032,25 @@ function renderPackagePerformance() {
     : escapeHtml(pkg.activeFramework);
   const current = packageScopeSignature();
   const resource = state.packagePerformance;
-  const fresh = resource.status !== "idle" && resource.key === current;
-  if (fresh && resource.status === "loading") {
-    return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Analyzing allocations…</h2><p>Classifying allocation and performance opportunities across every method body.</p></section>`;
+  const pending = `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
+
+  // Staleness first, so the switch dispatches only on a resource describing the scope
+  // being rendered and its `default` arm can reach `assertNever`.
+  if (resource.status === "idle" || resource.key !== current) return pending;
+
+  let data: PackagePerformance;
+  switch (resource.status) {
+    case "loading":
+      return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Analyzing allocations…</h2><p>Classifying allocation and performance opportunities across every method body.</p></section>`;
+    case "failed":
+      return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Analysis failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
+    case "ready":
+      data = resource.data;
+      break;
+    default:
+      assertNever(resource, "package performance resource status");
   }
-  if (fresh && resource.status === "failed") {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Analysis failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
-  }
-  const data = fresh && resource.status === "ready"
-    ? resource.data
-    : null;
-  if (!data) {
-    return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
-  }
+  if (!data) return pending;
 
   const members = data.members || [];
   const warning = data.inspectionError
@@ -3090,17 +3111,19 @@ function maybeAutoLoadPackagePerformance() {
 function renderPackageMetadata() {
   const isPlatform = state.package?.isRuntimePack === true;
   const resource = state.packageMetadata;
-  const fresh = resource.status !== "idle"
-    && resource.key === packageScopeSignature();
+
+  // `renderPackageMetadataHtml` still takes the flattened `fresh`/`loading`/`error`/
+  // `metadata` options, which is the very shape this state stopped being. Rather than
+  // reconstruct those four independently -- three `fresh &&` conjunctions that could
+  // each drift -- project them once from an exhaustive switch, so the union stays the
+  // single source of the answer and a new status is a compile error here.
+  const view = packageMetadataView(resource, packageScopeSignature());
   return renderPackageMetadataHtml({
     isPlatform,
     scopedLibrary: scopedPlatformLibrary() || "",
     activeFramework: state.package?.activeFramework || "",
     pickerHtml: isPlatform ? platformLensPicker("data-platform-metadata-library") : "",
-    fresh,
-    loading: fresh && resource.status === "loading",
-    error: fresh && resource.status === "failed" ? resource.error : "",
-    metadata: fresh && resource.status === "ready" ? resource.data : null,
+    ...view,
     escapeHtml,
     fmtBytes,
   });

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1,6 +1,7 @@
 import {
   accessibilityFilterIncludingType,
   activeSourceOperationKind,
+  asyncResourceData,
   asyncResourceKey,
   assemblyDescriptorForType,
   assertNever,
@@ -574,27 +575,15 @@ const initialState = {
   typeMetadataError: "",
   typeMetadataKey: "",
   typeMetadataGeneration: 0,
-  packageDependencies: null,
-  packageDependenciesLoading: false,
-  packageDependenciesError: "",
-  packageDependenciesKey: "",
+  packageDependencies: idleAsyncResource<BrowserPackageDependencies>(),
   dependenciesGroupIndex: null,
   workspaceDependencies: {},
   workspaceDependencyErrors: {},
   workspaceDependencyLoads: new Set<string>(),
-  packageIntegrations: null,
-  packageIntegrationsLoading: false,
-  packageIntegrationsError: "",
-  packageIntegrationsKey: "",
+  packageIntegrations: idleAsyncResource<BrowserPackageIntegrations>(),
   packageOpportunities: idleAsyncResource<BrowserPackageOpportunities>(),
-  packagePerformance: null,
-  packagePerformanceLoading: false,
-  packagePerformanceError: "",
-  packagePerformanceKey: "",
-  packageMetadata: null,
-  packageMetadataLoading: false,
-  packageMetadataError: "",
-  packageMetadataKey: "",
+  packagePerformance: idleAsyncResource<PackagePerformance>(),
+  packageMetadata: idleAsyncResource<PackageMetadata>(),
   explorer: null,
   memberCallGraph: null,
   memberCallGraphLoading: false,
@@ -692,14 +681,10 @@ interface StateOverrides {
   memberAnnotatedNodeIds: number[];
   typeSource: BrowserSource | null;
   typeMetadata: BrowserTypeMetadata | null;
-  packageDependencies: BrowserPackageDependencies | null;
   dependenciesGroupIndex: number | null;
   workspaceDependencies: Record<string, DependencyGroupData>;
   workspaceDependencyErrors: Record<string, string>;
   workspaceDependencyLoads: Set<string>;
-  packageIntegrations: BrowserPackageIntegrations | null;
-  packagePerformance: PackagePerformance | null;
-  packageMetadata: PackageMetadata | null;
   explorer: AppExplorerState | null;
   memberCallGraph: BrowserCallGraph | null;
   pendingGraphMemberDeepLink: PendingGraphMemberDeepLink | null;
@@ -2639,14 +2624,17 @@ function packageDependenciesSignature() {
 
 function renderPackageDependencies() {
   const current = packageDependenciesSignature();
-  const fresh = state.packageDependenciesKey === current;
-  if (state.packageDependenciesLoading && fresh) {
+  const resource = state.packageDependencies;
+  const fresh = resource.status !== "idle" && resource.key === current;
+  if (fresh && resource.status === "loading") {
     return `<section class="document-section source-progress"><span class="loader"></span><h2>Reading dependencies…</h2><p>Parsing the package manifest and assembly references.</p></section>`;
   }
-  if (fresh && state.packageDependenciesError) {
-    return `<section class="document-section empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(state.packageDependenciesError)}</p></section>`;
+  if (fresh && resource.status === "failed") {
+    return `<section class="document-section empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
   }
-  const data = fresh ? state.packageDependencies : null;
+  const data = fresh && resource.status === "ready"
+    ? resource.data
+    : null;
   if (!data) {
     return `<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
   }
@@ -2751,7 +2739,8 @@ function dependencyListSectionHtml(
 // toggle the active chip, swap the dependency list in place, and let renderDependencyGraph
 // swap the diagram (it keeps the old SVG until the new one is ready, so no loader flash).
 function patchDependenciesGroup() {
-  const groups = state.packageDependencies?.dependencyGroups || [];
+  const groups =
+    asyncResourceData(state.packageDependencies)?.dependencyGroups || [];
   const listSection = document.querySelector<HTMLElement>("#dep-list-section");
   if (!groups.length || !listSection) { render(); return; }
   const selectedGroupIndex = resolveDependenciesGroupIndex(groups);
@@ -2836,8 +2825,9 @@ async function loadPackageDependencies() {
 
 function maybeAutoLoadPackageDependencies() {
   if (!state.atPackageRoot || state.packageLens !== "dependencies") return;
-  if (state.packageDependenciesKey === packageDependenciesSignature()) {
-    if (state.packageDependencies) {
+  if (asyncResourceKey(state.packageDependencies)
+      === packageDependenciesSignature()) {
+    if (state.packageDependencies.status === "ready") {
       observeAsync(renderDependencyGraph(), "Rendering the dependency graph");
       observeAsync(ensureWorkspaceDependencies(), "Loading workspace dependencies");
     }
@@ -2890,14 +2880,17 @@ function renderPackageIntegrations() {
     ? `${scopedLib} · ${escapeHtml(pkg.activeFramework)}`
     : escapeHtml(pkg.activeFramework);
   const current = packageIntegrationsSignature();
-  const fresh = state.packageIntegrationsKey === current;
-  if (state.packageIntegrationsLoading && fresh) {
+  const resource = state.packageIntegrations;
+  const fresh = resource.status !== "idle" && resource.key === current;
+  if (fresh && resource.status === "loading") {
     return `${platformPicker}<section class="document-section source-progress"><span class="loader"></span><h2>Scanning integrations…</h2><p>Reading the public surface of ${isPlatform ? escapeHtml(scopedLib) : "each assembly"} for ecosystem signals.</p></section>`;
   }
-  if (fresh && state.packageIntegrationsError) {
-    return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Integration scan failed</h2><p>${escapeHtml(state.packageIntegrationsError)}</p></section>`;
+  if (fresh && resource.status === "failed") {
+    return `${platformPicker}<section class="document-section empty-document"><span class="large-glyph">◈</span><h2>Integration scan failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
   }
-  const data = fresh ? state.packageIntegrations : null;
+  const data = fresh && resource.status === "ready"
+    ? resource.data
+    : null;
   if (!data) {
     return `${platformPicker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
   }
@@ -2955,7 +2948,10 @@ async function loadPackageIntegrations() {
 
 function maybeAutoLoadPackageIntegrations() {
   if (!state.atPackageRoot || state.packageLens !== "integrations") return;
-  if (state.packageIntegrationsKey === packageIntegrationsSignature()) return;
+  if (asyncResourceKey(state.packageIntegrations)
+      === packageIntegrationsSignature()) {
+    return;
+  }
   observeAsync(loadPackageIntegrations(), "Loading package integrations");
 }
 
@@ -3020,14 +3016,17 @@ function renderPackagePerformance() {
     ? `${escapeHtml(scopedLib)} · ${escapeHtml(pkg.activeFramework)}`
     : escapeHtml(pkg.activeFramework);
   const current = packageScopeSignature();
-  const fresh = state.packagePerformanceKey === current;
-  if (state.packagePerformanceLoading && fresh) {
+  const resource = state.packagePerformance;
+  const fresh = resource.status !== "idle" && resource.key === current;
+  if (fresh && resource.status === "loading") {
     return `${picker}<section class="document-section source-progress"><span class="loader"></span><h2>Analyzing allocations…</h2><p>Classifying allocation and performance opportunities across every method body.</p></section>`;
   }
-  if (fresh && state.packagePerformanceError) {
-    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Analysis failed</h2><p>${escapeHtml(state.packagePerformanceError)}</p></section>`;
+  if (fresh && resource.status === "failed") {
+    return `${picker}<section class="document-section empty-document"><span class="large-glyph">△</span><h2>Analysis failed</h2><p>${escapeHtml(resource.error)}</p></section>`;
   }
-  const data = fresh ? state.packagePerformance : null;
+  const data = fresh && resource.status === "ready"
+    ? resource.data
+    : null;
   if (!data) {
     return `${picker}<section class="document-section empty-document"><span class="loader"></span><h2>Loading…</h2></section>`;
   }
@@ -3077,7 +3076,9 @@ async function loadPackagePerformance() {
 function maybeAutoLoadPackagePerformance() {
   if (!state.atPackageRoot || state.packageLens !== "analysis") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
-  if (state.packagePerformanceKey === packageScopeSignature()) return;
+  if (asyncResourceKey(state.packagePerformance) === packageScopeSignature()) {
+    return;
+  }
   observeAsync(loadPackagePerformance(), "Loading package analysis");
 }
 
@@ -3088,16 +3089,18 @@ function maybeAutoLoadPackagePerformance() {
 // NuGet package it describes every active-framework lib/ assembly.
 function renderPackageMetadata() {
   const isPlatform = state.package?.isRuntimePack === true;
-  const fresh = state.packageMetadataKey === packageScopeSignature();
+  const resource = state.packageMetadata;
+  const fresh = resource.status !== "idle"
+    && resource.key === packageScopeSignature();
   return renderPackageMetadataHtml({
     isPlatform,
     scopedLibrary: scopedPlatformLibrary() || "",
     activeFramework: state.package?.activeFramework || "",
     pickerHtml: isPlatform ? platformLensPicker("data-platform-metadata-library") : "",
     fresh,
-    loading: state.packageMetadataLoading,
-    error: state.packageMetadataError || "",
-    metadata: state.packageMetadata || null,
+    loading: fresh && resource.status === "loading",
+    error: fresh && resource.status === "failed" ? resource.error : "",
+    metadata: fresh && resource.status === "ready" ? resource.data : null,
     escapeHtml,
     fmtBytes,
   });
@@ -3115,7 +3118,9 @@ async function loadPackageMetadata() {
 function maybeAutoLoadPackageMetadata() {
   if (!state.atPackageRoot || state.packageLens !== "metadata") return;
   if (Boolean(state.package?.isRuntimePack) && !scopedPlatformLibrary()) return;
-  if (state.packageMetadataKey === packageScopeSignature()) return;
+  if (asyncResourceKey(state.packageMetadata) === packageScopeSignature()) {
+    return;
+  }
   observeAsync(loadPackageMetadata(), "Loading package metadata");
 }
 
@@ -3156,7 +3161,7 @@ function openExplorerHeap(assemblyFileName: string, heapName: string) {
 // The common explorer state: the table + heap directories drawn from the loaded overview, plus
 // empty window caches. Focus is set by the caller (openExplorer / openExplorerHeap).
 function buildBaseExplorer(assemblyFileName: string): AppExplorerState | null {
-  const data = state.packageMetadata;
+  const data = asyncResourceData(state.packageMetadata);
   const asm = (data?.assemblies || []).find(a => a.assembly === assemblyFileName)
     || (data?.assemblies || [])[0];
   if (!asm) return null;
@@ -6746,7 +6751,8 @@ async function renderDependencyGraph() {
     document.querySelector<HTMLElement>("#dependency-graph-diagram");
   if (!container) return;
   const pending = createDependencyGraphPendingState(container.dataset);
-  const groups = state.packageDependencies?.dependencyGroups || [];
+  const dependencies = asyncResourceData(state.packageDependencies);
+  const groups = dependencies?.dependencyGroups || [];
   if (!groups.length) {
     depGraphRenderSequence.invalidate();
     pending.invalidate();
@@ -6760,8 +6766,8 @@ async function renderDependencyGraph() {
       packages: state.packages,
       dependenciesGroupIndex: state.dependenciesGroupIndex,
       workspaceDependencies: state.workspaceDependencies,
-      ...(state.packageDependencies
-        ? { packageDependencies: state.packageDependencies }
+      ...(dependencies
+        ? { packageDependencies: dependencies }
         : {}),
     },
     (_packages, packageId, versionRange) =>

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -1,4 +1,5 @@
 import {
+  assertNever,
   packageIdentityKey,
   type AsyncResource,
   type DependencyGroupData,
@@ -43,6 +44,34 @@ export interface PackageInspectionState {
   packageOpportunities: AsyncResource<BrowserPackageOpportunities>;
   packagePerformance: AsyncResource<PackagePerformance>;
   packageMetadata: AsyncResource<PackageMetadata>;
+}
+
+// The metadata renderer predates `AsyncResource` and still takes four flattened
+// options. Project them here, from the union, in one exhaustive switch: the renderer's
+// signature is a rendering concern, but deciding *which* of those four combinations the
+// state means is a state concern, and it belongs with the state.
+export function packageMetadataView(
+  resource: AsyncResource<PackageMetadata>,
+  signature: string,
+): {
+  fresh: boolean;
+  loading: boolean;
+  error: string;
+  metadata: PackageMetadata | null;
+} {
+  if (resource.status === "idle" || resource.key !== signature) {
+    return { fresh: false, loading: false, error: "", metadata: null };
+  }
+  switch (resource.status) {
+    case "loading":
+      return { fresh: true, loading: true, error: "", metadata: null };
+    case "failed":
+      return { fresh: true, loading: false, error: resource.error, metadata: null };
+    case "ready":
+      return { fresh: true, loading: false, error: "", metadata: resource.data };
+    default:
+      return assertNever(resource, "package metadata resource status");
+  }
 }
 
 export interface PackageInspectionDependencies {
@@ -136,50 +165,6 @@ export function createPackageInspectionCoordinator(
 ): PackageInspectionCoordinator {
   const { state } = dependencies;
 
-  // The completion of the opportunity request that owns the live `loading` resource. A
-  // duplicate caller has to await this rather than returning: a `loading` resource means the
-  // work is still running, and returning told the caller it had finished. Joining is keyed
-  // on the *identity* of that resource as well as the signature -- the signature alone could
-  // join a request that was already abandoned and will publish nothing.
-  let opportunitiesInFlight: {
-    readonly resource: AsyncResource<BrowserPackageOpportunities>;
-    readonly completion: Promise<void>;
-  } | null = null;
-
-  // Query failures are published as resource state. Rendering can still reject, so the
-  // in-flight record observes completion even if the starting caller's render throws.
-  const publishOpportunities = async (
-    packageModel: AppPackage,
-    signature: string,
-    scopedLibrary: string | null | undefined,
-    pending: AsyncResource<BrowserPackageOpportunities>,
-  ): Promise<void> => {
-    try {
-      const coordinates = packageModel.isRuntimePack
-        ? platformCoordinates(packageModel, scopedLibrary ?? "")
-        : null;
-      const result = coordinates
-        ? await dependencies.queryPlatformOpportunities(
-            coordinates.framework,
-            coordinates.assemblyFileName,
-            coordinates.pack)
-        : await dependencies.queryPackageOpportunities(packageModel);
-      if (state.packageOpportunities === pending) {
-        state.packageOpportunities = { status: "ready", key: signature, data: result };
-      }
-    } catch (error) {
-      if (state.packageOpportunities === pending) {
-        state.packageOpportunities = {
-          status: "failed",
-          key: signature,
-          error: dependencies.describeError(error),
-        };
-      }
-    } finally {
-      dependencies.render();
-    }
-  };
-
   const platformCoordinates = (
     packageModel: AppPackage,
     scopedLibrary: string,
@@ -237,8 +222,81 @@ export function createPackageInspectionCoordinator(
     dependencies.refreshPackageStats();
   };
 
+  // These loaders are `async`, so returning early resolves the caller's await. When a
+  // same-key request was already in flight the old guard did exactly that: it re-rendered
+  // and returned, telling the second caller the load had finished while the first request
+  // was still running. "Reuse" has to mean the second caller joins the first, so the
+  // original request's promise is handed back instead.
+  //
+  // A settled resource with the same key is a different case and still returns
+  // immediately: that work really is done, and re-querying it is the duplication this
+  // guard exists to avoid.
+  const inFlight = new Map<
+    string,
+    { resource: AsyncResource<unknown>; promise: Promise<void>; settle: () => void }>();
+
+  // Join on the identity of the pending resource, not on its key. A request that has
+  // lost ownership -- because a newer request or a scope change overwrote the slot --
+  // will discard its own result when it lands, so joining it would leave the caller
+  // awaiting a request that publishes nothing. Two requests for one scope can carry the
+  // same key while only one of them still owns the state, so key equality cannot tell
+  // them apart and object identity can.
+  // Identity alone is not enough: it says the in-flight request still owns the state, not
+  // that it is the request this caller wants. Restacking onto the opportunities slice
+  // showed why -- its A->B->A tests deadlocked here, because a caller for a *different*
+  // scope matched on identity, joined the running request, and returned without ever
+  // starting its own. The key comparison is what makes this "the same request", and the
+  // identity comparison is what makes it "still the live one".
+  function joinInFlight(
+    lens: string,
+    live: AsyncResource<unknown>,
+    signature: string,
+  ): Promise<void> | null {
+    const active = inFlight.get(lens);
+    if (!active || active.resource !== live) return null;
+    if (live.status !== "loading" || live.key !== signature) return null;
+    dependencies.render();
+    return active.promise;
+  }
+
+  // The body runs inside this function's `try`, so settling is not something a caller can
+  // forget or be skipped past. Round 2 review (Claude Opus 5, GPT-5.6 Sol) found the
+  // previous shape -- `beginInFlight` returning a `settle` the caller invoked from its own
+  // `finally` -- deadlocked the lens: `dependencies.render()` sat between the registration
+  // and the `try`, so a throwing render skipped `settle` while `state[lens]` was still the
+  // exact pending object the join requires. The next same-key caller joined a promise
+  // nobody would ever resolve. `loadDependencies` had a second instance of the same bug,
+  // settling after an awaited call inside its own `finally`.
+  //
+  // Taking the body removes the window rather than narrowing it: there is no way to
+  // register an entry without this `finally`. `test/in-flight-settlement.test.ts` drives
+  // every lens with a render callback that throws on the nth call, for every n, and proves
+  // a later same-key caller still settles.
+  function runInFlight(
+    lens: string,
+    resource: AsyncResource<unknown>,
+    body: () => Promise<void>,
+  ): Promise<void> {
+    let settle: () => void = () => {};
+    const promise = new Promise<void>(resolve => {
+      settle = resolve;
+    });
+    const entry = { resource, promise, settle };
+    inFlight.set(lens, entry);
+    return (async () => {
+      try {
+        await body();
+      } finally {
+        if (inFlight.get(lens) === entry) inFlight.delete(lens);
+        entry.settle();
+      }
+    })();
+  }
+
   return {
     async loadDependencies(packageModel, signature) {
+      const joined = joinInFlight("packageDependencies", state.packageDependencies, signature);
+      if (joined) return joined;
       if (state.packageDependencies.status !== "idle"
         && state.packageDependencies.key === signature) {
         dependencies.render();
@@ -246,15 +304,16 @@ export function createPackageInspectionCoordinator(
       }
       const pending = { status: "loading", key: signature } as const;
       state.packageDependencies = pending;
-      dependencies.render();
-      const packageRequest = {
-        id: packageModel.id,
-        version: packageModel.version,
-        activeFramework: packageModel.activeFramework,
-        assemblyId: packageModel.assemblyId,
-      };
-      const workspaceKey = workspaceDependencyKey(packageRequest);
-      try {
+      return runInFlight("packageDependencies", pending, async () => {
+        dependencies.render();
+        const packageRequest = {
+          id: packageModel.id,
+          version: packageModel.version,
+          activeFramework: packageModel.activeFramework,
+          assemblyId: packageModel.assemblyId,
+        };
+        const workspaceKey = workspaceDependencyKey(packageRequest);
+        try {
         const result = await dependencies.queryDependencies(packageRequest);
         if (state.packageDependencies === pending) {
           state.packageDependencies = {
@@ -284,17 +343,20 @@ export function createPackageInspectionCoordinator(
             error: dependencies.describeError(error),
           };
         }
-      } finally {
-        dependencies.refreshPackageStats();
-        dependencies.render();
-        await ensureWorkspaceDependencies();
-      }
+        } finally {
+          dependencies.refreshPackageStats();
+          dependencies.render();
+          await ensureWorkspaceDependencies();
+        }
+      });
     },
 
     ensureWorkspaceDependencies,
 
     async loadIntegrations(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
+      const joined = joinInFlight("packageIntegrations", state.packageIntegrations, signature);
+      if (joined) return joined;
       if (state.packageIntegrations.status !== "idle"
         && state.packageIntegrations.key === signature) {
         dependencies.render();
@@ -302,67 +364,87 @@ export function createPackageInspectionCoordinator(
       }
       const pending = { status: "loading", key: signature } as const;
       state.packageIntegrations = pending;
-      dependencies.render();
-      try {
-        const coordinates = packageModel.isRuntimePack
-          ? platformCoordinates(packageModel, scopedLibrary ?? "")
-          : null;
-        const result = coordinates
-          ? await dependencies.queryPlatformIntegrations(
-              coordinates.framework,
-              coordinates.assemblyFileName,
-              coordinates.pack)
-          : await dependencies.queryPackageIntegrations(packageModel);
-        if (state.packageIntegrations === pending) {
-          state.packageIntegrations = {
-            status: "ready",
-            key: signature,
-            data: result,
-          };
-        }
-      } catch (error) {
-        if (state.packageIntegrations === pending) {
-          state.packageIntegrations = {
-            status: "failed",
-            key: signature,
-            error: dependencies.describeError(error),
-          };
-        }
-      } finally {
+      return runInFlight("packageIntegrations", pending, async () => {
         dependencies.render();
-      }
+          try {
+          const coordinates = packageModel.isRuntimePack
+            ? platformCoordinates(packageModel, scopedLibrary ?? "")
+            : null;
+          const result = coordinates
+            ? await dependencies.queryPlatformIntegrations(
+                coordinates.framework,
+                coordinates.assemblyFileName,
+                coordinates.pack)
+            : await dependencies.queryPackageIntegrations(packageModel);
+          if (state.packageIntegrations === pending) {
+            state.packageIntegrations = {
+              status: "ready",
+              key: signature,
+              data: result,
+            };
+          }
+        } catch (error) {
+          if (state.packageIntegrations === pending) {
+            state.packageIntegrations = {
+              status: "failed",
+              key: signature,
+              error: dependencies.describeError(error),
+            };
+          }
+        } finally {
+          dependencies.render();
+        }
+      });
     },
 
     async loadOpportunities(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      const current = state.packageOpportunities;
-      if (current.status !== "idle" && current.key === signature) {
-        // A settled resource is the finished answer, so returning is correct. A `loading`
-        // one is not finished, and returning reported a completion that had not happened.
-        const joined = current.status === "loading"
-          && opportunitiesInFlight?.resource === current
-          ? opportunitiesInFlight.completion
-          : null;
+      const joined = joinInFlight("packageOpportunities", state.packageOpportunities, signature);
+      if (joined) return joined;
+      if (state.packageOpportunities.status !== "idle"
+        && state.packageOpportunities.key === signature) {
         dependencies.render();
-        if (joined) await joined;
         return;
       }
       const pending = { status: "loading", key: signature } as const;
       state.packageOpportunities = pending;
-      const completion = publishOpportunities(
-        packageModel, signature, scopedLibrary, pending);
-      opportunitiesInFlight = { resource: pending, completion };
-      void completion.then(() => {
-        if (opportunitiesInFlight?.resource === pending) opportunitiesInFlight = null;
-      }, () => {
-        if (opportunitiesInFlight?.resource === pending) opportunitiesInFlight = null;
+      return runInFlight("packageOpportunities", pending, async () => {
+        dependencies.render();
+        try {
+          const coordinates = packageModel.isRuntimePack
+            ? platformCoordinates(packageModel, scopedLibrary ?? "")
+            : null;
+          const result = coordinates
+            ? await dependencies.queryPlatformOpportunities(
+                coordinates.framework,
+                coordinates.assemblyFileName,
+                coordinates.pack)
+            : await dependencies.queryPackageOpportunities(packageModel);
+          if (state.packageOpportunities === pending) {
+            state.packageOpportunities = {
+              status: "ready",
+              key: signature,
+              data: result,
+            };
+          }
+        } catch (error) {
+          if (state.packageOpportunities === pending) {
+            state.packageOpportunities = {
+              status: "failed",
+              key: signature,
+              error: dependencies.describeError(error),
+            };
+          }
+        } finally {
+          dependencies.render();
+        }
       });
-      dependencies.render();
-      await completion;
     },
 
     async loadPerformance(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
+      const joined = joinInFlight("packagePerformance", state.packagePerformance, signature);
+      if (joined) return joined;
       if (state.packagePerformance.status !== "idle"
         && state.packagePerformance.key === signature) {
         dependencies.render();
@@ -370,39 +452,43 @@ export function createPackageInspectionCoordinator(
       }
       const pending = { status: "loading", key: signature } as const;
       state.packagePerformance = pending;
-      dependencies.render();
-      try {
-        const coordinates = packageModel.isRuntimePack
-          ? platformCoordinates(packageModel, scopedLibrary ?? "")
-          : null;
-        const result = coordinates
-          ? await dependencies.queryPlatformPerformance(
-              coordinates.framework,
-              coordinates.assemblyFileName,
-              coordinates.pack)
-          : await dependencies.queryPackagePerformance(packageModel);
-        if (state.packagePerformance === pending) {
-          state.packagePerformance = {
-            status: "ready",
-            key: signature,
-            data: result,
-          };
-        }
-      } catch (error) {
-        if (state.packagePerformance === pending) {
-          state.packagePerformance = {
-            status: "failed",
-            key: signature,
-            error: dependencies.describeError(error),
-          };
-        }
-      } finally {
+      return runInFlight("packagePerformance", pending, async () => {
         dependencies.render();
-      }
+          try {
+          const coordinates = packageModel.isRuntimePack
+            ? platformCoordinates(packageModel, scopedLibrary ?? "")
+            : null;
+          const result = coordinates
+            ? await dependencies.queryPlatformPerformance(
+                coordinates.framework,
+                coordinates.assemblyFileName,
+                coordinates.pack)
+            : await dependencies.queryPackagePerformance(packageModel);
+          if (state.packagePerformance === pending) {
+            state.packagePerformance = {
+              status: "ready",
+              key: signature,
+              data: result,
+            };
+          }
+        } catch (error) {
+          if (state.packagePerformance === pending) {
+            state.packagePerformance = {
+              status: "failed",
+              key: signature,
+              error: dependencies.describeError(error),
+            };
+          }
+        } finally {
+          dependencies.render();
+        }
+      });
     },
 
     async loadMetadata(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
+      const joined = joinInFlight("packageMetadata", state.packageMetadata, signature);
+      if (joined) return joined;
       if (state.packageMetadata.status !== "idle"
         && state.packageMetadata.key === signature) {
         dependencies.render();
@@ -410,35 +496,37 @@ export function createPackageInspectionCoordinator(
       }
       const pending = { status: "loading", key: signature } as const;
       state.packageMetadata = pending;
-      dependencies.render();
-      try {
-        const coordinates = packageModel.isRuntimePack
-          ? platformCoordinates(packageModel, scopedLibrary ?? "")
-          : null;
-        const result = coordinates
-          ? await dependencies.queryPlatformMetadata(
-              coordinates.framework,
-              coordinates.assemblyFileName,
-              coordinates.pack)
-          : await dependencies.queryPackageMetadata(packageModel);
-        if (state.packageMetadata === pending) {
-          state.packageMetadata = {
-            status: "ready",
-            key: signature,
-            data: result,
-          };
-        }
-      } catch (error) {
-        if (state.packageMetadata === pending) {
-          state.packageMetadata = {
-            status: "failed",
-            key: signature,
-            error: dependencies.describeError(error),
-          };
-        }
-      } finally {
+      return runInFlight("packageMetadata", pending, async () => {
         dependencies.render();
-      }
+          try {
+          const coordinates = packageModel.isRuntimePack
+            ? platformCoordinates(packageModel, scopedLibrary ?? "")
+            : null;
+          const result = coordinates
+            ? await dependencies.queryPlatformMetadata(
+                coordinates.framework,
+                coordinates.assemblyFileName,
+                coordinates.pack)
+            : await dependencies.queryPackageMetadata(packageModel);
+          if (state.packageMetadata === pending) {
+            state.packageMetadata = {
+              status: "ready",
+              key: signature,
+              data: result,
+            };
+          }
+        } catch (error) {
+          if (state.packageMetadata === pending) {
+            state.packageMetadata = {
+              status: "failed",
+              key: signature,
+              error: dependencies.describeError(error),
+            };
+          }
+        } finally {
+          dependencies.render();
+        }
+      });
     },
   };
 }

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -35,26 +35,14 @@ export interface PackageInspectionState {
   packages: AppPackage[];
   atPackageRoot: boolean;
   packageLens: PackageLens;
-  packageDependencies: BrowserPackageDependencies | null;
-  packageDependenciesLoading: boolean;
-  packageDependenciesError: string;
-  packageDependenciesKey: string;
+  packageDependencies: AsyncResource<BrowserPackageDependencies>;
   workspaceDependencies: Record<string, DependencyGroupData>;
   workspaceDependencyErrors: Record<string, string>;
   workspaceDependencyLoads: Set<string>;
-  packageIntegrations: BrowserPackageIntegrations | null;
-  packageIntegrationsLoading: boolean;
-  packageIntegrationsError: string;
-  packageIntegrationsKey: string;
+  packageIntegrations: AsyncResource<BrowserPackageIntegrations>;
   packageOpportunities: AsyncResource<BrowserPackageOpportunities>;
-  packagePerformance: PackagePerformance | null;
-  packagePerformanceLoading: boolean;
-  packagePerformanceError: string;
-  packagePerformanceKey: string;
-  packageMetadata: PackageMetadata | null;
-  packageMetadataLoading: boolean;
-  packageMetadataError: string;
-  packageMetadataKey: string;
+  packagePerformance: AsyncResource<PackagePerformance>;
+  packageMetadata: AsyncResource<PackageMetadata>;
 }
 
 export interface PackageInspectionDependencies {
@@ -251,15 +239,13 @@ export function createPackageInspectionCoordinator(
 
   return {
     async loadDependencies(packageModel, signature) {
-      if (state.packageDependenciesKey === signature
-        && (state.packageDependencies || state.packageDependenciesError)) {
+      if (state.packageDependencies.status !== "idle"
+        && state.packageDependencies.key === signature) {
         dependencies.render();
         return;
       }
-      state.packageDependenciesKey = signature;
-      state.packageDependencies = null;
-      state.packageDependenciesError = "";
-      state.packageDependenciesLoading = true;
+      const pending = { status: "loading", key: signature } as const;
+      state.packageDependencies = pending;
       dependencies.render();
       const packageRequest = {
         id: packageModel.id,
@@ -270,8 +256,12 @@ export function createPackageInspectionCoordinator(
       const workspaceKey = workspaceDependencyKey(packageRequest);
       try {
         const result = await dependencies.queryDependencies(packageRequest);
-        if (state.packageDependenciesKey === signature) {
-          state.packageDependencies = result;
+        if (state.packageDependencies === pending) {
+          state.packageDependencies = {
+            status: "ready",
+            key: signature,
+            data: result,
+          };
         }
         if (result?.dependencyGroups
           && packageIsResident(state.packages, packageRequest)) {
@@ -287,13 +277,14 @@ export function createPackageInspectionCoordinator(
           }
         }
       } catch (error) {
-        if (state.packageDependenciesKey === signature) {
-          state.packageDependenciesError = dependencies.describeError(error);
+        if (state.packageDependencies === pending) {
+          state.packageDependencies = {
+            status: "failed",
+            key: signature,
+            error: dependencies.describeError(error),
+          };
         }
       } finally {
-        if (state.packageDependenciesKey === signature) {
-          state.packageDependenciesLoading = false;
-        }
         dependencies.refreshPackageStats();
         dependencies.render();
         await ensureWorkspaceDependencies();
@@ -304,15 +295,13 @@ export function createPackageInspectionCoordinator(
 
     async loadIntegrations(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      if (state.packageIntegrationsKey === signature
-        && (state.packageIntegrations || state.packageIntegrationsError)) {
+      if (state.packageIntegrations.status !== "idle"
+        && state.packageIntegrations.key === signature) {
         dependencies.render();
         return;
       }
-      state.packageIntegrationsKey = signature;
-      state.packageIntegrations = null;
-      state.packageIntegrationsError = "";
-      state.packageIntegrationsLoading = true;
+      const pending = { status: "loading", key: signature } as const;
+      state.packageIntegrations = pending;
       dependencies.render();
       try {
         const coordinates = packageModel.isRuntimePack
@@ -324,17 +313,22 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackageIntegrations(packageModel);
-        if (state.packageIntegrationsKey === signature) {
-          state.packageIntegrations = result;
+        if (state.packageIntegrations === pending) {
+          state.packageIntegrations = {
+            status: "ready",
+            key: signature,
+            data: result,
+          };
         }
       } catch (error) {
-        if (state.packageIntegrationsKey === signature) {
-          state.packageIntegrationsError = dependencies.describeError(error);
+        if (state.packageIntegrations === pending) {
+          state.packageIntegrations = {
+            status: "failed",
+            key: signature,
+            error: dependencies.describeError(error),
+          };
         }
       } finally {
-        if (state.packageIntegrationsKey === signature) {
-          state.packageIntegrationsLoading = false;
-        }
         dependencies.render();
       }
     },
@@ -369,15 +363,13 @@ export function createPackageInspectionCoordinator(
 
     async loadPerformance(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      if (state.packagePerformanceKey === signature
-        && (state.packagePerformance || state.packagePerformanceError)) {
+      if (state.packagePerformance.status !== "idle"
+        && state.packagePerformance.key === signature) {
         dependencies.render();
         return;
       }
-      state.packagePerformanceKey = signature;
-      state.packagePerformance = null;
-      state.packagePerformanceError = "";
-      state.packagePerformanceLoading = true;
+      const pending = { status: "loading", key: signature } as const;
+      state.packagePerformance = pending;
       dependencies.render();
       try {
         const coordinates = packageModel.isRuntimePack
@@ -389,32 +381,35 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackagePerformance(packageModel);
-        if (state.packagePerformanceKey === signature) {
-          state.packagePerformance = result;
+        if (state.packagePerformance === pending) {
+          state.packagePerformance = {
+            status: "ready",
+            key: signature,
+            data: result,
+          };
         }
       } catch (error) {
-        if (state.packagePerformanceKey === signature) {
-          state.packagePerformanceError = dependencies.describeError(error);
+        if (state.packagePerformance === pending) {
+          state.packagePerformance = {
+            status: "failed",
+            key: signature,
+            error: dependencies.describeError(error),
+          };
         }
       } finally {
-        if (state.packagePerformanceKey === signature) {
-          state.packagePerformanceLoading = false;
-        }
         dependencies.render();
       }
     },
 
     async loadMetadata(packageModel, signature, scopedLibrary) {
       if (packageModel.isRuntimePack && !scopedLibrary) return;
-      if (state.packageMetadataKey === signature
-        && (state.packageMetadata || state.packageMetadataError)) {
+      if (state.packageMetadata.status !== "idle"
+        && state.packageMetadata.key === signature) {
         dependencies.render();
         return;
       }
-      state.packageMetadataKey = signature;
-      state.packageMetadata = null;
-      state.packageMetadataError = "";
-      state.packageMetadataLoading = true;
+      const pending = { status: "loading", key: signature } as const;
+      state.packageMetadata = pending;
       dependencies.render();
       try {
         const coordinates = packageModel.isRuntimePack
@@ -426,17 +421,22 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackageMetadata(packageModel);
-        if (state.packageMetadataKey === signature) {
-          state.packageMetadata = result;
+        if (state.packageMetadata === pending) {
+          state.packageMetadata = {
+            status: "ready",
+            key: signature,
+            data: result,
+          };
         }
       } catch (error) {
-        if (state.packageMetadataKey === signature) {
-          state.packageMetadataError = dependencies.describeError(error);
+        if (state.packageMetadata === pending) {
+          state.packageMetadata = {
+            status: "failed",
+            key: signature,
+            error: dependencies.describeError(error),
+          };
         }
       } finally {
-        if (state.packageMetadataKey === signature) {
-          state.packageMetadataLoading = false;
-        }
         dependencies.render();
       }
     },

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -233,7 +233,12 @@ export function createPackageInspectionCoordinator(
   // guard exists to avoid.
   const inFlight = new Map<
     string,
-    { resource: AsyncResource<unknown>; promise: Promise<void>; settle: () => void }>();
+    {
+      key: string;
+      resource: AsyncResource<unknown>;
+      promise: Promise<void>;
+      settle: () => void;
+    }>();
 
   // Join on the identity of the pending resource, not on its key. A request that has
   // lost ownership -- because a newer request or a scope change overwrote the slot --
@@ -274,6 +279,7 @@ export function createPackageInspectionCoordinator(
   // a later same-key caller still settles.
   function runInFlight(
     lens: string,
+    key: string,
     resource: AsyncResource<unknown>,
     body: () => Promise<void>,
   ): Promise<void> {
@@ -281,7 +287,7 @@ export function createPackageInspectionCoordinator(
     const promise = new Promise<void>(resolve => {
       settle = resolve;
     });
-    const entry = { resource, promise, settle };
+    const entry = { key, resource, promise, settle };
     inFlight.set(lens, entry);
     return (async () => {
       try {

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -234,24 +234,25 @@ export function createPackageInspectionCoordinator(
   const inFlight = new Map<
     string,
     {
-      key: string;
       resource: AsyncResource<unknown>;
       promise: Promise<void>;
       settle: () => void;
     }>();
 
-  // Join on the identity of the pending resource, not on its key. A request that has
-  // lost ownership -- because a newer request or a scope change overwrote the slot --
-  // will discard its own result when it lands, so joining it would leave the caller
-  // awaiting a request that publishes nothing. Two requests for one scope can carry the
-  // same key while only one of them still owns the state, so key equality cannot tell
-  // them apart and object identity can.
-  // Identity alone is not enough: it says the in-flight request still owns the state, not
-  // that it is the request this caller wants. Restacking onto the opportunities slice
-  // showed why -- its A->B->A tests deadlocked here, because a caller for a *different*
+  // Joining takes both halves, and neither one alone is sufficient.
+  //
+  // Identity is what makes the in-flight request the *live* one. A request that has lost
+  // ownership -- because a newer request or a scope change overwrote the slot -- will
+  // discard its own result when it lands, so joining it would leave the caller awaiting a
+  // request that publishes nothing. Two requests for one scope can carry the same key
+  // while only one still owns the state, and key equality cannot tell them apart.
+  //
+  // The key is what makes it the request this caller *wants*. Identity alone says the in-flight request still owns the state, not
+  // that. Restacking onto the opportunities slice
+  // showed why: its A->B->A tests deadlocked here, because a caller for a *different*
   // scope matched on identity, joined the running request, and returned without ever
-  // starting its own. The key comparison is what makes this "the same request", and the
-  // identity comparison is what makes it "still the live one".
+  // starting its own. The pending resource carries its own key, so this reads that rather
+  // than storing a second copy that could drift from it.
   function joinInFlight(
     lens: string,
     live: AsyncResource<unknown>,
@@ -274,12 +275,11 @@ export function createPackageInspectionCoordinator(
   // settling after an awaited call inside its own `finally`.
   //
   // Taking the body removes the window rather than narrowing it: there is no way to
-  // register an entry without this `finally`. `test/in-flight-settlement.test.ts` drives
+  // register an entry without this `finally`. `test/package-inspection.test.ts` drives
   // every lens with a render callback that throws on the nth call, for every n, and proves
   // a later same-key caller still settles.
   function runInFlight(
     lens: string,
-    key: string,
     resource: AsyncResource<unknown>,
     body: () => Promise<void>,
   ): Promise<void> {
@@ -287,7 +287,7 @@ export function createPackageInspectionCoordinator(
     const promise = new Promise<void>(resolve => {
       settle = resolve;
     });
-    const entry = { key, resource, promise, settle };
+    const entry = { resource, promise, settle };
     inFlight.set(lens, entry);
     return (async () => {
       try {

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -277,7 +277,8 @@ export function createPackageInspectionCoordinator(
   // Taking the body removes the window rather than narrowing it: there is no way to
   // register an entry without this `finally`. `test/package-inspection.test.ts` drives
   // every lens with a render callback that throws on the nth call, for every n, and proves
-  // a later same-key caller still settles.
+  // a later same-key caller reaches a settled resource rather than returning from an
+  // ownerless `loading` state.
   function runInFlight(
     lens: string,
     resource: AsyncResource<unknown>,
@@ -299,12 +300,19 @@ export function createPackageInspectionCoordinator(
     })();
   }
 
+  function isSettledFor(
+    resource: AsyncResource<unknown>,
+    signature: string,
+  ): boolean {
+    return (resource.status === "ready" || resource.status === "failed")
+      && resource.key === signature;
+  }
+
   return {
     async loadDependencies(packageModel, signature) {
       const joined = joinInFlight("packageDependencies", state.packageDependencies, signature);
       if (joined) return joined;
-      if (state.packageDependencies.status !== "idle"
-        && state.packageDependencies.key === signature) {
+      if (isSettledFor(state.packageDependencies, signature)) {
         dependencies.render();
         return;
       }
@@ -363,8 +371,7 @@ export function createPackageInspectionCoordinator(
       if (packageModel.isRuntimePack && !scopedLibrary) return;
       const joined = joinInFlight("packageIntegrations", state.packageIntegrations, signature);
       if (joined) return joined;
-      if (state.packageIntegrations.status !== "idle"
-        && state.packageIntegrations.key === signature) {
+      if (isSettledFor(state.packageIntegrations, signature)) {
         dependencies.render();
         return;
       }
@@ -407,8 +414,7 @@ export function createPackageInspectionCoordinator(
       if (packageModel.isRuntimePack && !scopedLibrary) return;
       const joined = joinInFlight("packageOpportunities", state.packageOpportunities, signature);
       if (joined) return joined;
-      if (state.packageOpportunities.status !== "idle"
-        && state.packageOpportunities.key === signature) {
+      if (isSettledFor(state.packageOpportunities, signature)) {
         dependencies.render();
         return;
       }
@@ -451,8 +457,7 @@ export function createPackageInspectionCoordinator(
       if (packageModel.isRuntimePack && !scopedLibrary) return;
       const joined = joinInFlight("packagePerformance", state.packagePerformance, signature);
       if (joined) return joined;
-      if (state.packagePerformance.status !== "idle"
-        && state.packagePerformance.key === signature) {
+      if (isSettledFor(state.packagePerformance, signature)) {
         dependencies.render();
         return;
       }
@@ -495,8 +500,7 @@ export function createPackageInspectionCoordinator(
       if (packageModel.isRuntimePack && !scopedLibrary) return;
       const joined = joinInFlight("packageMetadata", state.packageMetadata, signature);
       if (joined) return joined;
-      if (state.packageMetadata.status !== "idle"
-        && state.packageMetadata.key === signature) {
+      if (isSettledFor(state.packageMetadata, signature)) {
         dependencies.render();
         return;
       }

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -20,99 +20,144 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  parseSync,
+  type Expression,
+  type ObjectExpression,
+  type Program,
+  type PropertyKey,
+  type TSInterfaceDeclaration,
+  type TSPropertySignature,
+} from "oxc-parser";
+
 const sourceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
 
 function read(file: string): string {
   return readFileSync(join(sourceRoot, file), "utf8");
 }
 
-function block(source: string, anchor: RegExp): string {
-  const start = source.search(anchor);
-  assert.ok(
-    start >= 0, `the anchor ${anchor} no longer matches, so this gate derives nothing`);
-  let depth = 0;
-  let end = -1;
-  for (let cursor = start; cursor < source.length && end < 0; cursor += 1) {
-    const character = source[cursor];
-    if (character === "{") depth += 1;
-    else if (character === "}") {
-      depth -= 1;
-      if (depth === 0) end = cursor + 1;
+function parse(file: string): Program {
+  const parsed = parseSync(file, read(file));
+  assert.deepEqual(
+    parsed.errors,
+    [],
+    `${file} must parse before its state ownership can be inspected`);
+  return parsed.program;
+}
+
+function packageInspectionState(program: Program): TSInterfaceDeclaration {
+  const declarations = program.body.flatMap(node => {
+    const declaration = node.type === "ExportNamedDeclaration"
+      ? node.declaration
+      : node;
+    return declaration?.type === "TSInterfaceDeclaration"
+      && declaration.id.name === "PackageInspectionState"
+      ? [declaration]
+      : [];
+  });
+  assert.equal(
+    declarations.length,
+    1,
+    "PackageInspectionState must have exactly one declaration");
+  const declaration = declarations[0];
+  assert.ok(declaration);
+  return declaration;
+}
+
+function propertyName(key: PropertyKey, computed: boolean): string {
+  if (key.type === "Identifier" && !computed) return key.name;
+  if (key.type === "Literal" && typeof key.value === "string") return key.value;
+  throw new Error("state ownership keys must be statically named");
+}
+
+function stateProperties(declaration: TSInterfaceDeclaration): TSPropertySignature[] {
+  return declaration.body.body.filter(
+    (member): member is TSPropertySignature => member.type === "TSPropertySignature");
+}
+
+function resourceFields(declaration: TSInterfaceDeclaration): string[] {
+  return stateProperties(declaration)
+    .filter(property => {
+      const annotation = property.typeAnnotation?.typeAnnotation;
+      return annotation?.type === "TSTypeReference"
+        && annotation.typeName.type === "Identifier"
+        && annotation.typeName.name === "AsyncResource";
+    })
+    .map(property => propertyName(property.key, property.computed));
+}
+
+function objectExpression(expression: Expression | null): ObjectExpression | null {
+  if (expression?.type === "ObjectExpression") return expression;
+  if (expression?.type === "TSAsExpression"
+    || expression?.type === "TSSatisfiesExpression"
+    || expression?.type === "TSTypeAssertion") {
+    return objectExpression(expression.expression);
+  }
+  return null;
+}
+
+function objectDeclarations(program: Program): Map<string, ObjectExpression> {
+  const declarations = new Map<string, ObjectExpression>();
+  for (const statement of program.body) {
+    if (statement.type !== "VariableDeclaration") continue;
+    for (const declaration of statement.declarations) {
+      if (declaration.id.type !== "Identifier") continue;
+      const object = objectExpression(declaration.init);
+      if (object) declarations.set(declaration.id.name, object);
     }
   }
-  assert.ok(end >= 0, `the block at ${anchor} is unterminated`);
-  return source.slice(start, end);
+  return declarations;
 }
 
-// The converted lenses, discovered from their declared type rather than named here.
-function resourceFields(declaration: string): string[] {
-  return [...declaration.matchAll(/(\w+)\s*:\s*AsyncResource</g)]
-    .map(match => match[1])
-    .filter((name): name is string => name !== undefined);
-}
-
-// Read the keys the block actually declares, at its own nesting level, rather than the
-// keys that happen to be formatted one-per-line. Layout is not the property being gated,
-// and a scan anchored on indentation misses a single-line object -- which is exactly the
-// shape a spread source takes.
-function propertyNames(literalOrInterface: string): string[] {
-  const depths: number[] = [];
-  let depth = 0;
-  for (const character of literalOrInterface) {
-    if (character === "}") depth -= 1;
-    depths.push(depth);
-    if (character === "{") depth += 1;
-  }
-
+function objectPropertyNames(
+  object: ObjectExpression,
+  declarations: ReadonlyMap<string, ObjectExpression>,
+  seen: ReadonlySet<ObjectExpression> = new Set(),
+): string[] {
+  assert.equal(
+    seen.has(object),
+    false,
+    "state ownership spreads must not form a cycle");
+  const nextSeen = new Set(seen).add(object);
   const names: string[] = [];
-  for (const key of literalOrInterface.matchAll(/[{,;]\s*"?(\w+)"?\s*\??\s*:/g)) {
-    const name = key[1];
-    // Measure at the colon, not at the leading delimiter: for the first property that
-    // delimiter is the opening brace itself, which sits one level out.
-    if (name !== undefined && depths[key.index + key[0].length - 1] === 1) {
-      names.push(name);
+  for (const property of object.properties) {
+    if (property.type === "Property") {
+      names.push(propertyName(property.key, property.computed));
+      continue;
     }
-  }
-  return names;
-}
-
-// A spread carries its source object's properties into the literal, so a gate that reads
-// only the literal's own keys can be walked around by moving the field into a spread
-// object. Round 2 review of PR #4585 (GPT-5.6 Sol) did exactly that. Resolve each spread
-// to the declaration it names and include those keys; refuse to pass on one that cannot
-// be resolved, because an unresolved spread is an unread surface, not an empty one.
-function spreadNames(literal: string, source: string): string[] {
-  const names: string[] = [];
-  for (const spread of literal.matchAll(/^\s{2}\.\.\.(\w+),/gm)) {
-    const identifier = spread[1];
-    if (identifier === undefined) continue;
-    const declaration = new RegExp(`(?:const|let|var) ${identifier}\\b[^=]*= \\{`);
-    const start = source.search(declaration);
+    const inline = objectExpression(property.argument);
+    const named = property.argument.type === "Identifier"
+      ? declarations.get(property.argument.name)
+      : undefined;
+    const spread = inline ?? named;
     assert.ok(
-      start >= 0,
-      `the spread \`...${identifier}\` could not be resolved, so its keys are unchecked`);
-    names.push(...propertyNames(block(source, declaration)));
+      spread,
+      "a spread in initialState could not be resolved, so its keys are unchecked");
+    names.push(...objectPropertyNames(spread, declarations, nextSeen));
   }
   return names;
 }
 
 test("a lens converted to AsyncResource keeps exactly one state field", () => {
-  const coordinatorState = block(
-    read("package-inspection.ts"), /export interface PackageInspectionState \{/);
-  const initialState = block(read("dotnet-inspect.ts"), /^const initialState = \{/m);
+  const coordinatorProgram = parse("package-inspection.ts");
+  const coordinatorState = packageInspectionState(coordinatorProgram);
+  const rootProgram = parse("dotnet-inspect.ts");
+  const declarations = objectDeclarations(rootProgram);
+  const initialState = declarations.get("initialState");
+  assert.ok(initialState, "initialState must be a statically inspectable object");
 
   const converted = resourceFields(coordinatorState);
   assert.ok(
     converted.length > 0,
     "no AsyncResource state field was found, so the anchor has stopped resolving");
 
-  const rootSource = read("dotnet-inspect.ts");
   const surfaces: readonly (readonly [string, readonly string[]])[] = [
-    ["PackageInspectionState", propertyNames(coordinatorState)],
     [
-      "initialState",
-      [...propertyNames(initialState), ...spreadNames(initialState, rootSource)],
+      "PackageInspectionState",
+      stateProperties(coordinatorState)
+        .map(property => propertyName(property.key, property.computed)),
     ],
+    ["initialState", objectPropertyNames(initialState, declarations)],
   ];
 
   const survivors: string[] = [];
@@ -138,14 +183,19 @@ test("the parallel-field gate sees both surfaces", () => {
   // Non-vacuity, and the specific shape of the two mutations that were silent: a gate that
   // reads only one surface, or whose property scan stops matching, would pass above while
   // proving nothing.
-  const coordinatorState = block(
-    read("package-inspection.ts"), /export interface PackageInspectionState \{/);
-  const initialState = block(read("dotnet-inspect.ts"), /^const initialState = \{/m);
+  const coordinatorProgram = parse("package-inspection.ts");
+  const coordinatorState = packageInspectionState(coordinatorProgram);
+  const rootProgram = parse("dotnet-inspect.ts");
+  const declarations = objectDeclarations(rootProgram);
+  const initialState = declarations.get("initialState");
+  assert.ok(initialState, "initialState must be a statically inspectable object");
 
   assert.ok(
-    propertyNames(coordinatorState).includes("packageOpportunities"),
+    stateProperties(coordinatorState)
+      .some(property => propertyName(property.key, property.computed)
+        === "packageOpportunities"),
     "the coordinator-state property scan no longer sees the converted lens");
   assert.ok(
-    propertyNames(initialState).includes("packageOpportunities"),
+    objectPropertyNames(initialState, declarations).includes("packageOpportunities"),
     "the initial-state property scan no longer sees the converted lens");
 });

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -51,10 +51,49 @@ function resourceFields(declaration: string): string[] {
     .filter((name): name is string => name !== undefined);
 }
 
+// Read the keys the block actually declares, at its own nesting level, rather than the
+// keys that happen to be formatted one-per-line. Layout is not the property being gated,
+// and a scan anchored on indentation misses a single-line object -- which is exactly the
+// shape a spread source takes.
 function propertyNames(literalOrInterface: string): string[] {
-  return [...literalOrInterface.matchAll(/^\s{2}(\w+)\s*[:?]/gm)]
-    .map(match => match[1])
-    .filter((name): name is string => name !== undefined);
+  const depths: number[] = [];
+  let depth = 0;
+  for (const character of literalOrInterface) {
+    if (character === "}") depth -= 1;
+    depths.push(depth);
+    if (character === "{") depth += 1;
+  }
+
+  const names: string[] = [];
+  for (const key of literalOrInterface.matchAll(/[{,;]\s*"?(\w+)"?\s*\??\s*:/g)) {
+    const name = key[1];
+    // Measure at the colon, not at the leading delimiter: for the first property that
+    // delimiter is the opening brace itself, which sits one level out.
+    if (name !== undefined && depths[key.index + key[0].length - 1] === 1) {
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+// A spread carries its source object's properties into the literal, so a gate that reads
+// only the literal's own keys can be walked around by moving the field into a spread
+// object. Round 2 review of PR #4585 (GPT-5.6 Sol) did exactly that. Resolve each spread
+// to the declaration it names and include those keys; refuse to pass on one that cannot
+// be resolved, because an unresolved spread is an unread surface, not an empty one.
+function spreadNames(literal: string, source: string): string[] {
+  const names: string[] = [];
+  for (const spread of literal.matchAll(/^\s{2}\.\.\.(\w+),/gm)) {
+    const identifier = spread[1];
+    if (identifier === undefined) continue;
+    const declaration = new RegExp(`(?:const|let|var) ${identifier}\\b[^=]*= \\{`);
+    const start = source.search(declaration);
+    assert.ok(
+      start >= 0,
+      `the spread \`...${identifier}\` could not be resolved, so its keys are unchecked`);
+    names.push(...propertyNames(block(source, declaration)));
+  }
+  return names;
 }
 
 test("a lens converted to AsyncResource keeps exactly one state field", () => {
@@ -67,9 +106,13 @@ test("a lens converted to AsyncResource keeps exactly one state field", () => {
     converted.length > 0,
     "no AsyncResource state field was found, so the anchor has stopped resolving");
 
+  const rootSource = read("dotnet-inspect.ts");
   const surfaces: readonly (readonly [string, readonly string[]])[] = [
     ["PackageInspectionState", propertyNames(coordinatorState)],
-    ["initialState", propertyNames(initialState)],
+    [
+      "initialState",
+      [...propertyNames(initialState), ...spreadNames(initialState, rootSource)],
+    ],
   ];
 
   const survivors: string[] = [];

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -294,14 +294,20 @@ async function verifyPackageLensLifecycle<T>(
 
       await fixture.load(coordinator, "current").catch(() => {});
 
-      const settled = await Promise.race([
-        fixture.load(coordinator, "current").then(() => "settled", () => "settled"),
+      const recovery = fixture.load(coordinator, "current");
+      const outcome = await Promise.race([
+        recovery.then(() => "settled", () => "settled"),
         new Promise(resolve => { setTimeout(() => resolve("deadlocked"), 250); }),
       ]);
       assert.equal(
-        settled,
+        outcome,
         "settled",
         `${fixture.name} deadlocked after render ${throwOn} of ${cleanRenders} threw`);
+      const status = fixture.read(state).status;
+      assert.ok(
+        status === "ready" || status === "failed",
+        `${fixture.name} remained ${status} after render ${throwOn} of `
+        + `${cleanRenders} threw`);
     }
   }
 
@@ -514,6 +520,69 @@ test("foreground dependency success refreshes cached groups and clears a prior e
     workspace.dependencyGroups?.[0]?.dependencies?.[0]?.id,
     "Example.Dependency");
   assert.equal(Object.hasOwn(state.workspaceDependencyErrors, key), false);
+});
+
+test("foreground dependency failures preserve resident cached evidence", async () => {
+  const packageItem = packageModel();
+  const key = workspaceDependencyKey(packageItem);
+  const cached = {
+    dependencyGroups: dependencyResult().dependencyGroups,
+    dependencyGroupError: "prior partial failure",
+  };
+  const state = inspectionState({
+    packages: [packageItem],
+    workspaceDependencies: { [key]: cached },
+    workspaceDependencyErrors: { [key]: "prior partial failure" },
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => {
+        throw new Error("current request failed");
+      },
+    }));
+
+  await coordinator.loadDependencies(packageItem, "current");
+
+  assert.deepEqual(state.packageDependencies, {
+    status: "failed",
+    key: "current",
+    error: "current request failed",
+  });
+  assert.strictEqual(state.workspaceDependencies[key], cached);
+  assert.equal(state.workspaceDependencyErrors[key], "prior partial failure");
+});
+
+test("abandoned dependency failures preserve newer state and cached evidence", async () => {
+  const packageItem = packageModel();
+  const key = workspaceDependencyKey(packageItem);
+  const request = deferred<BrowserPackageDependencies>();
+  const cached = {
+    dependencyGroups: dependencyResult().dependencyGroups,
+    dependencyGroupError: "prior partial failure",
+  };
+  const state = inspectionState({
+    packages: [packageItem],
+    workspaceDependencies: { [key]: cached },
+    workspaceDependencyErrors: { [key]: "prior partial failure" },
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryDependencies: async () => request.promise,
+    }));
+
+  const abandoned = coordinator.loadDependencies(packageItem, "first");
+  const newer: AsyncResource<BrowserPackageDependencies> = {
+    status: "failed",
+    key: "second",
+    error: "newer failure",
+  };
+  state.packageDependencies = newer;
+  request.reject(new Error("abandoned failure"));
+  await abandoned;
+
+  assert.strictEqual(state.packageDependencies, newer);
+  assert.strictEqual(state.workspaceDependencies[key], cached);
+  assert.equal(state.workspaceDependencyErrors[key], "prior partial failure");
 });
 
 test("package lens loaders reuse cached results without querying or clearing them", async () => {

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   createPackageInspectionCoordinator,
+  packageMetadataView,
   workspaceDependencyKey,
   type PackageInspectionDependencies,
   type PackageInspectionState,
@@ -207,6 +211,23 @@ async function verifyPackageLensLifecycle<T>(
       ["render", "render"],
       `${fixture.name} start and reuse renders`);
 
+    // Not querying twice is only half of reuse. These loaders are `async`, so the
+    // duplicate caller is awaiting a promise, and the first version of this guard
+    // returned early -- which resolved that promise immediately and told the caller the
+    // load had finished while the request was still in flight. Counting queries could
+    // not see it, because the early return also queries zero times.
+    //
+    // So assert the duplicate has not settled while the original is still pending. A
+    // reused request has to hand back the original's promise, not a resolved one.
+    let duplicateSettled = false;
+    void duplicate.then(() => { duplicateSettled = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(
+      duplicateSettled,
+      false,
+      `${fixture.name} duplicate settled before the in-flight request completed`);
+
     query.resolve(fixture.result);
     await Promise.all([load, duplicate]);
 
@@ -227,13 +248,61 @@ async function verifyPackageLensLifecycle<T>(
       throw new Error("current failure");
     });
 
-    await fixture.load(coordinator, "current");
+    const load = fixture.load(coordinator, "current");
+    const duplicate = fixture.load(coordinator, "current");
+    await Promise.all([load, duplicate]);
 
     assert.deepEqual(fixture.read(state), {
       status: "failed",
       key: "current",
       error: "current failure",
     }, `${fixture.name} current failure`);
+  }
+
+  {
+    // A render that throws must not be able to strand the in-flight entry. The window that
+    // matters is the one where `state[lens]` is still the exact pending object the join
+    // matches on, so a stranded entry is not merely a leak -- the next same-key caller is
+    // handed a promise nobody will resolve, and the lens deadlocks for the rest of the
+    // session.
+    //
+    // Rather than restate where the throw-safe boundary is, drive the loader with a render
+    // that throws on the nth call for every n a clean run makes, and require that a
+    // subsequent same-key call still settles. That derives the property from the loader's
+    // own behavior, so a loader that grows another render site is covered without this
+    // test being updated.
+    let cleanRenders = 0;
+    const counted = fixture.createCoordinator(
+      inspectionState(),
+      async () => fixture.result,
+      () => { cleanRenders++; });
+    await fixture.load(counted, "current");
+    assert.ok(
+      cleanRenders > 0,
+      `${fixture.name} made no renders, so the throwing-render sweep would prove nothing`);
+
+    for (let throwOn = 1; throwOn <= cleanRenders; throwOn++) {
+      const state = inspectionState();
+      let renders = 0;
+      const coordinator = fixture.createCoordinator(
+        state,
+        async () => fixture.result,
+        () => {
+          renders++;
+          if (renders === throwOn) throw new Error(`render ${throwOn} failed`);
+        });
+
+      await fixture.load(coordinator, "current").catch(() => {});
+
+      const settled = await Promise.race([
+        fixture.load(coordinator, "current").then(() => "settled", () => "settled"),
+        new Promise(resolve => { setTimeout(() => resolve("deadlocked"), 250); }),
+      ]);
+      assert.equal(
+        settled,
+        "settled",
+        `${fixture.name} deadlocked after render ${throwOn} of ${cleanRenders} threw`);
+    }
   }
 
   {
@@ -280,6 +349,56 @@ async function verifyPackageLensLifecycle<T>(
       fixture.read(state),
       newer,
       `${fixture.name} stale failure`);
+  }
+
+  {
+    // Every staleness case above changes the key between the two requests, so key
+    // equality and object identity give the same answer and none of them can tell the
+    // two mechanisms apart. Adversarial review exploited exactly that: replacing the
+    // ownership checks with `status !== "idle" && key === signature` left the whole
+    // suite green, even though a late completion could then publish into a newer
+    // request that happens to share its key.
+    //
+    // This is the interleaving that separates them -- one scope requested, abandoned,
+    // and requested again, which is a user navigating away and back. Both requests for
+    // that scope carry the same key, so only object identity can reject the first.
+    const first = deferred<T>();
+    const second = deferred<T>();
+    const pending = [first, second];
+    const state = inspectionState();
+    const coordinator = fixture.createCoordinator(
+      state,
+      async () => (pending.shift() ?? first).promise);
+
+    const abandoned = fixture.load(coordinator, "scope-a");
+
+    // Writing a different scope's state releases scope-a's ownership, so the reload
+    // below starts a genuinely new request rather than joining the in-flight one.
+    fixture.write(state, {
+      status: "failed",
+      key: "scope-b",
+      error: "other scope",
+    });
+
+    const reloaded = fixture.load(coordinator, "scope-a");
+    second.resolve(fixture.result);
+    await reloaded;
+
+    const live = fixture.read(state);
+    assert.deepEqual(live, {
+      status: "ready",
+      key: "scope-a",
+      data: fixture.result,
+    }, `${fixture.name} reloaded scope`);
+
+    // The abandoned request lands last, carrying the same key as the live one. Identity
+    // ownership rejects it; key equality would accept it and publish the stale result.
+    first.resolve(fixture.result);
+    await abandoned;
+    assert.strictEqual(
+      fixture.read(state),
+      live,
+      `${fixture.name} same-key stale completion replaced the live request`);
   }
 }
 
@@ -1392,4 +1511,89 @@ test("runtime package lenses wait for an explicit library scope", async () => {
   assert.equal(state.packageOpportunities.status, "idle");
   assert.equal(state.packagePerformance.status, "idle");
   assert.equal(state.packageMetadata.status, "idle");
+});
+
+// `packageMetadataView` is the only bridge from the metadata `AsyncResource` to the
+// renderer's four flattened options, and round 2 review (GPT-5.6 Sol, Claude Opus 5) found
+// it had no test at all: discarding `resource.error` in the `failed` arm, and deleting the
+// staleness gate the README claims is gated, both left the whole suite green. Losing the
+// error text is user-visible -- the renderer falls through to its generic "Loading…"
+// placeholder instead of reporting that the metadata read failed.
+const metadataProjections: readonly {
+  status: string;
+  resource: AsyncResource<PackageMetadata>;
+  signature: string;
+  expected: ReturnType<typeof packageMetadataView>;
+}[] = [
+  {
+    status: "idle",
+    resource: { status: "idle" },
+    signature: "scope",
+    expected: { fresh: false, loading: false, error: "", metadata: null },
+  },
+  {
+    status: "loading",
+    resource: { status: "loading", key: "scope" },
+    signature: "scope",
+    expected: { fresh: true, loading: true, error: "", metadata: null },
+  },
+  {
+    status: "loading",
+    resource: { status: "loading", key: "other" },
+    signature: "scope",
+    expected: { fresh: false, loading: false, error: "", metadata: null },
+  },
+  {
+    status: "failed",
+    resource: { status: "failed", key: "scope", error: "metadata failed" },
+    signature: "scope",
+    expected: { fresh: true, loading: false, error: "metadata failed", metadata: null },
+  },
+  {
+    status: "failed",
+    resource: { status: "failed", key: "other", error: "metadata failed" },
+    signature: "scope",
+    expected: { fresh: false, loading: false, error: "", metadata: null },
+  },
+  {
+    status: "ready",
+    resource: { status: "ready", key: "scope", data: metadataResult() },
+    signature: "scope",
+    expected: { fresh: true, loading: false, error: "", metadata: metadataResult() },
+  },
+  {
+    status: "ready",
+    resource: { status: "ready", key: "other", data: metadataResult() },
+    signature: "scope",
+    expected: { fresh: false, loading: false, error: "", metadata: null },
+  },
+];
+
+test("packageMetadataView projects every request state", () => {
+  for (const projection of metadataProjections) {
+    const stale = projection.expected.fresh ? "fresh" : "stale";
+    assert.deepEqual(
+      packageMetadataView(projection.resource, projection.signature),
+      projection.expected,
+      `${stale} ${projection.status} projection`);
+  }
+});
+
+test("the projection table covers every AsyncResource variant", () => {
+  // Derived, not restated: a new variant added to the union is an untested projection
+  // until it appears here, and this fails rather than passing quietly.
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "src", "data.ts"), "utf8");
+  const declaration = /export type AsyncResource<T> =([\s\S]*?);\n/.exec(source)?.[1] ?? "";
+  const variants = [...declaration.matchAll(/status\s*:\s*"([^"]+)"/g)]
+    .map(match => match[1])
+    .filter((status): status is string => status !== undefined);
+
+  assert.ok(
+    variants.length >= 4,
+    "the AsyncResource anchor stopped matching, so this gate derives nothing");
+  assert.deepEqual(
+    [...new Set(metadataProjections.map(projection => projection.status))].sort(),
+    [...new Set(variants)].sort(),
+    "the metadata projection table no longer covers the AsyncResource union");
 });

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -400,6 +400,47 @@ async function verifyPackageLensLifecycle<T>(
       live,
       `${fixture.name} same-key stale completion replaced the live request`);
   }
+
+  {
+    // Joining takes both halves. Identity alone cannot reject a caller asking for a
+    // *different* scope while the first request is still in flight: that request is
+    // still the live one, so identity says join -- and the caller would then be handed
+    // a request that will never describe the scope it asked about. Only the key rejects
+    // it.
+    const first = deferred<T>();
+    const second = deferred<T>();
+    const pending = [first, second];
+    let queries = 0;
+    const state = inspectionState();
+    const coordinator = fixture.createCoordinator(state, async () => {
+      queries++;
+      return (pending.shift() ?? first).promise;
+    });
+
+    const stale = fixture.load(coordinator, "first");
+    const newer = fixture.load(coordinator, "second");
+    assert.equal(
+      queries,
+      2,
+      `${fixture.name} second scope joined the first scope's request`);
+
+    second.resolve(fixture.result);
+    await newer;
+
+    const live = fixture.read(state);
+    assert.deepEqual(live, {
+      status: "ready",
+      key: "second",
+      data: fixture.result,
+    }, `${fixture.name} second scope result`);
+
+    first.resolve(fixture.result);
+    await stale;
+    assert.strictEqual(
+      fixture.read(state),
+      live,
+      `${fixture.name} first scope overwrote the second`);
+  }
 }
 
 test("workspace dependency keys normalize complete package coordinates", () => {

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -179,6 +179,7 @@ async function verifyPackageLensLifecycle<T>(
   {
     const query = deferred<T>();
     const events: string[] = [];
+    let queries = 0;
     const state = inspectionState();
     fixture.write(state, {
       status: "failed",
@@ -187,19 +188,27 @@ async function verifyPackageLensLifecycle<T>(
     });
     const coordinator = fixture.createCoordinator(
       state,
-      async () => query.promise,
+      async () => {
+        queries++;
+        return query.promise;
+      },
       () => events.push("render"));
 
     const load = fixture.load(coordinator, "current");
+    const duplicate = fixture.load(coordinator, "current");
 
     assert.deepEqual(fixture.read(state), {
       status: "loading",
       key: "current",
     }, `${fixture.name} started loading`);
-    assert.deepEqual(events, ["render"], `${fixture.name} start render`);
+    assert.equal(queries, 1, `${fixture.name} reused in-flight request`);
+    assert.deepEqual(
+      events,
+      ["render", "render"],
+      `${fixture.name} start and reuse renders`);
 
     query.resolve(fixture.result);
-    await load;
+    await Promise.all([load, duplicate]);
 
     assert.deepEqual(fixture.read(state), {
       status: "ready",
@@ -208,7 +217,7 @@ async function verifyPackageLensLifecycle<T>(
     }, `${fixture.name} current result`);
     assert.deepEqual(
       events,
-      ["render", "render"],
+      ["render", "render", "render"],
       `${fixture.name} completion render`);
   }
 

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -8,6 +8,7 @@ import {
   type PackageInspectionState,
   type PackagePerformance,
 } from "../src/package-inspection.ts";
+import type { AsyncResource } from "../src/data.ts";
 import type { AppPackage } from "../src/package-acquisition.ts";
 import type {
   BrowserPackageDependencies,
@@ -46,26 +47,14 @@ function inspectionState(
     packages: [],
     atPackageRoot: false,
     packageLens: "overview",
-    packageDependencies: null,
-    packageDependenciesLoading: false,
-    packageDependenciesError: "",
-    packageDependenciesKey: "",
+    packageDependencies: { status: "idle" },
     workspaceDependencies: {},
     workspaceDependencyErrors: {},
     workspaceDependencyLoads: new Set<string>(),
-    packageIntegrations: null,
-    packageIntegrationsLoading: false,
-    packageIntegrationsError: "",
-    packageIntegrationsKey: "",
+    packageIntegrations: { status: "idle" },
     packageOpportunities: { status: "idle" },
-    packagePerformance: null,
-    packagePerformanceLoading: false,
-    packagePerformanceError: "",
-    packagePerformanceKey: "",
-    packageMetadata: null,
-    packageMetadataLoading: false,
-    packageMetadataError: "",
-    packageMetadataKey: "",
+    packagePerformance: { status: "idle" },
+    packageMetadata: { status: "idle" },
     ...overrides,
   };
 }
@@ -177,11 +166,11 @@ interface PackageLensFixture<T> {
       PackageInspectionCoordinator;
   load: (coordinator: PackageInspectionCoordinator, signature: string) =>
     Promise<void>;
-  readResult: (state: PackageInspectionState) => T | null;
-  readLoading: (state: PackageInspectionState) => boolean;
-  readError: (state: PackageInspectionState) => string;
-  setKey: (state: PackageInspectionState, key: string) => void;
-  setError: (state: PackageInspectionState, error: string) => void;
+  read: (state: PackageInspectionState) => AsyncResource<T>;
+  write: (
+    state: PackageInspectionState,
+    resource: AsyncResource<T>,
+  ) => void;
 }
 
 async function verifyPackageLensLifecycle<T>(
@@ -191,8 +180,11 @@ async function verifyPackageLensLifecycle<T>(
     const query = deferred<T>();
     const events: string[] = [];
     const state = inspectionState();
-    fixture.setKey(state, "old");
-    fixture.setError(state, "old failure");
+    fixture.write(state, {
+      status: "failed",
+      key: "old",
+      error: "old failure",
+    });
     const coordinator = fixture.createCoordinator(
       state,
       async () => query.promise,
@@ -200,35 +192,20 @@ async function verifyPackageLensLifecycle<T>(
 
     const load = fixture.load(coordinator, "current");
 
-    assert.equal(
-      fixture.readResult(state),
-      null,
-      `${fixture.name} cleared result`);
-    assert.equal(
-      fixture.readLoading(state),
-      true,
-      `${fixture.name} started loading`);
-    assert.equal(
-      fixture.readError(state),
-      "",
-      `${fixture.name} cleared error`);
+    assert.deepEqual(fixture.read(state), {
+      status: "loading",
+      key: "current",
+    }, `${fixture.name} started loading`);
     assert.deepEqual(events, ["render"], `${fixture.name} start render`);
 
     query.resolve(fixture.result);
     await load;
 
-    assert.deepEqual(
-      fixture.readResult(state),
-      fixture.result,
-      `${fixture.name} current result`);
-    assert.equal(
-      fixture.readLoading(state),
-      false,
-      `${fixture.name} current loading`);
-    assert.equal(
-      fixture.readError(state),
-      "",
-      `${fixture.name} current error`);
+    assert.deepEqual(fixture.read(state), {
+      status: "ready",
+      key: "current",
+      data: fixture.result,
+    }, `${fixture.name} current result`);
     assert.deepEqual(
       events,
       ["render", "render"],
@@ -243,25 +220,22 @@ async function verifyPackageLensLifecycle<T>(
 
     await fixture.load(coordinator, "current");
 
-    assert.equal(
-      fixture.readResult(state),
-      null,
-      `${fixture.name} failed result`);
-    assert.equal(
-      fixture.readLoading(state),
-      false,
-      `${fixture.name} failed loading`);
-    assert.equal(
-      fixture.readError(state),
-      "current failure",
-      `${fixture.name} current failure`);
+    assert.deepEqual(fixture.read(state), {
+      status: "failed",
+      key: "current",
+      error: "current failure",
+    }, `${fixture.name} current failure`);
   }
 
   {
     let queries = 0;
     const state = inspectionState();
-    fixture.setKey(state, "cached");
-    fixture.setError(state, "cached failure");
+    const cached: AsyncResource<T> = {
+      status: "failed",
+      key: "cached",
+      error: "cached failure",
+    };
+    fixture.write(state, cached);
     const coordinator = fixture.createCoordinator(state, async () => {
       queries++;
       return fixture.result;
@@ -270,9 +244,9 @@ async function verifyPackageLensLifecycle<T>(
     await fixture.load(coordinator, "cached");
 
     assert.equal(queries, 0, `${fixture.name} cached query`);
-    assert.equal(
-      fixture.readError(state),
-      "cached failure",
+    assert.strictEqual(
+      fixture.read(state),
+      cached,
       `${fixture.name} cached failure`);
   }
 
@@ -284,19 +258,19 @@ async function verifyPackageLensLifecycle<T>(
       async () => query.promise);
 
     const load = fixture.load(coordinator, "first");
-    fixture.setKey(state, "second");
-    fixture.setError(state, "newer failure");
+    const newer: AsyncResource<T> = {
+      status: "failed",
+      key: "second",
+      error: "newer failure",
+    };
+    fixture.write(state, newer);
     query.reject(new Error("stale failure"));
     await load;
 
-    assert.equal(
-      fixture.readError(state),
-      "newer failure",
+    assert.strictEqual(
+      fixture.read(state),
+      newer,
       `${fixture.name} stale failure`);
-    assert.equal(
-      fixture.readLoading(state),
-      true,
-      `${fixture.name} stale loading`);
   }
 }
 
@@ -326,13 +300,21 @@ test("dependency results cache for a resident package after the foreground lens 
     }));
 
   const load = coordinator.loadDependencies(packageItem, "first");
-  assert.equal(state.packageDependenciesLoading, true);
-  state.packageDependenciesKey = "second";
+  assert.deepEqual(state.packageDependencies, {
+    status: "loading",
+    key: "first",
+  });
+  state.packageDependencies = {
+    status: "loading",
+    key: "second",
+  };
   request.resolve(dependencyResult(packageItem.id, "partial dependency data"));
   await load;
 
-  assert.equal(state.packageDependencies, null);
-  assert.equal(state.packageDependenciesLoading, true);
+  assert.deepEqual(state.packageDependencies, {
+    status: "loading",
+    key: "second",
+  });
   const key = workspaceDependencyKey(packageItem);
   const workspace = state.workspaceDependencies[key];
   assert.ok(workspace);
@@ -377,10 +359,16 @@ test("package lens loaders reuse cached results without querying or clearing the
       name: "dependencies",
       cached: dependencies,
       state: inspectionState({
-        packageDependenciesKey: "cached",
-        packageDependencies: dependencies,
+        packageDependencies: {
+          status: "ready",
+          key: "cached",
+          data: dependencies,
+        },
       }),
-      read: (state: PackageInspectionState) => state.packageDependencies,
+      read: (state: PackageInspectionState) =>
+        state.packageDependencies.status === "ready"
+          ? state.packageDependencies.data
+          : null,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadDependencies(packageItem, "cached"),
     },
@@ -388,10 +376,16 @@ test("package lens loaders reuse cached results without querying or clearing the
       name: "integrations",
       cached: integrations,
       state: inspectionState({
-        packageIntegrationsKey: "cached",
-        packageIntegrations: integrations,
+        packageIntegrations: {
+          status: "ready",
+          key: "cached",
+          data: integrations,
+        },
       }),
-      read: (state: PackageInspectionState) => state.packageIntegrations,
+      read: (state: PackageInspectionState) =>
+        state.packageIntegrations.status === "ready"
+          ? state.packageIntegrations.data
+          : null,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadIntegrations(packageItem, "cached", null),
     },
@@ -416,10 +410,16 @@ test("package lens loaders reuse cached results without querying or clearing the
       name: "performance",
       cached: performance,
       state: inspectionState({
-        packagePerformanceKey: "cached",
-        packagePerformance: performance,
+        packagePerformance: {
+          status: "ready",
+          key: "cached",
+          data: performance,
+        },
       }),
-      read: (state: PackageInspectionState) => state.packagePerformance,
+      read: (state: PackageInspectionState) =>
+        state.packagePerformance.status === "ready"
+          ? state.packagePerformance.data
+          : null,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadPerformance(packageItem, "cached", null),
     },
@@ -427,10 +427,16 @@ test("package lens loaders reuse cached results without querying or clearing the
       name: "metadata",
       cached: metadata,
       state: inspectionState({
-        packageMetadataKey: "cached",
-        packageMetadata: metadata,
+        packageMetadata: {
+          status: "ready",
+          key: "cached",
+          data: metadata,
+        },
       }),
-      read: (state: PackageInspectionState) => state.packageMetadata,
+      read: (state: PackageInspectionState) =>
+        state.packageMetadata.status === "ready"
+          ? state.packageMetadata.data
+          : null,
       load: (coordinator: ReturnType<typeof createPackageInspectionCoordinator>) =>
         coordinator.loadMetadata(packageItem, "cached", null),
     },
@@ -477,8 +483,11 @@ test("package lens loaders reuse cached failures without querying", async () => 
   let queries = 0;
   let renders = 0;
   const state = inspectionState({
-    packagePerformanceKey: "cached",
-    packagePerformanceError: "cached failure",
+    packagePerformance: {
+      status: "failed",
+      key: "cached",
+      error: "cached failure",
+    },
   });
   const coordinator = createPackageInspectionCoordinator(
     inspectionDependencies(state, {
@@ -493,7 +502,11 @@ test("package lens loaders reuse cached failures without querying", async () => 
 
   assert.equal(queries, 0);
   assert.equal(renders, 1);
-  assert.equal(state.packagePerformanceError, "cached failure");
+  assert.deepEqual(state.packagePerformance, {
+    status: "failed",
+    key: "cached",
+    error: "cached failure",
+  });
 });
 
 test("every package lens preserves its complete request lifecycle", async () => {
@@ -510,11 +523,8 @@ test("every package lens preserves its complete request lifecycle", async () => 
         })),
     load: (coordinator, signature) =>
       coordinator.loadDependencies(packageItem, signature),
-    readResult: state => state.packageDependencies,
-    readLoading: state => state.packageDependenciesLoading,
-    readError: state => state.packageDependenciesError,
-    setKey: (state, key) => { state.packageDependenciesKey = key; },
-    setError: (state, error) => { state.packageDependenciesError = error; },
+    read: state => state.packageDependencies,
+    write: (state, resource) => { state.packageDependencies = resource; },
   });
   await verifyPackageLensLifecycle({
     name: "integrations",
@@ -527,11 +537,22 @@ test("every package lens preserves its complete request lifecycle", async () => 
         })),
     load: (coordinator, signature) =>
       coordinator.loadIntegrations(packageItem, signature, null),
-    readResult: state => state.packageIntegrations,
-    readLoading: state => state.packageIntegrationsLoading,
-    readError: state => state.packageIntegrationsError,
-    setKey: (state, key) => { state.packageIntegrationsKey = key; },
-    setError: (state, error) => { state.packageIntegrationsError = error; },
+    read: state => state.packageIntegrations,
+    write: (state, resource) => { state.packageIntegrations = resource; },
+  });
+  await verifyPackageLensLifecycle({
+    name: "opportunities",
+    result: opportunitiesResult(),
+    createCoordinator: (state, query, render = () => {}) =>
+      createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryPackageOpportunities: async () => query(),
+          render,
+        })),
+    load: (coordinator, signature) =>
+      coordinator.loadOpportunities(packageItem, signature, null),
+    read: state => state.packageOpportunities,
+    write: (state, resource) => { state.packageOpportunities = resource; },
   });
   await verifyPackageLensLifecycle({
     name: "performance",
@@ -544,11 +565,8 @@ test("every package lens preserves its complete request lifecycle", async () => 
         })),
     load: (coordinator, signature) =>
       coordinator.loadPerformance(packageItem, signature, null),
-    readResult: state => state.packagePerformance,
-    readLoading: state => state.packagePerformanceLoading,
-    readError: state => state.packagePerformanceError,
-    setKey: (state, key) => { state.packagePerformanceKey = key; },
-    setError: (state, error) => { state.packagePerformanceError = error; },
+    read: state => state.packagePerformance,
+    write: (state, resource) => { state.packagePerformance = resource; },
   });
   await verifyPackageLensLifecycle({
     name: "metadata",
@@ -561,11 +579,8 @@ test("every package lens preserves its complete request lifecycle", async () => 
         })),
     load: (coordinator, signature) =>
       coordinator.loadMetadata(packageItem, signature, null),
-    readResult: state => state.packageMetadata,
-    readLoading: state => state.packageMetadataLoading,
-    readError: state => state.packageMetadataError,
-    setKey: (state, key) => { state.packageMetadataKey = key; },
-    setError: (state, error) => { state.packageMetadataError = error; },
+    read: state => state.packageMetadata,
+    write: (state, resource) => { state.packageMetadata = resource; },
   });
 });
 
@@ -789,25 +804,6 @@ test("a re-requested scope keeps the newest result when the abandoned one fails 
       data: { ...opportunitiesResult(), totalOpportunities: 99 },
     });
   });
-
-test("stale package lens rejection cannot overwrite newer state", async () => {
-  const packageItem = packageModel();
-  const request = deferred<PackagePerformance>();
-  const state = inspectionState();
-  const coordinator = createPackageInspectionCoordinator(
-    inspectionDependencies(state, {
-      queryPackagePerformance: async () => request.promise,
-    }));
-
-  const load = coordinator.loadPerformance(packageItem, "first", null);
-  state.packagePerformanceKey = "second";
-  state.packagePerformanceError = "newer failure";
-  request.reject(new Error("stale failure"));
-  await load;
-
-  assert.equal(state.packagePerformanceError, "newer failure");
-  assert.equal(state.packagePerformanceLoading, true);
-});
 
 test("workspace dependency loading records failures and ignores runtime packs", async () => {
   const good = packageModel({ id: "Example.Good" });
@@ -1101,7 +1097,10 @@ test("scoped package lenses route platform coordinates and suppress stale result
   await coordinator.loadPerformance(packageItem, "performance", null);
   const metadataLoad =
     coordinator.loadMetadata(packageItem, "metadata-first", null);
-  state.packageMetadataKey = "metadata-second";
+  state.packageMetadata = {
+    status: "loading",
+    key: "metadata-second",
+  };
   metadata.resolve(metadataResult());
   await metadataLoad;
 
@@ -1111,13 +1110,17 @@ test("scoped package lenses route platform coordinates and suppress stale result
     "performance:Example.Package",
     "metadata:Example.Package",
   ]);
-  assert.ok(state.packageIntegrations);
+  assert.equal(state.packageIntegrations.status, "ready");
   assert.equal(state.packageOpportunities.status, "ready");
-  assert.equal(state.packagePerformance, null);
-  assert.equal(state.packagePerformanceError, "analysis unavailable");
-  assert.equal(state.packagePerformanceLoading, false);
-  assert.equal(state.packageMetadata, null);
-  assert.equal(state.packageMetadataLoading, true);
+  assert.deepEqual(state.packagePerformance, {
+    status: "failed",
+    key: "performance",
+    error: "analysis unavailable",
+  });
+  assert.deepEqual(state.packageMetadata, {
+    status: "loading",
+    key: "metadata-second",
+  });
 });
 
 test("all scoped runtime package lenses route exact platform coordinates", async () => {
@@ -1167,16 +1170,21 @@ test("package lens results clear before a different request completes", async ()
   {
     const query = deferred<BrowserPackageDependencies>();
     const state = inspectionState({
-      packageDependenciesKey: "old",
-      packageDependencies: dependencyResult(),
+      packageDependencies: {
+        status: "ready",
+        key: "old",
+        data: dependencyResult(),
+      },
     });
     const coordinator = createPackageInspectionCoordinator(
       inspectionDependencies(state, {
         queryDependencies: async () => query.promise,
       }));
     const load = coordinator.loadDependencies(packageItem, "new");
-    assert.equal(state.packageDependencies, null);
-    assert.equal(state.packageDependenciesLoading, true);
+      assert.deepEqual(state.packageDependencies, {
+        status: "loading",
+        key: "new",
+      });
     query.resolve(dependencyResult());
     await load;
   }
@@ -1184,16 +1192,21 @@ test("package lens results clear before a different request completes", async ()
   {
     const query = deferred<BrowserPackageIntegrations>();
     const state = inspectionState({
-      packageIntegrationsKey: "old",
-      packageIntegrations: integrationsResult(),
+      packageIntegrations: {
+        status: "ready",
+        key: "old",
+        data: integrationsResult(),
+      },
     });
     const coordinator = createPackageInspectionCoordinator(
       inspectionDependencies(state, {
         queryPackageIntegrations: async () => query.promise,
       }));
     const load = coordinator.loadIntegrations(packageItem, "new", null);
-    assert.equal(state.packageIntegrations, null);
-    assert.equal(state.packageIntegrationsLoading, true);
+      assert.deepEqual(state.packageIntegrations, {
+        status: "loading",
+        key: "new",
+      });
     query.resolve(integrationsResult());
     await load;
   }
@@ -1223,16 +1236,21 @@ test("package lens results clear before a different request completes", async ()
   {
     const query = deferred<PackagePerformance>();
     const state = inspectionState({
-      packagePerformanceKey: "old",
-      packagePerformance: performanceResult(),
+      packagePerformance: {
+        status: "ready",
+        key: "old",
+        data: performanceResult(),
+      },
     });
     const coordinator = createPackageInspectionCoordinator(
       inspectionDependencies(state, {
         queryPackagePerformance: async () => query.promise,
       }));
     const load = coordinator.loadPerformance(packageItem, "new", null);
-    assert.equal(state.packagePerformance, null);
-    assert.equal(state.packagePerformanceLoading, true);
+      assert.deepEqual(state.packagePerformance, {
+        status: "loading",
+        key: "new",
+      });
     query.resolve(performanceResult());
     await load;
   }
@@ -1240,16 +1258,21 @@ test("package lens results clear before a different request completes", async ()
   {
     const query = deferred<PackageMetadata>();
     const state = inspectionState({
-      packageMetadataKey: "old",
-      packageMetadata: metadataResult(),
+      packageMetadata: {
+        status: "ready",
+        key: "old",
+        data: metadataResult(),
+      },
     });
     const coordinator = createPackageInspectionCoordinator(
       inspectionDependencies(state, {
         queryPackageMetadata: async () => query.promise,
       }));
     const load = coordinator.loadMetadata(packageItem, "new", null);
-    assert.equal(state.packageMetadata, null);
-    assert.equal(state.packageMetadataLoading, true);
+      assert.deepEqual(state.packageMetadata, {
+        status: "loading",
+        key: "new",
+      });
     query.resolve(metadataResult());
     await load;
   }
@@ -1266,11 +1289,16 @@ test("package lens results require their current request key", async () => {
         queryPackageIntegrations: async () => query.promise,
       }));
     const load = coordinator.loadIntegrations(packageItem, "first", null);
-    state.packageIntegrationsKey = "second";
+      state.packageIntegrations = {
+        status: "loading",
+        key: "second",
+      };
     query.resolve(integrationsResult());
     await load;
-    assert.equal(state.packageIntegrations, null);
-    assert.equal(state.packageIntegrationsLoading, true);
+    assert.deepEqual(state.packageIntegrations, {
+      status: "loading",
+      key: "second",
+    });
   }
 
   {
@@ -1301,11 +1329,16 @@ test("package lens results require their current request key", async () => {
         queryPackagePerformance: async () => query.promise,
       }));
     const load = coordinator.loadPerformance(packageItem, "first", null);
-    state.packagePerformanceKey = "second";
+      state.packagePerformance = {
+        status: "loading",
+        key: "second",
+      };
     query.resolve(performanceResult());
     await load;
-    assert.equal(state.packagePerformance, null);
-    assert.equal(state.packagePerformanceLoading, true);
+    assert.deepEqual(state.packagePerformance, {
+      status: "loading",
+      key: "second",
+    });
   }
 });
 
@@ -1346,8 +1379,8 @@ test("runtime package lenses wait for an explicit library scope", async () => {
 
   assert.equal(queries, 0);
   assert.equal(renders, 0);
-  assert.equal(state.packageIntegrationsKey, "");
+  assert.equal(state.packageIntegrations.status, "idle");
   assert.equal(state.packageOpportunities.status, "idle");
-  assert.equal(state.packagePerformanceKey, "");
-  assert.equal(state.packageMetadataKey, "");
+  assert.equal(state.packagePerformance.status, "idle");
+  assert.equal(state.packageMetadata.status, "idle");
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -767,8 +767,8 @@ test("typed package inspection owns package-root request coordination", () => {
   assert.match(appSource, /packageInspection\.loadMetadata\(/);
   assert.match(
     packageInspectionSource,
-    /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependenciesKey/);
-  assert.doesNotMatch(dependenciesLoader, /state\.packageDependenciesKey/);
+    /async loadDependencies\(packageModel, signature\)[\s\S]*state\.packageDependencies = pending/);
+  assert.doesNotMatch(dependenciesLoader, /state\.packageDependencies\s*=/);
 });
 
 test("typed package view owns package navigation bindings", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -4909,3 +4909,9 @@ test("dependency graph rendering contains artifact labels", () => {
   assert.equal(definition.definition.includes("\u200D"), false);
   assert.equal(definition.definition.includes("\uDC00"), false);
 });
+
+// The parallel-field guarantee moved to `test/async-resource-state.test.ts`. The gate that
+// stood here derived its lens roster but restated the *suffixes*, and round 2 review walked
+// around it twice: with a suffix that was not on the list, and by moving the field into a
+// spread the source scan never read. The replacement names no suffixes -- it rejects any
+// state key that starts with a converted lens name and is not that lens.


### PR DESCRIPTION
Part of #4570

Dependencies, Integrations, Analysis, and Metadata now join Opportunities in using one request-owned `AsyncResource` state per package lens. Impossible combinations such as loading with stale data and an error are no longer representable, same-key requests are reused, and stale success or failure cannot overwrite a newer request.

Dependency workspace caching remains independent of foreground ownership: a result from a lens the user left can still populate the resident-package graph cache without replacing the newer foreground request. Existing renderer states, platform-library scoping, and metadata explorer handoff are preserved.

## Stack

- Slice 5 of the semantic TypeScript conversion stack.
- Parent: #4583 (`type/4570-opportunity-state`).
- Residual: source, member-detail, document, catalog, Spotlight, top-level view, and workspace-selection state families in #4570; #4572-#4575 remain separate.

## Validation

- `npm test` (615 tests)
- `npm run analyze`
- `npm run build`
- `node --test test/package-inspection.test.ts test/package-opportunities.test.ts` (52 tests)
- `npx --yes markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check`

## Latest-main restack

Restacked onto #4583 head `e7d8a16e0`; current head is `91f147988`.

- Full suite: 615/615.
- Focused package-inspection and opportunity tests after the second parent
  refresh: 52/52.
- Analyzer, production build, range-diff, and `git diff --check`: clean.
