### PR TITLE
Fix duplicate inspect-web staging route

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -987,14 +987,16 @@ Trusted build and deployment steps also verify that Vite preserved the authored
 .NET placeholders, that every file in Vite's generated manifest exists and is
 loaded by the index where required, that the SDK injected a mapping to the
 fingerprinted `dotnet.js`, and that the import map precedes the Vite module
-entry. That configuration serves `/` and `/index.html` with `Cache-Control:
-no-cache, no-store, must-revalidate`, so an Azure edge cannot retain an old
-browser boot graph after its fingerprinted Wasm assets rotate.
-`BrowserStaticWebAppConfigTests.RootDocumentsAreNotCachedAndConfigIsPublished`
-gates the header contract and publish wiring. The staging publish step embeds
-the CLI's authoritative `VersionPrefix`, exact source SHA, and UTC build
-timestamp. The home and workspace status bars show that version, link the
-short commit to GitHub, and disclose the binary build time.
+entry. That configuration serves `/`, `/index.html`, and the Azure-canonical
+`/credits` route with `Cache-Control: no-cache, no-store, must-revalidate`, so
+an Azure edge cannot retain an old browser boot graph after its fingerprinted
+Wasm assets rotate. Azure treats trailing-slash variants as the same route;
+`BrowserStaticWebAppConfigTests.EntryDocumentsAreNotCachedAndConfigIsPublished`
+gates both route uniqueness and the header and publish-wiring contracts. The
+staging publish step embeds the CLI's authoritative `VersionPrefix`, exact
+source SHA, and UTC build timestamp. The home and workspace status bars show
+that version, link the short commit to GitHub, and disclose the binary build
+time.
 `BuildIdentity_UsesVersionedRepositoryProvenance` and
 `ready status shows versioned linked build provenance` gate the engine and UI
 halves.

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -497,13 +497,17 @@ boundary.
 
 The home page identifies the browser stack below its search surface and links
 to the client-rendered `/credits` route. `src/credits-panel.ts` owns that page's
-markup, route recognition, and rendered control bindings. Azure Static Web Apps
-rewrites direct Credits requests to the non-cacheable `index.html`; the
-document's root base keeps SDK-generated framework imports valid on both
-`/credits` and `/credits/`. `scripts/verify-site-artifact.js` gates that base
-and its ordering in the Vite bundle and SDK-published site. Other application
-routes use the navigation fallback, while API, asset, and framework requests
-remain excluded.
+markup, route recognition, and rendered control bindings. The Static Web Apps
+configuration uses an exact `/credits` route plus Azure's documented
+`/credits/*` child wildcard to rewrite both `/credits` and `/credits/` to the
+non-cacheable `index.html`; the document's root base keeps SDK-generated
+framework imports valid on both paths.
+`BrowserStaticWebAppConfigTests.EntryDocumentsAreNotCachedAndConfigIsPublished`
+gates the authored wildcard and header, while a successful staging deployment
+and direct header probes remain the required evidence for Azure's hosted
+behavior. `scripts/verify-site-artifact.js` gates the root base and its ordering
+in the Vite bundle and SDK-published site. Other application routes use the
+navigation fallback, while API, asset, and framework requests remain excluded.
 
 The .NET 11 preview Emscripten wrapper currently mishandles an SDK packs path
 that contains whitespace. If that applies to the local SDK installation, pass
@@ -987,16 +991,17 @@ Trusted build and deployment steps also verify that Vite preserved the authored
 .NET placeholders, that every file in Vite's generated manifest exists and is
 loaded by the index where required, that the SDK injected a mapping to the
 fingerprinted `dotnet.js`, and that the import map precedes the Vite module
-entry. That configuration serves `/`, `/index.html`, and the Azure-canonical
-`/credits` route with `Cache-Control: no-cache, no-store, must-revalidate`, so
-an Azure edge cannot retain an old browser boot graph after its fingerprinted
-Wasm assets rotate. Azure treats trailing-slash variants as the same route;
+entry. That configuration gives `/`, `/index.html`, `/credits`, and the
+documented `/credits/*` child wildcard `Cache-Control: no-cache, no-store,
+must-revalidate`, so the authored routes do not permit an Azure edge to retain
+an old browser boot graph after its fingerprinted Wasm assets rotate.
 `BrowserStaticWebAppConfigTests.EntryDocumentsAreNotCachedAndConfigIsPublished`
-gates both route uniqueness and the header and publish-wiring contracts. The
-staging publish step embeds the CLI's authoritative `VersionPrefix`, exact
-source SHA, and UTC build timestamp. The home and workspace status bars show
-that version, link the short commit to GitHub, and disclose the binary build
-time.
+gates route uniqueness, the wildcard and header shape, and publish wiring.
+Hosted wildcard matching remains unverified until a successful staging
+deployment and direct `/credits` and `/credits/` header probes. The staging
+publish step embeds the CLI's authoritative `VersionPrefix`, exact source SHA,
+and UTC build timestamp. The home and workspace status bars show that version,
+link the short commit to GitHub, and disclose the binary build time.
 `BuildIdentity_UsesVersionedRepositoryProvenance` and
 `ready status shows versioned linked build provenance` gate the engine and UI
 halves.

--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -21,11 +21,17 @@ public class BrowserStaticWebAppConfigTests
             .. config.RootElement.GetProperty("routes").EnumerateArray(),
         ];
 
-        Assert.Equal(4, routes.Length);
+        Assert.Equal(3, routes.Length);
         AssertRoute(routes[0], "/");
         AssertRoute(routes[1], "/index.html");
         AssertRoute(routes[2], "/credits", "/index.html");
-        AssertRoute(routes[3], "/credits/", "/index.html");
+        Assert.Equal(
+            routes.Length,
+            routes
+                .Select(route => NormalizeAzureRoute(
+                    route.GetProperty("route").GetString()!))
+                .Distinct(StringComparer.Ordinal)
+                .Count());
         Assert.Equal(
             "dotnet-isolated:8.0",
             config.RootElement
@@ -92,6 +98,12 @@ public class BrowserStaticWebAppConfigTests
                 .GetProperty("headers")
                 .GetProperty("Cache-Control")
                 .GetString());
+    }
+
+    private static string NormalizeAzureRoute(string route)
+    {
+        string normalized = route.TrimEnd('/');
+        return normalized.Length == 0 ? "/" : normalized;
     }
 
     private static string RepositoryRoot()

--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -21,10 +21,11 @@ public class BrowserStaticWebAppConfigTests
             .. config.RootElement.GetProperty("routes").EnumerateArray(),
         ];
 
-        Assert.Equal(3, routes.Length);
+        Assert.Equal(4, routes.Length);
         AssertRoute(routes[0], "/");
         AssertRoute(routes[1], "/index.html");
         AssertRoute(routes[2], "/credits", "/index.html");
+        AssertRoute(routes[3], "/credits/*", "/index.html");
         Assert.Equal(
             routes.Length,
             routes

--- a/prototypes/inspect-web/staticwebapp.config.json
+++ b/prototypes/inspect-web/staticwebapp.config.json
@@ -18,6 +18,13 @@
       "headers": {
         "Cache-Control": "no-cache, no-store, must-revalidate"
       }
+    },
+    {
+      "route": "/credits/*",
+      "rewrite": "/index.html",
+      "headers": {
+        "Cache-Control": "no-cache, no-store, must-revalidate"
+      }
     }
   ],
   "navigationFallback": {

--- a/prototypes/inspect-web/staticwebapp.config.json
+++ b/prototypes/inspect-web/staticwebapp.config.json
@@ -18,13 +18,6 @@
       "headers": {
         "Cache-Control": "no-cache, no-store, must-revalidate"
       }
-    },
-    {
-      "route": "/credits/",
-      "rewrite": "/index.html",
-      "headers": {
-        "Cache-Control": "no-cache, no-store, must-revalidate"
-      }
     }
   ],
   "navigationFallback": {

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -74,14 +74,10 @@ test("static hosting serves direct credits links through the application entry p
         "Cache-Control": "no-cache, no-store, must-revalidate",
       },
     },
-    {
-      route: "/credits/",
-      rewrite: "/index.html",
-      headers: {
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-      },
-    },
   ]);
+  const normalizedRoutes = staticWebAppConfig.routes
+    .map(({ route }) => route === "/" ? route : route.replace(/\/+$/, ""));
+  assert.equal(new Set(normalizedRoutes).size, normalizedRoutes.length);
   assert.equal(staticWebAppConfig.navigationFallback.rewrite, "/index.html");
   assert.deepEqual(
     staticWebAppConfig.navigationFallback.exclude,

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -62,13 +62,20 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   );
 });
 
-test("static hosting serves direct credits links through the application entry point", () => {
+test("static hosting configures non-overlapping credits routes", () => {
   const creditsRoutes = staticWebAppConfig.routes
-    .filter(route => route.route === "/credits" || route.route === "/credits/");
+    .filter(route => route.route.startsWith("/credits"));
 
   assert.deepEqual(creditsRoutes, [
     {
       route: "/credits",
+      rewrite: "/index.html",
+      headers: {
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+      },
+    },
+    {
+      route: "/credits/*",
       rewrite: "/index.html",
       headers: {
         "Cache-Control": "no-cache, no-store, must-revalidate",


### PR DESCRIPTION
## Summary

- replace Azure-conflicting `/credits` and `/credits/` route rules with non-overlapping `/credits` and `/credits/*` rules
- preserve direct navigation and `no-store` caching for both canonical Credits URL spellings
- gate Azure-normalized route uniqueness and the exact child wildcard in both hosting contract suites
- distinguish locally gated configuration from hosted behavior that requires post-merge deployment evidence

The Mono and CoreCLR staging builds and artifact verification were succeeding, but Azure rejected both uploads with `A rule was already processed with a duplicate route /credits/`. The literal-plus-child-wildcard pair follows Azure's documented route syntax without broadening matching to paths such as `/credits-other`.

## Validation

- `npm test` (487 passed on the initial candidate)
- `npm run analyze`
- `npm run build`
- `node --test test/toolchain.test.js` (6 passed on the replacement)
- `dotnet build prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release --no-restore -m:1 --nologo`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release --no-build -- -class InspectWeb.Engine.Tests.BrowserStaticWebAppConfigTests`
- Azure Static Web Apps CLI 2.0.10: `/credits`, `/credits/`, and `/credits/child` return `no-cache, no-store, must-revalidate`; `/credits-other` and `/nope` retain fallback caching
- `npx --no-install markdownlint-cli prototypes/inspect-web/README.md`
- `git diff --check origin/main...HEAD`

## Non-action boundary

This PR does not alter Azure resources, deployment credentials, application route recognition, or production promotion. Hosted Azure behavior remains unverified until post-merge staging deployments and direct header probes succeed.