### PR TITLE
Separate review status from approval prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,17 @@ literal token `PR #<number>` or `PR <number>`, plus the branch or expected head
 when relevant. Round completions must use the report in
 [`docs/round-orchestration.md`](docs/round-orchestration.md#the-round-report).
 
+### Separate status from approval prompts
+
+When a decision needs supporting status or analysis, emit that material first
+as normal visible assistant output. Only after it appears in the session log
+may you open the interactive approval prompt.
+
+The prompt contains only the concise decision question and short answer labels.
+Do not repeat or move the round report, architectural checkpoint, carry-forward
+analysis, evidence, or recommendation into the prompt. The prompt is a control,
+not the record.
+
 ### Publish your state where tooling can read it
 
 Update both window-scoped options whenever state changes:
@@ -508,8 +519,10 @@ A review is **review-clean** when public reconciliation leaves no finding
 unresolved and the head did not move in response. A justified dismissal counts
 only when recorded publicly. A fix-producing round can complete but is not
 review-clean; only the replacement head can earn that status. A review-clean
-round ends adversarial review. The report classification `clean` is narrower:
-use it only when reviewers returned no findings.
+round ends adversarial review. The report classification `clean` is narrower
+and mandatory when every required reviewer returned no findings and the locked
+head stayed unchanged. Use `converging`, `neutral`, or `diverging` only when at
+least one reviewer returned a finding.
 
 #### Recovery transitions
 
@@ -560,6 +573,10 @@ the change and the user approves, integrate that exact tip and carry the clean
 reviews to the new head without another round. If the tip moves again before
 integration, re-analyze and ask again. A decline leaves the reviewed head
 blocked; do not re-ask.
+
+Publish the analysis and recommendation as normal session output before opening
+the approval prompt. The prompt asks only whether to carry the clean reviews
+forward to the named tip.
 
 If the range can interact, carry-forward is unavailable. Ask whether to
 integrate, validate, and re-review, or leave the PR blocked. Do not re-ask after
@@ -648,6 +665,10 @@ implementation block, switch to a docs-only design PR, or stop. If consecutive
 rounds only strengthen the harness while the product goes unchallenged, report
 that count and recommend a final round or a stop waiver rather than continuing
 by reflex.
+
+Publish the complete checkpoint as normal session output before opening the
+approval prompt. The prompt asks only which recommended action to authorize; it
+must not contain the checkpoint itself.
 
 ## Lead with the demo
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -208,7 +208,8 @@ starting the next one, emit this report as the assistant's visible user-facing
 response in the terminal, filling every field and choosing exactly one feedback
 classification. Do not emit it through a shell command such as `printf`, leave
 it only in tool output, collapse it behind a tool-call summary, or replace it
-with a shorter completion summary:
+with a shorter completion summary. Do not put it in an interactive approval
+prompt:
 
 ```text
 Round <n> is complete for PR <number>.
@@ -225,17 +226,25 @@ Recommendation: [Wait, Merge, Approve next rounds, Stop (reason)]
 Fix description: <prose description of changes made in response to the round>.
 ```
 
-Use `Fix description` to state the concrete review-driven changes. For a `clean`
-classification, say that no findings or fixes were produced and that the locked
-head remained unchanged. For a no-fix round with dismissed findings, use
-`converging`, `diverging`, or `neutral` and explain the dismissals in the public
-reconciliation.
+Use `Fix description` to state the concrete review-driven changes.
+Classification must match the reviewer outcomes:
+
+- If every required reviewer returned no findings and the locked head remained
+  unchanged, use `clean`. Do not use `converging` as a generic positive label.
+- If any reviewer returned a finding, use `converging`, `diverging`, or
+  `neutral`, even when every finding was dismissed and the head stayed
+  unchanged. Explain dismissals in the public reconciliation.
 
 `Reviews` records the dual-clean count that GitHub cannot observe. Every
 `Blocked` entry must be an existing PR or issue; file one before citing a new
 shared failure. `Wait` requires a non-empty blocker list and means the agent
 will resume when it clears. `Merge`, `Approve next rounds`, and `Stop` request a
 user decision; `Stop` does not close anything until approved.
+
+When the recommendation needs approval, render the complete report first as
+normal session output. Then open a separate prompt containing only the concise
+decision question and answer labels. Do not repeat the report or its evidence
+inside the prompt.
 
 The same report may also be posted on the PR; the public reconciliation may
 include more detail when the findings or fixes warrant it.
@@ -251,11 +260,11 @@ path applies and when it does not. This is the procedure once it does.
    PR, not the live branch tip.
 2. **Inspect without integrating.** A non-mutating fetch is permitted solely to
    read the exact landed range.
-3. **Analyze and ask.** Report which commits touch files this change touches,
-   which behavior this change relies on that they alter, and any conflict a
-   textual merge would resolve silently but wrongly. Say plainly when nothing in
-   the range interacts — that is the common case and the most useful thing you
-   can report.
+3. **Report, then ask.** As normal session output, report which commits touch
+   files this change touches, which relied-on behavior they alter, and any
+   conflict a textual merge would resolve silently but wrongly. Say plainly
+   when nothing interacts. After that output is visible, open a separate prompt
+   that asks only whether to carry the clean reviews forward to the named tip.
 4. **Execute the rule's decision.** Exactly one of its outcomes runs here: when
    it authorizes carry-forward, integrate that exact analyzed tip by SHA, not a
    moving branch ref, and re-run the claimed validation and current-head CI.


### PR DESCRIPTION
Review status is now required to remain in normal session output, while interactive approval prompts contain only the decision. Dual-clean, unchanged-head rounds must also be classified as `clean`.

## Demo

Before: agents placed complete round reports, architectural checkpoints, and carry-forward analysis inside approval dialogs. Those dialogs were hard to scan and did not persist the information like ordinary assistant output. Agents could also label a round `converging` while stating that both reviewers returned clean.

After:

1. The complete report, analysis, evidence, and recommendation are emitted as ordinary session output.
2. A separate approval prompt asks only the concise decision with short answer labels.
3. When every required reviewer returned no findings and the locked head stayed unchanged, the feedback classification is obligatorily `clean`; non-clean classifications require at least one finding.

## Summary

- Define approval prompts as controls rather than the persisted record.
- Apply status-before-prompt sequencing to round reports, carry-forward decisions, and six-round architectural checkpoints.
- Prohibit moving or repeating supporting analysis inside the approval dialog.
- Make report classification agree with actual reviewer outcomes.

## Non-action boundary

This does not change review eligibility, carry-forward authority, the six-round approval boundary, or merge authorization.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md`
