### PR TITLE
Give the graph source modal one request-owned state union

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1090,9 +1090,10 @@ a settled resource rather than returning from ownerless loading state. It also
 projects every `AsyncResource` variant through `packageMetadataView`, deriving
 both rosters from the union declaration.
 `test/async-resource-state.test.ts` derives the converted lenses from their
-declared type and fails if one regains any parallel state field -- named,
-quoted, or carried in by a spread -- on either the coordinator state or the
-initial state.
+declared type and fails if one regains a lifecycle-prefixed parallel state
+field -- direct, inherited, named, quoted, or carried in by a spread -- on
+either the coordinator state or the initial state. It also rejects mutable
+coordinator-owned bindings outside that declared state.
 `test/package-opportunities.test.ts` gates the platform pick-a-library prompt,
 the idle/loading/ready/failed states (fresh versus stale scope), the
 no-opportunities and inspection-error banners, the category summary counts,

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -1443,6 +1443,29 @@ export function memberRequestKey(parts: readonly string[], taste: readonly strin
   return [...parts, ...taste].join("\u0000");
 }
 
+// The graph-source modal's lifecycle statuses. This module owns the status vocabulary so
+// that visibility and cancellation can reason about it without depending on the request and
+// payload types; `source-inspection.ts` owns the full discriminated union built on these.
+export const graphSourceStatuses = [
+  "closed",
+  "loading",
+  "ready",
+  "failed",
+  "cancelled",
+] as const;
+
+type GraphSourceStatus = (typeof graphSourceStatuses)[number];
+
+export interface GraphSourceStatusCarrier {
+  readonly status: GraphSourceStatus;
+}
+
+export function graphSourceIsOpen(
+  graphSource: GraphSourceStatusCarrier | null | undefined,
+): boolean {
+  return graphSource != null && graphSource.status !== "closed";
+}
+
 export interface SourceWorkbenchState {
   settings?: boolean;
   explorer?: { open?: boolean } | null;
@@ -1450,7 +1473,7 @@ export interface SourceWorkbenchState {
   error?: string;
   home?: boolean;
   package?: unknown;
-  graphSourceOpen?: boolean;
+  graphSource?: GraphSourceStatusCarrier | null;
   atPackageRoot?: boolean;
   lens?: TypeLens;
   selectedMemberKey?: string;
@@ -1473,7 +1496,7 @@ export type SourceOperationKind = "graph" | "type" | "member" | null;
 
 export function activeSourceOperationKind(state: SourceWorkbenchState): SourceOperationKind {
   if (!sourceWorkbenchIsVisible(state)) return null;
-  if (state.graphSourceOpen) return "graph";
+  if (graphSourceIsOpen(state.graphSource)) return "graph";
   if (state.atPackageRoot) return null;
   if (state.lens === "source") return "type";
   if (state.lens === "api"
@@ -1495,7 +1518,7 @@ export function sourceReloadKind(state: SourceWorkbenchState): SourceReloadKind 
   if (active) return active;
   if (!sourceWorkbenchIsVisible(state)
     || state.atPackageRoot
-    || state.graphSourceOpen) {
+    || graphSourceIsOpen(state.graphSource)) {
     return null;
   }
   if (state.lens === "api"
@@ -1523,29 +1546,40 @@ export interface SourceRequestState {
   typeSourceLoading?: boolean;
   typeSourceKey?: string;
   typeSourceError?: string;
-  graphSourceLoading?: boolean;
-  graphSourceError?: string;
-  graphSourceSeq?: number;
 }
 
-export function beginSourceRequestState(state: SourceRequestState): number {
+// The graph-source modal shares the engine's single source-request channel, so starting or
+// cancelling any source request must also retire an in-flight graph load. The caller supplies
+// that transition because `source-inspection.ts` owns the graph union; it is a required
+// parameter rather than an optional one so a new call site cannot silently skip it.
+export type CancelGraphSource = () => boolean;
+
+export function beginSourceRequestState(
+  state: SourceRequestState,
+  cancelGraphSource: CancelGraphSource,
+): number {
   state.sourceRequestGeneration = (state.sourceRequestGeneration ?? 0) + 1;
-  clearInFlightSourceState(state);
+  clearInFlightSourceState(state, cancelGraphSource);
   return state.sourceRequestGeneration;
 }
 
-export function cancelSourceRequestState(state: SourceRequestState): boolean {
-  if (!state.memberSourceLoading
-    && !state.typeSourceLoading
-    && !state.graphSourceLoading) {
+export function cancelSourceRequestState(
+  state: SourceRequestState,
+  cancelGraphSource: CancelGraphSource,
+): boolean {
+  const graphWasLoading = cancelGraphSource();
+  if (!state.memberSourceLoading && !state.typeSourceLoading && !graphWasLoading) {
     return false;
   }
   state.sourceRequestGeneration = (state.sourceRequestGeneration ?? 0) + 1;
-  clearInFlightSourceState(state);
+  clearInFlightSourceState(state, () => false);
   return true;
 }
 
-function clearInFlightSourceState(state: SourceRequestState): void {
+function clearInFlightSourceState(
+  state: SourceRequestState,
+  cancelGraphSource: CancelGraphSource,
+): void {
   if (state.memberSourceLoading) {
     state.memberSourceLoading = false;
     state.memberSourceKey = "";
@@ -1556,11 +1590,7 @@ function clearInFlightSourceState(state: SourceRequestState): void {
     state.typeSourceKey = "";
     state.typeSourceError = "";
   }
-  if (state.graphSourceLoading) {
-    state.graphSourceLoading = false;
-    state.graphSourceError = "";
-    state.graphSourceSeq = (state.graphSourceSeq ?? 0) + 1;
-  }
+  cancelGraphSource();
 }
 
 export interface SectionableMember {

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -1463,7 +1463,18 @@ export interface GraphSourceStatusCarrier {
 export function graphSourceIsOpen(
   graphSource: GraphSourceStatusCarrier | null | undefined,
 ): boolean {
-  return graphSource != null && graphSource.status !== "closed";
+  if (graphSource == null) return false;
+  switch (graphSource.status) {
+    case "closed":
+      return false;
+    case "loading":
+    case "ready":
+    case "failed":
+    case "cancelled":
+      return true;
+    default:
+      return assertNever(graphSource.status, "GraphSourceStatus");
+  }
 }
 
 export interface SourceWorkbenchState {

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -1454,7 +1454,7 @@ export const graphSourceStatuses = [
   "cancelled",
 ] as const;
 
-type GraphSourceStatus = (typeof graphSourceStatuses)[number];
+export type GraphSourceStatus = (typeof graphSourceStatuses)[number];
 
 export interface GraphSourceStatusCarrier {
   readonly status: GraphSourceStatus;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -140,6 +140,7 @@ import {
 import {
   createSourceInspectionCoordinator,
   closedGraphSource,
+  graphSourceAutoLoad,
   type GraphSourceRequest,
   type GraphSourceState,
 } from "./source-inspection.ts";
@@ -2420,12 +2421,13 @@ function render() {
 function maybeAutoLoadVisibleSource() {
   const kind = activeSourceOperationKind(state);
   if (kind === "graph") {
-    // "cancelled" is exactly the open-but-unsettled state a competing source request
-    // leaves behind: no load in flight, no result, and no error to show. Every other open
-    // variant is either still loading or already settled.
-    if (state.graphSource.status === "cancelled") {
+    // `graphSourceAutoLoad` owns which states have no result coming, and gates that
+    // decision for every variant of the union. It hands back the request so there is no
+    // second comparison here to drift from its answer.
+    const reload = graphSourceAutoLoad(state.graphSource);
+    if (reload) {
       observeAsync(
-        openGraphSource(state.graphSource.request, state.graphSource.title),
+        openGraphSource(reload.request, reload.title),
         "Loading graph source");
     }
     return;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -21,6 +21,7 @@ import {
   graphMemberSelection,
   graphMemberTargetFromShare,
   graphOnlyBodyTarget,
+  graphSourceIsOpen,
   idleAsyncResource,
   MARKDOWN_SANITIZE_OPTIONS,
   MAX_WORKSPACE_PACKAGES,
@@ -138,7 +139,9 @@ import {
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,
+  closedGraphSource,
   type GraphSourceRequest,
+  type GraphSourceState,
 } from "./source-inspection.ts";
 import {
   createMetadataInspectionCoordinator,
@@ -635,14 +638,8 @@ const initialState = {
   runtimePackLoading: false,
   runtimePackError: "",
   selectedBodyTarget: null,
-  graphSourceOpen: false,
-  graphSource: null,
-  graphSourceLoading: false,
-  graphSourceError: "",
+  graphSource: closedGraphSource,
   docViewer: { status: "closed" } as const,
-  graphSourceTitle: "",
-  graphSourceRequest: null,
-  graphSourceSeq: 0,
   styleTiers: null,
   styleOptions: null,
   styleCatalogError: "",
@@ -702,9 +699,8 @@ interface StateOverrides {
   platformRecent: PlatformRecent[];
   recentPackages: RecentPackage[];
   selectedBodyTarget: BodyTarget | null;
-  graphSource: BrowserSource | null;
+  graphSource: GraphSourceState;
   docViewer: DocumentViewerState;
-  graphSourceRequest: { request: GraphSourceRequest; title: string } | null;
   styleTiers: StyleTier[] | null;
   styleOptions: StyleOption[] | null;
   history: string[];
@@ -1288,12 +1284,12 @@ function isInteractiveElement(element: Element | null) {
 
 function focusTypeList(generation = spotlightFocusGeneration) {
   if (generation !== spotlightFocusGeneration
-      || state.spotlightOpen || state.graphSourceOpen
+      || state.spotlightOpen || graphSourceIsOpen(state.graphSource)
       || isDocViewerOpen(state.docViewer)
       || isTextEntry()) return;
   requestAnimationFrame(() => {
     if (generation !== spotlightFocusGeneration
-        || state.spotlightOpen || state.graphSourceOpen
+        || state.spotlightOpen || graphSourceIsOpen(state.graphSource)
         || isDocViewerOpen(state.docViewer)
         || isTextEntry()) return;
     document.querySelector<HTMLElement>("#type-list")?.focus();
@@ -2399,7 +2395,7 @@ function render() {
         expanded: state.statusBarExpanded,
       }, escapeHtml)}
       ${state.spotlightOpen ? spotlight.modalHtml() : ""}
-      ${state.graphSourceOpen ? renderGraphSource() : ""}
+      ${renderGraphSource()}
       ${isDocViewerOpen(state.docViewer) ? renderDocViewer() : ""}
       ${state.tasteOpen ? renderTastePopoverHtml() : ""}
     </div>`;
@@ -2424,16 +2420,12 @@ function render() {
 function maybeAutoLoadVisibleSource() {
   const kind = activeSourceOperationKind(state);
   if (kind === "graph") {
-    if (state.graphSourceRequest
-      && sourceRequestNeedsLoad(
-        true,
-        state.graphSourceLoading,
-        state.graphSource,
-        state.graphSourceError)) {
+    // "cancelled" is exactly the open-but-unsettled state a competing source request
+    // leaves behind: no load in flight, no result, and no error to show. Every other open
+    // variant is either still loading or already settled.
+    if (state.graphSource.status === "cancelled") {
       observeAsync(
-        openGraphSource(
-          state.graphSourceRequest.request,
-          state.graphSourceRequest.title),
+        openGraphSource(state.graphSource.request, state.graphSource.title),
         "Loading graph source");
     }
     return;
@@ -5810,7 +5802,7 @@ function workbenchOverlayOwnsFocus() {
 
 function workbenchModalOwnsFocus() {
   return state.spotlightOpen
-    || state.graphSourceOpen
+    || graphSourceIsOpen(state.graphSource)
     || isDocViewerOpen(state.docViewer);
 }
 
@@ -7878,11 +7870,9 @@ function invalidateSourceCaches() {
 function reloadVisibleSource() {
   switch (sourceReloadKind(state)) {
     case "graph":
-      if (state.graphSourceRequest) {
+      if (state.graphSource.status !== "closed") {
         observeAsync(
-          openGraphSource(
-            state.graphSourceRequest.request,
-            state.graphSourceRequest.title),
+          openGraphSource(state.graphSource.request, state.graphSource.title),
           "Reloading graph source");
       }
       break;
@@ -7962,11 +7952,9 @@ function renderSettingsViewHtml() {
 }
 
 function renderGraphSource() {
+  if (state.graphSource.status === "closed") return "";
   return renderGraphSourcePure({
-    title: state.graphSourceTitle,
-    loading: state.graphSourceLoading,
-    source: state.graphSource,
-    error: state.graphSourceError,
+    state: state.graphSource,
     escapeHtml,
     highlightCSharp,
   });
@@ -8756,7 +8744,7 @@ function workspaceKeyboardContextIsActive(): boolean {
     && !state.home
     && !state.loading
     && !state.error
-    && !state.graphSourceOpen
+    && !graphSourceIsOpen(state.graphSource)
     && !isDocViewerOpen(state.docViewer)
     && !state.spotlightOpen;
 }
@@ -8764,7 +8752,7 @@ function workspaceKeyboardContextIsActive(): boolean {
 const workspaceModalContextIsAvailable = () =>
   !state.home && !state.loading && !state.error;
 const graphSourceContextIsActive = () =>
-  workspaceModalContextIsAvailable() && state.graphSourceOpen;
+  workspaceModalContextIsAvailable() && graphSourceIsOpen(state.graphSource);
 const documentViewerContextIsActive = () =>
   workspaceModalContextIsAvailable() && isDocViewerOpen(state.docViewer);
 const spotlightContextIsActive = () =>

--- a/prototypes/inspect-web/src/graph-source.ts
+++ b/prototypes/inspect-web/src/graph-source.ts
@@ -1,13 +1,13 @@
-import { pdbSourceLimitationHtml } from "./data.ts";
-import type { BrowserSource } from "./inspect-web-engine.d.ts";
+import { assertNever, pdbSourceLimitationHtml } from "./data.ts";
+import type { GraphSourceState } from "./source-inspection.ts";
 
-type GraphSourceResult = BrowserSource;
+// The modal renders only when it is open, so the renderer takes the open variants and the
+// composition root narrows before calling it. A closed modal is therefore not a state this
+// function can be asked to draw.
+export type OpenGraphSourceState = Exclude<GraphSourceState, { status: "closed" }>;
 
 export interface RenderGraphSourceOptions {
-  title: string;
-  loading: boolean;
-  source: GraphSourceResult | null;
-  error: string;
+  state: OpenGraphSourceState;
   escapeHtml: (value: unknown) => string;
   highlightCSharp: (value: string) => string;
 }
@@ -30,19 +30,42 @@ export function bindGraphSource(
     actions.onClose);
 }
 
+// Exhaustive over the open variants, terminating in `assertNever`, so a new variant is a
+// compile error here until it is given a body. That is the gate for the modal never
+// rendering a state it does not understand.
+function graphSourceBodyHtml(
+  state: OpenGraphSourceState,
+  escapeHtml: (value: unknown) => string,
+  highlightCSharp: (value: string) => string,
+): string {
+  switch (state.status) {
+    case "loading":
+      return `<div class="graph-source-status">Resolving source for ${escapeHtml(state.title)}…</div>`;
+    case "ready": {
+      const { source } = state;
+      return `<div class="source-provenance"><strong>${source.provider === "pdb" ? "PDB Source" : "Decompiled source"}</strong><span>${escapeHtml(source.provenance)}</span>${source.url ? `<a href="${escapeHtml(source.url)}" target="_blank" rel="noreferrer">open source ↗</a>` : ""}${pdbSourceLimitationHtml(source)}</div>
+         <pre class="language-csharp"><code class="language-csharp">${highlightCSharp(source.text)}</code></pre>`;
+    }
+    case "failed":
+      return `<div class="graph-source-status error">${escapeHtml(state.error || "No source was returned.")}</div>`;
+    case "cancelled":
+      // A competing source request retired this load while its modal stayed open. The
+      // previous field layout produced exactly this text for that state by falling through
+      // to an empty error; the variant names the state without changing what a user sees.
+      return `<div class="graph-source-status error">No source was returned.</div>`;
+    default:
+      return assertNever(state, "open graph source status");
+  }
+}
+
 export function renderGraphSource(options: RenderGraphSourceOptions): string {
-  const { title, loading, source, error, escapeHtml, highlightCSharp } = options;
-  const body = loading
-    ? `<div class="graph-source-status">Resolving source for ${escapeHtml(title)}…</div>`
-    : source
-      ? `<div class="source-provenance"><strong>${source.provider === "pdb" ? "PDB Source" : "Decompiled source"}</strong><span>${escapeHtml(source.provenance)}</span>${source.url ? `<a href="${escapeHtml(source.url)}" target="_blank" rel="noreferrer">open source ↗</a>` : ""}${pdbSourceLimitationHtml(source)}</div>
-         <pre class="language-csharp"><code class="language-csharp">${highlightCSharp(source.text)}</code></pre>`
-      : `<div class="graph-source-status error">${escapeHtml(error || "No source was returned.")}</div>`;
+  const { state, escapeHtml, highlightCSharp } = options;
+  const body = graphSourceBodyHtml(state, escapeHtml, highlightCSharp);
   return `
     <div class="graph-source-backdrop" id="graph-source-backdrop">
       <div class="graph-source" role="dialog" aria-modal="true" aria-label="Member source">
         <div class="graph-source-head">
-          <span class="graph-source-title">${escapeHtml(title)}</span>
+          <span class="graph-source-title">${escapeHtml(state.title)}</span>
           <button id="graph-source-close" type="button" aria-label="Close">esc</button>
         </div>
         <div class="graph-source-body">${body}</div>

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -42,9 +42,9 @@ export interface GraphSourceRequest extends SourceCoordinates {
 //
 // The `loading` object itself is the request-ownership token: `openGraphSource` keeps a
 // reference to the object it installed and only commits a result when `state.graphSource`
-// is still that exact object. That is strictly stronger than the sequence counter it
-// replaces, because an identity cannot collide -- closing and reopening the same member
-// rejects the first request's late result, which an equal-valued key would have accepted.
+// is still that exact object. It is a typed replacement for the prior monotonic sequence:
+// both distinguish repeated requests for the same member and reject a stale completion,
+// while object identity keeps ownership and visible lifecycle state in one value.
 //
 // `cancelled` exists because a competing member- or type-source request retires an in-flight
 // graph load while its modal is still open. It renders the same "No source was returned."

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -34,6 +34,48 @@ export interface GraphSourceRequest extends SourceCoordinates {
   metadataToken: number;
 }
 
+// One state for the graph-source modal, replacing the previous open/loading/error/result/
+// title/request fields and their sequence counter. Every non-closed variant carries the
+// request and title it belongs to, so a rendered modal can never show one request's title
+// beside another's result.
+//
+// The `loading` object itself is the request-ownership token: `openGraphSource` keeps a
+// reference to the object it installed and only commits a result when `state.graphSource`
+// is still that exact object. That is strictly stronger than the sequence counter it
+// replaces, because an identity cannot collide -- closing and reopening the same member
+// rejects the first request's late result, which an equal-valued key would have accepted.
+//
+// `cancelled` exists because a competing member- or type-source request retires an in-flight
+// graph load while its modal is still open. It renders the same "No source was returned."
+// text the previous field layout produced for that state, but names it rather than leaving
+// it as the absence of all three of loading, result, and error.
+export type GraphSourceState =
+  | { readonly status: "closed" }
+  | {
+    readonly status: "loading";
+    readonly request: GraphSourceRequest;
+    readonly title: string;
+  }
+  | {
+    readonly status: "ready";
+    readonly request: GraphSourceRequest;
+    readonly title: string;
+    readonly source: BrowserSource;
+  }
+  | {
+    readonly status: "failed";
+    readonly request: GraphSourceRequest;
+    readonly title: string;
+    readonly error: string;
+  }
+  | {
+    readonly status: "cancelled";
+    readonly request: GraphSourceRequest;
+    readonly title: string;
+  };
+
+export const closedGraphSource: GraphSourceState = { status: "closed" };
+
 export interface MemberSourceLoadRequest extends MemberSourceQuery {
   signature: string;
   isCurrent(): boolean;
@@ -55,16 +97,7 @@ export interface SourceInspectionState
   typeSourceLoading: boolean;
   typeSourceError: string;
   typeSourceKey: string;
-  graphSourceOpen: boolean;
-  graphSource: BrowserSource | null;
-  graphSourceLoading: boolean;
-  graphSourceError: string;
-  graphSourceTitle: string;
-  graphSourceRequest: {
-    request: GraphSourceRequest;
-    title: string;
-  } | null;
-  graphSourceSeq: number;
+  graphSource: GraphSourceState;
   taste: string[];
 }
 
@@ -100,10 +133,24 @@ export function createSourceInspectionCoordinator(
 ): SourceInspectionCoordinator {
   const { state } = dependencies;
 
+  // Retire an in-flight graph load without disturbing a closed, settled, or already-cancelled
+  // modal. Returning whether it cancelled anything is what lets the shared request-state
+  // helpers report that a cancellation actually happened.
+  function cancelGraphSource(): boolean {
+    const current = state.graphSource;
+    if (current.status !== "loading") return false;
+    state.graphSource = {
+      status: "cancelled",
+      request: current.request,
+      title: current.title,
+    };
+    return true;
+  }
+
   return {
     cancelHiddenRequest() {
       if (!sourceSurfaceIsVisible(state)
-        && cancelSourceRequestState(state)) {
+        && cancelSourceRequestState(state, cancelGraphSource)) {
         dependencies.cancelEngineSourceRequest();
       }
     },
@@ -118,7 +165,7 @@ export function createSourceInspectionCoordinator(
         return;
       }
 
-      const generation = beginSourceRequestState(state);
+      const generation = beginSourceRequestState(state, cancelGraphSource);
       state.memberSourceKey = request.signature;
       state.memberSource = null;
       state.memberSourceLoading = true;
@@ -158,7 +205,7 @@ export function createSourceInspectionCoordinator(
         dependencies.renderPreservingMemberFocus();
         return;
       }
-      const generation = beginSourceRequestState(state);
+      const generation = beginSourceRequestState(state, cancelGraphSource);
       state.typeSourceKey = request.signature;
       state.typeSource = null;
       state.typeSourceError = "";
@@ -185,46 +232,40 @@ export function createSourceInspectionCoordinator(
     },
 
     async openGraphSource(request, title) {
-      const generation = beginSourceRequestState(state);
-      const sequence = ++state.graphSourceSeq;
-      state.graphSourceOpen = true;
-      state.graphSourceTitle = title;
-      state.graphSourceRequest = { request, title };
-      state.graphSource = null;
-      state.graphSourceError = "";
-      state.graphSourceLoading = true;
+      beginSourceRequestState(state, cancelGraphSource);
+      // This object is the ownership token. Nothing below commits to `state.graphSource`
+      // unless it is still exactly this object, so a close, a reopen, or a competing
+      // source request all reject this request's late result without a counter.
+      const pending: GraphSourceState = { status: "loading", request, title };
+      state.graphSource = pending;
       dependencies.render();
-      const isCurrent = () =>
-        generation === state.sourceRequestGeneration
-        && sequence === state.graphSourceSeq
-        && state.graphSourceOpen;
       try {
         const source = await dependencies.queryGraphSource(
           request,
           JSON.stringify(state.taste));
-        if (isCurrent()) state.graphSource = source;
+        if (state.graphSource !== pending) return;
+        state.graphSource = { status: "ready", request, title, source };
       } catch (error) {
-        if (isCurrent()) {
-          state.graphSourceError = dependencies.describeError(error);
-        }
-      } finally {
-        if (isCurrent()) {
-          state.graphSourceLoading = false;
-          dependencies.render();
-        }
+        if (state.graphSource !== pending) return;
+        state.graphSource = {
+          status: "failed",
+          request,
+          title,
+          error: dependencies.describeError(error),
+        };
       }
+      // Reached only when this request still owned the modal and settled it, matching the
+      // previous behavior of rendering the resolution exactly once for the owning request.
+      dependencies.render();
     },
 
     closeGraphSource() {
-      if (cancelSourceRequestState(state)) {
+      if (cancelSourceRequestState(state, cancelGraphSource)) {
         dependencies.cancelEngineSourceRequest();
       }
-      state.graphSourceSeq++;
-      state.graphSourceOpen = false;
-      state.graphSource = null;
-      state.graphSourceError = "";
-      state.graphSourceLoading = false;
-      state.graphSourceRequest = null;
+      // One assignment both resets the modal and invalidates any request that owned the
+      // previous object.
+      state.graphSource = closedGraphSource;
       dependencies.render();
     },
   };

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -1,4 +1,5 @@
 import {
+  assertNever,
   beginSourceRequestState,
   cancelSourceRequestState,
   sourceRequestNeedsLoad,
@@ -75,6 +76,39 @@ export type GraphSourceState =
   };
 
 export const closedGraphSource: GraphSourceState = { status: "closed" };
+
+// Whether the auto-load pass -- which runs at the end of *every* render -- should reissue
+// this request. `cancelled` is the one state that has no result coming: open, unsettled,
+// nothing in flight, nothing to show. Every other variant is either still loading or
+// already settled, and reissuing a settled one is the retry loop this union was
+// introduced to end.
+//
+// This is a function rather than a condition at the call site because round 2 review
+// (GPT-5.6 Sol) defeated the source-text gate that guarded that condition: writing the
+// added comparison Yoda-style (`"failed" === state.graphSource.status`) restored the
+// user-visible retry loop with the whole suite green. A decision that can be called can be
+// tested for every variant of the union, and `assertNever` makes a new variant declare its
+// answer instead of inheriting one.
+//
+// It returns the work rather than a boolean so the caller has nothing left to decide: with
+// a boolean the caller still needs its own comparison to reach `request` and `title`, and
+// that comparison is free to disagree with this answer. Handing back the arguments removes
+// the second opinion.
+export function graphSourceAutoLoad(
+  graphSource: GraphSourceState,
+): { readonly request: GraphSourceRequest; readonly title: string } | null {
+  switch (graphSource.status) {
+    case "cancelled":
+      return { request: graphSource.request, title: graphSource.title };
+    case "closed":
+    case "loading":
+    case "ready":
+    case "failed":
+      return null;
+    default:
+      return assertNever(graphSource, "GraphSourceState");
+  }
+}
 
 export interface MemberSourceLoadRequest extends MemberSourceQuery {
   signature: string;
@@ -247,8 +281,17 @@ export function createSourceInspectionCoordinator(
         // The engine's `.d.ts` is hand-written and promises a source, but the previous
         // renderer guarded the payload with a truthiness check and drew "No source was
         // returned." when it was absent. A `failed` variant with no message renders that
-        // same string, so an empty payload keeps its old behavior rather than reaching
+        // same string, so an empty payload draws what it always drew rather than reaching
         // `source.provider` on nothing.
+        //
+        // What it renders is unchanged; what it *does* afterwards is not, and round 2
+        // review (GPT-5.6 Sol) measured the difference. The predecessor left
+        // `loading=false`, `source=null`, and `error=""`, which its auto-load predicate
+        // read as work never attempted -- so it reissued the request on the next render,
+        // and on every render after that. Recording `failed` settles it, and
+        // `graphSourceAutoLoad` does not reload a settled state. A falsy payload now
+        // stops instead of retrying forever. That is the same retry loop the empty-error
+        // case fixed, reached by a second route.
         state.graphSource = source
           ? { status: "ready", request, title, source }
           : { status: "failed", request, title, error: "" };

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -244,7 +244,14 @@ export function createSourceInspectionCoordinator(
           request,
           JSON.stringify(state.taste));
         if (state.graphSource !== pending) return;
-        state.graphSource = { status: "ready", request, title, source };
+        // The engine's `.d.ts` is hand-written and promises a source, but the previous
+        // renderer guarded the payload with a truthiness check and drew "No source was
+        // returned." when it was absent. A `failed` variant with no message renders that
+        // same string, so an empty payload keeps its old behavior rather than reaching
+        // `source.provider` on nothing.
+        state.graphSource = source
+          ? { status: "ready", request, title, source }
+          : { status: "failed", request, title, error: "" };
       } catch (error) {
         if (state.graphSource !== pending) return;
         state.graphSource = {

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -1,19 +1,8 @@
-// A request lifecycle union holds its whole lifecycle in one state field.
-// The parallel `…Loading`/`…Error`/`…Key` fields it replaces are gone -- but nothing proved
-// they were gone, and adversarial review (GPT-5.6 Sol, Claude Opus 5) resurrected them two
-// ways with the suite and the analyzer silent:
-//
-//   * adding optional legacy fields to `PackageInspectionState`, and
-//   * adding all three concrete fields beside the resource in `initialState`.
-//
-// Neither is caught by the type system. `AppState` is derived *from* the `initialState`
-// literal, so extra properties simply join the type, and `state` reaches the coordinator as
-// a non-fresh value, so no excess-property check applies. Neither oxlint nor knip sees an
-// object property as unused.
-//
-// A literal search for the three old names would restate today's roster. This derives the
-// converted lenses from the state type instead, so converting the next lens extends the
-// check automatically and a resurrected parallel field is red on either surface.
+// A request lifecycle union holds its whole lifecycle in one state field. Nothing in the
+// type system stops a parallel loading flag, error, key, or counter from being added beside
+// it and becoming a second authority. This gate derives lifecycle fields from their declared
+// types, then rejects every parallel field on coordinator state, root initial state, and
+// module-level mutable bindings.
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
@@ -28,6 +17,8 @@ import {
   type PropertyKey,
   type TSInterfaceDeclaration,
   type TSPropertySignature,
+  type TSTypeAliasDeclaration,
+  type TSTypeLiteral,
 } from "oxc-parser";
 
 const sourceRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "src");
@@ -67,6 +58,17 @@ function inspectionState(
   return declaration;
 }
 
+function typeAliases(program: Program): TSTypeAliasDeclaration[] {
+  return program.body.flatMap(node => {
+    const declaration = node.type === "ExportNamedDeclaration"
+      ? node.declaration
+      : node;
+    return declaration?.type === "TSTypeAliasDeclaration"
+      ? [declaration]
+      : [];
+  });
+}
+
 function propertyName(key: PropertyKey, computed: boolean): string {
   if (key.type === "Identifier" && !computed) return key.name;
   if (key.type === "Literal" && typeof key.value === "string") return key.value;
@@ -78,13 +80,51 @@ function stateProperties(declaration: TSInterfaceDeclaration): TSPropertySignatu
     (member): member is TSPropertySignature => member.type === "TSPropertySignature");
 }
 
-function lifecycleFields(declaration: TSInterfaceDeclaration): string[] {
+function isStatusVariant(type: TSTypeLiteral): boolean {
+  return type.members.some(member => {
+    if (member.type !== "TSPropertySignature"
+      || propertyName(member.key, member.computed) !== "status") {
+      return false;
+    }
+    const annotation = member.typeAnnotation?.typeAnnotation;
+    return annotation?.type === "TSLiteralType"
+      && annotation.literal.type === "Literal"
+      && typeof annotation.literal.value === "string";
+  });
+}
+
+// A status-discriminated object union is another lifecycle owner, just like
+// `AsyncResource<T>`. Discovering it from the AST means a new status spelling or variant
+// cannot walk past a hand-written suffix or member roster.
+function stateUnionTypes(programs: readonly Program[]): ReadonlySet<string> {
+  const found = new Set<string>();
+  for (const program of programs) {
+    for (const alias of typeAliases(program)) {
+      const annotation = alias.typeAnnotation;
+      if (annotation.type === "TSUnionType"
+        && annotation.types.length >= 2
+        && annotation.types.every(
+          type => type.type === "TSTypeLiteral" && isStatusVariant(type))) {
+        found.add(alias.id.name);
+      }
+    }
+  }
+  return found;
+}
+
+function lifecycleFields(
+  declaration: TSInterfaceDeclaration,
+  unionTypes: ReadonlySet<string>,
+): string[] {
   return stateProperties(declaration)
     .filter(property => {
       const annotation = property.typeAnnotation?.typeAnnotation;
-      return annotation?.type === "TSTypeReference"
-        && annotation.typeName.type === "Identifier"
-        && ["AsyncResource", "DocumentViewerState"].includes(annotation.typeName.name);
+      if (annotation?.type !== "TSTypeReference"
+        || annotation.typeName.type !== "Identifier") {
+        return false;
+      }
+      return annotation.typeName.name === "AsyncResource"
+        || unionTypes.has(annotation.typeName.name);
     })
     .map(property => propertyName(property.key, property.computed));
 }
@@ -141,48 +181,81 @@ function objectPropertyNames(
   return names;
 }
 
+function mutableBindingNames(program: Program): string[] {
+  return program.body.flatMap(statement => {
+    const declaration = statement.type === "ExportNamedDeclaration"
+      ? statement.declaration
+      : statement;
+    if (declaration?.type !== "VariableDeclaration"
+      || declaration.kind === "const") {
+      return [];
+    }
+    return declaration.declarations.flatMap(binding =>
+      binding.id.type === "Identifier" ? [binding.id.name] : []);
+  });
+}
+
+interface LifecycleOwner {
+  file: string;
+  name: string;
+  program: Program;
+  declaration: TSInterfaceDeclaration;
+}
+
+function lifecycleOwners(): LifecycleOwner[] {
+  return [
+    ["package-inspection.ts", "PackageInspectionState"],
+    ["document-inspection.ts", "DocumentInspectionState"],
+    ["source-inspection.ts", "SourceInspectionState"],
+  ].map(([file, name]) => {
+    assert.ok(file);
+    assert.ok(name);
+    const program = parse(file);
+    return {
+      file,
+      name,
+      program,
+      declaration: inspectionState(program, name),
+    };
+  });
+}
+
 test("a request lifecycle union keeps exactly one state field", () => {
-  const coordinatorProgram = parse("package-inspection.ts");
-  const coordinatorState = inspectionState(
-    coordinatorProgram,
-    "PackageInspectionState");
-  const documentState = inspectionState(
-    parse("document-inspection.ts"),
-    "DocumentInspectionState");
+  const owners = lifecycleOwners();
   const rootProgram = parse("dotnet-inspect.ts");
-  const declarations = objectDeclarations(rootProgram);
-  const initialState = declarations.get("initialState");
+  const rootDeclarations = objectDeclarations(rootProgram);
+  const initialState = rootDeclarations.get("initialState");
   assert.ok(initialState, "initialState must be a statically inspectable object");
 
-  const converted = [
-    ...lifecycleFields(coordinatorState),
-    ...lifecycleFields(documentState),
-  ];
+  const unions = stateUnionTypes(owners.map(owner => owner.program));
+  const converted = owners.flatMap(owner =>
+    lifecycleFields(owner.declaration, unions));
   assert.ok(
     converted.length > 0,
-    "no AsyncResource state field was found, so the anchor has stopped resolving");
+    "no converted state field was found, so the anchor has stopped resolving");
 
   const surfaces: readonly (readonly [string, readonly string[]])[] = [
-    [
-      "PackageInspectionState",
-      stateProperties(coordinatorState)
+    ...owners.map(owner => [
+      owner.name,
+      stateProperties(owner.declaration)
         .map(property => propertyName(property.key, property.computed)),
-    ],
-    [
-      "DocumentInspectionState",
-      stateProperties(documentState)
-        .map(property => propertyName(property.key, property.computed)),
-    ],
-    ["initialState", objectPropertyNames(initialState, declarations)],
+    ] as const),
+    ["initialState", objectPropertyNames(initialState, rootDeclarations)],
+    ...[
+      ...owners.map(owner => [owner.file, owner.program] as const),
+      ["dotnet-inspect.ts", rootProgram] as const,
+    ].map(([file, program]) => [
+      `${file} (module scope)`,
+      mutableBindingNames(program),
+    ] as const),
   ];
 
   const survivors: string[] = [];
   for (const [surface, names] of surfaces) {
     for (const name of names) {
-      for (const lens of converted) {
-        // `packageOpportunitiesKey` beside `packageOpportunities` is a parallel field;
-        // `packageOpportunities` itself is the resource.
-        if (name !== lens && name.startsWith(lens)) survivors.push(`${surface}.${name}`);
+      for (const lifecycle of converted) {
+        if (name !== lifecycle && name.startsWith(lifecycle))
+          survivors.push(`${surface}.${name}`);
       }
     }
   }
@@ -192,39 +265,33 @@ test("a request lifecycle union keeps exactly one state field", () => {
     [],
     "a request lifecycle union also has a parallel state field. "
     + "The union is the single source of truth for that request; a second field beside "
-    + "it can disagree with it.");
+    + "it -- a counter, a key, or a cached copy -- can disagree with it.");
 });
 
-test("the parallel-field gate sees every lifecycle surface", () => {
-  // Non-vacuity, and the specific shape of the two mutations that were silent: a gate that
-  // reads only one surface, or whose property scan stops matching, would pass above while
-  // proving nothing.
-  const coordinatorProgram = parse("package-inspection.ts");
-  const coordinatorState = inspectionState(
-    coordinatorProgram,
-    "PackageInspectionState");
-  const documentState = inspectionState(
-    parse("document-inspection.ts"),
-    "DocumentInspectionState");
+test("the parallel-field gate sees every surface and lifecycle shape", () => {
+  const owners = lifecycleOwners();
   const rootProgram = parse("dotnet-inspect.ts");
-  const declarations = objectDeclarations(rootProgram);
-  const initialState = declarations.get("initialState");
+  const rootDeclarations = objectDeclarations(rootProgram);
+  const initialState = rootDeclarations.get("initialState");
   assert.ok(initialState, "initialState must be a statically inspectable object");
 
+  const unions = stateUnionTypes(owners.map(owner => owner.program));
   assert.ok(
-    stateProperties(coordinatorState)
-      .some(property => propertyName(property.key, property.computed)
-        === "packageOpportunities"),
-    "the coordinator-state property scan no longer sees the converted lens");
+    unions.has("DocumentViewerState"),
+    "the document status union is no longer discovered");
   assert.ok(
-    stateProperties(documentState)
-      .some(property => propertyName(property.key, property.computed)
-        === "docViewer"),
-    "the document-state property scan no longer sees the converted viewer");
-  assert.ok(
-    objectPropertyNames(initialState, declarations).includes("packageOpportunities"),
-    "the initial-state property scan no longer sees the converted lens");
-  assert.ok(
-    objectPropertyNames(initialState, declarations).includes("docViewer"),
-    "the initial-state property scan no longer sees the converted viewer");
+    unions.has("GraphSourceState"),
+    "the graph-source status union is no longer discovered");
+
+  const expected = ["packageOpportunities", "docViewer", "graphSource"];
+  const converted = owners.flatMap(owner =>
+    lifecycleFields(owner.declaration, unions));
+  for (const field of expected) {
+    assert.ok(
+      converted.includes(field),
+      `${field} is no longer discovered as a lifecycle field`);
+    assert.ok(
+      objectPropertyNames(initialState, rootDeclarations).includes(field),
+      `initialState no longer exposes the ${field} lifecycle field`);
+  }
 });

--- a/prototypes/inspect-web/test/async-resource-state.test.ts
+++ b/prototypes/inspect-web/test/async-resource-state.test.ts
@@ -1,8 +1,9 @@
 // A request lifecycle union holds its whole lifecycle in one state field. Nothing in the
 // type system stops a parallel loading flag, error, key, or counter from being added beside
 // it and becoming a second authority. This gate derives lifecycle fields from their declared
-// types, then rejects every parallel field on coordinator state, root initial state, and
-// module-level mutable bindings.
+// types, then rejects lifecycle-prefixed fields on inherited/direct coordinator state and
+// root initial state. Coordinator factory and module scopes are state-free boundaries, so
+// any written binding there is also rejected rather than guessed from its name.
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
@@ -11,7 +12,9 @@ import { fileURLToPath } from "node:url";
 
 import {
   parseSync,
+  visitorKeys,
   type Expression,
+  type Node,
   type ObjectExpression,
   type Program,
   type PropertyKey,
@@ -27,13 +30,17 @@ function read(file: string): string {
   return readFileSync(join(sourceRoot, file), "utf8");
 }
 
-function parse(file: string): Program {
-  const parsed = parseSync(file, read(file));
+function parseSource(file: string, source: string): Program {
+  const parsed = parseSync(file, source);
   assert.deepEqual(
     parsed.errors,
     [],
     `${file} must parse before its state ownership can be inspected`);
   return parsed.program;
+}
+
+function parse(file: string): Program {
+  return parseSource(file, read(file));
 }
 
 function inspectionState(
@@ -75,9 +82,44 @@ function propertyName(key: PropertyKey, computed: boolean): string {
   throw new Error("state ownership keys must be statically named");
 }
 
-function stateProperties(declaration: TSInterfaceDeclaration): TSPropertySignature[] {
-  return declaration.body.body.filter(
+function interfaceDeclarations(program: Program): TSInterfaceDeclaration[] {
+  return program.body.flatMap(node => {
+    const declaration = node.type === "ExportNamedDeclaration"
+      ? node.declaration
+      : node;
+    return declaration?.type === "TSInterfaceDeclaration" ? [declaration] : [];
+  });
+}
+
+function interfaceRegistry(
+  programs: readonly Program[],
+): ReadonlyMap<string, TSInterfaceDeclaration> {
+  return new Map(programs.flatMap(program =>
+    interfaceDeclarations(program).map(declaration =>
+      [declaration.id.name, declaration] as const)));
+}
+
+function stateProperties(
+  declaration: TSInterfaceDeclaration,
+  interfaces: ReadonlyMap<string, TSInterfaceDeclaration>,
+  seen: ReadonlySet<string> = new Set(),
+): TSPropertySignature[] {
+  assert.equal(
+    seen.has(declaration.id.name),
+    false,
+    "state ownership inheritance must not form a cycle");
+  const nextSeen = new Set(seen).add(declaration.id.name);
+  const direct = declaration.body.body.filter(
     (member): member is TSPropertySignature => member.type === "TSPropertySignature");
+  const inherited = declaration.extends.flatMap(base => {
+    if (base.expression.type !== "Identifier") return [];
+    const inheritedDeclaration = interfaces.get(base.expression.name);
+    assert.ok(
+      inheritedDeclaration,
+      `${declaration.id.name} inherits unchecked state ${base.expression.name}`);
+    return stateProperties(inheritedDeclaration, interfaces, nextSeen);
+  });
+  return [...direct, ...inherited];
 }
 
 function isStatusVariant(type: TSTypeLiteral): boolean {
@@ -115,8 +157,9 @@ function stateUnionTypes(programs: readonly Program[]): ReadonlySet<string> {
 function lifecycleFields(
   declaration: TSInterfaceDeclaration,
   unionTypes: ReadonlySet<string>,
+  interfaces: ReadonlyMap<string, TSInterfaceDeclaration>,
 ): string[] {
-  return stateProperties(declaration)
+  return stateProperties(declaration, interfaces)
     .filter(property => {
       const annotation = property.typeAnnotation?.typeAnnotation;
       if (annotation?.type !== "TSTypeReference"
@@ -195,25 +238,134 @@ function mutableBindingNames(program: Program): string[] {
   });
 }
 
+function isNode(value: unknown): value is Node {
+  return typeof value === "object"
+    && value !== null
+    && typeof Reflect.get(value, "type") === "string";
+}
+
+function visit(node: Node, action: (candidate: Node) => void): void {
+  action(node);
+  for (const key of visitorKeys[node.type] ?? []) {
+    const child = Reflect.get(node, key) as unknown;
+    if (Array.isArray(child)) {
+      for (const candidate of child) {
+        if (isNode(candidate)) visit(candidate, action);
+      }
+    } else if (isNode(child)) {
+      visit(child, action);
+    }
+  }
+}
+
+function declaredFunctionBody(
+  program: Program,
+  name: string,
+): readonly Node[] {
+  const functions = program.body.flatMap(statement => {
+    const declaration = statement.type === "ExportNamedDeclaration"
+      ? statement.declaration
+      : statement;
+    return declaration?.type === "FunctionDeclaration"
+      && declaration.id?.name === name
+      ? [declaration]
+      : [];
+  });
+  assert.equal(functions.length, 1, `${name} must have exactly one declaration`);
+  const found = functions[0];
+  assert.ok(found);
+  return found.body?.body.filter(isNode) ?? [];
+}
+
+function bindingNames(
+  declaration: Extract<Node, { type: "VariableDeclaration" }>,
+): string[] {
+  return declaration.declarations.flatMap(binding =>
+    binding.id.type === "Identifier" ? [binding.id.name] : []);
+}
+
+function assignedRoot(node: Node): string | null {
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "TSAsExpression"
+    || node.type === "TSSatisfiesExpression"
+    || node.type === "TSTypeAssertion") {
+    return assignedRoot(node.expression);
+  }
+  if (node.type === "MemberExpression") {
+    return assignedRoot(node.object);
+  }
+  return null;
+}
+
+function writtenBindingNames(program: Program): ReadonlySet<string> {
+  const written = new Set<string>();
+  visit(program, node => {
+    const target = node.type === "AssignmentExpression"
+      ? node.left
+      : node.type === "UpdateExpression"
+        ? node.argument
+        : null;
+    if (!isNode(target)) return;
+    const root = assignedRoot(target);
+    if (root) written.add(root);
+  });
+  return written;
+}
+
+function coordinatorOwnedMutableBindings(
+  program: Program,
+  factoryName: string,
+): string[] {
+  const moduleBindings = program.body.flatMap(statement => {
+    const declaration = statement.type === "ExportNamedDeclaration"
+      ? statement.declaration
+      : statement;
+    return declaration?.type === "VariableDeclaration"
+      ? bindingNames(declaration)
+      : [];
+  });
+  const factoryBindings = declaredFunctionBody(program, factoryName)
+    .flatMap(statement =>
+      statement.type === "VariableDeclaration" ? bindingNames(statement) : []);
+  const written = writtenBindingNames(program);
+  return [...new Set([...moduleBindings, ...factoryBindings])]
+    .filter(name => written.has(name));
+}
+
 interface LifecycleOwner {
   file: string;
   name: string;
+  factoryName: string;
   program: Program;
   declaration: TSInterfaceDeclaration;
 }
 
 function lifecycleOwners(): LifecycleOwner[] {
   return [
-    ["package-inspection.ts", "PackageInspectionState"],
-    ["document-inspection.ts", "DocumentInspectionState"],
-    ["source-inspection.ts", "SourceInspectionState"],
-  ].map(([file, name]) => {
+    [
+      "package-inspection.ts",
+      "PackageInspectionState",
+      "createPackageInspectionCoordinator",
+    ],
+    [
+      "document-inspection.ts",
+      "DocumentInspectionState",
+      "createDocumentInspectionCoordinator",
+    ],
+    [
+      "source-inspection.ts",
+      "SourceInspectionState",
+      "createSourceInspectionCoordinator",
+    ],
+  ].map(([file, name, factoryName]) => {
     assert.ok(file);
     assert.ok(name);
+    assert.ok(factoryName);
     const program = parse(file);
     return {
       file,
       name,
+      factoryName,
       program,
       declaration: inspectionState(program, name),
     };
@@ -222,6 +374,10 @@ function lifecycleOwners(): LifecycleOwner[] {
 
 test("a request lifecycle union keeps exactly one state field", () => {
   const owners = lifecycleOwners();
+  const interfaces = interfaceRegistry([
+    ...owners.map(owner => owner.program),
+    parse("data.ts"),
+  ]);
   const rootProgram = parse("dotnet-inspect.ts");
   const rootDeclarations = objectDeclarations(rootProgram);
   const initialState = rootDeclarations.get("initialState");
@@ -229,7 +385,7 @@ test("a request lifecycle union keeps exactly one state field", () => {
 
   const unions = stateUnionTypes(owners.map(owner => owner.program));
   const converted = owners.flatMap(owner =>
-    lifecycleFields(owner.declaration, unions));
+    lifecycleFields(owner.declaration, unions, interfaces));
   assert.ok(
     converted.length > 0,
     "no converted state field was found, so the anchor has stopped resolving");
@@ -237,7 +393,7 @@ test("a request lifecycle union keeps exactly one state field", () => {
   const surfaces: readonly (readonly [string, readonly string[]])[] = [
     ...owners.map(owner => [
       owner.name,
-      stateProperties(owner.declaration)
+      stateProperties(owner.declaration, interfaces)
         .map(property => propertyName(property.key, property.computed)),
     ] as const),
     ["initialState", objectPropertyNames(initialState, rootDeclarations)],
@@ -259,17 +415,28 @@ test("a request lifecycle union keeps exactly one state field", () => {
       }
     }
   }
+  for (const owner of owners) {
+    for (const binding of coordinatorOwnedMutableBindings(
+      owner.program,
+      owner.factoryName)) {
+      survivors.push(`${owner.file} (coordinator ownership).${binding}`);
+    }
+  }
 
   assert.deepEqual(
     survivors.sort((left, right) => left.localeCompare(right)),
     [],
-    "a request lifecycle union also has a parallel state field. "
-    + "The union is the single source of truth for that request; a second field beside "
-    + "it -- a counter, a key, or a cached copy -- can disagree with it.");
+    "a request lifecycle union also has a parallel authority. "
+    + "Lifecycle-prefixed state and mutable coordinator-owned bindings can disagree "
+    + "with the declared union.");
 });
 
 test("the parallel-field gate sees every surface and lifecycle shape", () => {
   const owners = lifecycleOwners();
+  const interfaces = interfaceRegistry([
+    ...owners.map(owner => owner.program),
+    parse("data.ts"),
+  ]);
   const rootProgram = parse("dotnet-inspect.ts");
   const rootDeclarations = objectDeclarations(rootProgram);
   const initialState = rootDeclarations.get("initialState");
@@ -285,7 +452,7 @@ test("the parallel-field gate sees every surface and lifecycle shape", () => {
 
   const expected = ["packageOpportunities", "docViewer", "graphSource"];
   const converted = owners.flatMap(owner =>
-    lifecycleFields(owner.declaration, unions));
+    lifecycleFields(owner.declaration, unions, interfaces));
   for (const field of expected) {
     assert.ok(
       converted.includes(field),
@@ -294,4 +461,36 @@ test("the parallel-field gate sees every surface and lifecycle shape", () => {
       objectPropertyNames(initialState, rootDeclarations).includes(field),
       `initialState no longer exposes the ${field} lifecycle field`);
   }
+});
+
+test("the ownership gate sees inherited fields and externally mutable bindings", () => {
+  const program = parseSource("probe.ts", `
+    interface BaseState {
+      graphSourceEpoch: number;
+    }
+    interface SourceInspectionState extends BaseState {
+      graphSource: GraphSourceState;
+    }
+    const moduleEpoch = { value: 0 };
+    function createSourceInspectionCoordinator() {
+      let graphEpoch = 0;
+      moduleEpoch.value++;
+      graphEpoch++;
+      return {};
+    }
+  `);
+  const interfaces = interfaceRegistry([program]);
+  const state = inspectionState(program, "SourceInspectionState");
+
+  assert.ok(
+    stateProperties(state, interfaces)
+      .some(property => propertyName(property.key, property.computed)
+        === "graphSourceEpoch"),
+    "inherited state is inspected");
+  assert.deepEqual(
+    coordinatorOwnedMutableBindings(
+      program,
+      "createSourceInspectionCoordinator").sort(),
+    ["graphEpoch", "moduleEpoch"],
+    "written bindings outside coordinator state are inspected");
 });

--- a/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
+++ b/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
@@ -2,7 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { graphSourceStatuses, type GraphSourceStatus } from "../src/data.ts";
-import type { GraphSourceState } from "../src/source-inspection.ts";
+import {
+  graphSourceAutoLoad,
+  type GraphSourceState,
+} from "../src/source-inspection.ts";
+import type { BrowserSource } from "../src/inspect-web-engine.d.ts";
+
+function source(text: string): BrowserSource {
+  return {
+    provider: "pdb",
+    provenance: "SourceLink",
+    url: "https://example.test/source.cs",
+    pdbSourceLimitation: null,
+    text,
+  };
+}
 
 // `data.ts` owns the graph-source status vocabulary so that visibility and cancellation
 // can reason about the modal without depending on its request and payload types, while
@@ -50,4 +64,73 @@ test("the graph source union and its vocabulary describe the same statuses", () 
   assert.ok(
     graphSourceStatuses.includes("closed"),
     "a closed status the modal can return to");
+});
+
+// The auto-load decision, tested by outcome for every variant of the union.
+//
+// Round 2 review (GPT-5.6 Sol) defeated the source-text gate this replaces. That gate
+// isolated the auto-load branch and collected `state.graphSource.status === "..."`
+// comparisons, requiring the set to be exactly `["cancelled"]`. Writing the widening
+// Yoda-style -- `"failed" === state.graphSource.status` -- added `failed` to the branch
+// without adding a match, and the whole suite stayed green while a settled failure
+// rendered, was treated as reloadable, and started another request forever.
+//
+// A regex over one comparison spelling can only ever pin that spelling. Asking the
+// decision itself removes the spelling from the question.
+test("the graph modal auto-loads exactly the state that has no result coming", () => {
+  const request = {
+    packageId: "Contoso.Widgets",
+    version: "1.0.0",
+    framework: "net10.0",
+    assembly: "Contoso.Widgets.dll",
+    type: "Contoso.Widgets.Widget",
+    member: "Build",
+    selectorKey: "method:Build",
+    metadataToken: 100663297,
+  };
+  const title = "Widget.Build";
+
+  // One representative state per status, and the answer expected for it. `satisfies`
+  // rather than a type annotation so the members stay literal and a status that is not in
+  // the union is a compile error here, not a silently accepted extra row.
+  const decisions = {
+    closed: [{ status: "closed" }, false],
+    loading: [{ status: "loading", request, title }, false],
+    ready: [
+      { status: "ready", request, title, source: source("class Widget {}") },
+      false,
+    ],
+    failed: [{ status: "failed", request, title, error: "engine failed" }, false],
+    cancelled: [{ status: "cancelled", request, title }, true],
+  } satisfies Record<GraphSourceStatus, readonly [GraphSourceState, boolean]>;
+
+  // `satisfies Record<GraphSourceStatus, ...>` already makes a missing status a compile
+  // error, but only while every key is spelled statically. Assert the coverage at runtime
+  // too, so the table cannot be rebuilt dynamically and quietly shrink.
+  assert.deepEqual(
+    Object.keys(decisions).sort(),
+    [...graphSourceStatuses].sort(),
+    "auto-load decisions cover the graph-source vocabulary",
+  );
+
+  for (const [status, [state, expected]] of Object.entries(decisions)) {
+    const reload = graphSourceAutoLoad(state);
+    assert.equal(
+      reload !== null,
+      expected,
+      `graphSourceAutoLoad reloads ${status}`,
+    );
+    if (reload) {
+      // The reload has to carry the request the state belongs to. Returning the work
+      // rather than a boolean is what keeps the caller from picking its own.
+      assert.equal(reload.request, request, `${status} reloads its own request`);
+      assert.equal(reload.title, title, `${status} reloads its own title`);
+    }
+  }
+
+  // Non-vacuity: the table above is only evidence if at least one status answers each
+  // way. A table that said `false` everywhere would pass every assertion in the loop.
+  const answers = Object.values(decisions).map(([, expected]) => expected);
+  assert.ok(answers.includes(true), "some status auto-loads");
+  assert.ok(answers.includes(false), "some status does not auto-load");
 });

--- a/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
+++ b/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { graphSourceStatuses, type GraphSourceStatus } from "../src/data.ts";
+import {
+  graphSourceIsOpen,
+  graphSourceStatuses,
+  type GraphSourceStatus,
+} from "../src/data.ts";
 import {
   graphSourceAutoLoad,
   type GraphSourceState,
@@ -64,6 +68,25 @@ test("the graph source union and its vocabulary describe the same statuses", () 
   assert.ok(
     graphSourceStatuses.includes("closed"),
     "a closed status the modal can return to");
+});
+
+test("the graph modal is open for every status except closed", () => {
+  const decisions = {
+    closed: false,
+    loading: true,
+    ready: true,
+    failed: true,
+    cancelled: true,
+  } satisfies Record<GraphSourceStatus, boolean>;
+
+  assert.equal(graphSourceIsOpen(null), false);
+  assert.equal(graphSourceIsOpen(undefined), false);
+  for (const status of graphSourceStatuses) {
+    assert.equal(
+      graphSourceIsOpen({ status }),
+      decisions[status],
+      `graphSourceIsOpen handles ${status}`);
+  }
 });
 
 // The auto-load decision, tested by outcome for every variant of the union.

--- a/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
+++ b/prototypes/inspect-web/test/graph-source-vocabulary.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { graphSourceStatuses, type GraphSourceStatus } from "../src/data.ts";
+import type { GraphSourceState } from "../src/source-inspection.ts";
+
+// `data.ts` owns the graph-source status vocabulary so that visibility and cancellation
+// can reason about the modal without depending on its request and payload types, while
+// `source-inspection.ts` owns the full discriminated union built on those statuses. That
+// split is deliberate, and it means the two declarations can drift: the vocabulary could
+// gain a status the union never declares, or the union could gain one `graphSourceIsOpen`
+// has never heard of.
+//
+// The first version of this gate read the union out of the source with a regular
+// expression and compared the two lists. Adversarial review defeated it in one move: a
+// status added to the vocabulary, plus a comment placed where the regex stopped
+// capturing, and the gate passed while the two lists disagreed. Any gate that parses its
+// own source text has that failure mode, because the thing it actually checks is the
+// formatting.
+//
+// So let the compiler answer instead. Assigning each type to the other in turn is exactly
+// the claim "these two describe the same set of statuses", and it is not sensitive to
+// layout, comments, or declaration order.
+
+// `[A] extends [B]` rather than `A extends B`: the bare form distributes over a union and
+// collapses a partial match to `boolean`, which would accept `true` and make the gate
+// vacuous. The tuple wrapper compares the sets whole, so a mismatch is `false` and
+// assigning `true` to it is a compile error.
+type Covers<A, B> = [A] extends [B] ? true : false;
+
+// Every status the union declares is in the vocabulary. Adding a variant to
+// `GraphSourceState` without adding its status to `graphSourceStatuses` fails here.
+const unionStatusesAreInVocabulary: Covers<GraphSourceState["status"], GraphSourceStatus> =
+  true;
+
+// And every status in the vocabulary is one the union declares, so a status added to
+// `graphSourceStatuses` alone -- which is what review used to defeat the regex -- fails
+// here instead.
+const vocabularyStatusesAreInUnion: Covers<GraphSourceStatus, GraphSourceState["status"]> =
+  true;
+
+test("the graph source union and its vocabulary describe the same statuses", () => {
+  // The two declarations above are the gate and they run at compile time; `npm test`
+  // typechecks this project before executing it. This case exists so the file is not
+  // silently dropped from the suite, and so the vocabulary is also non-empty at runtime
+  // -- a compiler asked to compare two empty sets will happily agree.
+  assert.equal(unionStatusesAreInVocabulary, true);
+  assert.equal(vocabularyStatusesAreInUnion, true);
+  assert.ok(graphSourceStatuses.length > 0, "graph source statuses");
+  assert.ok(
+    graphSourceStatuses.includes("closed"),
+    "a closed status the modal can return to");
+});

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -1,7 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import test from "node:test";
-import { graphSourceStatuses } from "../src/data.ts";
 import {
   bindGraphSource,
   renderGraphSource,
@@ -225,31 +223,3 @@ test("markup carries the modal dialog scaffolding and close button", () => {
   assert.match(html, /<button id="graph-source-close" type="button" aria-label="Close">esc<\/button>/);
 });
 
-
-test("the graph source union declares exactly the vocabulary data.ts owns", () => {
-  // `data.ts` owns the status vocabulary so that visibility and cancellation can reason
-  // about the modal without depending on its request and payload types, and
-  // `source-inspection.ts` builds the full discriminated union on top of it. Nothing
-  // made those two agree: the vocabulary could gain a status the union never declares,
-  // or the union a status `graphSourceIsOpen` has never heard of.
-  //
-  // Derive the union's discriminants from the declaration and compare the sets, so a
-  // status added to either side fails until it is added to both.
-  const source = readFileSync(
-    new URL("../src/source-inspection.ts", import.meta.url),
-    "utf8");
-  // Capture to the next top-level declaration: the union's own members end in `;` too,
-  // so stopping at the first one would read only the `loading` variant.
-  const union = source.match(
-    /export type GraphSourceState =([\s\S]*?)\n\n(?=export |\/\/ )/);
-  const body = union?.[1];
-  assert.ok(body, "GraphSourceState declaration");
-  const declared = [...body.matchAll(/readonly status: "([a-z]+)"/g)]
-    .map(match => String(match[1]));
-
-  const byName = (left: string, right: string) => left.localeCompare(right);
-  assert.deepEqual(
-    declared.sort(byName),
-    [...graphSourceStatuses].sort(byName),
-    "graph source union statuses");
-});

--- a/prototypes/inspect-web/test/graph-source.test.ts
+++ b/prototypes/inspect-web/test/graph-source.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { graphSourceStatuses } from "../src/data.ts";
 import {
   bindGraphSource,
   renderGraphSource,
@@ -66,38 +68,45 @@ function highlightCSharp(value: unknown) {
   return `<mark>${escapeHtml(value)}</mark>`;
 }
 
-test("loading state shows a status scoped to the title, not stale source or error", () => {
+const request = {
+  packageId: "Widget",
+  version: "1.0.0",
+  framework: "net10.0",
+  assembly: "Widget.dll",
+  type: "Widget.Renderer",
+  member: "Render",
+  selectorKey: "Widget.Renderer.Render()",
+  metadataToken: 100663297,
+} as const;
+
+// The predecessor of this test passed a source and an error alongside `loading: true` to prove
+// the renderer ignored them. The union removes those fields from the loading variant, so that
+// input no longer type-checks and the stale-content case cannot be constructed. What remains to
+// assert is that the status is scoped to the request's own title.
+test("loading state shows a status scoped to the title", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: true,
-    source: {
-      provider: "pdb",
-      provenance: "unused while loading",
-      url: "",
-      pdbSourceLimitation: null,
-      text: "unused",
-    },
-    error: "unused while loading",
+    state: { status: "loading", request, title: "Widget.Render()" },
     escapeHtml,
     highlightCSharp,
   });
 
   assert.match(html, /graph-source-status">Resolving source for Widget\.Render\(\)…/);
-  assert.doesNotMatch(html, /unused/);
 });
 
 test("loaded PDB source renders provenance, an open-source link, and highlighted text", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: {
-      provider: "pdb",
-      provenance: "github.com/example/widget",
-      url: "https://github.com/example/widget/blob/main/Widget.cs",
-      pdbSourceLimitation: null,
-      text: "void Render() {}",
+    state: {
+      status: "ready",
+      request,
+      title: "Widget.Render()",
+      source: {
+        provider: "pdb",
+        provenance: "github.com/example/widget",
+        url: "https://github.com/example/widget/blob/main/Widget.cs",
+        pdbSourceLimitation: null,
+        text: "void Render() {}",
+      },
     },
-    error: "",
     escapeHtml,
     highlightCSharp,
   });
@@ -110,16 +119,18 @@ test("loaded PDB source renders provenance, an open-source link, and highlighted
 
 test("loaded decompiled source labels the provenance as decompiled and omits the link when url is null", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: {
-      provider: "decompiled",
-      provenance: "decompiled from IL",
-      url: null,
-      pdbSourceLimitation: "<checksum mismatch>",
-      text: "void Render() {}",
+    state: {
+      status: "ready",
+      request,
+      title: "Widget.Render()",
+      source: {
+        provider: "decompiled",
+        provenance: "decompiled from IL",
+        url: null,
+        pdbSourceLimitation: "<checksum mismatch>",
+        text: "void Render() {}",
+      },
     },
-    error: "",
     escapeHtml,
     highlightCSharp,
   });
@@ -129,12 +140,9 @@ test("loaded decompiled source labels the provenance as decompiled and omits the
   assert.match(html, /PDB source unavailable: &lt;checksum mismatch&gt;/);
 });
 
-test("error state without a source shows the error message, falling back to a default", () => {
+test("a failure with no message falls back to the default text", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: null,
-    error: "",
+    state: { status: "failed", request, title: "Widget.Render()", error: "" },
     escapeHtml,
     highlightCSharp,
   });
@@ -142,12 +150,29 @@ test("error state without a source shows the error message, falling back to a de
   assert.match(html, /graph-source-status error">No source was returned\.</);
 });
 
+// A competing member- or type-source request retires an in-flight graph load while its modal
+// stays open. The previous field layout expressed that as the absence of loading, result and
+// error all at once, which rendered the same default text; this pins that the named variant
+// still renders it, so naming the state did not change what a user sees.
+test("a cancelled load renders the same default text as an unexplained failure", () => {
+  const html = renderGraphSource({
+    state: { status: "cancelled", request, title: "Widget.Render()" },
+    escapeHtml,
+    highlightCSharp,
+  });
+
+  assert.match(html, /graph-source-status error">No source was returned\.</);
+  assert.match(html, /graph-source-title">Widget\.Render\(\)</);
+});
+
 test("error state with an explicit message renders that message escaped", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: null,
-    error: "<script>alert(1)</script>",
+    state: {
+      status: "failed",
+      request,
+      title: "Widget.Render()",
+      error: "<script>alert(1)</script>",
+    },
     escapeHtml,
     highlightCSharp,
   });
@@ -157,16 +182,18 @@ test("error state with an explicit message renders that message escaped", () => 
 
 test("provenance and url are escaped", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: {
-      provider: "pdb",
-      provenance: '<b>"evil"</b>',
-      url: 'https://example.com/"><script>alert(1)</script>',
-      pdbSourceLimitation: null,
-      text: "void Render() {}",
+    state: {
+      status: "ready",
+      request,
+      title: "Widget.Render()",
+      source: {
+        provider: "pdb",
+        provenance: '<b>"evil"</b>',
+        url: 'https://example.com/"><script>alert(1)</script>',
+        pdbSourceLimitation: null,
+        text: "void Render() {}",
+      },
     },
-    error: "",
     escapeHtml,
     highlightCSharp,
   });
@@ -177,10 +204,7 @@ test("provenance and url are escaped", () => {
 
 test("the title is escaped in both the header and the loading status", () => {
   const html = renderGraphSource({
-    title: "<b>Evil</b>",
-    loading: true,
-    source: null,
-    error: "",
+    state: { status: "loading", request, title: "<b>Evil</b>" },
     escapeHtml,
     highlightCSharp,
   });
@@ -191,10 +215,7 @@ test("the title is escaped in both the header and the loading status", () => {
 
 test("markup carries the modal dialog scaffolding and close button", () => {
   const html = renderGraphSource({
-    title: "Widget.Render()",
-    loading: false,
-    source: null,
-    error: "boom",
+    state: { status: "failed", request, title: "Widget.Render()", error: "boom" },
     escapeHtml,
     highlightCSharp,
   });
@@ -202,4 +223,33 @@ test("markup carries the modal dialog scaffolding and close button", () => {
   assert.match(html, /<div class="graph-source-backdrop" id="graph-source-backdrop">/);
   assert.match(html, /role="dialog" aria-modal="true" aria-label="Member source"/);
   assert.match(html, /<button id="graph-source-close" type="button" aria-label="Close">esc<\/button>/);
+});
+
+
+test("the graph source union declares exactly the vocabulary data.ts owns", () => {
+  // `data.ts` owns the status vocabulary so that visibility and cancellation can reason
+  // about the modal without depending on its request and payload types, and
+  // `source-inspection.ts` builds the full discriminated union on top of it. Nothing
+  // made those two agree: the vocabulary could gain a status the union never declares,
+  // or the union a status `graphSourceIsOpen` has never heard of.
+  //
+  // Derive the union's discriminants from the declaration and compare the sets, so a
+  // status added to either side fails until it is added to both.
+  const source = readFileSync(
+    new URL("../src/source-inspection.ts", import.meta.url),
+    "utf8");
+  // Capture to the next top-level declaration: the union's own members end in `;` too,
+  // so stopping at the first one would read only the `loading` variant.
+  const union = source.match(
+    /export type GraphSourceState =([\s\S]*?)\n\n(?=export |\/\/ )/);
+  const body = union?.[1];
+  assert.ok(body, "GraphSourceState declaration");
+  const declared = [...body.matchAll(/readonly status: "([a-z]+)"/g)]
+    .map(match => String(match[1]));
+
+  const byName = (left: string, right: string) => left.localeCompare(right);
+  assert.deepEqual(
+    declared.sort(byName),
+    [...graphSourceStatuses].sort(byName),
+    "graph source union statuses");
 });

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -117,6 +117,96 @@ test("hidden source work is cancelled through the shared engine boundary", () =>
   assert.equal(state.memberSourceLoading, true);
 });
 
+test("hiding an in-flight graph source preserves reloadable work", async () => {
+  const graphQuery = deferred<BrowserSource>();
+  let cancellations = 0;
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => graphQuery.promise,
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+  const request = {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  };
+
+  const load = coordinator.openGraphSource(request, "Example.Widget.Build");
+  state.settings = true;
+  coordinator.cancelHiddenRequest();
+
+  assert.equal(cancellations, 1);
+  assert.deepEqual(state.graphSource, {
+    status: "cancelled",
+    request,
+    title: "Example.Widget.Build",
+  });
+  assert.deepEqual(graphSourceAutoLoad(state.graphSource), {
+    request,
+    title: "Example.Widget.Build",
+  });
+
+  graphQuery.resolve(source("stale graph"));
+  await load;
+  assert.equal(state.graphSource.status, "cancelled");
+});
+
+test("competing source work preserves a cancelled graph request for reload", async () => {
+  const graphQuery = deferred<BrowserSource>();
+  const typeQuery = deferred<BrowserSource>();
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => graphQuery.promise,
+      queryTypeSource: async () => typeQuery.promise,
+    }));
+  const request = {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  };
+
+  const graphLoad = coordinator.openGraphSource(
+    request,
+    "Example.Widget.Build");
+  const typeLoad = coordinator.loadTypeSource({
+    signature: "type-signature",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    taste: "[]",
+    isVisible: () => true,
+  });
+
+  assert.deepEqual(state.graphSource, {
+    status: "cancelled",
+    request,
+    title: "Example.Widget.Build",
+  });
+  assert.deepEqual(graphSourceAutoLoad(state.graphSource), {
+    request,
+    title: "Example.Widget.Build",
+  });
+
+  graphQuery.resolve(source("stale graph"));
+  typeQuery.resolve(source("type"));
+  await Promise.all([graphLoad, typeLoad]);
+  assert.equal(state.graphSource.status, "cancelled");
+});
+
 test("member source publishes only for the current member selection", async () => {
   const query = deferred<BrowserSource>();
   const focusRenders: Array<string | null> = [];

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -82,10 +82,12 @@ function inspectionDependencies(
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>(accept => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((accept, fail) => {
     resolve = accept;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 test("hidden source work is cancelled through the shared engine boundary", () => {
@@ -303,5 +305,44 @@ test("current graph source failures settle as visible errors", async () => {
   assert.equal(
     state.graphSource.status === "failed" ? state.graphSource.error : null,
     "graph source unavailable");
+  assert.equal(renders, 2);
+});
+
+// Ownership has two sides and they are separate guards. The test above covers a stale
+// *resolve*; adversarial review pointed out that deleting the guard on the *reject* path
+// left the whole suite green, because nothing ever abandoned a request that was going to
+// fail. A failure is exactly as capable of arriving late as a success, and it is worse
+// when it does: it paints an error over a modal the user has already moved on from.
+test("an abandoned graph source failure cannot overwrite the closed modal", async () => {
+  const query = deferred<BrowserSource>();
+  let renders = 0;
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => query.promise,
+      render: () => renders++,
+    }));
+
+  const load = coordinator.openGraphSource({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  }, "Example.Widget.Build");
+
+  assert.equal(state.graphSource.status, "loading");
+  coordinator.closeGraphSource();
+  assert.deepEqual(state.graphSource, closedGraphSource);
+
+  query.reject(new Error("graph source unavailable"));
+  await load;
+
+  assert.deepEqual(state.graphSource, closedGraphSource);
+  // The owning request renders on start and the close renders once. A rejected request
+  // that no longer owns the modal returns before the settling render, so it adds none.
   assert.equal(renders, 2);
 });

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -346,3 +346,74 @@ test("an abandoned graph source failure cannot overwrite the closed modal", asyn
   // that no longer owns the modal returns before the settling render, so it adds none.
   assert.equal(renders, 2);
 });
+
+// This is the one place the slice is not behavior-preserving, and it is deliberate.
+//
+// The old auto-reload guard asked `!loading && !result && !error`, which an engine
+// rejection carrying an empty message satisfied exactly: `describeError` returns "" for
+// `new Error("")`, a thrown non-Error, or a thrown null. The modal therefore looked like
+// it had never been attempted, and since the auto-reload runs at the end of every
+// `render()`, it re-issued the request -- a render/reload/render loop with no bound.
+//
+// The union distinguishes the two states the old fields could not: a failure with no
+// message is `failed`, and only `cancelled` -- open, unsettled, nothing in flight -- is
+// the state the auto-reload is for. Adversarial review found this divergence; these two
+// tests pin both halves of it.
+test("an empty engine rejection settles as a failure, not as unattempted work", async () => {
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => {
+        throw new Error("");
+      },
+      describeError: (error: unknown) =>
+        error instanceof Error ? error.message : "",
+    }));
+
+  await coordinator.openGraphSource({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  }, "Example.Widget.Build");
+
+  // Not `cancelled`, which is what the auto-reload acts on. The modal settles and stays
+  // settled instead of re-requesting on every render.
+  assert.equal(state.graphSource.status, "failed");
+  assert.equal(
+    state.graphSource.status === "failed" ? state.graphSource.error : null,
+    "");
+});
+
+test("a missing source payload settles without dereferencing it", async () => {
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      // The engine type promises a source; the hand-written declaration is not a runtime
+      // guarantee, and the previous renderer guarded against exactly this.
+      // The declared return type forbids this value; producing it is the point.
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+      queryGraphSource: (async () => null) as unknown as
+        SourceInspectionDependencies["queryGraphSource"],
+    }));
+
+  await coordinator.openGraphSource({
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+  }, "Example.Widget.Build");
+
+  assert.equal(state.graphSource.status, "failed");
+  assert.equal(
+    state.graphSource.status === "failed" ? state.graphSource.error : null,
+    "");
+});

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   closedGraphSource,
   createSourceInspectionCoordinator,
+  graphSourceAutoLoad,
   type SourceInspectionDependencies,
   type SourceInspectionState,
 } from "../src/source-inspection.ts";
@@ -387,6 +388,16 @@ test("an empty engine rejection settles as a failure, not as unattempted work", 
   assert.equal(
     state.graphSource.status === "failed" ? state.graphSource.error : null,
     "");
+
+  // The disclosed lifecycle change, gated rather than only described. The predecessor
+  // left `loading=false`, `source=null`, `error=""` for a message-less rejection, and its
+  // auto-load predicate read that as work never attempted -- so it reissued on every
+  // render, forever. Settling as `failed` ends that loop, and this is the assertion that
+  // says so rather than a comment claiming it.
+  assert.equal(
+    graphSourceAutoLoad(state.graphSource),
+    null,
+    "an empty-message rejection settles instead of retrying on every render");
 });
 
 test("a missing source payload settles without dereferencing it", async () => {
@@ -416,4 +427,136 @@ test("a missing source payload settles without dereferencing it", async () => {
   assert.equal(
     state.graphSource.status === "failed" ? state.graphSource.error : null,
     "");
+
+  // The second route to the same divergence, and the one round 2 review measured:
+  // `oldWouldReload: true` against `currentWouldReload: false`. A falsy payload used to
+  // look identical to unattempted work, so it retried on every render too.
+  assert.equal(
+    graphSourceAutoLoad(state.graphSource),
+    null,
+    "a falsy payload settles instead of retrying on every render");
+});
+
+// A -> B -> A, on both settlement paths.
+//
+// Ownership of the graph modal is the identity of the pending state object, not the
+// identity of the request. Round 2 review (GPT-5.6 Sol) weakened both guards to compare
+// requests instead -- rejecting a late result only when a *different* request had taken
+// over -- and the whole suite stayed green, because nothing reopened the same request.
+// That is the exact shape a user produces by opening a member's graph, opening another,
+// and coming back: the first attempt's late result lands on the third attempt's modal.
+//
+// Two attempts at the same request are two different pieces of work, and the first one's
+// answer is stale even though it "matches". These tests say that by outcome, which makes
+// the source-text assertion about the guard's spelling unnecessary.
+function settle<T>(
+  queries: readonly ReturnType<typeof deferred<T>>[],
+  index: number,
+): ReturnType<typeof deferred<T>> {
+  const query = queries[index];
+  assert.ok(query, `no graph query was started at index ${index}`);
+  return query;
+}
+
+// Read the modal's payload without narrowing `state.graphSource` for the rest of the test:
+// a status assertion narrows the field permanently, and these tests assert on it more than
+// once as later attempts settle.
+function graphSourceText(graphSource: SourceInspectionState["graphSource"]): string | null {
+  return graphSource.status === "ready" ? graphSource.source.text : null;
+}
+
+function graphRequest(member: string) {
+  return {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member,
+    selectorKey: `method:${member}`,
+    metadataToken: 42,
+  };
+}
+
+test("a superseded graph request does not publish its result over a later attempt "
+  + "at the same request", async () => {
+  const queries: Array<ReturnType<typeof deferred<BrowserSource>>> = [];
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => {
+        const query = deferred<BrowserSource>();
+        queries.push(query);
+        return query.promise;
+      },
+    }));
+
+  // The same request object throughout, so a guard that compares requests sees a match
+  // on every resumption and a guard that compares pending states does not.
+  const a = graphRequest("Build");
+  const b = graphRequest("Dispose");
+
+  const firstA = coordinator.openGraphSource(a, "Widget.Build");
+  const openB = coordinator.openGraphSource(b, "Widget.Dispose");
+  const secondA = coordinator.openGraphSource(a, "Widget.Build");
+  assert.equal(state.graphSource.status, "loading");
+
+  // Settle each stage before starting the next, so "the first attempt resolves last" is a
+  // fact about the test rather than about microtask ordering.
+  settle(queries, 1).resolve(source("B source"));
+  await openB;
+  settle(queries, 2).resolve(source("second A source"));
+  await secondA;
+  assert.equal(
+    graphSourceText(state.graphSource),
+    "second A source",
+    "the attempt the user is waiting on publishes its own result");
+
+  // The first attempt's answer arrives long after the user moved away and came back.
+  settle(queries, 0).resolve(source("first A source"));
+  await firstA;
+
+  assert.equal(state.graphSource.status, "ready");
+  assert.equal(
+    graphSourceText(state.graphSource),
+    "second A source",
+    "a superseded attempt does not overwrite the attempt that replaced it");
+});
+
+test("a superseded graph request does not publish its rejection over a later attempt "
+  + "at the same request", async () => {
+  const queries: Array<ReturnType<typeof deferred<BrowserSource>>> = [];
+  const state = inspectionState();
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryGraphSource: async () => {
+        const query = deferred<BrowserSource>();
+        queries.push(query);
+        return query.promise;
+      },
+    }));
+
+  const a = graphRequest("Build");
+  const b = graphRequest("Dispose");
+
+  const firstA = coordinator.openGraphSource(a, "Widget.Build");
+  const openB = coordinator.openGraphSource(b, "Widget.Dispose");
+  const secondA = coordinator.openGraphSource(a, "Widget.Build");
+
+  settle(queries, 1).reject(new Error("B failed"));
+  settle(queries, 0).reject(new Error("first A failed"));
+  // Deliberately not awaiting `secondA`: the point of this test is what the modal shows
+  // while the third attempt is still in flight.
+  await Promise.all([firstA, openB]);
+
+  // The third attempt is still in flight. A stale rejection must not paint an error over
+  // it -- the user would see a failure for work that has not finished.
+  assert.equal(
+    state.graphSource.status,
+    "loading",
+    "a stale rejection does not settle the attempt still running");
+
+  settle(queries, 2).resolve(source("second A source"));
+  await secondA;
+  assert.equal(state.graphSource.status, "ready");
 });

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  closedGraphSource,
   createSourceInspectionCoordinator,
   type SourceInspectionDependencies,
   type SourceInspectionState,
@@ -41,7 +42,6 @@ function inspectionState(
     error: "",
     home: false,
     package: {},
-    graphSourceOpen: false,
     atPackageRoot: false,
     lens: "api",
     selectedMemberKey: "method:Build",
@@ -55,12 +55,7 @@ function inspectionState(
     typeSourceLoading: false,
     typeSourceError: "",
     typeSourceKey: "",
-    graphSource: null,
-    graphSourceLoading: false,
-    graphSourceError: "",
-    graphSourceTitle: "",
-    graphSourceRequest: null,
-    graphSourceSeq: 0,
+    graphSource: closedGraphSource,
     taste: [],
     ...overrides,
   };
@@ -260,20 +255,20 @@ test("closing graph source invalidates its result and cancels the engine", async
   };
 
   const load = coordinator.openGraphSource(request, "Example.Widget.Build");
-  assert.equal(state.graphSourceOpen, true);
-  assert.equal(state.graphSourceSeq, 1);
-  assert.deepEqual(state.graphSourceRequest, {
+  assert.deepEqual(state.graphSource, {
+    status: "loading",
     request,
     title: "Example.Widget.Build",
   });
   coordinator.closeGraphSource();
-  assert.equal(state.graphSourceSeq, 3);
+  // Closing is one assignment, not a flag clear plus a counter bump. The in-flight
+  // request loses ownership because `state.graphSource` no longer holds the object
+  // it captured, so the late resolve below cannot find its way back into state.
+  assert.deepEqual(state.graphSource, closedGraphSource);
   query.resolve(source("stale graph"));
   await load;
 
-  assert.equal(state.graphSourceOpen, false);
-  assert.equal(state.graphSource, null);
-  assert.equal(state.graphSourceRequest, null);
+  assert.deepEqual(state.graphSource, closedGraphSource);
   assert.deepEqual(events, [
     "render",
     "query:Build/[\"expression-bodied-members\"]",
@@ -304,7 +299,9 @@ test("current graph source failures settle as visible errors", async () => {
     metadataToken: 42,
   }, "Example.Widget.Build");
 
-  assert.equal(state.graphSourceError, "graph source unavailable");
-  assert.equal(state.graphSourceLoading, false);
+  assert.equal(state.graphSource.status, "failed");
+  assert.equal(
+    state.graphSource.status === "failed" ? state.graphSource.error : null,
+    "graph source unavailable");
   assert.equal(renders, 2);
 });

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -4994,3 +4994,51 @@ test("dependency graph rendering contains artifact labels", () => {
 // around it twice: with a suffix that was not on the list, and by moving the field into a
 // spread the source scan never read. The replacement names no suffixes -- it rejects any
 // state key that starts with a converted lens name and is not that lens.
+
+test("the graph source modal owns its request by identity, not a counter", () => {
+  // The modal's five parallel fields collapsed into one union, and the sequence number
+  // that decided whether a completion was still wanted collapsed with them: ownership is
+  // now the identity of the pending state object. Adversarial review pointed out that
+  // nothing enforced the second half of that. A `graphSourceSeq` could be reintroduced
+  // and actively incremented on both open and close with the suite still green, leaving
+  // two competing answers to "is this result still wanted?" -- which is the condition
+  // the union was meant to end.
+  //
+  // Derive the ownership requirement from the awaits rather than counting guards, so an
+  // await added without a guard fails here whatever the guard is named.
+  const openBody = sourceInspectionSource.match(
+    /async openGraphSource\(request, title\)[\s\S]*?\n {4}\},\n/)?.[0] ?? "";
+  assert.ok(openBody, "could not isolate the openGraphSource() body");
+
+  const resumptions = openBody.split("await ").slice(1);
+  assert.ok(
+    resumptions.length >= 1,
+    `expected the loader to await at least once, saw ${resumptions.length}`);
+  for (const [index, segment] of resumptions.entries()) {
+    const guard = segment.indexOf("state.graphSource !== pending");
+    const write = segment.indexOf("state.graphSource =");
+    assert.notEqual(
+      guard, -1,
+      `resumption ${index} after an await does not re-check request ownership`);
+    if (write !== -1)
+      assert.ok(
+        guard < write,
+        `resumption ${index} writes state.graphSource before re-checking ownership`);
+  }
+
+  // A rejection arrives just as late as a result, and painting an error over a modal the
+  // user has moved on from is worse than showing a stale success.
+  const catchBody = openBody.match(/\} catch \(error\) \{[\s\S]*?\n {6}\}/)?.[0] ?? "";
+  assert.match(catchBody, /state\.graphSource !== pending/);
+
+  // Ban the mechanism rather than one spelling of it. This is deliberately scoped to
+  // graph-source names: `sourceRequestGeneration` is the *shared* cancellation authority
+  // for member and type source requests, which this slice does not convert and which
+  // remains legitimate.
+  for (const { path, source } of productionTypeScriptSources) {
+    assert.doesNotMatch(
+      source,
+      /graphSource\w*(Seq|Sequence|Generation|Counter)/i,
+      `${String(path)} reintroduces a graph source counter`);
+  }
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1943,7 +1943,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /const unavailableWorkspaceContext = \(\) =>[\s\S]*!state\.home && \(state\.loading \|\| Boolean\(state\.error\)\)[\s\S]*unavailable-workspace\.contain-browser-shortcut[\s\S]*unavailable-workspace\.contain-filter-shortcut/);
   assert.match(
     appSource,
-    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*!isDocViewerOpen\(state\.docViewer\)[\s\S]*!state\.spotlightOpen/);
+    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!graphSourceIsOpen\(state\.graphSource\)[\s\S]*!isDocViewerOpen\(state\.docViewer\)[\s\S]*!state\.spotlightOpen/);
   assert.equal(
     keybindingRegistrySource.match(/addEventListener\("keydown"/g)?.length,
     1);
@@ -2510,7 +2510,7 @@ test("Type Source completion settles behind workbench overlays", () => {
     ?? "";
   assert.match(
     appSource,
-    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| isDocViewerOpen\(state\.docViewer\);/);
+    /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\)\s*\|\| state\.tasteOpen;[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| graphSourceIsOpen\(state\.graphSource\)\s*\|\| isDocViewerOpen\(state\.docViewer\);/);
   assert.match(
     appSource,
     /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*activeSourceOperationKind\(state\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);
@@ -2860,9 +2860,13 @@ test("source operations cancel when superseded or hidden", () => {
   assert.match(
     appSource,
     /createSourceInspectionCoordinator\(\{[\s\S]*cancelEngineSourceRequest: \(\) => cancelSourceInspection\?\.\(\)/);
+  // The graph-source canceller is a required parameter, not an optional one, so this
+  // pins that `cancelHiddenRequest` actually hands it over. Cancelling the member and
+  // type requests while leaving an in-flight graph source owning `state.graphSource`
+  // is exactly the partial cancellation the union was introduced to make impossible.
   assert.match(
     sourceInspectionSource,
-    /cancelHiddenRequest\(\)[\s\S]*sourceSurfaceIsVisible\(state\)[\s\S]*cancelSourceRequestState\(state\)/);
+    /cancelHiddenRequest\(\)[\s\S]*sourceSurfaceIsVisible\(state\)[\s\S]*cancelSourceRequestState\(state, cancelGraphSource\)/);
   assert.match(appSource, /sourceInspection\.loadMemberSource\(\{/);
   assert.match(appSource, /sourceInspection\.loadTypeSource\(\{/);
   assert.match(appSource, /sourceInspection\.openGraphSource\(request, title\)/);
@@ -2906,7 +2910,7 @@ test("source operations cancel when superseded or hidden", () => {
     home: false,
     package: {},
     atPackageRoot: false,
-    graphSourceOpen: false,
+    graphSource: { status: "closed" },
     lens: "source",
     selectedMemberKey: "",
     memberSection: "overview"
@@ -2927,7 +2931,7 @@ test("source operations cancel when superseded or hidden", () => {
     activeSourceOperationKind({
       ...visible,
       atPackageRoot: true,
-      graphSourceOpen: true
+      graphSource: { status: "ready" }
     }),
     "graph");
   assert.equal(
@@ -2976,17 +2980,27 @@ test("source operations cancel when superseded or hidden", () => {
     memberSourceError: "",
     typeSourceLoading: false,
     typeSourceKey: "",
-    typeSourceError: "",
-    graphSourceLoading: false,
-    graphSourceError: "",
-    graphSourceSeq: 0
+    typeSourceError: ""
   };
-  assert.equal(beginSourceRequestState(requestState), 5);
+
+  // The graph modal shares the engine's single source-request channel, so both entry
+  // points have to retire an in-flight graph load as well. The canceller is a required
+  // parameter for exactly that reason, and counting its calls is what proves neither
+  // path forgets it.
+  let cancellations = 0;
+  const cancelGraphSource = () => {
+    cancellations++;
+    return true;
+  };
+
+  assert.equal(beginSourceRequestState(requestState, cancelGraphSource), 5);
   assert.equal(requestState.memberSourceLoading, false);
   assert.equal(requestState.memberSourceKey, "");
+  assert.equal(cancellations, 1);
   requestState.typeSourceLoading = true;
   requestState.typeSourceKey = "type";
-  assert.equal(cancelSourceRequestState(requestState), true);
+  assert.equal(cancelSourceRequestState(requestState, cancelGraphSource), true);
+  assert.equal(cancellations, 2);
   assert.equal(requestState.sourceRequestGeneration, 6);
   assert.equal(requestState.typeSourceLoading, false);
   assert.equal(requestState.typeSourceKey, "");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -5004,8 +5004,15 @@ test("the graph source modal owns its request by identity, not a counter", () =>
   // two competing answers to "is this result still wanted?" -- which is the condition
   // the union was meant to end.
   //
-  // Derive the ownership requirement from the awaits rather than counting guards, so an
-  // await added without a guard fails here whatever the guard is named.
+  // The proof that ownership works is now behavioral: `test/source-inspection.test.ts`
+  // runs A -> B -> A on both the resolve and the reject path and fails if a superseded
+  // attempt publishes. Round 2 review showed why that was needed -- this scan checks that
+  // the guard's *text* is present and ordered, and review kept the text while gutting its
+  // meaning, so the suite stayed green through both races.
+  //
+  // What remains here is structural cover the outcome tests cannot give: it is derived
+  // from the awaits, so an await added later without a guard fails immediately, before
+  // anyone has written the scenario that would expose it.
   const openBody = sourceInspectionSource.match(
     /async openGraphSource\(request, title\)[\s\S]*?\n {4}\},\n/)?.[0] ?? "";
   assert.ok(openBody, "could not isolate the openGraphSource() body");
@@ -5031,36 +5038,15 @@ test("the graph source modal owns its request by identity, not a counter", () =>
   const catchBody = openBody.match(/\} catch \(error\) \{[\s\S]*?\n {6}\}/)?.[0] ?? "";
   assert.match(catchBody, /state\.graphSource !== pending/);
 
-  // Ban the mechanism rather than one spelling of it. This is deliberately scoped to
-  // graph-source names: `sourceRequestGeneration` is the *shared* cancellation authority
-  // for member and type source requests, which this slice does not convert and which
-  // remains legitimate.
-  for (const { path, source } of productionTypeScriptSources) {
-    assert.doesNotMatch(
-      source,
-      /graphSource\w*(Seq|Sequence|Generation|Counter)/i,
-      `${String(path)} reintroduces a graph source counter`);
-  }
+  // The counter ban that lived here listed the spellings `Seq`, `Sequence`, `Generation`,
+  // and `Counter`. Round 2 review walked past it with a live `graphSourceEpoch`. A
+  // vocabulary of suffixes bans only the suffixes someone thought of, so the ban now lives
+  // in `test/async-resource-state.test.ts`, derived from the lens's own name: any state
+  // field or mutable binding named after a converted lens is a second authority, whatever
+  // it is called.
 });
 
-test("the graph modal auto-reloads only the state that has no result coming", () => {
-  // The old guard asked `!loading && !result && !error`, and an engine rejection with an
-  // empty message satisfied all three -- so a settled failure looked like unattempted
-  // work and the auto-reload, which runs at the end of every render, re-issued it
-  // forever. `cancelled` is the state that condition was reaching for: open, unsettled,
-  // nothing in flight, nothing to show.
-  //
-  // Pin the branch to that one status. Widening it back to a payload-and-error test is
-  // how the retry loop comes back.
-  const branch = appSource.match(
-    /if \(kind === "graph"\) \{[\s\S]*?\n {4}\}/)?.[0] ?? "";
-  assert.ok(branch, "could not isolate the graph auto-reload branch");
-
-  // Check exclusivity, not presence. Asserting only that `cancelled` appears is defeated
-  // by widening the condition to `cancelled || failed`, which is most of the way back to
-  // the loop. So collect every status the branch tests and require it to be that one.
-  const tested = [...branch.matchAll(/state\.graphSource\.status === "([a-z]+)"/g)]
-    .map(match => match[1]);
-  assert.deepEqual(tested, ["cancelled"], "statuses the graph auto-reload acts on");
-  assert.doesNotMatch(branch, /sourceRequestNeedsLoad/);
-});
+// The graph auto-reload exclusivity gate that lived here read the auto-reload branch out
+// of the source and collected the statuses it compared against. Round 2 review walked past
+// it with a Yoda-style comparison. `test/graph-source-vocabulary.test.ts` now asks
+// `graphSourceAutoLoad` for its answer on every variant of the union instead.

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -5042,3 +5042,25 @@ test("the graph source modal owns its request by identity, not a counter", () =>
       `${String(path)} reintroduces a graph source counter`);
   }
 });
+
+test("the graph modal auto-reloads only the state that has no result coming", () => {
+  // The old guard asked `!loading && !result && !error`, and an engine rejection with an
+  // empty message satisfied all three -- so a settled failure looked like unattempted
+  // work and the auto-reload, which runs at the end of every render, re-issued it
+  // forever. `cancelled` is the state that condition was reaching for: open, unsettled,
+  // nothing in flight, nothing to show.
+  //
+  // Pin the branch to that one status. Widening it back to a payload-and-error test is
+  // how the retry loop comes back.
+  const branch = appSource.match(
+    /if \(kind === "graph"\) \{[\s\S]*?\n {4}\}/)?.[0] ?? "";
+  assert.ok(branch, "could not isolate the graph auto-reload branch");
+
+  // Check exclusivity, not presence. Asserting only that `cancelled` appears is defeated
+  // by widening the condition to `cancelled || failed`, which is most of the way back to
+  // the loop. So collect every status the branch tests and require it to be that one.
+  const tested = [...branch.matchAll(/state\.graphSource\.status === "([a-z]+)"/g)]
+    .map(match => match[1]);
+  assert.deepEqual(tested, ["cancelled"], "statuses the graph auto-reload acts on");
+  assert.doesNotMatch(branch, /sourceRequestNeedsLoad/);
+});

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -188,25 +188,76 @@ function containsTypeQuery(node: Node): boolean {
 // `GraphSourceStatus` is gated that way: its union carries per-variant payloads, so it
 // cannot be generated from the catalog, and the pair is what keeps the two in step.
 //
-// This discovers that mechanism rather than exempting a name. Both directions are
-// required, so a single-direction pair does not count, and if this discovery ever stops
-// matching, the vocabulary it was covering becomes uncovered and the assertion below
-// fails -- the safe direction for a decayed anchor.
+// This discovers that mechanism rather than exempting a name. Only live `const` declarations
+// that assign `true` to the result count: a comment or an unused alias does not make the
+// compiler enforce anything. Both directions are required, so a single-direction pair does
+// not count, and if this discovery ever stops matching, the vocabulary it was covering
+// becomes uncovered and the assertion below fails -- the safe direction for a decayed anchor.
+function coversEvidence(
+  file: string,
+  source: string,
+): { directions: Set<string>; names: Set<string> } {
+  const directions = new Set<string>();
+  const names = new Set<string>();
+  const parsed = parseSync(file, source);
+  assert.deepEqual(
+    parsed.errors,
+    [],
+    `${file} must parse before Covers<> declarations can be inspected`);
+
+  function visit(node: Node): void {
+    if (node.type === "VariableDeclaration" && node.kind === "const") {
+      for (const declaration of node.declarations) {
+        const annotation = declaration.id.type === "Identifier"
+          ? declaration.id.typeAnnotation?.typeAnnotation
+          : null;
+        if (annotation?.type !== "TSTypeReference"
+          || annotation.typeName.type !== "Identifier"
+          || annotation.typeName.name !== "Covers"
+          || annotation.typeArguments?.params.length !== 2
+          || declaration.init?.type !== "Literal"
+          || declaration.init.value !== true) {
+          continue;
+        }
+        const [fromType, toType] = annotation.typeArguments.params;
+        assert.ok(fromType);
+        assert.ok(toType);
+        const from = source.slice(fromType.start, fromType.end).replaceAll(/\s/g, "");
+        const to = source.slice(toType.start, toType.end).replaceAll(/\s/g, "");
+        directions.add(`${from}=>${to}`);
+        for (const side of [fromType, toType]) {
+          if (side.type === "TSTypeReference"
+            && side.typeName.type === "Identifier"
+            && side.typeArguments == null) {
+            names.add(side.typeName.name);
+          }
+        }
+      }
+    }
+    for (const key of visitorKeys[node.type] ?? []) {
+      const child = Reflect.get(node, key) as unknown;
+      if (Array.isArray(child)) {
+        for (const candidate of child) {
+          if (isNode(candidate)) visit(candidate);
+        }
+      } else if (isNode(child)) {
+        visit(child);
+      }
+    }
+  }
+  visit(parsed.program);
+  return { directions, names };
+}
+
 function typeLevelCoveredVocabularies(): Set<string> {
   const directions = new Set<string>();
   const names = new Set<string>();
   for (const entry of readdirSync(join(projectRoot, "test"), { withFileTypes: true })) {
     if (!entry.isFile() || !entry.name.endsWith(".test.ts")) continue;
     const source = readFileSync(join(entry.parentPath, entry.name), "utf8");
-    for (const match of source.matchAll(/Covers<\s*([^,]+?)\s*,\s*([^>]+?)\s*>/g)) {
-      const from = match[1]?.trim();
-      const to = match[2]?.trim();
-      if (!from || !to) continue;
-      directions.add(`${from}=>${to}`);
-      for (const side of [from, to]) {
-        if (/^[A-Za-z_$][\w$]*$/.test(side)) names.add(side);
-      }
-    }
+    const evidence = coversEvidence(entry.name, source);
+    for (const direction of evidence.directions) directions.add(direction);
+    for (const name of evidence.names) names.add(name);
   }
   const covered = new Set<string>();
   for (const name of names) {
@@ -218,6 +269,19 @@ function typeLevelCoveredVocabularies(): Set<string> {
   }
   return covered;
 }
+
+test("Covers discovery counts only compiler-enforced directions", () => {
+  const evidence = coversEvidence("probe.ts", `
+    type Covers<A, B> = [A] extends [B] ? true : false;
+    const enforced: Covers<Left, Right> = true;
+    // Covers<Right, Left>
+    export type Unenforced = Covers<Right, Left>;
+    let Mutable: Covers<Third, Fourth> = true;
+    const FalseAssertion: Covers<Fifth, Sixth> = false;
+  `);
+  assert.deepEqual([...evidence.directions], ["Left=>Right"]);
+  assert.deepEqual([...evidence.names].sort(), ["Left", "Right"]);
+});
 
 function catalogTypeAliases(program: Program): TSTypeAliasDeclaration[] {
   return program.body.flatMap(node => {

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -9,7 +9,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -174,6 +181,44 @@ function containsTypeQuery(node: Node): boolean {
   return false;
 }
 
+// A vocabulary can be closed by the compiler without going through `assertNever`. A
+// bidirectional `Covers<>` pair ties the vocabulary to a union declared elsewhere, so a
+// value added to *either* side fails to compile -- which is strictly stronger than a
+// widening case here, because the widening cases only catch additions to the catalog.
+// `GraphSourceStatus` is gated that way: its union carries per-variant payloads, so it
+// cannot be generated from the catalog, and the pair is what keeps the two in step.
+//
+// This discovers that mechanism rather than exempting a name. Both directions are
+// required, so a single-direction pair does not count, and if this discovery ever stops
+// matching, the vocabulary it was covering becomes uncovered and the assertion below
+// fails -- the safe direction for a decayed anchor.
+function typeLevelCoveredVocabularies(): Set<string> {
+  const directions = new Set<string>();
+  const names = new Set<string>();
+  for (const entry of readdirSync(join(projectRoot, "test"), { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".test.ts")) continue;
+    const source = readFileSync(join(entry.parentPath, entry.name), "utf8");
+    for (const match of source.matchAll(/Covers<\s*([^,]+?)\s*,\s*([^>]+?)\s*>/g)) {
+      const from = match[1]?.trim();
+      const to = match[2]?.trim();
+      if (!from || !to) continue;
+      directions.add(`${from}=>${to}`);
+      for (const side of [from, to]) {
+        if (/^[A-Za-z_$][\w$]*$/.test(side)) names.add(side);
+      }
+    }
+  }
+  const covered = new Set<string>();
+  for (const name of names) {
+    for (const direction of directions) {
+      const [from, to] = direction.split("=>");
+      if (to !== name || !from) continue;
+      if (directions.has(`${name}=>${from}`)) covered.add(name);
+    }
+  }
+  return covered;
+}
+
 function catalogTypeAliases(program: Program): TSTypeAliasDeclaration[] {
   return program.body.flatMap(node => {
     const declaration = node.type === "ExportNamedDeclaration"
@@ -200,14 +245,25 @@ test("every closed UI vocabulary is covered by this gate", () => {
   // derives an empty roster and passes.
   assert.deepEqual(
     [...declared].sort((a, b) => a.localeCompare(b)),
-    ["MemberSection", "PackageLens", "SpotlightScope", "TypeLens", "WorkspaceScope"],
+    [
+      "GraphSourceStatus",
+      "MemberSection",
+      "PackageLens",
+      "SpotlightScope",
+      "TypeLens",
+      "WorkspaceScope",
+    ],
     "the catalog-union anchor stopped matching the vocabularies it is meant to discover");
 
-  const covered = new Set<string>(widenings.map(widening => widening.vocabulary));
+  const covered = new Set<string>([
+    ...widenings.map(widening => widening.vocabulary),
+    ...typeLevelCoveredVocabularies(),
+  ]);
   assert.deepEqual(
     [...declared].filter(name => !covered.has(name)).sort((a, b) => a.localeCompare(b)),
     [],
-    "a closed vocabulary is declared in src/ but has no case in this gate");
+    "a closed vocabulary is declared in src/ but is gated by neither a widening case here "
+      + "nor a bidirectional Covers<> pair");
 });
 
 test("widening a UI vocabulary catalog fails compilation until every consumer handles it", () => {


### PR DESCRIPTION
The graph-source modal now carries one request-owned state union instead of five
independently-moving fields.

## What changed

`state.graphSourceOpen`, `graphSourceLoading`, `graphSourceError`, the source
payload, and `graphSourceSeq` become one `GraphSourceState` discriminated union.
Each open variant carries exactly the data that state has: `loading` has a
request and title, `ready` adds the source, `failed` adds the error, and
`cancelled` names the state a competing source request leaves behind — which
previously rendered by falling through to an empty error string, so this is the
same text with a name.

Ownership moves from the sequence number to the object. A load installs its
pending state and keeps the reference, then commits only if `state.graphSource`
is still that object. This is a typed replacement for the prior monotonic
sequence token, not a stronger race guarantee: both distinguish repeated
requests for one member and reject stale completions. The gain is that
ownership and visible lifecycle state are now one value.

## Evidence

- 637/637 tests, 178/178 focused state/source/vocabulary tests, `tsc --noEmit`
  for both projects, `npm run analyze` and the production build clean.
- The renderer takes `OpenGraphSourceState`, so a closed modal is not a state it
  can be asked to draw. Its switch terminates in `assertNever`.
- Bidirectional `Covers<>` declarations make the compiler prove that the union's
  discriminants and `graphSourceStatuses` describe the same set. The vocabulary
  roster discovers only live `const` assertions of those relationships through
  the TypeScript AST; comment and unevaluated-type spoofs are mutation-verified
  red.
- The structural gate pins `cancelSourceRequestState(state, cancelGraphSource)`,
  so the canceller is handed over rather than reconstructed, and the request-state
  test now counts cancellations to prove neither entry point forgets the graph
  channel.
- Coordinator outcomes drive both hidden-work and competing type-source
  cancellation into `cancelled`, require `graphSourceAutoLoad` to preserve the
  original request and title, and reject each request's late result.
- `graphSourceIsOpen` exhaustively handles all five status variants, with a
  vocabulary-derived truth table.
- The lifecycle ownership gate discovers both `AsyncResource<T>` fields and
  status-discriminated unions through the TypeScript AST. It covers inherited
  and direct coordinator state, root state, lifecycle-prefixed module bindings,
  and every written binding at a coordinator's module/factory boundary.
  Inherited fields, closure counters, and mutable module `const` objects are
  mutation-verified red. This is a bounded structural contract, not general
  name-independent dataflow analysis; the outcome tests own race behavior.

## Behavior boundary

Behavior-preserving except for the settled empty-error auto-reload fix described
below. The `cancelled` variant renders the same text the old empty-error
fall-through produced. No network, acquisition, or engine contract changes.

## Stack

Slice 6 of the #4570 stack, on top of #4589 (document viewer state). Enumerated
residual: the type- and member-source request fields in `data.ts`
(`typeSourceLoading`/`typeSourceKey`/`typeSourceError` and the member
equivalents) remain parallel-field state and are not converted here.

Part of #4569.


## One deliberate divergence

This slice is behavior-preserving with one stated exception, found by adversarial review.

The old auto-reload guard asked `!loading && !result && !error`. An engine rejection carrying an empty message satisfied all three — `describeError` returns `""` for `new Error("")`, for a thrown non-Error, and for a thrown `null` — so a settled failure was indistinguishable from unattempted work. Because `maybeAutoLoadVisibleSource()` runs at the end of every `render()`, that modal re-issued its request on every frame with nothing to bound it.

The union separates the two states those three fields could not, and only `cancelled` — open, unsettled, nothing in flight — now triggers a reload. A failure with no message settles as `failed` and renders "No source was returned."

Pinned by a vocabulary-derived outcome table that calls `graphSourceAutoLoad`
for every union variant and requires exactly `cancelled` to return preserved
work. The cancellation-producer outcomes additionally prove that real
transitions reach that reloadable state.

## Latest-main restack

Restacked onto #4589 head `0f45e253a`; current head is `b5ee11748`.
All seven slice commits map exactly in range-diff. The full suite, focused
state/source/vocabulary gate, analyzer, and production build are clean at this
head.
