### PR TITLE
Give the document viewer one request-owned state union

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1021,11 +1021,15 @@ open, close, and bare-backdrop bindings. `src/document-inspection.ts` owns its
 request-owned `closed`/`loading`/`ready`/`failed` state, visible failure, and
 frontmatter projection. The loading object is the request-ownership token, so a
 stale completion cannot publish into a newer open or closed state and result,
-metadata, and error fields exist only on their applicable variants.
+metadata, and error fields exist only on their applicable variants. The renderer
+receives that status rather than four flattened fields, so it cannot re-derive
+"this failed" from a string being empty: a failure with no message renders as a
+failure, and an empty document renders as a document. `isDocViewerOpen` is the
+one place that decides what counts as open.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and
-error presentation, the
+error presentation, both halves of the empty-message/empty-document pair, the
 frontmatter card's presence and fields, and title/subtitle/frontmatter-name
 escaping, package-document list output, open dispatch, and button/backdrop
 close dispatch;

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1018,8 +1018,10 @@ notes, and the row inspector.
 `src/doc-viewer.ts` owns the package document modal (the Markdown reader
 opened from a package's documents list) and that list's markup, including its
 open, close, and bare-backdrop bindings. `src/document-inspection.ts` owns its
-sequence-guarded async load/close lifecycle, visible failure, and frontmatter
-projection.
+request-owned `closed`/`loading`/`ready`/`failed` state, visible failure, and
+frontmatter projection. The loading object is the request-ownership token, so a
+stale completion cannot publish into a newer open or closed state and result,
+metadata, and error fields exist only on their applicable variants.
 `dotnet-inspect.ts` validates the selected package document and supplies the
 engine, sanitized Markdown-rendering, state, and render ports.
 `test/doc-viewer.test.ts` gates the closed/no-document fallback, loading and

--- a/prototypes/inspect-web/src/doc-viewer.ts
+++ b/prototypes/inspect-web/src/doc-viewer.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "./data.ts";
 import type { BrowserPackageDocument } from "./inspect-web-engine.d.ts";
 
 type DocViewerDocument = Pick<BrowserPackageDocument, "name" | "path">;
@@ -12,12 +13,21 @@ export interface DocViewerMeta {
   descriptionHtml: string;
 }
 
+// The body is a union, not five independent fields. Flattening the viewer's state into
+// `loading`/`error`/`html` made the renderer re-derive which state it was in by asking
+// whether a string was empty -- so a *failed* document whose message was empty and a
+// *ready* document whose body was empty became the same value, and the failure rendered
+// as a successful empty article. Round 2 review (Claude Opus 5) demonstrated it end to
+// end. Discriminating on status makes that pair unrepresentable rather than merely
+// unlikely.
+export type DocViewerBody =
+  | { status: "loading" }
+  | { status: "ready"; meta: DocViewerMeta | null; html: string }
+  | { status: "failed"; error: string };
+
 export interface RenderDocViewerOptions {
   doc: DocViewerDocument | null;
-  meta: DocViewerMeta | null;
-  loading: boolean;
-  error: string;
-  html: string;
+  body: DocViewerBody;
   escapeHtml: (value: unknown) => string;
 }
 
@@ -73,21 +83,40 @@ export function renderPackageDocuments(
     </section>`;
 }
 
-export function renderDocViewer(options: RenderDocViewerOptions): string {
-  const { doc, meta, loading, error, html, escapeHtml } = options;
-  const title = doc ? doc.name : "Document";
-  const subtitle = doc ? doc.path : "";
-  const metaCard = meta
-    ? `<div class="doc-frontmatter">
+function docViewerMetaCard(
+  meta: DocViewerMeta | null,
+  escapeHtml: (value: unknown) => string,
+): string {
+  if (!meta) return "";
+  return `<div class="doc-frontmatter">
         <div class="doc-fm-head"><strong>${escapeHtml(meta.name)}</strong>${meta.version ? `<span class="doc-fm-version">v${escapeHtml(meta.version)}</span>` : ""}</div>
         ${meta.descriptionHtml ? `<p class="doc-fm-desc">${meta.descriptionHtml}</p>` : ""}
-      </div>`
-    : "";
-  const body = loading
-    ? `<div class="doc-viewer-status">Loading ${escapeHtml(title)}…</div>`
-    : error
-      ? `<div class="doc-viewer-status error">${escapeHtml(error)}</div>`
-      : `${metaCard}<article class="markdown-body">${html}</article>`;
+      </div>`;
+}
+
+export function renderDocViewer(options: RenderDocViewerOptions): string {
+  const { doc, body: viewerBody, escapeHtml } = options;
+  const title = doc ? doc.name : "Document";
+  const subtitle = doc ? doc.path : "";
+  let body: string;
+  switch (viewerBody.status) {
+    case "loading":
+      body = `<div class="doc-viewer-status">Loading ${escapeHtml(title)}…</div>`;
+      break;
+    case "failed":
+      // A failure with nothing to say is still a failure. An empty message must not be
+      // able to render as an empty success, which is what re-deriving state from
+      // truthiness allowed.
+      body = `<div class="doc-viewer-status error">${
+        escapeHtml(viewerBody.error || "The document could not be loaded.")}</div>`;
+      break;
+    case "ready":
+      body = docViewerMetaCard(viewerBody.meta, escapeHtml)
+        + `<article class="markdown-body">${viewerBody.html}</article>`;
+      break;
+    default:
+      return assertNever(viewerBody, "DocViewerBody");
+  }
   return `
     <div class="doc-viewer-backdrop" id="doc-viewer-backdrop">
       <div class="doc-viewer" role="dialog" aria-modal="true" aria-label="Package document">

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "./data.ts";
 import type { DocViewerMeta, RenderDocViewerOptions } from "./doc-viewer.ts";
 import type {
   BrowserPackageDocument,
@@ -41,9 +42,9 @@ export type OpenDocumentViewerState =
 //
 // So the projection is a named pure function rather than five ternaries at the call site,
 // which is what makes it reachable from a test. It is a `default`-less switch in a
-// value-returning function, so `noImplicitReturns` rejects a new union member here until
-// it says what it renders -- the same exhaustiveness the `assertNever` dispatches get,
-// without this module taking a dependency on `data.ts` for it.
+// value-returning function terminating in `assertNever`, so a new union member is
+// rejected here until it says what it renders -- the same gate the other closed
+// vocabularies in this prototype use.
 export function docViewerOptions(
   viewer: OpenDocumentViewerState,
 ): Omit<RenderDocViewerOptions, "escapeHtml"> {
@@ -61,6 +62,8 @@ export function docViewerOptions(
       };
     case "failed":
       return { doc, meta: null, loading: false, error: viewer.error, html: "" };
+    default:
+      return assertNever(viewer, "DocumentViewerState");
   }
 }
 

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -5,13 +5,7 @@ import type {
 } from "./inspect-web-engine.d.ts";
 
 export interface DocumentInspectionState {
-  docViewerOpen: boolean;
-  docViewer: BrowserPackageDocument | null;
-  docViewerLoading: boolean;
-  docViewerError: string;
-  docViewerHtml: string;
-  docViewerMeta: DocViewerMeta | null;
-  docViewerSeq: number;
+  docViewer: DocumentViewerState;
 }
 
 export interface PackageDocumentRequest {
@@ -19,6 +13,21 @@ export interface PackageDocumentRequest {
   version: string;
   document: BrowserPackageDocument;
 }
+
+export type DocumentViewerState =
+  | { status: "closed" }
+  | { status: "loading"; request: PackageDocumentRequest }
+  | {
+      status: "ready";
+      request: PackageDocumentRequest;
+      html: string;
+      meta: DocViewerMeta | null;
+    }
+  | {
+      status: "failed";
+      request: PackageDocumentRequest;
+      error: string;
+    };
 
 export interface DocumentInspectionDependencies {
   state: DocumentInspectionState;
@@ -84,26 +93,21 @@ export function createDocumentInspectionCoordinator(
 
   return {
     async open(request: PackageDocumentRequest) {
-      const sequence = ++state.docViewerSeq;
-      state.docViewerOpen = true;
-      state.docViewer = request.document;
-      state.docViewerHtml = "";
-      state.docViewerMeta = null;
-      state.docViewerError = "";
-      state.docViewerLoading = true;
+      const pending = { status: "loading", request } as const;
+      state.docViewer = pending;
       dependencies.render();
       try {
         const content = await dependencies.queryDocument(request);
-        if (sequence !== state.docViewerSeq) return;
+        if (state.docViewer !== pending) return;
         if (typeof content.text !== "string")
           throw new TypeError("The document content did not contain text.");
         const { meta, body } = splitFrontmatter(content.text);
         const html = await dependencies.renderMarkdown(body);
-        if (sequence !== state.docViewerSeq) return;
+        if (state.docViewer !== pending) return;
         const descriptionHtml = meta?.description
           ? await dependencies.renderMarkdownInline(meta.description)
           : "";
-        if (sequence !== state.docViewerSeq) return;
+        if (state.docViewer !== pending) return;
         const projectedMeta = meta && (meta.name || meta.description)
           ? {
               name: meta.name || request.document.name,
@@ -111,27 +115,25 @@ export function createDocumentInspectionCoordinator(
               descriptionHtml,
             }
           : null;
-        state.docViewerHtml = html;
-        state.docViewerMeta = projectedMeta;
+        state.docViewer = {
+          status: "ready",
+          request,
+          html,
+          meta: projectedMeta,
+        };
       } catch (error) {
-        if (sequence !== state.docViewerSeq) return;
-        state.docViewerError = dependencies.describeError(error);
-      } finally {
-        if (sequence === state.docViewerSeq) {
-          state.docViewerLoading = false;
-          dependencies.render();
-        }
+        if (state.docViewer !== pending) return;
+        state.docViewer = {
+          status: "failed",
+          request,
+          error: dependencies.describeError(error),
+        };
       }
+      dependencies.render();
     },
 
     close() {
-      state.docViewerSeq++;
-      state.docViewerOpen = false;
-      state.docViewer = null;
-      state.docViewerHtml = "";
-      state.docViewerMeta = null;
-      state.docViewerError = "";
-      state.docViewerLoading = false;
+      state.docViewer = { status: "closed" };
       dependencies.render();
     },
   };

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -1,4 +1,4 @@
-import type { DocViewerMeta } from "./doc-viewer.ts";
+import type { DocViewerMeta, RenderDocViewerOptions } from "./doc-viewer.ts";
 import type {
   BrowserPackageDocument,
   BrowserPackageDocumentContent,
@@ -28,6 +28,41 @@ export type DocumentViewerState =
       request: PackageDocumentRequest;
       error: string;
     };
+
+export type OpenDocumentViewerState =
+  Exclude<DocumentViewerState, { status: "closed" }>;
+
+// The union guarantees that `error` and `html` exist only on the variants that own them,
+// but nothing about that stops a projection from declining to pass the error along. That
+// is a real gap rather than a hypothetical one: adversarial review mutated the previous
+// inline projection to `error: ""` and the whole suite stayed green, so a document that
+// had failed to load rendered as an empty article that looked like a successful, empty
+// document.
+//
+// So the projection is a named pure function rather than five ternaries at the call site,
+// which is what makes it reachable from a test. It is a `default`-less switch in a
+// value-returning function, so `noImplicitReturns` rejects a new union member here until
+// it says what it renders -- the same exhaustiveness the `assertNever` dispatches get,
+// without this module taking a dependency on `data.ts` for it.
+export function docViewerOptions(
+  viewer: OpenDocumentViewerState,
+): Omit<RenderDocViewerOptions, "escapeHtml"> {
+  const doc = viewer.request.document;
+  switch (viewer.status) {
+    case "loading":
+      return { doc, meta: null, loading: true, error: "", html: "" };
+    case "ready":
+      return {
+        doc,
+        meta: viewer.meta,
+        loading: false,
+        error: "",
+        html: viewer.html,
+      };
+    case "failed":
+      return { doc, meta: null, loading: false, error: viewer.error, html: "" };
+  }
+}
 
 export interface DocumentInspectionDependencies {
   state: DocumentInspectionState;

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -33,15 +33,22 @@ export type DocumentViewerState =
 export type OpenDocumentViewerState =
   Exclude<DocumentViewerState, { status: "closed" }>;
 
-// Five call sites asked "is the viewer open?" by spelling `status !== "closed"`, and round
-// 2 review (Claude Opus 5) pointed out that a new *closed-like* member -- dismissed,
-// cancelled -- would be silently treated as open at all five, with no compile error to
-// prompt a decision. `Exclude` absorbs it the same way. One predicate makes that a single
-// place to review instead of five identical literals to find.
+// Five root call sites ask whether the viewer owns rendering, focus, or keyboard input.
+// Keep that decision exhaustive here so a new state cannot silently acquire or lose all
+// three kinds of ownership.
 export function isDocViewerOpen(
   viewer: DocumentViewerState,
 ): viewer is OpenDocumentViewerState {
-  return viewer.status !== "closed";
+  switch (viewer.status) {
+    case "closed":
+      return false;
+    case "loading":
+    case "ready":
+    case "failed":
+      return true;
+    default:
+      return assertNever(viewer, "DocumentViewerState");
+  }
 }
 
 // The union guarantees that `error` and `html` exist only on the variants that own them,

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -33,6 +33,17 @@ export type DocumentViewerState =
 export type OpenDocumentViewerState =
   Exclude<DocumentViewerState, { status: "closed" }>;
 
+// Five call sites asked "is the viewer open?" by spelling `status !== "closed"`, and round
+// 2 review (Claude Opus 5) pointed out that a new *closed-like* member -- dismissed,
+// cancelled -- would be silently treated as open at all five, with no compile error to
+// prompt a decision. `Exclude` absorbs it the same way. One predicate makes that a single
+// place to review instead of five identical literals to find.
+export function isDocViewerOpen(
+  viewer: DocumentViewerState,
+): viewer is OpenDocumentViewerState {
+  return viewer.status !== "closed";
+}
+
 // The union guarantees that `error` and `html` exist only on the variants that own them,
 // but nothing about that stops a projection from declining to pass the error along. That
 // is a real gap rather than a hypothetical one: adversarial review mutated the previous
@@ -51,17 +62,11 @@ export function docViewerOptions(
   const doc = viewer.request.document;
   switch (viewer.status) {
     case "loading":
-      return { doc, meta: null, loading: true, error: "", html: "" };
+      return { doc, body: { status: "loading" } };
     case "ready":
-      return {
-        doc,
-        meta: viewer.meta,
-        loading: false,
-        error: "",
-        html: viewer.html,
-      };
+      return { doc, body: { status: "ready", meta: viewer.meta, html: viewer.html } };
     case "failed":
-      return { doc, meta: null, loading: false, error: viewer.error, html: "" };
+      return { doc, body: { status: "failed", error: viewer.error } };
     default:
       return assertNever(viewer, "DocumentViewerState");
   }

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -153,7 +153,10 @@ import {
   createCallGraphInspectionCoordinator,
   type PlatformStackEntry,
 } from "./call-graph-inspection.ts";
-import { createDocumentInspectionCoordinator } from "./document-inspection.ts";
+import {
+  createDocumentInspectionCoordinator,
+  type DocumentViewerState,
+} from "./document-inspection.ts";
 import {
   captureMemberFocus,
   createMemberFocusRestorer,
@@ -186,7 +189,6 @@ import {
   bindDocViewer,
   renderDocViewer as renderDocViewerPure,
   renderPackageDocuments,
-  type DocViewerMeta,
 } from "./doc-viewer.ts";
 import {
   bindGraphSource,
@@ -270,7 +272,6 @@ import type {
   BrowserPackageCacheStats,
   BrowserPackageDependencies,
   BrowserPackageDependencyGroup,
-  BrowserPackageDocument,
   BrowserPackageIntegrations,
   BrowserPackageOpportunities,
   BrowserPackageSurface,
@@ -636,13 +637,7 @@ const initialState = {
   graphSource: null,
   graphSourceLoading: false,
   graphSourceError: "",
-  docViewerOpen: false,
-  docViewer: null,
-  docViewerLoading: false,
-  docViewerError: "",
-  docViewerHtml: "",
-  docViewerMeta: null,
-  docViewerSeq: 0,
+  docViewer: { status: "closed" } as const,
   graphSourceTitle: "",
   graphSourceRequest: null,
   graphSourceSeq: 0,
@@ -706,8 +701,7 @@ interface StateOverrides {
   recentPackages: RecentPackage[];
   selectedBodyTarget: BodyTarget | null;
   graphSource: BrowserSource | null;
-  docViewer: BrowserPackageDocument | null;
-  docViewerMeta: DocViewerMeta | null;
+  docViewer: DocumentViewerState;
   graphSourceRequest: { request: GraphSourceRequest; title: string } | null;
   styleTiers: StyleTier[] | null;
   styleOptions: StyleOption[] | null;
@@ -1292,11 +1286,13 @@ function isInteractiveElement(element: Element | null) {
 
 function focusTypeList(generation = spotlightFocusGeneration) {
   if (generation !== spotlightFocusGeneration
-      || state.spotlightOpen || state.graphSourceOpen || state.docViewerOpen
+      || state.spotlightOpen || state.graphSourceOpen
+      || state.docViewer.status !== "closed"
       || isTextEntry()) return;
   requestAnimationFrame(() => {
     if (generation !== spotlightFocusGeneration
-        || state.spotlightOpen || state.graphSourceOpen || state.docViewerOpen
+        || state.spotlightOpen || state.graphSourceOpen
+        || state.docViewer.status !== "closed"
         || isTextEntry()) return;
     document.querySelector<HTMLElement>("#type-list")?.focus();
   });
@@ -2402,7 +2398,7 @@ function render() {
       }, escapeHtml)}
       ${state.spotlightOpen ? spotlight.modalHtml() : ""}
       ${state.graphSourceOpen ? renderGraphSource() : ""}
-      ${state.docViewerOpen ? renderDocViewer() : ""}
+      ${state.docViewer.status !== "closed" ? renderDocViewer() : ""}
       ${state.tasteOpen ? renderTastePopoverHtml() : ""}
     </div>`;
 
@@ -5813,7 +5809,7 @@ function workbenchOverlayOwnsFocus() {
 function workbenchModalOwnsFocus() {
   return state.spotlightOpen
     || state.graphSourceOpen
-    || state.docViewerOpen;
+    || state.docViewer.status !== "closed";
 }
 
 function captureWorkspaceUrlState(): WorkspaceUrlState | null {
@@ -7840,12 +7836,14 @@ function closeDocViewer() {
 }
 
 function renderDocViewer() {
+  const viewer = state.docViewer;
+  if (viewer.status === "closed") return "";
   return renderDocViewerPure({
-    doc: state.docViewer,
-    meta: state.docViewerMeta,
-    loading: state.docViewerLoading,
-    error: state.docViewerError,
-    html: state.docViewerHtml,
+    doc: viewer.request.document,
+    meta: viewer.status === "ready" ? viewer.meta : null,
+    loading: viewer.status === "loading",
+    error: viewer.status === "failed" ? viewer.error : "",
+    html: viewer.status === "ready" ? viewer.html : "",
     escapeHtml,
   });
 }
@@ -8760,7 +8758,7 @@ function workspaceKeyboardContextIsActive(): boolean {
     && !state.loading
     && !state.error
     && !state.graphSourceOpen
-    && !state.docViewerOpen
+    && state.docViewer.status === "closed"
     && !state.spotlightOpen;
 }
 
@@ -8769,7 +8767,7 @@ const workspaceModalContextIsAvailable = () =>
 const graphSourceContextIsActive = () =>
   workspaceModalContextIsAvailable() && state.graphSourceOpen;
 const documentViewerContextIsActive = () =>
-  workspaceModalContextIsAvailable() && state.docViewerOpen;
+  workspaceModalContextIsAvailable() && state.docViewer.status !== "closed";
 const spotlightContextIsActive = () =>
   workspaceModalContextIsAvailable() && state.spotlightOpen;
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -155,6 +155,7 @@ import {
 } from "./call-graph-inspection.ts";
 import {
   createDocumentInspectionCoordinator,
+  docViewerOptions,
   type DocumentViewerState,
 } from "./document-inspection.ts";
 import {
@@ -7835,17 +7836,14 @@ function closeDocViewer() {
   documentInspection.close();
 }
 
+// The projection from the union to the renderer's options lives in
+// `document-inspection.ts` as `docViewerOptions`, which is exhaustive and testable.
+// Keeping it out of here is the point: as an inline set of ternaries it was reachable
+// from no test, and mutating it to drop the error message left the suite green.
 function renderDocViewer() {
   const viewer = state.docViewer;
   if (viewer.status === "closed") return "";
-  return renderDocViewerPure({
-    doc: viewer.request.document,
-    meta: viewer.status === "ready" ? viewer.meta : null,
-    loading: viewer.status === "loading",
-    error: viewer.status === "failed" ? viewer.error : "",
-    html: viewer.status === "ready" ? viewer.html : "",
-    escapeHtml,
-  });
+  return renderDocViewerPure({ ...docViewerOptions(viewer), escapeHtml });
 }
 
 // The decompiler style ("taste") catalog, grouped by tier, as checkbox rows. Shared by the

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -156,6 +156,7 @@ import {
 import {
   createDocumentInspectionCoordinator,
   docViewerOptions,
+  isDocViewerOpen,
   type DocumentViewerState,
 } from "./document-inspection.ts";
 import {
@@ -1288,12 +1289,12 @@ function isInteractiveElement(element: Element | null) {
 function focusTypeList(generation = spotlightFocusGeneration) {
   if (generation !== spotlightFocusGeneration
       || state.spotlightOpen || state.graphSourceOpen
-      || state.docViewer.status !== "closed"
+      || isDocViewerOpen(state.docViewer)
       || isTextEntry()) return;
   requestAnimationFrame(() => {
     if (generation !== spotlightFocusGeneration
         || state.spotlightOpen || state.graphSourceOpen
-        || state.docViewer.status !== "closed"
+        || isDocViewerOpen(state.docViewer)
         || isTextEntry()) return;
     document.querySelector<HTMLElement>("#type-list")?.focus();
   });
@@ -2399,7 +2400,7 @@ function render() {
       }, escapeHtml)}
       ${state.spotlightOpen ? spotlight.modalHtml() : ""}
       ${state.graphSourceOpen ? renderGraphSource() : ""}
-      ${state.docViewer.status !== "closed" ? renderDocViewer() : ""}
+      ${isDocViewerOpen(state.docViewer) ? renderDocViewer() : ""}
       ${state.tasteOpen ? renderTastePopoverHtml() : ""}
     </div>`;
 
@@ -5810,7 +5811,7 @@ function workbenchOverlayOwnsFocus() {
 function workbenchModalOwnsFocus() {
   return state.spotlightOpen
     || state.graphSourceOpen
-    || state.docViewer.status !== "closed";
+    || isDocViewerOpen(state.docViewer);
 }
 
 function captureWorkspaceUrlState(): WorkspaceUrlState | null {
@@ -8756,7 +8757,7 @@ function workspaceKeyboardContextIsActive(): boolean {
     && !state.loading
     && !state.error
     && !state.graphSourceOpen
-    && state.docViewer.status === "closed"
+    && !isDocViewerOpen(state.docViewer)
     && !state.spotlightOpen;
 }
 
@@ -8765,7 +8766,7 @@ const workspaceModalContextIsAvailable = () =>
 const graphSourceContextIsActive = () =>
   workspaceModalContextIsAvailable() && state.graphSourceOpen;
 const documentViewerContextIsActive = () =>
-  workspaceModalContextIsAvailable() && state.docViewer.status !== "closed";
+  workspaceModalContextIsAvailable() && isDocViewerOpen(state.docViewer);
 const spotlightContextIsActive = () =>
   workspaceModalContextIsAvailable() && state.spotlightOpen;
 

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -1,4 +1,4 @@
-// A lens converted to `AsyncResource` holds its whole request lifecycle in one state field.
+// A request lifecycle union holds its whole lifecycle in one state field.
 // The parallel `…Loading`/`…Error`/`…Key` fields it replaces are gone -- but nothing proved
 // they were gone, and adversarial review (GPT-5.6 Sol, Claude Opus 5) resurrected them two
 // ways with the suite and the analyzer silent:
@@ -45,20 +45,23 @@ function parse(file: string): Program {
   return parsed.program;
 }
 
-function packageInspectionState(program: Program): TSInterfaceDeclaration {
+function inspectionState(
+  program: Program,
+  name: string,
+): TSInterfaceDeclaration {
   const declarations = program.body.flatMap(node => {
     const declaration = node.type === "ExportNamedDeclaration"
       ? node.declaration
       : node;
     return declaration?.type === "TSInterfaceDeclaration"
-      && declaration.id.name === "PackageInspectionState"
+      && declaration.id.name === name
       ? [declaration]
       : [];
   });
   assert.equal(
     declarations.length,
     1,
-    "PackageInspectionState must have exactly one declaration");
+    `${name} must have exactly one declaration`);
   const declaration = declarations[0];
   assert.ok(declaration);
   return declaration;
@@ -75,13 +78,13 @@ function stateProperties(declaration: TSInterfaceDeclaration): TSPropertySignatu
     (member): member is TSPropertySignature => member.type === "TSPropertySignature");
 }
 
-function resourceFields(declaration: TSInterfaceDeclaration): string[] {
+function lifecycleFields(declaration: TSInterfaceDeclaration): string[] {
   return stateProperties(declaration)
     .filter(property => {
       const annotation = property.typeAnnotation?.typeAnnotation;
       return annotation?.type === "TSTypeReference"
         && annotation.typeName.type === "Identifier"
-        && annotation.typeName.name === "AsyncResource";
+        && ["AsyncResource", "DocumentViewerState"].includes(annotation.typeName.name);
     })
     .map(property => propertyName(property.key, property.computed));
 }
@@ -138,15 +141,23 @@ function objectPropertyNames(
   return names;
 }
 
-test("a lens converted to AsyncResource keeps exactly one state field", () => {
+test("a request lifecycle union keeps exactly one state field", () => {
   const coordinatorProgram = parse("package-inspection.ts");
-  const coordinatorState = packageInspectionState(coordinatorProgram);
+  const coordinatorState = inspectionState(
+    coordinatorProgram,
+    "PackageInspectionState");
+  const documentState = inspectionState(
+    parse("document-inspection.ts"),
+    "DocumentInspectionState");
   const rootProgram = parse("dotnet-inspect.ts");
   const declarations = objectDeclarations(rootProgram);
   const initialState = declarations.get("initialState");
   assert.ok(initialState, "initialState must be a statically inspectable object");
 
-  const converted = resourceFields(coordinatorState);
+  const converted = [
+    ...lifecycleFields(coordinatorState),
+    ...lifecycleFields(documentState),
+  ];
   assert.ok(
     converted.length > 0,
     "no AsyncResource state field was found, so the anchor has stopped resolving");
@@ -155,6 +166,11 @@ test("a lens converted to AsyncResource keeps exactly one state field", () => {
     [
       "PackageInspectionState",
       stateProperties(coordinatorState)
+        .map(property => propertyName(property.key, property.computed)),
+    ],
+    [
+      "DocumentInspectionState",
+      stateProperties(documentState)
         .map(property => propertyName(property.key, property.computed)),
     ],
     ["initialState", objectPropertyNames(initialState, declarations)],
@@ -174,17 +190,22 @@ test("a lens converted to AsyncResource keeps exactly one state field", () => {
   assert.deepEqual(
     survivors.sort((left, right) => left.localeCompare(right)),
     [],
-    "a lens holding its lifecycle in an AsyncResource also has a parallel state field. "
-    + "The resource is the single source of truth for that request; a second field beside "
+    "a request lifecycle union also has a parallel state field. "
+    + "The union is the single source of truth for that request; a second field beside "
     + "it can disagree with it.");
 });
 
-test("the parallel-field gate sees both surfaces", () => {
+test("the parallel-field gate sees every lifecycle surface", () => {
   // Non-vacuity, and the specific shape of the two mutations that were silent: a gate that
   // reads only one surface, or whose property scan stops matching, would pass above while
   // proving nothing.
   const coordinatorProgram = parse("package-inspection.ts");
-  const coordinatorState = packageInspectionState(coordinatorProgram);
+  const coordinatorState = inspectionState(
+    coordinatorProgram,
+    "PackageInspectionState");
+  const documentState = inspectionState(
+    parse("document-inspection.ts"),
+    "DocumentInspectionState");
   const rootProgram = parse("dotnet-inspect.ts");
   const declarations = objectDeclarations(rootProgram);
   const initialState = declarations.get("initialState");
@@ -196,6 +217,14 @@ test("the parallel-field gate sees both surfaces", () => {
         === "packageOpportunities"),
     "the coordinator-state property scan no longer sees the converted lens");
   assert.ok(
+    stateProperties(documentState)
+      .some(property => propertyName(property.key, property.computed)
+        === "docViewer"),
+    "the document-state property scan no longer sees the converted viewer");
+  assert.ok(
     objectPropertyNames(initialState, declarations).includes("packageOpportunities"),
     "the initial-state property scan no longer sees the converted lens");
+  assert.ok(
+    objectPropertyNames(initialState, declarations).includes("docViewer"),
+    "the initial-state property scan no longer sees the converted viewer");
 });

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -190,6 +190,21 @@ test("error state reports the error instead of loading or body content", () => {
   assert.doesNotMatch(html, /markdown-body/);
 });
 
+test("error state escapes hostile failure text", () => {
+  const html = renderDocViewer({
+    doc,
+    body: {
+      status: "failed",
+      error: "</div><script>globalThis.compromised = true</script>",
+    },
+    escapeHtml,
+  });
+
+  assert.doesNotMatch(html, /<script>/);
+  assert.match(html, /&lt;\/div&gt;&lt;script&gt;/);
+  assert.match(html, /doc-viewer-status error/);
+});
+
 test("loaded state without frontmatter renders the body with no frontmatter card", () => {
   const html = renderDocViewer({
     doc,

--- a/prototypes/inspect-web/test/doc-viewer.test.ts
+++ b/prototypes/inspect-web/test/doc-viewer.test.ts
@@ -161,10 +161,7 @@ test("package document list stays absent when the package ships no documents", (
 test("closed viewer with no document falls back to a generic title and empty subtitle", () => {
   const html = renderDocViewer({
     doc: null,
-    meta: null,
-    loading: false,
-    error: "",
-    html: "",
+    body: { status: "ready", meta: null, html: "" },
     escapeHtml,
   });
 
@@ -174,38 +171,29 @@ test("closed viewer with no document falls back to a generic title and empty sub
 test("loading state shows a loading status scoped to the document title, not the body", () => {
   const html = renderDocViewer({
     doc,
-    meta: null,
-    loading: true,
-    error: "unused while loading",
-    html: "<p>unused while loading</p>",
+    body: { status: "loading" },
     escapeHtml,
   });
 
   assert.match(html, /doc-viewer-status">Loading CHANGELOG\.md…/);
-  assert.doesNotMatch(html, /unused while loading/);
+  assert.doesNotMatch(html, /markdown-body/);
 });
 
 test("error state reports the error instead of loading or body content", () => {
   const html = renderDocViewer({
     doc,
-    meta: null,
-    loading: false,
-    error: "network error",
-    html: "<p>unused on error</p>",
+    body: { status: "failed", error: "network error" },
     escapeHtml,
   });
 
   assert.match(html, /doc-viewer-status error">network error/);
-  assert.doesNotMatch(html, /unused on error/);
+  assert.doesNotMatch(html, /markdown-body/);
 });
 
 test("loaded state without frontmatter renders the body with no frontmatter card", () => {
   const html = renderDocViewer({
     doc,
-    meta: null,
-    loading: false,
-    error: "",
-    html: "<p>Body content.</p>",
+    body: { status: "ready", meta: null, html: "<p>Body content.</p>" },
     escapeHtml,
   });
 
@@ -216,10 +204,15 @@ test("loaded state without frontmatter renders the body with no frontmatter card
 test("loaded state with frontmatter renders the name, version, and description", () => {
   const html = renderDocViewer({
     doc,
-    meta: { name: "Changelog", version: "1.2.3", descriptionHtml: "<p>What changed.</p>" },
-    loading: false,
-    error: "",
-    html: "<p>Body content.</p>",
+    body: {
+      status: "ready",
+      meta: {
+        name: "Changelog",
+        version: "1.2.3",
+        descriptionHtml: "<p>What changed.</p>",
+      },
+      html: "<p>Body content.</p>",
+    },
     escapeHtml,
   });
 
@@ -232,10 +225,11 @@ test("loaded state with frontmatter renders the name, version, and description",
 test("frontmatter without a version omits the version badge", () => {
   const html = renderDocViewer({
     doc,
-    meta: { name: "Changelog", version: "", descriptionHtml: "" },
-    loading: false,
-    error: "",
-    html: "<p>Body content.</p>",
+    body: {
+      status: "ready",
+      meta: { name: "Changelog", version: "", descriptionHtml: "" },
+      html: "<p>Body content.</p>",
+    },
     escapeHtml,
   });
 
@@ -246,10 +240,7 @@ test("frontmatter without a version omits the version badge", () => {
 test("the document title and subtitle are escaped", () => {
   const html = renderDocViewer({
     doc: { name: "<script>alert(1)</script>", path: "<b>path</b>" },
-    meta: null,
-    loading: false,
-    error: "",
-    html: "",
+    body: { status: "ready", meta: null, html: "" },
     escapeHtml,
   });
 
@@ -262,14 +253,48 @@ test("the document title and subtitle are escaped", () => {
 test("frontmatter name is escaped but the description HTML passes through unescaped", () => {
   const html = renderDocViewer({
     doc,
-    meta: { name: "<script>alert(1)</script>", version: "", descriptionHtml: "<p>trusted markdown</p>" },
-    loading: false,
-    error: "",
-    html: "",
+    body: {
+      status: "ready",
+      meta: {
+        name: "<script>alert(1)</script>",
+        version: "",
+        descriptionHtml: "<p>trusted markdown</p>",
+      },
+      html: "",
+    },
     escapeHtml,
   });
 
   assert.doesNotMatch(html, /<script>alert/);
   assert.match(html, /&lt;script&gt;alert/);
   assert.match(html, /<p>trusted markdown<\/p>/);
+});
+
+test("a failure with no message still renders as a failure, not an empty document", () => {
+  // Round 2 review (Claude Opus 5) showed this rendering as a *successful empty
+  // document*: the renderer asked whether the error string was truthy, so an
+  // undescribable rejection -- which `errorMessage` reports as "" -- was indistinguishable
+  // from a document that loaded and had no content. `describeError` returning "" is
+  // reachable in the real wiring, for `undefined`, `null`, an array, a Symbol, or an
+  // `Error` whose message is empty.
+  const html = renderDocViewer({
+    doc,
+    body: { status: "failed", error: "" },
+    escapeHtml,
+  });
+
+  assert.match(html, /doc-viewer-status error">The document could not be loaded\./);
+  assert.doesNotMatch(html, /markdown-body/);
+});
+
+test("an empty document renders as a document, not as a failure", () => {
+  // The close negative case: emptiness on the success side must stay success-shaped.
+  const html = renderDocViewer({
+    doc,
+    body: { status: "ready", meta: null, html: "" },
+    escapeHtml,
+  });
+
+  assert.match(html, /<article class="markdown-body"><\/article>/);
+  assert.doesNotMatch(html, /doc-viewer-status/);
 });

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -823,13 +823,7 @@ const projectionRequest = {
 test("a loading document projects as loading, with nothing else claimed", () => {
   assert.deepEqual(
     docViewerOptions({ status: "loading", request: projectionRequest }),
-    {
-      doc: projectionDocument,
-      meta: null,
-      loading: true,
-      error: "",
-      html: "",
-    });
+    { doc: projectionDocument, body: { status: "loading" } });
 });
 
 test("a ready document projects its html and metadata", () => {
@@ -843,10 +837,7 @@ test("a ready document projects its html and metadata", () => {
     }),
     {
       doc: projectionDocument,
-      meta,
-      loading: false,
-      error: "",
-      html: "<p>body</p>",
+      body: { status: "ready", meta, html: "<p>body</p>" },
     });
 });
 
@@ -856,11 +847,10 @@ test("a failed document projects its error and claims no content", () => {
     request: projectionRequest,
     error: "the document could not be read",
   });
-  // The error has to survive the projection, or the renderer takes its success branch and
-  // shows an empty article instead of the failure.
-  assert.equal(options.error, "the document could not be read");
-  assert.equal(options.loading, false);
-  // And it must not simultaneously offer content, which would render *both* as a success.
-  assert.equal(options.html, "");
-  assert.equal(options.meta, null);
+  // The projection carries the status through rather than flattening it, so "failed with
+  // no content" is one value instead of a combination of four fields that could disagree.
+  assert.deepEqual(options.body, {
+    status: "failed",
+    error: "the document could not be read",
+  });
 });

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   createDocumentInspectionCoordinator,
   docViewerOptions,
+  isDocViewerOpen,
   type DocumentInspectionDependencies,
   type DocumentInspectionState,
   type DocumentViewerState,
@@ -800,6 +801,28 @@ test("closing replaces every document surface with a closed state", () => {
   assert.equal(renders, 1);
 });
 
+test("document viewer ownership is explicit for every state", () => {
+  assert.equal(isDocViewerOpen({ status: "closed" }), false);
+  assert.equal(
+    isDocViewerOpen({ status: "loading", request: projectionRequest }),
+    true);
+  assert.equal(
+    isDocViewerOpen({
+      status: "ready",
+      request: projectionRequest,
+      html: "",
+      meta: null,
+    }),
+    true);
+  assert.equal(
+    isDocViewerOpen({
+      status: "failed",
+      request: projectionRequest,
+      error: "",
+    }),
+    true);
+});
+
 // The union decides which fields *exist*; this projection decides which ones the renderer
 // is actually told about, and the two are not the same property. Adversarial review made
 // the point concretely by rewriting the old inline projection to pass `error: ""`: every
@@ -849,8 +872,11 @@ test("a failed document projects its error and claims no content", () => {
   });
   // The projection carries the status through rather than flattening it, so "failed with
   // no content" is one value instead of a combination of four fields that could disagree.
-  assert.deepEqual(options.body, {
-    status: "failed",
-    error: "the document could not be read",
+  assert.deepEqual(options, {
+    doc: projectionDocument,
+    body: {
+      status: "failed",
+      error: "the document could not be read",
+    },
   });
 });

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -5,6 +5,7 @@ import {
   createDocumentInspectionCoordinator,
   type DocumentInspectionDependencies,
   type DocumentInspectionState,
+  type DocumentViewerState,
 } from "../src/document-inspection.ts";
 import type {
   BrowserPackageDocument,
@@ -37,15 +38,48 @@ function inspectionState(
   overrides: Partial<DocumentInspectionState> = {},
 ): DocumentInspectionState {
   return {
-    docViewerOpen: false,
-    docViewer: null,
-    docViewerLoading: false,
-    docViewerError: "",
-    docViewerHtml: "",
-    docViewerMeta: null,
-    docViewerSeq: 0,
+    docViewer: { status: "closed" },
     ...overrides,
   };
+}
+
+function loadingViewer(
+  state: DocumentInspectionState,
+  expectedDocument: BrowserPackageDocument,
+): Extract<DocumentViewerState, { status: "loading" }> {
+  const viewer = state.docViewer;
+  assert.equal(viewer.status, "loading");
+  if (viewer.status !== "loading") assert.fail("Expected a loading document");
+  assert.equal(viewer.request.document, expectedDocument);
+  return viewer;
+}
+
+function readyViewer(
+  state: DocumentInspectionState,
+  expectedDocument: BrowserPackageDocument,
+  expectedHtml?: string,
+): Extract<DocumentViewerState, { status: "ready" }> {
+  const viewer = state.docViewer;
+  assert.equal(viewer.status, "ready");
+  if (viewer.status !== "ready") assert.fail("Expected a ready document");
+  assert.equal(viewer.request.document, expectedDocument);
+  if (expectedHtml !== undefined) assert.equal(viewer.html, expectedHtml);
+  return viewer;
+}
+
+function failedViewer(
+  state: DocumentInspectionState,
+  expectedError: string,
+): Extract<DocumentViewerState, { status: "failed" }> {
+  const viewer = state.docViewer;
+  assert.equal(viewer.status, "failed");
+  if (viewer.status !== "failed") assert.fail("Expected a failed document");
+  assert.equal(viewer.error, expectedError);
+  return viewer;
+}
+
+function assertViewerClosed(state: DocumentInspectionState) {
+  assert.equal(state.docViewer.status, "closed");
 }
 
 function inspectionDependencies(
@@ -103,12 +137,7 @@ test("document requests publish sanitized body HTML for exact coordinates", asyn
     document,
   });
 
-  assert.equal(state.docViewerOpen, true);
-  assert.equal(state.docViewer, document);
-  assert.equal(state.docViewerHtml, "<h1>Read me</h1>");
-  assert.equal(state.docViewerMeta, null);
-  assert.equal(state.docViewerLoading, false);
-  assert.equal(state.docViewerError, "");
+  assert.equal(readyViewer(state, document, "<h1>Read me</h1>").meta, null);
   assert.deepEqual(events, ["render", "query", "markdown", "render"]);
 });
 
@@ -141,12 +170,12 @@ test("document frontmatter projects folded descriptions and version", async () =
     document,
   });
 
-  assert.deepEqual(state.docViewerMeta, {
+  const viewer = readyViewer(state, document, "<h1>Body</h1>");
+  assert.deepEqual(viewer.meta, {
     name: "Package guide",
     version: "2.0",
     descriptionHtml: "<p>First line second line</p>",
   });
-  assert.equal(state.docViewerHtml, "<h1>Body</h1>");
 });
 
 test("frontmatter descriptions fall back to the document name", async () => {
@@ -173,7 +202,7 @@ test("frontmatter descriptions fall back to the document name", async () => {
     document,
   });
 
-  assert.deepEqual(state.docViewerMeta, {
+  assert.deepEqual(readyViewer(state, document).meta, {
     name: "README.md",
     version: "2.0",
     descriptionHtml: "<p>Description</p>",
@@ -193,7 +222,7 @@ test("frontmatter with only a version does not create a metadata card", async ()
     document,
   });
 
-  assert.equal(state.docViewerMeta, null);
+  assert.equal(readyViewer(state, document).meta, null);
 });
 
 test("closing during acquisition suppresses stale document publication", async () => {
@@ -222,9 +251,7 @@ test("closing during acquisition suppresses stale document publication", async (
 
   assert.equal(markdownRenders, 0);
   assert.equal(renders, 2);
-  assert.equal(state.docViewerOpen, false);
-  assert.equal(state.docViewer, null);
-  assert.equal(state.docViewerHtml, "");
+  assertViewerClosed(state);
 });
 
 test("a newer document remains published after an older request completes", async () => {
@@ -252,9 +279,7 @@ test("a newer document remains published after an older request completes", asyn
   first.resolve(content("stale"));
   await firstOpen;
 
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerHtml, "<p>current</p>");
-  assert.equal(state.docViewerLoading, false);
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
 test("replacement during acquisition does not enter stale rendering", async () => {
@@ -286,15 +311,11 @@ test("replacement during acquisition does not enter stale rendering", async () =
   await firstOpen;
 
   assert.equal(staleBodyRenders, 0);
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, guideDocument);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
 test("reopening the same document during acquisition rejects stale identity", async () => {
@@ -327,16 +348,11 @@ test("reopening the same document during acquisition rejects stale identity", as
   await firstOpen;
 
   assert.equal(staleBodyRenders, 0);
-  assert.equal(state.docViewer, document);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, document);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
-  assert.equal(state.docViewerLoading, false);
+  readyViewer(state, document, "<p>current</p>");
 });
 
 test("replacement during body rendering suppresses stale description work", async () => {
@@ -379,15 +395,11 @@ test("replacement during body rendering suppresses stale description work", asyn
   await firstOpen;
 
   assert.equal(inlineRenders, 0);
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, guideDocument);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
 test("reopening the same document during body rendering suppresses stale work", async () => {
@@ -431,10 +443,7 @@ test("reopening the same document during body rendering suppresses stale work", 
   await firstOpen;
 
   assert.equal(inlineRenders, 0);
-  assert.equal(state.docViewer, document);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, document);
 
   second.resolve(content("current"));
   await secondOpen;
@@ -472,15 +481,11 @@ test("replacement during description rendering suppresses stale publication", as
   description.resolve("<p>stale description</p>");
   await firstOpen;
 
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, guideDocument);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
 test("reopening the same document during description rendering suppresses stale publication", async () => {
@@ -516,10 +521,7 @@ test("reopening the same document during description rendering suppresses stale 
   description.resolve("<p>stale description</p>");
   await firstOpen;
 
-  assert.equal(state.docViewer, document);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, document);
 
   second.resolve(content("current"));
   await secondOpen;
@@ -551,17 +553,12 @@ test("rejected replaced documents cannot settle the current request", async () =
   first.reject(new Error("stale failure"));
   await firstOpen;
 
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
+  loadingViewer(state, guideDocument);
   assert.equal(renders, 2);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "<p>current</p>");
-  assert.equal(state.docViewerLoading, false);
+  readyViewer(state, guideDocument, "<p>current</p>");
   assert.equal(renders, 3);
 });
 
@@ -590,14 +587,11 @@ test("reopening the same document suppresses a stale rejection", async () => {
   first.reject(new Error("stale failure"));
   await firstOpen;
 
-  assert.equal(state.docViewer, document);
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerError, "");
+  loadingViewer(state, document);
 
   second.resolve(content("current"));
   await secondOpen;
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerLoading, false);
+  readyViewer(state, document, "<p>current</p>");
 });
 
 test("closing during body rendering suppresses description and publication", async () => {
@@ -630,8 +624,7 @@ test("closing during body rendering suppresses description and publication", asy
   await open;
 
   assert.equal(inlineRenders, 0);
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  assertViewerClosed(state);
 });
 
 test("closing during description rendering suppresses all publication", async () => {
@@ -659,8 +652,7 @@ test("closing during description rendering suppresses all publication", async ()
   description.resolve("<p>stale description</p>");
   await open;
 
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  assertViewerClosed(state);
 });
 
 test("closing before a rejected request suppresses its stale failure", async () => {
@@ -687,8 +679,7 @@ test("closing before a rejected request suppresses its stale failure", async () 
   query.reject(new Error("stale failure"));
   await open;
 
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerLoading, false);
+  assertViewerClosed(state);
   assert.equal(renders, 2);
 });
 
@@ -709,8 +700,7 @@ test("current document failures remain visible and settle loading", async () => 
     document,
   });
 
-  assert.equal(state.docViewerError, "Markdown renderer unavailable");
-  assert.equal(state.docViewerLoading, false);
+  failedViewer(state, "Markdown renderer unavailable");
   assert.equal(renders, 2);
 });
 
@@ -733,7 +723,7 @@ test("opening another document clears a prior visible failure", async () => {
     version: "1.2.3",
     document,
   });
-  assert.equal(state.docViewerError, "Document unavailable");
+  failedViewer(state, "Document unavailable");
 
   const open = coordinator.open({
     packageId: "Example.Package",
@@ -741,16 +731,11 @@ test("opening another document clears a prior visible failure", async () => {
     document: guideDocument,
   });
 
-  assert.equal(state.docViewer, guideDocument);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, guideDocument);
 
   replacement.resolve(content("current"));
   await open;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
-  assert.equal(state.docViewerLoading, false);
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
 test("opening another document clears prior published surfaces immediately", async () => {
@@ -770,8 +755,7 @@ test("opening another document clears prior published surfaces immediately", asy
     version: "1.2.3",
     document,
   });
-  assert.equal(state.docViewerHtml, "<p>old body</p>");
-  assert.notEqual(state.docViewerMeta, null);
+  assert.notEqual(readyViewer(state, document, "<p>old body</p>").meta, null);
 
   const open = coordinator.open({
     packageId: "Example.Package",
@@ -779,29 +763,30 @@ test("opening another document clears prior published surfaces immediately", asy
     document: guideDocument,
   });
 
-  assert.equal(state.docViewerLoading, true);
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  loadingViewer(state, guideDocument);
 
   replacement.resolve(content("current"));
   await open;
-  assert.equal(state.docViewerHtml, "<p>current</p>");
+  readyViewer(state, guideDocument, "<p>current</p>");
 });
 
-test("closing resets every document surface and invalidates its sequence", () => {
+test("closing replaces every document surface with a closed state", () => {
   let renders = 0;
   const state = inspectionState({
-    docViewerOpen: true,
-    docViewer: document,
-    docViewerLoading: true,
-    docViewerError: "old error",
-    docViewerHtml: "<p>old</p>",
-    docViewerMeta: {
-      name: "Old",
-      version: "1.0",
-      descriptionHtml: "<p>old</p>",
+    docViewer: {
+      status: "ready",
+      request: {
+        packageId: "Example.Package",
+        version: "1.2.3",
+        document,
+      },
+      html: "<p>old</p>",
+      meta: {
+        name: "Old",
+        version: "1.0",
+        descriptionHtml: "<p>old</p>",
+      },
     },
-    docViewerSeq: 4,
   });
   const coordinator = createDocumentInspectionCoordinator(
     inspectionDependencies(state, {
@@ -810,12 +795,6 @@ test("closing resets every document surface and invalidates its sequence", () =>
 
   coordinator.close();
 
-  assert.equal(state.docViewerSeq, 5);
-  assert.equal(state.docViewerOpen, false);
-  assert.equal(state.docViewer, null);
-  assert.equal(state.docViewerLoading, false);
-  assert.equal(state.docViewerError, "");
-  assert.equal(state.docViewerHtml, "");
-  assert.equal(state.docViewerMeta, null);
+  assertViewerClosed(state);
   assert.equal(renders, 1);
 });

--- a/prototypes/inspect-web/test/document-inspection.test.ts
+++ b/prototypes/inspect-web/test/document-inspection.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   createDocumentInspectionCoordinator,
+  docViewerOptions,
   type DocumentInspectionDependencies,
   type DocumentInspectionState,
   type DocumentViewerState,
@@ -797,4 +798,69 @@ test("closing replaces every document surface with a closed state", () => {
 
   assertViewerClosed(state);
   assert.equal(renders, 1);
+});
+
+// The union decides which fields *exist*; this projection decides which ones the renderer
+// is actually told about, and the two are not the same property. Adversarial review made
+// the point concretely by rewriting the old inline projection to pass `error: ""`: every
+// one of the 497 tests still passed, and a document that had failed to load rendered as an
+// empty `<article>` -- a failure wearing the shape of a successful, empty document.
+//
+// These cover the mapping itself, so dropping any field's route to the renderer is red.
+const projectionDocument: BrowserPackageDocument = {
+  kind: "doc",
+  name: "README.md",
+  path: "docs/README.md",
+  size: 10,
+};
+
+const projectionRequest = {
+  packageId: "Example.Package",
+  version: "1.2.3",
+  document: projectionDocument,
+} as const;
+
+test("a loading document projects as loading, with nothing else claimed", () => {
+  assert.deepEqual(
+    docViewerOptions({ status: "loading", request: projectionRequest }),
+    {
+      doc: projectionDocument,
+      meta: null,
+      loading: true,
+      error: "",
+      html: "",
+    });
+});
+
+test("a ready document projects its html and metadata", () => {
+  const meta = { name: "Example", version: "1.2.3", descriptionHtml: "<p>d</p>" };
+  assert.deepEqual(
+    docViewerOptions({
+      status: "ready",
+      request: projectionRequest,
+      html: "<p>body</p>",
+      meta,
+    }),
+    {
+      doc: projectionDocument,
+      meta,
+      loading: false,
+      error: "",
+      html: "<p>body</p>",
+    });
+});
+
+test("a failed document projects its error and claims no content", () => {
+  const options = docViewerOptions({
+    status: "failed",
+    request: projectionRequest,
+    error: "the document could not be read",
+  });
+  // The error has to survive the projection, or the renderer takes its success branch and
+  // shows an empty article instead of the failure.
+  assert.equal(options.error, "the document could not be read");
+  assert.equal(options.loading, false);
+  // And it must not simultaneously offer content, which would render *both* as a success.
+  assert.equal(options.html, "");
+  assert.equal(options.meta, null);
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1120,7 +1120,46 @@ test("typed document inspection owns package document request coordination", () 
   assert.match(
     documentInspectionSource,
     /async open\(request: PackageDocumentRequest\)[\s\S]*const pending = \{ status: "loading", request \} as const;[\s\S]*if \(state\.docViewer !== pending\) return;/);
-  assert.doesNotMatch(documentInspectionSource, /docViewerSeq/);
+
+  // The ownership property is "every await re-checks ownership before writing state",
+  // and it has to be checked that way round. An earlier version of this gate asserted
+  // that *one* `!== pending` guard existed and banned the literal spelling
+  // `docViewerSeq`; adversarial review defeated it by keeping the first identity guard
+  // and replacing the other three with a counter under a different name, which passed.
+  //
+  // So derive the requirement from the awaits instead of restating a count: split the
+  // body at each `await` and require that every resumption point re-establishes
+  // ownership before it assigns to `state.docViewer`. Adding an await without a guard
+  // now fails here, whatever the guard is named.
+  const openBody =
+    documentInspectionSource.match(
+      /async open\(request: PackageDocumentRequest\)[\s\S]*?\n {4}\},\n/)?.[0]
+    ?? "";
+  assert.ok(openBody, "could not isolate the document open() body");
+  const resumptions = openBody.split("await ").slice(1);
+  assert.ok(
+    resumptions.length >= 3,
+    `expected the loader to await at least 3 times, saw ${resumptions.length}`);
+  for (const [index, segment] of resumptions.entries()) {
+    const guard = segment.indexOf("state.docViewer !== pending");
+    const write = segment.indexOf("state.docViewer =");
+    assert.notEqual(
+      guard, -1,
+      `resumption ${index} after an await does not re-check request ownership`);
+    if (write !== -1)
+      assert.ok(
+        guard < write,
+        `resumption ${index} writes state.docViewer before re-checking ownership`);
+  }
+  // The catch path is a resumption too: a rejection from a superseded request must not
+  // be allowed to overwrite the live request's state with a failure.
+  const catchBody = openBody.match(/\} catch \(error\) \{[\s\S]*?\n {6}\}/)?.[0] ?? "";
+  assert.match(catchBody, /state\.docViewer !== pending/);
+
+  // Ownership is object identity, not a counter. A counter can be renamed, so ban the
+  // mechanism rather than one spelling of it.
+  assert.doesNotMatch(
+    documentInspectionSource, /docViewer\w*(Seq|Sequence|Generation|Counter)/i);
 });
 
 test("typed catalog requests own release and package-version coordination", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1943,7 +1943,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /const unavailableWorkspaceContext = \(\) =>[\s\S]*!state\.home && \(state\.loading \|\| Boolean\(state\.error\)\)[\s\S]*unavailable-workspace\.contain-browser-shortcut[\s\S]*unavailable-workspace\.contain-filter-shortcut/);
   assert.match(
     appSource,
-    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*state\.docViewer\.status === "closed"[\s\S]*!state\.spotlightOpen/);
+    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*!isDocViewerOpen\(state\.docViewer\)[\s\S]*!state\.spotlightOpen/);
   assert.equal(
     keybindingRegistrySource.match(/addEventListener\("keydown"/g)?.length,
     1);
@@ -2488,7 +2488,7 @@ test("Type Source completion settles behind workbench overlays", () => {
     ?? "";
   assert.match(
     appSource,
-    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewer\.status !== "closed";/);
+    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| isDocViewerOpen\(state\.docViewer\);/);
   assert.match(
     appSource,
     /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*activeSourceOperationKind\(state\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1962,6 +1962,25 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) \{\s*focus\(\);\s*return;\s*}\s*requestAnimationFrame\(focus\);/);
 });
 
+test("document viewer ownership reaches every root focus, render, and keyboard site", () => {
+  const predicate = /isDocViewerOpen\(state\.docViewer\)/g;
+  assert.equal(appSource.match(predicate)?.length, 5);
+
+  const focusOwner =
+    appSource.match(/function focusTypeList\([\s\S]*?\n}\n\nfunction openSpotlight/)?.[0]
+    ?? "";
+  assert.equal(focusOwner.match(predicate)?.length, 2);
+  assert.match(
+    appSource,
+    /function render\(\)[\s\S]*isDocViewerOpen\(state\.docViewer\) \? renderDocViewer\(\) : ""/);
+  assert.match(
+    appSource,
+    /function workbenchModalOwnsFocus\(\)[\s\S]*isDocViewerOpen\(state\.docViewer\);/);
+  assert.match(
+    appSource,
+    /document\.addEventListener\("keydown"[\s\S]*if \(isDocViewerOpen\(state\.docViewer\)\)/);
+});
+
 test("Spotlight navigation waits for selection data before restoring focus", () => {
   const typeLensLoader =
     appSource.match(/function loadSelectedTypeLensData\([\s\S]*?\n}/)?.[0];

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1112,11 +1112,15 @@ test("typed document inspection owns package document request coordination", () 
     documentLoader,
     /return documentInspection\.open\(\{\s*packageId: pkg\.id,\s*version: pkg\.version,\s*document: doc,\s*\}\)/);
   assert.match(documentCloser, /documentInspection\.close\(\)/);
-  assert.doesNotMatch(documentLoader, /state\.docViewer(?:Seq|Open|Loading)/);
-  assert.doesNotMatch(documentCloser, /state\.docViewer(?:Seq|Open|Loading)/);
+  assert.doesNotMatch(documentLoader, /state\.docViewer/);
+  assert.doesNotMatch(documentCloser, /state\.docViewer/);
   assert.match(
     documentInspectionSource,
-    /async open\(request: PackageDocumentRequest\)[\s\S]*state\.docViewerSeq/);
+    /type DocumentViewerState =[\s\S]*status: "closed"[\s\S]*status: "loading"[\s\S]*status: "ready"[\s\S]*status: "failed"/);
+  assert.match(
+    documentInspectionSource,
+    /async open\(request: PackageDocumentRequest\)[\s\S]*const pending = \{ status: "loading", request \} as const;[\s\S]*if \(state\.docViewer !== pending\) return;/);
+  assert.doesNotMatch(documentInspectionSource, /docViewerSeq/);
 });
 
 test("typed catalog requests own release and package-version coordination", () => {
@@ -1900,7 +1904,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /const unavailableWorkspaceContext = \(\) =>[\s\S]*!state\.home && \(state\.loading \|\| Boolean\(state\.error\)\)[\s\S]*unavailable-workspace\.contain-browser-shortcut[\s\S]*unavailable-workspace\.contain-filter-shortcut/);
   assert.match(
     appSource,
-    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*!state\.docViewerOpen[\s\S]*!state\.spotlightOpen/);
+    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*state\.docViewer\.status === "closed"[\s\S]*!state\.spotlightOpen/);
   assert.equal(
     keybindingRegistrySource.match(/addEventListener\("keydown"/g)?.length,
     1);
@@ -2445,7 +2449,7 @@ test("Type Source completion settles behind workbench overlays", () => {
     ?? "";
   assert.match(
     appSource,
-    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewerOpen;/);
+    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewer\.status !== "closed";/);
   assert.match(
     appSource,
     /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*activeSourceOperationKind\(state\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1964,7 +1964,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
 
 test("document viewer ownership reaches every root focus, render, and keyboard site", () => {
   const predicate = /isDocViewerOpen\(state\.docViewer\)/g;
-  assert.equal(appSource.match(predicate)?.length, 5);
+  assert.equal(appSource.match(predicate)?.length, 6);
 
   const focusOwner =
     appSource.match(/function focusTypeList\([\s\S]*?\n}\n\nfunction openSpotlight/)?.[0]
@@ -1978,7 +1978,10 @@ test("document viewer ownership reaches every root focus, render, and keyboard s
     /function workbenchModalOwnsFocus\(\)[\s\S]*isDocViewerOpen\(state\.docViewer\);/);
   assert.match(
     appSource,
-    /document\.addEventListener\("keydown"[\s\S]*if \(isDocViewerOpen\(state\.docViewer\)\)/);
+    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!isDocViewerOpen\(state\.docViewer\)/);
+  assert.match(
+    appSource,
+    /const documentViewerContextIsActive = \(\) =>[\s\S]*isDocViewerOpen\(state\.docViewer\)[\s\S]*id: "document-viewer\.dismiss"[\s\S]*when: documentViewerContextIsActive/);
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {


### PR DESCRIPTION
## Conclusion

The package document modal now has exactly one state value — a discriminated `closed`/`loading`/`ready`/`failed` union whose loading variant is the request-ownership token — replacing seven parallel fields and a value-compared sequence counter.

## Stack

Slice 6 of the #4570/#4571 semantic typing stack.

- Parent PR: #4585 (`type/4570-package-request-states`)
- Base branch: `type/4570-package-request-states`
- Residual: the remaining #4570 request surfaces (graph-source modal, Spotlight package search, runtime pack, package versions) still use parallel flag/sequence fields. Those are separate slices; this PR changes only the document viewer.

## What changed

`DocumentInspectionState` previously carried seven fields: `docViewerOpen`, `docViewer`, `docViewerLoading`, `docViewerError`, `docViewerHtml`, `docViewerMeta`, and `docViewerSeq`. Their legal combinations were implied by convention, so nothing typed prevented an open-but-null viewer, a ready-and-failed viewer, or HTML surviving a close.

It is now one field:

```ts
export type DocumentViewerState =
  | { status: "closed" }
  | { status: "loading"; request: PackageDocumentRequest }
  | { status: "ready"; request: PackageDocumentRequest; html: string; meta: DocViewerMeta | null }
  | { status: "failed"; request: PackageDocumentRequest; error: string };
```

Result HTML, frontmatter metadata, and error text exist only on the variants that can carry them, so clearing them on transition is no longer a discipline the code has to remember.

## Request ownership replaces sequence comparison

Each of the three await points (`queryDocument`, `renderMarkdown`, `renderMarkdownInline`) previously compared a captured `sequence` number against `state.docViewerSeq`. They now compare `state.docViewer` against the exact `pending` loading object the request created:

```ts
const pending = { status: "loading", request } as const;
state.docViewer = pending;
// ...
if (state.docViewer !== pending) return;
```

This is the same object-identity ownership rule the package lenses use (#4583, #4585). It is a typed replacement for the prior monotonic sequence token, not a stronger race guarantee: both reject a stale close/reopen completion, including when the document coordinates are textually equal. The gain is that ownership and visible lifecycle state are now one value rather than independent mechanisms.

`close()` is now a single assignment of `{ status: "closed" }`, which both resets every surface and invalidates any in-flight request, because no pending object can ever equal it.

## Composition root

`dotnet-inspect.ts` narrows by status rather than reading parallel flags:

- `renderDocViewer()` derives `doc`/`meta`/`loading`/`error`/`html` for the presentation boundary from the variant, and returns `""` when closed.
- The exhaustive `isDocViewerOpen` predicate owns the modal decision for both `focusTypeList` checks, `workbenchModalOwnsFocus`, the keyboard router, and the render call.
- `DocViewerMeta` and `BrowserPackageDocument` are no longer imported by the root; the union owns those shapes.

`doc-viewer.ts` now receives one discriminated body value rather than independent loading, error, metadata, and HTML fields. That contract change prevents a failed empty message from becoming a successful empty article.

## Compatibility

Loading, successful content, and nonempty failures render as before. An empty or undescribable failure now renders the visible fallback `The document could not be loaded.` instead of a success-shaped empty article. Request cancellation and same-document close/reopen behavior are unchanged; object identity replaces the sequence token without claiming a new race guarantee.

## Evidence

All run on the round-3 replacement:

- Focused document-state, renderer, lifecycle-ownership, and root-composition tests — 189/189 pass. They cover every open/closed predicate variant, all five root ownership sites, hostile failure escaping, failed-state document identity, every await ownership check, and anti-resurrection on both the coordinator and root state surfaces.
- `npm test` — 623/623 pass (typecheck plus full suite).
- `npm run analyze` — clean (`verify-analysis-host`, `oxlint`, `knip`).
- `npm run build` — clean, artifact verified.

The product comments name the unit and composition gates that enforce the request-owned lifecycle.

## Latest-main restack

Restacked onto #4585 head `91f147988`; current head is `0f45e253a`.
All five slice commits map exactly in range-diff.
