### PR TITLE
AGENTS.md: report the facts tooling cannot observe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,30 +148,40 @@ on every round completion, and omit `Blocked` only when it is genuinely empty.
   in your PR, and no one should be dispatched at it. Naming them is what stops
   several agents converging on one shared flake; behind a known blocker the
   correct action for everyone is to wait, and an idle agent is the right outcome
-  there rather than a wasted one. Give numbers rather than prose — this list is
-  what `Recommendation: Wait` points at, and what a watcher re-checks to decide
-  when you are worth waking.
+  there rather than a wasted one.
+
+  **Every entry must be a number someone can open, and it is your job to make
+  sure one exists.** If a flake is blocking you and no issue has been filed for
+  it, file the issue, then cite it. Being unable to point at what is blocking
+  you is the failure this field exists to prevent: an uncitable blocker cannot
+  be prioritised, cannot be deduplicated against the next agent that hits the
+  same flake, and leaves your `Wait` indistinguishable from a stall.
 - **`Recommendation:`** — exactly one of `Wait`, `Merge`, `Approve next rounds`,
   or `Stop (reason)`: the disposition of this window, not a summary of your
-  progress. Two of the four are your own disposition and ask nobody for
-  anything; two are requests only the operator can satisfy.
+  progress. What separates them is whether the window needs a **decision**
+  before anything moves. Three of them do. `Wait` is the one that does not —
+  which is not the same as it being silent.
 
   **`Wait` means "let me wait — what I listed in `Blocked:` is still
   outstanding."** It is not idleness in need of explanation and not a request
-  for instructions: nobody should dispatch you, re-plan you, or send you at CI.
-  It is only coherent next to a non-empty `Blocked:` — if nothing is blocking
-  you then you are not waiting, and one of the other three is the honest answer.
-  That pairing is what makes `Wait` watchable: the window becomes interesting
-  again exactly when the numbers you named close, and not before.
+  for instructions: nobody should dispatch you, re-plan you, or send you at CI,
+  and you resume yourself when the blockers clear. What it does put in front of
+  the operator is the blocker list, because they may not know that a particular
+  PR or flake is holding work back and may decide to prioritise it. That is why
+  the entries have to be citable. `Wait` is also only coherent beside a
+  non-empty `Blocked:` — if nothing is blocking you then you are not waiting,
+  and one of the other three is the honest answer.
 
-  **`Stop (reason)` means "let me stop."** You are ceasing work on this PR, and
-  the reason is the load-bearing part — superseded by another PR, approach
-  rejected, six rounds without convergence. Unlike `Wait` it is terminal:
-  nothing will make this window interesting again, so saying it plainly is what
-  lets the slot be reclaimed instead of leaving finished work to look stalled.
+  **`Stop (reason)` is a request, not a fait accompli.** You are asking to be
+  released from this work and naming why — superseded by another PR, approach
+  rejected, six rounds without convergence. Granting it is a decision with
+  follow-up attached: granted, you write a note on the PR recording why the work
+  stopped and then close it; declined, the work continues, possibly with
+  reframed goals, or becomes a `Wait` on whatever has to land first. Until you
+  have an answer, change nothing and close nothing.
 
-  **`Merge` and `Approve next rounds` are the two that need a person.** Together
-  they are the operator's queue; everything else can stay quiet.
+  **`Merge` and `Approve next rounds`** each need a person before anything moves
+  at all.
 
 Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,19 +201,21 @@ moving](#clean-reviews-are-not-spent-by-main-moving), which is stop-and-ask and
 a possible carry-forward, never an integration you launch on your own
 initiative.
 
-What you assert **readiness** on is dual-clean reviews and mergeability. A green
-run is evidence toward that, not the definition of it: checks go red for reasons
-that have nothing to do with your change, and a change is not ready merely
-because they passed.
+Ready to merge means two things: **the reviews are clean, and the branch
+merges.** Say it when both hold, and not before.
+
+Green CI is not a third condition. Chase it — it is useful evidence and part of
+finishing the work — but checks go red for reasons that have nothing to do with
+your change, so passing checks alone do not make a PR ready.
 
 Two claims have to be earned rather than assumed:
 
 - **Do not report `mergeable` from a local merge check.** GitHub computes
   `mergeable_state` lazily — the first read after a change returns `unknown` and
-  only starts the calculation, so the answer arrives on a later read. Observed
-  2026-08-23: 18 of 32 open PRs answered `unknown` on first read, and two
-  resolved to `dirty` — both belonging to agents that had just reported their PR
-  as mergeable. Re-read until it is no longer `unknown`, and say `mergeability
+  only starts the calculation, so the answer arrives on a later read. A one-off
+  check of the open PRs found 18 of 32 answering `unknown` on the first read,
+  and two of those resolved to `dirty` — both on PRs whose agents had just
+  reported them as mergeable. Re-read until it is no longer `unknown`, and say `mergeability
   unverified` rather than guessing.
 - **Do not report `ready to merge` while a round is still in flight.** The state
   is the round, not the destination.
@@ -226,6 +228,36 @@ and CI or mergeability disagrees, that discrepancy is routed to the **operator**
 rather than back to you — nobody re-dispatches an agent that has declared itself
 done. An unearned "ready to merge" therefore does not cost you another round; it
 spends the attention of the one participant who cannot be automated.
+
+### Checking costs a budget you share
+
+Every agent draws on the same GitHub account, so there is one hourly request
+budget across all of them, on every host. Nothing divides it fairly and nothing
+warns you when it is gone — a starved agent simply gets errors back and stops
+being able to see its own PR.
+
+It is currently spent very unevenly. A one-off check found the account's GraphQL
+budget fully exhausted — 0 remaining, with more attempted than the hourly limit
+allows — while REST sat at 4,967 of 5,000, barely touched. An agent that cannot
+read its PR's state cannot move it forward, so this is a plausible reason some
+PRs advance steadily while others stall for no visible reason.
+
+Two habits recover most of it.
+
+**Prefer REST.** `gh pr view`, `gh pr checks`, and `gh pr list --json` are
+GraphQL, which is the exhausted half. These answer the same questions from the
+half that is idle:
+
+```sh
+gh api repos/{owner}/{repo}/pulls/{number}                 # state, mergeable_state, head
+gh api repos/{owner}/{repo}/commits/{sha}/check-runs       # checks on that head
+```
+
+**Check at a point, then set when you will check again.** Decide what you are
+waiting for, look once, and if it has not happened, pick a time to look again
+and stop until then. Do not sit in a query loop: re-asking about a head that has
+not moved cannot return anything new, and doing it on a timer is what drains the
+budget everyone else is also drawing on.
 
 ### Publish your state where tooling can read it
 
@@ -246,10 +278,10 @@ Omit your window number from the value — the bar already knows where it is.
 Update on real transitions, not on a timer.
 
 **Verify the write landed on your own window.** That `-t "$TMUX_PANE"` is the
-whole safety of this mechanism, and dropping it is not a theoretical risk:
-observed 2026-08-23 on a live host, three windows all carried an identical
-`@agent` describing a *fourth* window's PR, while that PR's own window held a
-newer value. One agent's writes had landed on three neighbours, making three
+whole safety of this mechanism, and dropping it is not a theoretical risk: a
+one-off check of a live host found three windows all carrying an identical
+`@agent` that described a *fourth* window's PR, while that PR's own window held
+a newer value. One agent's writes had landed on three neighbours, making three
 agents appear to be working on a PR they had never touched. Read it back once
 after you set it, and fix it if it names someone else's PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,10 +148,30 @@ on every round completion, and omit `Blocked` only when it is genuinely empty.
   in your PR, and no one should be dispatched at it. Naming them is what stops
   several agents converging on one shared flake; behind a known blocker the
   correct action for everyone is to wait, and an idle agent is the right outcome
-  there rather than a wasted one.
+  there rather than a wasted one. Give numbers rather than prose — this list is
+  what `Recommendation: Wait` points at, and what a watcher re-checks to decide
+  when you are worth waking.
 - **`Recommendation:`** — exactly one of `Wait`, `Merge`, `Approve next rounds`,
-  or `Stop (reason)`. It says what you want the **operator** to do, which is not
-  the same as what you would do next. `Wait` is a complete answer.
+  or `Stop (reason)`: the disposition of this window, not a summary of your
+  progress. Two of the four are your own disposition and ask nobody for
+  anything; two are requests only the operator can satisfy.
+
+  **`Wait` means "let me wait — what I listed in `Blocked:` is still
+  outstanding."** It is not idleness in need of explanation and not a request
+  for instructions: nobody should dispatch you, re-plan you, or send you at CI.
+  It is only coherent next to a non-empty `Blocked:` — if nothing is blocking
+  you then you are not waiting, and one of the other three is the honest answer.
+  That pairing is what makes `Wait` watchable: the window becomes interesting
+  again exactly when the numbers you named close, and not before.
+
+  **`Stop (reason)` means "let me stop."** You are ceasing work on this PR, and
+  the reason is the load-bearing part — superseded by another PR, approach
+  rejected, six rounds without convergence. Unlike `Wait` it is terminal:
+  nothing will make this window interesting again, so saying it plainly is what
+  lets the slot be reclaimed instead of leaving finished work to look stalled.
+
+  **`Merge` and `Approve next rounds` are the two that need a person.** Together
+  they are the operator's queue; everything else can stay quiet.
 
 Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,10 +187,24 @@ Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a
 window nobody can identify.
 
-### Ready means dual-clean and mergeable, not green CI
+### Green and mergeable is your job, best effort
 
-Report readiness against reviews and mergeability. CI is the operator's concern,
-and a green run is neither necessary nor sufficient for you to call a PR ready.
+Getting CI green and the branch mergeable is part of finishing the work. Pursue
+both — it is not somebody else's problem, and handing over a red or conflicted
+PR you could have fixed is not a handover.
+
+**Best effort, though, because main moves.** Rebasing onto a main that is
+landing PRs faster than you can reconcile is not a race you win by rebasing
+harder, and every extra pass costs a round you could have spent on the change
+itself. When conflicts keep reappearing on the same PR, or a green run goes red
+again on a base you never touched, stop reconciling and say so: name what you
+are racing in `Blocked:` and recommend `Wait`. Sequencing work against a busy
+main is an operator call. Handing it over is the correct move, not a concession.
+
+What you assert **readiness** on is dual-clean reviews and mergeability. A green
+run is evidence toward that, not the definition of it — checks go red for
+reasons that have nothing to do with your change, and a change is not ready
+merely because they passed.
 
 Two claims have to be earned rather than assumed:
 
@@ -206,6 +220,12 @@ Two claims have to be earned rather than assumed:
 
 A conflict found late costs a whole extra pass. Checking mergeability at the
 moment you claim it is what holds that to one.
+
+Accuracy here has a specific consequence worth knowing. When you report ready
+and CI or mergeability disagrees, that discrepancy is routed to the **operator**
+rather than back to you — nobody re-dispatches an agent that has declared itself
+done. An unearned "ready to merge" therefore does not cost you another round; it
+spends the attention of the one participant who cannot be automated.
 
 ### Publish your state where tooling can read it
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,24 +187,24 @@ Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a
 window nobody can identify.
 
-### Green and mergeable is your job, best effort
+### Claiming ready to merge
 
 Getting CI green and the branch mergeable is part of finishing the work. Pursue
-both — it is not somebody else's problem, and handing over a red or conflicted
-PR you could have fixed is not a handover.
+both; handing over a red or conflicted PR you could have fixed is not a handover.
 
-**Best effort, though, because main moves.** Rebasing onto a main that is
-landing PRs faster than you can reconcile is not a race you win by rebasing
-harder, and every extra pass costs a round you could have spent on the change
-itself. When conflicts keep reappearing on the same PR, or a green run goes red
-again on a base you never touched, stop reconciling and say so: name what you
-are racing in `Blocked:` and recommend `Wait`. Sequencing work against a busy
-main is an operator call. Handing it over is the correct move, not a concession.
+**This section is about what you may claim, not about when you may integrate.**
+Integration cadence is already specified and this does not modify it: the two
+integrations per round in [the round flow](#canonical-round-flow), and — for the
+narrow case where a required review is already clean at the current head and
+`origin/main` has since moved — [Clean reviews are not spent by main
+moving](#clean-reviews-are-not-spent-by-main-moving), which is stop-and-ask and
+a possible carry-forward, never an integration you launch on your own
+initiative.
 
 What you assert **readiness** on is dual-clean reviews and mergeability. A green
-run is evidence toward that, not the definition of it — checks go red for
-reasons that have nothing to do with your change, and a change is not ready
-merely because they passed.
+run is evidence toward that, not the definition of it: checks go red for reasons
+that have nothing to do with your change, and a change is not ready merely
+because they passed.
 
 Two claims have to be earned rather than assumed:
 
@@ -283,9 +283,9 @@ Whenever you stop and wait on a human decision, raise a flag that persists and
 send one nudge that does not:
 
 ```sh
-tmux set -w -t "$TMUX_PANE" @agent "HELP: rebase pr4405 onto main, or close it?"
+tmux set -w -t "$TMUX_PANE" @agent "HELP: integrate main into pr4405, or close it?"
 tmux display-message -d 10000 -t "$TMUX_PANE" \
-  "HELP pr4405 in w#{window_index}: rebase onto main, or close it?"
+  "HELP pr4405 in w#{window_index}: integrate main, or close it?"
 ```
 
 The `HELP` prefix marks your window with `!` in the window list, so you are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ window nobody can identify.
 ### Claiming ready to merge
 
 Getting CI green and the branch mergeable is part of finishing the work. Pursue
-both; handing over a red or conflicted PR you could have fixed is not a handover.
+both; handing over a red or conflicted PR you could have fixed is not an effective handover.
 
 **This section is about what you may claim, not about when you may integrate.**
 Integration cadence is already specified and this does not modify it: the two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,8 @@ guessing.
 
 Work runs in many concurrent agent windows across several machines. Whoever is
 watching must be able to tell, without attaching to any of them, which PR each
-window is on and which one needs a person. Three conventions carry that. Use
-them.
+window is on and which one needs a person. These conventions carry that, along
+with one rule about what you are entitled to claim. Use them.
 
 ### Name the window for identity
 
@@ -129,11 +129,53 @@ Completing a round:
 > - Review feedback is: converging.
 > - Round start / end / duration.
 >
+> Reviews: 1/2 clean — GPT-5.6 Sol clean, Claude Opus 5 pending
+> Blocked: 4597, 4611
+> Recommendation: Wait
+>
 > Fix description: …
+
+Those three lines are the ones a reader cannot get anywhere else. Include them
+on every round completion, and omit `Blocked` only when it is genuinely empty.
+
+- **`Reviews: <clean>/<required>`** — the dual-clean count, and the actual bar
+  for done. **This is the one fact no tool can observe.** GitHub knows whether
+  CI passed and whether the branch merges; it has no idea that one reviewer came
+  back clean and the other has not reported. Without it nobody can tell a PR
+  that is one review from landing apart from one nobody has reviewed at all.
+- **`Blocked: <numbers>`** — PRs or issues you are waiting on that are **not
+  yours to fix**. Red CI attributable to something on this list is not a defect
+  in your PR, and no one should be dispatched at it. Naming them is what stops
+  several agents converging on one shared flake; behind a known blocker the
+  correct action for everyone is to wait, and an idle agent is the right outcome
+  there rather than a wasted one.
+- **`Recommendation:`** — exactly one of `Wait`, `Merge`, `Approve next rounds`,
+  or `Stop (reason)`. It says what you want the **operator** to do, which is not
+  the same as what you would do next. `Wait` is a complete answer.
 
 Restate it after every resume and at the start of every round, not once at the
 beginning. A window that has scrolled past its only mention of the PR is a
 window nobody can identify.
+
+### Ready means dual-clean and mergeable, not green CI
+
+Report readiness against reviews and mergeability. CI is the operator's concern,
+and a green run is neither necessary nor sufficient for you to call a PR ready.
+
+Two claims have to be earned rather than assumed:
+
+- **Do not report `mergeable` from a local merge check.** GitHub computes
+  `mergeable_state` lazily — the first read after a change returns `unknown` and
+  only starts the calculation, so the answer arrives on a later read. Observed
+  2026-08-23: 18 of 32 open PRs answered `unknown` on first read, and two
+  resolved to `dirty` — both belonging to agents that had just reported their PR
+  as mergeable. Re-read until it is no longer `unknown`, and say `mergeability
+  unverified` rather than guessing.
+- **Do not report `ready to merge` while a round is still in flight.** The state
+  is the round, not the destination.
+
+A conflict found late costs a whole extra pass. Checking mergeability at the
+moment you claim it is what holds that to one.
 
 ### Publish your state where tooling can read it
 
@@ -152,6 +194,38 @@ option; writing it directly would overwrite every other agent, the same way bare
 
 Omit your window number from the value — the bar already knows where it is.
 Update on real transitions, not on a timer.
+
+**Verify the write landed on your own window.** That `-t "$TMUX_PANE"` is the
+whole safety of this mechanism, and dropping it is not a theoretical risk:
+observed 2026-08-23 on a live host, three windows all carried an identical
+`@agent` describing a *fourth* window's PR, while that PR's own window held a
+newer value. One agent's writes had landed on three neighbours, making three
+agents appear to be working on a PR they had never touched. Read it back once
+after you set it, and fix it if it names someone else's PR.
+
+Alongside `@agent`, set a second option carrying the same state as fields.
+`@agent` is the sentence a person reads off the bar; `@agent_state` is the copy
+a tool reads, and because it is never rendered it is neither truncated nor
+abbreviated:
+
+```sh
+tmux set -w -t "$TMUX_PANE" @agent_state \
+  "pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
+tmux show -w -t "$TMUX_PANE" @agent_state      # read back: must name YOUR pr
+```
+
+`pr` and `head` are always required, the rest when they apply. `rec` takes the
+same four values as `Recommendation`, lowercased, with `Approve next rounds`
+written `approve`. Values carry no spaces. Update it on the same transitions as
+`@agent` and clear it with `-u` when the window stops owning a PR.
+
+**Why an option rather than only your output.** This UI runs on the alternate
+screen, so tmux keeps no scrollback for it — `capture-pane -S -400` returns the
+same single screen as a plain capture. Once your report scrolls past the top it
+is unrecoverable by any tool and the window goes anonymous. A window option
+persists until you change it, outlives the report scrolling away, and cannot be
+garbled by line wrapping. Your output stays where a person reads the detail;
+this is what remains legible after it is gone.
 
 ### Signal when you need a person
 


### PR DESCRIPTION
## Summary

Adds three lines to the round-completion report, plus a machine-readable twin of `@agent`, and corrects what an agent is entitled to claim about readiness.

All of it comes from one measurement pass: **34 agent windows across merritt, fernie and annies-mac-mini on 2026-08-23**, every pane captured and every referenced PR compared against GitHub.

## Why this matters

The reports agents write today are articulate. They still leave a watcher unable to answer the only question that matters — *which window needs me?* — because three facts exist nowhere except in the agent's head.

**Reviews.** GitHub knows whether CI passed and whether the branch merges. It has no idea that one reviewer came back clean and the other has not reported. One window read:

> PR #4130 remains green, mergeable, and clean at `6d8bbd1d8`. GPT is clean; waiting only for Claude.

That is a PR one review away from landing, and to anything reading GitHub it is indistinguishable from one nobody has reviewed. `Reviews: 1/2 clean` makes it legible.

**Blocked.** Another window read *"Round 28 is blocked pending explicit authorization"* with every check on the PR red. Nothing distinguishes that from a PR whose own tests are broken — so the obvious automated response, *go fix CI*, is exactly wrong. `Blocked:` names what you are waiting on that is not yours to fix. Behind a known blocker the correct action for every agent is to wait, and an idle agent is the right outcome there rather than a wasted one. This is what stops several agents converging on one shared flake.

**Recommendation.** The disposition of the window — `Wait` / `Merge` / `Approve next rounds` / `Stop (reason)`. What separates them is whether the window needs a **decision** before anything moves. Three of them do; `Wait` is the one that does not, which is not the same as being silent.

- **`Wait`** — *"let me wait; what I listed in `Blocked:` is still outstanding."* Nobody has to act for the agent to resume, but the blocker list is exactly what an operator may not know about and may want to prioritise. Hence the hard rule added to `Blocked:`: **every entry must be a number someone can open, and filing it is the agent's job.** If a flake is blocking and no issue exists, file the issue and cite it. Asking to wait while unable to point at why is the failure the field exists to prevent — an uncitable blocker cannot be prioritised, cannot be deduplicated against the next agent to hit the same flake, and leaves the wait indistinguishable from a stall.
- **`Stop (reason)`** — a *request* to be released from the work, pending until someone answers. Granted, it carries follow-up: a note on the PR recording why the work stopped, then close. Declined, the work continues — sometimes with reframed goals, sometimes as a `Wait` on whatever has to land first. Until then the agent changes nothing and closes nothing.
- **`Merge`** and **`Approve next rounds`** each need a person before anything moves at all.

## What changed

**Round-completion block** gains `Reviews:`, `Blocked:` and `Recommendation:`, each explained by what it makes visible.

**New: `### Claiming ready to merge`.** Scoped deliberately narrowly — it governs what an agent may *claim*, not when it may integrate. Integration cadence is already specified by the round flow and by `Clean reviews are not spent by main moving`, and this section points at both rather than restating them.

Readiness is asserted on dual-clean reviews and mergeability, with a green run as evidence toward it rather than the definition of it. Two agents reported their PR as mergeable while GitHub had it `dirty`:

```
fernie cp:5   "PR #4130 ... green, mergeable, and clean at 6d8bbd1d8"   GitHub: dirty
fernie cp:12  "PR #4563: replacement head 2c58e7be3 ... mergeable"      GitHub: dirty
```

The trap is that GitHub computes `mergeable_state` **lazily**: the first read after a change returns `unknown` and merely starts the calculation. Measured here, **18 of 32 open PRs answered `unknown` on first read**, and re-reading is what exposed both conflicts.

The section closes with why accuracy matters to the agent: a report of ready that CI or mergeability contradicts is routed to the **operator**, not back to the agent. Nobody re-dispatches an agent that has declared itself done, so an unearned "ready to merge" does not cost a round — it spends the attention of the one participant who cannot be automated.

**Drive-by fix:** the `HELP` example asked *"rebase pr4405 onto main, or close it?"* about a pushed PR branch, which this file's own rule forbids — once a branch is public, a later main is integrated by merge. Changed to "integrate main into pr4405". Happy to drop this hunk if you would rather keep it separate.

**New: `@agent_state`**, a fields copy of `@agent` for tooling:

```sh
tmux set -w -t "$TMUX_PANE" @agent_state \
  "pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
```

`@agent` stays the sentence a person reads off the bar. The reason a second option is worth it: **this UI runs on the alternate screen, so tmux keeps no scrollback for it** — `capture-pane -S -400` returns byte-identical output to a plain capture, 51 lines, always. Once a report scrolls past the top it is unrecoverable by any tool and the window goes anonymous. Adoption of `@agent` is already high (28 of 34 windows), so this is a small addition to a habit that has clearly taken.

**Evidence added to the `-t "$TMUX_PANE"` warning.** It is not a theoretical risk. On merritt, three windows all carried an identical `@agent` describing a *fourth* window's PR, while that PR's own window held a newer value:

```
tune-performance-triage-capa | PR #4560 round 4 in progress on exact head 11e4e257c…
pr4488                       | PR #4560 round 4 in progress on exact head 11e4e257c…
pr4448                       | PR #4560 round 4 in progress on exact head 11e4e257c…
pr4560                       | round 5 complete on pr4560; replacement c51e12af green and mergeable
```

One agent's writes had landed on three neighbours, making three agents appear to be working on a PR they had never touched. The guidance now asks for a read-back after every set.

## Validation

`markdownlint-cli2 AGENTS.md` — 0 issues. Docs-only; no code paths touched.

## Resolves

No issue — filed from a direct observability pass over the fleet. Companion tooling is being built in `richlander/nightshift` (#157, #159).
