### PR TITLE
Run browser home demos through product plans

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -958,9 +958,11 @@ Implementation must add, at minimum:
   resolve the static product-registry scenario to `WorkspaceMemberCoordinate`
   plans, member anchor `74b6b4b321`, browser workspace requests, and exact
   activation identity;
+  `BrowserProductHomeDemosTests.ToCallGraphRunPlan_DerivesNonFirstFocusFromNavigation`
+  gates non-first focus derivation from the product navigation plan;
   `BrowserEngineBoundaryTests.HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`
-  gates aggregate workspace projection, non-first focus, digest-prefix
-  selection, and graph execution;
+  gates aggregate workspace projection, non-first focus consumption,
+  digest-prefix selection, and graph execution;
 - a demo-section constraint (design rule under
   [Product demos are closed section presets](#product-demos-are-closed-section-presets)):
   each product home demo names only existing section ids and runs through the

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -19,13 +19,14 @@ named in [Status and gates](#status-and-gates) exist.
 
 ## Purpose
 
-Three consumers need a portable workspace description and are currently served
-by none (the browser workbench described below lives in the main tree under
-`prototypes/inspect-web`; claims about it cite that implementation):
+The initiative began with three consumers needing a portable workspace
+description and being served by none (the browser workbench described below
+lives in the main tree under `prototypes/inspect-web`; claims about it cite that
+implementation):
 
-- The browser workbench's home demos are hand-authored base64 URL strings, and
-  one demo (`runCallGraphDemo`) is imperative code because the URL packet
-  cannot express its selection stably (only by positional overload index).
+- The browser workbench's home demos were hand-authored base64 URL strings, and
+  one demo (`runCallGraphDemo`) was imperative code because the URL packet
+  could not express its selection stably (only by positional overload index).
 - Share links carry a terse, unversioned packet whose two wire forms are
   distinguished by shape sniffing (`Array.isArray` vs `.t`).
 - The platform rides in package-shaped slots under the display id
@@ -216,7 +217,7 @@ scheme.
 A call-graph demo over the Extensions family is the composition case: its
 workspace context subscribes `:Platform+Extensions`, referencing the catalog's
 group rather than restating it (the members above are the three packages the
-current imperative demo loads, so the subscription covers its scope — a
+original imperative demo loaded, so the subscription covers its scope — a
 superset, since the demo itself loads no runtime pack). A peer view preset
 selects the target overload by anchor digest.
 
@@ -405,7 +406,11 @@ Hard constraints:
 
 The product registry (`ProductInspectionDemos`) stays a static id→metadata
 table plus peer definition records lowered to a `ResolvedScenario`. Listing
-remains metadata-only. **Home demos now bind product section display names**
+remains metadata-only. `ProductDemoRunPlan` is the host-neutral lowering of a
+resolved scenario into its selected context, navigation focus, type/member
+selection, and section; CLI and browser encodings consume that plan rather than
+parsing the member selection independently. **Home demos now bind product
+section display names**
 through `ProductDemoSections` (today: `Methods` for STJ; `Call Graph` primary
 bind for the extensions member, expanded at run via `ExpandRunSections` /
 `DemoScenarioRunner` so the closed preset matches the multi-package
@@ -426,18 +431,22 @@ a home-demo entry (home catalog is package- and graph-shaped scenarios).
 output from the existing pipelines; multi-package workspaces encode extra
 package members as `--caller-package` for the call-graph demo. **inspect-web**
 loads home-demo catalog and coordinates from the product registry through the
-browser engine (`ListHomeDemos` / `ResolveHomeDemo` over
-`ProductInspectionDemos`); host-only share encoding and the residual platform
-→ `Microsoft.NETCore.App` runtime-pack mapping (for future platform members)
-live in `prototypes/inspect-web/src/product-home-demos.ts`. STJ restores via
-share deep links built from the resolved projection; member-bound Call Graph
-demos still run the imperative multi-package member path. Residual: (1) minted
-facet ids replacing display-name allow list; (2) realize via
+browser engine (`ListHomeDemos` / `ResolveHomeDemo` /
+`RunHomeDemo` over `ProductInspectionDemos`); host-only share encoding and the
+residual platform → `Microsoft.NETCore.App` runtime-pack mapping (for future
+platform members) live in
+`prototypes/inspect-web/src/product-home-demos.ts`. STJ restores via share deep
+links built from the resolved projection. The member-bound Call Graph button
+passes only the product scenario id to `RunHomeDemo`; the engine resolves the
+workspace, focus, member anchor, and section, opens one aggregate browser
+workspace, and returns its package surfaces, exact activation identity, and
+ordinary Call Graph projection. TypeScript applies that typed result to the UI
+without parsing definition member keys or reconstructing package/query inputs.
+Residual: (1) minted facet ids replacing display-name allow list; (2) realize via
 `WorkspaceContextLoader` into one `AssemblyContextGroup` instead of CLI
 package/`--caller-package` encoding and the browser runtime-pack share
-encoding for platform; (3) replace the imperative call-graph web path with
-the same group-run substrate; (4) Call Graph / Callers structured JSON
-projection remains the shared member-pipeline gap (Markdown/Mermaid are the
+encoding for platform; (3) Call Graph / Callers structured JSON projection
+remains the shared member-pipeline gap (Markdown/Mermaid are the
 faithful graph formats today).
 
 ### Member coordinates
@@ -733,8 +742,8 @@ layer refuses those with a typed outcome rather than silently flattening them.
 - **Member selection moves to anchor digests.** The positional overload
   index (`o`) is replaced by the `MemberAnchor` fingerprint the UI already
   displays and the call-graph demo already matches on. With that, every
-  existing demo — including the imperative call-graph demo — becomes a data
-  definition plus an ordinary link. The call-graph demo's cross-package scope
+  existing demo — including the formerly imperative call-graph demo — can be a
+  data definition plus an ordinary link. The call-graph demo's cross-package scope
   becomes one `g` entry referencing its package tuples, while `a` independently
   preserves its focused tab. This makes the digest a
   compatibility surface: it hashes the canonical-signature spelling under a
@@ -944,10 +953,14 @@ Implementation must add, at minimum:
 - a demo-parity gate showing the previously imperative call-graph demo loads
   from a definition and lands on the anchor-digest-selected overload —
   `InspectionDefinitionTests.ProductHomeDemos_ResolveCallGraphByMemberAnchor`
-  (and STJ/platform companions) resolve static product-registry scenarios to
-  `WorkspaceMemberCoordinate` plans and view `memberAnchor` `74b6b4b321`; host
-  acquisition and UI landing remain host work on top of
-  `ProductInspectionDemos` / `ResolvedScenario`;
+  and
+  `BrowserProductHomeDemosTests.ExtensionsCallGraph_RunPlanOwnsWorkspaceFocusAndMemberSelection`
+  resolve the static product-registry scenario to `WorkspaceMemberCoordinate`
+  plans, member anchor `74b6b4b321`, browser workspace requests, and exact
+  activation identity;
+  `BrowserEngineBoundaryTests.HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`
+  gates aggregate workspace projection, non-first focus, digest-prefix
+  selection, and graph execution;
 - a demo-section constraint (design rule under
   [Product demos are closed section presets](#product-demos-are-closed-section-presets)):
   each product home demo names only existing section ids and runs through the
@@ -975,10 +988,12 @@ Definition records and product demos (this slice):
   `WorkspaceMemberCoordinate` for `WorkspaceContextLoader` (group `subscribe`
   expressions and filesystem coordinates are typed failures in this slice);
 - `ProductInspectionDemos` is a static id→factory registry (smooth-markdown-table
-  `RendererRegistry` style) of the three home scenarios; listing is metadata-only
+  `RendererRegistry` style) of the two home scenarios; listing is metadata-only
   and `ResolveHomeScenario` allocates only that demo's peer records and enforces
   `ProductDemoSections` binding; JSON remains the portable load path for external
   definitions;
+- `ProductDemoRunPlan` lowers the resolved context, focus, type/member
+  selection, and section once for host encodings;
 - `ProductDemoSections` is the closed allow list of product section display names
   home demos may select until minted view-facet ids land; `ExpandRunSections`
   expands Call Graph binds format-aware (Markdown: Call Graph + Callers;
@@ -989,12 +1004,12 @@ Definition records and product demos (this slice):
   including `--mermaid` and fail-closed Call Graph `--json`;
 - `InspectionDefinitionTests` / `DemoCommandTests` gate round-trip, separation,
   demo-parity, section binding, CLI lowering, and real section output for the
-  three homes; and
+  two home demos; inspect-web's generated `RunHomeDemo` binding runs the
+  member-bound Call Graph preset from its product scenario id; and
 - **not yet:** minted view-facet ids; `WorkspaceContextLoader` group realization
   as the run substrate (CLI still uses package + `--caller-package` encoding;
-  inspect-web platform still uses the resident runtime-pack share encoding);
-  replace the imperative `extensions-callgraph` web runner with that group-run
-  path.
+  inspect-web's package workspace remains its dual reference/body group owner,
+  and platform still uses the resident runtime-pack share encoding).
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -681,8 +681,8 @@ inspection APIs; a capability that is not a product section is not a home demo
 until the section exists. CLI argv, definition plans, and browser engine
 operations (including a generated TypeScript binding of that engine surface)
 must be encodings of the same preset—not parallel demo systems. Residual:
-minted view-facet ids, `WorkspaceContextLoader` group run, inspect-web button
-convergence, and Call Graph structured-JSON projection (see
+minted view-facet ids, `WorkspaceContextLoader` as the shared group-run owner,
+and Call Graph structured-JSON projection (see
 workspace-definitions). Detail:
 [workspace-definitions.md — Product demos are closed section
 presets](design/workspace-definitions.md#product-demos-are-closed-section-presets).

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2613,10 +2613,13 @@ public sealed class BrowserEngineBoundaryTests
                 surface.Types,
                 candidate => candidate.Id
                     == typeof(BrowserEngineBoundaryTests).FullName);
-            BrowserMemberSurface member = Assert.Single(
-                type.Api,
-                candidate => candidate.Name
-                    == nameof(HomeDemoRunFixture));
+            BrowserMemberSurface[] members =
+            [
+                .. type.Api.Where(candidate => candidate.Name
+                    == nameof(HomeDemoRunFixture)),
+            ];
+            Assert.Equal(2, members.Length);
+            BrowserMemberSurface member = members[1];
             var plan = new BrowserHomeDemoRunPlan(
                 [
                     new BrowserPackageRequest(
@@ -2661,6 +2664,9 @@ public sealed class BrowserEngineBoundaryTests
 
     public static int HomeDemoRunFixture(int value) =>
         Math.Abs(value);
+
+    public static string HomeDemoRunFixture(string value) =>
+        value.Trim();
 
     [Fact]
     public void CallGraphMermaid_ContainsArtifactLabels()

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2584,6 +2584,85 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Home.Demo.Run.{suffix}";
+        string peerPackageId = $"Home.Demo.Peer.{suffix}";
+        string assemblyPath =
+            typeof(BrowserEngineBoundaryTests).Assembly.Location;
+        string peerAssemblyPath = typeof(BrowserPackage).Assembly.Location;
+        BrowserPackageCoordinate coordinate = Coordinate(
+            packageId,
+            Package(
+                File.ReadAllBytes(assemblyPath),
+                $"lib/net11.0/{Path.GetFileName(assemblyPath)}"));
+        BrowserPackageCoordinate peerCoordinate = Coordinate(
+            peerPackageId,
+            Package(
+                File.ReadAllBytes(peerAssemblyPath),
+                $"lib/net11.0/{Path.GetFileName(peerAssemblyPath)}"));
+        BrowserInspectionScope scope =
+            BrowserPackageWorkspace.OpenScope(
+                [peerCoordinate, coordinate]);
+        try
+        {
+            BrowserPackageSurface surface =
+                InspectionEngine.ProjectPackageSurface(scope, coordinate);
+            BrowserTypeSurface type = Assert.Single(
+                surface.Types,
+                candidate => candidate.Id
+                    == typeof(BrowserEngineBoundaryTests).FullName);
+            BrowserMemberSurface member = Assert.Single(
+                type.Api,
+                candidate => candidate.Name
+                    == nameof(HomeDemoRunFixture));
+            var plan = new BrowserHomeDemoRunPlan(
+                [
+                    new BrowserPackageRequest(
+                        peerPackageId,
+                        "1.0.0",
+                        "net11.0"),
+                    new BrowserPackageRequest(
+                        packageId,
+                        "1.0.0",
+                        "net11.0"),
+                ],
+                FocusRequestIndex: 1,
+                type.Id,
+                member.Name,
+                member.Kind,
+                member.AnchorDigest[..6],
+                MemberSection: "call-graph");
+            var resolution = new BrowserScopeResolution(
+                scope,
+                [peerCoordinate, coordinate]);
+
+            BrowserHomeDemoRunResult result =
+                InspectionEngine.RunHomeDemoCore(plan, resolution);
+
+            Assert.True(result.Found);
+            Assert.Equal(2, result.Packages.Length);
+            Assert.Equal(member.AnchorDigest, result.Activation?.MemberAnchorDigest);
+            Assert.Equal("call-graph", result.Activation?.MemberSection);
+            Assert.NotNull(result.CallGraph);
+            Assert.False(result.CallGraph.NoBody);
+            Assert.Equal(2, result.CallGraph.Scope.Packages);
+            Assert.Contains(
+                nameof(HomeDemoRunFixture),
+                result.CallGraph.Mermaid,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            BrowserPackageWorkspace.RemoveScope(scope);
+        }
+    }
+
+    public static int HomeDemoRunFixture(int value) =>
+        Math.Abs(value);
+
+    [Fact]
     public void CallGraphMermaid_ContainsArtifactLabels()
     {
         TypeRef declaringType = TypeRef.Definition(

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -109,6 +109,60 @@ public sealed class BrowserProductHomeDemosTests
     }
 
     [Fact]
+    public void ToCallGraphRunPlan_DerivesNonFirstFocusFromNavigation()
+    {
+        const int version = InspectionDefinitionJson.CurrentSchemaVersion;
+        var first = new DefinitionMemberCoordinate.PackageCoordinate(
+            "Demo.First",
+            "1.0.0",
+            "net11.0");
+        var second = new DefinitionMemberCoordinate.PackageCoordinate(
+            "Demo.Second",
+            "2.0.0",
+            "net11.0");
+        var registry = new InspectionDefinitionRegistry();
+        registry.Add(new WorkspaceDefinition(
+            version,
+            "workspace",
+            [
+                new WorkspaceContextDefinition(
+                    "context",
+                    framework: "net11.0",
+                    members: [first, second]),
+            ]));
+        registry.Add(new ViewDefinition(
+            version,
+            "view",
+            type: "Demo.Second.Target",
+            memberAnchor: "1234567890",
+            memberKey: "method:Run",
+            section: ProductDemoSections.CallGraph));
+        registry.Add(new NavigationDefinition(
+            version,
+            "navigation",
+            [
+                new NavigationTabDefinition("first", coordinate: first),
+                new NavigationTabDefinition("second", coordinate: second),
+            ],
+            focus: "second"));
+        registry.Add(new ScenarioDefinition(
+            version,
+            "scenario",
+            workspace: "workspace",
+            context: "context",
+            view: "view",
+            navigation: "navigation"));
+
+        BrowserHomeDemoRunPlan plan = BrowserProductHomeDemos.ToCallGraphRunPlan(
+            registry.ResolveScenario("scenario"));
+
+        Assert.Equal(1, plan.FocusRequestIndex);
+        Assert.Equal(
+            "Demo.Second",
+            plan.Requests[plan.FocusRequestIndex].PackageId);
+    }
+
+    [Fact]
     public async Task RunHomeDemo_UnknownId_ReturnsNotFound()
     {
         using var document = JsonDocument.Parse(

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -84,4 +84,44 @@ public sealed class BrowserProductHomeDemosTests
         Assert.Equal(ProductDemoSections.CallGraph, view.GetProperty("section").GetString());
     }
 
+    [Fact]
+    public void ExtensionsCallGraph_RunPlanOwnsWorkspaceFocusAndMemberSelection()
+    {
+        BrowserHomeDemoRunPlan plan =
+            BrowserProductHomeDemos.ToCallGraphRunPlan(
+                ProductInspectionDemos.ResolveHomeScenario(
+                    ProductInspectionDemos.ExtensionsCallGraphScenarioId));
+
+        Assert.Equal(3, plan.Requests.Length);
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.Abstractions",
+            plan.Requests[0].PackageId);
+        Assert.Equal("10.0.0", plan.Requests[0].Version);
+        Assert.Equal("net10.0", plan.Requests[0].TargetFramework);
+        Assert.Equal(0, plan.FocusRequestIndex);
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
+            plan.TypeId);
+        Assert.Equal("TryAddEnumerable", plan.MemberName);
+        Assert.Equal("method", plan.MemberKind);
+        Assert.Equal("74b6b4b321", plan.MemberAnchorDigest);
+        Assert.Equal("call-graph", plan.MemberSection);
     }
+
+    [Fact]
+    public async Task RunHomeDemo_UnknownId_ReturnsNotFound()
+    {
+        using var document = JsonDocument.Parse(
+            await InspectionEngine.RunHomeDemo("not-a-demo"));
+
+        Assert.False(document.RootElement.GetProperty("found").GetBoolean());
+        Assert.Empty(document.RootElement.GetProperty("packages").EnumerateArray());
+        Assert.Equal(
+            JsonValueKind.Null,
+            document.RootElement.GetProperty("activation").ValueKind);
+        Assert.Equal(
+            JsonValueKind.Null,
+            document.RootElement.GetProperty("callGraph").ValueKind);
+    }
+
+}

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -263,6 +263,32 @@ public sealed record BrowserHomeDemoResolveResult(
     BrowserHomeDemoResolved? Demo);
 
 /// <summary>
+/// Exact browser selection produced while running one product home demo.
+/// The frontend applies this identity to the package surfaces returned by the
+/// same operation; it does not parse product view or navigation definitions.
+/// </summary>
+public sealed record BrowserHomeDemoRunActivation(
+    string FocusPackage,
+    string FocusVersion,
+    string FocusFramework,
+    string TypeId,
+    string MemberName,
+    string MemberKind,
+    string MemberAnchorDigest,
+    string MemberSection);
+
+/// <summary>
+/// Browser result of running one product home demo through the normal package
+/// workspace and query path. Unknown ids return <see cref="Found"/> false;
+/// known-demo failures remain visible exceptions.
+/// </summary>
+public sealed record BrowserHomeDemoRunResult(
+    bool Found,
+    BrowserPackageSurface[] Packages,
+    BrowserHomeDemoRunActivation? Activation,
+    BrowserCallGraph? CallGraph);
+
+/// <summary>
 /// One type's metadata projection, adapted from <c>ResearchViews.TypeProjectionResult</c> — the
 /// presentation-neutral seam the CLI consumes — so the browser never reimplements type-fact
 /// composition.
@@ -548,4 +574,5 @@ public sealed record BrowserWorkspacePackage(
 [JsonSerializable(typeof(BrowserHomeDemoCatalog))]
 [JsonSerializable(typeof(BrowserHomeDemoResolved))]
 [JsonSerializable(typeof(BrowserHomeDemoResolveResult))]
+[JsonSerializable(typeof(BrowserHomeDemoRunResult))]
 internal sealed partial class BrowserJsonContext : JsonSerializerContext;

--- a/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
+++ b/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
@@ -47,6 +47,78 @@ internal static class BrowserProductHomeDemos
                 view.Section));
     }
 
+    internal static BrowserHomeDemoRunPlan ToCallGraphRunPlan(
+        ResolvedScenario scenario)
+    {
+        ProductDemoRunPlan productPlan = ProductDemoRunPlan.Create(scenario);
+        if (!string.Equals(
+                productPlan.Section,
+                ProductDemoSections.CallGraph,
+                StringComparison.Ordinal))
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' does not select the Call Graph section.");
+        }
+
+        if (productPlan.Member is not
+            {
+                Anchor: { Length: > 0 } memberAnchor,
+            } member)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' Call Graph view must select a member anchor.");
+        }
+
+        BrowserPackageRequest[] requests =
+        [
+            .. productPlan.Context.Members.Select(coordinate =>
+                ToPackageRequest(scenario.ScenarioId, coordinate)),
+        ];
+        ResolvedNavigationTab focusTab = productPlan.Focus
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' browser execution requires navigation focus.");
+        BrowserPackageRequest focus =
+            ToPackageRequest(scenario.ScenarioId, focusTab.Coordinate);
+        if (requests.Distinct().Count() != requests.Length)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' browser workspace contains duplicate package coordinates.");
+        }
+        int focusIndex = Array.FindIndex(
+            requests,
+            request => request == focus);
+
+        return new BrowserHomeDemoRunPlan(
+            requests,
+            focusIndex,
+            productPlan.TypeName,
+            member.Name,
+            member.Kind,
+            memberAnchor,
+            MemberSection: "call-graph");
+    }
+
+    private static BrowserPackageRequest ToPackageRequest(
+        string scenarioId,
+        WorkspaceMemberCoordinate coordinate) =>
+        coordinate switch
+        {
+            WorkspaceMemberCoordinate.PackageMember
+            {
+                Version: { Length: > 0 } version,
+                Framework: { Length: > 0 } framework,
+            } package =>
+                new BrowserPackageRequest(
+                    package.PackageId,
+                    version,
+                    framework),
+            WorkspaceMemberCoordinate.PackageMember package =>
+                throw new InspectionDefinitionException(
+                    $"Home demo '{scenarioId}' package '{package.PackageId}' must pin version and framework for browser execution."),
+            _ => throw new InspectionDefinitionException(
+                $"Home demo '{scenarioId}' browser execution does not support coordinate kind '{coordinate.GetType().Name}'."),
+        };
+
     private static BrowserHomeDemoNavigationTab ToTab(ResolvedNavigationTab tab) =>
         new(tab.Id, ToMember(tab.Coordinate));
 
@@ -71,3 +143,12 @@ internal static class BrowserProductHomeDemos
                 $"Home demo export does not support coordinate kind '{coordinate.GetType().Name}'."),
         };
 }
+
+internal sealed record BrowserHomeDemoRunPlan(
+    BrowserPackageRequest[] Requests,
+    int FocusRequestIndex,
+    string TypeId,
+    string MemberName,
+    string? MemberKind,
+    string MemberAnchorDigest,
+    string MemberSection);

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -56,8 +56,24 @@ public static partial class InspectionEngine
             packageId,
             version,
             targetFramework);
-        BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserPackageSurface surface =
+            ProjectPackageSurface(scope, scope.Coordinates[0]);
+        return JsonSerializer.Serialize(
+            surface,
+            BrowserJsonContext.Default.BrowserPackageSurface);
+    }
 
+    internal static BrowserPackageSurface ProjectPackageSurface(
+        BrowserInspectionScope scope,
+        BrowserPackageCoordinate coordinate) =>
+        ProjectPackage(scope, coordinate).Surface;
+
+    static BrowserPackageProjection ProjectPackage(
+        BrowserInspectionScope scope,
+        BrowserPackageCoordinate coordinate)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(coordinate);
         // Only this coordinate's assemblies are projected. A composite workspace may hold several
         // packages, and projecting all of them here materialized every other package's surface
         // only to discard it.
@@ -106,7 +122,7 @@ public static partial class InspectionEngine
             ?? projected.Assemblies.FirstOrDefault()?.Id
             ?? coordinate.DefaultAsset.Id;
 
-        return JsonSerializer.Serialize(
+        return new BrowserPackageProjection(
             new BrowserPackageSurface(
                 coordinate.PackageId,
                 coordinate.Version,
@@ -119,8 +135,12 @@ public static partial class InspectionEngine
                 projected.TotalMembers,
                 [.. coordinate.Package.Documents()],
                 projected.InspectionError),
-            BrowserJsonContext.Default.BrowserPackageSurface);
+            surfaces);
     }
+
+    sealed record BrowserPackageProjection(
+        BrowserPackageSurface Surface,
+        AssemblyContextApiSurfaceResult ApiSurfaces);
 
     /// <summary>
     /// One type's metadata projection, produced by
@@ -716,6 +736,19 @@ public static partial class InspectionEngine
             return session.HasCrossLibraryScope ? session.CrossLibrary() : session.Callers();
         });
 
+        BrowserCallGraph graph =
+            ProjectCallGraph(scope, view);
+        return JsonSerializer.Serialize(
+            graph,
+            BrowserJsonContext.Default.BrowserCallGraph);
+    }
+
+    internal static BrowserCallGraph ProjectCallGraph(
+        BrowserInspectionScope scope,
+        MemberCallGraphView view)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(view);
         CallGraphProjection projection = CallGraphProjection.Create(
             view.CallerRoot,
             view.CalleeRoot);
@@ -724,26 +757,24 @@ public static partial class InspectionEngine
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Count();
 
-        return JsonSerializer.Serialize(
-            new BrowserCallGraph(
-                Mermaid(projection),
-                Tree(view.CallerRoot),
-                Tree(view.CalleeRoot),
-                new BrowserCallGraphScope(
-                    scope.Coordinates.Length,
-                    scope.ImplementationParticipants.Length,
-                    callerAssemblies,
-                    view.Tier.ToString()),
-                Targets(
-                    projection.Nodes,
-                    scope.ImplementationParticipants.Select(
-                        participant => participant.Assembly.Identity)),
-                Diagnostics(
-                    view.Diagnostics,
-                    projection.HasUnexploredTraversalBoundary,
-                    projection.HasAnalysisFailureBoundary),
-                NoBody: view.CalleeRoot is null && view.CallerRoot is null),
-            BrowserJsonContext.Default.BrowserCallGraph);
+        return new BrowserCallGraph(
+            Mermaid(projection),
+            Tree(view.CallerRoot),
+            Tree(view.CalleeRoot),
+            new BrowserCallGraphScope(
+                scope.Coordinates.Length,
+                scope.ImplementationParticipants.Length,
+                callerAssemblies,
+                view.Tier.ToString()),
+            Targets(
+                projection.Nodes,
+                scope.ImplementationParticipants.Select(
+                    participant => participant.Assembly.Identity)),
+            Diagnostics(
+                view.Diagnostics,
+                projection.HasUnexploredTraversalBoundary,
+                projection.HasAnalysisFailureBoundary),
+            NoBody: view.CalleeRoot is null && view.CallerRoot is null);
     }
 
     /// <summary>
@@ -1013,6 +1044,176 @@ public static partial class InspectionEngine
         return JsonSerializer.Serialize(
             new BrowserHomeDemoResolveResult(true, BrowserProductHomeDemos.ToResolved(resolved)),
             BrowserJsonContext.Default.BrowserHomeDemoResolveResult);
+    }
+
+    /// <summary>
+    /// Runs one member-bound Call Graph home demo from its product definition.
+    /// The browser supplies only the scenario id: workspace coordinates,
+    /// navigation focus, member-anchor selection, and query execution remain
+    /// on the engine side.
+    /// </summary>
+    [JSExport]
+    public static async Task<string> RunHomeDemo(string scenarioId)
+    {
+        if (!ProductInspectionDemos.TryResolveHomeScenario(scenarioId, out var resolved))
+        {
+            return JsonSerializer.Serialize(
+                new BrowserHomeDemoRunResult(false, [], null, null),
+                BrowserJsonContext.Default.BrowserHomeDemoRunResult);
+        }
+
+        BrowserHomeDemoRunPlan plan =
+            BrowserProductHomeDemos.ToCallGraphRunPlan(resolved);
+        BrowserScopeResolution resolution =
+            await BrowserPackageWorkspace.RunPackageOperationAsync(
+                deadline => BrowserPackageWorkspace.ResolveAndOpenScopeAsync(
+                    plan.Requests,
+                    deadline.Token),
+                BrowserPackageWorkspace.PackageOperationTimeout);
+        BrowserHomeDemoRunResult result =
+            RunHomeDemoCore(plan, resolution);
+        return JsonSerializer.Serialize(
+            result,
+            BrowserJsonContext.Default.BrowserHomeDemoRunResult);
+    }
+
+    internal static BrowserHomeDemoRunResult RunHomeDemoCore(
+        BrowserHomeDemoRunPlan plan,
+        BrowserScopeResolution resolution)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        BrowserInspectionScope scope = resolution.Scope;
+        BrowserPackageProjection[] projections =
+        [
+            .. resolution.RequestedCoordinates.Select(requested =>
+                ProjectPackage(scope, scope.Coordinate(requested))),
+        ];
+        if (resolution.RequestedCoordinates.Length != plan.Requests.Length)
+        {
+            throw new InvalidOperationException(
+                "The product home demo workspace did not preserve its distinct request ordering.");
+        }
+
+        BrowserPackageCoordinate focusCoordinate =
+            scope.Coordinate(
+                resolution.RequestedCoordinates[plan.FocusRequestIndex]);
+        BrowserPackageProjection focusProjection =
+            projections[plan.FocusRequestIndex];
+        BrowserPackageSurface focusPackage = focusProjection.Surface;
+        BrowserTypeSurface[] types =
+        [
+            .. focusPackage.Types.Where(type =>
+                string.Equals(
+                    type.Id,
+                    plan.TypeId,
+                    StringComparison.Ordinal)),
+        ];
+        if (types.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"The product home demo type '{plan.TypeId}' resolved to "
+                + $"{types.Length} browser surface rows.");
+        }
+
+        BrowserTypeSurface type = types[0];
+        (ApiType Type, AssemblyContextSubject Subject)[] apiTypes =
+        [
+            .. focusProjection.ApiSurfaces.Assemblies.Assemblies
+                .OfType<AssemblyContextEntry<AssemblyApiSurface>.Available>()
+                .SelectMany(entry => entry.Value.Surface.Types
+                    .Where(candidate => string.Equals(
+                        AssemblyContextApiSurfaceQuery.MetadataTypeIdentity(
+                            candidate),
+                        type.DefinitionId,
+                        StringComparison.Ordinal))
+                    .Select(candidate => (candidate, entry.Subject))),
+        ];
+        if (apiTypes.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"The product home demo type '{plan.TypeId}' resolved to "
+                + $"{apiTypes.Length} product API rows.");
+        }
+
+        (ApiType apiType, AssemblyContextSubject subject) = apiTypes[0];
+        var selector = new MemberTargetSelector(
+            $"{plan.MemberName}~{plan.MemberAnchorDigest}",
+            plan.MemberName,
+            DigestPrefix: plan.MemberAnchorDigest,
+            Kind: plan.MemberKind);
+        MemberTargetResolution target =
+            MemberTargetResolver.Resolve(apiType, selector);
+        if (target.Diagnostic is { } diagnostic)
+        {
+            throw new InvalidOperationException(
+                $"The product home demo member could not be selected: {diagnostic.Message}");
+        }
+
+        BrowserMemberSurface projectedMember =
+            BrowserSurfaceProjection.Member(
+                apiType,
+                target.Target!.ApiMember.Member);
+        BrowserMemberSurface[] transportedMembers =
+        [
+            .. type.Api.Where(member =>
+                string.Equals(
+                    member.AnchorDigest,
+                    projectedMember.AnchorDigest,
+                    StringComparison.OrdinalIgnoreCase)),
+        ];
+        if (transportedMembers.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"The selected product home demo member projected to "
+                + $"{transportedMembers.Length} browser surface rows.");
+        }
+
+        BrowserMemberSurface member = transportedMembers[0];
+        if (!string.Equals(
+                type.AssemblyName,
+                subject.Identity.Name,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "The product home demo type projection lost its owning assembly identity.");
+        }
+        (
+            BrowserWorkspaceParticipant participant,
+            Analysis.CallGraphMemberResolution memberResolution
+        ) = ResolveImplementationMember(
+            scope,
+            focusCoordinate,
+            type.Assembly,
+            type.DefinitionId,
+            member.Name,
+            member.GraphSelectorKey,
+            member.MetadataToken ?? 0);
+        MemberCallGraphView view = scope.UseImplementation(group =>
+        {
+            using var session = new MemberCallGraphSession(
+                group,
+                participant.Assembly,
+                memberResolution.BodyToken);
+            return session.HasCrossLibraryScope
+                ? session.CrossLibrary()
+                : session.Callers();
+        });
+
+        return new BrowserHomeDemoRunResult(
+            true,
+            [.. projections.Select(projection => projection.Surface)],
+            new BrowserHomeDemoRunActivation(
+                focusCoordinate.PackageId,
+                focusCoordinate.Version,
+                focusCoordinate.Framework,
+                type.Id,
+                member.Name,
+                member.Kind,
+                member.AnchorDigest,
+                plan.MemberSection),
+            ProjectCallGraph(scope, view));
     }
 
     /// <summary>

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
@@ -43,6 +43,7 @@ let queryTypeProjectionExport;
 let queryTypeSourceExport;
 let resolveHomeDemoExport;
 let resolvePackageDependencyVersionExport;
+let runHomeDemoExport;
 let searchTypesExport;
 
 export async function initializeEngine(onStatus = () => {}) {
@@ -87,6 +88,7 @@ export async function initializeEngine(onStatus = () => {}) {
   queryTypeSourceExport = exports.InspectionEngine.QueryTypeSource;
   resolveHomeDemoExport = exports.InspectionEngine.ResolveHomeDemo;
   resolvePackageDependencyVersionExport = exports.InspectionEngine.ResolvePackageDependencyVersion;
+  runHomeDemoExport = exports.InspectionEngine.RunHomeDemo;
   searchTypesExport = exports.InspectionEngine.SearchTypes;
   configureHostExport(window.location.origin);
   await runtime.runMain();
@@ -299,6 +301,12 @@ export function resolveHomeDemo(scenarioId) {
 export async function resolvePackageDependencyVersion(packageId, declaredRange) {
   if (!resolvePackageDependencyVersionExport) throw new Error("The browser inspection engine is not initialized.");
   return await resolvePackageDependencyVersionExport(packageId, declaredRange);
+}
+
+export async function runHomeDemo(scenarioId) {
+  if (!runHomeDemoExport) throw new Error("The browser inspection engine is not initialized.");
+  const result = await runHomeDemoExport(scenarioId);
+  return JSON.parse(result);
 }
 
 export function searchTypes(query, candidatesJson) {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -81,6 +81,7 @@ import {
   type WorkspaceView,
 } from "./workspace-navigation.ts";
 import {
+  createNuGetPackageModel,
   createPackageAcquisition,
   runtimeAssemblyIsResident,
   runtimePackIsResident,
@@ -110,12 +111,10 @@ import {
   type WorkbenchShellBindingActions,
 } from "./shell-controls.ts";
 import {
-  callGraphDemoRunnerSpec,
   homeDemoRowHtml,
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
   type ProductHomeDemoId,
-  type ProductHomeDemoResolved,
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,
@@ -245,6 +244,7 @@ import type {
   BrowserBuildIdentity,
   BrowserCallGraph,
   BrowserCallGraphTarget,
+  BrowserHomeDemoRunResult,
   BrowserMemberSurface,
   BrowserPackageCacheStats,
   BrowserPackageDependencies,
@@ -267,6 +267,7 @@ let inspectGraphMemberSurface: EngineModule["queryGraphMemberSurface"];
 let inspectVocabulary: EngineModule["listVocabulary"];
 let inspectListHomeDemos: EngineModule["listHomeDemos"];
 let inspectResolveHomeDemo: EngineModule["resolveHomeDemo"];
+let inspectRunHomeDemo: EngineModule["runHomeDemo"];
 let inspectLoadRuntimePack: EngineModule["loadRuntimePack"];
 let inspectLoadRuntimePackAssembly: EngineModule["loadRuntimePackAssembly"];
 let inspectMemberAnnotatedSource: EngineModule["queryMemberAnnotatedSource"];
@@ -309,6 +310,7 @@ async function loadEngineModule() {
     listHomeDemos: inspectListHomeDemos,
     listVocabulary: inspectVocabulary,
     resolveHomeDemo: inspectResolveHomeDemo,
+    runHomeDemo: inspectRunHomeDemo,
     loadRuntimePack: inspectLoadRuntimePack,
     loadRuntimePackAssembly: inspectLoadRuntimePackAssembly,
     matchPackageDependencyCoordinate,
@@ -6179,8 +6181,8 @@ function bindHomeEvents() {
 // Home buttons use product demo ids from engine `listHomeDemos` / `resolveHomeDemo`
 // (`ProductInspectionDemos` / CLI `demo <id>`). STJ + platform restore via share
 // deep links built from the resolved projection; member-bound Call Graph demos
-// stay an imperative multi-package member load until WorkspaceContextLoader
-// group run is the browser substrate.
+// execute through one generated engine operation over the product-resolved
+// workspace and view.
 function runHomeDemo(kind: ProductHomeDemoId) {
   state.home = false;
   const resolveResult = inspectResolveHomeDemo(kind);
@@ -6194,7 +6196,7 @@ function runHomeDemo(kind: ProductHomeDemoId) {
   }
   const link = productHomeDemoLocationHref(resolved);
   if (!link) {
-    observeAsync(runCallGraphDemo(resolved), "Loading the call graph demo");
+    observeAsync(runCallGraphDemo(kind), "Loading the call graph demo");
     return;
   }
   workspaceLocation.push(link);
@@ -8200,61 +8202,117 @@ async function loadRuntimePackAssembly(
   };
 }
 
-async function runCallGraphDemo(demo: ProductHomeDemoResolved) {
-  const retry = () => observeAsync(runCallGraphDemo(demo), "Loading the call graph demo");
+async function runCallGraphDemo(demoId: ProductHomeDemoId) {
+  const retry = () =>
+    observeAsync(runCallGraphDemo(demoId), "Loading the call graph demo");
+  const navigationSeq = navigationSequence.begin();
   state.loading = true;
   state.error = "";
+  state.errorDetail = "";
+  state.retryAction = null;
   state.loadingMessage = "Loading cross-package call graph demo…";
-  state.loadingSubtitle = "";
+  state.loadingSubtitle =
+    "Resolving the product workspace and anchored member…";
   render();
 
-  const spec = callGraphDemoRunnerSpec(demo);
-  const packages: AppPackage[] = [];
-  for (const packageSpec of spec.packages) {
-    const loaded = await loadPackage(
-      packageSpec.id,
-      packageSpec.version,
-      packageSpec.framework,
-      { retryAction: retry });
-    if (!loaded) {
-      state.retryAction = retry;
-      render();
-      return;
-    }
-    packages.push(loaded);
-  }
-
-  const targetPackage = packages.find(item => item.id === spec.focusPackageId)
-    ?? packages[0];
-  activatePackage(targetPackage);
-  const type = targetPackage.types.find(item => item.id === spec.typeId);
-  const member = type && memberGroups(type).find(item =>
-    item.name === spec.memberName
-    && item.kind === spec.memberKind);
-  const overloadIndex = member?.overloads.findIndex(item =>
-    item.anchorDigest === spec.memberAnchorDigest) ?? -1;
-  if (!type || !member || overloadIndex < 0) {
+  const fail = (error: unknown) => {
     state.loading = false;
-    state.error = "The call graph demo member was not found in the selected package.";
+    state.error = errorMessage(error);
     state.errorTitle = "Call graph demo failed";
+    state.errorDetail = error instanceof Error
+      ? error.stack || error.message
+      : String(error);
     state.retryAction = retry;
+    render();
+  };
+  let result: BrowserHomeDemoRunResult;
+  try {
+    result = await inspectRunHomeDemo(demoId);
+  } catch (error) {
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    fail(error);
+    return;
+  }
+  if (!navigationSequence.isCurrent(navigationSeq)) return;
+  if (!result.found) {
+    state.loading = false;
+    state.error = `Unknown product home demo '${demoId}'.`;
+    state.errorTitle = "Call graph demo failed";
+    state.retryAction = null;
     render();
     return;
   }
+  if (!result.activation || !result.callGraph) {
+    fail("The engine returned an incomplete product home demo result.");
+    return;
+  }
+  if (result.activation.memberSection !== "call-graph") {
+    fail(
+      `The engine returned unsupported demo section '${result.activation.memberSection}'.`,
+    );
+    return;
+  }
 
-  state.selectedTypeId = type.id;
-  state.atPackageRoot = false;
-  state.lens = "api";
-  state.packageLens = "overview";
-  resetMemberFilters();
-  resetMemberSectionState();
-  state.memberBrowseTypeId = type.id;
-  state.selectedMemberKey = member.key;
-  state.selectedOverloadIndex = overloadIndex;
-  state.memberSection = spec.memberSection;
-  state.loading = false;
-  render();
-  await loadSelectedMemberCallGraph();
+  try {
+    const packages = result.packages.map(createNuGetPackageModel);
+    const activation = result.activation;
+    const targetPackage = packages.find(item =>
+      item.id === activation.focusPackage
+      && item.version === activation.focusVersion
+      && item.activeFramework === activation.focusFramework);
+    const type = targetPackage?.types.find(item =>
+      item.id === activation.typeId);
+    const member = type && memberGroups(type).find(item =>
+      item.name === activation.memberName
+      && item.kind === activation.memberKind);
+    const overloadIndex = member?.overloads.findIndex(item =>
+      item.anchorDigest === activation.memberAnchorDigest) ?? -1;
+    if (!targetPackage || !type || !member || overloadIndex < 0) {
+      throw new Error(
+        "The engine-run demo selection was not present in its returned package surfaces.");
+    }
+
+    for (const packageModel of packages) {
+      retainPackageModel(packageModel);
+      recordRecentPackage(
+        packageModel.id,
+        packageModel.version,
+        packageModel.activeFramework);
+    }
+    refreshPackageStats();
+
+    activatePackage(targetPackage, { resetAccessibility: true });
+    state.typeFilter = "";
+    state.namespaceFilter = "";
+    state.kindFilter = "";
+    state.libraryScope = null;
+    state.selectedTypeId = type.id;
+    state.atPackageRoot = false;
+    state.lens = "api";
+    state.packageLens = "overview";
+    resetMemberFilters();
+    resetMemberSectionState();
+    state.memberBrowseTypeId = type.id;
+    state.selectedMemberKey = member.key;
+    state.selectedOverloadIndex = overloadIndex;
+    state.memberSection = "call-graph";
+    // This graph is scoped to the product-defined demo workspace, not any
+    // unrelated tabs the user may already have open.
+    state.memberCallGraph = result.callGraph;
+    state.memberCallGraphError = "";
+    state.memberCallGraphLoading = false;
+    state.memberCallGraphExpanding = false;
+    state.memberCallGraphKey = memberRequestSignature(
+      type,
+      member.overloads[overloadIndex],
+      true);
+    state.loading = false;
+    render();
+    await renderMermaidCallGraph();
+  } catch (error) {
+    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    fail(error);
+  }
 }
 
 // Loads the full open-tab set described by a parsed location (opaque workspace bucket, or a

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -8292,6 +8292,7 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
     state.packageLens = "overview";
     resetMemberFilters();
     resetMemberSectionState();
+    state.platformStack = [];
     state.memberBrowseTypeId = type.id;
     state.selectedMemberKey = member.key;
     state.selectedOverloadIndex = overloadIndex;

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -160,6 +160,24 @@ export interface BrowserHomeDemoResolved {
   view: BrowserHomeDemoView;
 }
 
+export interface BrowserHomeDemoRunActivation {
+  focusPackage: string;
+  focusVersion: string;
+  focusFramework: string;
+  typeId: string;
+  memberName: string;
+  memberKind: string;
+  memberAnchorDigest: string;
+  memberSection: string;
+}
+
+export interface BrowserHomeDemoRunResult {
+  found: boolean;
+  packages: BrowserPackageSurface[];
+  activation: BrowserHomeDemoRunActivation | null;
+  callGraph: BrowserCallGraph | null;
+}
+
 export interface BrowserHomeDemoView {
   library: string | null;
   type: string | null;
@@ -486,4 +504,5 @@ export declare function queryTypeProjection(packageId: string, version: string, 
 export declare function queryTypeSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserSource>;
 export declare function resolveHomeDemo(scenarioId: string): BrowserHomeDemoResolveResult;
 export declare function resolvePackageDependencyVersion(packageId: string, declaredRange: string | null): Promise<string>;
+export declare function runHomeDemo(scenarioId: string): Promise<BrowserHomeDemoRunResult>;
 export declare function searchTypes(query: string, candidatesJson: string): BrowserTypeSearchHit[];

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -14,8 +14,8 @@ import {
  *
  * Catalog ids/titles/summaries and resolved coordinates come from C#. This
  * module owns only host encoding: workspace share packets, the residual
- * platform → Microsoft.NETCore.App runtime-pack mapping, product section →
- * web member-section tokens, and the imperative call-graph runner inputs.
+ * platform → Microsoft.NETCore.App runtime-pack mapping, and location state
+ * for demos that restore through a share packet.
  */
 
 export type ProductHomeDemoId = string;
@@ -120,7 +120,7 @@ function packageTab(member: BrowserHomeDemoMember): {
 
 /**
  * Deep-link for demos that restore via workspace location.
- * Returns null when the demo needs the imperative multi-package runner
+ * Returns null when the demo runs through an engine operation instead
  * (member-bound Call Graph today).
  */
 export function productHomeDemoLocationHref(
@@ -147,56 +147,6 @@ export function productHomeDemoLocationHref(
     library: demo.view.library,
     selectedTypeId: demo.view.type ?? "",
   }));
-}
-
-/** Inputs for the residual imperative multi-package call-graph runner. */
-export function callGraphDemoRunnerSpec(demo: ProductHomeDemoResolved): {
-  packages: { id: string; version: string; framework: string }[];
-  /** Package id for the navigation focus tab (primary activation target). */
-  focusPackageId: string;
-  typeId: string;
-  memberName: string;
-  memberKind: string;
-  memberAnchorDigest: string;
-  memberSection: "call-graph";
-} {
-  if (demo.view.section !== "Call Graph" || !demo.view.memberAnchor || !demo.view.type) {
-    throw new Error(
-      `Product home demo '${demo.id}' is not a member-bound Call Graph runner.`);
-  }
-
-  const packages = demo.workspaceMembers.map(packageTab);
-  if (packages.length === 0) {
-    throw new Error(`Product home demo '${demo.id}' has no workspace members.`);
-  }
-
-  const focusTabs = demo.tabs.map(tab => packageTab(tab.member));
-  if (focusTabs.length === 0) {
-    throw new Error(`Product home demo '${demo.id}' has no navigation tabs.`);
-  }
-  const focusIndex = Math.min(
-    Math.max(demo.focusTabIndex, 0),
-    focusTabs.length - 1);
-  const focusPackageId = focusTabs[focusIndex].id;
-
-  const memberKey = demo.view.memberKey ?? "";
-  const colon = memberKey.indexOf(":");
-  const memberKind = colon >= 0 ? memberKey.slice(0, colon) : "method";
-  const memberName = colon >= 0 ? memberKey.slice(colon + 1) : memberKey;
-  if (!memberName) {
-    throw new Error(
-      `Product home demo '${demo.id}' Call Graph view is missing memberKey.`);
-  }
-
-  return {
-    packages,
-    focusPackageId,
-    typeId: demo.view.type,
-    memberName,
-    memberKind,
-    memberAnchorDigest: demo.view.memberAnchor,
-    memberSection: "call-graph",
-  };
 }
 
 /**

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -4,7 +4,6 @@ import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import {
   HOME_DEMO_PENDING_SLOT_COUNT,
   PLATFORM_RUNTIME_PACK,
-  callGraphDemoRunnerSpec,
   homeDemoRowHtml,
   isProductHomeDemoId,
   productHomeDemoLocationHref,
@@ -211,50 +210,8 @@ test("unversioned platform residual maps to the browser runtime pack", () => {
   assert.equal(location.package, PLATFORM_RUNTIME_PACK.id);
 });
 
-test("extensions-callgraph has no deep link and runner spec keeps product pins", () => {
+test("extensions-callgraph delegates execution to the engine instead of encoding a location", () => {
   assert.equal(productHomeDemoLocationHref(callGraphResolved), null);
-  const spec = callGraphDemoRunnerSpec(callGraphResolved);
-  assert.equal(spec.packages.length, 3);
-  assert.equal(spec.memberAnchorDigest, "74b6b4b321");
-  assert.equal(spec.memberSection, "call-graph");
-  assert.equal(spec.memberKind, "method");
-  assert.equal(spec.memberName, "TryAddEnumerable");
-  assert.equal(
-    spec.packages[0].id,
-    "Microsoft.Extensions.DependencyInjection.Abstractions",
-  );
-  assert.equal(
-    spec.focusPackageId,
-    "Microsoft.Extensions.DependencyInjection.Abstractions",
-  );
-});
-
-test("call-graph runner focus follows navigation focusTabIndex", () => {
-  const reordered: BrowserHomeDemoResolved = {
-    ...callGraphResolved,
-    workspaceMembers: [
-      callGraphResolved.workspaceMembers[1],
-      callGraphResolved.workspaceMembers[0],
-      callGraphResolved.workspaceMembers[2],
-    ],
-    tabs: [
-      {
-        id: "logging",
-        member: callGraphResolved.workspaceMembers[1],
-      },
-      {
-        id: "di",
-        member: callGraphResolved.workspaceMembers[0],
-      },
-    ],
-    focusTabIndex: 1,
-  };
-  const spec = callGraphDemoRunnerSpec(reordered);
-  assert.equal(spec.packages[0].id, "Microsoft.Extensions.Logging");
-  assert.equal(
-    spec.focusPackageId,
-    "Microsoft.Extensions.DependencyInjection.Abstractions",
-  );
 });
 
 test("platform residual rejects pinned runtime coordinates", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2169,11 +2169,13 @@ test("home demos restore the complete parsed location", () => {
     appSource,
     /function applyLocationView\(loc: ParsedLocation\) \{\s*state\.lens = loc\.lens \|\| "api";\s*state\.atPackageRoot = loc\.atPackageRoot \|\| false;\s*state\.packageLens = loc\.packageLens \|\| "overview";/);
   const callGraphDemo =
-    appSource.match(/async function runCallGraphDemo\(demo: ProductHomeDemoResolved\) \{[\s\S]*?\n}\n\n\/\/ Loads the full/)?.[0]
+    appSource.match(/async function runCallGraphDemo\(demoId: ProductHomeDemoId\) \{[\s\S]*?\n}\n\n\/\/ Loads the full/)?.[0]
     ?? "";
+  assert.match(callGraphDemo, /result = await inspectRunHomeDemo\(demoId\)/);
+  assert.doesNotMatch(callGraphDemo, /callGraphDemoRunnerSpec|loadPackage\(/);
   assert.match(
     callGraphDemo,
-    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = spec\.memberSection/);
+    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = "call-graph";[\s\S]*state\.memberCallGraph = result\.callGraph;[\s\S]*await renderMermaidCallGraph\(\)/);
   const platformHistory =
     appSource.match(/async function restorePlatformScopeThenDeepLink\([\s\S]*?\n}\n\n\/\/ Load and scope/)?.[0]
     ?? "";
@@ -4646,7 +4648,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /assemblyDescriptorForType\(pkg\.assemblies, stat\)/);
   assert.match(
     appSource,
-    /activatePackage\(targetPackage\)/);
+    /activatePackage\(targetPackage, \{ resetAccessibility: true \}\)/);
 });
 
 test("member documentation state is scoped to the exact request", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2175,7 +2175,7 @@ test("home demos restore the complete parsed location", () => {
   assert.doesNotMatch(callGraphDemo, /callGraphDemoRunnerSpec|loadPackage\(/);
   assert.match(
     callGraphDemo,
-    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = "call-graph";[\s\S]*state\.memberCallGraph = result\.callGraph;[\s\S]*await renderMermaidCallGraph\(\)/);
+    /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.platformStack = \[\];\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = "call-graph";[\s\S]*state\.memberCallGraph = result\.callGraph;[\s\S]*await renderMermaidCallGraph\(\)/);
   const platformHistory =
     appSource.match(/async function restorePlatformScopeThenDeepLink\([\s\S]*?\n}\n\n\/\/ Load and scope/)?.[0]
     ?? "";

--- a/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
@@ -839,6 +839,15 @@ public class InspectionDefinitionTests
             callGraph.Navigation.FocusTab.Coordinate);
         Assert.Equal("Microsoft.Extensions.DependencyInjection.Abstractions", focus.PackageId);
         Assert.Equal("10.0.0", focus.Version);
+
+        ProductDemoRunPlan run = ProductDemoRunPlan.Create(callGraph);
+        Assert.Same(callGraph.SelectedContext, run.Context);
+        Assert.Same(callGraph.Navigation.FocusTab, run.Focus);
+        Assert.Equal(callGraph.View.Type, run.TypeName);
+        Assert.Equal(ProductDemoSections.CallGraph, run.Section);
+        Assert.Equal("TryAddEnumerable", run.Member!.Name);
+        Assert.Equal("method", run.Member.Kind);
+        Assert.Equal("74b6b4b321", run.Member.Anchor);
     }
 
     [Fact]
@@ -850,6 +859,7 @@ public class InspectionDefinitionTests
         var stjPackage = Assert.IsType<WorkspaceMemberCoordinate.PackageMember>(
             stj.SelectedContext!.Members[0]);
         Assert.Equal("System.Text.Json", stjPackage.PackageId);
+        Assert.Null(ProductDemoRunPlan.Create(stj).Member);
         Assert.False(ProductInspectionDemos.HasScenario("platform-list"));
     }
 

--- a/src/DotnetInspector.Queries/AssemblyContextApiSurfaceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextApiSurfaceQuery.cs
@@ -577,7 +577,11 @@ public static class AssemblyContextApiSurfaceQuery
         _ => ApiSurfaceExtractionScope.Public,
     };
 
-    internal static string MetadataTypeIdentity(ApiType type)
+    /// <summary>
+    /// Stable metadata/definition identity used to join a projected type back
+    /// to a product selector without relying on display text.
+    /// </summary>
+    public static string MetadataTypeIdentity(ApiType type)
     {
         ArgumentNullException.ThrowIfNull(type);
         if (type.DefinitionName is { } definitionName)

--- a/src/DotnetInspector.Queries/Definitions/ProductDemoRunPlan.cs
+++ b/src/DotnetInspector.Queries/Definitions/ProductDemoRunPlan.cs
@@ -1,0 +1,106 @@
+namespace DotnetInspector.Queries.Definitions;
+
+/// <summary>
+/// Host-neutral lowering of one resolved product demo into the workspace,
+/// navigation focus, type/member selection, and product section it runs.
+/// Hosts may encode the plan differently, but do not parse the member
+/// selection independently.
+/// </summary>
+public sealed record ProductDemoRunPlan(
+    ResolvedScenario Scenario,
+    ResolvedWorkspaceContext Context,
+    ResolvedNavigationTab? Focus,
+    string TypeName,
+    ProductDemoMemberSelection? Member,
+    string Section)
+{
+    public static ProductDemoRunPlan Create(ResolvedScenario scenario)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+        ProductDemoSections.EnsureHomeDemoBinding(scenario);
+
+        var context = scenario.SelectedContext
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' has no selected workspace context.");
+        var view = scenario.View
+            ?? throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' has no view.");
+        if (view.Type is not { Length: > 0 } typeName)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' view must set type.");
+        }
+
+        ResolvedNavigationTab? focus = scenario.Navigation?.FocusTab;
+        if (focus is not null && !context.Members.Contains(focus.Coordinate))
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' navigation focus is not a member of its selected workspace context.");
+        }
+
+        ProductDemoMemberSelection? member = ProductDemoMemberSelection.Create(
+            scenario.ScenarioId,
+            view.MemberKey,
+            view.MemberAnchor,
+            view.MemberSignature);
+        return new ProductDemoRunPlan(
+            scenario,
+            context,
+            focus,
+            typeName,
+            member,
+            view.Section!);
+    }
+}
+
+/// <summary>Product member selector carried by a demo run plan.</summary>
+public sealed record ProductDemoMemberSelection(
+    string Name,
+    string? Kind,
+    string? Anchor,
+    string? Signature)
+{
+    internal static ProductDemoMemberSelection? Create(
+        string scenarioId,
+        string? memberKey,
+        string? memberAnchor,
+        string? memberSignature)
+    {
+        bool hasMemberSelection =
+            memberKey is { Length: > 0 }
+            || memberAnchor is { Length: > 0 }
+            || memberSignature is { Length: > 0 };
+        if (!hasMemberSelection)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(memberKey))
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenarioId}' member view must set memberKey for run.");
+        }
+
+        int separator = memberKey.IndexOf(':');
+        if (separator <= 0 || separator >= memberKey.Length - 1)
+        {
+            return new ProductDemoMemberSelection(
+                memberKey,
+                Kind: null,
+                memberAnchor,
+                memberSignature);
+        }
+
+        string kind = memberKey[..separator];
+        string name = memberKey[(separator + 1)..];
+        if (string.IsNullOrWhiteSpace(kind) || string.IsNullOrWhiteSpace(name))
+        {
+            throw new InspectionDefinitionException(
+                $"Invalid memberKey '{memberKey}' (expected kind:name).");
+        }
+
+        return new ProductDemoMemberSelection(
+            name,
+            kind,
+            memberAnchor,
+            memberSignature);
+    }
+}

--- a/src/dotnet-inspect/Commands/DemoCommand.cs
+++ b/src/dotnet-inspect/Commands/DemoCommand.cs
@@ -181,43 +181,42 @@ public static class DemoScenarioRunner
         options = null!;
         error = null;
 
+        ProductDemoRunPlan plan;
         try
         {
-            ProductDemoSections.EnsureHomeDemoBinding(resolved);
+            plan = ProductDemoRunPlan.Create(resolved);
         }
         catch (InspectionDefinitionException ex)
         {
             error = ex.Message;
             return false;
         }
-
         var view = resolved.View!;
-        var section = view.Section!;
-        if (view.Type is not { Length: > 0 })
-        {
-            error = $"Home demo '{resolved.ScenarioId}' view must set type.";
-            return false;
-        }
-
-        var context = resolved.SelectedContext;
-        if (context is null)
-        {
-            error = $"Home demo '{resolved.ScenarioId}' has no selected workspace context.";
-            return false;
-        }
-
-        var isMemberDemo = view.MemberAnchor is { Length: > 0 }
-            || view.MemberSignature is { Length: > 0 }
-            || view.MemberKey is { Length: > 0 };
-
-        if (isMemberDemo)
+        if (plan.Member is { } member)
         {
             return TryCreateMemberOptions(
-                resolved, view, section, context, format, noHeader, embeddedMermaid, out options, out error);
+                resolved,
+                view,
+                member,
+                plan.Section,
+                plan.Context,
+                format,
+                noHeader,
+                embeddedMermaid,
+                out options,
+                out error);
         }
 
         return TryCreateTypeOptions(
-            resolved, view, section, context, format, noHeader, embeddedMermaid, out options, out error);
+            resolved,
+            view,
+            plan.Section,
+            plan.Context,
+            format,
+            noHeader,
+            embeddedMermaid,
+            out options,
+            out error);
     }
 
     private static bool TryCreateTypeOptions(
@@ -263,6 +262,7 @@ public static class DemoScenarioRunner
     private static bool TryCreateMemberOptions(
         ResolvedScenario resolved,
         ViewDefinition view,
+        ProductDemoMemberSelection selection,
         string section,
         ResolvedWorkspaceContext context,
         OutputFormat format,
@@ -274,26 +274,17 @@ public static class DemoScenarioRunner
         options = null!;
         error = null;
 
-        if (!TryParseMemberKey(view.MemberKey, out var memberName, out var kind, out error))
-            return false;
-
-        if (memberName is null && view.MemberAnchor is null && view.MemberSignature is null)
-        {
-            error = $"Home demo '{resolved.ScenarioId}' member view needs memberKey, memberAnchor, or memberSignature.";
-            return false;
-        }
-
-        // Anchor demos still need a member name for the CLI selector; prefer memberKey.
-        if (memberName is null)
-        {
-            error = $"Home demo '{resolved.ScenarioId}' member view must set memberKey (kind:name) for CLI run.";
-            return false;
-        }
-
-        var memberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { memberName };
-        var kindFilter = kind is null
+        var memberFilter =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                selection.Name,
+            };
+        var kindFilter = selection.Kind is null
             ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            : new HashSet<string>(StringComparer.OrdinalIgnoreCase) { kind };
+            : new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                selection.Kind,
+            };
 
         if (!TryResolveSource(resolved, view, context, out var source, out error))
             return false;
@@ -310,7 +301,7 @@ public static class DemoScenarioRunner
             TypeName = view.Type,
             MemberFilter = memberFilter,
             KindFilter = kindFilter,
-            MemberDigest = view.MemberAnchor,
+            MemberDigest = selection.Anchor,
             Select = [.. runSections],
             IncludeSections = ToIncludeSet(runSections),
             TipLevel = TipLevel.Quiet,
@@ -485,36 +476,6 @@ public static class DemoScenarioRunner
         // Platform-only extras are not expressible as --caller-package; ignore for this encoding.
         _ = resolved;
         callers = list.ToArray();
-        return true;
-    }
-
-    private static bool TryParseMemberKey(
-        string? memberKey,
-        out string? memberName,
-        out string? kind,
-        out string? error)
-    {
-        memberName = null;
-        kind = null;
-        error = null;
-        if (string.IsNullOrWhiteSpace(memberKey))
-            return true;
-
-        var colon = memberKey.IndexOf(':');
-        if (colon <= 0 || colon >= memberKey.Length - 1)
-        {
-            memberName = memberKey;
-            return true;
-        }
-
-        kind = memberKey[..colon];
-        memberName = memberKey[(colon + 1)..];
-        if (string.IsNullOrWhiteSpace(kind) || string.IsNullOrWhiteSpace(memberName))
-        {
-            error = $"Invalid memberKey '{memberKey}' (expected kind:name).";
-            return false;
-        }
-
         return true;
     }
 


### PR DESCRIPTION
## Summary

Run inspect-web's **Cross-package call graph** home demo through one generated
Browser engine operation backed by the product-owned scenario definition.
The browser no longer reconstructs package membership, focus, member-key
parsing, anchor selection, or graph execution in TypeScript.

- Add a host-neutral `ProductDemoRunPlan` consumed by the CLI and Browser
  encodings.
- Add generated `runHomeDemo(id)` bindings that return package surfaces, exact
  activation identity, and the call graph in one typed result.
- Preserve Browser's bounded reference-surface/implementation-body workspace,
  package limits, and single-threaded Wasm compatibility.
- Resolve the anchored member through `MemberTargetResolver`, including digest
  prefixes and a non-first focus package.
- Keep loading failures visible and reset stale API filters when the demo
  activates.

## Demo

At exact head `86d9b7736`, a real engine-host run of
`runHomeDemo("extensions-callgraph")` returned:

| Result | Observed value |
| --- | --- |
| Scenario found | `true` |
| Package surfaces | `3` |
| Focused member | `ServiceCollectionDescriptorExtensions.TryAddEnumerable` |
| Exact member anchor | `74b6b4b321` |
| Graph scope | `3` packages |
| Target has an implementation body | `true` |

The website button now makes that single engine call and installs the returned
workspace, exact member activation, and already-projected graph. The CLI
continues to produce the matching Mermaid graph from the same product scenario:

```bash
dotnet-inspect demo extensions-callgraph --mermaid
```

```mermaid
graph TD
    n0["Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.DependencyInjection.ServiceDescriptor) (fanout 22, fanin 1, depth 4, target)"]
    n1["Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Collections.Generic.IEnumerable#60;Microsoft.Extensions.DependencyInjection.ServiceDescriptor#62;)"]
    n5["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.GetImplementationType() (fanout 21, fanin 1, depth 3)"]
    n6["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ImplementationFactory() (fanout 1, fanin 3, depth 2)"]
    n7["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_IsKeyedService() (…, fanout 1, fanin 8)"]
    n8["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ImplementationInstance() (fanout 1, fanin 3, depth 2)"]
    n9["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ImplementationType() (fanout 1, fanin 3, depth 2)"]
    n10["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_KeyedImplementationFactory() (fanout 2, fanin 3, depth 2)"]
    n11["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.ThrowNonKeyedDescriptor() (…, fanout 2, fanin 3)"]
    n12["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_KeyedImplementationInstance() (fanout 2, fanin 3, depth 2)"]
    n13["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_KeyedImplementationType() (fanout 2, fanin 3, depth 2)"]
    n14["Microsoft.Extensions.DependencyInjection.ServiceDescriptor.get_ServiceKey() (fanin 9)"]
    subgraph sg0["External"]
        n2["System.Collections.Generic.ICollection#60;Microsoft.Extensions.DependencyInjection.ServiceDescriptor#62;.Add(Microsoft.Extensions.DependencyInjection.ServiceDescriptor) (external, fanin 11)"]
        n3["System.Collections.Generic.ICollection#60;Microsoft.Extensions.DependencyInjection.ServiceDescriptor#62;.get_Count() (external, fanin 5)"]
        n4["System.Collections.Generic.IList#60;Microsoft.Extensions.DependencyInjection.ServiceDescriptor#62;.get_Item(int) (external, fanin 5)"]
        n15["System.Type.get_GenericTypeArguments() (external, fanin 1, from corelib)"]
        n16["System.Type.op_Inequality(System.Type, System.Type) (external, fanin 4, from corelib)"]
        n17["object.GetType() (external, fanin 3, from corelib)"]
    end
    n1 -->|"loop call"| n0
    n0 --> n2
    n0 --> n3
    n0 -->|"loop"| n4
    n0 -->|"loop"| n5
    n5 --> n6
    n6 --> n7
    n5 --> n8
    n8 --> n7
    n5 --> n9
    n9 --> n7
    n5 --> n10
    n10 --> n11
    n10 --> n7
    n5 --> n12
    n12 --> n11
    n12 --> n7
    n5 --> n13
    n13 --> n11
    n13 --> n7
    n5 --> n14
    n5 --> n15
    n5 --> n16
    n5 --> n17
    n0 -->|"loop"| n14
    classDef markoutFocus stroke-width:3px;
    class n0 markoutFocus;
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  — 506 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`
  — 115 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
  — 4,404 passed, 16 environment/oracle skips
- `npm test` — 570 passed
- `npm run analyze`
- `npm run build`
- `eng/generate-inspect-web-engine-dts.sh --check`
- `npx markdownlint-cli docs/inspection-space.md
  docs/design/workspace-definitions.md`

## Non-action boundary

This closes the host-private `extensions-callgraph` demo runner residual from
#4463 and uses the exact workspace/member navigation delivered by #4420.
It does not replace Browser's bounded dual reference/body workspace with
`WorkspaceContextLoader`; that broader workspace-owner convergence remains a
separate design slice so ordinary package and System.Text.Json behavior do not
change here.
