### PR TITLE
Align inspect-web home demos with product demo ids

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -424,15 +424,17 @@ registry binding).
 **CLI run** lowers the resolved plan to `TypeCommand` / `MemberCommand` options
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
-package members as `--caller-package` for the call-graph demo. Residual: (1)
-minted facet ids replacing display-name allow list; (2) realize via
-`WorkspaceContextLoader` into one `AssemblyContextGroup` instead of the CLI
-package/caller encoding; (3) inspect-web home buttons and the imperative
-call-graph path converge on the same registry/sections; TypeScript export of
-the engine surface can land on its own schedule before the web host switches
-buttons over; (4) Call Graph / Callers structured JSON projection remains the
-shared member-pipeline gap (Markdown/Mermaid are the faithful graph formats
-today).
+package members as `--caller-package` for the call-graph demo. **inspect-web**
+home buttons use the same product demo ids/titles/summaries and package/type
+anchors (`prototypes/inspect-web/src/product-home-demos.ts`); STJ and platform
+restore via share deep links, while `extensions-callgraph` still runs the
+imperative multi-package member path. Residual: (1) minted facet ids replacing
+display-name allow list; (2) realize via `WorkspaceContextLoader` into one
+`AssemblyContextGroup` instead of CLI package/`--caller-package` encoding and
+the browser runtime-pack share encoding for platform; (3) replace the
+imperative call-graph web path with the same group-run substrate; (4) Call
+Graph / Callers structured JSON projection remains the shared member-pipeline
+gap (Markdown/Mermaid are the faithful graph formats today).
 
 ### Member coordinates
 
@@ -985,9 +987,10 @@ Definition records and product demos (this slice):
   demo-parity, section binding, CLI lowering, and real section output for the
   three homes; and
 - **not yet:** minted view-facet ids; `WorkspaceContextLoader` group realization
-  as the run substrate (CLI still uses package + `--caller-package` encoding);
-  inspect-web home buttons / imperative call-graph path switched onto the same
-  registry and sections (engine / generated TS surface can precede that switch).
+  as the run substrate (CLI still uses package + `--caller-package` encoding;
+  inspect-web platform still uses the resident runtime-pack share encoding);
+  replace the imperative `extensions-callgraph` web runner with that group-run
+  path.
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -88,6 +88,13 @@ import {
   type WorkbenchShellBindingActions,
 } from "./shell-controls.ts";
 import {
+  EXTENSIONS_CALLGRAPH,
+  EXTENSIONS_CALLGRAPH_DEMO_ID,
+  PRODUCT_HOME_DEMO_CATALOG,
+  productHomeDemoLocationHref,
+  type ProductHomeDemoId,
+} from "./product-home-demos.ts";
+import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
@@ -5634,9 +5641,8 @@ function renderHomeView() {
           <div class="home-demos">
             <span class="home-demos-label">Or jump straight into a demo</span>
             <div class="home-demo-row">
-              <button class="home-demo" data-home-demo="stj" ${enginePending ? "disabled" : ""}><strong>System.Text.Json</strong><small>Browse a real package API</small></button>
-              <button class="home-demo" data-home-demo="callgraph" ${enginePending ? "disabled" : ""}><strong>Cross-package call graph</strong><small>Trace calls across four packages</small></button>
-              <button class="home-demo" data-home-demo="runtime" ${enginePending ? "disabled" : ""}><strong>.NET Platform</strong><small>Inspect platform BCL types</small></button>
+              ${PRODUCT_HOME_DEMO_CATALOG.map(entry =>
+                `<button class="home-demo" data-home-demo="${entry.id}" ${enginePending ? "disabled" : ""}><strong>${escapeHtml(entry.title)}</strong><small>${escapeHtml(entry.summary)}</small></button>`).join("")}
             </div>
           </div>
         </div>
@@ -5680,22 +5686,18 @@ function bindHomeEvents() {
     document.querySelector<HTMLInputElement>("#spotlight-input")?.focus());
 }
 
-// The two package demos jump to a rich, curated deep link (open tabs + selected type +,
-// for the platform, a scoped library) so the buttons showcase the workbench, not a bare
-// package root. pushState keeps them shareable/refreshable; the workspace restore reuses
-// the same path as a shared link. The call-graph demo stays a bespoke multi-package load.
-const HOME_DEMO_LINKS = {
-  stj: "?package=System.Text.Json&w=eyJ0IjpbWyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCJdXSwiYSI6MCwieSI6IlN5c3RlbS5UZXh0Lkpzb24uSnNvblNlcmlhbGl6ZXIifQ",
-  runtime: "?package=Microsoft.NETCore.App&w=eyJ0IjpbWyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCJdLFsiTWljcm9zb2Z0Lk5FVENvcmUuQXBwIiwiMTAuMC4xMCIsIm5ldDEwLjAiXV0sImEiOjEsImwiOiJTeXN0ZW0uUHJpdmF0ZS5Db3JlTGliIiwieSI6IlN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkxpc3RgMSJ9"
-};
-
-function runHomeDemo(kind: keyof typeof HOME_DEMO_LINKS | "callgraph") {
+// Home buttons use product demo ids (`ProductInspectionDemos` / CLI `demo <id>`).
+// STJ + platform restore via share deep links built from that registry projection;
+// extensions-callgraph stays an imperative multi-package member load (same packages
+// and TryAddEnumerable anchor as the product demo) until WorkspaceContextLoader
+// group run is the browser substrate.
+function runHomeDemo(kind: ProductHomeDemoId) {
   state.home = false;
-  if (kind === "callgraph") {
+  if (kind === EXTENSIONS_CALLGRAPH_DEMO_ID) {
     observeAsync(runCallGraphDemo(), "Loading the call graph demo");
     return;
   }
-  const link = HOME_DEMO_LINKS[kind];
+  const link = productHomeDemoLocationHref(kind);
   if (!link) return;
   workspaceLocation.push(link);
   const loc = parseLocation();
@@ -7228,10 +7230,11 @@ async function runCallGraphDemo() {
   state.loadingSubtitle = "";
   render();
 
+  const [targetSpec, loggingSpec, httpSpec] = EXTENSIONS_CALLGRAPH.packages;
   const targetPackage = await loadPackage(
-    "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "10.0.0",
-    "net10.0",
+    targetSpec.id,
+    targetSpec.version,
+    targetSpec.framework,
     { retryAction: runCallGraphDemo });
   if (!targetPackage) {
     state.retryAction = runCallGraphDemo;
@@ -7239,9 +7242,9 @@ async function runCallGraphDemo() {
     return;
   }
   const loggingPackage = await loadPackage(
-    "Microsoft.Extensions.Logging",
-    "10.0.0",
-    "net10.0",
+    loggingSpec.id,
+    loggingSpec.version,
+    loggingSpec.framework,
     { retryAction: runCallGraphDemo });
   if (!loggingPackage) {
     state.retryAction = runCallGraphDemo;
@@ -7249,9 +7252,9 @@ async function runCallGraphDemo() {
     return;
   }
   const httpPackage = await loadPackage(
-    "Microsoft.Extensions.Http",
-    "10.0.0",
-    "net10.0",
+    httpSpec.id,
+    httpSpec.version,
+    httpSpec.framework,
     { retryAction: runCallGraphDemo });
   if (!httpPackage) {
     state.retryAction = runCallGraphDemo;
@@ -7261,10 +7264,12 @@ async function runCallGraphDemo() {
 
   activatePackage(targetPackage);
   const type = targetPackage.types.find(item =>
-    item.id === "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions");
+    item.id === EXTENSIONS_CALLGRAPH.typeId);
   const member = type && memberGroups(type).find(item =>
-    item.name === "TryAddEnumerable" && item.kind === "method");
-  const overloadIndex = member?.overloads.findIndex(item => item.anchorDigest === "74b6b4b321") ?? -1;
+    item.name === EXTENSIONS_CALLGRAPH.memberName
+    && item.kind === EXTENSIONS_CALLGRAPH.memberKind);
+  const overloadIndex = member?.overloads.findIndex(item =>
+    item.anchorDigest === EXTENSIONS_CALLGRAPH.memberAnchorDigest) ?? -1;
   if (!type || !member || overloadIndex < 0) {
     state.loading = false;
     state.error = "The call graph demo member was not found in the selected package.";
@@ -7283,7 +7288,7 @@ async function runCallGraphDemo() {
   state.memberBrowseTypeId = type.id;
   state.selectedMemberKey = member.key;
   state.selectedOverloadIndex = overloadIndex;
-  state.memberSection = "call-graph";
+  state.memberSection = EXTENSIONS_CALLGRAPH.memberSection;
   state.loading = false;
   render();
   await loadSelectedMemberCallGraph();

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -1,0 +1,166 @@
+import {
+  encodeWorkspaceShareState,
+  type WorkspaceUrlState,
+} from "./workspace-navigation.ts";
+
+/**
+ * Browser projection of `ProductInspectionDemos` (CLI `demo list` / `demo <id>`).
+ * Ids, titles, summaries, package pins, and type/member anchors must stay aligned
+ * with `src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs`.
+ *
+ * Acquisition substrate still differs for platform: product uses an unversioned
+ * host `runtime` coordinate; inspect-web loads the resident Microsoft.NETCore.App
+ * runtime pack until WorkspaceContextLoader platform groups land. Call-graph run
+ * stays imperative (multi-package member section) rather than a share deep link.
+ */
+
+export const STJ_SERIALIZER_DEMO_ID = "stj-serializer";
+export const EXTENSIONS_CALLGRAPH_DEMO_ID = "extensions-callgraph";
+export const PLATFORM_LIST_DEMO_ID = "platform-list";
+
+export type ProductHomeDemoId =
+  | typeof STJ_SERIALIZER_DEMO_ID
+  | typeof EXTENSIONS_CALLGRAPH_DEMO_ID
+  | typeof PLATFORM_LIST_DEMO_ID;
+
+export interface ProductHomeDemoCatalogEntry {
+  id: ProductHomeDemoId;
+  title: string;
+  summary: string;
+}
+
+/** Catalog order matches `ProductInspectionDemos.Entries`. */
+export const PRODUCT_HOME_DEMO_CATALOG: readonly ProductHomeDemoCatalogEntry[] = [
+  {
+    id: STJ_SERIALIZER_DEMO_ID,
+    title: "System.Text.Json",
+    summary: "Browse a real package API",
+  },
+  {
+    id: EXTENSIONS_CALLGRAPH_DEMO_ID,
+    title: "Cross-package call graph",
+    summary: "Trace calls across three packages",
+  },
+  {
+    id: PLATFORM_LIST_DEMO_ID,
+    title: ".NET Platform",
+    summary: "Inspect platform BCL types",
+  },
+];
+
+const PRODUCT_HOME_DEMO_ID_SET: ReadonlySet<string> = new Set(
+  PRODUCT_HOME_DEMO_CATALOG.map(entry => entry.id),
+);
+
+export function isProductHomeDemoId(value: string | undefined | null): value is ProductHomeDemoId {
+  return typeof value === "string" && PRODUCT_HOME_DEMO_ID_SET.has(value);
+}
+
+/** STJ package pin shared with `ProductInspectionDemos.CreateStjSerializerRecords`. */
+export const STJ_SERIALIZER_PACKAGE = {
+  id: "System.Text.Json",
+  version: "10.0.0",
+  framework: "net10.0",
+} as const;
+
+export const STJ_SERIALIZER_TYPE = "System.Text.Json.JsonSerializer";
+
+/**
+ * Browser runtime-pack tab for the platform-list demo. Product CLI uses unversioned
+ * host `runtime`; this is the inspect-web share encoding of that platform member.
+ */
+export const PLATFORM_RUNTIME_PACK = {
+  id: "Microsoft.NETCore.App",
+  version: "10.0.10",
+  framework: "net10.0",
+} as const;
+
+export const PLATFORM_LIST_LIBRARY = "System.Private.CoreLib";
+export const PLATFORM_LIST_TYPE = "System.Collections.Generic.List`1";
+
+/** Packages and member anchor for `extensions-callgraph` (product + web). */
+export const EXTENSIONS_CALLGRAPH = {
+  packages: [
+    {
+      id: "Microsoft.Extensions.DependencyInjection.Abstractions",
+      version: "10.0.0",
+      framework: "net10.0",
+    },
+    {
+      id: "Microsoft.Extensions.Logging",
+      version: "10.0.0",
+      framework: "net10.0",
+    },
+    {
+      id: "Microsoft.Extensions.Http",
+      version: "10.0.0",
+      framework: "net10.0",
+    },
+  ],
+  typeId:
+    "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
+  memberName: "TryAddEnumerable",
+  memberKind: "method",
+  memberAnchorDigest: "74b6b4b321",
+  memberSection: "call-graph",
+} as const;
+
+function workspaceUrlState(partial: Partial<WorkspaceUrlState> & Pick<
+  WorkspaceUrlState,
+  "package" | "tabs" | "active"
+>): WorkspaceUrlState {
+  return {
+    lens: "api",
+    atPackageRoot: false,
+    packageLens: "overview",
+    library: null,
+    selectedTypeId: "",
+    selectedMemberKey: "",
+    selectedOverloadIndex: null,
+    memberSection: "overview",
+    selectedBodyTarget: null,
+    memberBrowse: false,
+    memberTextFilter: "",
+    memberKindFilter: "all",
+    memberAccessibilityFilter: "all",
+    memberTraitFilter: "",
+    ...partial,
+  };
+}
+
+function locationHref(state: WorkspaceUrlState): string {
+  const params = new URLSearchParams();
+  params.set("package", state.package);
+  params.set("w", encodeWorkspaceShareState(state));
+  return `?${params.toString()}`;
+}
+
+/** Deep-link for demos that restore via workspace location; null = imperative runner. */
+export function productHomeDemoLocationHref(id: ProductHomeDemoId): string | null {
+  switch (id) {
+    case STJ_SERIALIZER_DEMO_ID:
+      return locationHref(workspaceUrlState({
+        package: STJ_SERIALIZER_PACKAGE.id,
+        tabs: [{ ...STJ_SERIALIZER_PACKAGE }],
+        active: 0,
+        selectedTypeId: STJ_SERIALIZER_TYPE,
+      }));
+    case PLATFORM_LIST_DEMO_ID:
+      return locationHref(workspaceUrlState({
+        package: PLATFORM_RUNTIME_PACK.id,
+        tabs: [
+          { ...STJ_SERIALIZER_PACKAGE },
+          { ...PLATFORM_RUNTIME_PACK },
+        ],
+        active: 1,
+        library: PLATFORM_LIST_LIBRARY,
+        selectedTypeId: PLATFORM_LIST_TYPE,
+      }));
+    case EXTENSIONS_CALLGRAPH_DEMO_ID:
+      return null;
+    default: {
+      const _exhaustive: never = id;
+      return _exhaustive;
+    }
+  }
+}

--- a/prototypes/inspect-web/src/shell-controls.ts
+++ b/prototypes/inspect-web/src/shell-controls.ts
@@ -1,6 +1,11 @@
 import { parsePackageQuery } from "./package-bar.ts";
+import {
+  isProductHomeDemoId,
+  type ProductHomeDemoId,
+} from "./product-home-demos.ts";
 
-export type HomeDemo = "stj" | "runtime" | "callgraph";
+/** Product home-demo ids (`ProductInspectionDemos` / CLI `demo <id>`). */
+export type HomeDemo = ProductHomeDemoId;
 
 export interface WorkbenchShellBindingActions {
   onDismissNotice: () => void;
@@ -60,7 +65,7 @@ export function bindHomeShell(
   root.querySelectorAll<HTMLElement>("[data-home-demo]").forEach(button =>
     button.addEventListener("click", () => {
       const demo = button.dataset.homeDemo;
-      if (demo === "stj" || demo === "runtime" || demo === "callgraph") {
+      if (isProductHomeDemoId(demo)) {
         actions.onDemo(demo);
       }
     }));

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  EXTENSIONS_CALLGRAPH,
+  EXTENSIONS_CALLGRAPH_DEMO_ID,
+  PLATFORM_LIST_DEMO_ID,
+  PLATFORM_LIST_LIBRARY,
+  PLATFORM_LIST_TYPE,
+  PLATFORM_RUNTIME_PACK,
+  PRODUCT_HOME_DEMO_CATALOG,
+  STJ_SERIALIZER_DEMO_ID,
+  STJ_SERIALIZER_PACKAGE,
+  STJ_SERIALIZER_TYPE,
+  isProductHomeDemoId,
+  productHomeDemoLocationHref,
+} from "../src/product-home-demos.ts";
+import { parseWorkspaceLocation } from "../src/workspace-navigation.ts";
+
+function parseDemoHref(href: string) {
+  const url = new URL(href, "https://inspect.local/");
+  return {
+    url,
+    location: parseWorkspaceLocation({
+      href: url.href,
+      pathname: url.pathname,
+      search: url.search,
+      hash: url.hash,
+    }),
+  };
+}
+
+test("product home catalog uses ProductInspectionDemos ids and labels", () => {
+  assert.deepEqual(
+    PRODUCT_HOME_DEMO_CATALOG.map(entry => entry.id),
+    [STJ_SERIALIZER_DEMO_ID, EXTENSIONS_CALLGRAPH_DEMO_ID, PLATFORM_LIST_DEMO_ID],
+  );
+  assert.equal(
+    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === STJ_SERIALIZER_DEMO_ID)?.title,
+    "System.Text.Json",
+  );
+  assert.equal(
+    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === EXTENSIONS_CALLGRAPH_DEMO_ID)?.summary,
+    "Trace calls across three packages",
+  );
+  assert.equal(
+    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === PLATFORM_LIST_DEMO_ID)?.title,
+    ".NET Platform",
+  );
+});
+
+test("isProductHomeDemoId accepts only product ids", () => {
+  assert.equal(isProductHomeDemoId("stj-serializer"), true);
+  assert.equal(isProductHomeDemoId("platform-list"), true);
+  assert.equal(isProductHomeDemoId("extensions-callgraph"), true);
+  assert.equal(isProductHomeDemoId("stj"), false);
+  assert.equal(isProductHomeDemoId("runtime"), false);
+  assert.equal(isProductHomeDemoId("callgraph"), false);
+  assert.equal(isProductHomeDemoId(""), false);
+  assert.equal(isProductHomeDemoId(undefined), false);
+});
+
+test("stj-serializer deep link selects JsonSerializer on STJ 10.0.0", () => {
+  const href = productHomeDemoLocationHref(STJ_SERIALIZER_DEMO_ID);
+  assert.ok(href);
+  const { url, location } = parseDemoHref(href);
+  assert.equal(url.searchParams.get("package"), STJ_SERIALIZER_PACKAGE.id);
+  assert.deepEqual(location.tabs, [{ ...STJ_SERIALIZER_PACKAGE }]);
+  assert.equal(location.active, 0);
+  assert.equal(location.type, STJ_SERIALIZER_TYPE);
+  assert.equal(location.package, STJ_SERIALIZER_PACKAGE.id);
+});
+
+test("platform-list deep link focuses CoreLib List`1 on runtime pack", () => {
+  const href = productHomeDemoLocationHref(PLATFORM_LIST_DEMO_ID);
+  assert.ok(href);
+  const { url, location } = parseDemoHref(href);
+  assert.equal(url.searchParams.get("package"), PLATFORM_RUNTIME_PACK.id);
+  assert.deepEqual(location.tabs, [
+    { ...STJ_SERIALIZER_PACKAGE },
+    { ...PLATFORM_RUNTIME_PACK },
+  ]);
+  assert.equal(location.active, 1);
+  assert.equal(location.library, PLATFORM_LIST_LIBRARY);
+  assert.equal(location.type, PLATFORM_LIST_TYPE);
+  assert.equal(location.package, PLATFORM_RUNTIME_PACK.id);
+});
+
+test("extensions-callgraph has no deep link and keeps product packages/anchor", () => {
+  assert.equal(productHomeDemoLocationHref(EXTENSIONS_CALLGRAPH_DEMO_ID), null);
+  assert.equal(EXTENSIONS_CALLGRAPH.packages.length, 3);
+  assert.equal(EXTENSIONS_CALLGRAPH.memberAnchorDigest, "74b6b4b321");
+  assert.equal(EXTENSIONS_CALLGRAPH.memberSection, "call-graph");
+  assert.equal(
+    EXTENSIONS_CALLGRAPH.packages[0].id,
+    "Microsoft.Extensions.DependencyInjection.Abstractions",
+  );
+});

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -99,9 +99,9 @@ test("home shell accepts only known demos", () => {
   const root = new FakeRoot();
   const theme = new FakeElement();
   const dismiss = new FakeElement();
-  const stj = new FakeElement({ homeDemo: "stj" });
-  const runtime = new FakeElement({ homeDemo: "runtime" });
-  const callgraph = new FakeElement({ homeDemo: "callgraph" });
+  const stj = new FakeElement({ homeDemo: "stj-serializer" });
+  const platform = new FakeElement({ homeDemo: "platform-list" });
+  const callgraph = new FakeElement({ homeDemo: "extensions-callgraph" });
   const unknown = new FakeElement({ homeDemo: "other" });
   const absent = new FakeElement();
   root.add("#home-theme", theme);
@@ -109,7 +109,7 @@ test("home shell accepts only known demos", () => {
   root.addAll(
     "[data-home-demo]",
     stj,
-    runtime,
+    platform,
     callgraph,
     unknown,
     absent,
@@ -126,16 +126,16 @@ test("home shell accepts only known demos", () => {
   theme.dispatch("click");
   dismiss.dispatch("click");
   stj.dispatch("click");
-  runtime.dispatch("click");
+  platform.dispatch("click");
   callgraph.dispatch("click");
   unknown.dispatch("click");
   absent.dispatch("click");
   assert.deepEqual(calls, [
     "theme",
     "dismiss",
-    "demo:stj",
-    "demo:runtime",
-    "demo:callgraph",
+    "demo:stj-serializer",
+    "demo:platform-list",
+    "demo:extensions-callgraph",
   ]);
 });
 

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -657,7 +657,7 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
     appSource.match(/function bindEvents\(\) \{[\s\S]*?\n}\n\nfunction toggleTheme/)?.[0]
     ?? "";
   const homeBinding =
-    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ The two package demos)/)?.[0]
+    appSource.match(/function bindHomeEvents\(\) \{[\s\S]*?\n}(?=\n\n\/\/ Home buttons use product demo ids)/)?.[0]
     ?? "";
   const loadingBinding =
     appSource.match(/function renderLoading\(\) \{[\s\S]*?\n}(?=\n\nasync function loadSelectedMemberDocumentation)/)?.[0]
@@ -1892,7 +1892,7 @@ test("home demos restore the complete parsed location", () => {
     ?? "";
   assert.match(
     callGraphDemo,
-    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = "call-graph"/);
+    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = EXTENSIONS_CALLGRAPH\.memberSection/);
   const platformHistory =
     appSource.match(/async function restorePlatformScopeThenDeepLink\([\s\S]*?\n}\n\n\/\/ Load and scope/)?.[0]
     ?? "";


### PR DESCRIPTION
## Summary
After #4463, inspect-web home buttons still used short ids (`stj` / `runtime` / `callgraph`) and opaque deep-link blobs. This aligns the web host with the product home-demo registry.

- Add `product-home-demos.ts` as the browser projection of `ProductInspectionDemos` (ids, titles, summaries, package/type anchors)
- Render home buttons from that catalog; accept only product ids in `bindHomeShell`
- Build STJ + platform share deep links via `encodeWorkspaceShareState` (no hand-maintained base64)
- Drive `runCallGraphDemo` from the same three packages + `TryAddEnumerable` anchor as CLI `extensions-callgraph`
- Update residual notes in `workspace-definitions.md`

## Evidence
- `cd prototypes/inspect-web && npm test` — **484/484** pass (Node 24)
- `npm run lint` — green

## Non-action / residual
- Platform still uses resident `Microsoft.NETCore.App` runtime-pack share encoding (product CLI uses unversioned host `runtime`); full substrate converges with `WorkspaceContextLoader` / #4405
- `extensions-callgraph` remains an imperative multi-package member load until group-run lands
- Minted view-facet ids; Call Graph structured JSON

Base: `d0b23738b` (origin/main at push)