### PR TITLE
Export product home demos through the browser engine

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -425,16 +425,20 @@ registry binding).
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
 package members as `--caller-package` for the call-graph demo. **inspect-web**
-home buttons use the same product demo ids/titles/summaries and package/type
-anchors (`prototypes/inspect-web/src/product-home-demos.ts`); STJ and platform
-restore via share deep links, while `extensions-callgraph` still runs the
-imperative multi-package member path. Residual: (1) minted facet ids replacing
-display-name allow list; (2) realize via `WorkspaceContextLoader` into one
-`AssemblyContextGroup` instead of CLI package/`--caller-package` encoding and
-the browser runtime-pack share encoding for platform; (3) replace the
-imperative call-graph web path with the same group-run substrate; (4) Call
-Graph / Callers structured JSON projection remains the shared member-pipeline
-gap (Markdown/Mermaid are the faithful graph formats today).
+loads home-demo catalog and coordinates from the product registry through the
+browser engine (`ListHomeDemos` / `ResolveHomeDemo` over
+`ProductInspectionDemos`); host-only share encoding and the residual platform
+→ `Microsoft.NETCore.App` runtime-pack mapping live in
+`prototypes/inspect-web/src/product-home-demos.ts`. STJ and platform restore
+via share deep links built from the resolved projection; member-bound Call
+Graph demos still run the imperative multi-package member path. Residual:
+(1) minted facet ids replacing display-name allow list; (2) realize via
+`WorkspaceContextLoader` into one `AssemblyContextGroup` instead of CLI
+package/`--caller-package` encoding and the browser runtime-pack share
+encoding for platform; (3) replace the imperative call-graph web path with
+the same group-run substrate; (4) Call Graph / Callers structured JSON
+projection remains the shared member-pipeline gap (Markdown/Mermaid are the
+faithful graph formats today).
 
 ### Member coordinates
 

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -1,0 +1,107 @@
+using System.Runtime.Versioning;
+using System.Text.Json;
+using DotnetInspector.Queries.Definitions;
+
+namespace InspectWeb.Engine.Tests;
+
+[SupportedOSPlatform("browser")]
+public sealed class BrowserProductHomeDemosTests
+{
+    [Fact]
+    public void ListHomeDemos_MatchesProductCatalogOrderAndLabels()
+    {
+        using var document = JsonDocument.Parse(InspectionEngine.ListHomeDemos());
+        var demos = document.RootElement.GetProperty("demos");
+        Assert.Equal(ProductInspectionDemos.Entries.Count, demos.GetArrayLength());
+        for (var i = 0; i < demos.GetArrayLength(); i++)
+        {
+            var expected = ProductInspectionDemos.Entries[i];
+            var actual = demos[i];
+            Assert.Equal(expected.Id, actual.GetProperty("id").GetString());
+            Assert.Equal(expected.Title, actual.GetProperty("title").GetString());
+            Assert.Equal(expected.Summary, actual.GetProperty("summary").GetString());
+        }
+    }
+
+    [Fact]
+    public void ResolveHomeDemo_UnknownId_ReturnsNotFound()
+    {
+        using var missing = JsonDocument.Parse(InspectionEngine.ResolveHomeDemo("not-a-demo"));
+        Assert.False(missing.RootElement.GetProperty("found").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, missing.RootElement.GetProperty("demo").ValueKind);
+
+        using var legacy = JsonDocument.Parse(InspectionEngine.ResolveHomeDemo("stj"));
+        Assert.False(legacy.RootElement.GetProperty("found").GetBoolean());
+    }
+
+    [Fact]
+    public void ResolveHomeDemo_StjSerializer_ProjectsPackageAndTypeView()
+    {
+        using var document = JsonDocument.Parse(
+            InspectionEngine.ResolveHomeDemo(ProductInspectionDemos.StjSerializerScenarioId));
+        var root = document.RootElement.GetProperty("demo");
+        Assert.True(document.RootElement.GetProperty("found").GetBoolean());
+        Assert.Equal(ProductInspectionDemos.StjSerializerScenarioId, root.GetProperty("id").GetString());
+        Assert.Equal("System.Text.Json", root.GetProperty("title").GetString());
+
+        var members = root.GetProperty("workspaceMembers");
+        Assert.Equal(1, members.GetArrayLength());
+        Assert.Equal("package", members[0].GetProperty("kind").GetString());
+        Assert.Equal("System.Text.Json", members[0].GetProperty("id").GetString());
+        Assert.Equal("10.0.0", members[0].GetProperty("version").GetString());
+        Assert.Equal("net10.0", members[0].GetProperty("framework").GetString());
+
+        Assert.Equal(0, root.GetProperty("focusTabIndex").GetInt32());
+        var view = root.GetProperty("view");
+        Assert.Equal("System.Text.Json.JsonSerializer", view.GetProperty("type").GetString());
+        Assert.Equal(ProductDemoSections.Methods, view.GetProperty("section").GetString());
+        Assert.Equal(JsonValueKind.Null, view.GetProperty("memberAnchor").ValueKind);
+    }
+
+    [Fact]
+    public void ResolveHomeDemo_ExtensionsCallGraph_ProjectsPackagesAndMemberAnchor()
+    {
+        using var document = JsonDocument.Parse(
+            InspectionEngine.ResolveHomeDemo(ProductInspectionDemos.ExtensionsCallGraphScenarioId));
+        var root = document.RootElement.GetProperty("demo");
+        var members = root.GetProperty("workspaceMembers");
+        Assert.Equal(3, members.GetArrayLength());
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.Abstractions",
+            members[0].GetProperty("id").GetString());
+        Assert.Equal("Microsoft.Extensions.Logging", members[1].GetProperty("id").GetString());
+        Assert.Equal("Microsoft.Extensions.Http", members[2].GetProperty("id").GetString());
+
+        Assert.Equal(0, root.GetProperty("focusTabIndex").GetInt32());
+        Assert.Equal("di", root.GetProperty("tabs")[0].GetProperty("id").GetString());
+
+        var view = root.GetProperty("view");
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
+            view.GetProperty("type").GetString());
+        Assert.Equal("74b6b4b321", view.GetProperty("memberAnchor").GetString());
+        Assert.Equal("method:TryAddEnumerable", view.GetProperty("memberKey").GetString());
+        Assert.Equal(ProductDemoSections.CallGraph, view.GetProperty("section").GetString());
+    }
+
+    [Fact]
+    public void ResolveHomeDemo_PlatformList_ProjectsUnversionedRuntimeAndListType()
+    {
+        using var document = JsonDocument.Parse(
+            InspectionEngine.ResolveHomeDemo(ProductInspectionDemos.PlatformListScenarioId));
+        var root = document.RootElement.GetProperty("demo");
+        var members = root.GetProperty("workspaceMembers");
+        Assert.Equal(2, members.GetArrayLength());
+        Assert.Equal("package", members[0].GetProperty("kind").GetString());
+        Assert.Equal("System.Text.Json", members[0].GetProperty("id").GetString());
+        Assert.Equal("platform", members[1].GetProperty("kind").GetString());
+        Assert.Equal("runtime", members[1].GetProperty("id").GetString());
+        Assert.Equal(JsonValueKind.Null, members[1].GetProperty("version").ValueKind);
+
+        Assert.Equal(1, root.GetProperty("focusTabIndex").GetInt32());
+        var view = root.GetProperty("view");
+        Assert.Equal("System.Private.CoreLib", view.GetProperty("library").GetString());
+        Assert.Equal("System.Collections.Generic.List`1", view.GetProperty("type").GetString());
+        Assert.Equal(ProductDemoSections.Methods, view.GetProperty("section").GetString());
+    }
+}

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -203,6 +203,64 @@ public sealed record BrowserVocabularyDocument(
     BrowserVocabularySection[] Sections);
 
 /// <summary>
+/// One product home-demo catalog row from <c>ProductInspectionDemos.Entries</c>.
+/// Browser-local so tsbindgen emits a real TypeScript interface.
+/// </summary>
+public sealed record BrowserHomeDemoCatalogEntry(
+    string Id,
+    string Title,
+    string Summary);
+
+/// <summary>Product home-demo catalog in display order.</summary>
+public sealed record BrowserHomeDemoCatalog(
+    BrowserHomeDemoCatalogEntry[] Demos);
+
+/// <summary>
+/// One workspace/navigation member coordinate projected for the browser.
+/// <see cref="Kind"/> is <c>package</c> or <c>platform</c>.
+/// </summary>
+public sealed record BrowserHomeDemoMember(
+    string Kind,
+    string Id,
+    string? Version,
+    string? Framework,
+    string? Assembly);
+
+/// <summary>One navigation tab from a resolved home demo.</summary>
+public sealed record BrowserHomeDemoNavigationTab(
+    string Id,
+    BrowserHomeDemoMember Member);
+
+/// <summary>View selectors from a resolved home demo.</summary>
+public sealed record BrowserHomeDemoView(
+    string? Library,
+    string? Type,
+    string? MemberAnchor,
+    string? MemberKey,
+    string? Section);
+
+/// <summary>
+/// Fully resolved product home demo: workspace members, navigation, and view.
+/// Hosts own share encoding and any residual platform pack mapping.
+/// </summary>
+public sealed record BrowserHomeDemoResolved(
+    string Id,
+    string Title,
+    string Summary,
+    BrowserHomeDemoMember[] WorkspaceMembers,
+    BrowserHomeDemoNavigationTab[] Tabs,
+    int FocusTabIndex,
+    BrowserHomeDemoView View);
+
+/// <summary>
+/// Result of resolving one home demo id. <see cref="Demo"/> is set only when
+/// <see cref="Found"/> is true (avoids a bare JSON null on the JSExport surface).
+/// </summary>
+public sealed record BrowserHomeDemoResolveResult(
+    bool Found,
+    BrowserHomeDemoResolved? Demo);
+
+/// <summary>
 /// One type's metadata projection, adapted from <c>ResearchViews.TypeProjectionResult</c> — the
 /// presentation-neutral seam the CLI consumes — so the browser never reimplements type-fact
 /// composition.
@@ -478,4 +536,7 @@ public sealed record BrowserWorkspacePackage(
 [JsonSerializable(typeof(BrowserTypeSearchHit[]))]
 [JsonSerializable(typeof(string[]))]
 [JsonSerializable(typeof(BrowserVocabularyDocument))]
+[JsonSerializable(typeof(BrowserHomeDemoCatalog))]
+[JsonSerializable(typeof(BrowserHomeDemoResolved))]
+[JsonSerializable(typeof(BrowserHomeDemoResolveResult))]
 internal sealed partial class BrowserJsonContext : JsonSerializerContext;

--- a/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
+++ b/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
@@ -1,0 +1,73 @@
+using DotnetInspector.Queries;
+using DotnetInspector.Queries.Definitions;
+
+namespace InspectWeb.Engine;
+
+/// <summary>
+/// Maps product-owned <see cref="ProductInspectionDemos"/> catalog and
+/// <see cref="ResolvedScenario"/> values to browser-local transport records so
+/// <c>tsbindgen</c> can generate real TypeScript interfaces (same reason as
+/// <see cref="BrowserVocabulary"/>).
+/// </summary>
+internal static class BrowserProductHomeDemos
+{
+    internal static BrowserHomeDemoCatalog ToCatalog(
+        IReadOnlyList<ProductInspectionDemos.Entry> entries) =>
+        new([.. entries.Select(static e => new BrowserHomeDemoCatalogEntry(
+            e.Id,
+            e.Title,
+            e.Summary))]);
+
+    internal static BrowserHomeDemoResolved ToResolved(ResolvedScenario scenario)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        var selected = scenario.SelectedContext
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' has no selected workspace context.");
+        var view = scenario.View
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' has no view.");
+        var navigation = scenario.Navigation
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' has no navigation.");
+
+        return new BrowserHomeDemoResolved(
+            scenario.ScenarioId,
+            scenario.Title ?? scenario.ScenarioId,
+            scenario.Description ?? "",
+            [.. selected.Members.Select(ToMember)],
+            [.. navigation.Tabs.Select(ToTab)],
+            navigation.FocusIndex,
+            new BrowserHomeDemoView(
+                view.Library,
+                view.Type,
+                view.MemberAnchor,
+                view.MemberKey,
+                view.Section));
+    }
+
+    private static BrowserHomeDemoNavigationTab ToTab(ResolvedNavigationTab tab) =>
+        new(tab.Id, ToMember(tab.Coordinate));
+
+    private static BrowserHomeDemoMember ToMember(WorkspaceMemberCoordinate coordinate) =>
+        coordinate switch
+        {
+            WorkspaceMemberCoordinate.PackageMember package =>
+                new BrowserHomeDemoMember(
+                    "package",
+                    package.PackageId,
+                    package.Version,
+                    package.Framework,
+                    Assembly: null),
+            WorkspaceMemberCoordinate.PlatformMember platform =>
+                new BrowserHomeDemoMember(
+                    "platform",
+                    platform.Family,
+                    platform.Version,
+                    platform.Framework,
+                    platform.Assembly),
+            _ => throw new InspectionDefinitionException(
+                $"Home demo export does not support coordinate kind '{coordinate.GetType().Name}'."),
+        };
+}

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
+using DotnetInspector.Queries.Definitions;
 using ILInspector.CallGraph;
 using ILInspector.Decompiler;
 using ILInspector.Metadata;
@@ -989,6 +990,33 @@ public static partial class InspectionEngine
                 DotnetInspector.Vocabulary.VocabularyJson.ToWireDocument(
                     DotnetInspector.Vocabulary.VocabularyCatalog.Document)),
             BrowserJsonContext.Default.BrowserVocabularyDocument);
+
+    // Home demos are product-owned closed presets. Catalog listing is metadata-only; resolve
+    // allocates one demo's definition graph. The browser builds share links / runners from the
+    // projected coordinates rather than a hand-maintained TypeScript twin.
+    [JSExport]
+    public static string ListHomeDemos() =>
+        JsonSerializer.Serialize(
+            BrowserProductHomeDemos.ToCatalog(ProductInspectionDemos.Entries),
+            BrowserJsonContext.Default.BrowserHomeDemoCatalog);
+
+    /// <summary>
+    /// Resolves one product home demo. <c>found</c> is false when the id is unknown.
+    /// </summary>
+    [JSExport]
+    public static string ResolveHomeDemo(string scenarioId)
+    {
+        if (!ProductInspectionDemos.TryResolveHomeScenario(scenarioId, out var resolved))
+        {
+            return JsonSerializer.Serialize(
+                new BrowserHomeDemoResolveResult(false, null),
+                BrowserJsonContext.Default.BrowserHomeDemoResolveResult);
+        }
+
+        return JsonSerializer.Serialize(
+            new BrowserHomeDemoResolveResult(true, BrowserProductHomeDemos.ToResolved(resolved)),
+            BrowserJsonContext.Default.BrowserHomeDemoResolveResult);
+    }
 
     /// <summary>
     /// Resolves one exact package/version/framework coordinate, reuses its workspace, and returns

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
@@ -11,6 +11,7 @@ let cancelSourceQueryExport;
 let configureHostExport;
 let expandPlatformCallGraphExport;
 let getPackageDocumentExport;
+let listHomeDemosExport;
 let listVocabularyExport;
 let loadRuntimePackExport;
 let loadRuntimePackAssemblyExport;
@@ -39,6 +40,7 @@ let queryPlatformPerformanceExport;
 let queryTypeMemberSourceExport;
 let queryTypeProjectionExport;
 let queryTypeSourceExport;
+let resolveHomeDemoExport;
 let resolvePackageDependencyVersionExport;
 let searchTypesExport;
 
@@ -52,6 +54,7 @@ export async function initializeEngine(onStatus = () => {}) {
   configureHostExport = exports.InspectionEngine.ConfigureHost;
   expandPlatformCallGraphExport = exports.InspectionEngine.ExpandPlatformCallGraph;
   getPackageDocumentExport = exports.InspectionEngine.GetPackageDocument;
+  listHomeDemosExport = exports.InspectionEngine.ListHomeDemos;
   listVocabularyExport = exports.InspectionEngine.ListVocabulary;
   loadRuntimePackExport = exports.InspectionEngine.LoadRuntimePack;
   loadRuntimePackAssemblyExport = exports.InspectionEngine.LoadRuntimePackAssembly;
@@ -80,6 +83,7 @@ export async function initializeEngine(onStatus = () => {}) {
   queryTypeMemberSourceExport = exports.InspectionEngine.QueryTypeMemberSource;
   queryTypeProjectionExport = exports.InspectionEngine.QueryTypeProjection;
   queryTypeSourceExport = exports.InspectionEngine.QueryTypeSource;
+  resolveHomeDemoExport = exports.InspectionEngine.ResolveHomeDemo;
   resolvePackageDependencyVersionExport = exports.InspectionEngine.ResolvePackageDependencyVersion;
   searchTypesExport = exports.InspectionEngine.SearchTypes;
   configureHostExport(window.location.origin);
@@ -111,6 +115,12 @@ export async function expandPlatformCallGraph(targetFramework, assembly, typeFul
 export async function getPackageDocument(packageId, version, path) {
   if (!getPackageDocumentExport) throw new Error("The browser inspection engine is not initialized.");
   const result = await getPackageDocumentExport(packageId, version, path);
+  return JSON.parse(result);
+}
+
+export function listHomeDemos() {
+  if (!listHomeDemosExport) throw new Error("The browser inspection engine is not initialized.");
+  const result = listHomeDemosExport();
   return JSON.parse(result);
 }
 
@@ -266,6 +276,12 @@ export async function queryTypeProjection(packageId, version, targetFramework, a
 export async function queryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
   if (!queryTypeSourceExport) throw new Error("The browser inspection engine is not initialized.");
   const result = await queryTypeSourceExport(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+  return JSON.parse(result);
+}
+
+export function resolveHomeDemo(scenarioId) {
+  if (!resolveHomeDemoExport) throw new Error("The browser inspection engine is not initialized.");
+  const result = resolveHomeDemoExport(scenarioId);
   return JSON.parse(result);
 }
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -89,7 +89,7 @@ import {
 } from "./shell-controls.ts";
 import {
   callGraphDemoRunnerSpec,
-  getProductHomeDemoCatalog,
+  homeDemoRowHtml,
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
   type ProductHomeDemoId,
@@ -5682,9 +5682,8 @@ function renderHomeView() {
           <p class="home-attribution">Built with .NET 11, WebAssembly, TypeScript 7, NuGet, and System.Reflection.Metadata. <a id="home-credits" href="/credits">Credits</a></p>
           <div class="home-demos">
             <span class="home-demos-label">Or jump straight into a demo</span>
-            <div class="home-demo-row">
-              ${getProductHomeDemoCatalog().map(entry =>
-                `<button class="home-demo" data-home-demo="${entry.id}" ${enginePending ? "disabled" : ""}><strong>${escapeHtml(entry.title)}</strong><small>${escapeHtml(entry.summary)}</small></button>`).join("")}
+            <div class="home-demo-row" aria-busy="${enginePending}">
+              ${homeDemoRowHtml(enginePending, escapeHtml)}
             </div>
           </div>
         </div>
@@ -7329,7 +7328,8 @@ async function runCallGraphDemo(demo: ProductHomeDemoResolved) {
     packages.push(loaded);
   }
 
-  const targetPackage = packages[0];
+  const targetPackage = packages.find(item => item.id === spec.focusPackageId)
+    ?? packages[0];
   activatePackage(targetPackage);
   const type = targetPackage.types.find(item => item.id === spec.typeId);
   const member = type && memberGroups(type).find(item =>

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -88,11 +88,12 @@ import {
   type WorkbenchShellBindingActions,
 } from "./shell-controls.ts";
 import {
-  EXTENSIONS_CALLGRAPH,
-  EXTENSIONS_CALLGRAPH_DEMO_ID,
-  PRODUCT_HOME_DEMO_CATALOG,
+  callGraphDemoRunnerSpec,
+  getProductHomeDemoCatalog,
   productHomeDemoLocationHref,
+  setProductHomeDemoCatalog,
   type ProductHomeDemoId,
+  type ProductHomeDemoResolved,
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,
@@ -238,6 +239,8 @@ let initializeEngine: EngineModule["initializeEngine"];
 let cancelSourceInspection: EngineModule["cancelSourceQuery"];
 let inspectExpandPlatformCallGraph: EngineModule["expandPlatformCallGraph"];
 let inspectVocabulary: EngineModule["listVocabulary"];
+let inspectListHomeDemos: EngineModule["listHomeDemos"];
+let inspectResolveHomeDemo: EngineModule["resolveHomeDemo"];
 let inspectLoadRuntimePack: EngineModule["loadRuntimePack"];
 let inspectLoadRuntimePackAssembly: EngineModule["loadRuntimePackAssembly"];
 let inspectMemberAnnotatedSource: EngineModule["queryMemberAnnotatedSource"];
@@ -277,7 +280,9 @@ async function loadEngineModule() {
     expandPlatformCallGraph: inspectExpandPlatformCallGraph,
     getPackageDocument: inspectPackageDocument,
     initializeEngine,
+    listHomeDemos: inspectListHomeDemos,
     listVocabulary: inspectVocabulary,
+    resolveHomeDemo: inspectResolveHomeDemo,
     loadRuntimePack: inspectLoadRuntimePack,
     loadRuntimePackAssembly: inspectLoadRuntimePackAssembly,
     matchPackageDependencyCoordinate,
@@ -5678,7 +5683,7 @@ function renderHomeView() {
           <div class="home-demos">
             <span class="home-demos-label">Or jump straight into a demo</span>
             <div class="home-demo-row">
-              ${PRODUCT_HOME_DEMO_CATALOG.map(entry =>
+              ${getProductHomeDemoCatalog().map(entry =>
                 `<button class="home-demo" data-home-demo="${entry.id}" ${enginePending ? "disabled" : ""}><strong>${escapeHtml(entry.title)}</strong><small>${escapeHtml(entry.summary)}</small></button>`).join("")}
             </div>
           </div>
@@ -5724,19 +5729,27 @@ function bindHomeEvents() {
     document.querySelector<HTMLInputElement>("#spotlight-input")?.focus());
 }
 
-// Home buttons use product demo ids (`ProductInspectionDemos` / CLI `demo <id>`).
-// STJ + platform restore via share deep links built from that registry projection;
-// extensions-callgraph stays an imperative multi-package member load (same packages
-// and TryAddEnumerable anchor as the product demo) until WorkspaceContextLoader
+// Home buttons use product demo ids from engine `listHomeDemos` / `resolveHomeDemo`
+// (`ProductInspectionDemos` / CLI `demo <id>`). STJ + platform restore via share
+// deep links built from the resolved projection; member-bound Call Graph demos
+// stay an imperative multi-package member load until WorkspaceContextLoader
 // group run is the browser substrate.
 function runHomeDemo(kind: ProductHomeDemoId) {
   state.home = false;
-  if (kind === EXTENSIONS_CALLGRAPH_DEMO_ID) {
-    observeAsync(runCallGraphDemo(), "Loading the call graph demo");
+  const resolveResult = inspectResolveHomeDemo(kind);
+  const resolved = resolveResult.found ? resolveResult.demo : null;
+  if (!resolved) {
+    state.error = `Unknown product home demo '${kind}'.`;
+    state.errorTitle = "Demo failed";
+    state.home = true;
+    render();
     return;
   }
-  const link = productHomeDemoLocationHref(kind);
-  if (!link) return;
+  const link = productHomeDemoLocationHref(resolved);
+  if (!link) {
+    observeAsync(runCallGraphDemo(resolved), "Loading the call graph demo");
+    return;
+  }
   workspaceLocation.push(link);
   const loc = parseLocation();
   observeAsync(restoreWorkspaceFromLocation(loc, loc), "Loading the demo workspace");
@@ -7292,58 +7305,43 @@ async function loadRuntimePackAssembly(
   };
 }
 
-async function runCallGraphDemo() {
+async function runCallGraphDemo(demo: ProductHomeDemoResolved) {
+  const retry = () => observeAsync(runCallGraphDemo(demo), "Loading the call graph demo");
   state.loading = true;
   state.error = "";
   state.loadingMessage = "Loading cross-package call graph demo…";
   state.loadingSubtitle = "";
   render();
 
-  const [targetSpec, loggingSpec, httpSpec] = EXTENSIONS_CALLGRAPH.packages;
-  const targetPackage = await loadPackage(
-    targetSpec.id,
-    targetSpec.version,
-    targetSpec.framework,
-    { retryAction: runCallGraphDemo });
-  if (!targetPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-  const loggingPackage = await loadPackage(
-    loggingSpec.id,
-    loggingSpec.version,
-    loggingSpec.framework,
-    { retryAction: runCallGraphDemo });
-  if (!loggingPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
-  }
-  const httpPackage = await loadPackage(
-    httpSpec.id,
-    httpSpec.version,
-    httpSpec.framework,
-    { retryAction: runCallGraphDemo });
-  if (!httpPackage) {
-    state.retryAction = runCallGraphDemo;
-    render();
-    return;
+  const spec = callGraphDemoRunnerSpec(demo);
+  const packages: AppPackage[] = [];
+  for (const packageSpec of spec.packages) {
+    const loaded = await loadPackage(
+      packageSpec.id,
+      packageSpec.version,
+      packageSpec.framework,
+      { retryAction: retry });
+    if (!loaded) {
+      state.retryAction = retry;
+      render();
+      return;
+    }
+    packages.push(loaded);
   }
 
+  const targetPackage = packages[0];
   activatePackage(targetPackage);
-  const type = targetPackage.types.find(item =>
-    item.id === EXTENSIONS_CALLGRAPH.typeId);
+  const type = targetPackage.types.find(item => item.id === spec.typeId);
   const member = type && memberGroups(type).find(item =>
-    item.name === EXTENSIONS_CALLGRAPH.memberName
-    && item.kind === EXTENSIONS_CALLGRAPH.memberKind);
+    item.name === spec.memberName
+    && item.kind === spec.memberKind);
   const overloadIndex = member?.overloads.findIndex(item =>
-    item.anchorDigest === EXTENSIONS_CALLGRAPH.memberAnchorDigest) ?? -1;
+    item.anchorDigest === spec.memberAnchorDigest) ?? -1;
   if (!type || !member || overloadIndex < 0) {
     state.loading = false;
     state.error = "The call graph demo member was not found in the selected package.";
     state.errorTitle = "Call graph demo failed";
-    state.retryAction = runCallGraphDemo;
+    state.retryAction = retry;
     render();
     return;
   }
@@ -7357,7 +7355,7 @@ async function runCallGraphDemo() {
   state.memberBrowseTypeId = type.id;
   state.selectedMemberKey = member.key;
   state.selectedOverloadIndex = overloadIndex;
-  state.memberSection = EXTENSIONS_CALLGRAPH.memberSection;
+  state.memberSection = spec.memberSection;
   state.loading = false;
   render();
   await loadSelectedMemberCallGraph();
@@ -7563,6 +7561,11 @@ async function bootstrap() {
       state.styleTiers = [];
       state.styleOptions = [];
       state.styleCatalogError = errorMessage(error);
+    }
+    try {
+      setProductHomeDemoCatalog(inspectListHomeDemos().demos ?? []);
+    } catch {
+      setProductHomeDemoCatalog([]);
     }
     state.engineReady = true;
     state.engineStatus = "";

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -120,6 +120,52 @@ export interface BrowserExceptionSurface {
   description: string;
 }
 
+export interface BrowserHomeDemoCatalog {
+  demos: BrowserHomeDemoCatalogEntry[];
+}
+
+export interface BrowserHomeDemoCatalogEntry {
+  id: string;
+  title: string;
+  summary: string;
+}
+
+export interface BrowserHomeDemoMember {
+  kind: string;
+  id: string;
+  version: string | null;
+  framework: string | null;
+  assembly: string | null;
+}
+
+export interface BrowserHomeDemoNavigationTab {
+  id: string;
+  member: BrowserHomeDemoMember;
+}
+
+export interface BrowserHomeDemoResolveResult {
+  found: boolean;
+  demo: BrowserHomeDemoResolved | null;
+}
+
+export interface BrowserHomeDemoResolved {
+  id: string;
+  title: string;
+  summary: string;
+  workspaceMembers: BrowserHomeDemoMember[];
+  tabs: BrowserHomeDemoNavigationTab[];
+  focusTabIndex: number;
+  view: BrowserHomeDemoView;
+}
+
+export interface BrowserHomeDemoView {
+  library: string | null;
+  type: string | null;
+  memberAnchor: string | null;
+  memberKey: string | null;
+  section: string | null;
+}
+
 export interface BrowserIntegrationCategory {
   integration: string;
   signals: BrowserIntegrationSignal[];
@@ -400,6 +446,7 @@ export declare function cancelSourceQuery(): void;
 export declare function configureHost(origin: string): void;
 export declare function expandPlatformCallGraph(targetFramework: string, assembly: string, typeFullName: string, memberName: string, selectorKey: string, metadataToken: number): Promise<string>;
 export declare function getPackageDocument(packageId: string, version: string, path: string): Promise<BrowserPackageDocumentContent>;
+export declare function listHomeDemos(): BrowserHomeDemoCatalog;
 export declare function listVocabulary(): BrowserVocabularyDocument;
 export declare function loadRuntimePack(targetFramework: string): Promise<string>;
 export declare function loadRuntimePackAssembly(targetFramework: string, assemblyFileName: string, pack: string): Promise<string>;
@@ -428,5 +475,6 @@ export declare function queryPlatformPerformance(targetFramework: string, assemb
 export declare function queryTypeMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
 export declare function queryTypeProjection(packageId: string, version: string, targetFramework: string, assemblyName: string, typeId: string): Promise<BrowserTypeMetadata>;
 export declare function queryTypeSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserSource>;
+export declare function resolveHomeDemo(scenarioId: string): BrowserHomeDemoResolveResult;
 export declare function resolvePackageDependencyVersion(packageId: string, declaredRange: string | null): Promise<string>;
 export declare function searchTypes(query: string, candidatesJson: string): BrowserTypeSearchHit[];

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -1,109 +1,58 @@
+import type {
+  BrowserHomeDemoCatalogEntry,
+  BrowserHomeDemoMember,
+  BrowserHomeDemoResolved,
+} from "./inspect-web-engine.d.ts";
 import {
   encodeWorkspaceShareState,
   type WorkspaceUrlState,
 } from "./workspace-navigation.ts";
 
 /**
- * Browser projection of `ProductInspectionDemos` (CLI `demo list` / `demo <id>`).
- * Ids, titles, summaries, package pins, and type/member anchors must stay aligned
- * with `src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs`.
+ * Browser host adapters over product home demos exported by the Wasm engine
+ * (`ListHomeDemos` / `ResolveHomeDemo` → `ProductInspectionDemos`).
  *
- * Acquisition substrate still differs for platform: product uses an unversioned
- * host `runtime` coordinate; inspect-web loads the resident Microsoft.NETCore.App
- * runtime pack until WorkspaceContextLoader platform groups land. Call-graph run
- * stays imperative (multi-package member section) rather than a share deep link.
+ * Catalog ids/titles/summaries and resolved coordinates come from C#. This
+ * module owns only host encoding: workspace share packets, the residual
+ * platform → Microsoft.NETCore.App runtime-pack mapping, product section →
+ * web member-section tokens, and the imperative call-graph runner inputs.
  */
 
-export const STJ_SERIALIZER_DEMO_ID = "stj-serializer";
-export const EXTENSIONS_CALLGRAPH_DEMO_ID = "extensions-callgraph";
-export const PLATFORM_LIST_DEMO_ID = "platform-list";
+export type ProductHomeDemoId = string;
 
-export type ProductHomeDemoId =
-  | typeof STJ_SERIALIZER_DEMO_ID
-  | typeof EXTENSIONS_CALLGRAPH_DEMO_ID
-  | typeof PLATFORM_LIST_DEMO_ID;
+export type ProductHomeDemoCatalogEntry = BrowserHomeDemoCatalogEntry;
 
-export interface ProductHomeDemoCatalogEntry {
-  id: ProductHomeDemoId;
-  title: string;
-  summary: string;
-}
+export type ProductHomeDemoResolved = BrowserHomeDemoResolved;
 
-/** Catalog order matches `ProductInspectionDemos.Entries`. */
-export const PRODUCT_HOME_DEMO_CATALOG: readonly ProductHomeDemoCatalogEntry[] = [
-  {
-    id: STJ_SERIALIZER_DEMO_ID,
-    title: "System.Text.Json",
-    summary: "Browse a real package API",
-  },
-  {
-    id: EXTENSIONS_CALLGRAPH_DEMO_ID,
-    title: "Cross-package call graph",
-    summary: "Trace calls across three packages",
-  },
-  {
-    id: PLATFORM_LIST_DEMO_ID,
-    title: ".NET Platform",
-    summary: "Inspect platform BCL types",
-  },
-];
-
-const PRODUCT_HOME_DEMO_ID_SET: ReadonlySet<string> = new Set(
-  PRODUCT_HOME_DEMO_CATALOG.map(entry => entry.id),
-);
-
-export function isProductHomeDemoId(value: string | undefined | null): value is ProductHomeDemoId {
-  return typeof value === "string" && PRODUCT_HOME_DEMO_ID_SET.has(value);
-}
-
-/** STJ package pin shared with `ProductInspectionDemos.CreateStjSerializerRecords`. */
-export const STJ_SERIALIZER_PACKAGE = {
-  id: "System.Text.Json",
-  version: "10.0.0",
-  framework: "net10.0",
-} as const;
-
-export const STJ_SERIALIZER_TYPE = "System.Text.Json.JsonSerializer";
-
-/**
- * Browser runtime-pack tab for the platform-list demo. Product CLI uses unversioned
- * host `runtime`; this is the inspect-web share encoding of that platform member.
- */
+/** Residual browser share encoding for product unversioned `runtime` platform. */
 export const PLATFORM_RUNTIME_PACK = {
   id: "Microsoft.NETCore.App",
   version: "10.0.10",
   framework: "net10.0",
 } as const;
 
-export const PLATFORM_LIST_LIBRARY = "System.Private.CoreLib";
-export const PLATFORM_LIST_TYPE = "System.Collections.Generic.List`1";
+let catalogEntries: readonly ProductHomeDemoCatalogEntry[] = [];
+const catalogIdSet = new Set<string>();
 
-/** Packages and member anchor for `extensions-callgraph` (product + web). */
-export const EXTENSIONS_CALLGRAPH = {
-  packages: [
-    {
-      id: "Microsoft.Extensions.DependencyInjection.Abstractions",
-      version: "10.0.0",
-      framework: "net10.0",
-    },
-    {
-      id: "Microsoft.Extensions.Logging",
-      version: "10.0.0",
-      framework: "net10.0",
-    },
-    {
-      id: "Microsoft.Extensions.Http",
-      version: "10.0.0",
-      framework: "net10.0",
-    },
-  ],
-  typeId:
-    "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
-  memberName: "TryAddEnumerable",
-  memberKind: "method",
-  memberAnchorDigest: "74b6b4b321",
-  memberSection: "call-graph",
-} as const;
+/** Installs the engine-exported catalog (call once after `listHomeDemos`). */
+export function setProductHomeDemoCatalog(
+  demos: readonly ProductHomeDemoCatalogEntry[],
+): void {
+  catalogEntries = demos.slice();
+  catalogIdSet.clear();
+  for (const entry of demos)
+    catalogIdSet.add(entry.id);
+}
+
+export function getProductHomeDemoCatalog(): readonly ProductHomeDemoCatalogEntry[] {
+  return catalogEntries;
+}
+
+export function isProductHomeDemoId(
+  value: string | undefined | null,
+): value is ProductHomeDemoId {
+  return typeof value === "string" && catalogIdSet.has(value);
+}
 
 function workspaceUrlState(partial: Partial<WorkspaceUrlState> & Pick<
   WorkspaceUrlState,
@@ -135,32 +84,93 @@ function locationHref(state: WorkspaceUrlState): string {
   return `?${params.toString()}`;
 }
 
-/** Deep-link for demos that restore via workspace location; null = imperative runner. */
-export function productHomeDemoLocationHref(id: ProductHomeDemoId): string | null {
-  switch (id) {
-    case STJ_SERIALIZER_DEMO_ID:
-      return locationHref(workspaceUrlState({
-        package: STJ_SERIALIZER_PACKAGE.id,
-        tabs: [{ ...STJ_SERIALIZER_PACKAGE }],
-        active: 0,
-        selectedTypeId: STJ_SERIALIZER_TYPE,
-      }));
-    case PLATFORM_LIST_DEMO_ID:
-      return locationHref(workspaceUrlState({
-        package: PLATFORM_RUNTIME_PACK.id,
-        tabs: [
-          { ...STJ_SERIALIZER_PACKAGE },
-          { ...PLATFORM_RUNTIME_PACK },
-        ],
-        active: 1,
-        library: PLATFORM_LIST_LIBRARY,
-        selectedTypeId: PLATFORM_LIST_TYPE,
-      }));
-    case EXTENSIONS_CALLGRAPH_DEMO_ID:
-      return null;
-    default: {
-      const _exhaustive: never = id;
-      return _exhaustive;
+function packageTab(member: BrowserHomeDemoMember): {
+  id: string;
+  version: string;
+  framework: string;
+} {
+  if (member.kind === "package") {
+    if (!member.version || !member.framework) {
+      throw new Error(
+        `Product home demo package '${member.id}' is missing version/framework pins.`);
     }
+    return {
+      id: member.id,
+      version: member.version,
+      framework: member.framework,
+    };
   }
+
+  if (member.kind === "platform" && member.id === "runtime") {
+    // Residual until WorkspaceContextLoader platform groups are the browser substrate.
+    return { ...PLATFORM_RUNTIME_PACK };
+  }
+
+  throw new Error(
+    `Product home demo member '${member.kind}:${member.id}' has no browser tab mapping.`);
+}
+
+/**
+ * Deep-link for demos that restore via workspace location.
+ * Returns null when the demo needs the imperative multi-package runner
+ * (member-bound Call Graph today).
+ */
+export function productHomeDemoLocationHref(
+  demo: ProductHomeDemoResolved,
+): string | null {
+  const section = demo.view.section;
+  if (section === "Call Graph" && demo.view.memberAnchor) {
+    return null;
+  }
+
+  const tabs = demo.tabs.map(tab => packageTab(tab.member));
+  if (tabs.length === 0) {
+    throw new Error(`Product home demo '${demo.id}' has no navigation tabs.`);
+  }
+
+  const active = Math.min(
+    Math.max(demo.focusTabIndex, 0),
+    tabs.length - 1);
+  const focusPackage = tabs[active].id;
+  return locationHref(workspaceUrlState({
+    package: focusPackage,
+    tabs,
+    active,
+    library: demo.view.library,
+    selectedTypeId: demo.view.type ?? "",
+  }));
+}
+
+/** Inputs for the residual imperative multi-package call-graph runner. */
+export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
+  packages: { id: string; version: string; framework: string }[];
+  typeId: string;
+  memberName: string;
+  memberKind: string;
+  memberAnchorDigest: string;
+  memberSection: "call-graph";
+} {
+  if (demo.view.section !== "Call Graph" || !demo.view.memberAnchor || !demo.view.type) {
+    throw new Error(
+      `Product home demo '${demo.id}' is not a member-bound Call Graph runner.`);
+  }
+
+  const packages = demo.workspaceMembers.map(packageTab);
+  const memberKey = demo.view.memberKey ?? "";
+  const colon = memberKey.indexOf(":");
+  const memberKind = colon >= 0 ? memberKey.slice(0, colon) : "method";
+  const memberName = colon >= 0 ? memberKey.slice(colon + 1) : memberKey;
+  if (!memberName) {
+    throw new Error(
+      `Product home demo '${demo.id}' Call Graph view is missing memberKey.`);
+  }
+
+  return {
+    packages,
+    typeId: demo.view.type,
+    memberName,
+    memberKind,
+    memberAnchorDigest: demo.view.memberAnchor,
+    memberSection: "call-graph",
+  };
 }

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -44,7 +44,7 @@ export function setProductHomeDemoCatalog(
     catalogIdSet.add(entry.id);
 }
 
-export function getProductHomeDemoCatalog(): readonly ProductHomeDemoCatalogEntry[] {
+function getProductHomeDemoCatalog(): readonly ProductHomeDemoCatalogEntry[] {
   return catalogEntries;
 }
 
@@ -102,6 +102,12 @@ function packageTab(member: BrowserHomeDemoMember): {
   }
 
   if (member.kind === "platform" && member.id === "runtime") {
+    // Residual only for the product unversioned `runtime` shape. Explicit pins
+    // are not silently rewritten to the browser runtime-pack defaults.
+    if (member.version || member.framework || member.assembly) {
+      throw new Error(
+        "Product home demo platform 'runtime' is pinned; browser residual maps only the unversioned shape.");
+    }
     // Residual until WorkspaceContextLoader platform groups are the browser substrate.
     return { ...PLATFORM_RUNTIME_PACK };
   }
@@ -144,6 +150,8 @@ export function productHomeDemoLocationHref(
 /** Inputs for the residual imperative multi-package call-graph runner. */
 export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
   packages: { id: string; version: string; framework: string }[];
+  /** Package id for the navigation focus tab (primary activation target). */
+  focusPackageId: string;
   typeId: string;
   memberName: string;
   memberKind: string;
@@ -156,6 +164,19 @@ export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
   }
 
   const packages = demo.workspaceMembers.map(packageTab);
+  if (packages.length === 0) {
+    throw new Error(`Product home demo '${demo.id}' has no workspace members.`);
+  }
+
+  const focusTabs = demo.tabs.map(tab => packageTab(tab.member));
+  if (focusTabs.length === 0) {
+    throw new Error(`Product home demo '${demo.id}' has no navigation tabs.`);
+  }
+  const focusIndex = Math.min(
+    Math.max(demo.focusTabIndex, 0),
+    focusTabs.length - 1);
+  const focusPackageId = focusTabs[focusIndex].id;
+
   const memberKey = demo.view.memberKey ?? "";
   const colon = memberKey.indexOf(":");
   const memberKind = colon >= 0 ? memberKey.slice(0, colon) : "method";
@@ -167,10 +188,31 @@ export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
 
   return {
     packages,
+    focusPackageId,
     typeId: demo.view.type,
     memberName,
     memberKind,
     memberAnchorDigest: demo.view.memberAnchor,
     memberSection: "call-graph",
   };
+}
+
+/**
+ * Pending home-row paint while the Wasm engine catalog is not yet installed.
+ * Layout-only placeholders — titles come from `ListHomeDemos` after bootstrap.
+ */
+export const HOME_DEMO_PENDING_SLOT_COUNT = 3;
+
+export function homeDemoRowHtml(
+  enginePending: boolean,
+  escapeHtml: (value: string) => string,
+): string {
+  const catalog = getProductHomeDemoCatalog();
+  if (catalog.length > 0) {
+    return catalog.map(entry =>
+      `<button class="home-demo" data-home-demo="${escapeHtml(entry.id)}" ${enginePending ? "disabled" : ""}><strong>${escapeHtml(entry.title)}</strong><small>${escapeHtml(entry.summary)}</small></button>`).join("");
+  }
+  if (!enginePending) return "";
+  return Array.from({ length: HOME_DEMO_PENDING_SLOT_COUNT }, () =>
+    `<button class="home-demo home-demo-pending" type="button" disabled aria-hidden="true"><strong>&nbsp;</strong><small>&nbsp;</small></button>`).join("");
 }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1791,6 +1791,19 @@ kbd {
   cursor: wait;
   transform: none;
 }
+.home-demo.home-demo-pending {
+  min-width: 11rem;
+  min-height: 3.4rem;
+  pointer-events: none;
+}
+.home-demo.home-demo-pending strong,
+.home-demo.home-demo-pending small {
+  display: block;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--muted) 28%, transparent);
+}
+.home-demo.home-demo-pending strong { min-height: 0.85rem; }
+.home-demo.home-demo-pending small { min-height: 0.7rem; margin-top: 4px; }
 .home-demo strong { font: 13px var(--mono); color: var(--text); }
 .home-demo small { color: var(--muted); font-size: 11px; }
 

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -1,20 +1,150 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import {
-  EXTENSIONS_CALLGRAPH,
-  EXTENSIONS_CALLGRAPH_DEMO_ID,
-  PLATFORM_LIST_DEMO_ID,
-  PLATFORM_LIST_LIBRARY,
-  PLATFORM_LIST_TYPE,
   PLATFORM_RUNTIME_PACK,
-  PRODUCT_HOME_DEMO_CATALOG,
-  STJ_SERIALIZER_DEMO_ID,
-  STJ_SERIALIZER_PACKAGE,
-  STJ_SERIALIZER_TYPE,
+  callGraphDemoRunnerSpec,
   isProductHomeDemoId,
   productHomeDemoLocationHref,
+  setProductHomeDemoCatalog,
 } from "../src/product-home-demos.ts";
 import { parseWorkspaceLocation } from "../src/workspace-navigation.ts";
+
+const stjResolved: BrowserHomeDemoResolved = {
+  id: "stj-serializer",
+  title: "System.Text.Json",
+  summary: "Browse a real package API",
+  workspaceMembers: [
+    {
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+  ],
+  tabs: [
+    {
+      id: "stj",
+      member: {
+        kind: "package",
+        id: "System.Text.Json",
+        version: "10.0.0",
+        framework: "net10.0",
+        assembly: null,
+      },
+    },
+  ],
+  focusTabIndex: 0,
+  view: {
+    library: null,
+    type: "System.Text.Json.JsonSerializer",
+    memberAnchor: null,
+    memberKey: null,
+    section: "Methods",
+  },
+};
+
+const platformResolved: BrowserHomeDemoResolved = {
+  id: "platform-list",
+  title: ".NET Platform",
+  summary: "Inspect platform BCL types",
+  workspaceMembers: [
+    {
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+    {
+      kind: "platform",
+      id: "runtime",
+      version: null,
+      framework: null,
+      assembly: null,
+    },
+  ],
+  tabs: [
+    {
+      id: "stj",
+      member: {
+        kind: "package",
+        id: "System.Text.Json",
+        version: "10.0.0",
+        framework: "net10.0",
+        assembly: null,
+      },
+    },
+    {
+      id: "runtime",
+      member: {
+        kind: "platform",
+        id: "runtime",
+        version: null,
+        framework: null,
+        assembly: null,
+      },
+    },
+  ],
+  focusTabIndex: 1,
+  view: {
+    library: "System.Private.CoreLib",
+    type: "System.Collections.Generic.List`1",
+    memberAnchor: null,
+    memberKey: null,
+    section: "Methods",
+  },
+};
+
+const callGraphResolved: BrowserHomeDemoResolved = {
+  id: "extensions-callgraph",
+  title: "Cross-package call graph",
+  summary: "Trace calls across three packages",
+  workspaceMembers: [
+    {
+      kind: "package",
+      id: "Microsoft.Extensions.DependencyInjection.Abstractions",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+    {
+      kind: "package",
+      id: "Microsoft.Extensions.Logging",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+    {
+      kind: "package",
+      id: "Microsoft.Extensions.Http",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+  ],
+  tabs: [
+    {
+      id: "di",
+      member: {
+        kind: "package",
+        id: "Microsoft.Extensions.DependencyInjection.Abstractions",
+        version: "10.0.0",
+        framework: "net10.0",
+        assembly: null,
+      },
+    },
+  ],
+  focusTabIndex: 0,
+  view: {
+    library: null,
+    type: "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
+    memberAnchor: "74b6b4b321",
+    memberKey: "method:TryAddEnumerable",
+    section: "Call Graph",
+  },
+};
 
 function parseDemoHref(href: string) {
   const url = new URL(href, "https://inspect.local/");
@@ -29,26 +159,12 @@ function parseDemoHref(href: string) {
   };
 }
 
-test("product home catalog uses ProductInspectionDemos ids and labels", () => {
-  assert.deepEqual(
-    PRODUCT_HOME_DEMO_CATALOG.map(entry => entry.id),
-    [STJ_SERIALIZER_DEMO_ID, EXTENSIONS_CALLGRAPH_DEMO_ID, PLATFORM_LIST_DEMO_ID],
-  );
-  assert.equal(
-    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === STJ_SERIALIZER_DEMO_ID)?.title,
-    "System.Text.Json",
-  );
-  assert.equal(
-    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === EXTENSIONS_CALLGRAPH_DEMO_ID)?.summary,
-    "Trace calls across three packages",
-  );
-  assert.equal(
-    PRODUCT_HOME_DEMO_CATALOG.find(e => e.id === PLATFORM_LIST_DEMO_ID)?.title,
-    ".NET Platform",
-  );
-});
-
-test("isProductHomeDemoId accepts only product ids", () => {
+test("isProductHomeDemoId uses the installed engine catalog", () => {
+  setProductHomeDemoCatalog([
+    { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
+    { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
+    { id: "platform-list", title: ".NET Platform", summary: "Inspect platform BCL types" },
+  ]);
   assert.equal(isProductHomeDemoId("stj-serializer"), true);
   assert.equal(isProductHomeDemoId("platform-list"), true);
   assert.equal(isProductHomeDemoId("extensions-callgraph"), true);
@@ -60,38 +176,49 @@ test("isProductHomeDemoId accepts only product ids", () => {
 });
 
 test("stj-serializer deep link selects JsonSerializer on STJ 10.0.0", () => {
-  const href = productHomeDemoLocationHref(STJ_SERIALIZER_DEMO_ID);
+  const href = productHomeDemoLocationHref(stjResolved);
   assert.ok(href);
   const { url, location } = parseDemoHref(href);
-  assert.equal(url.searchParams.get("package"), STJ_SERIALIZER_PACKAGE.id);
-  assert.deepEqual(location.tabs, [{ ...STJ_SERIALIZER_PACKAGE }]);
+  assert.equal(url.searchParams.get("package"), "System.Text.Json");
+  assert.deepEqual(location.tabs, [{
+    id: "System.Text.Json",
+    version: "10.0.0",
+    framework: "net10.0",
+  }]);
   assert.equal(location.active, 0);
-  assert.equal(location.type, STJ_SERIALIZER_TYPE);
-  assert.equal(location.package, STJ_SERIALIZER_PACKAGE.id);
+  assert.equal(location.type, "System.Text.Json.JsonSerializer");
+  assert.equal(location.package, "System.Text.Json");
 });
 
-test("platform-list deep link focuses CoreLib List`1 on runtime pack", () => {
-  const href = productHomeDemoLocationHref(PLATFORM_LIST_DEMO_ID);
+test("platform-list deep link focuses CoreLib List`1 on residual runtime pack", () => {
+  const href = productHomeDemoLocationHref(platformResolved);
   assert.ok(href);
   const { url, location } = parseDemoHref(href);
   assert.equal(url.searchParams.get("package"), PLATFORM_RUNTIME_PACK.id);
   assert.deepEqual(location.tabs, [
-    { ...STJ_SERIALIZER_PACKAGE },
+    {
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+    },
     { ...PLATFORM_RUNTIME_PACK },
   ]);
   assert.equal(location.active, 1);
-  assert.equal(location.library, PLATFORM_LIST_LIBRARY);
-  assert.equal(location.type, PLATFORM_LIST_TYPE);
+  assert.equal(location.library, "System.Private.CoreLib");
+  assert.equal(location.type, "System.Collections.Generic.List`1");
   assert.equal(location.package, PLATFORM_RUNTIME_PACK.id);
 });
 
-test("extensions-callgraph has no deep link and keeps product packages/anchor", () => {
-  assert.equal(productHomeDemoLocationHref(EXTENSIONS_CALLGRAPH_DEMO_ID), null);
-  assert.equal(EXTENSIONS_CALLGRAPH.packages.length, 3);
-  assert.equal(EXTENSIONS_CALLGRAPH.memberAnchorDigest, "74b6b4b321");
-  assert.equal(EXTENSIONS_CALLGRAPH.memberSection, "call-graph");
+test("extensions-callgraph has no deep link and runner spec keeps product pins", () => {
+  assert.equal(productHomeDemoLocationHref(callGraphResolved), null);
+  const spec = callGraphDemoRunnerSpec(callGraphResolved);
+  assert.equal(spec.packages.length, 3);
+  assert.equal(spec.memberAnchorDigest, "74b6b4b321");
+  assert.equal(spec.memberSection, "call-graph");
+  assert.equal(spec.memberKind, "method");
+  assert.equal(spec.memberName, "TryAddEnumerable");
   assert.equal(
-    EXTENSIONS_CALLGRAPH.packages[0].id,
+    spec.packages[0].id,
     "Microsoft.Extensions.DependencyInjection.Abstractions",
   );
 });

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import {
+  HOME_DEMO_PENDING_SLOT_COUNT,
   PLATFORM_RUNTIME_PACK,
   callGraphDemoRunnerSpec,
+  homeDemoRowHtml,
   isProductHomeDemoId,
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
@@ -221,4 +223,80 @@ test("extensions-callgraph has no deep link and runner spec keeps product pins",
     spec.packages[0].id,
     "Microsoft.Extensions.DependencyInjection.Abstractions",
   );
+  assert.equal(
+    spec.focusPackageId,
+    "Microsoft.Extensions.DependencyInjection.Abstractions",
+  );
+});
+
+test("call-graph runner focus follows navigation focusTabIndex", () => {
+  const reordered: BrowserHomeDemoResolved = {
+    ...callGraphResolved,
+    workspaceMembers: [
+      callGraphResolved.workspaceMembers[1],
+      callGraphResolved.workspaceMembers[0],
+      callGraphResolved.workspaceMembers[2],
+    ],
+    tabs: [
+      {
+        id: "logging",
+        member: callGraphResolved.workspaceMembers[1],
+      },
+      {
+        id: "di",
+        member: callGraphResolved.workspaceMembers[0],
+      },
+    ],
+    focusTabIndex: 1,
+  };
+  const spec = callGraphDemoRunnerSpec(reordered);
+  assert.equal(spec.packages[0].id, "Microsoft.Extensions.Logging");
+  assert.equal(
+    spec.focusPackageId,
+    "Microsoft.Extensions.DependencyInjection.Abstractions",
+  );
+});
+
+test("platform residual rejects pinned runtime coordinates", () => {
+  const pinned = {
+    ...platformResolved,
+    tabs: [
+      platformResolved.tabs[0],
+      {
+        id: "runtime",
+        member: {
+          kind: "platform" as const,
+          id: "runtime",
+          version: "11.0.0",
+          framework: "net11.0",
+          assembly: "System.Private.CoreLib",
+        },
+      },
+    ],
+  };
+  assert.throws(
+    () => productHomeDemoLocationHref(pinned),
+    /unversioned shape/,
+  );
+});
+
+test("home demo row keeps pending slots before the engine catalog installs", () => {
+  setProductHomeDemoCatalog([]);
+  const pending = homeDemoRowHtml(true, value => value);
+  assert.equal(
+    (pending.match(/home-demo-pending/g) || []).length,
+    HOME_DEMO_PENDING_SLOT_COUNT,
+  );
+  assert.match(pending, /disabled/);
+  assert.equal(homeDemoRowHtml(false, value => value), "");
+
+  setProductHomeDemoCatalog([
+    { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
+  ]);
+  const ready = homeDemoRowHtml(false, value => value);
+  assert.match(ready, /data-home-demo="stj-serializer"/);
+  assert.doesNotMatch(ready, /home-demo-pending/);
+  assert.doesNotMatch(ready, /disabled/);
+  const stillLoading = homeDemoRowHtml(true, value => value);
+  assert.match(stillLoading, /disabled/);
 });

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -5,7 +5,14 @@ import {
   bindLoadErrorShell,
   bindWorkbenchShell,
 } from "../src/shell-controls.ts";
+import { setProductHomeDemoCatalog } from "../src/product-home-demos.ts";
 import { fakeDom } from "./fake-dom.ts";
+
+setProductHomeDemoCatalog([
+  { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
+  { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
+  { id: "platform-list", title: ".NET Platform", summary: "Inspect platform BCL types" },
+]);
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1906,11 +1906,11 @@ test("home demos restore the complete parsed location", () => {
     appSource,
     /function applyLocationView\(loc: ParsedLocation\) \{\s*state\.lens = loc\.lens \|\| "api";\s*state\.atPackageRoot = loc\.atPackageRoot \|\| false;\s*state\.packageLens = loc\.packageLens \|\| "overview";/);
   const callGraphDemo =
-    appSource.match(/async function runCallGraphDemo\(\) \{[\s\S]*?\n}\n\n\/\/ Loads the full/)?.[0]
+    appSource.match(/async function runCallGraphDemo\(demo: ProductHomeDemoResolved\) \{[\s\S]*?\n}\n\n\/\/ Loads the full/)?.[0]
     ?? "";
   assert.match(
     callGraphDemo,
-    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = EXTENSIONS_CALLGRAPH\.memberSection/);
+    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = spec\.memberSection/);
   const platformHistory =
     appSource.match(/async function restorePlatformScopeThenDeepLink\([\s\S]*?\n}\n\n\/\/ Load and scope/)?.[0]
     ?? "";
@@ -3083,7 +3083,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /state\.retryAction = options\.retryAction/);
   assert.match(
     appSource,
-    /state\.retryAction = runCallGraphDemo/);
+    /state\.retryAction = retry/);
   assert.match(
     appSource,
     /appendQueryNotice\(\s+friendly\.message,\s+options\.retryAction/);


### PR DESCRIPTION
## Summary

**Stack:** slice 2 of 2 — parent [PR #4597](https://github.com/richlander/dotnet-inspect/pull/4597) (`feature/inspect-web-home-demos`). Do not merge the parent alone; land bottom-up.

Stop hand-maintaining a TypeScript twin of `ProductInspectionDemos`. The browser engine now exports the product home-demo catalog and resolves demo coordinates; the host keeps only share-URL encoding and known residuals.

### Engine

- `ListHomeDemos` / `ResolveHomeDemo` (`[JSExport]`) over `ProductInspectionDemos`
- Browser DTOs in `BrowserContracts` + mapper `BrowserProductHomeDemos`
- Parity tests in `BrowserProductHomeDemosTests` against the product registry

### Host

- `product-home-demos.ts` is a catalog adapter (cache from engine bootstrap)
- Share deep links and platform → `Microsoft.NETCore.App` `10.0.10` pack mapping stay host-side
- Call Graph + memberAnchor still uses the imperative multi-package runner (`callGraphDemoRunnerSpec`)

### Residual (non-blocking)

1. Minted facet ids vs display-name allow list
2. `WorkspaceContextLoader` group run instead of CLI/`--caller-package` and browser pack share encoding
3. Replace imperative call-graph web path with the same group-run substrate
4. Call Graph / Callers structured JSON projection gap

## Demo

```bash
# list (CLI product surface — same registry)
dotnet run --project src/dotnet-inspect -c Release -- demo list

# run one home demo id
dotnet run --project src/dotnet-inspect -c Release -- demo stj-serialize

# browser catalog (after engine load)
# ListHomeDemos() / ResolveHomeDemo("stj-serialize")
```

## Evidence

- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 87 pass
- Node 24: `npm test` — 491 pass; `npm run analyze` / `npm run build` green
- `markdownlint-cli docs/design/workspace-definitions.md` clean

## Non-action boundary

Does not land the dedicated demo page (#4596), does not remove host share encoding, and does not merge #4597.