### PR TITLE
Drop platform-list from the product home demo catalog

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -406,21 +406,21 @@ Hard constraints:
 The product registry (`ProductInspectionDemos`) stays a static id→metadata
 table plus peer definition records lowered to a `ResolvedScenario`. Listing
 remains metadata-only. **Home demos now bind product section display names**
-through `ProductDemoSections` (today: `Methods` for STJ and platform List`1`;
-`Call Graph` primary bind for the extensions member, expanded at run via
-`ExpandRunSections` / `DemoScenarioRunner` so the closed preset matches the
-multi-package `--caller-package` companion rule: Markdown keeps
-`Call Graph` + `Callers`; table/tsv/jsonl select `Callers` alone (MemberCommand
-re-adds Callers under caller scope, so Call Graph-only tabular silently fell
-back to a member inventory); standalone `--mermaid` keeps `Call Graph`;
-document `--json` fails closed for Call Graph demos until graph sections
-project into that payload. `ResolveHomeScenario` fails when a home demo omits
-`View.Section` or names a section outside that allow list
-(`ProductHomeDemos_AllBindKnownProductSections`,
+through `ProductDemoSections` (today: `Methods` for STJ; `Call Graph` primary
+bind for the extensions member, expanded at run via `ExpandRunSections` /
+`DemoScenarioRunner` so the closed preset matches the multi-package
+`--caller-package` companion rule: Markdown keeps `Call Graph` + `Callers`;
+table/tsv/jsonl select `Callers` alone (MemberCommand re-adds Callers under
+caller scope, so Call Graph-only tabular silently fell back to a member
+inventory); standalone `--mermaid` keeps `Call Graph`; document `--json` fails
+closed for Call Graph demos until graph sections project into that payload.
+`ResolveHomeScenario` fails when a home demo omits `View.Section` or names a
+section outside that allow list (`ProductHomeDemos_AllBindKnownProductSections`,
 `ProductDemoSections_AreProductSectionNames`). Methods demos reject standalone
 mermaid rather than falling through to the type shape tree. Full minted
 view-facet ids remain open ([Open questions](#open-questions) — view-facet
-registry binding).
+registry binding). Platform workspaces remain product capability; they are not
+a home-demo entry (home catalog is package- and graph-shaped scenarios).
 **CLI run** lowers the resolved plan to `TypeCommand` / `MemberCommand` options
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
@@ -428,11 +428,11 @@ package members as `--caller-package` for the call-graph demo. **inspect-web**
 loads home-demo catalog and coordinates from the product registry through the
 browser engine (`ListHomeDemos` / `ResolveHomeDemo` over
 `ProductInspectionDemos`); host-only share encoding and the residual platform
-→ `Microsoft.NETCore.App` runtime-pack mapping live in
-`prototypes/inspect-web/src/product-home-demos.ts`. STJ and platform restore
-via share deep links built from the resolved projection; member-bound Call
-Graph demos still run the imperative multi-package member path. Residual:
-(1) minted facet ids replacing display-name allow list; (2) realize via
+→ `Microsoft.NETCore.App` runtime-pack mapping (for future platform members)
+live in `prototypes/inspect-web/src/product-home-demos.ts`. STJ restores via
+share deep links built from the resolved projection; member-bound Call Graph
+demos still run the imperative multi-package member path. Residual: (1) minted
+facet ids replacing display-name allow list; (2) realize via
 `WorkspaceContextLoader` into one `AssemblyContextGroup` instead of CLI
 package/`--caller-package` encoding and the browser runtime-pack share
 encoding for platform; (3) replace the imperative call-graph web path with

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -84,24 +84,4 @@ public sealed class BrowserProductHomeDemosTests
         Assert.Equal(ProductDemoSections.CallGraph, view.GetProperty("section").GetString());
     }
 
-    [Fact]
-    public void ResolveHomeDemo_PlatformList_ProjectsUnversionedRuntimeAndListType()
-    {
-        using var document = JsonDocument.Parse(
-            InspectionEngine.ResolveHomeDemo(ProductInspectionDemos.PlatformListScenarioId));
-        var root = document.RootElement.GetProperty("demo");
-        var members = root.GetProperty("workspaceMembers");
-        Assert.Equal(2, members.GetArrayLength());
-        Assert.Equal("package", members[0].GetProperty("kind").GetString());
-        Assert.Equal("System.Text.Json", members[0].GetProperty("id").GetString());
-        Assert.Equal("platform", members[1].GetProperty("kind").GetString());
-        Assert.Equal("runtime", members[1].GetProperty("id").GetString());
-        Assert.Equal(JsonValueKind.Null, members[1].GetProperty("version").ValueKind);
-
-        Assert.Equal(1, root.GetProperty("focusTabIndex").GetInt32());
-        var view = root.GetProperty("view");
-        Assert.Equal("System.Private.CoreLib", view.GetProperty("library").GetString());
-        Assert.Equal("System.Collections.Generic.List`1", view.GetProperty("type").GetString());
-        Assert.Equal(ProductDemoSections.Methods, view.GetProperty("section").GetString());
     }
-}

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -63,6 +63,7 @@ function workspaceUrlState(partial: Partial<WorkspaceUrlState> & Pick<
     atPackageRoot: false,
     packageLens: "overview",
     library: null,
+    libraryPack: null,
     selectedTypeId: "",
     selectedMemberKey: "",
     selectedOverloadIndex: null,
@@ -201,7 +202,7 @@ export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
  * Pending home-row paint while the Wasm engine catalog is not yet installed.
  * Layout-only placeholders — titles come from `ListHomeDemos` after bootstrap.
  */
-export const HOME_DEMO_PENDING_SLOT_COUNT = 3;
+export const HOME_DEMO_PENDING_SLOT_COUNT = 2;
 
 export function homeDemoRowHtml(
   enginePending: boolean,

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -47,10 +47,11 @@ const stjResolved: BrowserHomeDemoResolved = {
   },
 };
 
-const platformResolved: BrowserHomeDemoResolved = {
-  id: "platform-list",
-  title: ".NET Platform",
-  summary: "Inspect platform BCL types",
+/** Synthetic residual fixture — not a product home demo. */
+const unversionedRuntimeResolved: BrowserHomeDemoResolved = {
+  id: "synthetic-unversioned-runtime",
+  title: "Synthetic platform residual",
+  summary: "Host residual mapping only",
   workspaceMembers: [
     {
       kind: "package",
@@ -165,11 +166,10 @@ test("isProductHomeDemoId uses the installed engine catalog", () => {
   setProductHomeDemoCatalog([
     { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
     { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
-    { id: "platform-list", title: ".NET Platform", summary: "Inspect platform BCL types" },
   ]);
   assert.equal(isProductHomeDemoId("stj-serializer"), true);
-  assert.equal(isProductHomeDemoId("platform-list"), true);
   assert.equal(isProductHomeDemoId("extensions-callgraph"), true);
+  assert.equal(isProductHomeDemoId("platform-list"), false);
   assert.equal(isProductHomeDemoId("stj"), false);
   assert.equal(isProductHomeDemoId("runtime"), false);
   assert.equal(isProductHomeDemoId("callgraph"), false);
@@ -192,8 +192,8 @@ test("stj-serializer deep link selects JsonSerializer on STJ 10.0.0", () => {
   assert.equal(location.package, "System.Text.Json");
 });
 
-test("platform-list deep link focuses CoreLib List`1 on residual runtime pack", () => {
-  const href = productHomeDemoLocationHref(platformResolved);
+test("unversioned platform residual maps to the browser runtime pack", () => {
+  const href = productHomeDemoLocationHref(unversionedRuntimeResolved);
   assert.ok(href);
   const { url, location } = parseDemoHref(href);
   assert.equal(url.searchParams.get("package"), PLATFORM_RUNTIME_PACK.id);
@@ -259,9 +259,9 @@ test("call-graph runner focus follows navigation focusTabIndex", () => {
 
 test("platform residual rejects pinned runtime coordinates", () => {
   const pinned = {
-    ...platformResolved,
+    ...unversionedRuntimeResolved,
     tabs: [
-      platformResolved.tabs[0],
+      unversionedRuntimeResolved.tabs[0],
       {
         id: "runtime",
         member: {

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -11,7 +11,6 @@ import { fakeDom } from "./fake-dom.ts";
 setProductHomeDemoCatalog([
   { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
   { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
-  { id: "platform-list", title: ".NET Platform", summary: "Inspect platform BCL types" },
 ]);
 
 class FakeElement {
@@ -109,7 +108,6 @@ test("home shell accepts only known demos", () => {
   const dismiss = new FakeElement();
   const credits = new FakeElement();
   const stj = new FakeElement({ homeDemo: "stj-serializer" });
-  const platform = new FakeElement({ homeDemo: "platform-list" });
   const callgraph = new FakeElement({ homeDemo: "extensions-callgraph" });
   const unknown = new FakeElement({ homeDemo: "other" });
   const absent = new FakeElement();
@@ -119,7 +117,6 @@ test("home shell accepts only known demos", () => {
   root.addAll(
     "[data-home-demo]",
     stj,
-    platform,
     callgraph,
     unknown,
     absent,
@@ -141,7 +138,6 @@ test("home shell accepts only known demos", () => {
   assert.deepEqual(calls, ["theme", "dismiss"]);
   assert.equal(credits.dispatch("click"), true);
   stj.dispatch("click");
-  platform.dispatch("click");
   callgraph.dispatch("click");
   unknown.dispatch("click");
   absent.dispatch("click");
@@ -150,7 +146,6 @@ test("home shell accepts only known demos", () => {
     "dismiss",
     "credits",
     "demo:stj-serializer",
-    "demo:platform-list",
     "demo:extensions-callgraph",
   ]);
 });

--- a/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
@@ -809,9 +809,9 @@ public class InspectionDefinitionTests
     public void ProductHomeDemos_ResolveCallGraphByMemberAnchor()
     {
         Assert.Equal(
-            ["stj-serializer", "extensions-callgraph", "platform-list"],
+            ["stj-serializer", "extensions-callgraph"],
             ProductInspectionDemos.HomeScenarioIds);
-        Assert.Equal(3, ProductInspectionDemos.Entries.Count);
+        Assert.Equal(2, ProductInspectionDemos.Entries.Count);
         Assert.True(ProductInspectionDemos.HasScenario("extensions-callgraph"));
 
         // Per-demo resolve — does not require materializing the other home demos.
@@ -842,7 +842,7 @@ public class InspectionDefinitionTests
     }
 
     [Fact]
-    public void ProductHomeDemos_StjAndPlatformSelections()
+    public void ProductHomeDemos_StjSelection()
     {
         var stj = ProductInspectionDemos.ResolveHomeScenario("stj-serializer");
         Assert.Equal("System.Text.Json.JsonSerializer", stj.View!.Type);
@@ -850,20 +850,7 @@ public class InspectionDefinitionTests
         var stjPackage = Assert.IsType<WorkspaceMemberCoordinate.PackageMember>(
             stj.SelectedContext!.Members[0]);
         Assert.Equal("System.Text.Json", stjPackage.PackageId);
-
-        var platform = ProductInspectionDemos.ResolveHomeScenario("platform-list");
-        Assert.Equal("System.Collections.Generic.List`1", platform.View!.Type);
-        Assert.Equal("System.Private.CoreLib", platform.View.Library);
-        Assert.Equal(ProductDemoSections.Methods, platform.View.Section);
-        Assert.Equal(2, platform.SelectedContext!.Members.Count);
-        Assert.Contains(
-            platform.SelectedContext.Members,
-            member => member is WorkspaceMemberCoordinate.PlatformMember platformMember
-                && platformMember.Family == "runtime"
-                && string.IsNullOrEmpty(platformMember.Version));
-        Assert.Equal("runtime", platform.Navigation!.FocusTabId);
-        Assert.IsType<WorkspaceMemberCoordinate.PlatformMember>(
-            platform.Navigation.FocusTab.Coordinate);
+        Assert.False(ProductInspectionDemos.HasScenario("platform-list"));
     }
 
     [Fact]
@@ -881,8 +868,8 @@ public class InspectionDefinitionTests
     [Fact]
     public void ProductHomeDemos_FactoryRegistry_IsMetadataOnlyUntilResolved()
     {
-        // Catalog surface is three entries; factories are not invoked by listing.
-        Assert.Equal(3, ProductInspectionDemos.Entries.Count);
+        // Catalog surface is two entries; factories are not invoked by listing.
+        Assert.Equal(2, ProductInspectionDemos.Entries.Count);
         Assert.All(
             ProductInspectionDemos.Entries,
             entry =>
@@ -892,9 +879,9 @@ public class InspectionDefinitionTests
                 Assert.NotNull(entry.CreateRecords);
             });
 
-        // Full materialization is opt-in (4 records × 3 demos).
+        // Full materialization is opt-in (4 records × 2 demos).
         var all = ProductInspectionDemos.CreateRegistry();
-        Assert.Equal(12, all.Records.Count);
+        Assert.Equal(8, all.Records.Count);
 
         // Each factory owns exactly one scenario composition.
         foreach (var entry in ProductInspectionDemos.Entries)

--- a/src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs
+++ b/src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs
@@ -22,8 +22,6 @@ public static class ProductInspectionDemos
 
     public const string ExtensionsCallGraphScenarioId = "extensions-callgraph";
 
-    public const string PlatformListScenarioId = "platform-list";
-
     private static readonly Entry[] s_entries =
     [
         new(
@@ -36,11 +34,6 @@ public static class ProductInspectionDemos
             "Cross-package call graph",
             "Trace calls across three packages",
             CreateExtensionsCallGraphRecords),
-        new(
-            PlatformListScenarioId,
-            ".NET Platform",
-            "Inspect platform BCL types",
-            CreatePlatformListRecords),
     ];
 
     /// <summary>
@@ -221,57 +214,6 @@ public static class ProductInspectionDemos
                 context: "extensions",
                 view: "try-add-enumerable-call-graph",
                 navigation: "extensions-callgraph-navigation"),
-        ];
-    }
-
-    private static InspectionDefinitionRecord[] CreatePlatformListRecords()
-    {
-        const int v = InspectionDefinitionJson.CurrentSchemaVersion;
-        var stjPackage = Package("System.Text.Json", "10.0.0", "net10.0");
-        // Unversioned host runtime: CoreLib is runtime-only (no ref-pack download),
-        // so a patch pin would fail on machines without that exact shared framework
-        // (CI installs the 11.0.x SDK lane). Package demos still pin NuGet versions.
-        var runtimePlatform = new DefinitionMemberCoordinate.PlatformCoordinate(
-            "runtime",
-            Assembly: null,
-            Version: null,
-            Framework: null);
-        return
-        [
-            new WorkspaceDefinition(
-                v,
-                "platform-list-tour",
-                [
-                    new WorkspaceContextDefinition(
-                        "platform",
-                        framework: "net10.0",
-                        members: [stjPackage, runtimePlatform]),
-                ],
-                title: ".NET Platform List tour",
-                description: "Platform BCL List`1 with System.Text.Json also in the workspace."),
-            new ViewDefinition(
-                v,
-                "platform-list-view",
-                library: "System.Private.CoreLib",
-                type: "System.Collections.Generic.List`1",
-                section: ProductDemoSections.Methods),
-            new NavigationDefinition(
-                v,
-                "platform-navigation",
-                [
-                    new NavigationTabDefinition("stj", coordinate: stjPackage),
-                    new NavigationTabDefinition("runtime", coordinate: runtimePlatform),
-                ],
-                focus: "runtime"),
-            new ScenarioDefinition(
-                v,
-                PlatformListScenarioId,
-                title: ".NET Platform",
-                description: "Inspect platform BCL types",
-                workspace: "platform-list-tour",
-                context: "platform",
-                view: "platform-list-view",
-                navigation: "platform-navigation"),
         ];
     }
 

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -121,21 +121,6 @@ public class DemoCommandTests
     }
 
     [Fact]
-    public void Runner_LowersPlatformListToCoreLibMethods()
-    {
-        var resolved = ProductInspectionDemos.ResolveHomeScenario(ProductInspectionDemos.PlatformListScenarioId);
-        Assert.True(DemoScenarioRunner.TryCreateOptions(resolved, OutputFormat.Markdown, noHeader: false, out var options, out var error), error);
-        var type = Assert.IsType<TypeOptions>(options);
-        Assert.Equal("System.Collections.Generic.List`1", type.TypeName);
-        Assert.Equal("System.Private.CoreLib", type.PlatformAssembly);
-        Assert.Equal("runtime", type.PlatformFramework);
-        Assert.Equal(
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.Methods },
-            type.IncludeSections);
-        Assert.Null(type.PackagePath);
-    }
-
-    [Fact]
     public void Runner_LowersCallGraphToMemberSectionWithCallerPackages()
     {
         var resolved = ProductInspectionDemos.ResolveHomeScenario(ProductInspectionDemos.ExtensionsCallGraphScenarioId);
@@ -256,25 +241,6 @@ public class DemoCommandTests
         Assert.Equal(["## Methods"], MarkdownSectionHeadings(output));
         Assert.Contains("JsonSerializer", output, StringComparison.Ordinal);
         Assert.DoesNotContain("resolve-only", output, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task ExecuteScenario_PlatformList_ReturnsMethodsSection()
-    {
-        var (coreLibPath, _, _, coreLibError) = PlatformResolver.ResolveAssembly(
-            "System.Private.CoreLib",
-            frameworkSpec: "runtime");
-        if (coreLibPath is null)
-            Assert.Skip($"System.Private.CoreLib not available: {coreLibError}");
-
-        var (exitCode, output, error) = await ConsoleCapture.RunAsync(
-            () => DemoCommand.ExecuteScenarioAsync(
-                ProductInspectionDemos.PlatformListScenarioId,
-                OutputFormat.Markdown));
-
-        Assert.True(exitCode == 0, error + "\n" + output);
-        Assert.Equal(["## Methods"], MarkdownSectionHeadings(output));
-        Assert.Contains("List", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Remove `platform-list` from `ProductInspectionDemos`. Platform workspaces stay a product capability; they are not a home-demo entry. Home catalog is STJ + cross-package call graph so future work can grow real inspection scenarios.

CLI, engine export (`ListHomeDemos` / `ResolveHomeDemo`), and inspect-web home row all follow the C# registry.

## Demo

**Before (main):** three home demos including `.NET Platform`.

**After:**

```text
# Home demos

Product-resident inspection scenarios. Run one with `dotnet-inspect demo <id>` (returns real section output).

| Id | Title | Summary |
| -- | ----- | ------- |
| stj-serializer | System.Text.Json | Browse a real package API |
| extensions-callgraph | Cross-package call graph | Trace calls across three packages |
```

```bash
dotnet run --project src/dotnet-inspect -c Release -- demo list
# platform-list is unknown:
dotnet run --project src/dotnet-inspect -c Release -- demo platform-list
```

## Evidence

- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -method '*ProductHomeDemos*'` — 5 pass
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*Demo*'` — 27 pass
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 104 pass
- Node 24: `npm test` 511 pass; `npm run analyze` green

## Non-action

Does not remove platform loaders, runtime-pack UI, or the host residual mapping for future platform members.