### PR TITLE
Reuse matching package tabs for package queries

### DIFF
--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -161,7 +161,12 @@ import {
   typeMetadataSignature,
   typeSourceSignature,
 } from "./type-panel.ts";
-import { createPackageBar, type PackageBarPackage } from "./package-bar.ts";
+import {
+  createPackageBar,
+  findPackageTabForQuery,
+  type PackageBarPackage,
+  type ParsedPackageQuery,
+} from "./package-bar.ts";
 import {
   bindMetadataExplorer,
   cssEscape,
@@ -1164,8 +1169,7 @@ const packageBar = createPackageBar({
   closePackageTab,
   openRuntimePack: () =>
     observeAsync(openRuntimePackFromHome(), "Opening the .NET Platform"),
-  openPackage: (packageId, version) =>
-    observeAsync(loadPackage(packageId, version, ""), "Opening a package"),
+  openPackage: openPackageQuery,
   selectFramework: framework =>
     observeAsync(
       switchPackageFramework(framework),
@@ -5837,19 +5841,32 @@ function interstitialBotSrc(): string {
   return loadingBotSrc;
 }
 
-function openPackageFromError(packageId: string, version: string) {
+function openPackageQuery(query: ParsedPackageQuery) {
+  const packageTab = findPackageTabForQuery(state, query);
+  if (packageTab) {
+    state.loading = false;
+    state.error = "";
+    state.errorTitle = "";
+    state.errorDetail = "";
+    state.retryAction = null;
+    selectPackageTab(packageTab);
+    return;
+  }
+
   if (!state.engineReady) {
     const url = new URL("/", window.location.href);
-    url.searchParams.set("package", packageId);
-    url.searchParams.set("version", version);
+    url.searchParams.set("package", query.packageId);
+    url.searchParams.set("version", query.version);
     window.location.assign(url);
     return;
   }
-  observeAsync(loadPackage(packageId, version, ""), "Loading a package");
+  observeAsync(
+    loadPackage(query.packageId, query.version, ""),
+    "Loading a package");
 }
 
 const loadErrorShellActions: LoadErrorShellBindingActions = {
-  onOpenPackage: openPackageFromError,
+  onOpenPackage: openPackageQuery,
   onRetry: () =>
     observeAction(
       state.retryAction ?? bootstrap,

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -13,6 +13,7 @@ export interface PackageBarState {
 export interface ParsedPackageQuery {
   packageId: string;
   version: string;
+  explicitVersion: boolean;
 }
 
 interface PackageBarOptions {
@@ -23,7 +24,7 @@ interface PackageBarOptions {
   selectPackageTab: (pkg: PackageBarPackage) => void;
   closePackageTab: (packageKey: string) => void;
   openRuntimePack: () => void;
-  openPackage: (packageId: string, version: string) => void;
+  openPackage: (query: ParsedPackageQuery) => void;
   selectFramework: (framework: string) => void;
   selectVersion: (version: string) => void;
   showToast: (message: string) => void;
@@ -144,7 +145,25 @@ export function parsePackageQuery(value: string): ParsedPackageQuery | null {
 
   const packageId = separator > 0 ? trimmed.slice(0, separator) : trimmed;
   const version = separator > 0 ? trimmed.slice(separator + 1) : "latest";
-  return { packageId, version };
+  return { packageId, version, explicitVersion: separator > 0 };
+}
+
+export function findPackageTabForQuery(
+  state: PackageBarState,
+  query: ParsedPackageQuery,
+): PackageBarPackage | null {
+  const idMatches = state.packages.filter(item =>
+    !item.isRuntimePack
+    && item.id.toLowerCase() === query.packageId.toLowerCase());
+  const matches = query.explicitVersion
+    ? idMatches.filter(item =>
+      item.version.toLowerCase() === query.version.toLowerCase())
+    : idMatches;
+
+  if (state.package && matches.includes(state.package))
+    return state.package;
+  // Prefer the most recently retained matching tab when another package is active.
+  return matches.at(-1) ?? null;
 }
 
 export function createPackageBar(options: PackageBarOptions) {
@@ -220,7 +239,7 @@ export function createPackageBar(options: PackageBarOptions) {
         showToast("enter a package, optionally followed by @version");
         return;
       }
-      openPackage(parsed.packageId, parsed.version);
+      openPackage(parsed);
     });
   }
 

--- a/prototypes/inspect-web/src/shell-controls.ts
+++ b/prototypes/inspect-web/src/shell-controls.ts
@@ -1,4 +1,7 @@
-import { parsePackageQuery } from "./package-bar.ts";
+import {
+  parsePackageQuery,
+  type ParsedPackageQuery,
+} from "./package-bar.ts";
 
 export type HomeDemo = "stj" | "runtime" | "callgraph";
 
@@ -22,7 +25,7 @@ export interface HomeShellBindingActions {
 }
 
 export interface LoadErrorShellBindingActions {
-  onOpenPackage: (packageId: string, version: string) => void;
+  onOpenPackage: (query: ParsedPackageQuery) => void;
   onRetry: () => void;
 }
 
@@ -91,7 +94,7 @@ export function bindLoadErrorShell(
       const input =
         root.querySelector<HTMLInputElement>("#error-package-input");
       const parsed = parsePackageQuery(input?.value ?? "");
-      if (parsed) actions.onOpenPackage(parsed.packageId, parsed.version);
+      if (parsed) actions.onOpenPackage(parsed);
     });
   root.querySelector("#toggle-error-detail")
     ?.addEventListener("click", () => {

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   bindPackageSelections,
   createPackageBar,
+  findPackageTabForQuery,
   packageBarHtml,
   packageIdentityEquals,
   packageTabHtml,
@@ -10,7 +11,10 @@ import {
   parsePackageQuery,
   platformTabHtml,
 } from "../src/package-bar.ts";
-import type { PackageBarPackage } from "../src/package-bar.ts";
+import type {
+  PackageBarPackage,
+  ParsedPackageQuery,
+} from "../src/package-bar.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 function escapeHtml(value: unknown) {
@@ -47,7 +51,7 @@ class FakeElement {
 
   dispatch(type: string) {
     for (const listener of this.listeners.get(type) ?? []) {
-      listener(fakeDom.event({ target: this }));
+      listener(fakeDom.event({ target: this, preventDefault() {} }));
     }
   }
 }
@@ -244,10 +248,12 @@ test("parsing the open-package query accepts an id and an id@version, and reject
   assert.deepEqual(parsePackageQuery("System.Text.Json"), {
     packageId: "System.Text.Json",
     version: "latest",
+    explicitVersion: false,
   });
   assert.deepEqual(parsePackageQuery("System.Text.Json@8.0.0"), {
     packageId: "System.Text.Json",
     version: "8.0.0",
+    explicitVersion: true,
   });
   assert.equal(parsePackageQuery(""), null);
   assert.equal(parsePackageQuery("   "), null);
@@ -260,5 +266,86 @@ test("a leading '@' has no package id to reject, so it is preserved as the whole
   assert.deepEqual(parsePackageQuery("@1.0.0"), {
     packageId: "@1.0.0",
     version: "latest",
+    explicitVersion: false,
   });
+});
+
+test("a bare package query activates an already-open tab instead of loading another version", () => {
+  const older = pkg("System.Text.Json", "10.0.0");
+  const newer = pkg("System.Text.Json", "10.0.11");
+  const other = pkg("Newtonsoft.Json", "13.0.4");
+
+  assert.equal(findPackageTabForQuery(
+    { packages: [older, newer, other], package: older },
+    parsePackageQuery("system.text.json")!,
+  ), older);
+  assert.equal(findPackageTabForQuery(
+    { packages: [older, other], package: other },
+    parsePackageQuery("System.Text.Json")!,
+  ), older);
+  assert.equal(findPackageTabForQuery(
+    { packages: [older, newer, other], package: other },
+    parsePackageQuery("System.Text.Json")!,
+  ), newer);
+});
+
+test("an explicit package version activates only a matching open tab", () => {
+  const older = pkg("System.Text.Json", "10.0.0");
+  const newer = pkg("System.Text.Json", "10.0.11");
+  const state = { packages: [older, newer], package: newer };
+
+  assert.equal(findPackageTabForQuery(
+    state,
+    parsePackageQuery("System.Text.Json@10.0.0")!,
+  ), older);
+  assert.equal(findPackageTabForQuery(
+    state,
+    parsePackageQuery("System.Text.Json@9.0.0")!,
+  ), null);
+  assert.equal(findPackageTabForQuery(
+    {
+      packages: [pkg("Microsoft.NETCore.App", "10.0.0", "net10.0", true)],
+      package: null,
+    },
+    parsePackageQuery("Microsoft.NETCore.App@10.0.0")!,
+  ), null);
+});
+
+test("the package bar preserves whether the submitted version was explicit", () => {
+  const root = new FakeRoot();
+  const form = root.add("#package-query", new FakeElement());
+  const input = root.add("#package-query-input", new FakeElement());
+  const queries: ParsedPackageQuery[] = [];
+  const packageBar = createPackageBar({
+    state: { packages: [], package: null },
+    escapeHtml,
+    packageIdentityKey,
+    runtimePackPackage: () => null,
+    selectPackageTab: () => {},
+    closePackageTab: () => {},
+    openRuntimePack: () => {},
+    openPackage: query => queries.push(query),
+    selectFramework: () => {},
+    selectVersion: () => {},
+    showToast: () => {},
+  });
+  packageBar.bind(fakeDom.parentNode(root));
+
+  input.value = "System.Text.Json";
+  form.dispatch("submit");
+  input.value = "System.Text.Json@10.0.0";
+  form.dispatch("submit");
+
+  assert.deepEqual(queries, [
+    {
+      packageId: "System.Text.Json",
+      version: "latest",
+      explicitVersion: false,
+    },
+    {
+      packageId: "System.Text.Json",
+      version: "10.0.0",
+      explicitVersion: true,
+    },
+  ]);
 });

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -163,7 +163,8 @@ test("load error shell parses replacement packages and owns local detail state",
   const calls: string[] = [];
 
   bindLoadErrorShell(fakeDom.parentNode(root), {
-    onOpenPackage: (id, version) => calls.push(`open:${id}@${version}`),
+    onOpenPackage: query =>
+      calls.push(`open:${query.packageId}@${query.version}:${query.explicitVersion}`),
     onRetry: () => calls.push("retry"),
   });
 
@@ -183,8 +184,8 @@ test("load error shell parses replacement packages and owns local detail state",
   assert.equal(detail.hidden, true);
   assert.deepEqual(calls, [
     "retry",
-    "open:Example.Package@2.0.0",
-    "open:Latest.Package@latest",
+    "open:Example.Package@2.0.0:true",
+    "open:Latest.Package@latest:false",
   ]);
 });
 

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -675,7 +675,7 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
     /export function bindLoadErrorShell\([\s\S]*#retry-load[\s\S]*#error-package-query[\s\S]*#error-package-input[\s\S]*#toggle-error-detail[\s\S]*\.load-error-detail/);
   assert.match(
     shellControlsSource,
-    /import \{ parsePackageQuery \} from "\.\/package-bar\.ts"/);
+    /import \{\s*parsePackageQuery,\s*type ParsedPackageQuery,\s*\} from "\.\/package-bar\.ts"/);
   assert.equal(
     workspaceBinding.match(/\bbindWorkbenchShell\(\b/g)?.length,
     1);
@@ -702,7 +702,7 @@ test("typed shell controls own workbench, home, and load-error bindings", () => 
     /onDemo: runHomeDemo,\s*onDismissNotice: \(\) => \{[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*render\(\);\s*\},\n  onOpenCredits: openCredits,\n  onToggleTheme: toggleTheme/);
   assert.match(
     loadErrorActions,
-    /onOpenPackage: openPackageFromError,\s*onRetry: \(\) =>\s*observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
+    /onOpenPackage: openPackageQuery,\s*onRetry: \(\) =>\s*observeAction\(\s*state\.retryAction \?\? bootstrap,\s*"Retrying the inspection"\)/);
   assert.doesNotMatch(
     appSource,
     /\bquerySelector(?:All)?(?:<[^>]+>)?\("(?:#(?:share|dismiss-notice|retry-notice|dismiss-package-notice|nav-back|nav-forward|go-home|theme-toggle|help|home-theme|home-credits|retry-load|error-package-query|error-package-input|toggle-error-detail)|\[data-home-demo\]|\.load-error-detail)"\)/);
@@ -1684,7 +1684,7 @@ test("bare home paints before wasm engine download", () => {
   const homePaintWait =
     appSource.match(/function waitForHomePaint\(\)[\s\S]*?\n}\n\nfunction loadStoredTaste/)?.[0] ?? "";
   const errorPackageRecovery =
-    appSource.match(/function openPackageFromError[\s\S]*?\n}\n\nconst loadErrorShellActions/)?.[0] ?? "";
+    appSource.match(/function openPackageQuery[\s\S]*?\n}\n\nconst loadErrorShellActions/)?.[0] ?? "";
   const loadingView =
     appSource.match(/function renderLoading\(\)[\s\S]*?\n}\n\nasync function loadSelectedMemberDocumentation/)?.[0] ?? "";
   assert.doesNotMatch(appSource, /from "\/engine\.js"/);
@@ -1724,13 +1724,13 @@ test("bare home paints before wasm engine download", () => {
     /state\.retryAction = \(\) => window\.location\.reload\(\)/);
   assert.match(
     errorPackageRecovery,
-    /if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*observeAsync\(loadPackage\(packageId, version, ""\)/);
+    /findPackageTabForQuery\(state, query\)[\s\S]*selectPackageTab\(packageTab\);[\s\S]*return;[\s\S]*if \(!state\.engineReady\) \{[\s\S]*window\.location\.assign\(url\);[\s\S]*return;[\s\S]*\}\s*observeAsync\(\s*loadPackage\(query\.packageId, query\.version, ""\)/);
   assert.match(
     loadingView,
     /id="error-package-query"[\s\S]*bindLoadErrorShell\(document, loadErrorShellActions\)/);
   assert.doesNotMatch(
     loadingView,
-    /id="error-package-query"[\s\S]*(?:openPackageFromError|loadPackage)\(/);
+    /id="error-package-query"[\s\S]*(?:openPackageQuery|loadPackage)\(/);
 });
 
 test("Spotlight uses local type matches until the engine is ready", () => {


### PR DESCRIPTION
## Summary

- preserve whether package input used an explicit version
- activate an already-open matching package tab before resolving or loading another package
- apply the same behavior to the package bar and load-error recovery form

A bare package ID prefers the active matching tab, then the most recently retained matching version. An explicit `Package@version` query only reuses that version. Runtime-pack tabs remain separate from NuGet package matching.

## Validation

- `npm run analyze`
- `npm test` (487 passed)
- `npm run build`

## Non-action boundary

This prevents duplicate package tabs; it does not add Browser Platform workspace support, which remains owned by #4405.