### PR TITLE
Initialize product demo library pack state

### DIFF
--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -63,6 +63,7 @@ function workspaceUrlState(partial: Partial<WorkspaceUrlState> & Pick<
     atPackageRoot: false,
     packageLens: "overview",
     library: null,
+    libraryPack: null,
     selectedTypeId: "",
     selectedMemberKey: "",
     selectedOverloadIndex: null,


### PR DESCRIPTION
## Summary

Initialize the required `WorkspaceUrlState.libraryPack` field in the product-home demo URL helper. This restores the inspect-web TypeScript build activated by Metadata-changing PRs.

## Demo

Before:

```text
Type '{ ... }' is not assignable to type 'WorkspaceUrlState'.
Property 'libraryPack' is missing.
```

After:

```text
npm run typecheck
vite v7.3.6 building client environment for production...
✓ built
```

## Validation

- `npm run analyze`
- `npm run build` (TypeScript application + tests, Vite build, site artifact verification)
- `git diff --check`

This is trivial: one required URL-state default is initialized to `null`, matching `library: null` and the ordinary state-capture path. No product behavior or contract changes.

Closes #4628
