### PR TITLE
Move v3 package resources behind source client

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -726,12 +726,24 @@ endpoint query bytes. `Capabilities` describes operations implemented by the
 runtime client; a particular v3 feed that does not advertise a search resource
 returns typed `Unsupported` from that operation. The adapter does not restore
 the retired NuGet.org-only search shortcut.
+`NuGetV3PackageResourceClient` owns `PackageBaseAddress` discovery,
+normalization, version-index URL construction, and exact package URL
+construction for the v3 source client. The canonical NuGet.org v3 client
+discovers the advertised package base instead of substituting the legacy
+flat-container constant. Legacy `NuGetClient` delegates those operations to
+the same source-owned primitive while retaining its canonical shortcut until
+its consumers migrate. V3 package payloads retain the advertised response
+length. Custom v3 symbol payload remains explicitly unsupported because
+`PackageBaseAddress` defines no symbol-package download route; the operation
+does not probe NuGet.org or construct a `.snupkg` URL.
 The local-folder descriptor remains modeled without a runtime client.
 `PackageSourceClientTests.GalleryAndCanonicalV3ShareProducerIdentity`,
 `HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling`,
 `LegacyPackageSourceCreatesV3Client`,
 `V3SearchUsesHighestCompatibleResourcesAndFailsOver`,
 `CanonicalNuGetOrgV3DiscoversSearchWithoutShortcut`,
+`CanonicalV3VersionAndPackageDiscoverDeclaredBaseAddress`,
+`LegacyNuGetClientRetainsCanonicalFlatContainerShortcut`,
 `V3SearchPreservesDeclaredQueryBytes`,
 `V3SearchPreservesSignedBytesWhileNormalizingIdn`,
 `V3SearchNormalizesIdnServiceIndex`,
@@ -770,13 +782,15 @@ The local-folder descriptor remains modeled without a runtime client.
 `GalleryFinalListingProjectionExpiresToPartial`,
 `GalleryEscapesUnicodePackageIdsAsOneSegment`,
 `GalleryRequestsUseLibraryDeadlines`,
-`CanonicalV3EnumerationReportsUnknownListingState`,
 `V3InvalidVersionMetadataIsTypedFailure`,
 `V3UnusablePackageBaseAddressIsInvalidResponse`,
 `V3SignedPackageBaseAddressPreservesQuery`,
+`V3VersionAndPackageDoNotSendCredentialCrossOrigin`,
+`V3MissingPackageIsTypedAbsence`,
 `V3EscapesUnicodePackageIdsAsPathSegments`,
 `V3NormalizesIdnPackageBaseAddress`,
 `V3PreservesIpv6BracketsWhenEscapingBasePath`,
+`DefaultV3TransportBlocksPrivateCrossOriginVersionAndPackageResources`,
 `GalleryMissingPackageIsTypedAbsence`,
 `GalleryClassifiesBoundedMetadataRejection`,
 `GalleryClassifiesHttpFailures`,
@@ -798,15 +812,13 @@ The remaining structural problem is that existing package-resolution consumers
 still largely equate a source with a v3 service-index URL. The implementation
 should:
 
-1. Move remaining v3 version and payload resource discovery and URL
-   construction out of legacy `NuGetClient` and into the source client.
-2. Migrate package resolution from direct `PackageSource`/`NuGetClient` use to
+1. Migrate package resolution from direct `PackageSource`/`NuGetClient` use to
    the source-client boundary.
-3. Add environment-scoped availability observations without mutating durable
+2. Add environment-scoped availability observations without mutating durable
    candidate observations.
-4. Let desktop and browser hosts choose transport implementations without
+3. Let desktop and browser hosts choose transport implementations without
    changing producer identity above the acquisition layer.
-5. Replace the browser's singleton `default versus mirror` state with a source
+4. Replace the browser's singleton `default versus mirror` state with a source
    registry and selected source set.
 
 The product libraries must own these contracts. A browser harness may present

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -492,6 +492,12 @@ is returned, but a later consumption failure remains an exception because the
 operation result has already completed. These transport results do not yet
 perform multi-source aggregation and are not environment availability
 observations.
+The v3 source client owns service-index `PackageBaseAddress` discovery plus
+version-index and exact-package URL construction. The legacy `NuGetClient`
+delegates to that source-owned primitive and retains only its compatibility
+choice to bypass canonical NuGet.org service-index discovery. V3 symbol
+payload remains unsupported because the protocol has no package-base-relative
+symbol download contract.
 
 The current implementation source-scopes downloaded package content and
 candidate metadata, aggregates versions across sources while retaining the

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -1378,7 +1378,10 @@ Browser-Wasm cannot perform that connection-time DNS check. Its v3 client
 therefore accepts only same-origin feed resources and sets Fetch
 `redirect: error`; the built-in Gallery remains a separate fixed-host
 transport. `PackageSourceClientTests.DefaultV3TransportBlocksPrivateCrossOriginSearchEndpoint`
-gates the desktop source-client wiring,
+and
+`PackageSourceClientTests.DefaultV3TransportBlocksPrivateCrossOriginVersionAndPackageResources`
+gate the desktop source-client wiring for search, version, and package
+resources,
 `HttpClientFactoryTests.PackageSourceClient_AllowsConfiguredPrivateOriginButBlocksPrivateRedirect`
 gates redirect-hop enforcement,
 `PackageSourceClientTests.DefaultV3TransportAllowsConfiguredPrivateIpv6Source`

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -309,11 +309,29 @@ public sealed class PackageSourceClientTests
     }
 
     [Fact]
-    public async Task CanonicalV3EnumerationReportsUnknownListingState()
+    public async Task CanonicalV3VersionAndPackageDiscoverDeclaredBaseAddress()
     {
+        const string declaredBaseAddress =
+            "https://packages.example/flat/";
+        const string declaredVersions =
+            "https://packages.example/flat/contoso/index.json";
+        const string declaredPackage =
+            "https://packages.example/flat/contoso/1.0.0/contoso.1.0.0.nupkg";
         var handler = new RecordingHandler
         {
-            [NuGetOrgVersions] = """{"versions":["1.0.0"]}""",
+            [NuGetClient.NuGetOrgServiceIndex] = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    {
+                      "@id": "{{declaredBaseAddress}}",
+                      "@type": "PackageBaseAddress/3.0.0"
+                    }
+                  ]
+                }
+                """,
+            [declaredVersions] = """{"versions":["1.0.0"]}""",
+            [declaredPackage] = "package bytes",
         };
         HttpMessageHandler client = handler;
         using IPackageSourceClient runtime =
@@ -332,6 +350,39 @@ public sealed class PackageSourceClientTests
             PackageListingState.Unknown,
             candidate.ListingState);
         Assert.False(versions.HasAuthoritativeListingState);
+        PackageSourcePayload payload = Succeeded(
+            await runtime.GetPackageAsync(
+                "contoso",
+                "1.0.0",
+                TestContext.Current.CancellationToken));
+        await using Stream content = payload.Content;
+        Assert.Equal("package bytes".Length, payload.AdvertisedLength);
+        Assert.Equal(
+            [
+                NuGetClient.NuGetOrgServiceIndex,
+                declaredVersions,
+                declaredPackage,
+            ],
+            handler.Requested);
+        Assert.DoesNotContain(NuGetOrgVersions, handler.Requested);
+    }
+
+    [Fact]
+    public async Task LegacyNuGetClientRetainsCanonicalFlatContainerShortcut()
+    {
+        var handler = new RecordingHandler
+        {
+            [NuGetOrgVersions] = """{"versions":["1.0.0"]}""",
+        };
+        using var http = new HttpClient(handler);
+        var client = new NuGetClient(http);
+
+        IReadOnlyList<string> versions = await client.GetVersionsAsync(
+            "contoso",
+            cancellationToken:
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(["1.0.0"], versions);
         Assert.Equal([NuGetOrgVersions], handler.Requested);
     }
 
@@ -482,6 +533,43 @@ public sealed class PackageSourceClientTests
             handler.Requested);
     }
 
+    [Fact]
+    public async Task V3MissingPackageIsTypedAbsence()
+    {
+        var handler = new RecordingHandler
+        {
+            [ServiceIndex] = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    {
+                      "@id": "{{FlatContainer}}",
+                      "@type": "PackageBaseAddress/3.0.0"
+                    }
+                  ]
+                }
+                """,
+        };
+        handler.SetStatus(Package, HttpStatusCode.NotFound);
+        HttpMessageHandler client = handler;
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource("corporate", ServiceIndex),
+                client);
+
+        PackageSourceFailure failure = Failed(
+            await runtime.GetPackageAsync(
+                "contoso",
+                "1.0.0",
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(PackageSourceFailureKind.NotFound, failure.Kind);
+        Assert.Equal(
+            PackageSourceCoordinate.Create("contoso", "1.0.0"),
+            failure.Coordinate);
+        Assert.Equal([ServiceIndex, Package], handler.Requested);
+    }
+
     [Theory]
     [InlineData("https://feed.example/v3/flat/?sig=secret")]
     [InlineData("https://feed.example/v3/flat?sig=secret")]
@@ -535,6 +623,58 @@ public sealed class PackageSourceClientTests
                 signedPackage,
             ],
             handler.Requested);
+    }
+
+    [Fact]
+    public async Task V3VersionAndPackageDoNotSendCredentialCrossOrigin()
+    {
+        const string crossOriginBase =
+            "https://packages.example/flat/";
+        const string crossOriginVersions =
+            "https://packages.example/flat/contoso/index.json";
+        const string crossOriginPackage =
+            "https://packages.example/flat/contoso/1.0.0/contoso.1.0.0.nupkg";
+        var handler = new RecordingHandler
+        {
+            [ServiceIndex] = $$"""
+                {
+                  "version": "3.0.0",
+                  "resources": [
+                    {
+                      "@id": "{{crossOriginBase}}",
+                      "@type": "PackageBaseAddress/3.0.0"
+                    }
+                  ]
+                }
+                """,
+            [crossOriginVersions] = """{"versions":["1.0.0"]}""",
+            [crossOriginPackage] = "package bytes",
+        };
+        HttpMessageHandler client = handler;
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource(
+                    "credentialed",
+                    ServiceIndex,
+                    new PackageSourceCredential("user", "token")),
+                client);
+
+        Assert.Single(
+            Succeeded(
+                await runtime.GetVersionsAsync(
+                    "contoso",
+                    TestContext.Current.CancellationToken))
+                .Candidates);
+        PackageSourcePayload payload = Succeeded(
+            await runtime.GetPackageAsync(
+                "contoso",
+                "1.0.0",
+                TestContext.Current.CancellationToken));
+        await payload.Content.DisposeAsync();
+
+        Assert.Equal(
+            ["user:token", null, "user:token", null],
+            handler.Authentication.Select(DecodeBasic));
     }
 
     [Fact]
@@ -2946,6 +3086,85 @@ public sealed class PackageSourceClientTests
         Assert.Equal(
             PackageSourceFailureKind.Transport,
             failure.Failure.Kind);
+        Assert.False(targetReached);
+    }
+
+    [Fact]
+    public async Task DefaultV3TransportBlocksPrivateCrossOriginVersionAndPackageResources()
+    {
+        using var sourceListener =
+            new TcpListener(IPAddress.Loopback, 0);
+        using var targetListener =
+            new TcpListener(IPAddress.Loopback, 0);
+        sourceListener.Start();
+        targetListener.Start();
+        int sourcePort =
+            ((IPEndPoint)sourceListener.LocalEndpoint).Port;
+        int targetPort =
+            ((IPEndPoint)targetListener.LocalEndpoint).Port;
+        string sourceUrl =
+            $"http://127.0.0.1:{sourcePort}/index.json";
+        string targetUrl =
+            $"http://127.0.0.1:{targetPort}/flat/";
+        string serviceIndex = $$"""
+            {
+              "version": "3.0.0",
+              "resources": [
+                {
+                  "@id": "{{targetUrl}}",
+                  "@type": "PackageBaseAddress/3.0.0"
+                }
+              ]
+            }
+            """;
+
+        Task sourceServer = ServeHttpResponseAsync(
+            sourceListener,
+            serviceIndex,
+            TestContext.Current.CancellationToken);
+        using var targetCancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        Task<bool> targetServer = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await ServeHttpResponseAsync(
+                        targetListener,
+                        """{"versions":["1.0.0"]}""",
+                        targetCancellation.Token);
+                    return true;
+                }
+                catch (OperationCanceledException)
+                {
+                    return false;
+                }
+            },
+            CancellationToken.None);
+
+        using IPackageSourceClient runtime =
+            PackageSourceClientFactory.Create(
+                new PackageSource("private", sourceUrl));
+        PackageSourceFailure versionFailure = Failed(
+            await runtime.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken));
+        PackageSourceFailure packageFailure = Failed(
+            await runtime.GetPackageAsync(
+                "contoso",
+                "1.0.0",
+                TestContext.Current.CancellationToken));
+
+        targetCancellation.Cancel();
+        await sourceServer;
+        bool targetReached = await targetServer;
+        Assert.Equal(
+            PackageSourceFailureKind.Transport,
+            versionFailure.Kind);
+        Assert.Equal(
+            PackageSourceFailureKind.Transport,
+            packageFailure.Kind);
         Assert.False(targetReached);
     }
 

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -571,15 +571,25 @@ public sealed class PackageSourceClientTests
     }
 
     [Theory]
-    [InlineData("https://feed.example/v3/flat/?sig=secret")]
-    [InlineData("https://feed.example/v3/flat?sig=secret")]
+    [InlineData(
+        "https://feed.example/v3/flat/?sig=secret",
+        "?sig=secret")]
+    [InlineData(
+        "https://feed.example/v3/flat?sig=secret",
+        "?sig=secret")]
+    [InlineData(
+        "https://feed.example/v3/flat/?s%69g=\u2713",
+        "?s%69g=%E2%9C%93")]
     public async Task V3SignedPackageBaseAddressPreservesQuery(
-        string baseAddress)
+        string baseAddress,
+        string expectedQuery)
     {
-        const string signedVersions =
-            "https://feed.example/v3/flat/contoso/index.json?sig=secret";
-        const string signedPackage =
-            "https://feed.example/v3/flat/contoso/1.0.0/contoso.1.0.0.nupkg?sig=secret";
+        string signedVersions =
+            "https://feed.example/v3/flat/contoso/index.json"
+            + expectedQuery;
+        string signedPackage =
+            "https://feed.example/v3/flat/contoso/1.0.0/contoso.1.0.0.nupkg"
+            + expectedQuery;
         var handler = new RecordingHandler
         {
             [ServiceIndex] = $$"""

--- a/src/NuGetFetch/NuGetClient.cs
+++ b/src/NuGetFetch/NuGetClient.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using NuGet.Versioning;
 
@@ -10,13 +8,15 @@ namespace NuGetFetch;
 /// </summary>
 public class NuGetClient(HttpClient client)
 {
-    internal const string NuGetOrgFlatContainer = "https://api.nuget.org/v3-flatcontainer/";
-    internal const string NuGetOrgServiceIndex = "https://api.nuget.org/v3/index.json";
+    internal const string NuGetOrgFlatContainer =
+        NuGetV3PackageResourceClient.NuGetOrgFlatContainer;
+    internal const string NuGetOrgServiceIndex =
+        NuGetV3PackageResourceClient.NuGetOrgServiceIndex;
     internal const string NuGetOrgSearchUrl = "https://azuresearch-usnc.nuget.org/query";
 
     private readonly NuGetFetchOptions _options = new();
-    private readonly ConcurrentDictionary<string, string> _baseAddressCache =
-        new(StringComparer.Ordinal);
+    private readonly NuGetV3PackageResourceClient _packageResources =
+        new(client);
 
     /// <summary>
     /// Creates a NuGet client with configured resource limits and deadlines.
@@ -45,58 +45,14 @@ public class NuGetClient(HttpClient client)
         string packageId,
         string? sourceUrl,
         PackageSourceCredential? credential,
-        NuGetOperationDeadline operation)
-    {
-        string baseAddress = await ResolveBaseAddressAsync(
-            sourceUrl,
+        NuGetOperationDeadline operation) =>
+        await _packageResources.GetVersionsAsync(
+            packageId,
+            sourceUrl ?? NuGetOrgServiceIndex,
             credential,
-            operation).ConfigureAwait(false);
-        string normalizedId = packageId.ToLowerInvariant();
-        string url = AppendBaseAddressPath(
-            baseAddress,
-            $"{Uri.EscapeDataString(normalizedId)}/index.json");
-        PackageSourceCredential? endpointCredential =
-            NuGetSourceRequest.CredentialForEndpoint(
-                sourceUrl,
-                url,
-                credential);
-
-        try
-        {
-            return await operation.RunRequestAsync(
-                async requestToken =>
-                {
-                    using HttpRequestMessage request =
-                        NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
-                    NuGetSourceRequest.ApplyCredential(
-                        request,
-                        endpointCredential);
-                    using HttpResponseMessage response = await client.SendAsync(
-                        request,
-                        HttpCompletionOption.ResponseHeadersRead,
-                        requestToken).ConfigureAwait(false);
-
-                    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
-                        return [];
-
-                    response.EnsureSuccessStatusCode();
-                    VersionIndex? index =
-                        await NuGetMetadataReader.ReadResponseAsync(
-                            response,
-                            NuGetApi.DeserializeVersionIndexAsync,
-                            _options,
-                            client.Timeout,
-                            requestToken).ConfigureAwait(false);
-                    return (IReadOnlyList<string>?)index?.Versions
-                        ?? throw new NuGetSourceResponseException(
-                            "The package version response was not a valid version document.");
-                }).ConfigureAwait(false);
-        }
-        catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
-        {
-            return [];
-        }
-    }
+            _options,
+            operation,
+            useNuGetOrgShortcut: true).ConfigureAwait(false);
 
     /// <summary>
     /// Gets the latest version for a package. Uses the search API for nuget.org (faster).
@@ -180,48 +136,16 @@ public class NuGetClient(HttpClient client)
         var operation = CreateOperation(cancellationToken);
         try
         {
-            string baseAddress = await ResolveBaseAddressAsync(
-                sourceUrl,
-                credential,
-                operation).ConfigureAwait(false);
-            string id = packageId.ToLowerInvariant();
-            string ver = NormalizeVersion(version);
-            string url = AppendBaseAddressPath(
-                baseAddress,
-                $"{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(ver)}/"
-                + $"{Uri.EscapeDataString($"{id}.{ver}.nupkg")}");
-            PackageSourceCredential? endpointCredential =
-                NuGetSourceRequest.CredentialForEndpoint(
-                    sourceUrl,
-                    url,
-                    credential);
-
-            return await operation.RunStreamingRequestAsync(
-                async requestToken =>
-                {
-                    using HttpRequestMessage request =
-                        NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
-                    NuGetSourceRequest.ApplyCredential(
-                        request,
-                        endpointCredential);
-                    HttpResponseMessage response = await client.SendAsync(
-                        request,
-                        HttpCompletionOption.ResponseHeadersRead,
-                        requestToken).ConfigureAwait(false);
-                    try
-                    {
-                        response.EnsureSuccessStatusCode();
-                        Stream contentStream = await response.Content
-                            .ReadAsStreamAsync(requestToken)
-                            .ConfigureAwait(false);
-                        return (contentStream, response);
-                    }
-                    catch
-                    {
-                        response.Dispose();
-                        throw;
-                    }
-                }).ConfigureAwait(false);
+            (Stream content, _) =
+                await _packageResources.GetPackageAsync(
+                    packageId,
+                    version,
+                    sourceUrl ?? NuGetOrgServiceIndex,
+                    credential,
+                    _options,
+                    operation,
+                    useNuGetOrgShortcut: true).ConfigureAwait(false);
+            return content;
         }
         catch
         {
@@ -246,72 +170,11 @@ public class NuGetClient(HttpClient client)
     public async Task<string?> GetPackageBaseAddressAsync(string serviceIndexUrl, CancellationToken cancellationToken = default)
     {
         using var operation = CreateOperation(cancellationToken);
-        return await GetPackageBaseAddressAsync(
+        return await _packageResources.GetPackageBaseAddressAsync(
             serviceIndexUrl,
             credential: null,
+            _options,
             operation).ConfigureAwait(false);
-    }
-
-    private async Task<string?> GetPackageBaseAddressAsync(
-        string serviceIndexUrl,
-        PackageSourceCredential? credential,
-        NuGetOperationDeadline operation)
-    {
-        if (!NuGetSourceRequest.TryEndpointUrl(
-                serviceIndexUrl,
-                out string normalizedServiceIndexUrl))
-        {
-            throw new NuGetSourceResponseException(
-                "The package source service-index endpoint is unusable.");
-        }
-
-        ServiceIndex? index;
-        try
-        {
-            index = await operation.RunRequestAsync(
-                async requestToken =>
-                {
-                    using HttpRequestMessage request =
-                        NuGetHttpRequest
-                            .CreateGetPreservingPathAndQuery(
-                                normalizedServiceIndexUrl);
-                    NuGetSourceRequest.ApplyCredential(
-                        request,
-                        credential);
-                    using HttpResponseMessage response = await client.SendAsync(
-                        request,
-                        HttpCompletionOption.ResponseHeadersRead,
-                        requestToken).ConfigureAwait(false);
-                    response.EnsureSuccessStatusCode();
-
-                    return await NuGetMetadataReader.ReadResponseAsync(
-                        response,
-                        NuGetApi.DeserializeServiceIndexAsync,
-                        _options,
-                        client.Timeout,
-                        requestToken).ConfigureAwait(false);
-                }).ConfigureAwait(false);
-        }
-        catch (HttpRequestException exception)
-            when (exception.StatusCode
-                == System.Net.HttpStatusCode.NotFound)
-        {
-            throw new NuGetSourceResponseException(
-                "The package source service index was not found.",
-                exception);
-        }
-
-        string? baseAddress = index?.Resources
-            .Where(r => r.Type.StartsWith("PackageBaseAddress", StringComparison.OrdinalIgnoreCase))
-            .Select(r => r.Id)
-            .FirstOrDefault();
-
-        if (baseAddress is null)
-        {
-            return null;
-        }
-
-        return NormalizeBaseAddress(baseAddress);
     }
 
     /// <summary>
@@ -362,133 +225,6 @@ public class NuGetClient(HttpClient client)
         return results.FirstOrDefault()?.Version;
     }
 
-    private async Task<string> ResolveBaseAddressAsync(
-        string? sourceUrl,
-        PackageSourceCredential? credential,
-        NuGetOperationDeadline operation)
-    {
-        if (sourceUrl is null
-            || PackageSource.IsNuGetOrgServiceIndex(sourceUrl))
-        {
-            return NuGetOrgFlatContainer;
-        }
-
-        bool cacheableSource =
-            credential is null
-            && Uri.TryCreate(sourceUrl, UriKind.Absolute, out Uri? source)
-            && source.Query.Length == 0
-            && source.Fragment.Length == 0;
-        if (cacheableSource
-            && _baseAddressCache.TryGetValue(sourceUrl, out string? cached))
-        {
-            return cached;
-        }
-
-        string baseAddress = await GetPackageBaseAddressAsync(
-            sourceUrl,
-            credential,
-            operation).ConfigureAwait(false)
-            ?? throw new NuGetSourceResponseException(
-                "The source service index did not advertise PackageBaseAddress.");
-
-        if (cacheableSource
-            && Uri.TryCreate(baseAddress, UriKind.Absolute, out Uri? resource)
-            && resource.Query.Length == 0
-            && resource.Fragment.Length == 0)
-        {
-            _baseAddressCache.TryAdd(sourceUrl, baseAddress);
-        }
-
-        return baseAddress;
-    }
-
-    private static string NormalizeBaseAddress(string baseAddress)
-    {
-        if (!NuGetHttpRequest.HasValidRawText(
-                baseAddress,
-                allowNonAscii: true)
-            || !Uri.TryCreate(baseAddress, UriKind.Absolute, out Uri? endpoint)
-            || (endpoint.Scheme != Uri.UriSchemeHttp
-                && endpoint.Scheme != Uri.UriSchemeHttps)
-            || endpoint.UserInfo.Length > 0
-            || endpoint.Fragment.Length > 0)
-        {
-            throw new NuGetSourceResponseException(
-                "The source service index advertised an unusable PackageBaseAddress.");
-        }
-
-        int queryStart = baseAddress.IndexOf('?', StringComparison.Ordinal);
-        string pathAndOrigin = queryStart >= 0
-            ? baseAddress[..queryStart]
-            : baseAddress;
-        string query = queryStart >= 0
-            ? baseAddress[queryStart..]
-            : "";
-        if (pathAndOrigin.Any(character => character > 0x7F))
-        {
-            string escapedPath = endpoint.GetComponents(
-                UriComponents.Path,
-                UriFormat.UriEscaped);
-            string idnHost;
-            try
-            {
-                idnHost = endpoint.IdnHost;
-            }
-            catch (UriFormatException exception)
-            {
-                throw new NuGetSourceResponseException(
-                    "The source service index advertised an unusable PackageBaseAddress.",
-                    exception);
-            }
-
-            string host = endpoint.HostNameType == UriHostNameType.IPv6
-                ? $"[{idnHost}]"
-                : idnHost;
-            string origin =
-                $"{endpoint.Scheme}://{host}"
-                + (endpoint.IsDefaultPort
-                    ? ""
-                    : $":{endpoint.Port}");
-            pathAndOrigin =
-                origin
-                + (escapedPath.StartsWith("/", StringComparison.Ordinal)
-                    ? escapedPath
-                    : "/" + escapedPath);
-        }
-
-        if (query.Any(character => character > 0x7F))
-        {
-            query = endpoint.Query.Length == 0
-                ? ""
-                : "?" + endpoint.GetComponents(
-                    UriComponents.Query,
-                    UriFormat.UriEscaped);
-        }
-
-        string normalized = pathAndOrigin.EndsWith("/", StringComparison.Ordinal)
-            ? pathAndOrigin + query
-            : $"{pathAndOrigin}/{query}";
-        if (!NuGetHttpRequest.TryCreatePreservingPathAndQuery(
-                normalized,
-                out _))
-        {
-            throw new NuGetSourceResponseException(
-                "The source service index advertised an unusable PackageBaseAddress.");
-        }
-
-        return normalized;
-    }
-
-    private static string AppendBaseAddressPath(
-        string baseAddress,
-        string relativePath)
-    {
-        int queryStart = baseAddress.IndexOf('?', StringComparison.Ordinal);
-        return queryStart >= 0
-            ? $"{baseAddress[..queryStart]}{relativePath}{baseAddress[queryStart..]}"
-            : baseAddress + relativePath;
-    }
-
     private NuGetOperationDeadline CreateOperation(
         CancellationToken cancellationToken) =>
         new(_options, client.Timeout, cancellationToken);
@@ -521,12 +257,5 @@ public class NuGetClient(HttpClient client)
     /// Falls back to lowercasing if the version string can't be parsed.
     /// </summary>
     public static string NormalizeVersion(string version)
-    {
-        if (NuGetVersion.TryParse(version, out NuGetVersion? parsed))
-        {
-            return parsed.ToNormalizedString().ToLowerInvariant();
-        }
-
-        return version.ToLowerInvariant();
-    }
+        => NuGetV3PackageResourceClient.NormalizeVersion(version);
 }

--- a/src/NuGetFetch/NuGetV3PackageResourceClient.cs
+++ b/src/NuGetFetch/NuGetV3PackageResourceClient.cs
@@ -273,54 +273,25 @@ internal sealed class NuGetV3PackageResourceClient(HttpClient client)
                 "The source service index advertised an unusable PackageBaseAddress.");
         }
 
-        int queryStart = baseAddress.IndexOf('?', StringComparison.Ordinal);
+        string escaped;
+        try
+        {
+            escaped = NuGetSourceRequest.EndpointUrl(endpoint);
+        }
+        catch (NuGetSourceResponseException exception)
+        {
+            throw new NuGetSourceResponseException(
+                "The source service index advertised an unusable PackageBaseAddress.",
+                exception);
+        }
+
+        int queryStart = escaped.IndexOf('?', StringComparison.Ordinal);
         string pathAndOrigin = queryStart >= 0
-            ? baseAddress[..queryStart]
-            : baseAddress;
+            ? escaped[..queryStart]
+            : escaped;
         string query = queryStart >= 0
-            ? baseAddress[queryStart..]
+            ? escaped[queryStart..]
             : "";
-        if (pathAndOrigin.Any(character => character > 0x7F))
-        {
-            string escapedPath = endpoint.GetComponents(
-                UriComponents.Path,
-                UriFormat.UriEscaped);
-            string idnHost;
-            try
-            {
-                idnHost = endpoint.IdnHost;
-            }
-            catch (UriFormatException exception)
-            {
-                throw new NuGetSourceResponseException(
-                    "The source service index advertised an unusable PackageBaseAddress.",
-                    exception);
-            }
-
-            string host = endpoint.HostNameType == UriHostNameType.IPv6
-                ? $"[{idnHost}]"
-                : idnHost;
-            string origin =
-                $"{endpoint.Scheme}://{host}"
-                + (endpoint.IsDefaultPort
-                    ? ""
-                    : $":{endpoint.Port}");
-            pathAndOrigin =
-                origin
-                + (escapedPath.StartsWith("/", StringComparison.Ordinal)
-                    ? escapedPath
-                    : "/" + escapedPath);
-        }
-
-        if (query.Any(character => character > 0x7F))
-        {
-            query = endpoint.Query.Length == 0
-                ? ""
-                : "?" + endpoint.GetComponents(
-                    UriComponents.Query,
-                    UriFormat.UriEscaped);
-        }
-
         string normalized = pathAndOrigin.EndsWith("/", StringComparison.Ordinal)
             ? pathAndOrigin + query
             : $"{pathAndOrigin}/{query}";

--- a/src/NuGetFetch/NuGetV3PackageResourceClient.cs
+++ b/src/NuGetFetch/NuGetV3PackageResourceClient.cs
@@ -1,0 +1,357 @@
+using System.Collections.Concurrent;
+using NuGet.Versioning;
+
+namespace NuGetFetch;
+
+/// <summary>
+/// Owns NuGet v3 <c>PackageBaseAddress</c> discovery and source-relative
+/// version and package requests.
+/// </summary>
+/// <remarks>
+/// <c>CanonicalV3VersionAndPackageDiscoverDeclaredBaseAddress</c> gates
+/// service-index discovery without the legacy NuGet.org shortcut,
+/// <c>V3VersionAndPackageDoNotSendCredentialCrossOrigin</c> gates credential
+/// scope, and
+/// <c>DefaultV3TransportBlocksPrivateCrossOriginVersionAndPackageResources</c>
+/// gates the destination policy on both resource operations.
+/// </remarks>
+internal sealed class NuGetV3PackageResourceClient(HttpClient client)
+{
+    internal const string NuGetOrgFlatContainer =
+        "https://api.nuget.org/v3-flatcontainer/";
+    internal const string NuGetOrgServiceIndex =
+        "https://api.nuget.org/v3/index.json";
+
+    private readonly ConcurrentDictionary<string, string> _baseAddressCache =
+        new(StringComparer.Ordinal);
+
+    internal async Task<IReadOnlyList<string>> GetVersionsAsync(
+        string packageId,
+        string serviceIndexUrl,
+        PackageSourceCredential? credential,
+        NuGetFetchOptions options,
+        NuGetOperationDeadline operation,
+        bool useNuGetOrgShortcut)
+    {
+        string baseAddress = await ResolveBaseAddressAsync(
+            serviceIndexUrl,
+            credential,
+            options,
+            operation,
+            useNuGetOrgShortcut).ConfigureAwait(false);
+        string normalizedId = packageId.ToLowerInvariant();
+        string url = AppendBaseAddressPath(
+            baseAddress,
+            $"{Uri.EscapeDataString(normalizedId)}/index.json");
+        PackageSourceCredential? endpointCredential =
+            NuGetSourceRequest.CredentialForEndpoint(
+                serviceIndexUrl,
+                url,
+                credential);
+
+        try
+        {
+            return await operation.RunRequestAsync(
+                async requestToken =>
+                {
+                    using HttpRequestMessage request =
+                        NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
+                    NuGetSourceRequest.ApplyCredential(
+                        request,
+                        endpointCredential);
+                    using HttpResponseMessage response = await client.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        requestToken).ConfigureAwait(false);
+
+                    if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                        return [];
+
+                    response.EnsureSuccessStatusCode();
+                    VersionIndex? index =
+                        await NuGetMetadataReader.ReadResponseAsync(
+                            response,
+                            NuGetApi.DeserializeVersionIndexAsync,
+                            options,
+                            client.Timeout,
+                            requestToken).ConfigureAwait(false);
+                    return (IReadOnlyList<string>?)index?.Versions
+                        ?? throw new NuGetSourceResponseException(
+                            "The package version response was not a valid version document.");
+                }).ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+            when (exception.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return [];
+        }
+    }
+
+    internal async Task<(Stream Content, long? AdvertisedLength)> GetPackageAsync(
+        string packageId,
+        string version,
+        string serviceIndexUrl,
+        PackageSourceCredential? credential,
+        NuGetFetchOptions options,
+        NuGetOperationDeadline operation,
+        bool useNuGetOrgShortcut)
+    {
+        string baseAddress = await ResolveBaseAddressAsync(
+            serviceIndexUrl,
+            credential,
+            options,
+            operation,
+            useNuGetOrgShortcut).ConfigureAwait(false);
+        string id = packageId.ToLowerInvariant();
+        string normalizedVersion = NormalizeVersion(version);
+        string url = AppendBaseAddressPath(
+            baseAddress,
+            $"{Uri.EscapeDataString(id)}/{Uri.EscapeDataString(normalizedVersion)}/"
+            + $"{Uri.EscapeDataString($"{id}.{normalizedVersion}.nupkg")}");
+        PackageSourceCredential? endpointCredential =
+            NuGetSourceRequest.CredentialForEndpoint(
+                serviceIndexUrl,
+                url,
+                credential);
+
+        return await operation.RunStreamingRequestAsync(
+            async requestToken =>
+            {
+                using HttpRequestMessage request =
+                    NuGetHttpRequest.CreateGetPreservingPathAndQuery(url);
+                NuGetSourceRequest.ApplyCredential(
+                    request,
+                    endpointCredential);
+                HttpResponseMessage response = await client.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    requestToken).ConfigureAwait(false);
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                    Stream content = await response.Content
+                        .ReadAsStreamAsync(requestToken)
+                        .ConfigureAwait(false);
+                    return (
+                        content,
+                        response,
+                        response.Content.Headers.ContentLength);
+                }
+                catch
+                {
+                    response.Dispose();
+                    throw;
+                }
+            }).ConfigureAwait(false);
+    }
+
+    internal async Task<string?> GetPackageBaseAddressAsync(
+        string serviceIndexUrl,
+        PackageSourceCredential? credential,
+        NuGetFetchOptions options,
+        NuGetOperationDeadline operation)
+    {
+        if (!NuGetSourceRequest.TryEndpointUrl(
+                serviceIndexUrl,
+                out string normalizedServiceIndexUrl))
+        {
+            throw new NuGetSourceResponseException(
+                "The package source service-index endpoint is unusable.");
+        }
+
+        ServiceIndex? index;
+        try
+        {
+            index = await operation.RunRequestAsync(
+                async requestToken =>
+                {
+                    using HttpRequestMessage request =
+                        NuGetHttpRequest
+                            .CreateGetPreservingPathAndQuery(
+                                normalizedServiceIndexUrl);
+                    NuGetSourceRequest.ApplyCredential(
+                        request,
+                        credential);
+                    using HttpResponseMessage response = await client.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        requestToken).ConfigureAwait(false);
+                    response.EnsureSuccessStatusCode();
+
+                    return await NuGetMetadataReader.ReadResponseAsync(
+                        response,
+                        NuGetApi.DeserializeServiceIndexAsync,
+                        options,
+                        client.Timeout,
+                        requestToken).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+        }
+        catch (HttpRequestException exception)
+            when (exception.StatusCode
+                == System.Net.HttpStatusCode.NotFound)
+        {
+            throw new NuGetSourceResponseException(
+                "The package source service index was not found.",
+                exception);
+        }
+
+        string? baseAddress = index?.Resources
+            .Where(resource => resource.Type.StartsWith(
+                "PackageBaseAddress",
+                StringComparison.OrdinalIgnoreCase))
+            .Select(resource => resource.Id)
+            .FirstOrDefault();
+
+        return baseAddress is null
+            ? null
+            : NormalizeBaseAddress(baseAddress);
+    }
+
+    private async Task<string> ResolveBaseAddressAsync(
+        string serviceIndexUrl,
+        PackageSourceCredential? credential,
+        NuGetFetchOptions options,
+        NuGetOperationDeadline operation,
+        bool useNuGetOrgShortcut)
+    {
+        if (useNuGetOrgShortcut
+            && PackageSource.IsNuGetOrgServiceIndex(serviceIndexUrl))
+        {
+            return NuGetOrgFlatContainer;
+        }
+
+        bool cacheableSource =
+            credential is null
+            && Uri.TryCreate(
+                serviceIndexUrl,
+                UriKind.Absolute,
+                out Uri? source)
+            && source.Query.Length == 0
+            && source.Fragment.Length == 0;
+        if (cacheableSource
+            && _baseAddressCache.TryGetValue(
+                serviceIndexUrl,
+                out string? cached))
+        {
+            return cached;
+        }
+
+        string baseAddress = await GetPackageBaseAddressAsync(
+            serviceIndexUrl,
+            credential,
+            options,
+            operation).ConfigureAwait(false)
+            ?? throw new NuGetSourceResponseException(
+                "The source service index did not advertise PackageBaseAddress.");
+
+        if (cacheableSource
+            && Uri.TryCreate(
+                baseAddress,
+                UriKind.Absolute,
+                out Uri? resource)
+            && resource.Query.Length == 0
+            && resource.Fragment.Length == 0)
+        {
+            _baseAddressCache.TryAdd(serviceIndexUrl, baseAddress);
+        }
+
+        return baseAddress;
+    }
+
+    private static string NormalizeBaseAddress(string baseAddress)
+    {
+        if (!NuGetHttpRequest.HasValidRawText(
+                baseAddress,
+                allowNonAscii: true)
+            || !Uri.TryCreate(baseAddress, UriKind.Absolute, out Uri? endpoint)
+            || (endpoint.Scheme != Uri.UriSchemeHttp
+                && endpoint.Scheme != Uri.UriSchemeHttps)
+            || endpoint.UserInfo.Length > 0
+            || endpoint.Fragment.Length > 0)
+        {
+            throw new NuGetSourceResponseException(
+                "The source service index advertised an unusable PackageBaseAddress.");
+        }
+
+        int queryStart = baseAddress.IndexOf('?', StringComparison.Ordinal);
+        string pathAndOrigin = queryStart >= 0
+            ? baseAddress[..queryStart]
+            : baseAddress;
+        string query = queryStart >= 0
+            ? baseAddress[queryStart..]
+            : "";
+        if (pathAndOrigin.Any(character => character > 0x7F))
+        {
+            string escapedPath = endpoint.GetComponents(
+                UriComponents.Path,
+                UriFormat.UriEscaped);
+            string idnHost;
+            try
+            {
+                idnHost = endpoint.IdnHost;
+            }
+            catch (UriFormatException exception)
+            {
+                throw new NuGetSourceResponseException(
+                    "The source service index advertised an unusable PackageBaseAddress.",
+                    exception);
+            }
+
+            string host = endpoint.HostNameType == UriHostNameType.IPv6
+                ? $"[{idnHost}]"
+                : idnHost;
+            string origin =
+                $"{endpoint.Scheme}://{host}"
+                + (endpoint.IsDefaultPort
+                    ? ""
+                    : $":{endpoint.Port}");
+            pathAndOrigin =
+                origin
+                + (escapedPath.StartsWith("/", StringComparison.Ordinal)
+                    ? escapedPath
+                    : "/" + escapedPath);
+        }
+
+        if (query.Any(character => character > 0x7F))
+        {
+            query = endpoint.Query.Length == 0
+                ? ""
+                : "?" + endpoint.GetComponents(
+                    UriComponents.Query,
+                    UriFormat.UriEscaped);
+        }
+
+        string normalized = pathAndOrigin.EndsWith("/", StringComparison.Ordinal)
+            ? pathAndOrigin + query
+            : $"{pathAndOrigin}/{query}";
+        if (!NuGetHttpRequest.TryCreatePreservingPathAndQuery(
+                normalized,
+                out _))
+        {
+            throw new NuGetSourceResponseException(
+                "The source service index advertised an unusable PackageBaseAddress.");
+        }
+
+        return normalized;
+    }
+
+    private static string AppendBaseAddressPath(
+        string baseAddress,
+        string relativePath)
+    {
+        int queryStart = baseAddress.IndexOf('?', StringComparison.Ordinal);
+        return queryStart >= 0
+            ? $"{baseAddress[..queryStart]}{relativePath}{baseAddress[queryStart..]}"
+            : baseAddress + relativePath;
+    }
+
+    internal static string NormalizeVersion(string version)
+    {
+        if (NuGetVersion.TryParse(version, out NuGetVersion? parsed))
+        {
+            return parsed.ToNormalizedString().ToLowerInvariant();
+        }
+
+        return version.ToLowerInvariant();
+    }
+}

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -568,7 +568,7 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
     private readonly Uri _endpoint;
     private readonly PackageSourceCredential? _credential;
     private readonly HttpClient _client;
-    private readonly NuGetClient _nuget;
+    private readonly NuGetV3PackageResourceClient _packageResources;
     private readonly NuGetFetchOptions _options;
     private readonly TimeSpan _clientTimeout;
 
@@ -599,7 +599,7 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
         _client = client;
         _options = NuGetFetchOptions.Validate(options);
         _clientTimeout = client.Timeout;
-        _nuget = new NuGetClient(client, _options);
+        _packageResources = new NuGetV3PackageResourceClient(client);
     }
 
     public PackageSourceIdentity Identity => _identity;
@@ -713,11 +713,13 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
                     _clientTimeout,
                     cancellationToken);
                 IReadOnlyList<string> versions =
-                    await _nuget.GetVersionsAsync(
+                    await _packageResources.GetVersionsAsync(
                         packageId,
                         NuGetSourceRequest.EndpointUrl(_endpoint),
                         _credential,
-                        operation).ConfigureAwait(false);
+                        _options,
+                        operation,
+                        useNuGetOrgShortcut: false).ConfigureAwait(false);
                 return PackageSourceProjection.ProjectVersions(
                     packageId,
                     versions,
@@ -741,17 +743,37 @@ internal sealed class NuGetV3PackageSourceClient : IPackageSourceClient
             Identity,
             Kind,
             PackageSourceCapabilities.PackagePayload,
-            async () => new PackageSourcePayload(
-                coordinate,
-                Identity,
-                Kind,
-                PackageSourcePayloadKind.Package,
-                await _nuget.DownloadAsync(
-                    coordinate.PackageId,
-                    coordinate.Version,
-                    NuGetSourceRequest.EndpointUrl(_endpoint),
-                    _credential,
-                    cancellationToken).ConfigureAwait(false)),
+            async () =>
+            {
+                var operation = new NuGetOperationDeadline(
+                    _options,
+                    _clientTimeout,
+                    cancellationToken);
+                try
+                {
+                    (Stream content, long? advertisedLength) =
+                        await _packageResources.GetPackageAsync(
+                            coordinate.PackageId,
+                            coordinate.Version,
+                            NuGetSourceRequest.EndpointUrl(_endpoint),
+                            _credential,
+                            _options,
+                            operation,
+                            useNuGetOrgShortcut: false).ConfigureAwait(false);
+                    return new PackageSourcePayload(
+                        coordinate,
+                        Identity,
+                        Kind,
+                        PackageSourcePayloadKind.Package,
+                        content,
+                        advertisedLength);
+                }
+                catch
+                {
+                    operation.Dispose();
+                    throw;
+                }
+            },
             cancellationToken,
             coordinate).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary

Moves NuGet v3 `PackageBaseAddress` discovery, version enumeration, and exact package URL construction behind the typed source-client boundary.

- `NuGetV3PackageSourceClient` now discovers and uses the configured service index directly, including for canonical NuGet.org.
- Legacy `NuGetClient` delegates to the same protocol primitive while retaining its canonical flat-container shortcut for compatibility.
- V3 package payloads retain advertised content length, and version/package requests preserve the existing deadline, credential-origin, signed-query, and destination-policy contracts.

Part of #4239.

## Demo

The CLI still uses the compatibility consumer in this foundation slice. This actual command exercises version selection and package acquisition through the now-delegated legacy path:

```console
$ dotnet-inspect package NuGet.Versioning --source https://api.nuget.org/v3/index.json -v:q
# NuGet.Versioning

Version: 7.9.0 | Type: Library | Highest TFM: net8.0 | TFM Count: 2 | Built: 2026-07-21 | Source: NuGet
```

## Validation

- `dotnet run --project src/NuGetFetch.Tests -c Release`: 754 passed, 9 live Azure DevOps tests skipped, 0 failed
- `dotnet run --project src/NuGetFetch.Tests -c Release --no-build -- -class '*PackageSourceClientTests'`: 153 passed
- `dotnet build prototypes/inspect-web/engine/InspectWeb.Engine.csproj -c Release --no-restore`: succeeded for Browser/Wasm
- `npx markdownlint-cli docs/design/browser-package-sources.md docs/design/package-source-model.md docs/design/untrusted-data-threat-model.md`: passed

## Non-action boundary

This does not migrate package-resolution consumers to `IPackageSourceClient`, add multi-source aggregation, or invent standard-v3 `.snupkg` download semantics. Those remain follow-up work.
