### PR TITLE
Move Browser package roles into product workspace

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -12,10 +12,13 @@ contract, lifetime rules, and authorization model.
 This is a design proposal. Implementation has begun: the `package`,
 `platform`, and `embedded` member coordinates and one loader that realizes a
 selected context into exactly one `AssemblyContextGroup` now exist in product
-code, and the definition-record loader, registry, scenario resolution, and
-product home demos listed under [What exists today](#what-exists-today) are
-gated. Every other property asserted below is **unverified** until the gates
-named in [Status and gates](#status-and-gates) exist.
+code. Product code also realizes exact already-acquired descriptors into
+coordinated surface and implementation roles for Browser package workspaces.
+The definition-record loader, registry, scenario resolution, product home
+demos, and role realization listed under
+[What exists today](#what-exists-today) are gated. Every other property asserted
+below is **unverified** until the gates named in
+[Status and gates](#status-and-gates) exist.
 
 ## Purpose
 
@@ -442,12 +445,15 @@ workspace, focus, member anchor, and section, opens one aggregate browser
 workspace, and returns its package surfaces, exact activation identity, and
 ordinary Call Graph projection. TypeScript applies that typed result to the UI
 without parsing definition member keys or reconstructing package/query inputs.
-Residual: (1) minted facet ids replacing display-name allow list; (2) realize via
-`WorkspaceContextLoader` into one `AssemblyContextGroup` instead of CLI
-package/`--caller-package` encoding and the browser runtime-pack share
-encoding for platform; (3) Call Graph / Callers structured JSON projection
-remains the shared member-pipeline gap (Markdown/Mermaid are the
-faithful graph formats today).
+Browser package scopes now adapt their exact selected descriptors into
+product-owned `PackageAssemblyContextRoles`; Browser still owns Wasm
+acquisition, cache/deadline budgets, and package/asset provenance.
+Residual: (1) minted facet ids replacing display-name allow list; (2) realize
+definitions via `WorkspaceContextLoader` instead of CLI package/
+`--caller-package` encoding and the browser runtime-pack share encoding for
+platform; (3) Call Graph / Callers structured JSON projection remains the
+shared member-pipeline gap (Markdown/Mermaid are the faithful graph formats
+today).
 
 ### Member coordinates
 
@@ -1007,11 +1013,23 @@ Definition records and product demos (this slice):
 - `InspectionDefinitionTests` / `DemoCommandTests` gate round-trip, separation,
   demo-parity, section binding, CLI lowering, and real section output for the
   two home demos; inspect-web's generated `RunHomeDemo` binding runs the
-  member-bound Call Graph preset from its product scenario id; and
-- **not yet:** minted view-facet ids; `WorkspaceContextLoader` group realization
-  as the run substrate (CLI still uses package + `--caller-package` encoding;
-  inspect-web's package workspace remains its dual reference/body group owner,
-  and platform still uses the resident runtime-pack share encoding).
+  member-bound Call Graph preset from its product scenario id;
+- `InspectionWorkspace.CreatePackageAssemblyContextRoles` realizes exact,
+  already-acquired package descriptors as coordinated surface and
+  implementation groups. It owns role-local binding, identity collision
+  rejection, reference-only surfaces, explicit shared-group reuse, and exact
+  participant correspondence. `PackageAssemblyContextRolesTests` gate the
+  product contract;
+  `BrowserEngineBoundaryTests.WorkspaceBinding_RejectsPackageParticipantsForPlatformScope`,
+  `WorkspaceBinding_RejectsEquivalentAssemblyIdentities`,
+  `ImplementationPairing_RequiresEquivalentAssemblyIdentity`, and
+  `WorkspaceOwnership_AccountsArchivesAndCarriesSelectedFailures` gate the
+  Browser adapter and its unchanged Wasm limits; and
+- **not yet:** minted view-facet ids; `WorkspaceContextLoader` acquisition as
+  the run substrate (CLI still uses package + `--caller-package` encoding, the
+  Browser package path still supplies exact already-acquired descriptors to the
+  product role owner, and platform still uses the resident runtime-pack share
+  encoding).
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -40,18 +40,25 @@ shortening the selected assembly set.
    stable result. Neither path requests the NuGet.org v3 service index. The
    Browser adapter then selects one target framework — never "whatever the
    package happens to ship".
-2. **Mint typed participants.** `PackagePayloadAcquisition` downloads and
+2. **Select and realize typed roles.** `PackagePayloadAcquisition` downloads and
    admits the package from the Gallery package CDN through the shared typed
    source, transport, and archive policy. The Gallery payload carries its
    advertised length into the Browser reservation policy before body
    materialization.
    `PackageCompileAssetSelector` adds reference-group semantics around the
-   implementation universe selected by `PackageAssetSelector`, decodes each
-   healthy entry's real metadata identity, and creates one
+   implementation universe selected by `PackageAssetSelector`. The narrow
+   Browser acquisition adapter decodes each healthy entry's real metadata
+   identity and creates one
    `ResolvedAssemblyReference` per selected compile asset and, when the roles
    differ, per matching implementation asset. Malformed selected entries remain
    participants so queries report their rejection. Acquisition never inspects
    one.
+   `InspectionWorkspace.CreatePackageAssemblyContextRoles` then owns the
+   coordinated surface and implementation binding snapshots, equivalent-
+   identity rejection, group construction, reference-only surfaces, and exact
+   surface-to-implementation participant correspondence. Browser retains the
+   selected package/asset provenance used by source and navigation operations,
+   but does not implement assembly binding or group composition.
    The Browser adapter places one 30-second operation deadline around coordinate
    resolution and payload acquisition. The deadline token flows through the
    shared resolver, retry, response-body, archive-validation, and store paths;
@@ -92,9 +99,10 @@ shortening the selected assembly set.
    `BrowserGalleryDeadlineLeavesTimeForPartialRegistration`, and
    `VersionPickerRetainsFlatListWhenRegistrationTimesOut` gate Browser
    consumption.
-3. **Hand the group to a query.** The participants open one `InspectionWorkspace`
-   and one binding-consistent `AssemblyContextGroup`. `BrowserInspectionScope`
-   exposes exactly two hand-offs — `Use(group => query(group))` and
+3. **Hand a role group to a query.** The participants open one
+   `InspectionWorkspace` and one or two binding-consistent
+   `AssemblyContextGroup` instances. `BrowserInspectionScope` exposes exactly
+   two hand-offs — `Use(group => query(group))` and
    `UseParticipant(participant, (group, participant) => query(...))` — and no
    accessor for a session, an image, or a descriptor.
 
@@ -212,10 +220,10 @@ assemblies that receive a .NET platform lookup on click.
 | `engine/Program.cs` | the entry point, and nothing else |
 | `engine/BannedSymbols.txt` | the compiler-enforced workspace rule |
 | `engine/BrowserContracts.cs` | the transport records and their source-generated JSON context |
-| `engine/BrowserPackageWorkspace.cs` | the Browser adapter over shared package acquisition, the session cache/capacity policy, reference-role selection, participant minting, and the bounded workspace registry |
+| `engine/BrowserPackageWorkspace.cs` | the Browser adapter over shared package acquisition, the session cache/capacity policy, reference-role selection, descriptor minting, and the bounded workspace registry |
 | `engine/BrowserPlatformWorkspace.cs` | content-backed platform acquisition, exact family pins, cumulative group replacement, and shared package/workspace accounting |
 | `engine/BrowserApiSurfacePolicy.cs` | the explicit participant/type/member bounds every API-surface projection runs under |
-| `engine/BrowserInspectionScope.cs` | the `InspectionWorkspace` lifetime and its compile/implementation group hand-offs |
+| `engine/BrowserInspectionScope.cs` | package/asset provenance over product-owned surface/implementation roles, the `InspectionWorkspace` lifetime, and query hand-offs |
 | `engine/BrowserSurfaceProjection.cs` | adapting typed query models into transport records |
 | `engine/BrowserStyleOptions.cs` | resolving the client's style ids through `StyleOptionCatalog` |
 | `engine/BrowserXmlDocumentation.cs` | reading one member's package-shipped XML documentation |

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2086,6 +2086,47 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void WorkspaceDisposal_ClosesWorkspaceAfterRoleFailure()
+    {
+        byte[] image =
+            File.ReadAllBytes(
+                typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        BrowserPackageCoordinate coordinate = Coordinate(
+            "Dispose.Roles",
+            PackagePair(image, image, "Dispose.Roles.dll"));
+        var scope = new BrowserInspectionScope([coordinate]);
+        AssemblyContextGroup implementation =
+            scope.UseImplementation(group => group);
+        MethodInfo registerOwnedResource =
+            typeof(AssemblyContextGroup).GetMethod(
+                "RegisterOwnedResource",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "AssemblyContextGroup.RegisterOwnedResource was not found.");
+        registerOwnedResource.Invoke(
+            implementation,
+            [new ThrowingResource("browser role disposal failed")]);
+
+        AggregateException failure =
+            Assert.Throws<AggregateException>(scope.Dispose);
+
+        Assert.Contains(
+            failure.Flatten().InnerExceptions,
+            ex => ex.Message == "browser role disposal failed");
+        FieldInfo field =
+            typeof(BrowserInspectionScope).GetField(
+                "_workspace",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "BrowserInspectionScope._workspace was not found.");
+        var workspace =
+            Assert.IsType<InspectionWorkspace>(field.GetValue(scope));
+        Assert.Throws<ObjectDisposedException>(
+            () => workspace.CreateAssemblyContextGroup(
+                [scope.SurfaceParticipants[0].Participant]));
+    }
+
+    [Fact]
     public void CallGraphDiagnostics_PreserveIncompleteProductEvidence()
     {
         BrowserCallGraphDiagnostics diagnostics = InspectionEngine.Diagnostics(
@@ -4162,6 +4203,12 @@ public sealed class BrowserEngineBoundaryTests
         public void Dispose()
         {
         }
+    }
+
+    sealed class ThrowingResource(string message) : IDisposable
+    {
+        public void Dispose() =>
+            throw new InvalidOperationException(message);
     }
 
     sealed class RequestRecordingHandler : HttpMessageHandler

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2007,16 +2007,31 @@ public sealed class BrowserEngineBoundaryTests
         BrowserPackageCoordinate coordinate = Coordinate(
             "Platform.Confusable",
             Package(image, "lib/net11.0/Platform.Confusable.dll"));
-        PackageCompileAsset asset = Assert.Single(coordinate.Selection.Assets);
-        using var workspace = new InspectionWorkspace();
-        using var group = new BrowserWorkspaceGroup(
-            workspace,
-            [(coordinate, asset)],
-            BrowserInspectionScope.MaxRetainedImageBytes);
-        AssemblyReferenceIdentity identity = Assert.Single(group.Participants).Assembly.Identity;
+        BrowserInspectionScope scope =
+            BrowserPackageWorkspace.OpenScope([coordinate]);
+        BrowserWorkspaceParticipant participant =
+            Assert.Single(scope.SurfaceParticipants);
+        AssemblyBindingSelection any =
+            participant.Participant.BindingPolicy.Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(
+                        participant.Assembly.Identity),
+                    AssemblyBindingOrigin.FromAssembly(
+                        participant.Assembly),
+                    AssemblyResolutionScope.Any));
+        AssemblyBindingSelection platform =
+            participant.Participant.BindingPolicy.Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(
+                        participant.Assembly.Identity),
+                    AssemblyBindingOrigin.FromAssembly(
+                        participant.Assembly),
+                    AssemblyResolutionScope.Platform));
 
-        Assert.NotNull(group.Resolve(identity, AssemblyResolutionScope.Any));
-        Assert.Null(group.Resolve(identity, AssemblyResolutionScope.Platform));
+        Assert.Same(
+            participant.Assembly,
+            Assert.IsType<AssemblyBindingSelection.Selected>(any).Assembly);
+        Assert.IsType<AssemblyBindingSelection.Missing>(platform);
     }
 
     [Fact]

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineLayeringTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineLayeringTests.cs
@@ -34,10 +34,17 @@ public sealed class BrowserEngineLayeringTests
         Assert.Contains("T:ILInspector.Metadata.AssemblyReader", banned);
         Assert.Contains("T:ILInspector.Metadata.ApiSurfaceExtractor", banned);
         Assert.Contains("P:ILInspector.Metadata.ResolvedAssemblyReference.OpenRead", banned);
+        Assert.Contains("T:ILInspector.Metadata.IAssemblyReferenceResolver", banned);
+        Assert.Contains("T:ILInspector.Metadata.AssemblyReferenceBindingPolicy", banned);
         Assert.Contains("T:System.Reflection.PortableExecutable.PEReader", banned);
         Assert.Contains("T:System.Reflection.Metadata.MetadataReader", banned);
         Assert.Contains("T:ILInspector.Decompiler.Pipeline.MetadataSource", banned);
         Assert.Contains("T:ILInspector.Analysis.LibraryBodyIndex", banned);
+        Assert.Contains(
+            banned,
+            symbol => symbol.StartsWith(
+                "M:DotnetInspector.Queries.InspectionWorkspace.CreateAssemblyContextGroup",
+                StringComparison.Ordinal));
         Assert.Contains(
             banned,
             symbol => symbol.StartsWith(

--- a/prototypes/inspect-web/engine/BannedSymbols.txt
+++ b/prototypes/inspect-web/engine/BannedSymbols.txt
@@ -20,9 +20,12 @@ T:ILInspector.Analysis.LibraryBodyAnalysisResult;Body analysis is reached throug
 T:ILInspector.Metadata.AssemblyReader;Assembly projection belongs to a product query, never to the browser host.
 T:ILInspector.Metadata.ApiSurfaceExtractor;API projection belongs to a product query, never to the browser host.
 P:ILInspector.Metadata.ResolvedAssemblyReference.OpenRead;A descriptor may carry identity into a query, but the browser host must not open its image.
+T:ILInspector.Metadata.IAssemblyReferenceResolver;Assembly-role binding belongs to product workspace composition, never to the browser host.
+T:ILInspector.Metadata.AssemblyReferenceBindingPolicy;Assembly-role binding belongs to product workspace composition, never to the browser host.
 T:System.Reflection.PortableExecutable.PEReader;Raw image decoding is isolated in InspectWeb.Acquisition; the browser host uses product queries.
 T:System.Reflection.Metadata.MetadataReader;Raw metadata decoding is isolated in InspectWeb.Acquisition; the browser host uses product queries.
 
+M:DotnetInspector.Queries.InspectionWorkspace.CreateAssemblyContextGroup(System.Collections.Generic.IEnumerable{DotnetInspector.Queries.AssemblyContextParticipant},DotnetInspector.Queries.AssemblyContextGroupOptions);The browser supplies exact descriptors to CreatePackageAssemblyContextRoles; product code owns binding-consistent group composition.
 M:DotnetInspector.Queries.AssemblyContextGroup.UseAssemblyImage``1(ILInspector.Metadata.ResolvedAssemblyReference,DotnetInspector.Queries.AssemblyImageCallback{``0});Inspecting an image span in the host is the thing the workspace rule exists to prevent.
 M:DotnetInspector.Queries.AssemblyContextGroup.GetAssemblyImageSpan(ILInspector.Metadata.ResolvedAssemblyReference);Inspecting an image span in the host is the thing the workspace rule exists to prevent.
 M:DotnetInspector.Queries.AssemblyContextGroup.RetainAssemblyReference(ILInspector.Metadata.ResolvedAssemblyReference);A retained descriptor is content the query layer owns; ask a query for the projection instead.

--- a/prototypes/inspect-web/engine/BrowserInspectionScope.cs
+++ b/prototypes/inspect-web/engine/BrowserInspectionScope.cs
@@ -19,6 +19,16 @@ internal sealed record BrowserWorkspaceParticipant(
 }
 
 /// <summary>
+/// One selected package asset and the exact descriptor passed to product-owned
+/// assembly-role realization.
+/// </summary>
+[SupportedOSPlatform("browser")]
+internal sealed record BrowserRoleAssembly(
+    BrowserPackageCoordinate Coordinate,
+    PackageCompileAsset Asset,
+    ResolvedAssemblyReference Assembly);
+
+/// <summary>
 /// The workspace every browser inspection runs inside: one <see cref="InspectionWorkspace"/> and
 /// separate binding-consistent <see cref="AssemblyContextGroup"/> views over the product-selected
 /// compile and implementation assemblies of one or more exact package/version/framework
@@ -56,8 +66,9 @@ internal sealed class BrowserInspectionScope : IDisposable
     internal const int MaxAssembliesPerRole = 256;
 
     readonly InspectionWorkspace _workspace = new();
-    readonly BrowserWorkspaceGroup _surface;
-    readonly BrowserWorkspaceGroup? _implementation;
+    readonly PackageAssemblyContextRoles _roles;
+    readonly BrowserWorkspaceRole _surface;
+    readonly BrowserWorkspaceRole? _implementation;
 
     public BrowserInspectionScope(IReadOnlyList<BrowserPackageCoordinate> coordinates)
     {
@@ -80,35 +91,50 @@ internal sealed class BrowserInspectionScope : IDisposable
         long groupBudget = hasSeparateImplementation
             ? MaxRetainedImageBytes / 2
             : MaxRetainedImageBytes;
-        BrowserWorkspaceGroup.ValidateAssets(surfaceAssets, groupBudget);
+        BrowserWorkspaceRole.ValidateAssets(surfaceAssets, groupBudget);
         if (hasSeparateImplementation)
-            BrowserWorkspaceGroup.ValidateAssets(implementationAssets, groupBudget);
+            BrowserWorkspaceRole.ValidateAssets(implementationAssets, groupBudget);
 
-        // Group construction itself refuses a role it cannot bind — an empty role, or one whose
-        // participants collide on assembly identity — so it is inside the cleanup, not before it:
-        // a refused scope must not leave its workspace holding retained images.
-        BrowserWorkspaceGroup? surface = null;
-        BrowserWorkspaceGroup? implementation = null;
+        BrowserRoleAssembly[] surfaceRole = CreateRole(surfaceAssets);
+        BrowserRoleAssembly[] implementationRole = shared
+            ? surfaceRole
+            : CreateRole(implementationAssets);
+        AssemblyContextGroupOptions roleOptions = new()
+        {
+            MaxRetainedImageBytes = groupBudget,
+        };
+
+        PackageAssemblyContextRoles? roles = null;
         try
         {
-            surface = new BrowserWorkspaceGroup(_workspace, surfaceAssets, groupBudget);
-            implementation = shared
-                ? surface
-                : implementationAssets.Length == 0
+            // Product construction is inside the cleanup boundary: a refused
+            // implementation role must not leave the surface group registered.
+            roles = _workspace.CreatePackageAssemblyContextRoles(
+                surfaceRole.Select(entry => entry.Assembly),
+                implementationRole.Length == 0
                     ? null
-                    : new BrowserWorkspaceGroup(
-                        _workspace,
-                        implementationAssets,
-                        groupBudget);
-            _surface = surface;
-            _implementation = implementation;
-            ValidateImplementationPairs();
+                    : implementationRole.Select(entry => entry.Assembly),
+                Correspondences(surfaceRole, implementationRole),
+                shareImplementationGroup: shared,
+                surfaceOptions: roleOptions,
+                implementationOptions: roleOptions);
+            _roles = roles;
+            _surface = new BrowserWorkspaceRole(
+                roles.SurfaceGroup,
+                surfaceRole,
+                roles.SurfaceParticipants);
+            _implementation = roles.ImplementationGroup is null
+                ? null
+                : roles.SharesGroup
+                    ? _surface
+                    : new BrowserWorkspaceRole(
+                        roles.ImplementationGroup,
+                        implementationRole,
+                        roles.ImplementationParticipants);
         }
         catch
         {
-            if (!ReferenceEquals(implementation, surface))
-                implementation?.Dispose();
-            surface?.Dispose();
+            roles?.Dispose();
             _workspace.Dispose();
             throw;
         }
@@ -125,7 +151,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     public ImmutableArray<BrowserWorkspaceParticipant> ReferenceOnlySurfaceParticipants =>
     [
         .. SurfaceParticipants.Where(participant =>
-            participant.Coordinate.Selection.FindImplementationAsset(participant.Asset) is null),
+            _roles.ImplementationParticipant(participant.Participant) is null),
     ];
 
     /// <summary>
@@ -198,62 +224,86 @@ internal sealed class BrowserInspectionScope : IDisposable
                 nameof(surfaceParticipant));
         }
 
-        PackageCompileAsset implementationAsset =
-            surfaceParticipant.Coordinate.Selection.FindImplementationAsset(
-                surfaceParticipant.Asset)
+        AssemblyContextParticipant implementation =
+            _roles.ImplementationParticipant(surfaceParticipant.Participant)
             ?? throw new InvalidOperationException(
                 $"{surfaceParticipant.Coordinate.PackageId} "
                 + $"{surfaceParticipant.Coordinate.Version} ships "
                 + $"{surfaceParticipant.Asset.AssemblyName} for "
                 + $"{surfaceParticipant.Coordinate.Framework} as a reference assembly only.");
-        BrowserWorkspaceParticipant implementation =
-            Implementation.FindParticipant(
-                surfaceParticipant.Coordinate,
-                implementationAsset);
-        if (!implementation.Assembly.Identity.IsEquivalentTo(
-                surfaceParticipant.Assembly.Identity))
-        {
-            throw new InvalidOperationException(
-                $"The selected reference and implementation assets for "
-                + $"{surfaceParticipant.Asset.AssemblyName} have different assembly identities.");
-        }
-
-        return implementation;
+        return Implementation.FindParticipant(implementation);
     }
 
     public void Dispose()
     {
-        if (!ReferenceEquals(_implementation, _surface))
-            _implementation?.Dispose();
-        _surface.Dispose();
+        _roles.Dispose();
         _workspace.Dispose();
     }
 
-    void ValidateImplementationPairs()
+    static BrowserRoleAssembly[] CreateRole(
+        IReadOnlyList<(
+            BrowserPackageCoordinate Coordinate,
+            PackageCompileAsset Asset)> assets)
+        =>
+        [
+            .. assets.Select(entry => new BrowserRoleAssembly(
+                entry.Coordinate,
+                entry.Asset,
+                entry.Coordinate.Package.CreateReference(
+                    entry.Asset.Path,
+                    AssemblyResolutionProvenance.Package(
+                        entry.Coordinate.PackageId,
+                        entry.Coordinate.Version,
+                        entry.Asset.TargetFramework,
+                        rid: null)))),
+        ];
+
+    static ImmutableArray<PackageAssemblyRoleCorrespondence> Correspondences(
+        IReadOnlyList<BrowserRoleAssembly> surfaces,
+        IReadOnlyList<BrowserRoleAssembly> implementations)
     {
-        foreach (BrowserWorkspaceParticipant surfaceParticipant in SurfaceParticipants)
+        var pairs =
+            ImmutableArray.CreateBuilder<PackageAssemblyRoleCorrespondence>();
+        foreach (BrowserRoleAssembly surface in surfaces)
         {
             PackageCompileAsset? implementationAsset =
-                surfaceParticipant.Coordinate.Selection.FindImplementationAsset(
-                    surfaceParticipant.Asset);
+                surface.Coordinate.Selection.FindImplementationAsset(
+                    surface.Asset);
             if (implementationAsset is null)
                 continue;
 
-            BrowserWorkspaceParticipant implementation =
-                Implementation.FindParticipant(
-                    surfaceParticipant.Coordinate,
-                    implementationAsset);
-            if (!implementation.Assembly.Identity.IsEquivalentTo(
-                surfaceParticipant.Assembly.Identity))
+            BrowserRoleAssembly? implementation =
+                implementations.FirstOrDefault(candidate =>
+                    candidate.Coordinate.Key.Equals(
+                        surface.Coordinate.Key,
+                        StringComparison.Ordinal)
+                    && candidate.Asset.Path.Equals(
+                        implementationAsset.Path,
+                        StringComparison.Ordinal));
+            if (implementation is null)
+            {
+                throw new InvalidOperationException(
+                    $"The selected implementation asset '{implementationAsset.Path}' "
+                    + "is not part of the implementation workspace role.");
+            }
+            if (!surface.Assembly.Identity.IsEquivalentTo(
+                    implementation.Assembly.Identity))
             {
                 throw new InvalidOperationException(
                     $"The selected reference and implementation assets for "
-                    + $"{surfaceParticipant.Asset.AssemblyName} have different assembly identities.");
+                    + $"{surface.Asset.AssemblyName} have different assembly identities.");
             }
+
+            pairs.Add(
+                new PackageAssemblyRoleCorrespondence(
+                    surface.Assembly,
+                    implementation.Assembly));
         }
+
+        return pairs.ToImmutable();
     }
 
-    BrowserWorkspaceGroup Implementation => _implementation
+    BrowserWorkspaceRole Implementation => _implementation
         ?? throw new InvalidOperationException(
             "The selected packages ship no managed implementation assembly for their selected "
             + "frameworks, so this operation has no method bodies to inspect.");
@@ -272,93 +322,53 @@ internal sealed class BrowserInspectionScope : IDisposable
 }
 
 /// <summary>
-/// One binding-consistent participant role inside a browser workspace. Compile and implementation
-/// groups deliberately have distinct policies so references resolve within the same asset role.
+/// Browser package and asset provenance projected over one product-owned
+/// assembly-context role.
 /// </summary>
 [SupportedOSPlatform("browser")]
-internal sealed class BrowserWorkspaceGroup : IDisposable, IAssemblyReferenceResolver
+internal sealed class BrowserWorkspaceRole
 {
-    AssemblyContextGroup? _group;
+    readonly AssemblyContextGroup _group;
 
-    public BrowserWorkspaceGroup(
-        InspectionWorkspace workspace,
-        IReadOnlyList<(BrowserPackageCoordinate Coordinate, PackageCompileAsset Asset)> assets,
-        long maxRetainedImageBytes)
+    public BrowserWorkspaceRole(
+        AssemblyContextGroup group,
+        IReadOnlyList<BrowserRoleAssembly> assemblies,
+        ImmutableArray<AssemblyContextParticipant> participants)
     {
-        ArgumentNullException.ThrowIfNull(workspace);
-        ArgumentNullException.ThrowIfNull(assets);
-        ValidateAssets(assets, maxRetainedImageBytes);
-
-        // One binding-policy snapshot per role: a reference assembly resolves other references,
-        // while an implementation assembly resolves other implementations.
-        var policy = new AssemblyReferenceBindingPolicy(this);
-        var participants = ImmutableArray.CreateBuilder<BrowserWorkspaceParticipant>();
-        foreach ((BrowserPackageCoordinate coordinate, PackageCompileAsset asset) in assets)
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(assemblies);
+        if (assemblies.Count != participants.Length)
         {
-            ResolvedAssemblyReference reference = coordinate.Package.CreateReference(
-                asset.Path,
-                AssemblyResolutionProvenance.Package(
-                    coordinate.PackageId,
-                    coordinate.Version,
-                    asset.TargetFramework,
-                    rid: null));
-
-            participants.Add(new BrowserWorkspaceParticipant(
-                coordinate,
-                asset,
-                new AssemblyContextParticipant(reference, policy)));
+            throw new ArgumentException(
+                "Browser role provenance must have one entry per product participant.",
+                nameof(assemblies));
         }
 
-        if (participants.Count == 0)
+        _group = group;
+        Participants =
+        [
+            .. assemblies.Zip(
+                participants,
+                (assembly, participant) =>
+                    new BrowserWorkspaceParticipant(
+                        assembly.Coordinate,
+                        assembly.Asset,
+                        participant)),
+        ];
+        for (int index = 0; index < assemblies.Count; index++)
         {
-            throw new InvalidOperationException(
-                "The selected packages contain no managed assembly for this workspace role.");
-        }
-
-        Participants = participants.ToImmutable();
-        RejectEquivalentIdentities(Participants);
-        _group = workspace.CreateAssemblyContextGroup(
-            Participants.Select(participant => participant.Participant),
-            new AssemblyContextGroupOptions
+            if (!ReferenceEquals(
+                    assemblies[index].Assembly,
+                    participants[index].Assembly))
             {
-                // Preserve the workspace's own retained-snapshot defense after the host preflight.
-                MaxRetainedImageBytes = maxRetainedImageBytes,
-            });
-    }
-
-    public ImmutableArray<BrowserWorkspaceParticipant> Participants { get; }
-
-    /// <summary>
-    /// Refuses a workspace role in which two participants carry equivalent assembly identities.
-    /// </summary>
-    /// <remarks>
-    /// This is the invariant <c>WorkspaceContextLoader.FirstIdentityCollision</c> holds for a
-    /// desktop workspace context, applied here for the same reason: <see cref="Resolve"/> answers
-    /// an in-context reference by matching <see cref="AssemblyReferenceIdentity.IsEquivalentTo"/>
-    /// against the role's participants, so two equivalent identities make the answer depend on
-    /// asset path or declaration order — the first request would bind the reference to one image
-    /// and a differently ordered workspace would bind it to the other. Assemblies with different
-    /// versions are not equivalent and still coexist. The identity is decoded out of a package
-    /// artifact, so the failure names neither it nor the asset that carried it.
-    /// </remarks>
-    static void RejectEquivalentIdentities(
-        ImmutableArray<BrowserWorkspaceParticipant> participants)
-    {
-        for (int index = 1; index < participants.Length; index++)
-        {
-            AssemblyReferenceIdentity identity = participants[index].Assembly.Identity;
-            for (int earlier = 0; earlier < index; earlier++)
-            {
-                if (!participants[earlier].Assembly.Identity.IsEquivalentTo(identity))
-                    continue;
-
-                throw new InvalidOperationException(
-                    "The selected packages contribute more than one assembly with the same "
-                    + "assembly identity to one workspace role, so a reference to it could not "
-                    + "bind to a single image.");
+                throw new ArgumentException(
+                    "Browser role provenance must preserve product participant order.",
+                    nameof(assemblies));
             }
         }
     }
+
+    public ImmutableArray<BrowserWorkspaceParticipant> Participants { get; }
 
     internal static void ValidateAssets(
         IReadOnlyList<(BrowserPackageCoordinate Coordinate, PackageCompileAsset Asset)> assets,
@@ -431,29 +441,17 @@ internal sealed class BrowserWorkspaceGroup : IDisposable, IAssemblyReferenceRes
                 + $"{coordinate.Version} {coordinate.Framework} workspace role.");
     }
 
-    public ResolvedAssemblyReference? Resolve(
-        AssemblyReferenceIdentity identity,
-        AssemblyResolutionScope scope)
+    public BrowserWorkspaceParticipant FindParticipant(
+        AssemblyContextParticipant participant)
     {
-        ArgumentNullException.ThrowIfNull(identity);
-        if (scope == AssemblyResolutionScope.Platform)
-            return null;
-
-        // At most one participant can match: RejectEquivalentIdentities refused the role
-        // otherwise, so this is the role's only image for that identity rather than the first one
-        // enumeration happened to reach.
-        return Participants
-            .FirstOrDefault(participant =>
-                participant.Assembly.Identity.IsEquivalentTo(identity))
-            ?.Assembly;
+        ArgumentNullException.ThrowIfNull(participant);
+        return Participants.FirstOrDefault(
+                candidate => ReferenceEquals(
+                    candidate.Participant,
+                    participant))
+            ?? throw new InvalidOperationException(
+                "The product participant is not part of this browser workspace role.");
     }
 
-    public void Dispose()
-    {
-        _group?.Dispose();
-        _group = null;
-    }
-
-    AssemblyContextGroup Group => _group
-        ?? throw new InvalidOperationException("The assembly context group is not open.");
+    AssemblyContextGroup Group => _group;
 }

--- a/prototypes/inspect-web/engine/BrowserInspectionScope.cs
+++ b/prototypes/inspect-web/engine/BrowserInspectionScope.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Versioning;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
@@ -236,8 +237,30 @@ internal sealed class BrowserInspectionScope : IDisposable
 
     public void Dispose()
     {
-        _roles.Dispose();
-        _workspace.Dispose();
+        Exception? roleFailure = null;
+        try
+        {
+            _roles.Dispose();
+        }
+        catch (Exception ex)
+        {
+            roleFailure = ex;
+        }
+
+        try
+        {
+            _workspace.Dispose();
+        }
+        catch (Exception workspaceFailure)
+            when (roleFailure is not null)
+        {
+            throw new AggregateException(
+                roleFailure,
+                workspaceFailure);
+        }
+
+        if (roleFailure is not null)
+            ExceptionDispatchInfo.Capture(roleFailure).Throw();
     }
 
     static BrowserRoleAssembly[] CreateRole(

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
@@ -194,6 +194,45 @@ public sealed class PackageAssemblyContextRolesTests
         Assert.Equal(0, GroupCount(workspace));
     }
 
+    [Fact]
+    public void Dispose_ContinuesAfterBothRoleGroupsFail()
+    {
+        ResolvedAssemblyReference surface = Assembly("Dispose", marker: 1);
+        ResolvedAssemblyReference implementation =
+            Assembly("Dispose", marker: 2);
+        using var workspace = new InspectionWorkspace();
+        PackageAssemblyContextRoles roles =
+            workspace.CreatePackageAssemblyContextRoles(
+                [surface],
+                [implementation],
+                [new(surface, implementation)]);
+        roles.SurfaceGroup.RegisterOwnedResource(
+            new ThrowingResource("surface disposal failed"));
+        roles.ImplementationGroup!.RegisterOwnedResource(
+            new ThrowingResource("implementation disposal failed"));
+
+        AggregateException failure =
+            Assert.Throws<AggregateException>(roles.Dispose);
+
+        IReadOnlyCollection<Exception> failures =
+            failure.Flatten().InnerExceptions;
+        Assert.Contains(
+            failures,
+            ex => ex.Message == "surface disposal failed");
+        Assert.Contains(
+            failures,
+            ex => ex.Message == "implementation disposal failed");
+        Assert.Equal(0, GroupCount(workspace));
+        Assert.Throws<ObjectDisposedException>(
+            () => roles.SurfaceGroup.UseAssemblyImage(
+                surface,
+                static image => image.Content.Length));
+        Assert.Throws<ObjectDisposedException>(
+            () => roles.ImplementationGroup.UseAssemblyImage(
+                implementation,
+                static image => image.Content.Length));
+    }
+
     static ResolvedAssemblyReference Assembly(
         string name,
         byte marker) =>
@@ -221,5 +260,11 @@ public sealed class PackageAssemblyContextRolesTests
                 "InspectionWorkspace._groups was not found.");
         return ((System.Collections.ICollection)field.GetValue(workspace)!)
             .Count;
+    }
+
+    sealed class ThrowingResource(string message) : IDisposable
+    {
+        public void Dispose() =>
+            throw new InvalidOperationException(message);
     }
 }

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
@@ -1,0 +1,225 @@
+using System.Reflection;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class PackageAssemblyContextRolesTests
+{
+    [Fact]
+    public void SeparateRoles_PreserveExactSurfaceImplementationCorrespondence()
+    {
+        ResolvedAssemblyReference surface = Assembly("Sample", marker: 1);
+        ResolvedAssemblyReference implementation =
+            Assembly("Sample", marker: 2);
+        ResolvedAssemblyReference implementationOnly =
+            Assembly("Sample.Helper", marker: 3);
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRoles roles =
+            workspace.CreatePackageAssemblyContextRoles(
+                [surface],
+                [implementation, implementationOnly],
+                [new(surface, implementation)]);
+
+        Assert.NotSame(roles.SurfaceGroup, roles.ImplementationGroup);
+        AssemblyContextParticipant surfaceParticipant =
+            Assert.Single(roles.SurfaceParticipants);
+        Assert.Same(
+            implementation,
+            roles.ImplementationParticipant(surfaceParticipant)?.Assembly);
+        Assert.Equal(2, roles.ImplementationParticipants.Length);
+        Assert.IsType<AssemblyBindingSelection.Missing>(
+            surfaceParticipant.BindingPolicy.Select(
+                new AssemblyBindingRequest(
+                    AssemblyBindingTarget.Reference(
+                        implementationOnly.Identity),
+                    AssemblyBindingOrigin.FromAssembly(surface),
+                    AssemblyResolutionScope.Any)));
+    }
+
+    [Fact]
+    public void SharedRole_ReusesGroupAndLeavesReferenceOnlySurfaceUnpaired()
+    {
+        ResolvedAssemblyReference library = Assembly("Library", marker: 1);
+        ResolvedAssemblyReference referenceOnly =
+            Assembly("Reference.Only", marker: 2);
+        ResolvedAssemblyReference[] assemblies = [library, referenceOnly];
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRoles roles =
+            workspace.CreatePackageAssemblyContextRoles(
+                assemblies,
+                assemblies,
+                [new(library, library)],
+                shareImplementationGroup: true);
+
+        Assert.True(roles.SharesGroup);
+        Assert.Same(roles.SurfaceGroup, roles.ImplementationGroup);
+        Assert.Same(
+            roles.SurfaceParticipants[0],
+            roles.ImplementationParticipant(
+                roles.SurfaceParticipants[0]));
+        Assert.Null(
+            roles.ImplementationParticipant(
+                roles.SurfaceParticipants[1]));
+    }
+
+    [Fact]
+    public void PackageRole_DoesNotSatisfyPlatformScopedReference()
+    {
+        ResolvedAssemblyReference assembly =
+            Assembly("System.Confusable", marker: 1);
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRoles roles =
+            workspace.CreatePackageAssemblyContextRoles(
+                [assembly],
+                [assembly],
+                [new(assembly, assembly)],
+                shareImplementationGroup: true);
+        IAssemblyBindingPolicy policy =
+            Assert.Single(roles.SurfaceParticipants).BindingPolicy;
+
+        AssemblyBindingSelection any = policy.Select(
+            new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(assembly.Identity),
+                AssemblyBindingOrigin.FromAssembly(assembly),
+                AssemblyResolutionScope.Any));
+        AssemblyBindingSelection platform = policy.Select(
+            new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(assembly.Identity),
+                AssemblyBindingOrigin.FromAssembly(assembly),
+                AssemblyResolutionScope.Platform));
+
+        Assert.Same(
+            assembly,
+            Assert.IsType<AssemblyBindingSelection.Selected>(any).Assembly);
+        Assert.IsType<AssemblyBindingSelection.Missing>(platform);
+        var intrinsic =
+            Assert.IsType<AssemblyBindingSelection.Unavailable>(
+                policy.Select(
+                    new AssemblyBindingRequest(
+                        AssemblyBindingTarget.CoreLibrary(),
+                        AssemblyBindingOrigin.FromAssembly(assembly),
+                        AssemblyResolutionScope.Platform)));
+        Assert.Equal(
+            AssemblyBindingFailureKind.UnsupportedScope,
+            intrinsic.Failure.Kind);
+    }
+
+    [Fact]
+    public void SharedRole_RequiresExactDescriptorsAndOneLimitPolicy()
+    {
+        ResolvedAssemblyReference surface = Assembly("Shared", marker: 1);
+        ResolvedAssemblyReference equivalent =
+            Assembly("Shared", marker: 2);
+        using var workspace = new InspectionWorkspace();
+
+        ArgumentException descriptors = Assert.Throws<ArgumentException>(
+            () => workspace.CreatePackageAssemblyContextRoles(
+                [surface],
+                [equivalent],
+                [new(surface, equivalent)],
+                shareImplementationGroup: true));
+        Assert.Contains(
+            "exact surface descriptor sequence",
+            descriptors.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(0, GroupCount(workspace));
+
+        ArgumentException limits = Assert.Throws<ArgumentException>(
+            () => workspace.CreatePackageAssemblyContextRoles(
+                [surface],
+                [surface],
+                [new(surface, surface)],
+                shareImplementationGroup: true,
+                surfaceOptions: new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = 1,
+                },
+                implementationOptions: new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = 2,
+                }));
+        Assert.Contains(
+            "one resource-limit policy",
+            limits.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    [Fact]
+    public void InvalidRoles_CreateNoPartialGroup()
+    {
+        ResolvedAssemblyReference surface = Assembly("Surface", marker: 1);
+        ResolvedAssemblyReference mismatched =
+            Assembly("Implementation", marker: 2);
+        using var workspace = new InspectionWorkspace();
+
+        InvalidOperationException mismatch =
+            Assert.Throws<InvalidOperationException>(
+                () => workspace.CreatePackageAssemblyContextRoles(
+                    [surface],
+                    [mismatched],
+                    [new(surface, mismatched)]));
+        Assert.Contains(
+            "different assembly identities",
+            mismatch.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(0, GroupCount(workspace));
+
+        ResolvedAssemblyReference collision =
+            Assembly("Surface", marker: 3);
+        InvalidOperationException duplicate =
+            Assert.Throws<InvalidOperationException>(
+                () => workspace.CreatePackageAssemblyContextRoles(
+                    [surface, collision],
+                    implementationAssemblies: null,
+                    correspondences: []));
+        Assert.Contains(
+            "same assembly identity",
+            duplicate.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(0, GroupCount(workspace));
+
+        ResolvedAssemblyReference implementation =
+            Assembly("Surface", marker: 4);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => workspace.CreatePackageAssemblyContextRoles(
+                [surface],
+                [implementation],
+                [new(surface, implementation)],
+                implementationOptions: new AssemblyContextGroupOptions
+                {
+                    MaxRetainedImageBytes = -1,
+                }));
+        Assert.Equal(0, GroupCount(workspace));
+    }
+
+    static ResolvedAssemblyReference Assembly(
+        string name,
+        byte marker) =>
+        ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                name,
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            path: null,
+            () => new MemoryStream([marker], writable: false),
+            AssemblyResolutionProvenance.Package(
+                "Role.Tests",
+                "1.0.0",
+                "net10.0",
+                rid: null));
+
+    static int GroupCount(InspectionWorkspace workspace)
+    {
+        FieldInfo field =
+            typeof(InspectionWorkspace).GetField(
+                "_groups",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "InspectionWorkspace._groups was not found.");
+        return ((System.Collections.ICollection)field.GetValue(workspace)!)
+            .Count;
+    }
+}

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -792,7 +792,7 @@ public sealed class AssemblyContextGroup : IDisposable
 /// <summary>
 /// Shared owner for one or more assembly context groups.
 /// </summary>
-public sealed class InspectionWorkspace : IDisposable
+public sealed partial class InspectionWorkspace : IDisposable
 {
     readonly object _gate = new();
     readonly List<AssemblyContextGroup> _groups = [];

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
@@ -40,6 +40,11 @@ public sealed record PackageAssemblyRoleCorrespondence
 /// surface role. Correspondences are validated before either group is created,
 /// and preserve typed participant identity across the two roles.
 /// </para>
+/// <para>
+/// Disposal attempts every distinct role group even when an earlier group's
+/// owned-resource cleanup fails. Gated by
+/// <c>PackageAssemblyContextRolesTests.Dispose_ContinuesAfterBothRoleGroupsFail</c>.
+/// </para>
 /// </remarks>
 public sealed class PackageAssemblyContextRoles : IDisposable
 {
@@ -119,11 +124,21 @@ public sealed class PackageAssemblyContextRoles : IDisposable
                     implementationParticipants[pair.Implementation]);
             }
         }
-        catch
+        catch (Exception creationFailure)
         {
-            if (!ReferenceEquals(implementationGroup, surfaceGroup))
-                implementationGroup?.Dispose();
-            surfaceGroup?.Dispose();
+            try
+            {
+                DisposeGroups(
+                    implementationGroup,
+                    surfaceGroup);
+            }
+            catch (Exception disposalFailure)
+            {
+                throw new AggregateException(
+                    creationFailure,
+                    disposalFailure);
+            }
+
             throw;
         }
     }
@@ -170,9 +185,38 @@ public sealed class PackageAssemblyContextRoles : IDisposable
         if (_disposed)
             return;
         _disposed = true;
-        if (!ReferenceEquals(ImplementationGroup, SurfaceGroup))
-            ImplementationGroup?.Dispose();
-        SurfaceGroup.Dispose();
+        DisposeGroups(ImplementationGroup, SurfaceGroup);
+    }
+
+    static void DisposeGroups(
+        AssemblyContextGroup? implementation,
+        AssemblyContextGroup? surface)
+    {
+        List<Exception>? failures = null;
+        if (implementation is not null
+            && !ReferenceEquals(implementation, surface))
+        {
+            TryDispose(implementation, ref failures);
+        }
+        if (surface is not null)
+            TryDispose(surface, ref failures);
+
+        if (failures is not null)
+            throw new AggregateException(failures);
+    }
+
+    static void TryDispose(
+        IDisposable resource,
+        ref List<Exception>? failures)
+    {
+        try
+        {
+            resource.Dispose();
+        }
+        catch (Exception ex)
+        {
+            (failures ??= []).Add(ex);
+        }
     }
 
     static ImmutableArray<ResolvedAssemblyReference> SnapshotRole(

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
@@ -1,0 +1,401 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One exact correspondence between a surface assembly and the implementation
+/// assembly that supplies its method bodies.
+/// </summary>
+public sealed record PackageAssemblyRoleCorrespondence
+{
+    public PackageAssemblyRoleCorrespondence(
+        ResolvedAssemblyReference surface,
+        ResolvedAssemblyReference implementation)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(implementation);
+        Surface = surface;
+        Implementation = implementation;
+    }
+
+    public ResolvedAssemblyReference Surface { get; }
+    public ResolvedAssemblyReference Implementation { get; }
+}
+
+/// <summary>
+/// Coordinated surface and implementation assembly-context roles in one
+/// inspection workspace.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each role is one immutable binding domain. In-role references resolve only
+/// to exact participants in that role, and package participants never satisfy
+/// platform-scoped requests. Equivalent identities are rejected rather than
+/// selected by declaration order.
+/// </para>
+/// <para>
+/// The implementation role may be absent, distinct, or the same group as the
+/// surface role. Correspondences are validated before either group is created,
+/// and preserve typed participant identity across the two roles.
+/// </para>
+/// </remarks>
+public sealed class PackageAssemblyContextRoles : IDisposable
+{
+    readonly Dictionary<
+        AssemblyContextParticipant,
+        AssemblyContextParticipant> _implementationBySurface =
+            new(ReferenceEqualityComparer.Instance);
+    bool _disposed;
+
+    internal PackageAssemblyContextRoles(
+        InspectionWorkspace workspace,
+        IEnumerable<ResolvedAssemblyReference> surfaceAssemblies,
+        IEnumerable<ResolvedAssemblyReference>? implementationAssemblies,
+        IEnumerable<PackageAssemblyRoleCorrespondence> correspondences,
+        bool shareImplementationGroup,
+        AssemblyContextGroupOptions? surfaceOptions,
+        AssemblyContextGroupOptions? implementationOptions)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(surfaceAssemblies);
+        ArgumentNullException.ThrowIfNull(correspondences);
+
+        ImmutableArray<ResolvedAssemblyReference> surfaces =
+            SnapshotRole(surfaceAssemblies, nameof(surfaceAssemblies));
+        ImmutableArray<ResolvedAssemblyReference> implementations =
+            implementationAssemblies is null
+                ? []
+                : SnapshotRole(
+                    implementationAssemblies,
+                    nameof(implementationAssemblies),
+                    allowEmpty: true);
+        ImmutableArray<PackageAssemblyRoleCorrespondence> pairs =
+            [.. correspondences];
+
+        ValidateRole(surfaces);
+        ValidateRole(implementations);
+        ValidateCorrespondences(surfaces, implementations, pairs);
+        ValidateSharedRole(
+            surfaces,
+            implementations,
+            shareImplementationGroup,
+            surfaceOptions,
+            implementationOptions);
+
+        AssemblyContextGroup? surfaceGroup = null;
+        AssemblyContextGroup? implementationGroup = null;
+        try
+        {
+            surfaceGroup = CreateRole(workspace, surfaces, surfaceOptions);
+            implementationGroup = implementations.Length == 0
+                ? null
+                : shareImplementationGroup
+                    ? surfaceGroup
+                    : CreateRole(
+                        workspace,
+                        implementations,
+                        implementationOptions);
+
+            SurfaceGroup = surfaceGroup;
+            ImplementationGroup = implementationGroup;
+            SurfaceParticipants = surfaceGroup.Participants;
+            ImplementationParticipants =
+                implementationGroup?.Participants ?? [];
+
+            Dictionary<
+                ResolvedAssemblyReference,
+                AssemblyContextParticipant> surfaceParticipants =
+                    ParticipantsByAssembly(SurfaceParticipants);
+            Dictionary<
+                ResolvedAssemblyReference,
+                AssemblyContextParticipant> implementationParticipants =
+                    ParticipantsByAssembly(ImplementationParticipants);
+            foreach (PackageAssemblyRoleCorrespondence pair in pairs)
+            {
+                _implementationBySurface.Add(
+                    surfaceParticipants[pair.Surface],
+                    implementationParticipants[pair.Implementation]);
+            }
+        }
+        catch
+        {
+            if (!ReferenceEquals(implementationGroup, surfaceGroup))
+                implementationGroup?.Dispose();
+            surfaceGroup?.Dispose();
+            throw;
+        }
+    }
+
+    public AssemblyContextGroup SurfaceGroup { get; }
+
+    public AssemblyContextGroup? ImplementationGroup { get; }
+
+    public ImmutableArray<AssemblyContextParticipant> SurfaceParticipants
+    {
+        get;
+    }
+
+    public ImmutableArray<AssemblyContextParticipant> ImplementationParticipants
+    {
+        get;
+    }
+
+    public bool SharesGroup =>
+        ImplementationGroup is not null
+        && ReferenceEquals(SurfaceGroup, ImplementationGroup);
+
+    /// <summary>
+    /// Returns the implementation participant paired with an exact surface
+    /// participant, or <see langword="null"/> for a reference-only surface.
+    /// </summary>
+    public AssemblyContextParticipant? ImplementationParticipant(
+        AssemblyContextParticipant surface)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (!SurfaceParticipants.Contains(surface))
+        {
+            throw new ArgumentException(
+                "The participant does not belong to the surface assembly-context role.",
+                nameof(surface));
+        }
+
+        return _implementationBySurface.GetValueOrDefault(surface);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        if (!ReferenceEquals(ImplementationGroup, SurfaceGroup))
+            ImplementationGroup?.Dispose();
+        SurfaceGroup.Dispose();
+    }
+
+    static ImmutableArray<ResolvedAssemblyReference> SnapshotRole(
+        IEnumerable<ResolvedAssemblyReference> assemblies,
+        string parameterName,
+        bool allowEmpty = false)
+    {
+        ImmutableArray<ResolvedAssemblyReference> snapshot = [.. assemblies];
+        if (!allowEmpty && snapshot.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                "An assembly-context surface role requires at least one participant.");
+        }
+        if (snapshot.Any(static assembly => assembly is null))
+            throw new ArgumentException(
+                "An assembly-context role cannot contain a null assembly.",
+                parameterName);
+        return snapshot;
+    }
+
+    static void ValidateRole(
+        ImmutableArray<ResolvedAssemblyReference> assemblies)
+    {
+        var identities = new HashSet<AssemblyReferenceIdentity>(
+            AssemblyReferenceIdentity.EquivalentComparer);
+        foreach (ResolvedAssemblyReference assembly in assemblies)
+        {
+            if (identities.Add(assembly.Identity))
+                continue;
+
+            throw new InvalidOperationException(
+                "The selected artifacts contribute more than one assembly with the same "
+                + "assembly identity to one workspace role, so a reference to it could not "
+                + "bind to a single image.");
+        }
+    }
+
+    static void ValidateCorrespondences(
+        ImmutableArray<ResolvedAssemblyReference> surfaces,
+        ImmutableArray<ResolvedAssemblyReference> implementations,
+        ImmutableArray<PackageAssemblyRoleCorrespondence> pairs)
+    {
+        var surfaceSet = new HashSet<ResolvedAssemblyReference>(
+            surfaces,
+            ReferenceEqualityComparer.Instance);
+        var implementationSet = new HashSet<ResolvedAssemblyReference>(
+            implementations,
+            ReferenceEqualityComparer.Instance);
+        var pairedSurfaces = new HashSet<ResolvedAssemblyReference>(
+            ReferenceEqualityComparer.Instance);
+
+        foreach (PackageAssemblyRoleCorrespondence pair in pairs)
+        {
+            ArgumentNullException.ThrowIfNull(pair);
+            if (!surfaceSet.Contains(pair.Surface))
+            {
+                throw new ArgumentException(
+                    "A correspondence surface must belong to the surface role.",
+                    nameof(pairs));
+            }
+            if (!implementationSet.Contains(pair.Implementation))
+            {
+                throw new ArgumentException(
+                    "A correspondence implementation must belong to the implementation role.",
+                    nameof(pairs));
+            }
+            if (!pairedSurfaces.Add(pair.Surface))
+            {
+                throw new ArgumentException(
+                    "A surface assembly may have only one implementation correspondence.",
+                    nameof(pairs));
+            }
+            if (!pair.Surface.Identity.IsEquivalentTo(
+                    pair.Implementation.Identity))
+            {
+                throw new InvalidOperationException(
+                    "The selected surface and implementation assemblies have different assembly "
+                    + "identities.");
+            }
+        }
+    }
+
+    static AssemblyContextGroup CreateRole(
+        InspectionWorkspace workspace,
+        ImmutableArray<ResolvedAssemblyReference> assemblies,
+        AssemblyContextGroupOptions? options)
+    {
+        var policy = new RoleBindingPolicy(assemblies);
+        return workspace.CreateAssemblyContextGroup(
+            assemblies.Select(
+                assembly => new AssemblyContextParticipant(
+                    assembly,
+                    policy)),
+            options);
+    }
+
+    static void ValidateSharedRole(
+        ImmutableArray<ResolvedAssemblyReference> surfaces,
+        ImmutableArray<ResolvedAssemblyReference> implementations,
+        bool shareImplementationGroup,
+        AssemblyContextGroupOptions? surfaceOptions,
+        AssemblyContextGroupOptions? implementationOptions)
+    {
+        if (!shareImplementationGroup)
+            return;
+        if (implementations.IsEmpty
+            || surfaces.Length != implementations.Length
+            || !surfaces.Zip(implementations).All(
+                pair => ReferenceEquals(pair.First, pair.Second)))
+        {
+            throw new ArgumentException(
+                "A shared implementation role must use the exact surface descriptor sequence.",
+                nameof(implementations));
+        }
+
+        AssemblyContextGroupOptions effectiveSurface =
+            surfaceOptions ?? new AssemblyContextGroupOptions();
+        AssemblyContextGroupOptions effectiveImplementation =
+            implementationOptions ?? new AssemblyContextGroupOptions();
+        if (effectiveSurface != effectiveImplementation)
+        {
+            throw new ArgumentException(
+                "A shared surface and implementation group must use one resource-limit policy.",
+                nameof(implementationOptions));
+        }
+    }
+
+    static Dictionary<
+        ResolvedAssemblyReference,
+        AssemblyContextParticipant> ParticipantsByAssembly(
+            ImmutableArray<AssemblyContextParticipant> participants)
+    {
+        var result = new Dictionary<
+            ResolvedAssemblyReference,
+            AssemblyContextParticipant>(ReferenceEqualityComparer.Instance);
+        foreach (AssemblyContextParticipant participant in participants)
+            result.Add(participant.Assembly, participant);
+        return result;
+    }
+
+    sealed class RoleBindingPolicy(
+        ImmutableArray<ResolvedAssemblyReference> assemblies)
+        : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelection Select(
+            AssemblyBindingRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            if (request.Target
+                is AssemblyBindingTarget.IntrinsicCoreLibrary)
+            {
+                return AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.UnsupportedScope));
+            }
+            if (request.Target
+                    is not AssemblyBindingTarget.AssemblyReference reference)
+            {
+                return AssemblyBindingSelection.Invalid(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.InvalidPolicyResult));
+            }
+            if (request.Scope == AssemblyResolutionScope.Platform)
+                return AssemblyBindingSelection.NotFound();
+
+            ImmutableArray<ResolvedAssemblyReference> matches =
+            [
+                .. assemblies.Where(
+                    assembly => assembly.Identity.IsEquivalentTo(
+                        reference.Identity)),
+            ];
+            return matches.Length switch
+            {
+                0 => AssemblyBindingSelection.NotFound(),
+                1 => AssemblyBindingSelection.Found(matches[0]),
+                _ => AssemblyBindingSelection.Multiple(matches),
+            };
+        }
+    }
+}
+
+public sealed partial class InspectionWorkspace
+{
+    /// <summary>
+    /// Creates coordinated package surface and implementation roles from
+    /// exact, already-acquired assembly descriptors.
+    /// </summary>
+    /// <param name="surfaceAssemblies">
+    /// The reference-preferred assembly surface.
+    /// </param>
+    /// <param name="implementationAssemblies">
+    /// The body-bearing implementation universe, or <see langword="null"/> when
+    /// no implementation role exists.
+    /// </param>
+    /// <param name="correspondences">
+    /// Exact surface-to-implementation pairs. Surface assemblies omitted from
+    /// this list are reference-only.
+    /// </param>
+    /// <param name="shareImplementationGroup">
+    /// Whether the implementation role is the exact surface role and should
+    /// reuse its group. Sharing requires the same descriptor sequence and
+    /// equivalent group options.
+    /// </param>
+    /// <remarks>
+    /// Package roles refuse platform-scoped binding requests and intrinsic
+    /// core-library selection. Platform-containing contexts use
+    /// <see cref="WorkspaceContextLoader"/> instead.
+    /// </remarks>
+    public PackageAssemblyContextRoles CreatePackageAssemblyContextRoles(
+        IEnumerable<ResolvedAssemblyReference> surfaceAssemblies,
+        IEnumerable<ResolvedAssemblyReference>? implementationAssemblies,
+        IEnumerable<PackageAssemblyRoleCorrespondence> correspondences,
+        bool shareImplementationGroup = false,
+        AssemblyContextGroupOptions? surfaceOptions = null,
+        AssemblyContextGroupOptions? implementationOptions = null) =>
+        new(
+            this,
+            surfaceAssemblies,
+            implementationAssemblies,
+            correspondences,
+            shareImplementationGroup,
+            surfaceOptions,
+            implementationOptions);
+}


### PR DESCRIPTION
## Summary

- move package surface/implementation role construction into product-owned
  `InspectionWorkspace.CreatePackageAssemblyContextRoles`
- keep Browser/Wasm acquisition, deadlines, archive/cache budgets, LRU policy,
  selected package/asset provenance, and malformed-entry carriers in the host
- preserve reference-only surfaces, explicit shared-role reuse, separate
  reference/body groups, exact participant correspondence, and package
  exclusion from platform-scoped binding
- ban direct group construction and legacy reference-resolver policy use from
  the Browser engine so the ownership boundary cannot drift back

## Demo

A real dual-role package and the existing three-package home demo both run
through the product role owner:

```text
System.IO.FileSystem 4.3.0 / net46
  ref/net46/System.IO.FileSystem.dll -> surface role
  lib/net46/System.IO.FileSystem.dll -> implementation role

dual=System.IO.FileSystem assemblies=1 error=Null
aggregate-found=True packages=3
```

The first result proves a reference-preferred surface remains paired with its
body-bearing implementation. The aggregate result is the product-owned
`extensions-callgraph` demo over
`Microsoft.Extensions.DependencyInjection.Abstractions`,
`Microsoft.Extensions.Logging`, and `Microsoft.Extensions.Http`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  (512 passed)
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`
  (117 passed)
- `npx markdownlint-cli prototypes/inspect-web/README.md docs/design/workspace-definitions.md`
- real Browser engine canary against `System.IO.FileSystem` 4.3.0 and the
  three-package `extensions-callgraph` demo

## Non-action boundary

This does not move Browser transport, cancellation, cache/LRU, archive
retention, preflight limits, or UI state into product code. It also does not
replace definition acquisition with `WorkspaceContextLoader`: Browser supplies
exact already-acquired package descriptors to the package-role owner, while
Platform continues to use the existing product loader.
