### PR TITLE
Streamline repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,58 +27,25 @@ dotnet-inspect PR.
 
 ## Session resume
 
-Your process can be replaced without your work being finished — a machine
-reboot, a lost terminal, a session resumed from disk. This section covers that.
-It is distinct from a round restart, which
-[Canonical round flow](#canonical-round-flow) governs.
+The transcript survives a resumed session; repository and PR state may not.
+Before continuing:
 
-Your transcript comes back intact, and no conversation was missed: nothing
-happened between your last turn and this one, so there is nothing to catch up on
-and no new direction waiting to be found. What may have moved is machine state
-outside your process — CI runs asynchronously and other work merges — so a plan
-formed before you stopped can describe a world that no longer exists.
+1. Confirm the worktree, branch, and head from git. Fetch the effective base and
+   re-check the PR per [Canonical round flow](#canonical-round-flow). Do not pull
+   or rebase a pushed branch to catch up.
+2. Rename the window and re-announce the PR as described below.
+3. State which case applies:
 
-### First, re-establish the world
-
-- **Position comes from git, not from the transcript.** Confirm the worktree,
-  branch, and head. Fetch, and determine whether the effective base moved while
-  you were gone. Do not pull or rebase a pushed branch to "catch up"; reconcile
-  it the way this file already requires.
-- **Re-check PR state** per [Canonical round flow](#canonical-round-flow).
-- **Re-announce yourself.** A resumed window has lost whatever it had on
-  screen, so nothing identifies it. Rename it and restate your PR per
-  [Making your work findable](#making-your-work-findable).
-
-### Then act on where you stopped
-
-Exactly one of these applies. Say which, in one line, before doing anything
-else.
-
-- **Mid-stream — continue.** Pick the work back up. The re-check above takes
-  precedence: a conflict, a failed gate, or a moved base supersedes your
-  restored plan and is handled first. Conflict recovery remains the first
-  priority. If nothing changed, do not re-litigate decisions already made in
-  the transcript; carry on from them.
-- **Waiting on the user — restate the request.** Never assume the question was
-  seen or answered while you were gone. Restate it in full, including the
-  context needed to answer it and the options you were choosing between; a
-  pointer to an earlier message is not a restatement, because the user may be
-  looking at a fresh window with none of that history on screen. Then wait.
-- **Task complete — report and propose.** State what landed and what proves it.
-  Then either propose the next piece of work, with a reason it is the right
-  next thing, or ask for a task. Propose; do not start. Inventing scope after a
-  resume is how a finished PR grows changes nobody asked for.
-
-If you cannot tell which of the three applies, that is the fourth case: say so,
-summarize what the transcript claims and what git shows, and wait rather than
-guessing.
+- **Mid-stream:** continue, but handle conflicts, failed gates, or moved bases
+  first. Do not revisit decisions already settled in the transcript.
+- **Waiting on the user:** restate the full question and options, then wait.
+- **Task complete:** state what landed and what proves it, then propose the next
+  task without starting it.
+- **Unclear:** explain what the transcript claims and what git shows, then wait.
 
 ## Making your work findable
 
-Work runs in many concurrent agent windows across several machines. Whoever is
-watching must be able to tell, without attaching to any of them, which PR each
-window is on and which one needs a person. These conventions carry that, along
-with one rule about what you are entitled to claim. Use them.
+Each window must identify its PR, current state, and any decision it needs.
 
 ### Name the window for identity
 
@@ -86,233 +53,46 @@ with one rule about what you are entitled to claim. Use them.
 tmux rename-window -t "$TMUX_PANE" pr<number>
 ```
 
-**The `-t "$TMUX_PANE"` is required, not decoration.** Bare `tmux rename-window`
-resolves to the session's *current* window, not the window you are running in —
-so without it you rename whichever window the operator happens to be viewing,
-and every agent overwrites every other agent's name. Verified: a rename issued
-from window 2 renamed window 0.
+Always target `"$TMUX_PANE"`; a bare command can rename another window. Rename
+the window, never the shared session. Use `pr<number>`, or `i<number>` before a
+PR exists. Keep the name stable except for these temporary suffixes:
 
-Rename the window, never the session. A session is shared by every window on
-that host, so renaming it identifies nothing. Without a PR yet, use the issue:
-`i<number>`.
-
-Keep the name short and stable. The status bar truncates, and a truncated name
-reads as a corrupted one. Do not encode changing state in it — your terminal
-title already carries that, updates itself, and costs nothing.
-
-The one exception is a state a person must act on. Append a single token then,
-and remove it when it clears:
-
-| suffix | means |
+| Suffix | Meaning |
 | --- | --- |
 | `-blocked` | waiting on a human decision |
 | `-conflict` | in conflict recovery |
 
-`pr4405-conflict` is worth the eight characters. `pr4405-round-6-of-adversarial-review` is not.
-
 ### Announce PR identity in your output
 
-State which PR you are on, in your visible output, in a form a reader and a
-script can both parse. Either pattern below is sufficient and both is fine; what
-matters is that the literal token `PR #<number>` or `PR <number>` appears, and
-the branch name where it is relevant.
-
-Beginning or continuing work:
-
-> Continue PR #4405 readiness for frozen expected head `595e5d4b…` on branch
-> `browser-platform-workspace` after conflict recovery.
-
-Completing a round:
-
-> Round 6 is complete for PR 4463.
-> - Review models GPT-5.6 Sol and Claude Opus 5 were used for adversarial review.
-> - Review feedback is: converging.
-> - Round start / end / duration.
->
-> Reviews: 1/2 clean — GPT-5.6 Sol clean, Claude Opus 5 pending
-> Blocked: 4597, 4611
-> Recommendation: Wait
->
-> Fix description: …
-
-Those three lines are the ones a reader cannot get anywhere else. Include them
-on every round completion, and omit `Blocked` only when it is genuinely empty.
-
-- **`Reviews: <clean>/<required>`** — the dual-clean count, and the actual bar
-  for done. **This is the one fact no tool can observe.** GitHub knows whether
-  CI passed and whether the branch merges; it has no idea that one reviewer came
-  back clean and the other has not reported. Without it nobody can tell a PR
-  that is one review from landing apart from one nobody has reviewed at all.
-- **`Blocked: <numbers>`** — PRs or issues you are waiting on that are **not
-  yours to fix**. Red CI attributable to something on this list is not a defect
-  in your PR, and no one should be dispatched at it. Naming them is what stops
-  several agents converging on one shared flake; behind a known blocker the
-  correct action for everyone is to wait, and an idle agent is the right outcome
-  there rather than a wasted one.
-
-  **Every entry must be a number someone can open, and it is your job to make
-  sure one exists.** If a flake is blocking you and no issue has been filed for
-  it, file the issue, then cite it. Being unable to point at what is blocking
-  you is the failure this field exists to prevent: an uncitable blocker cannot
-  be prioritised, cannot be deduplicated against the next agent that hits the
-  same flake, and leaves your `Wait` indistinguishable from a stall.
-- **`Recommendation:`** — exactly one of `Wait`, `Merge`, `Approve next rounds`,
-  or `Stop (reason)`: the disposition of this window, not a summary of your
-  progress. What separates them is whether the window needs a **decision**
-  before anything moves. Three of them do. `Wait` is the one that does not —
-  which is not the same as it being silent.
-
-  **`Wait` means "let me wait — what I listed in `Blocked:` is still
-  outstanding."** It is not idleness in need of explanation and not a request
-  for instructions: nobody should dispatch you, re-plan you, or send you at CI,
-  and you resume yourself when the blockers clear. What it does put in front of
-  the operator is the blocker list, because they may not know that a particular
-  PR or flake is holding work back and may decide to prioritise it. That is why
-  the entries have to be citable. `Wait` is also only coherent beside a
-  non-empty `Blocked:` — if nothing is blocking you then you are not waiting,
-  and one of the other three is the honest answer.
-
-  **`Stop (reason)` is a request, not a fait accompli.** You are asking to be
-  released from this work and naming why — superseded by another PR, approach
-  rejected, six rounds without convergence. Granting it is a decision with
-  follow-up attached: granted, you write a note on the PR recording why the work
-  stopped and then close it; declined, the work continues, possibly with
-  reframed goals, or becomes a `Wait` on whatever has to land first. Until you
-  have an answer, change nothing and close nothing.
-
-  **`Merge` and `Approve next rounds`** each need a person before anything moves
-  at all.
-
-Restate it after every resume and at the start of every round, not once at the
-beginning. A window that has scrolled past its only mention of the PR is a
-window nobody can identify.
-
-### Claiming ready to merge
-
-Getting CI green and the branch mergeable is part of finishing the work. Pursue
-both; handing over a red or conflicted PR you could have fixed is not an effective handover.
-
-**This section is about what you may claim, not about when you may integrate.**
-Integration cadence is already specified and this does not modify it: the two
-integrations per round in [the round flow](#canonical-round-flow), and — for the
-narrow case where a required review is already clean at the current head and
-`origin/main` has since moved — [Clean reviews are not spent by main
-moving](#clean-reviews-are-not-spent-by-main-moving), which is stop-and-ask and
-a possible carry-forward, never an integration you launch on your own
-initiative.
-
-Ready to merge means two things: **the reviews are clean, and the branch
-merges.** Say it when both hold, and not before.
-
-Green CI is not a third condition. Chase it — it is useful evidence and part of
-finishing the work — but checks go red for reasons that have nothing to do with
-your change, so passing checks alone do not make a PR ready.
-
-Two claims have to be earned rather than assumed:
-
-- **Do not report `mergeable` from a local merge check.** GitHub computes
-  `mergeable_state` lazily — the first read after a change returns `unknown` and
-  only starts the calculation, so the answer arrives on a later read. A one-off
-  check of the open PRs found 18 of 32 answering `unknown` on the first read,
-  and two of those resolved to `dirty` — both on PRs whose agents had just
-  reported them as mergeable. Re-read until it is no longer `unknown`, and say `mergeability
-  unverified` rather than guessing.
-- **Do not report `ready to merge` while a round is still in flight.** The state
-  is the round, not the destination.
-
-A conflict found late costs a whole extra pass. Checking mergeability at the
-moment you claim it is what holds that to one.
-
-Accuracy here has a specific consequence worth knowing. When you report ready
-and CI or mergeability disagrees, that discrepancy is routed to the **operator**
-rather than back to you — nobody re-dispatches an agent that has declared itself
-done. An unearned "ready to merge" therefore does not cost you another round; it
-spends the attention of the one participant who cannot be automated.
-
-### Checking costs a budget you share
-
-Every agent draws on the same GitHub account, so there is one hourly request
-budget across all of them, on every host. Nothing divides it fairly and nothing
-warns you when it is gone — a starved agent simply gets errors back and stops
-being able to see its own PR.
-
-It is currently spent very unevenly. A one-off check found the account's GraphQL
-budget fully exhausted — 0 remaining, with more attempted than the hourly limit
-allows — while REST sat at 4,967 of 5,000, barely touched. An agent that cannot
-read its PR's state cannot move it forward, so this is a plausible reason some
-PRs advance steadily while others stall for no visible reason.
-
-Two habits recover most of it.
-
-**Prefer REST.** `gh pr view`, `gh pr checks`, and `gh pr list --json` are
-GraphQL, which is the exhausted half. These answer the same questions from the
-half that is idle:
-
-```sh
-gh api repos/{owner}/{repo}/pulls/{number}                 # state, mergeable_state, head
-gh api repos/{owner}/{repo}/commits/{sha}/check-runs       # checks on that head
-```
-
-**Check at a point, then set when you will check again.** Decide what you are
-waiting for, look once, and if it has not happened, pick a time to look again
-and stop until then. Do not sit in a query loop: re-asking about a head that has
-not moved cannot return anything new, and doing it on a timer is what drains the
-budget everyone else is also drawing on.
+At the start of work, after every resume, and at every round start, include the
+literal token `PR #<number>` or `PR <number>`, plus the branch or expected head
+when relevant. Round completions must use the report in
+[`docs/round-orchestration.md`](docs/round-orchestration.md#the-round-report).
 
 ### Publish your state where tooling can read it
 
-Set a window-scoped tmux option whenever your state changes. The bar renders it
-for whoever is viewing that window, and tooling reads it directly instead of
-scraping your output:
+Update both window-scoped options whenever state changes:
 
 ```sh
 tmux set -w -t "$TMUX_PANE" @agent "round 6 on pr4405, waiting on CI"
-tmux set -w -t "$TMUX_PANE" -u @agent          # clear when it no longer holds
-```
-
-`-w -t "$TMUX_PANE"` scopes it to **your** window. `status-right` is a session
-option; writing it directly would overwrite every other agent, the same way bare
-`rename-window` did.
-
-Omit your window number from the value — the bar already knows where it is.
-Update on real transitions, not on a timer.
-
-**Verify the write landed on your own window.** That `-t "$TMUX_PANE"` is the
-whole safety of this mechanism, and dropping it is not a theoretical risk: a
-one-off check of a live host found three windows all carrying an identical
-`@agent` that described a *fourth* window's PR, while that PR's own window held
-a newer value. One agent's writes had landed on three neighbours, making three
-agents appear to be working on a PR they had never touched. Read it back once
-after you set it, and fix it if it names someone else's PR.
-
-Alongside `@agent`, set a second option carrying the same state as fields.
-`@agent` is the sentence a person reads off the bar; `@agent_state` is the copy
-a tool reads, and because it is never rendered it is neither truncated nor
-abbreviated:
-
-```sh
 tmux set -w -t "$TMUX_PANE" @agent_state \
   "pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
-tmux show -w -t "$TMUX_PANE" @agent_state      # read back: must name YOUR pr
+tmux show -w -t "$TMUX_PANE" @agent_state
+
+# Clear when this window no longer owns the PR.
+tmux set -w -t "$TMUX_PANE" -u @agent
+tmux set -w -t "$TMUX_PANE" -u @agent_state
 ```
 
-`pr` and `head` are always required, the rest when they apply. `rec` takes the
-same four values as `Recommendation`, lowercased, with `Approve next rounds`
-written `approve`. Values carry no spaces. Update it on the same transitions as
-`@agent` and clear it with `-u` when the window stops owning a PR.
-
-**Why an option rather than only your output.** This UI runs on the alternate
-screen, so tmux keeps no scrollback for it — `capture-pane -S -400` returns the
-same single screen as a plain capture. Once your report scrolls past the top it
-is unrecoverable by any tool and the window goes anonymous. A window option
-persists until you change it, outlives the report scrolling away, and cannot be
-garbled by line wrapping. Your output stays where a person reads the detail;
-this is what remains legible after it is gone.
+Always use `-w -t "$TMUX_PANE"` and read back `@agent_state`. It must include
+`pr` and `head`; add `round`, `reviews`, `blocked`, and `rec` when applicable.
+Values contain no spaces. `rec` is `wait`, `merge`, `approve`, or `stop`.
+Clear both options when the window no longer owns a PR.
 
 ### Signal when you need a person
 
-Whenever you stop and wait on a human decision, raise a flag that persists and
-send one nudge that does not:
+When blocked on a human decision, set a persistent `HELP` state and send one
+best-effort nudge:
 
 ```sh
 tmux set -w -t "$TMUX_PANE" @agent "HELP: integrate main into pr4405, or close it?"
@@ -320,110 +100,53 @@ tmux display-message -d 10000 -t "$TMUX_PANE" \
   "HELP pr4405 in w#{window_index}: integrate main, or close it?"
 ```
 
-The `HELP` prefix marks your window with `!` in the window list, so you are
-visible from any window, not only your own. `display-message` expands
-`#{window_index}` against `-t`, so the nudge names both the PR and where to find
-you — a notification that says only "something needs a decision" makes the
-operator hunt.
-
-Send the nudge once, on becoming blocked — not on a timer, and not again for the
-same question. Clear `@agent` when you are unblocked; a stale `HELP` is worse
-than none, because it spends attention on a question already answered.
-
-**The nudge is best effort and will often go unseen.** Nobody may be attached;
-the person may be in another window, on another machine, or asleep. That is what
-the flag is for: it waits. Neither is a handoff — a raised flag is not a
-delivered question and never an answered one. Stop at your prompt and wait
-exactly as you would have without it, and restate the request in full when
-resumed.
-
-Flag only for being blocked. Progress and completion belong in `@agent` as
-ordinary state and in your output; resuming is not a signal at all.
+Send the nudge once, then stop and wait; the flag is not an answer. Clear `HELP`
+as soon as the decision arrives. Use ordinary state for progress and completion.
 
 ## User-directed workflow adjustments
 
-The workflow gates in this file establish the default safe sequencing. A user
-may explicitly adjust a process gate for a specific task or PR in the interests
-of speed, including directing work that normally waits on another step to run
-in parallel. Follow that direction rather than refusing solely because the
-default is described as a gate, and preserve every requirement the user did not
-adjust.
-
-An adjustment changes sequencing, not evidence. Record the scope of the
-adjustment and any consequence for what the result proves. Work tied to an
-exact head remains valid only for that head; if parallel validation or a later
-change moves it, apply the fixed-head rules to the new head. A user-directed
-adjustment does not turn failed validation into success or make an unmergeable
-change ready to merge.
+The user may adjust a sequencing gate for a specific task or PR. Follow that
+direction, record its scope and evidentiary consequence, and preserve every
+other requirement. An adjustment does not make failed validation successful,
+make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 
 ### Standing adjustments
 
-Two are common enough to name. Both still need the user's word for the specific
-PR; naming them means treating them as expected requests rather than exceptions
-to be argued about.
-
-**Review in parallel with CI.** The eligibility table makes an ordinary
-subsequent round wait for green current-head `ci-required`. When the user
-directs it, dispatch that round while CI runs. Sequencing changes, nothing else:
-a CI failure needing an author change still supersedes the attempt under
-[Recovery transitions](#recovery-transitions), and a superseded round's findings
-still carry forward.
-
-**Auto-merge on the final push.** Once every required review is review-clean and
-a push is intended to be the last, the user may direct that auto-merge be armed,
-letting GitHub merge when the required checks pass. **The agent may ask for
-this** — it is the one merge-related request to raise on its own initiative, and
-asking is not merging.
-
-Arming auto-merge authorizes the merge of the reviewed head; it is not a
-standing grant for the branch. GitHub keeps it armed across later pushes, so
-anything pushed afterward merges unreviewed once checks pass. If the head moves
-after arming — a review finding, a conflict resolution, a restack — disarm it,
-review the new head, and ask again.
+- **Review in parallel with CI:** requires the user's approval for that PR. A CI
+  failure requiring an author change still supersedes the attempt, and all
+  findings carry forward.
+- **Auto-merge on the final push:** once every required review is review-clean,
+  the user may authorize auto-merge for the intended final head; the agent may
+  ask. If the head moves after arming, disarm, review the new head, and ask
+  again.
 
 ## Before changing files
 
-- `main` is protected. Keep the primary repository checkout attached to
-  `main`; never detach its HEAD or develop in it.
-- Before starting a change, run `git fetch origin main` from the primary
-  checkout, then create a descriptive branch and linked worktree with
-  `git worktree add -b <branch> <repo>/.worktrees/<slug> origin/main`. Make all
-  edits, builds, tests, and commits in the worktree, not the primary checkout.
-  Do not create worktrees as direct children of the user's home directory. A
-  slice in a stack branches from its parent slice's branch instead. If a GitHub
-  outage prevents the fetch, the outage exception under [Stacked PRs for
-  multi-slice issues](#stacked-prs-for-multi-slice-issues) permits a new slice
-  to use its recorded last-known local base or parent until service recovers.
-- Use one development worktree per PR, plus temporary worktrees for independent
-  reviews. Development worktrees belong under the primary checkout's
-  `.worktrees/` directory. Reviewer worktrees belong there or under an
-  operating-system temporary directory; they are also prohibited at the root
-  of the user's home directory. Do not reuse a worktree across unrelated
-  changes.
-- Never amend commits; create follow-up commits.
-- For an open PR, the candidate, lock, CI, conflict, failed-gate, base-movement,
-  and round-restart rules have one source of truth: [Canonical round
-  flow](#canonical-round-flow). **Conflict recovery remains the first
-  priority**; apply that flow before tests, reviews, restacks, or unrelated
-  follow-up work.
-- Rebase only before the branch's first push. Once a branch is public or under
-  review, merge `origin/main`; never amend, rebase, or force-push reviewed
-  history. A slice in a stack is the standing exception: restacking rebases and
-  force-pushes a public branch by design — see
-  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues) for
-  the discipline that replaces this rule there.
-- After updating from main or resolving conflicts, re-read `AGENTS.md` and
-  task-relevant docs before continuing.
-- Do not mix unrelated changes into one commit or sweep another contributor's
-  working-tree changes into your work.
-- Treat worktrees as temporary. Remove a reviewer worktree after that reviewer
-  has returned or its cancellation is acknowledged and any required
-  reproduction there is complete. Remove the development worktree only after
-  the exact reviewed head is pushed, its head lock has ended with all required
-  concurrent gates successful, and every required fixed-head review at that
-  head is review-clean — or after merge, for a change that needs no adversarial
-  review. Do not retain inactive worktrees in case more work appears; recreate
-  one for the branch if follow-up work is needed.
+- Keep the primary checkout attached to protected `main`; never develop or
+  detach HEAD there.
+- From the primary checkout, run `git fetch origin main`, then create a
+  descriptive branch and linked worktree:
+
+  ```sh
+  git worktree add -b <branch> <repo>/.worktrees/<slug> origin/main
+  ```
+
+  A stacked slice branches from its parent. During a GitHub outage, use the
+  recorded last-known base allowed by [the stack rules](#stacked-prs-for-multi-slice-issues).
+- Use one development worktree per PR and one temporary worktree per reviewer.
+  Put them under `.worktrees/` or, for reviewers, an OS temporary directory;
+  never directly under the home directory.
+- For an open PR, apply [Canonical round flow](#canonical-round-flow) before
+  other work. Conflict recovery has first priority.
+- Never amend. Rebase only before the first push. After publication, merge the
+  effective base; never rebase or force-push reviewed history except when
+  restacking your own slices under the stack rules.
+- After integrating or resolving conflicts, re-read this file and the relevant
+  focused docs. Do not include unrelated or another contributor's changes.
+- Remove reviewer worktrees after review and reproduction finish. Remove a
+  development worktree after merge, or after the exact pushed head is unlocked,
+  all concurrent gates pass, and every required review is review-clean. Recreate
+  it later if needed.
 
 ## Task-specific guidance
 
@@ -543,29 +266,27 @@ Match the surrounding casing and word form when substituting (for example
 
 ## Building and testing
 
-Use the SDK and toolchain selected by current repository configuration and CI.
-Version requirements belong with those owners, not in this file. Before
-installing an SDK or changing `PATH`, inspect the current selection:
+Use the SDK selected by repository configuration and CI. Before installing an
+SDK or changing `PATH`, inspect the current selection:
 
 ```bash
 command -v dotnet
 dotnet --version
 ```
 
-If `dotnet` is centrally installed (for example under `/usr/bin`,
-`/usr/local/share/dotnet`, `/snap`, or `C:\Program Files\dotnet`), stop and ask
-before installing, replacing, or shadowing it. Follow
-`README.md#repository-development-sdk` for the current SDK acquisition
-workflow. Do not modify shell startup files unless explicitly requested.
+If `dotnet` is centrally installed, stop and ask before replacing or shadowing
+it. Follow `README.md#repository-development-sdk`; do not change shell startup
+files unless asked.
 
-Build the normal product, test, and fixture graph with:
+Build the normal graph with:
 
 ```bash
 dotnet build dotnet-inspect.slnx -c Release
 ```
 
-Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
-`dotnet test` silently executes no tests here.
+Tests are xUnit executables. **Use `dotnet run`, not `dotnet test`**;
+`dotnet test` silently executes no tests here. Always use Release because
+compiler-generated IL shapes differ in Debug.
 
 | Area | Command |
 | --- | --- |
@@ -578,49 +299,20 @@ Tests use xUnit executable projects. **Use `dotnet run`, not `dotnet test`**;
 | Metadata and SourceLink | `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` |
 | Metadata rendering and `mdi` | `dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release` |
 
-Run the suite in **Release** for input fidelity, not speed: the optimized IL a
-Release build of the compilers emits is what ships and what the decompiler
-corpus consumes, so a Debug run would validate the decompiler against IL shapes
-users never see. A correctness check therefore must not hide behind
-`[Conditional("DEBUG")]` — such a call is stripped from the Release test
-assembly and asserts nothing. Make it a runtime opt-in that the test host arms
-instead; the IR invariant check (`IrInvariants`, on by default in every host but
-the shipped CLI) is the worked example, and
-`docs/decompiler-correctness-pipeline.md` owns its host contract, its structural
-and semantic levels, and what to do when a fixture trips one.
+A .NET correctness gate must run in Release. Do not use
+`[Conditional("DEBUG")]`; use a runtime opt-in such as `IrInvariants`. The host
+contract lives in `docs/decompiler-correctness-pipeline.md`.
 
-Some tests use external tools as independent oracles and **skip** when those
-tools are absent: `ilasm`/`ildasm` (CLI and decompiler suites) and `mdv`
-(the metadata projection oracle). A machine without them reports a green run
-that proved less than it appears to, so restore them before trusting a clean
-result:
+The CLI and decompiler suites skip `ilasm`/`ildasm` checks when those tools are
+missing; metadata tests do the same for `mdv`. Activate all three before relying
+on a clean run:
 
 ```bash
 source eng/activate-iltools.sh --mdv
 ```
 
-`eng/restore-iltools.sh` does the acquisition and prints the directories;
-`eng/activate-iltools.sh` is the sourceable wrapper that puts them on PATH.
-Source the wrapper rather than assembling PATH by hand. A child process cannot
-change its parent's PATH, so the assembly has to happen in your shell, and
-every way of getting it wrong is silent -- a masked exit status, a lost
-trailing newline, or empty output prepending an empty PATH entry, which means
-the current directory. Each leaves a plausible PATH with no oracles on it. The
-wrapper is the one tested copy of that logic; `IlToolsActivationTests` in
-`src/dotnet-inspect.Tests` is its gate, and also fails if this documentation
-goes back to hand-rolling the assembly.
-
-The script pins the `ilasm`/`ildasm` version for CI and local runs alike;
-`ci.yml` and `deep-inspect.yml` invoke `eng/restore-iltools.sh` directly,
-appending its output to `$GITHUB_PATH` so the runner does the joining. Only
-`ci.yml` passes `--mdv`, because it is the only workflow that runs the metadata
-oracle suite. Each install step is `continue-on-error` so that a feed outage
-does not cost every other result in the lane, but a terminal
-`Check ilasm/ildasm[/mdv] result` step fails the lane if acquisition failed:
-losing oracle coverage is red, not a quietly shorter skip list. Deep Inspect
-cannot certify that commit, so `release.yml` rejects the run before building
-packages. `IlToolsActivationTests.SlowWorkflows_FailAfterOracleRestoreFailure`
-gates the Deep Inspect wiring.
+Source the wrapper; do not assemble `PATH` by hand. CI restores the same pinned
+tools and fails its lane if acquisition fails.
 
 The IL round-trip project has separate dependency restore and fast/full test
 commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.
@@ -628,48 +320,24 @@ commands; follow `tests/DotnetInspector.ILRoundtrip.Tests/README.md`.
 `--gate <preset>` flag (`--gate list` prints the table); the taxonomy and the
 per-change targeting advice live in `docs/decompiler-correctness-pipeline.md`.
 
-Only tool projects explicitly set `IsPackable=true`, and `IsTool` makes those
-same projects available to solution-level `dotnet publish`. Internal libraries
-carry no versioning story or API-stability commitment: treat their public
-surface as an internal design constraint, not an external compatibility
-surface. Packability and publishability control SDK commands; release workflow
-membership remains owned by `docs/release-workflow.md`.
-
-Changing `VersionPrefix` in `src/dotnet-inspect/dotnet-inspect.csproj` is a
-release, and `README.md` (packed as the package readme) and the shipped
-`SKILL.md` files (embedded in the binary) ship with it. Consult both before the
-version moves and update whatever the release changed; the checklist is in
-`docs/release-workflow.md`.
+Only tool projects set `IsPackable=true`; `IsTool` also makes them available to
+solution-level publish. Internal library APIs are not external compatibility
+surfaces. Changing `VersionPrefix` is a release: follow
+`docs/release-workflow.md` and update the shipped `README.md` and skills.
 
 ### Package acquisition when nuget.org is disabled
 
-Some machine-level NuGet configurations disable nuget.org in favor of a
-company-imposed proxy feed. When that proxy does not mirror a pinned package
-version -- the co-developed `Markout` pins in `Directory.Packages.props` are
-the common case -- restore fails with `NU1603` ("was not found ... resolved
-instead") even though nuget.org serves the exact pin.
-
-Do not edit the machine-level NuGet config, and do not commit a repository
-`nuget.config` that starts with `<clear/>`: clearing the inherited sources on
-such a machine has previously left it with no usable feed at all. Instead,
-override the source list for a single restore. `--source`/`-s` replaces the
-configured feeds for that one invocation only and downloads the pinned
-versions into the global package cache (`~/.nuget/packages`):
+If a machine-level proxy lacks an exact pinned version and restore reports
+`NU1603`, do not edit machine configuration or commit a clearing
+`nuget.config`. Override sources for one restore:
 
 ```bash
 dotnet restore dotnet-inspect.slnx -s https://api.nuget.org/v3/index.json
 ```
 
-Subsequent restores resolve exact centrally-pinned versions from that cache
-without consulting any feed, so plain `dotnet build` works afterward. The fix
-is per-machine and must be repeated after `dotnet nuget locals all --clear` or
-when a pin moves to a version the proxy still lacks.
-
-Prefer `--source` over `--add-source` for this recovery: a restore given both
-nuget.org and the proxy has been observed to still fail with `NU1603` when the
-proxy answers with a different version of the same package.
-
-Acquiring the shipped tool accepts the same override, verified for both forms:
+Prefer `--source` to `--add-source`; the package cache then satisfies later
+restores. Repeat after clearing the cache or changing to an uncached pin. Tool
+acquisition accepts the same override:
 
 ```bash
 dotnet tool install -g dotnet-inspect --source https://api.nuget.org/v3/index.json
@@ -678,9 +346,9 @@ dnx dotnet-inspect --source https://api.nuget.org/v3/index.json
 
 ### File-based apps
 
-Do not use `dotnet-script`, `dotnet script`, `dotnet-fsi`, or `.csx` files.
-Prefer .NET file-based apps for throwaway probes unless a specific Python
-library is needed. Write probes under `/tmp/` and run them with:
+For throwaway probes, use .NET file-based apps under `/tmp/` unless a specific
+Python library is required. Do not use `.csx`, `dotnet-script`, `dotnet script`,
+or `dotnet-fsi`.
 
 ```bash
 dotnet run /tmp/check.cs
@@ -734,51 +402,22 @@ Match evidence to the claim and use the smallest existing check that proves it:
 
 ### Asserted properties name their gate
 
-"Unverified" is an acceptable answer; an unmarked, ungated claim is not. A
-green suite plus a confident comment reads exactly like a verified property,
-and a reviewer can only tell them apart by tampering with the code to see
-whether anything notices. Naming the gate moves that cost to the author, where
-it is a one-line answer.
-
-Prefer making the declaration *drive* the enforcement set over restating it, so
-that stale and missing entries both fail — `ByteNeutralityGateTests` derives its
-coverage set from the style catalog
-(`StyleOptionCatalog.Options.Where(o => !o.ByteDivergent)`) and asserts set
-equality against the specimens; `SpanAttributionTests` asserts set equality
-between the body-intrinsic error allowlist and the pin for the current
-`MethodologyVersion`. When the property depends on wiring rather than on a set,
-write one named non-vacuity test that fails if the wiring dies, and say in its
-doc comment that it is that test —
-`IrInvariantCheckTests.PipelineRunner_UnderTestHost_ThrowsWhenAPassCorruptsTheTree`
-is the example.
-
-A gate only counts if it runs in the configuration the suite uses. The suite
-runs Release for fixture fidelity (see [Building and
-testing](#building-and-testing)), so a `[Conditional("DEBUG")]` check asserts
-nothing. Make such a check a runtime opt-in that the test host arms; do not
-switch the suite to Debug.
+A safety, soundness, or faithfulness claim must name its enforcing gate or say
+`unverified`. Prefer deriving the gate's expected set from the declaration so
+both missing and stale entries fail. For wiring properties, add one named
+non-vacuity test that fails when the wiring is removed. A gate counts only when
+it runs in the suite's Release configuration; use runtime opt-ins, not
+`[Conditional("DEBUG")]`.
 
 ### Harness boundary
 
-Test harnesses own orchestration, fixtures, independent oracles, comparison,
-and reporting. When behavior belongs to the product, a harness must exercise
-the product-owned capability rather than reconstructing or replacing it.
-
-Harnesses may parse source or diagnostics to observe and measure independent
-evidence. They must not use that parsed representation to construct, normalize,
-repair, or rewrite C# that the harness later compiles as product evidence. The
-product must own that artifact construction and expose typed identities, ranges,
-or replacement operations so the harness never becomes a second C# producer.
-
-Do not add harness-side adaptive mechanisms, fallback resolvers, special-case
-shape recognition, or normalization that compensates for missing, incomplete,
-or incorrect product behavior. Such compensation hides the product gap and
-makes the harness a second implementation.
-
-If a test cannot express its claim without covering for the product, stop and
-ask for guidance. File an issue against the missing product capability and
-either fix that capability first or record the harness work as blocked; do not
-make the harness substitute for the product.
+Harnesses own orchestration, fixtures, independent oracles, comparison, and
+reporting. They may parse source or diagnostics to measure evidence, but must
+exercise product-owned artifact construction. Do not construct, normalize,
+repair, or rewrite C# that is later compiled as product evidence, and do not add
+fallbacks or shape recognition that compensate for missing product behavior.
+If a test requires that compensation, stop, file the product gap, and fix it or
+mark the harness work blocked.
 
 Decompiler raising, typing, structuring, fidelity, or printer changes have
 additional evidence requirements. Follow the decompiler docs and PR templates
@@ -827,43 +466,29 @@ driving the loop is
 
 ### Canonical round flow
 
-This section is the sole source of truth for candidate formation, round
-eligibility, head locking, supersession, and recovery. Other sections add
-reviewer, stack, or readiness detail without redefining these transitions.
+This section owns candidate formation, eligibility, locking, supersession, and
+recovery. `docs/round-orchestration.md` owns the mechanics.
 
 #### The round cycle
 
-Steps 1-5 run with no lock held. The lock begins at the push, and ends at step
-10 unless a [recovery transition](#recovery-transitions) supersedes the attempt
-first.
+Steps 1-5 run unlocked. The push at step 6 locks the head until step 10 or a
+recovery transition supersedes it.
 
-1. **Integrate** the effective base, so the work is written against current
-   `main` rather than against history.
-2. **Fix** — the review-driven changes, or the initial authoring for round 1.
-3. **Validate** the fix with the focused gate.
-4. **Integrate again.** Fixing takes real time, and `main` moves during it.
-5. **Validate again**, enough to prove the integration did not break the fix.
-   Scope it by the rerun rule under [Evidence and
-   validation](#evidence-and-validation): focused gates for whatever the landed
-   range can interact with, not the broad suite again.
-6. **Push.** That head is the candidate, and the lock begins here.
-7. **Confirm zero conflicts and green current-head `ci-required`** — unless the
-   round's row below leaves them pending, or the user authorized reviewing in
-   parallel with CI. A conflict or a failed check here does not mean waiting
-   longer; take the matching [recovery transition](#recovery-transitions).
-8. **Review**: dispatch every required reviewer at that exact head.
-9. **Reconcile** the feedback publicly.
-10. **Close the round** once it is also green (invariant 6). The lock ends here,
-    and only here is the round number spent. Emit the round report as your
-    visible response — required, format in [the round
-    report](docs/round-orchestration.md#the-round-report) — and if the
-    reconciliation produced fixes, the next round begins at step 1.
+1. Integrate the effective base.
+2. Make the initial or review-driven change.
+3. Run the focused gate.
+4. Integrate the effective base again.
+5. Re-run focused gates for anything the integrated range can affect.
+6. Push and record the candidate head and effective base; the lock begins.
+7. Satisfy the applicable eligibility row below.
+8. Dispatch every required reviewer at the exact candidate head.
+9. Reconcile all feedback publicly.
+10. Close only when reconciliation and every current-head gate are green. The
+    lock ends, the round number is spent, and the visible
+    [round report](docs/round-orchestration.md#the-round-report) is required.
 
-**Two integrations per round, both before the push.** The first makes the work
-current; the second closes the window the fix itself opened, which can be an
-hour wide and several merges deep. After the push, base movement does not
-reopen the candidate — that is invariant 3, and it is what stops the cycle from
-running forever.
+Both integrations happen before the push. Base movement after the push does not
+reopen the locked candidate.
 
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
@@ -872,482 +497,216 @@ running forever.
 | Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, zero conflicts, green current-head `ci-required` | Nothing required |
 
-Documentation-only ordinary candidates use Markdown linting as their focused
-gate. A documentation conflict-recovery attempt instead lints after the
-resolution push; it may start review immediately, but cannot reconcile or
-complete until lint succeeds.
-
-The user may direct that a round run in parallel with CI, waiving the green
-`ci-required` requirement in the rows above; see [Standing
-adjustments](#standing-adjustments).
-
-The head lock ends when the round closes: reconciled, current-head
-zero-conflict evidence confirmed, and every required current-head check and
-concurrent local gate succeeded. A superseded attempt is the other exit — it
-releases the lock through recovery, spends no round number, and never reaches
-closure. The fixed replacement is a new candidate and its review is a new round.
+Markdown lint is the focused gate for documentation-only changes. A
+documentation conflict-recovery attempt may review before lint finishes, but
+cannot reconcile or close without it. The user may authorize review in parallel
+with CI.
 
 #### Review-clean, and what it gates
 
-A fixed-head review is **review-clean** when its public reconciliation leaves no
-finding unresolved **and the reviewed head did not move in response to that
-round**. A justified dismissal counts as a resolution only when the reason is
-recorded publicly.
-
-Three consequences follow, and they are the ones most often missed:
-
-- A round that pushes a fix is *complete* but not review-clean. Only the
-  replacement head can earn that status, which means a fix-producing round
-  always implies at least one more round.
-- Merge readiness requires a review-clean review **at the current head**. An
-  author who wants to stop while the last round pushed a fix is asking for a
-  waiver, not making a judgment call. Ask for it explicitly. An approved
-  carry-forward integration is the one move that *transfers* review-clean status
-  to a head no reviewer saw; nothing else does.
-- A review-clean round ends adversarial review. Do not move the head merely to
-  buy another pass.
-
-The report classification `clean` is narrower than review-clean: use it only
-when the reviewers returned no findings at all.
+A review is **review-clean** when public reconciliation leaves no finding
+unresolved and the head did not move in response. A justified dismissal counts
+only when recorded publicly. A fix-producing round can complete but is not
+review-clean; only the replacement head can earn that status. A review-clean
+round ends adversarial review. The report classification `clean` is narrower:
+use it only when reviewers returned no findings.
 
 #### Recovery transitions
 
-Apply one transition when the locked head becomes invalid:
+- **Conflict:** supersede the attempt, integrate and resolve, push immediately,
+  and restart the same round without waiting for CI. The six-round boundary
+  still applies.
+- **Failure requiring an author change:** supersede the attempt, push the fix,
+  satisfy the failed-gate row, and restart the same round.
+- **Cancelled or evidenced transient failure:** keep the lock and retry the
+  unchanged head. Repeat only with concrete transient evidence; otherwise treat
+  it as requiring an author change.
 
-- **Conflict:** supersede the attempt, release the lock, integrate and resolve
-  the effective base, push immediately, and restart the same numbered round
-  without waiting for CI. The six-round approval boundary still applies.
-- **Failure requiring an author change:** supersede the attempt, release the
-  lock, push the fix, satisfy the failed-gate restart row, and restart the same
-  numbered round.
-- **Cancelled or evidenced transient failure:** keep the unchanged head and its
-  lock, re-run the failed check, and continue if it passes. After another
-  failure, repeat only with concrete transient evidence or classify it as
-  requiring an author change. Never continue or complete while a required check
-  remains red.
-
-A superseded attempt consumes no round number and receives no completion
-report. Let its reviewers finish or cancel them explicitly. Before completing
-the restarted round, wait for every superseded reviewer to finish or have its
-cancellation acknowledged, carry forward every returned finding, and
-disposition each one publicly. Supersession never retires a finding.
+Never close with a required check red. A superseded attempt spends no round and
+gets no completion report. Let its reviewers finish or have cancellation
+acknowledged, carry every returned finding forward, and reconcile each one
+before the restarted round closes.
 
 ### Forming a candidate
 
-Adversarial review is scarce, but serial wall-clock time is also a cost. Spend
-review only on a named frozen head with focused local evidence, then accept the
-bounded risk that later CI may supersede it. A branch whose head is unpushed or
-still moving, whose candidate was formed without integrating its effective base,
-or whose PR has a known failure or conflict has no single answer to "what am I
-reviewing?"
+Spend review only on a pushed, settled head formed by the canonical cycle.
+Record the exact head and effective base. If a conflict, author change, finding,
+or restack moves the head, form a replacement through the cycle again.
 
-Form and freeze one candidate before the first round, and again before every
-subsequent round:
+While a candidate is locked, do not push or integrate. Recovery is the only
+mutation exception; a non-mutating fetch is allowed to re-establish state after
+a resume and for the carry-forward analysis below.
 
-- **The head is pushed, named, and settled.** Reviewers get an exact base and
-  head, not a branch that moves under them. Finish your own edits first, and do
-  not push again until both reviewers have returned and their feedback has been
-  reconciled. A confirmed merge conflict or failing required gate that requires
-  an author change is the exception: it supersedes the incomplete attempt and
-  releases the lock. Conflict recovery pushes immediately; failed-gate recovery
-  pushes the fix and waits for the ordinary subsequent-round status gate.
-- **The candidate includes its effective base.** Integrate twice, per [the round
-  cycle](#the-round-cycle): once before fixing, once after, recording the tip
-  you finally integrated. That head is the candidate — keep it fixed through
-  push, CI, and review. Do **not** refetch once it is pushed; that restarts the
-  cycle without making the review more useful.
-- **Re-integrate whenever the head moves.** When a conflict, an author change,
-  or a review finding ends a candidate, the replacement is formed by running the
-  cycle again. A multi-round PR therefore picks up `main` on each round that
-  produced a fix — not never, and not continuously while a head is frozen.
-- **Before merge, the PR is mergeable and green.** That means four things at
-  once: the returned head is the pushed head, the PR is not a draft,
-  mergeability is positive, and the current head's `ci-required` completed with
-  a `SUCCESS` conclusion. A `BLOCKED` or `DRAFT` merge state is an independent
-  readiness blocker — clear it before posting `Ready to merge`. One status check
-  answers all of it; see [status
-  discovery](docs/round-orchestration.md#status-discovery) for the REST default,
-  when GraphQL is worth a point, the traps each result carries, and the polling
-  cadence. The first attempt at round 1 and conflict-recovery rounds do not wait
-  for this result; a failed-gate restart, an ordinary subsequent round, and merge
-  readiness do.
-- **Every PR in a stack meets the applicable conditions**, not only the slice
-  under review. A known-conflicted or known-red parent blocks review of
-  everything above it. A pending parent does not block a slice's first or
-  conflict-recovery round, provided each layer has a settled pushed head and
-  passed focused local evidence. A conflict-recovery round is scoped to the
-  recovered slice; do not review an upper slice until its own conflicts are
-  recovered. Before any ordinary subsequent round, a current-head aggregate
-  check for every open layer must confirm zero conflicts and green
-  `ci-required`. A slice rebases onto its parent, never onto `main`: only the
-  bottom open slice takes `origin/main` as its base, and rebasing an upper slice
-  onto `main` pulls in work its parent has not landed and makes the slice's diff
-  report its parent's changes as its own. `ci.yml` applies no base-branch
-  filter, so every non-documentation slice schedules the same CI wherever it
-  targets; a non-documentation slice reporting *no* checks is therefore not
-  green. Re-query after the registration window, following the status-discovery
-  cadence, and verify the current head; if no matching workflow run appears,
-  that is a scheduling bug to investigate — a PR that triggers no workflow
-  leaves `ci-required` nothing to block on and displays as MERGEABLE and CLEAN.
+Before merge, re-read GitHub state and confirm the expected head, non-draft
+status, positive mergeability, and successful current-head `ci-required`.
+`BLOCKED`, `DRAFT`, `UNKNOWN`, a missing check, or a check from another head is
+not ready. Follow
+[status discovery](docs/round-orchestration.md#status-discovery).
 
-Once the candidate is pushed, do not fetch or integrate the base while CI or
-review is in progress. After a review-clean result, a non-mutating fetch is
-permitted solely to inspect the landed range for the carry-forward decision
+For stacks, every open layer must meet its applicable eligibility row. A
+known-red or conflicted parent blocks upper slices; a pending parent does not
+block a first or conflict-recovery attempt. Apply the remaining stack rules
 below.
 
 ### Clean reviews are not spent by main moving
 
-For a PR that targets `main` — including the bottom open slice of a stack —
-when its required review is review-clean at the current head and `origin/main`
-has since moved, **stop and ask.** Do not integrate, and do not open another
-round on your own initiative.
+When a `main`-targeting PR has a review-clean current head and `origin/main`
+moves, **stop and ask**; do not integrate or start another round. This also
+applies to the bottom open stack slice. An upper slice follows its parent, so
+parent movement is a restack and requires review at the new head.
 
-**This path does not apply to an upper stack slice.** Its effective base is its
-parent branch, so `origin/main` moving is not base movement for it, and the
-carry-forward procedure would compare against the parent instead. When a parent
-does move, that is a restack, and a restack requires a review-clean round at the
-resulting head.
+After a non-mutating fetch, analyze the exact landed range. If it cannot affect
+the change and the user approves, integrate that exact tip and carry the clean
+reviews to the new head without another round. If the tip moves again before
+integration, re-analyze and ask again. A decline leaves the reviewed head
+blocked; do not re-ask.
 
-Absent an actual conflict, a round that produces no review-driven fix and then
-integrates newer `main` to create another round is a failed round: the review
-produced no change and the integration discarded the value of the locked-head
-result.
+If the range can interact, carry-forward is unavailable. Ask whether to
+integrate, validate, and re-review, or leave the PR blocked. Do not re-ask after
+a decline. Evaluate eligibility from the latest review-clean result.
+Carry-forward is unavailable when a finding remains unresolved or the head
+moved after that result because of an author change, conflict resolution, or
+restack.
 
-The user may then approve carrying the clean reviews forward across a
-non-interacting base integration, without another round. **The integrated head
-inherits the review-clean status**, and is merge-ready on that basis — that
-transfer is the whole point, and without it the integration would strand the PR
-at a head no review covers. It rests on the approved analysis, not on the merge
-being mechanical: the reviews carry because the landed range was shown not to
-interact and the user accepted that finding.
-
-Carrying forward is the sole default path that integrates the base when no
-conflict, review-driven fix, author change, current-head merge-path failure,
-required cascading restack, or explicit user workflow adjustment has ended the
-candidate.
-
-**Carry forward only a non-interacting range.** If the analyzed range cannot
-affect the change and the user approves, integrate it and carry the clean
-reviews without another round; if the live tip moves before you integrate,
-analyze the additional range and obtain renewed approval. A decline keeps the
-reviewed head and leaves the PR blocked there. **If it can affect the
-change**, carry-forward is unavailable: keep the reviewed head, say the PR is
-not merge-ready, and ask whether to adjust the workflow to integrate,
-re-validate, and re-review the replacement head, or to leave the PR blocked.
-Approving that adjustment buys a **re-review**, never a carried one. Declining
-it leaves the PR blocked at the reviewed head. Do not re-ask either decline.
-
-**Repeat it whenever the base moves again**; a carried-forward head is
-review-clean, and each pass needs its own analysis and its own approval. **A
-failure in the post-integration validation or CI ends the candidate**: it is a
-current-head merge-path failure, so the reviews do not carry, the fix is an
-author change, and the replacement head owes a normal round. Carry-forward
-transfers a clean result across an integration; it does not survive that
-integration going wrong.
-
-The procedure, and the analysis to bring to the user, are in
-[carry-forward after clean reviews](docs/round-orchestration.md#carry-forward-after-clean-reviews).
-
-Evaluate eligibility from the *latest* review-clean result: an earlier finding
-that was fixed and then reviewed clean does not disqualify it. Carry-forward
-does not apply, and the head must be reviewed normally, when a finding remains
-unresolved, or when the head moved after that result because of an author
-change, conflict resolution, or a restack.
-
-This is the one place the settled-branch rule yields, and it has to, or the
-budget is unbounded: on a busy `main`, a round takes longer than the interval
-between commits, so integrate-and-re-review by reflex never converges. A pair of
-clean reviews is a result. Unrelated commits landing behind it do not retract
-it.
+After an approved carry-forward, re-run the applicable validation and
+current-head CI. Failure ends the candidate and requires a normal replacement
+round. Repeat the analysis and approval for every later base movement. Follow
+the full
+[carry-forward procedure](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 ### A quick read is not a round
 
-The gate above forbids spending a *round* on an unsettled branch. It does not
-forbid getting early signal. When you want a fast read on a design or an
-in-progress implementation ahead of a later adversarial review, **use
-MAI-Code** — that is what it is for here: cheap enough to run on a branch that
-is still moving, and useful well before there is anything to gate.
-
-Keep the two distinct. A quick read gets no isolated worktree, no fixed head,
-and **satisfies no tier** — a PR that had one still owes its full review once
-the branch settles. When you cite its findings, say which it was.
+Use MAI-Code for early feedback on unsettled work. A quick read gets no isolated
+worktree or fixed head and satisfies no review tier. Label its findings as early
+feedback; the settled PR still requires its full round.
 
 ### How many reviewers, and from which models
-
-The review gate has one threshold: trivial changes may skip review; everything
-else gets the standard round. Risk scales how deeply the reviewers attack the
-change, not how the round is staffed. If you are unsure whether a change is
-trivial, escalate: default to review, not none.
 
 | Tier | Requirement |
 | --- | --- |
 | Trivial | No review. State why the change is trivial. |
 | Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer. |
 
-Adversarial-review roster — this list is the single source of truth, and
-scenario docs should reference it rather than restating it:
+When uncertain, use the standard round. The roster is:
 
 - **GPT-5.6 Sol** — the fixed seat, in every round
 - Claude Opus
 - Gemini Pro
 
-**Strongly prefer a second seat from a different model family than the one that
-authored the change.** Two families fail differently, and an author reviewing
-its own work brings the same blind spot that produced the bug — the second seat
-exists for the perspective the first cannot have. Reuse of your own model is
-permitted rather than blocking, because the fixed seat already guarantees one
-independent perspective, but treat it as the fallback when no other roster
-reviewer is available, and say on the PR which case applied.
-
-**Use the highest version and quality level a model offers** in the second seat
-— given both Opus 4.8 and Opus 5, use Opus 5. The GPT-5.6 Sol seat is a
-deliberate pin rather than a "highest available" slot; when it should move, move
-it here.
-
-These tiers assume a harness — such as the GitHub Copilot CLI — that can
-delegate to the roster. A harness with only some roster models changes how the
-round is obtained, never the bar: run the roster reviewer it has and request
-every missing seat from the user. An out-of-roster model may provide a quick
-read but does not fill a seat.
-
-A **round** evaluates one settled head with every reviewer its tier requires.
-Two reviewers in the same round count as one round, not two.
+Prefer a second seat from a different family than the author, using that
+model's highest available quality. Reuse the author's family only as a fallback
+and record it on the PR. If the harness lacks a required roster model, run the
+available seat and ask the user for the missing one; an out-of-roster model does
+not count. One round evaluates one settled head with all required reviewers.
 
 ### Running the round
 
-A round starts when its reviewers are dispatched. It ends when all current and
-carried feedback is publicly reconciled, every resulting fix is committed and
-pushed, current-head zero-conflict evidence is confirmed, and every required
-current-head check and post-push local gate for that round has completed
-successfully.
-
-Every reviewer gets the same self-contained prompt and its own isolated
-worktree; findings are reproduced before they are acted on and reconciled
-publicly on the PR. Address actionable findings only after the locked-head
-reviews finish. See
-[running a round](docs/round-orchestration.md#running-a-round) for dispatch,
-reconciliation, and the required round report.
-
-Review the whole head. An author may not declare a subsystem out of scope for a
-round — including a test harness the previous rounds have already hardened —
-without explicit user approval, because a round narrowed by the author is not
-evidence about the head.
+Give every reviewer the same self-contained prompt and a separate worktree.
+Review the whole head unless the user narrows scope. Reproduce findings before
+acting on them, wait for all locked-head reviews, and reconcile publicly. Follow
+[running a round](docs/round-orchestration.md#running-a-round) for mechanics and
+reporting.
 
 ### Keep review proportional to the contract
 
-Review the invariant the design actually promises. Unless the threat model
-explicitly includes hostile in-process callers, require the invariant for
-well-behaved code that follows the design — not for arbitrary code that bypasses
-or misuses its abstractions.
+Review the invariant the design promises, not arbitrary misuse outside the
+threat model. A surviving mutation justifies a gate only when it exposes a
+plausible regression of promised behavior. Prefer outcome-level tests and
+simple, auditable enforcement over fixture seams or abstractions hardened
+against callers the contract excludes.
 
-Mutation testing is evidence, not an admission rule. A mutation surviving the
-suite does not by itself justify another gate: require a plausible regression
-of promised behavior that existing contract-level coverage misses. Prefer one
-outcome-level test over tests coupled to every branch or call site, and do not
-add fixture seams solely to make each intentional-looking weakening
-independently red.
-
-Prefer simple, auditable enforcement over making every abstraction a fortress
-against rogue callers. `InertString` is the model: code that uses the type
-properly gets its invariant, while bypasses and misuse are deliberately easy to
-find with a targeted search. A reviewer should report such a caller so it can be
-fixed, but should not demand bend-over-backwards features in the type merely to
-make misuse impossible. Escalate to stronger enforcement only when the stated
-contract or threat model requires it.
+A reviewer concern that materially expands functionality is a scope proposal,
+not automatically a landing requirement. Do not accept it without explicit
+operator approval. The default is to reject it as out of scope or record it as
+follow-up work; significant scope growth is normally not part of landing the
+current PR.
 
 ### Stop after six rounds
 
-Do not begin a seventh review round without explicit user approval. Each
-approval authorizes one new block of up to six rounds: rounds 7-12, then 13-18,
-and so on. Stop as soon as review converges; approval is a ceiling, not a
-requirement to spend the full block.
+Do not start round 7 without user approval. Each approval allows at most six
+more rounds; stop sooner when review converges. Conflict recovery may resolve
+and push immediately, but reviewers still wait for approval at the boundary.
 
-Conflict recovery does not waive this approval boundary. Resolve and push a
-conflict immediately so CI starts, but if its review would begin a new
-unauthorized block, request approval before dispatching reviewers. Once
-approved, start that conflict-recovery round without waiting for CI.
+Before requesting another block, answer:
 
-Before requesting each block, present an architectural checkpoint, not merely
-a request for permission. Answer all of these:
+1. **What changed?** Summarize product, architecture, and test improvements,
+   findings retired, and confidence gained. Separate durable progress from
+   churn.
+2. **Are reviews converging?** Cite clean counts and repeated versus new finding
+   categories. State why dual-clean is or is not likely in the next block.
+3. **Are the foundations sound?** Classify remaining findings as architectural,
+   coverage gaps, contract expansion, or harness-only concerns.
+4. **Should implementation pause for a docs-only design PR?** Recommend it when
+   contracts, ownership, or architecture need direct repository-owner
+   engagement.
+5. **If design work was skipped last block, why skip it again?** The prior
+   decision is not standing authorization; identify the new evidence that makes
+   implementation rounds the better investment.
 
-1. **What did the last block accomplish?** Summarize the product, architecture,
-   and test changes made, the findings retired, and the confidence gained.
-   Distinguish durable progress from churn that only moved the findings.
-2. **Are the reviews converging toward dual-clean soon?** Cite the trend across
-   the block: clean responses, repeated versus new finding categories, and
-   whether findings are moving out of the product and into tests or the harness.
-   State how likely the next block is to produce two clean responses at one
-   current head, and why.
-3. **Do the remaining findings expose local defects or shaky foundations?**
-   Classify the repeated findings as architectural problems in the change,
-   missing test coverage, reviewers expanding the contract beyond the intended
-   threat model, or **findings confined to the change's own test harness** while
-   the product diff goes unchallenged.
-4. **Is a docs-only, design-focused PR now warranted?** Give an explicit
-   recommendation. That alternative pauses implementation review and uses
-   direct, full engagement from the repository owner to settle the disputed
-   contracts, ownership boundaries, or architecture before implementation
-   resumes. If it is warranted, recommend it instead of another implementation
-   block.
-5. **If that design-focused path was skipped for the prior block at the user's
-   request, why should it be skipped again?** The earlier decision is not
-   standing authorization. Identify what the last block changed, what evidence
-   now supports implementation-level convergence, and why another six rounds
-   are a better investment than settling the design first.
-
-State the proposed architectural or test remedy, or explain why the remaining
-concern should be dismissed. End with one recommendation: approve the next
-implementation block, switch to a docs-only design PR, or stop the work.
-
-The harness-only case deserves its own judgment, because it looks like
-convergence and behaves like a ratchet. When successive rounds find only new
-ways to strengthen a test generator, each finding is real and each fix is cheap,
-so the loop can run indefinitely on a product diff nobody has disputed. Say so
-plainly when you see it: report how many consecutive rounds produced no product
-finding, and recommend either a final round or stopping. Stopping still needs
-the user's waiver under invariant 5 — but asking for one, with that evidence, is
-the correct move rather than opening another round by reflex.
+State the proposed remedy and end with one recommendation: approve the next
+implementation block, switch to a docs-only design PR, or stop. If consecutive
+rounds only strengthen the harness while the product goes unchallenged, report
+that count and recommend a final round or a stop waiver rather than continuing
+by reflex.
 
 ## Lead with the demo
 
-Two clean adversarial reviews and a green suite establish that the change is
-**correct**. Neither establishes that it is **worth shipping**. The demo is the
-only part of a PR that shows the product actually got better, and it is the part
-someone reading this work back in six months will actually read.
+Validation proves correctness; a demo shows value. Post the intended demo early
+enough to change the implementation.
 
-### Choose it before you are done, and say what it is
+A useful demo:
 
-Post the demo you intend to present — one line is enough — while there is still
-time to change it. Do not wait to be asked for one, and do not treat it as
-write-up performed after the work is finished. Three things come of choosing
-early:
+- shows a real canonical invocation and its real output;
+- includes before and after for a fix;
+- says what to notice; and
+- still works for a neighboring scenario, proving the implementation was not
+  fitted to the sample.
 
-- **Calibration.** The operator can tell you a demo is not compelling *before*
-  you have finished building around it. That exchange costs one line and a reply,
-  and it is dramatically cheaper than discovering the mismatch at the end.
-- **Real-scenario validation.** A scenario a person would genuinely run exercises
-  paths that fixture-shaped tests do not. Turning up bugs at that point is the
-  system working. Turning them up *after* two clean reviews — which is what
-  happens when the demo is an afterthought — means the reviews were spent on a
-  version nobody had tried to use.
-- **A legible record.** These PRs are the archive. One that opens with a demo can
-  be read by somebody who was not there; one that opens with a list of test
-  invocations cannot.
-
-### Do not build to the demo
-
-The demo is a **sample of the space the change has to cover, never the definition
-of it.** The issue and its contract decide what you build; the demo shows one
-real path through it landing. Two smells that the two have been inverted: you
-special-cased an input so the demo would render, or you picked the scenario
-because it was the one you already knew worked.
-
-The self-check is to swap it. Take a neighbouring scenario a user would just as
-plausibly run, and confirm it behaves. If the demo is the only path that holds
-up, you have fit the demo rather than the problem — and choosing it early is
-what let you find that out while it was still cheap to fix.
-
-### What makes one compelling
-
-- **A real invocation and its real output**, pasted, not paraphrased or
-  reconstructed from memory.
-- **The canonical path** a user would take. A hidden alias or compatibility
-  selector demonstrates the seam, not the product; if the change is about the
-  primary path, lead with the primary path and add the alias only as a second
-  block.
-- **The before as well as the after, whenever the change is a fix.** A demo that
-  shows only the fixed output asks the reader to imagine the bug. The pair shows
-  it. This is the single largest difference between a demo that lands and one
-  that is merely present.
-- **One sentence naming what to notice**, because what is obvious to you after a
-  week inside the change is not obvious to anyone else.
-
-Put it in the PR body under a `## Demo` heading, **above** the validation list.
-Validation is the argument that the change is correct; the demo is the argument
-that it is worth having, and it should be read first.
+Put it under `## Demo` above validation in the PR body.
 
 ## PR and CI discipline
 
-- Prefer fewer coherent PRs over many small PRs that each pay fixed CI cost and
-  increase merge contention. That is an argument against splitting one coherent
-  change, not against sequencing a genuinely multi-slice one — see
-  [Stacked PRs for multi-slice issues](#stacked-prs-for-multi-slice-issues).
+- Prefer fewer coherent PRs over mechanical splits; use a stack for genuinely
+  independent slices.
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
-- Treat CI as confirmation, not discovery: run the smallest relevant local gate
-  first, then push the frozen candidate promptly. Run broader local validation,
-  CI, and eligible fixed-head review concurrently, subject to the per-round CI
-  and conflict gates above.
-- Check PR state through [status
-  discovery](docs/round-orchestration.md#status-discovery) — REST by default,
-  GraphQL when breadth pays for the point, and a scheduled check rather than a
-  watch loop. That applies to any PR, not only one under review.
+- Treat CI as confirmation: run the focused local gate, then push promptly.
+  Run eligible local suites, CI, and review concurrently.
+- Use [status discovery](docs/round-orchestration.md#status-discovery): REST by
+  default, GraphQL only when breadth is worth its shared quota, and scheduled
+  checks rather than polling.
 - A settled candidate should spend wall-clock time in parallel. If an hour
-  passes without an authored change while an eligible independent gate has not
-  started, stop and correct the sequencing or record the concrete blocker. Do
-  not respond by refreshing the base or rerunning a broad suite that already
-  proved the unchanged authored head.
-- `ci-required` is the only check that may gate merges, and the one the `main`
-  ruleset is meant to require: an aggregate that fails if any job in `ci.yml`
-  failed or was cancelled. It passes `skipped`, because most jobs are
-  path-gated, so a green `ci-required` means "nothing that ran went wrong", not
-  "everything ran". Never require a path-gated job directly — a required check
-  that does not run blocks the merge forever.
-- Do not broaden CI without a measured need. The PR `test` job validates the
-  merge path; `pack` is path-gated; release artifacts are built by
-  `release.yml`.
-- Keep PR summaries conclusion-first. Include the behavioral claim, evidence,
-  compatibility or non-action boundary, and exact validation appropriate to
-  the change.
-- Agents are not authorized to merge pull requests unless the user explicitly
-  directs them to merge that specific PR. A clean review, green CI, mergeable
-  state, `Ready to merge` comment, or general request to prepare or finish a PR
-  is not merge authorization. Arming auto-merge at the user's direction is, for
-  the reviewed head only — see [Standing
-  adjustments](#standing-adjustments). Asking whether to arm it is always
-  permitted.
-- When all merge-blocking validation, CI, and required review are complete, post
-  a PR comment that says `Ready to merge`. Label later work as non-blocking
-  follow-up so readiness remains unambiguous.
+  passes without an authored change while an independent gate has not started,
+  fix the sequencing or record the blocker.
+- `ci-required` is the only merge-gating check. It passes when all jobs that ran
+  succeeded or skipped; a missing aggregate is not green. Never require a
+  path-gated job directly, and do not broaden CI without measured need.
+- Keep PR summaries conclusion-first: claim, evidence, compatibility or
+  non-action boundary, and exact validation.
+- `Ready to merge` means review-clean current-head evidence plus positive
+  GitHub mergeability. Do not infer mergeability locally or claim readiness
+  during a round. Pursue green CI and report any external blocker separately,
+  but CI is not part of this claim.
+- Never merge without explicit authorization for that PR. A clean review, green
+  CI, readiness comment, or request to prepare a PR is not authorization.
+  User-directed auto-merge authorizes only the reviewed head.
 
 ### Stacked PRs for multi-slice issues
 
 When an issue is too large for one coherent PR, prefer a **stack** — a sequence
-of PRs, each targeting its predecessor's branch — over a single PR that grows
-until it is unreviewable, and over parallel PRs that race in the same files.
-`docs/stacked-prs.md` owns the mechanics; the rules that bind are:
+of PRs targeting their predecessors — over one unreviewable PR or parallel PRs
+that race in the same files. `docs/stacked-prs.md` owns the mechanics.
 
-- **Every slice lands on its own**, carrying one behavioral claim and its own
-  evidence. If a slice is only defensible once the next one lands, fold it in.
-- **Name the stack in every PR**: the slice's position, its parent PR, and the
-  enumerated residual, which is the non-action boundary the PR-summary rule
-  already requires.
-- **Name every slice branch descriptively.** No prefix is required for CI:
-  `ci.yml` applies no base-branch filter, so a PR runs CI whatever it targets.
-- **One branch and one worktree per slice**, branched from the parent slice, and
-  targeted at the parent branch (`gh pr create --base <parent-branch>`).
-- **During a GitHub outage, use stacked branches for new coherent slices** so
-  local work can continue without pretending remote evidence exists. Branch
-  each new slice from its recorded last-known local base or parent slice, create
-  its worktree under `.worktrees/`, record that base SHA, and keep its commits
-  isolated. When GitHub recovers, fetch the effective base, update the bottom
-  slice, cascade required restacks and focused validation through the stack,
-  then push and open it bottom-up. Run each slice's required CI, status, and
-  review gates before treating it as ready.
-- **Merge bottom-up, one at a time**, then confirm the next PR retargeted and
-  still shows only its own slice.
-- **Restacking rebases and force-pushes a public branch by design** — the
-  standing exception to the never-force-push rule, and it cascades to every
-  slice above. Use `--force-with-lease`, restack only your own slices, and post
-  a `range-diff` proving the restack changed the base and nothing else.
-- **Review depth is per-slice, by that slice's own risk**, not the stack's size.
-- **Apply the canonical eligibility table stack-wide.** Before an ordinary
-  subsequent round, every open layer must have a settled pushed head, focused
-  evidence, zero conflicts, and green current-head `ci-required`. A first
-  attempt may retain pending CI. A conflict-recovery attempt is scoped to the
-  recovered slice and may retain the pending work allowed by its table row;
-  upper-slice review remains blocked until that slice is conflict-free. Merge
-  readiness still requires every layer to be green and mergeable.
-- **A moved head — including one moved by a restack — needs a review-clean round
-  at the new head**, and a restack never retires an open finding.
-- **Stop stacking when a slice would exist only to continue the stack.** CI cost
-  is per PR; three coherent slices beat ten mechanical ones.
+- Each slice must land independently with one claim and its own evidence. Fold
+  in any slice that depends on later work for correctness.
+- In every PR, name the slice position, parent PR, and remaining work.
+- Give each slice its own branch and worktree, branched from and targeted at its
+  parent. Only the bottom open slice uses `main`.
+- During a GitHub outage, branch from the recorded last-known base or parent.
+  On recovery, update and validate bottom-up before pushing.
+- Merge bottom-up and confirm each retargeted diff still shows only its slice.
+- Restacking your own slices is the exception to the no-force-push rule. Use
+  `--force-with-lease` and post a `range-diff` proving only the base changed.
+- Apply review depth and the canonical eligibility table per slice and
+  stack-wide. Every moved head needs a review-clean round; restacking never
+  retires findings.
+- Stop when another slice would exist only to continue the stack.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -218,6 +218,10 @@ Round <n> is complete for PR <number>.
 - Round end: <datetime>.
 - Round duration: <hours:minutes>
 
+Reviews: <clean>/<required> clean — <status by reviewer>
+Blocked: <PR or issue numbers not yours to fix; omit when empty>
+Recommendation: [Wait, Merge, Approve next rounds, Stop (reason)]
+
 Fix description: <prose description of changes made in response to the round>.
 ```
 
@@ -226,6 +230,12 @@ classification, say that no findings or fixes were produced and that the locked
 head remained unchanged. For a no-fix round with dismissed findings, use
 `converging`, `diverging`, or `neutral` and explain the dismissals in the public
 reconciliation.
+
+`Reviews` records the dual-clean count that GitHub cannot observe. Every
+`Blocked` entry must be an existing PR or issue; file one before citing a new
+shared failure. `Wait` requires a non-empty blocker list and means the agent
+will resume when it clears. `Merge`, `Approve next rounds`, and `Stop` request a
+user decision; `Stop` does not close anything until approved.
 
 The same report may also be posted on the PR; the public reconciliation may
 include more detail when the findings or fixes warrant it.


### PR DESCRIPTION
`AGENTS.md` is now substantially shorter and more direct while preserving its binding engineering, review, and merge gates.

## Demo

Before: `AGENTS.md` was 1,353 lines and 11,370 words, with operational history and repeated rationale interleaved with enforceable rules.

After: it is 712 lines and 4,958 words — 47% fewer lines and 56% fewer words. Repository-wide contracts remain in `AGENTS.md`; round-report mechanics now live with their existing owner in `docs/round-orchestration.md`.

## Summary

- Collapse session-resume, tmux-state, build, review, demo, CI, and stack guidance around actions and decision points.
- Preserve candidate locking, two pre-push integrations, review eligibility, carry-forward, reviewer roster, six-round approval, merge authorization, platform, output, harness, and validation rules.
- Move the observable round-report fields into the focused round-orchestration document without changing their semantics.
- Require operator approval before accepting reviewer requests that materially expand functionality; default those requests to out-of-scope dismissal or follow-up work.
- Remove incident narratives and duplicated mechanics that obscured the rules agents must follow.

## Non-action boundary

This changes presentation and ownership of operational detail, not the review bar, CI bar, merge authority, supported platforms, or engineering contracts.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md`
- Independent semantic audit of the old and new guidance, including inbound and outbound anchors
