### PR TITLE
Fix duplicate static website route

### DIFF
--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -21,11 +21,10 @@ public class BrowserStaticWebAppConfigTests
             .. config.RootElement.GetProperty("routes").EnumerateArray(),
         ];
 
-        Assert.Equal(4, routes.Length);
+        Assert.Equal(3, routes.Length);
         AssertRoute(routes[0], "/");
         AssertRoute(routes[1], "/index.html");
         AssertRoute(routes[2], "/credits", "/index.html");
-        AssertRoute(routes[3], "/credits/", "/index.html");
         Assert.Equal(
             "dotnet-isolated:8.0",
             config.RootElement
@@ -69,6 +68,34 @@ public class BrowserStaticWebAppConfigTests
             "$(PublishDir)wwwroot",
             (string?)verificationCommand.Attribute("Command"));
     }
+
+    [Fact]
+    public void RouteKeysAreUniqueAfterTrailingSlashNormalization()
+    {
+        string repository = RepositoryRoot();
+        string configPath = Path.Combine(
+            repository,
+            "prototypes",
+            "inspect-web",
+            "staticwebapp.config.json");
+
+        using JsonDocument config = JsonDocument.Parse(File.ReadAllText(configPath));
+        string[] routeKeys =
+        [
+            .. config.RootElement
+                .GetProperty("routes")
+                .EnumerateArray()
+                .Select(route => NormalizeRouteKey(
+                    route.GetProperty("route").GetString()!)),
+        ];
+
+        Assert.Equal(
+            routeKeys.Length,
+            routeKeys.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static string NormalizeRouteKey(string route) =>
+        route.Length > 1 ? route.TrimEnd('/') : route;
 
     private static void AssertRoute(
         JsonElement route,

--- a/prototypes/inspect-web/staticwebapp.config.json
+++ b/prototypes/inspect-web/staticwebapp.config.json
@@ -18,13 +18,6 @@
       "headers": {
         "Cache-Control": "no-cache, no-store, must-revalidate"
       }
-    },
-    {
-      "route": "/credits/",
-      "rewrite": "/index.html",
-      "headers": {
-        "Cache-Control": "no-cache, no-store, must-revalidate"
-      }
     }
   ],
   "navigationFallback": {

--- a/prototypes/inspect-web/test/toolchain.test.js
+++ b/prototypes/inspect-web/test/toolchain.test.js
@@ -62,20 +62,13 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   );
 });
 
-test("static hosting serves direct credits links through the application entry point", () => {
+test("static hosting serves credits links through the application entry point", () => {
   const creditsRoutes = staticWebAppConfig.routes
     .filter(route => route.route === "/credits" || route.route === "/credits/");
 
   assert.deepEqual(creditsRoutes, [
     {
       route: "/credits",
-      rewrite: "/index.html",
-      headers: {
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-      },
-    },
-    {
-      route: "/credits/",
       rewrite: "/index.html",
       headers: {
         "Cache-Control": "no-cache, no-store, must-revalidate",


### PR DESCRIPTION
Azure Static Web Apps rejects the staged site because `/credits` and `/credits/` normalize to the same route. Keep the canonical `/credits` rule, let the existing SPA navigation fallback serve `/credits/`, and gate route-key uniqueness using Azure's trailing-slash normalization.

## Demo

Before, both website deployments stopped at Azure validation:

```text
Encountered an issue while validating staticwebapp.config.json: A rule was already processed with a duplicate route /credits/.
```

After this change, the static-hosting config has one canonical Credits route while the existing fallback still sends neighboring client routes to the application entry point:

```json
{
  "route": "/credits",
  "rewrite": "/index.html"
}

"navigationFallback": {
  "rewrite": "/index.html"
}
```

## Validation

- `npm test` - 571 passed
- `npm run build`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -- -method '*BrowserStaticWebAppConfigTests*'` - 2 passed