### PR TITLE
AGENTS.md: give machine-checkable waits a field of their own

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,26 @@ tmux set -w -t "$TMUX_PANE" -u @agent_state
 ```
 
 Always use `-w -t "$TMUX_PANE"` and read back `@agent_state`. It must include
-`pr` and `head`; add `round`, `reviews`, `blocked`, and `rec` when applicable.
-Values contain no spaces. `rec` is `continue`, `wait`, `merge`, `approve`, or
-`stop`. Clear both options when the window no longer owns a PR.
+`head` and either `pr` or, before a PR exists, `issue`; add `round`, `reviews`,
+`blocked`, `waiting`, and `rec` when applicable. Values contain no spaces. `rec`
+is `continue`, `wait`, `merge`, `approve`, or `stop`. Clear both options when the
+window no longer owns the work.
+
+`blocked` and `waiting` are both things you are waiting on, split by **who can
+act on them**:
+
+- **`blocked`** takes issue or PR numbers only — things a person can open and
+  prioritise, and that the next agent hitting the same wall can find instead of
+  re-investigating it. If a flake blocks you and no issue exists, file one and
+  cite it.
+- **`waiting`** takes a predicate a tool can evaluate against your `head`:
+  `check:<name>`, `checks`, `merge`, or `review`. Use it when nothing is wrong
+  and nothing is openable — a check that has not reported yet is not a defect
+  and does not deserve an issue.
+
+`rec=wait` is coherent when either is populated. `blocked=ci` is the specific
+error this split exists to remove: it names nothing a person can open and
+nothing a tool can evaluate, so it reads as a wait on nothing.
 
 ### Signal when you need a person
 


### PR DESCRIPTION
## Summary

Splits `@agent_state`'s "what am I waiting on" into two fields, and allows `issue=` before a PR exists.

## Why

`blocked` carries two properties that turned out to be independent, and requiring numbers fused them:

| | **Citable** — a person can open and prioritise it | **Evaluable** — a tool can test whether it cleared |
|---|---|---|
| `4629` (a PR) | ✅ | ✅ |
| `ci-required` not yet reported | ❌ nothing to open | ✅ exact and cheap |
| mergeability not yet computed | ❌ | ✅ |

The citability rule is right and worth keeping — it exists so a blocker can be prioritised, and so the *next* agent hitting the same flake finds the issue instead of re-investigating. But "waiting for `ci-required` to report" is a true, common state with nothing to open, because **nothing is wrong**. CI just has not finished.

## The fleet already showed the consequence

With no legal way to say it, agents invented one:

```
pr4142, pr4448   blocked=ci             ← names nothing openable
pr4616, pr4600   rec=wait, no blocked   ← incoherent per the spec
```

That is a **schema forcing an error**, not agents being careless: a required field with no legal value in a state they are legitimately in. Left alone, `blocked=ci` becomes the norm and the citability rule quietly dies — the whole force of "every entry must be a number someone can open" evaporates the moment agents learn a non-openable token is tolerated.

## The split

Two properties, two fields, divided by **who can act**:

- **`blocked`** — issue or PR numbers only. Unchanged, including the obligation to file an issue for a flake and cite it.
- **`waiting`** — a predicate evaluated against `head`: `check:<name>`, `checks`, `merge`, `review`. For when nothing is wrong and nothing is openable.

`rec=wait` is coherent when *either* is populated. One line teaches the split: **if a person could act on it, it is `blocked`; if only a machine can check it, it is `waiting`.**

Evaluating `waiting` against `head` is deliberate — it inherits the falsifiability rule the record already has, so a wait is void the moment the head moves, exactly like every other claim in the state.

## Also: `issue=` before a PR exists

The window naming convention already says to use `i<number>` before a PR exists, but `@agent_state` required `pr` regardless. Same defect, same schema — a required field with no legal value in a legitimate state. `head` plus either `pr` or `issue` is now the requirement.

## Note on scope

This does **not** claim to wake a stopped agent — `rec=wait` still relies on the agent self-scheduling. What it fixes is that the state can now be stated truthfully, and a reader can evaluate it. Waking is a separate, unbuilt piece.

## Validation

`markdownlint-cli2 AGENTS.md` — 0 issues. Docs-only.

Timing: adoption is 11 of 34 windows and the malformed records cluster exactly in this gap, so the schema is cheaper to fix now than once it is universal.
