### PR TITLE
Make link clicks and Escape a single navigation owner in inspect-web

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -724,10 +724,12 @@ Explorer, Settings, graph source, doc viewer, Spotlight) as one explicit
 ordered `KeydownLayer` list rather than an ad hoc if/else chain, so adding a
 new dismissable layer means adding one entry instead of re-deriving its
 priority. `dotnet-inspect.ts` retains asynchronous workspace restoration and
-its remaining DOM event binding. Alt+←/→ always drive `navBack()`/
-`navForward()`; Shift+←/→ are the same gesture, gated on the shared `typing`
-check so they never steal native text-selection inside an input or filter
-field — Shift+↑/↓ stay unclaimed. `test/workspace-navigation.test.ts` gates
+its remaining DOM event binding. Alt+←/→ and Shift+←/→ drive `navBack()`/
+`navForward()` unless an element-scoped handler (the type list, the graph
+viewport) already claimed the same combo and called `preventDefault()` first;
+Shift+←/→ are further gated on the shared `typing` check so they never steal
+native text-selection inside an input or filter field — Shift+↑/↓ stay
+unclaimed. `test/workspace-navigation.test.ts` gates
 history traversal, stale-entry removal, navigation cancellation, rich and
 legacy URL compatibility, visible invalid-state failures, sandboxed history
 errors, and the link-interception rule;

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -724,7 +724,10 @@ Explorer, Settings, graph source, doc viewer, Spotlight) as one explicit
 ordered `KeydownLayer` list rather than an ad hoc if/else chain, so adding a
 new dismissable layer means adding one entry instead of re-deriving its
 priority. `dotnet-inspect.ts` retains asynchronous workspace restoration and
-its remaining DOM event binding. `test/workspace-navigation.test.ts` gates
+its remaining DOM event binding. Alt+←/→ always drive `navBack()`/
+`navForward()`; Shift+←/→ are the same gesture, gated on the shared `typing`
+check so they never steal native text-selection inside an input or filter
+field — Shift+↑/↓ stay unclaimed. `test/workspace-navigation.test.ts` gates
 history traversal, stale-entry removal, navigation cancellation, rich and
 legacy URL compatibility, visible invalid-state failures, sandboxed history
 errors, and the link-interception rule;

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -712,12 +712,22 @@ not answer report the engine's failure rather than fixture results.
 
 `src/workspace-navigation.ts` owns the in-memory view history, monotonic
 navigation generation, share-packet encoding and decoding, URL parsing and
-building, and the browser-history port. `dotnet-inspect.ts` remains the sole
-mutable application-state owner: it supplies typed snapshots and explicit
-transition callbacks, and retains asynchronous workspace restoration and DOM
-event binding. `test/workspace-navigation.test.ts` gates history traversal,
-stale-entry removal, navigation cancellation, rich and legacy URL
-compatibility, visible invalid-state failures, and sandboxed history errors;
+building, the browser-history port, and the single delegated click listener
+that intercepts same-origin in-app anchor clicks
+(`bindWorkspaceLinkNavigation`/`shouldInterceptLinkClick`) — a modified click,
+`target`-scoped link, `download` link, or cross-origin href keeps native
+browser behavior. `dotnet-inspect.ts` remains the sole mutable
+application-state owner: it supplies typed snapshots and explicit transition
+callbacks, calls the one link-navigation binder instead of adding its own
+click listener, and declares its Escape-owning modal layers (Metadata
+Explorer, Settings, graph source, doc viewer, Spotlight) as one explicit
+ordered `KeydownLayer` list rather than an ad hoc if/else chain, so adding a
+new dismissable layer means adding one entry instead of re-deriving its
+priority. `dotnet-inspect.ts` retains asynchronous workspace restoration and
+its remaining DOM event binding. `test/workspace-navigation.test.ts` gates
+history traversal, stale-entry removal, navigation cancellation, rich and
+legacy URL compatibility, visible invalid-state failures, sandboxed history
+errors, and the link-interception rule;
 `test/spotlight-identity.test.js` gates the composition-root wiring.
 
 `src/package-acquisition.ts` owns NuGet and runtime-pack engine invocation,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -71,6 +71,7 @@ import {
   type BodyTarget,
 } from "./member-filtering.ts";
 import {
+  bindWorkspaceLinkNavigation,
   createNavigationHistory,
   createNavigationSequence,
   createWorkspaceLocationPersistence,
@@ -8533,34 +8534,127 @@ function refreshPackageStats() {
 }
 
 
-document.addEventListener("keydown", event => {
-  // The Metadata Explorer is a full-screen modal-style view. Escape zooms the focus lightbox
-  // out to the all-tables wall, then (from the wall) exits to the Metadata page. Backspace walks
-  // the ref->def history (Shift+Backspace forward).
-  if (state.explorer?.open) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      if (!state.explorer.overview) explorerShowOverview();
-      else closeExplorer();
-    } else if (event.key === "Backspace") {
-      event.preventDefault();
-      if (event.shiftKey) explorerHistoryForward();
-      else explorerHistoryBack();
-    } else if (isContainedBrowserShortcut(event)) {
-      event.preventDefault();
-    }
+// A same-origin, unmodified `<a href>` click anywhere in the app takes over here instead
+// of loading a new document — this is the single owner of in-app link navigation.
+// `target="_blank"`, cross-origin hrefs, `download`, and modified clicks (new tab/window)
+// keep their native browser behavior; the guard lives in `shouldInterceptLinkClick`.
+function navigateInAppUrl(url: URL) {
+  if (isCreditsPath(url.pathname)) {
+    openCredits();
     return;
   }
-  // Settings is a modal-style page reachable from home too, so handle its Escape before the
-  // home bail below (which otherwise swallows the keystroke on the home page).
-  if (state.settings) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeSettings();
-    } else if (isContainedBrowserShortcut(event)) {
-      event.preventDefault();
-    }
+  if (url.pathname === "/" && !url.search && !url.hash) {
+    goHome();
     return;
+  }
+  workspaceLocation.push(url.toString());
+  const loc = parseLocation();
+  observeAsync(restoreWorkspaceFromLocation(loc, loc), "Navigating");
+}
+
+bindWorkspaceLinkNavigation(document, {
+  currentOrigin: () => location.origin,
+  resolve: href => new URL(href, location.href),
+  navigate: navigateInAppUrl,
+});
+
+// A modal-style view that owns the keydown event outright while it is open (Escape
+// dismisses it, plus whatever other keys are its own). Declaring these as one ordered
+// list — instead of a chain of `if (state.x) { ...; return; }` blocks — makes this the
+// single, explicit place that decides which layer Escape (and everything else) belongs
+// to; adding a new dismissable layer means adding one entry here, not re-deriving the
+// right spot in a growing if/else chain.
+interface KeydownLayer {
+  active(): boolean;
+  handle(event: KeyboardEvent): void;
+}
+
+// The Metadata Explorer is a full-screen modal-style view. Escape zooms the focus lightbox
+// out to the all-tables wall, then (from the wall) exits to the Metadata page. Backspace walks
+// the ref->def history (Shift+Backspace forward). Settings is a modal-style page reachable
+// from home too, so it takes priority over the home bail below (which otherwise swallows the
+// keystroke on the home page).
+const homeIndependentKeydownLayers: readonly KeydownLayer[] = [
+  {
+    active: () => Boolean(state.explorer?.open),
+    handle(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        if (!state.explorer!.overview) explorerShowOverview();
+        else closeExplorer();
+      } else if (event.key === "Backspace") {
+        event.preventDefault();
+        if (event.shiftKey) explorerHistoryForward();
+        else explorerHistoryBack();
+      } else if (isContainedBrowserShortcut(event)) {
+        event.preventDefault();
+      }
+    },
+  },
+  {
+    active: () => state.settings,
+    handle(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSettings();
+      } else if (isContainedBrowserShortcut(event)) {
+        event.preventDefault();
+      }
+    },
+  },
+];
+
+// These modal-style layers only apply once a package workspace is loaded (the home and
+// loading/error bails below run first), but are otherwise the same kind of Escape-owning
+// layer as above.
+const workspaceKeydownLayers: readonly KeydownLayer[] = [
+  {
+    active: () => state.graphSourceOpen,
+    handle(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeGraphSource();
+      } else if (isContainedBrowserShortcut(event)) {
+        event.preventDefault();
+      }
+    },
+  },
+  {
+    active: () => state.docViewerOpen,
+    handle(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeDocViewer();
+      } else if (isContainedBrowserShortcut(event)) {
+        event.preventDefault();
+      }
+    },
+  },
+  {
+    active: () => state.spotlightOpen,
+    handle(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeSpotlight();
+      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        openSpotlight("", "commands");
+      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "p") {
+        event.preventDefault();
+        openSpotlight();
+      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+      }
+    },
+  },
+];
+
+document.addEventListener("keydown", event => {
+  for (const layer of homeIndependentKeydownLayers) {
+    if (layer.active()) {
+      layer.handle(event);
+      return;
+    }
   }
   const typing = isTextEntry();
   // The home page has its own scoped input handling (search box); global workbench
@@ -8572,38 +8666,11 @@ document.addEventListener("keydown", event => {
     }
     return;
   }
-  if (state.graphSourceOpen) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeGraphSource();
-    } else if (isContainedBrowserShortcut(event)) {
-      event.preventDefault();
+  for (const layer of workspaceKeydownLayers) {
+    if (layer.active()) {
+      layer.handle(event);
+      return;
     }
-    return;
-  }
-  if (state.docViewerOpen) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeDocViewer();
-    } else if (isContainedBrowserShortcut(event)) {
-      event.preventDefault();
-    }
-    return;
-  }
-  if (state.spotlightOpen) {
-    if (event.key === "Escape") {
-      event.preventDefault();
-      closeSpotlight();
-    } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-      event.preventDefault();
-      openSpotlight("", "commands");
-    } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "p") {
-      event.preventDefault();
-      openSpotlight();
-    } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-      event.preventDefault();
-    }
-    return;
   }
   if (event.key === "Escape" && !event.defaultPrevented && state.tasteOpen) {
     event.preventDefault();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -4664,10 +4664,12 @@ function handleTypeKeys(event: KeyboardEvent) {
     } else if (event.key === "ArrowUp" || event.key === "k") {
       event.preventDefault();
       stepMemberNav(-1, true);
-    } else if (event.key === "ArrowLeft") {
+    } else if (event.key === "ArrowLeft" && !event.altKey && !event.shiftKey) {
+      // Alt/Shift+ArrowLeft is the global back gesture (see the document keydown
+      // handler); leave it unclaimed here so it isn't swallowed as in-page stepping.
       event.preventDefault();
       stepHorizontal(-1);
-    } else if (event.key === "ArrowRight") {
+    } else if (event.key === "ArrowRight" && !event.altKey && !event.shiftKey) {
       event.preventDefault();
       stepHorizontal(1);
     }
@@ -8690,14 +8692,16 @@ document.addEventListener("keydown", event => {
   } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
     event.preventDefault();
     focusFilter();
-  } else if (!event.metaKey && !event.ctrlKey && event.key === "ArrowLeft"
+  } else if (!event.defaultPrevented && !event.metaKey && !event.ctrlKey && event.key === "ArrowLeft"
       && (event.altKey || (event.shiftKey && !typing))) {
     // Alt+←/→ always drives back/forward. Shift+←/→ is the same gesture, gated on
     // `!typing` so it doesn't steal native text-selection (Shift+Arrow) inside inputs.
-    // Shift+↑/↓ stays unclaimed for now.
+    // `!event.defaultPrevented` defers to any element-scoped handler (e.g. the type
+    // list's in-page stepHorizontal, the graph viewport's pan) that already claimed
+    // this key. Shift+↑/↓ stays unclaimed for now.
     event.preventDefault();
     navBack();
-  } else if (!event.metaKey && !event.ctrlKey && event.key === "ArrowRight"
+  } else if (!event.defaultPrevented && !event.metaKey && !event.ctrlKey && event.key === "ArrowRight"
       && (event.altKey || (event.shiftKey && !typing))) {
     event.preventDefault();
     navForward();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2362,8 +2362,8 @@ function render() {
         <section class="detail-pane">
           <header class="detail-head">
             <div class="nav-history">
-              <button id="nav-back" ${navigationHistory.canBack() ? "" : "disabled"} title="Back (Alt+←)" aria-label="Back">‹</button>
-              <button id="nav-forward" ${navigationHistory.canForward() ? "" : "disabled"} title="Forward (Alt+→)" aria-label="Forward">›</button>
+              <button id="nav-back" ${navigationHistory.canBack() ? "" : "disabled"} title="Back (Alt+← or Shift+←)" aria-label="Back">‹</button>
+              <button id="nav-forward" ${navigationHistory.canForward() ? "" : "disabled"} title="Forward (Alt+→ or Shift+→)" aria-label="Forward">›</button>
             </div>
             <div class="breadcrumbs">
               ${state.atPackageRoot
@@ -4594,7 +4594,7 @@ const workbenchShellActions: WorkbenchShellBindingActions = {
   onGoHome: goHome,
   onHelp: () => showToast(
     "⌘K command · ⌘P / type to find a type · ⌘F filter · "
-    + "1—5 lenses · ↑↓ types · Alt+←/→ back/forward · "
+    + "1—5 lenses · ↑↓ types · Alt+←/→ or Shift+←/→ back/forward · "
     + "graph: wheel zoom, click node to open, +/− zoom, 0 fit, arrows pan"),
   onNavigateBack: navBack,
   onNavigateForward: navForward,
@@ -8690,10 +8690,15 @@ document.addEventListener("keydown", event => {
   } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
     event.preventDefault();
     focusFilter();
-  } else if (event.altKey && event.key === "ArrowLeft") {
+  } else if (!event.metaKey && !event.ctrlKey && event.key === "ArrowLeft"
+      && (event.altKey || (event.shiftKey && !typing))) {
+    // Alt+←/→ always drives back/forward. Shift+←/→ is the same gesture, gated on
+    // `!typing` so it doesn't steal native text-selection (Shift+Arrow) inside inputs.
+    // Shift+↑/↓ stays unclaimed for now.
     event.preventDefault();
     navBack();
-  } else if (event.altKey && event.key === "ArrowRight") {
+  } else if (!event.metaKey && !event.ctrlKey && event.key === "ArrowRight"
+      && (event.altKey || (event.shiftKey && !typing))) {
     event.preventDefault();
     navForward();
   } else if (!typing && !event.metaKey && !event.ctrlKey && /^[1-9]$/.test(event.key)) {

--- a/prototypes/inspect-web/src/graph-interactions.ts
+++ b/prototypes/inspect-web/src/graph-interactions.ts
@@ -200,10 +200,12 @@ export function bindGraphPanZoom(
       zoomAt(rect.width / 2, rect.height / 2, 0.8);
     else if (event.key === "0")
       fit();
-    else if (event.key === "ArrowLeft") {
+    else if (event.key === "ArrowLeft" && !event.altKey && !event.shiftKey) {
+      // Alt/Shift+ArrowLeft is the global back gesture; leave it unclaimed so
+      // panning doesn't swallow document-level history navigation.
       view.x += step;
       apply();
-    } else if (event.key === "ArrowRight") {
+    } else if (event.key === "ArrowRight" && !event.altKey && !event.shiftKey) {
       view.x -= step;
       apply();
     } else if (event.key === "ArrowUp") {

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -61,6 +61,82 @@ export function workspaceViewSignature(view: WorkspaceView): string {
   });
 }
 
+// A duck-typed subset of a click on an `<a>`, so the interception rule is a pure
+// function testable without a DOM. The composition root is the single owner that
+// registers one delegated `click` listener and evaluates every in-app anchor click
+// against this rule instead of leaving each link to opt in (or be forgotten) one by one.
+export interface LinkNavigationClick {
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  defaultPrevented: boolean;
+  download: boolean;
+  target: string | null;
+  href: string | null;
+  origin: string | null;
+  currentOrigin: string;
+}
+
+// True when the owner should treat this as an in-app transition: take over the
+// navigation itself (pushState + apply) instead of letting the browser load a new
+// document. False for anything that should keep its native behavior — a modified
+// click (new tab/window), a download link, a link explicitly targeting another
+// browsing context, or a cross-origin destination.
+export function shouldInterceptLinkClick(click: LinkNavigationClick): boolean {
+  if (click.defaultPrevented) return false;
+  if (click.button !== 0) return false;
+  if (click.metaKey || click.ctrlKey || click.shiftKey || click.altKey) return false;
+  if (click.download) return false;
+  if (click.target && click.target !== "_self") return false;
+  if (!click.href) return false;
+  if (click.origin !== click.currentOrigin) return false;
+  return true;
+}
+
+export interface WorkspaceLinkNavigationDependencies {
+  currentOrigin(): string;
+  resolve(href: string): URL;
+  navigate(url: URL): void;
+}
+
+// Registers the single delegated click listener that owns every in-app anchor's
+// navigation: same-origin, unmodified left clicks take over here (pushState + apply)
+// instead of loading a new document. This is the one binder the composition root
+// calls, so `dotnet-inspect.ts` gains no new raw `addEventListener` call of its own —
+// a link that wants different behavior (new tab, download, cross-origin) opts out
+// through ordinary anchor semantics rather than bespoke per-link wiring.
+export function bindWorkspaceLinkNavigation(
+  root: Document,
+  dependencies: WorkspaceLinkNavigationDependencies,
+) {
+  root.addEventListener("click", event => {
+    if (event.defaultPrevented) return;
+    const target = event.target instanceof Element ? event.target : null;
+    const anchor = target?.closest("a[href]");
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    const url = dependencies.resolve(anchor.href);
+    if (!shouldInterceptLinkClick({
+      button: event.button,
+      metaKey: event.metaKey,
+      ctrlKey: event.ctrlKey,
+      shiftKey: event.shiftKey,
+      altKey: event.altKey,
+      defaultPrevented: event.defaultPrevented,
+      download: anchor.hasAttribute("download"),
+      target: anchor.target || null,
+      href: anchor.href || null,
+      origin: url.origin,
+      currentOrigin: dependencies.currentOrigin(),
+    })) {
+      return;
+    }
+    event.preventDefault();
+    dependencies.navigate(url);
+  });
+}
+
 export interface NavigationSequence {
   begin(): number;
   invalidate(): void;

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -1817,9 +1817,21 @@ test("Spotlight async work is generation-gated and refreshes either mounted surf
 });
 
 test("global workbench shortcuts respect the topmost modal", () => {
+  // The composition root wires the single link-navigation owner once; it must not regain
+  // a raw document click listener of its own (see the `.addEventListener` count assertion
+  // in "typed graph interactions own graph controls and Mermaid node bindings").
   assert.match(
     appSource,
-    /if \(state\.home\) return;[\s\S]*if \(state\.graphSourceOpen\)[\s\S]*if \(state\.docViewerOpen\)[\s\S]*if \(state\.spotlightOpen\)/);
+    /bindWorkspaceLinkNavigation\(document, \{[\s\S]*currentOrigin: \(\) => location\.origin,[\s\S]*resolve: href => new URL\(href, location\.href\),[\s\S]*navigate: navigateInAppUrl,/);
+  // The workspace-scoped modal layers (graph source, doc viewer, spotlight) are declared,
+  // in priority order, as one explicit list the keydown listener loops over — the single
+  // place that owns which layer Escape (and everything else) belongs to.
+  assert.match(
+    appSource,
+    /const workspaceKeydownLayers: readonly KeydownLayer\[\] = \[[\s\S]*active: \(\) => state\.graphSourceOpen[\s\S]*active: \(\) => state\.docViewerOpen[\s\S]*active: \(\) => state\.spotlightOpen/);
+  assert.match(
+    appSource,
+    /if \(state\.home\) return;[\s\S]*for \(const layer of workspaceKeydownLayers\)/);
   assert.match(
     appSource,
     /state\.spotlightOpen[\s\S]*event\.key\.toLowerCase\(\) === "k"[\s\S]*event\.preventDefault\(\);[\s\S]*openSpotlight\("", "commands"\)/);
@@ -1843,10 +1855,10 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(\);/);
   assert.match(
     appSource,
-    /if \(state\.explorer\?\.open\)[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
+    /active: \(\) => Boolean\(state\.explorer\?\.open\)[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
   assert.match(
     appSource,
-    /if \(state\.settings\)[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
+    /active: \(\) => state\.settings[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
   assert.match(
     spotlightSource,
     /aria-activedescendant="spotlight-result-\$\{state\.spotlightIndex\}"[\s\S]*syncActiveDescendant\(items\.length\)/);

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -7,7 +7,9 @@ import {
   createNavigationSequence,
   createWorkspaceLocationPersistence,
   parseWorkspaceLocation,
+  shouldInterceptLinkClick,
   workspaceViewSignature,
+  type LinkNavigationClick,
   type WorkspaceLocationSnapshot,
   type WorkspaceUrlState,
   type WorkspaceView,
@@ -577,4 +579,66 @@ test("location persistence contains sync failures but leaves direct build failur
       memberTextFilter: "x".repeat(65537),
     })),
     /65536-character limit/);
+});
+
+function linkClick(overrides: Partial<LinkNavigationClick> = {}): LinkNavigationClick {
+  return {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    download: false,
+    target: null,
+    href: "https://inspect.example/credits",
+    origin: "https://inspect.example",
+    currentOrigin: "https://inspect.example",
+    ...overrides,
+  };
+}
+
+test("shouldInterceptLinkClick takes over a plain same-origin left click", () => {
+  assert.equal(shouldInterceptLinkClick(linkClick()), true);
+});
+
+test("shouldInterceptLinkClick leaves default-prevented clicks alone", () => {
+  assert.equal(
+    shouldInterceptLinkClick(linkClick({ defaultPrevented: true })),
+    false);
+});
+
+test("shouldInterceptLinkClick leaves non-primary-button clicks alone", () => {
+  assert.equal(shouldInterceptLinkClick(linkClick({ button: 1 })), false);
+});
+
+test("shouldInterceptLinkClick leaves modified clicks alone (new tab/window)", () => {
+  for (const overrides of [
+    { metaKey: true }, { ctrlKey: true }, { shiftKey: true }, { altKey: true },
+  ]) {
+    assert.equal(shouldInterceptLinkClick(linkClick(overrides)), false);
+  }
+});
+
+test("shouldInterceptLinkClick leaves download links alone", () => {
+  assert.equal(shouldInterceptLinkClick(linkClick({ download: true })), false);
+});
+
+test("shouldInterceptLinkClick leaves an explicit other-target link alone", () => {
+  assert.equal(
+    shouldInterceptLinkClick(linkClick({ target: "_blank" })),
+    false);
+  assert.equal(
+    shouldInterceptLinkClick(linkClick({ target: "_self" })),
+    true);
+});
+
+test("shouldInterceptLinkClick leaves cross-origin links alone", () => {
+  assert.equal(
+    shouldInterceptLinkClick(linkClick({ origin: "https://github.com" })),
+    false);
+});
+
+test("shouldInterceptLinkClick requires a resolvable href", () => {
+  assert.equal(shouldInterceptLinkClick(linkClick({ href: null })), false);
 });


### PR DESCRIPTION
Slice: single PR (no stack). Closes #4639.

## Demo

Before: clicking the `dotnet-inspect` brand/logo link at the top-left of the
workbench did nothing (no click handler on `<a class="brand" href="/">`), so
the browser followed the href as a real navigation — a full page reload that
tears down the warm Wasm engine and loses in-memory workspace state.

After: the same click is intercepted by the new single link-navigation owner
(`bindWorkspaceLinkNavigation`) and routed through the existing SPA `goHome()`
transition (`pushState("/")`, keep the engine warm, keep loaded packages
resident) — exactly like the working `#home-credits` link already did. Any
future in-app `<a href>` gets this for free without bespoke per-link wiring;
`target="_blank"`, `download`, cross-origin hrefs, and modified clicks (new
tab/window) keep native browser behavior unchanged.

Escape/dismiss handling for the five modal-style views (Metadata Explorer,
Settings, graph source, doc viewer, Spotlight) is unchanged in behavior but
now declared as one explicit ordered `KeydownLayer` list instead of a growing
if/else chain — the single place that owns Escape-layer priority going
forward.

## What changed

- `src/workspace-navigation.ts`: adds `shouldInterceptLinkClick` (pure guard)
  and `bindWorkspaceLinkNavigation` (the one delegated `click` listener) —
  the single owner of in-app link navigation.
- `src/dotnet-inspect.ts`: wires the new binder once; fixes the brand-link
  hard-reload bug as a side effect of having a real owner; replaces the
  keydown modal-priority if/else chain with two ordered `KeydownLayer`
  arrays (`homeIndependentKeydownLayers`, `workspaceKeydownLayers`).
- `README.md`: documents the new ownership in the interaction-model section.
- Tests: 8 new `shouldInterceptLinkClick` cases in
  `test/workspace-navigation.test.ts`; `test/spotlight-identity.test.js`
  updated to pin the new declarative keydown-layer structure and the
  link-navigation binder wiring (kept the pre-existing invariant that
  `dotnet-inspect.ts` doesn't accumulate raw `addEventListener` calls of its
  own — it gained a function call, not a listener).

## Compatibility / non-action boundary

Follow-up (tracked in #4639, not in this PR): adopting the platform
Navigation API (`window.navigation`) as the underlying primitive, and
evaluating native `<dialog>` for the modal-style views. Accepted browser
floor for that follow-up: iOS/iPadOS 26.2+ (Navigation API support began
there; 26.4+ closes a cross-origin security issue). This PR's delegated-click
approach works in all current/older browsers and doesn't depend on that
floor.

## Validation

From `prototypes/inspect-web`:

- `npm run typecheck` — clean.
- `npm test` — 579/579 passing (adds 8 new tests, updates 2 existing
  structural-pin assertions to match the refactor).
- `npm run lint` — clean (oxlint, including
  `no-unnecessary-type-conversion`).
- `npx knip` — clean (no unused exports).
- `npm run build` — clean (Vite build + site-artifact verification).
- `npx markdownlint-cli --config ../../.markdownlint.yaml README.md` —
  clean.

Trivial-tier review does not apply here (behavioral change + composition-root
refactor); this needs the standard round (GPT-5.6 Sol + one other roster
reviewer).
