### PR TITLE
Clarify continuation within review blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ tmux set -w -t "$TMUX_PANE" -u @agent_state
 
 Always use `-w -t "$TMUX_PANE"` and read back `@agent_state`. It must include
 `pr` and `head`; add `round`, `reviews`, `blocked`, and `rec` when applicable.
-Values contain no spaces. `rec` is `wait`, `merge`, `approve`, or `stop`.
-Clear both options when the window no longer owns a PR.
+Values contain no spaces. `rec` is `continue`, `wait`, `merge`, `approve`, or
+`stop`. Clear both options when the window no longer owns a PR.
 
 ### Signal when you need a person
 
@@ -640,9 +640,15 @@ current PR.
 
 ### Stop after six rounds
 
-Do not start round 7 without user approval. Each approval allows at most six
-more rounds; stop sooner when review converges. Conflict recovery may resolve
-and push immediately, but reviewers still wait for approval at the boundary.
+Rounds 1-6 are the initial authorized block. Within an authorized block, a
+fix-producing round that requires replacement review continues automatically
+to the next round. Report `Recommendation: Continue` and begin the next
+candidate cycle; do not ask for approval, set `HELP`, or wait for user input.
+
+Approval is required only before rounds 7, 13, 19, and so on. Each approval
+allows at most six more rounds; stop sooner when review converges. At a block
+boundary, conflict recovery may resolve and push immediately, but reviewers
+still wait for approval.
 
 Before requesting another block, answer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -642,7 +642,7 @@ current PR.
 
 Rounds 1-6 are the initial authorized block. Within an authorized block, a
 fix-producing round that requires replacement review continues automatically
-to the next round. Report `Recommendation: Continue` and begin the next
+to the next round. Report `Recommendation: continue` and begin the next
 candidate cycle; do not ask for approval, set `HELP`, or wait for user input.
 
 Approval is required only before rounds 7, 13, 19, and so on. Each approval

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -221,7 +221,7 @@ Round <n> is complete for PR <number>.
 
 Reviews: <clean>/<required> clean — <status by reviewer>
 Blocked: <PR or issue numbers not yours to fix; omit when empty>
-Recommendation: [Continue, Wait, Merge, Approve next rounds, Stop (reason)]
+Recommendation: [continue, wait, merge, approve next rounds, stop (reason)]
 
 Fix description: <prose description of changes made in response to the round>.
 ```
@@ -239,15 +239,15 @@ Classification must match the reviewer outcomes:
 `Blocked` entry must be an existing PR or issue; file one before citing a new
 shared failure.
 
-- `Continue` means the next round is inside the current authorized six-round
+- `continue` means the next round is inside the current authorized six-round
   block. Emit the report, then immediately begin the next candidate cycle. Do
   not ask, set `HELP`, or wait for user input.
-- `Wait` requires a non-empty blocker list and means the agent will resume when
+- `wait` requires a non-empty blocker list and means the agent will resume when
   it clears.
-- `Approve next rounds` is valid only after rounds 6, 12, 18, and so on, after
+- `approve next rounds` is valid only after rounds 6, 12, 18, and so on, after
   the required architectural checkpoint. Never use it for an earlier round in
   the current block.
-- `Merge`, `Approve next rounds`, and `Stop` request a user decision; `Stop`
+- `merge`, `approve next rounds`, and `stop` request a user decision; `stop`
   does not close anything until approved.
 
 When the recommendation needs approval, render the complete report first as

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -221,7 +221,7 @@ Round <n> is complete for PR <number>.
 
 Reviews: <clean>/<required> clean — <status by reviewer>
 Blocked: <PR or issue numbers not yours to fix; omit when empty>
-Recommendation: [Wait, Merge, Approve next rounds, Stop (reason)]
+Recommendation: [Continue, Wait, Merge, Approve next rounds, Stop (reason)]
 
 Fix description: <prose description of changes made in response to the round>.
 ```
@@ -237,9 +237,18 @@ Classification must match the reviewer outcomes:
 
 `Reviews` records the dual-clean count that GitHub cannot observe. Every
 `Blocked` entry must be an existing PR or issue; file one before citing a new
-shared failure. `Wait` requires a non-empty blocker list and means the agent
-will resume when it clears. `Merge`, `Approve next rounds`, and `Stop` request a
-user decision; `Stop` does not close anything until approved.
+shared failure.
+
+- `Continue` means the next round is inside the current authorized six-round
+  block. Emit the report, then immediately begin the next candidate cycle. Do
+  not ask, set `HELP`, or wait for user input.
+- `Wait` requires a non-empty blocker list and means the agent will resume when
+  it clears.
+- `Approve next rounds` is valid only after rounds 6, 12, 18, and so on, after
+  the required architectural checkpoint. Never use it for an earlier round in
+  the current block.
+- `Merge`, `Approve next rounds`, and `Stop` request a user decision; `Stop`
+  does not close anything until approved.
 
 When the recommendation needs approval, render the complete report first as
 normal session output. Then open a separate prompt containing only the concise


### PR DESCRIPTION
Review rounds now continue automatically inside an authorized six-round block instead of incorrectly requesting approval after every fix-producing round.

## Demo

Before, a Round 2 report could say:

```text
Reviews: 1/2 clean — GPT clean; Claude finding fixed
Recommendation: Approve next rounds
```

That implied the agent should stop even though rounds 3-6 were already authorized.

After, the same state is:

```text
Reviews: 1/2 clean — GPT clean; Claude finding fixed
Recommendation: Continue
```

`Continue` directs the agent to emit the report and immediately begin the next candidate cycle without asking, setting `HELP`, or waiting for user input.

## Summary

- Add `Continue` to the round-report and structured-state recommendation values.
- Define rounds 1-6 as the initial authorized block.
- Permit `Approve next rounds` only after rounds 6, 12, 18, and so on, following the architectural checkpoint.
- Preserve immediate conflict resolution at a block boundary while keeping reviewer dispatch approval-gated.

## Non-action boundary

This does not change review eligibility, the six-round approval ceiling, candidate locking, or merge authorization.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md`
