### PR TITLE
Centralize inspect-web keybinding arbitration

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -719,21 +719,40 @@ that intercepts same-origin in-app anchor clicks
 browser behavior. `dotnet-inspect.ts` remains the sole mutable
 application-state owner: it supplies typed snapshots and explicit transition
 callbacks, calls the one link-navigation binder instead of adding its own
-click listener, and declares its Escape-owning modal layers (Metadata
-Explorer, Settings, graph source, doc viewer, Spotlight) as one explicit
-ordered `KeydownLayer` list rather than an ad hoc if/else chain, so adding a
-new dismissable layer means adding one entry instead of re-deriving its
-priority. `dotnet-inspect.ts` retains asynchronous workspace restoration and
-its remaining DOM event binding. Alt+←/→ and Shift+←/→ drive `navBack()`/
-`navForward()` unless an element-scoped handler (the type list, the graph
-viewport) already claimed the same combo and called `preventDefault()` first;
-Shift+←/→ are further gated on the shared `typing` check so they never steal
-native text-selection inside an input or filter field — Shift+↑/↓ stay
-unclaimed. `test/workspace-navigation.test.ts` gates
+click listener, and registers application-level gestures and context
+predicates with the shared keybinding dispatcher.
+
+`src/keybinding-registry.ts` is a dependency-free general component with no
+inspect-web imports. A registration declares keys, exact modifiers by default,
+priority, an optional event-path scope and context predicate, and a handler
+whose Boolean result distinguishes "matched" from "handled". The registry
+orders active matches by priority and nearest event-path scope, stops at the
+first handled result, and centrally applies `preventDefault()`. A false result
+falls through to the next candidate. Equal-precedence matches produce a
+structured conflict callback while retaining deterministic registration order.
+Event-scoped registrations live in a `WeakMap`; registration also returns an
+explicit disposer.
+
+`src/workbench-keybindings.ts` is the inspect-web adapter: it defines the
+workspace, element, and modal priority policy and reports conflicts. Local
+owners including Spotlight, type/member filters, package tabs, and graph
+interactions register their gestures against the rendered element. The
+composition root registers workspace and modal gestures, then attaches the
+registry's only raw `keydown` listener to `document`. Alt+←/→ and Shift+←/→
+drive `navBack()`/`navForward()`; element-scoped gestures arbitrate in the same
+dispatcher instead of relying on bubbling order or `defaultPrevented`
+cooperation. Shift+←/→ remain gated by the shared typing check so they never
+steal native text selection inside an input or filter field; Shift+↑/↓ stay
+unclaimed globally.
+
+`test/keybinding-registry.test.ts` gates precedence, scoped arbitration,
+handled fallthrough, exact modifiers, conflict reporting, disposal, and the
+original stack-navigation collision. `test/spotlight-identity.test.js` gates
+the single-listener wiring and the complete workbench priority order.
+`test/workspace-navigation.test.ts` gates
 history traversal, stale-entry removal, navigation cancellation, rich and
 legacy URL compatibility, visible invalid-state failures, sandboxed history
-errors, and the link-interception rule;
-`test/spotlight-identity.test.js` gates the composition-root wiring.
+errors, and the link-interception rule.
 
 `src/package-acquisition.ts` owns NuGet and runtime-pack engine invocation,
 surface-to-workspace-model projection, serialized runtime-pack loading, and
@@ -930,8 +949,9 @@ image rather than the API surface within it, so they share one module the way
 `metadata-inspection.ts` coordinates type metadata and the explorer's
 table-window and heap-listing requests. `dotnet-inspect.ts` still owns `state`,
 the explorer's focus/history stack, lazy `IntersectionObserver` hydration,
-resize coordination, and the global keydown handler, supplying those effects
-through typed callbacks; the shared helpers used well beyond these views
+resize coordination, and global gesture effects, supplying those effects
+through typed callbacks and registry declarations; the shared helpers used
+well beyond these views
 (`escapeHtml`, `fmtBytes`,
 `platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`) stay
 in `dotnet-inspect.ts` and are injected the same way.

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -82,6 +82,10 @@ import {
   type WorkspaceView,
 } from "./workspace-navigation.ts";
 import {
+  createWorkbenchKeybindings,
+  WORKBENCH_KEYBINDING_PRIORITY,
+} from "./workbench-keybindings.ts";
+import {
   createNuGetPackageModel,
   createPackageAcquisition,
   runtimeAssemblyIsResident,
@@ -728,6 +732,7 @@ interface StateOverrides {
 type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides;
 
 const state: AppState = initialState;
+const keybindings = createWorkbenchKeybindings();
 const sourceInspection = createSourceInspectionCoordinator({
   state,
   queryMemberSource: request => inspectMemberSource(
@@ -1271,6 +1276,7 @@ const catalogRequests = createCatalogRequests({
   updatePackageVersionSelect: updateVersionSelect,
 });
 const spotlight = createSpotlight({
+  keybindings,
   state,
   lenses: () => typeLensesFor(state.package),
   escapeHtml,
@@ -1308,11 +1314,6 @@ function isInteractiveElement(element: Element | null) {
     + "[role=button], [role=link], [role=checkbox]"));
 }
 
-function isContainedBrowserShortcut(event: KeyboardEvent) {
-  return (event.metaKey || event.ctrlKey)
-    && ["f", "k", "p"].includes(event.key.toLowerCase());
-}
-
 function focusTypeList(generation = spotlightFocusGeneration) {
   if (generation !== spotlightFocusGeneration
       || state.spotlightOpen || state.graphSourceOpen || state.docViewerOpen
@@ -1337,6 +1338,7 @@ function closeSpotlight() {
 }
 
 const packageBar = createPackageBar({
+  keybindings,
   state,
   escapeHtml,
   packageIdentityKey,
@@ -4353,8 +4355,7 @@ function bindTypePanelEvents() {
     },
     onMemberFilterKeyDown: (event, value) => {
       if (event.key === "Escape") {
-        if (navMode() !== "member" && value === "") return;
-        event.preventDefault();
+        if (navMode() !== "member" && value === "") return false;
         if (navMode() === "member") {
           exitMemberScope();
         } else {
@@ -4362,11 +4363,11 @@ function bindTypePanelEvents() {
           normalizeMemberSelection();
           renderMemberFilterAndRestoreFocus("#member-filter");
         }
-        return;
+        return true;
       }
-      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-      event.preventDefault();
+      if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return false;
       stepMemberNav(event.key === "ArrowDown" ? 1 : -1, true);
+      return true;
     },
     onMemberGroupOpen: memberKey => {
       enterMemberNavigation(() => openMemberGroup(memberKey));
@@ -4428,7 +4429,7 @@ function bindTypePanelEvents() {
         .findIndex(item => item.id === state.selectedTypeId);
       render();
     },
-  });
+  }, keybindings);
 }
 
 function bindScopeBarEvents() {
@@ -4658,47 +4659,45 @@ function setTheme(theme: "light" | "dark", renderView = true) {
   }
 }
 
-function handleTypeKeys(event: KeyboardEvent) {
+function handleTypeKeys(event: KeyboardEvent): boolean {
   if (navMode() === "member") {
     if (event.key === "ArrowDown" || event.key === "j") {
-      event.preventDefault();
       stepMemberNav(1, true);
+      return true;
     } else if (event.key === "ArrowUp" || event.key === "k") {
-      event.preventDefault();
       stepMemberNav(-1, true);
+      return true;
     } else if (event.key === "ArrowLeft" && !event.altKey && !event.shiftKey) {
       // Alt/Shift+ArrowLeft is the global back gesture (see the document keydown
       // handler); leave it unclaimed here so it isn't swallowed as in-page stepping.
-      event.preventDefault();
       stepHorizontal(-1);
+      return true;
     } else if (event.key === "ArrowRight" && !event.altKey && !event.shiftKey) {
-      event.preventDefault();
       stepHorizontal(1);
+      return true;
     }
-    return;
+    return false;
   }
   const items = filteredTypes();
-  if (!items.length) return;
+  if (!items.length) return false;
   let cursor = items.findIndex(item => item.id === state.selectedTypeId);
   if (cursor < 0) cursor = Math.min(state.typeCursor, items.length - 1);
   if (event.key === "ArrowDown" || event.key === "j") {
-    event.preventDefault();
     cursor = Math.min(items.length - 1, cursor + 1);
   } else if (event.key === "ArrowUp" || event.key === "k") {
-    event.preventDefault();
     cursor = Math.max(0, cursor - 1);
   } else if (event.key === "Home") {
     cursor = 0;
   } else if (event.key === "End") {
     cursor = items.length - 1;
   } else if (event.key === "/") {
-    event.preventDefault();
     focusFilter();
-    return;
+    return true;
   } else {
-    return;
+    return false;
   }
   selectTypeByCursor(cursor, items, true);
+  return true;
 }
 
 function selectTypeByCursor(
@@ -6590,7 +6589,7 @@ async function renderTypeGraph() {
       container.querySelector<HTMLElement>(".graph-viewport");
     if (!viewport) return;
     viewport.innerHTML = svg;
-    bindGraphPanZoom(container, viewport);
+    bindGraphPanZoom(container, viewport, { keybindings });
     bindTypeGraphNodes(viewport, nodeId => {
       const graphNode = nodeId ? graphNodeOf.get(nodeId) : null;
       if (!graphNode) return null;
@@ -6735,7 +6734,7 @@ async function renderDependencyGraph() {
     if (!viewport) return;
     viewport.innerHTML = svg;
     container.dataset.graphDef = signature;
-    bindGraphPanZoom(container, viewport);
+    bindGraphPanZoom(container, viewport, { keybindings });
     bindDependencyGraphNodes(viewport, nodeId => {
       const info = nodeId ? built.nodeInfoById.get(nodeId) : null;
       if (!info || info.kind === "self") return null;
@@ -6959,6 +6958,7 @@ async function renderMermaidCallGraph() {
       viewport.innerHTML = svg;
       container.dataset.graphDef = active.mermaid;
       bindGraphPanZoom(container, viewport, {
+        keybindings,
         resolveCallGraphNode: nodeId =>
           callGraphNodeBinding(active, nodeId),
       });
@@ -8619,189 +8619,395 @@ bindWorkspaceLinkNavigation(document, {
   navigate: navigateInAppUrl,
 });
 
-// A modal-style view that owns the keydown event outright while it is open (Escape
-// dismisses it, plus whatever other keys are its own). Declaring these as one ordered
-// list — instead of a chain of `if (state.x) { ...; return; }` blocks — makes this the
-// single, explicit place that decides which layer Escape (and everything else) belongs
-// to; adding a new dismissable layer means adding one entry here, not re-deriving the
-// right spot in a growing if/else chain.
-interface KeydownLayer {
-  active(): boolean;
-  handle(event: KeyboardEvent): void;
+const containedShortcutKeys = ["f", "k", "p"] as const;
+const alphabetKeys = "abcdefghijklmnopqrstuvwxyz".split("");
+
+function registerContainedShortcuts(
+  id: string,
+  priority: number,
+  when: () => boolean,
+): void {
+  keybindings.register({
+    id,
+    key: containedShortcutKeys,
+    modifiers: { commandOrControl: true },
+    allowExtraModifiers: true,
+    priority,
+    when,
+    run: () => true,
+  });
 }
 
-// The Metadata Explorer is a full-screen modal-style view. Escape zooms the focus lightbox
-// out to the all-tables wall, then (from the wall) exits to the Metadata page. Backspace walks
-// the ref->def history (Shift+Backspace forward). Settings is a modal-style page reachable
-// from home too, so it takes priority over the home bail below (which otherwise swallows the
-// keystroke on the home page).
-const homeIndependentKeydownLayers: readonly KeydownLayer[] = [
-  {
-    active: () => Boolean(state.explorer?.open),
-    handle(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        if (!state.explorer!.overview) explorerShowOverview();
-        else closeExplorer();
-      } else if (event.key === "Backspace") {
-        event.preventDefault();
-        if (event.shiftKey) explorerHistoryForward();
-        else explorerHistoryBack();
-      } else if (isContainedBrowserShortcut(event)) {
-        event.preventDefault();
-      }
-    },
-  },
-  {
-    active: () => state.settings,
-    handle(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeSettings();
-      } else if (isContainedBrowserShortcut(event)) {
-        event.preventDefault();
-      }
-    },
-  },
-];
+function workspaceKeyboardContextIsActive(): boolean {
+  return !state.explorer?.open
+    && !state.settings
+    && !state.home
+    && !state.loading
+    && !state.error
+    && !state.graphSourceOpen
+    && !state.docViewerOpen
+    && !state.spotlightOpen;
+}
 
-// These modal-style layers only apply once a package workspace is loaded (the home and
-// loading/error bails below run first), but are otherwise the same kind of Escape-owning
-// layer as above.
-const workspaceKeydownLayers: readonly KeydownLayer[] = [
-  {
-    active: () => state.graphSourceOpen,
-    handle(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeGraphSource();
-      } else if (isContainedBrowserShortcut(event)) {
-        event.preventDefault();
-      }
-    },
-  },
-  {
-    active: () => state.docViewerOpen,
-    handle(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeDocViewer();
-      } else if (isContainedBrowserShortcut(event)) {
-        event.preventDefault();
-      }
-    },
-  },
-  {
-    active: () => state.spotlightOpen,
-    handle(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        closeSpotlight();
-      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-        event.preventDefault();
-        openSpotlight("", "commands");
-      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "p") {
-        event.preventDefault();
-        openSpotlight();
-      } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-        event.preventDefault();
-      }
-    },
-  },
-];
+const workspaceModalContextIsAvailable = () =>
+  !state.home && !state.loading && !state.error;
+const graphSourceContextIsActive = () =>
+  workspaceModalContextIsAvailable() && state.graphSourceOpen;
+const documentViewerContextIsActive = () =>
+  workspaceModalContextIsAvailable() && state.docViewerOpen;
+const spotlightContextIsActive = () =>
+  workspaceModalContextIsAvailable() && state.spotlightOpen;
 
-document.addEventListener("keydown", event => {
-  for (const layer of homeIndependentKeydownLayers) {
-    if (layer.active()) {
-      layer.handle(event);
-      return;
-    }
-  }
-  const typing = isTextEntry();
-  // The home page has its own scoped input handling (search box); global workbench
-  // shortcuts assume a loaded package, so stay out of the way here.
-  if (state.home) return;
-  if (state.loading || state.error) {
-    if (isContainedBrowserShortcut(event) || event.key === "/") {
-      event.preventDefault();
-    }
-    return;
-  }
-  for (const layer of workspaceKeydownLayers) {
-    if (layer.active()) {
-      layer.handle(event);
-      return;
-    }
-  }
-  if (event.key === "Escape" && !event.defaultPrevented && state.tasteOpen) {
-    event.preventDefault();
+keybindings.register({
+  id: "metadata-explorer.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.metadataExplorer,
+  when: () => Boolean(state.explorer?.open),
+  run: () => {
+    if (!state.explorer!.overview) explorerShowOverview();
+    else closeExplorer();
+    return true;
+  },
+});
+keybindings.register({
+  id: "metadata-explorer.history",
+  key: "Backspace",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.metadataExplorer,
+  when: () => Boolean(state.explorer?.open),
+  run: event => {
+    if (event.shiftKey) explorerHistoryForward();
+    else explorerHistoryBack();
+    return true;
+  },
+});
+registerContainedShortcuts(
+  "metadata-explorer.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.metadataExplorer,
+  () => Boolean(state.explorer?.open),
+);
+
+keybindings.register({
+  id: "settings.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.settings,
+  when: () => state.settings,
+  run: () => {
+    closeSettings();
+    return true;
+  },
+});
+registerContainedShortcuts(
+  "settings.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.settings,
+  () => state.settings,
+);
+
+const unavailableWorkspaceContext = () =>
+  !state.home && (state.loading || Boolean(state.error));
+registerContainedShortcuts(
+  "unavailable-workspace.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.unavailableWorkspace,
+  unavailableWorkspaceContext,
+);
+keybindings.register({
+  id: "unavailable-workspace.contain-filter-shortcut",
+  key: "/",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.unavailableWorkspace,
+  when: unavailableWorkspaceContext,
+  run: () => true,
+});
+
+keybindings.register({
+  id: "graph-source.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.graphSource,
+  when: graphSourceContextIsActive,
+  run: () => {
+    closeGraphSource();
+    return true;
+  },
+});
+registerContainedShortcuts(
+  "graph-source.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.graphSource,
+  graphSourceContextIsActive,
+);
+
+keybindings.register({
+  id: "document-viewer.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.documentViewer,
+  when: documentViewerContextIsActive,
+  run: () => {
+    closeDocViewer();
+    return true;
+  },
+});
+registerContainedShortcuts(
+  "document-viewer.contain-browser-shortcut",
+  WORKBENCH_KEYBINDING_PRIORITY.documentViewer,
+  documentViewerContextIsActive,
+);
+
+keybindings.register({
+  id: "spotlight.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.spotlight,
+  when: spotlightContextIsActive,
+  run: () => {
+    closeSpotlight();
+    return true;
+  },
+});
+keybindings.register({
+  id: "spotlight.open-commands",
+  key: "k",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.spotlight,
+  when: spotlightContextIsActive,
+  run: () => {
+    openSpotlight("", "commands");
+    return true;
+  },
+});
+keybindings.register({
+  id: "spotlight.open-all",
+  key: "p",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.spotlight,
+  when: spotlightContextIsActive,
+  run: () => {
+    openSpotlight();
+    return true;
+  },
+});
+keybindings.register({
+  id: "spotlight.contain-browser-find",
+  key: "f",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.spotlight,
+  when: spotlightContextIsActive,
+  run: () => true,
+});
+
+keybindings.register({
+  id: "taste.dismiss",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.popover,
+  when: () => workspaceKeyboardContextIsActive() && state.tasteOpen,
+  run: () => {
     state.tasteOpen = false;
     render();
-  } else if (event.key === "Escape" && !event.defaultPrevented && !typing
-      && (navMode() === "member" || !state.atPackageRoot)) {
-    event.preventDefault();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.drill-out-escape",
+  key: "Escape",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: () => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && (navMode() === "member" || !state.atPackageRoot),
+  run: () => {
     if (navMode() === "member") exitMemberScope();
     else drillOut();
-  } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
-    event.preventDefault();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.open-commands",
+  key: "k",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: workspaceKeyboardContextIsActive,
+  run: () => {
     openSpotlight("", "commands");
-  } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "p") {
-    event.preventDefault();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.open-all",
+  key: "p",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: workspaceKeyboardContextIsActive,
+  run: () => {
     openSpotlight();
-  } else if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
-    event.preventDefault();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.focus-filter",
+  key: "f",
+  modifiers: { commandOrControl: true },
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: workspaceKeyboardContextIsActive,
+  run: () => {
     focusFilter();
-  } else if (!event.defaultPrevented && !event.metaKey && !event.ctrlKey && event.key === "ArrowLeft"
-      && (event.altKey || (event.shiftKey && !typing))) {
-    // Alt+←/→ always drives back/forward. Shift+←/→ is the same gesture, gated on
-    // `!typing` so it doesn't steal native text-selection (Shift+Arrow) inside inputs.
-    // `!event.defaultPrevented` defers to any element-scoped handler (e.g. the type
-    // list's in-page stepHorizontal, the graph viewport's pan) that already claimed
-    // this key. Shift+↑/↓ stays unclaimed for now.
-    event.preventDefault();
-    navBack();
-  } else if (!event.defaultPrevented && !event.metaKey && !event.ctrlKey && event.key === "ArrowRight"
-      && (event.altKey || (event.shiftKey && !typing))) {
-    event.preventDefault();
-    navForward();
-  } else if (!typing && !event.metaKey && !event.ctrlKey && /^[1-9]$/.test(event.key)) {
+    return true;
+  },
+});
+
+for (const [key, action] of [
+  ["ArrowLeft", navBack],
+  ["ArrowRight", navForward],
+] as const) {
+  keybindings.register({
+    id: `workspace.history-alt-${key}`,
+    key,
+    modifiers: { alt: true },
+    allowExtraModifiers: true,
+    priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+    when: event => workspaceKeyboardContextIsActive()
+      && !event.metaKey
+      && !event.ctrlKey,
+    run: () => {
+      action();
+      return true;
+    },
+  });
+  keybindings.register({
+    id: `workspace.history-shift-${key}`,
+    key,
+    modifiers: { shift: true },
+    priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+    when: () => workspaceKeyboardContextIsActive() && !isTextEntry(),
+    run: () => {
+      action();
+      return true;
+    },
+  });
+}
+
+keybindings.register({
+  id: "workspace.select-lens",
+  key: ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+  allowExtraModifiers: true,
+  preventDefault: false,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: event => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && !event.metaKey
+    && !event.ctrlKey,
+  run: event => {
     const set = activeLenses();
     const index = Number(event.key) - 1;
     if (index < set.length) {
       const sc = scope();
-      if (sc === "package") { state.packageLens = set[index][0]; render(); }
-      else if (sc === "member" && isMemberSection(set[index][0]))
+      if (sc === "package") {
+        state.packageLens = set[index][0];
+        render();
+      } else if (sc === "member" && isMemberSection(set[index][0])) {
         applyMemberSection(set[index][0]);
-      else { state.lens = set[index][0]; render(); }
+      } else {
+        state.lens = set[index][0];
+        render();
+      }
     }
-  } else if (!typing && !event.defaultPrevented && !event.metaKey && !event.ctrlKey && !event.altKey
-      && (event.key === "ArrowUp" || event.key === "ArrowDown")) {
-    event.preventDefault();
-    stepNav(event.key === "ArrowDown" ? 1 : -1);
-  } else if (!typing && !event.defaultPrevented && !event.metaKey && !event.ctrlKey && !event.altKey
-      && (event.key === "ArrowLeft" || event.key === "ArrowRight")) {
-    event.preventDefault();
-    stepHorizontal(event.key === "ArrowRight" ? 1 : -1);
-  } else if (!typing && !event.defaultPrevented && !event.metaKey && !event.ctrlKey && !event.altKey
-      && !state.spotlightOpen
-      && !isInteractiveElement(
-        event.target instanceof Element ? event.target : null)
-      && event.key === "Enter") {
-    event.preventDefault();
-    drillIn();
-  } else if (!typing && !event.defaultPrevented && !event.metaKey && !event.ctrlKey && !event.altKey
-      && event.key === "Backspace" && (navMode() === "member" || !state.atPackageRoot)) {
-    event.preventDefault();
-    drillOut();
-  } else if (!typing && event.key === "/") {
-    event.preventDefault();
-    focusFilter();
-  } else if (!typing && !state.spotlightOpen && !event.metaKey && !event.ctrlKey && !event.altKey
-      && !event.defaultPrevented && event.key.length === 1 && /[a-zA-Z]/.test(event.key)) {
-    event.preventDefault();
-    openSpotlight(event.key);
-  }
+    return true;
+  },
 });
+keybindings.register({
+  id: "workspace.navigate-vertical",
+  key: ["ArrowUp", "ArrowDown"],
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: event => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && !event.metaKey
+    && !event.ctrlKey
+    && !event.altKey,
+  run: event => {
+    stepNav(event.key === "ArrowDown" ? 1 : -1);
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.navigate-horizontal",
+  key: ["ArrowLeft", "ArrowRight"],
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: () => workspaceKeyboardContextIsActive() && !isTextEntry(),
+  run: event => {
+    stepHorizontal(event.key === "ArrowRight" ? 1 : -1);
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.drill-in",
+  key: "Enter",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: event => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && !event.metaKey
+    && !event.ctrlKey
+    && !event.altKey
+    && !isInteractiveElement(
+      event.target instanceof Element ? event.target : null),
+  run: () => {
+    drillIn();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.drill-out-backspace",
+  key: "Backspace",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: event => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && !event.metaKey
+    && !event.ctrlKey
+    && !event.altKey
+    && (navMode() === "member" || !state.atPackageRoot),
+  run: () => {
+    drillOut();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.focus-filter-slash",
+  key: "/",
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: () => workspaceKeyboardContextIsActive() && !isTextEntry(),
+  run: () => {
+    focusFilter();
+    return true;
+  },
+});
+keybindings.register({
+  id: "workspace.seed-spotlight",
+  key: alphabetKeys,
+  allowExtraModifiers: true,
+  priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+  when: event => workspaceKeyboardContextIsActive()
+    && !isTextEntry()
+    && !event.metaKey
+    && !event.ctrlKey
+    && !event.altKey,
+  run: event => {
+    openSpotlight(event.key);
+    return true;
+  },
+});
+
+keybindings.attach(document);
 
 document.addEventListener("mousedown", event => {
   if (!state.tasteOpen) return;

--- a/prototypes/inspect-web/src/graph-interactions.ts
+++ b/prototypes/inspect-web/src/graph-interactions.ts
@@ -1,3 +1,6 @@
+import type { KeybindingRegistry } from "./keybinding-registry.ts";
+import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
+
 export interface GraphBackBindingActions {
   onBack: () => void;
 }
@@ -10,6 +13,7 @@ export interface CallGraphNodeBinding {
 }
 
 export interface GraphPanZoomBindingOptions {
+  keybindings: KeybindingRegistry;
   resolveCallGraphNode?: (
     nodeId: string,
   ) => CallGraphNodeBinding | null;
@@ -80,7 +84,7 @@ export function bindDependencyGraphNodes(
 export function bindGraphPanZoom(
   container: ParentNode,
   viewport: HTMLElement,
-  options: GraphPanZoomBindingOptions = {},
+  options: GraphPanZoomBindingOptions,
 ) {
   const svg = viewport.querySelector<SVGSVGElement>("svg");
   if (!svg) return;
@@ -191,7 +195,7 @@ export function bindGraphPanZoom(
     });
 
   viewport.tabIndex = 0;
-  viewport.addEventListener("keydown", event => {
+  const handlePanZoomKey = (event: KeyboardEvent): boolean => {
     const rect = viewport.getBoundingClientRect();
     const step = 45;
     if (event.key === "+" || event.key === "=")
@@ -215,10 +219,32 @@ export function bindGraphPanZoom(
       view.y -= step;
       apply();
     } else {
-      return;
+      return false;
     }
-    event.preventDefault();
-  });
+    return true;
+  };
+  options.keybindings.register({
+    id: "graph.zoom",
+    key: ["+", "=", "-", "_", "0"],
+    allowExtraModifiers: true,
+    priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+    run: handlePanZoomKey,
+  }, viewport);
+  options.keybindings.register({
+    id: "graph.pan-horizontal",
+    key: ["ArrowLeft", "ArrowRight"],
+    allowExtraModifiers: true,
+    priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+    when: event => !event.altKey && !event.shiftKey,
+    run: handlePanZoomKey,
+  }, viewport);
+  options.keybindings.register({
+    id: "graph.pan-vertical",
+    key: ["ArrowUp", "ArrowDown"],
+    allowExtraModifiers: true,
+    priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+    run: handlePanZoomKey,
+  }, viewport);
 
   if (options.resolveCallGraphNode) {
     svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
@@ -234,11 +260,16 @@ export function bindGraphPanZoom(
       node.addEventListener("click", () => {
         if (!moved) binding.onSelect();
       });
-      node.addEventListener("keydown", event => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-        event.preventDefault();
-        binding.onSelect();
-      });
+      options.keybindings.register({
+        id: "call-graph-node.activate",
+        key: ["Enter", " "],
+        allowExtraModifiers: true,
+        priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+        run: () => {
+          binding.onSelect();
+          return true;
+        },
+      }, node);
     });
   }
 

--- a/prototypes/inspect-web/src/keybinding-registry.ts
+++ b/prototypes/inspect-web/src/keybinding-registry.ts
@@ -1,0 +1,264 @@
+export interface KeybindingModifiers {
+  alt?: boolean;
+  commandOrControl?: boolean;
+  control?: boolean;
+  meta?: boolean;
+  shift?: boolean;
+}
+
+export interface Keybinding {
+  id: string;
+  key: string | readonly string[];
+  modifiers?: KeybindingModifiers;
+  allowExtraModifiers?: boolean;
+  priority?: number;
+  when?: (event: KeyboardEvent) => boolean;
+  run: (event: KeyboardEvent) => boolean;
+  preventDefault?: boolean;
+}
+
+export interface KeybindingDescription {
+  id: string;
+  keys: readonly string[];
+  modifiers: Readonly<KeybindingModifiers>;
+  allowExtraModifiers: boolean;
+  priority: number;
+  preventDefault: boolean;
+}
+
+export interface KeybindingConflict {
+  event: KeyboardEvent;
+  bindings: readonly KeybindingDescription[];
+}
+
+export interface KeybindingRegistryOptions {
+  onConflict?: (conflict: KeybindingConflict) => void;
+  respectDefaultPrevented?: boolean;
+}
+
+export interface KeybindingDispatchResult {
+  handled: boolean;
+  bindingId?: string;
+}
+
+interface RegisteredKeybinding {
+  description: KeybindingDescription;
+  order: number;
+  when?: (event: KeyboardEvent) => boolean;
+  run: (event: KeyboardEvent) => boolean;
+}
+
+interface Candidate {
+  binding: RegisteredKeybinding;
+  scopeDepth: number;
+}
+
+function normalizeKey(key: string): string {
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+function modifierMatches(
+  actual: boolean,
+  expected: boolean | undefined,
+  allowExtraModifiers: boolean,
+): boolean {
+  return expected === undefined
+    ? allowExtraModifiers || !actual
+    : actual === expected;
+}
+
+function matches(
+  binding: RegisteredKeybinding,
+  event: KeyboardEvent,
+): boolean {
+  const { description } = binding;
+  if (!description.keys.includes(normalizeKey(event.key))) return false;
+
+  const modifiers = description.modifiers;
+  if (!modifierMatches(
+    event.altKey,
+    modifiers.alt,
+    description.allowExtraModifiers,
+  )) return false;
+  if (!modifierMatches(
+    event.shiftKey,
+    modifiers.shift,
+    description.allowExtraModifiers,
+  )) return false;
+
+  if (modifiers.commandOrControl !== undefined) {
+    if (modifiers.control !== undefined || modifiers.meta !== undefined) {
+      throw new Error(
+        `Keybinding '${description.id}' combines commandOrControl with control or meta.`,
+      );
+    }
+    if ((event.ctrlKey || event.metaKey) !== modifiers.commandOrControl) {
+      return false;
+    }
+  } else {
+    if (!modifierMatches(
+      event.ctrlKey,
+      modifiers.control,
+      description.allowExtraModifiers,
+    )) return false;
+    if (!modifierMatches(
+      event.metaKey,
+      modifiers.meta,
+      description.allowExtraModifiers,
+    )) return false;
+  }
+
+  return binding.when?.(event) ?? true;
+}
+
+function eventPath(event: KeyboardEvent): readonly EventTarget[] {
+  const path = event.composedPath();
+  return path.length > 0
+    ? path
+    : event.target
+      ? [event.target]
+      : [];
+}
+
+function isKeyboardEvent(event: Event): event is KeyboardEvent {
+  return "key" in event;
+}
+
+export class KeybindingRegistry {
+  readonly #globalBindings: RegisteredKeybinding[] = [];
+  readonly #scopedBindings =
+    new WeakMap<EventTarget, RegisteredKeybinding[]>();
+  readonly #onConflict: ((conflict: KeybindingConflict) => void) | undefined;
+  readonly #respectDefaultPrevented: boolean;
+  #nextOrder = 0;
+
+  constructor(options: KeybindingRegistryOptions = {}) {
+    this.#onConflict = options.onConflict;
+    this.#respectDefaultPrevented = options.respectDefaultPrevented ?? true;
+  }
+
+  register(binding: Keybinding, scope?: EventTarget): () => void {
+    if (binding.id.trim() === "") {
+      throw new Error("A keybinding id cannot be empty.");
+    }
+    const keys = [...new Set((typeof binding.key === "string"
+      ? [binding.key]
+      : [...binding.key])
+      .map(normalizeKey))];
+    if (keys.length === 0 || keys.some(key => key === "")) {
+      throw new Error(`Keybinding '${binding.id}' must declare a key.`);
+    }
+    const priority = binding.priority ?? 0;
+    if (!Number.isFinite(priority)) {
+      throw new Error(`Keybinding '${binding.id}' has a non-finite priority.`);
+    }
+    if (binding.modifiers?.commandOrControl !== undefined
+      && (binding.modifiers.control !== undefined
+        || binding.modifiers.meta !== undefined)) {
+      throw new Error(
+        `Keybinding '${binding.id}' combines commandOrControl with control or meta.`,
+      );
+    }
+
+    const description = Object.freeze({
+      id: binding.id,
+      keys: Object.freeze(keys),
+      modifiers: Object.freeze({ ...binding.modifiers }),
+      allowExtraModifiers: binding.allowExtraModifiers ?? false,
+      priority,
+      preventDefault: binding.preventDefault ?? true,
+    });
+    const registered: RegisteredKeybinding = {
+      description,
+      order: this.#nextOrder++,
+      run: binding.run,
+      ...(binding.when ? { when: binding.when } : {}),
+    };
+    const bindings = scope === undefined
+      ? this.#globalBindings
+      : this.#scopedBindings.get(scope) ?? [];
+    if (scope !== undefined && !this.#scopedBindings.has(scope)) {
+      this.#scopedBindings.set(scope, bindings);
+    }
+    bindings.push(registered);
+
+    return () => {
+      const index = bindings.indexOf(registered);
+      if (index >= 0) bindings.splice(index, 1);
+    };
+  }
+
+  bindingsFor(scope?: EventTarget): readonly KeybindingDescription[] {
+    const bindings = scope === undefined
+      ? this.#globalBindings
+      : this.#scopedBindings.get(scope) ?? [];
+    return bindings.map(binding => binding.description);
+  }
+
+  dispatch(event: KeyboardEvent): KeybindingDispatchResult {
+    if (this.#respectDefaultPrevented && event.defaultPrevented) {
+      return { handled: false };
+    }
+
+    const candidates: Candidate[] = [];
+    const path = eventPath(event);
+    for (let scopeDepth = 0; scopeDepth < path.length; scopeDepth++) {
+      const bindings = this.#scopedBindings.get(path[scopeDepth]);
+      if (!bindings) continue;
+      for (const binding of bindings) {
+        if (matches(binding, event)) {
+          candidates.push({ binding, scopeDepth });
+        }
+      }
+    }
+    for (const binding of this.#globalBindings) {
+      if (matches(binding, event)) {
+        candidates.push({ binding, scopeDepth: Number.MAX_SAFE_INTEGER });
+      }
+    }
+    candidates.sort((left, right) =>
+      right.binding.description.priority
+        - left.binding.description.priority
+      || left.scopeDepth - right.scopeDepth
+      || left.binding.order - right.binding.order);
+
+    for (let index = 0; index < candidates.length;) {
+      const first = candidates[index];
+      let end = index + 1;
+      while (end < candidates.length
+        && candidates[end].binding.description.priority
+          === first.binding.description.priority
+        && candidates[end].scopeDepth === first.scopeDepth) {
+        end++;
+      }
+      const group = candidates.slice(index, end);
+      if (group.length > 1) {
+        this.#onConflict?.({
+          event,
+          bindings: group.map(candidate => candidate.binding.description),
+        });
+      }
+      for (const candidate of group) {
+        if (!candidate.binding.run(event)) continue;
+        if (candidate.binding.description.preventDefault) {
+          event.preventDefault();
+        }
+        return {
+          handled: true,
+          bindingId: candidate.binding.description.id,
+        };
+      }
+      index = end;
+    }
+
+    return { handled: false };
+  }
+
+  attach(target: EventTarget): () => void {
+    const listener: EventListener = event => {
+      if (isKeyboardEvent(event)) this.dispatch(event);
+    };
+    target.addEventListener("keydown", listener);
+    return () => target.removeEventListener("keydown", listener);
+  }
+}

--- a/prototypes/inspect-web/src/package-bar.ts
+++ b/prototypes/inspect-web/src/package-bar.ts
@@ -1,3 +1,6 @@
+import type { KeybindingRegistry } from "./keybinding-registry.ts";
+import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
+
 export interface PackageBarPackage {
   id: string;
   version: string;
@@ -17,6 +20,7 @@ export interface ParsedPackageQuery {
 }
 
 interface PackageBarOptions {
+  keybindings: KeybindingRegistry;
   state: PackageBarState;
   escapeHtml: (value: unknown) => string;
   packageIdentityKey: (pkg: PackageBarPackage) => string;
@@ -168,6 +172,7 @@ export function findPackageTabForQuery(
 
 export function createPackageBar(options: PackageBarOptions) {
   const {
+    keybindings,
     state,
     escapeHtml,
     packageIdentityKey,
@@ -199,11 +204,16 @@ export function createPackageBar(options: PackageBarOptions) {
         if (event.target instanceof Element && event.target.closest("[data-package-close]")) return;
         activate();
       });
-      tab.addEventListener("keydown", event => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-        event.preventDefault();
-        activate();
-      });
+      keybindings.register({
+        id: "package-tab.activate",
+        key: ["Enter", " "],
+        allowExtraModifiers: true,
+        priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+        run: () => {
+          activate();
+          return true;
+        },
+      }, tab);
     });
 
     root.querySelectorAll<HTMLButtonElement>("[data-package-close]").forEach(button =>

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -4,6 +4,8 @@ import {
   type CommandContext,
   type CommandPaletteResult,
 } from "./command-bar.ts";
+import type { KeybindingRegistry } from "./keybinding-registry.ts";
+import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
 
 type LensDefinition = readonly [id: string, label: string];
 type SpotlightFocus = "input" | "chips";
@@ -102,6 +104,7 @@ export interface SpotlightState {
 }
 
 interface SpotlightOptions {
+  keybindings: KeybindingRegistry;
   state: SpotlightState;
   lenses: () => readonly LensDefinition[];
   escapeHtml: (value: unknown) => string;
@@ -654,14 +657,12 @@ export function createSpotlight(options: SpotlightOptions) {
     focus();
   }
 
-  function handleModalKeys(event: KeyboardEvent): void {
+  function handleModalKeys(event: KeyboardEvent): boolean {
     if (event.key === "Escape") {
-      event.preventDefault();
       close();
-      return;
+      return true;
     }
     if (event.key === "Tab") {
-      event.preventDefault();
       const available = scopes();
       const current = available.findIndex(scope => scope.id === state.spotlightScope);
       const next = nextSpotlightScope(
@@ -671,64 +672,62 @@ export function createSpotlight(options: SpotlightOptions) {
       );
       state.spotlightChipIndex = next;
       setScope(available[next].id);
-      return;
+      return true;
     }
 
     if (state.spotlightFocus === "chips") {
       const available = scopes();
       if (event.key === "ArrowRight") {
-        event.preventDefault();
         if (state.spotlightChipIndex < available.length - 1) {
           moveChip(state.spotlightChipIndex + 1);
         }
       } else if (event.key === "ArrowLeft") {
-        event.preventDefault();
         if (state.spotlightChipIndex === 0) focusInput();
         else moveChip(state.spotlightChipIndex - 1);
       } else if (event.key === "ArrowUp") {
-        event.preventDefault();
         focusInput();
       } else if (event.key === "ArrowDown" || event.key === "Enter") {
-        event.preventDefault();
         state.spotlightIndex = 0;
         rememberSelection(renderedResults);
         focusInput();
         highlightSelection();
+      } else {
+        return false;
       }
-      return;
+      return true;
     }
 
     if (event.key === "ArrowRight") {
-      const input = event.currentTarget;
-      if (!isTextInputTarget(input)) return;
+      const input = event.target;
+      if (!isTextInputTarget(input)) return false;
       const atEnd = input.selectionStart === input.selectionEnd
         && input.selectionStart === input.value.length;
       if (atEnd) {
-        event.preventDefault();
         state.spotlightFocus = "chips";
         state.spotlightChipIndex = scopeIndex();
         updateChips();
+        return true;
       }
     } else if (event.key === "ArrowDown") {
-      event.preventDefault();
       moveSelection(1);
+      return true;
     } else if (event.key === "ArrowUp") {
-      event.preventDefault();
       if (!moveSelection(-1)) {
         state.spotlightFocus = "chips";
         state.spotlightChipIndex = scopeIndex();
         updateChips();
       }
+      return true;
     } else if (event.key === "Enter") {
-      event.preventDefault();
       pick(renderedResults[state.spotlightIndex]);
+      return true;
     }
+    return false;
   }
 
-  function handleInlineKeys(event: KeyboardEvent): void {
+  function handleInlineKeys(event: KeyboardEvent): boolean {
     const items = renderedResults;
     if (event.key === "ArrowDown") {
-      event.preventDefault();
       state.spotlightIndex = nextSpotlightSelection(
         state.spotlightIndex,
         1,
@@ -736,8 +735,8 @@ export function createSpotlight(options: SpotlightOptions) {
       ) ?? 0;
       rememberSelection(items);
       highlightSelection();
+      return true;
     } else if (event.key === "ArrowUp") {
-      event.preventDefault();
       state.spotlightIndex = nextSpotlightSelection(
         state.spotlightIndex,
         -1,
@@ -745,10 +744,12 @@ export function createSpotlight(options: SpotlightOptions) {
       ) ?? 0;
       rememberSelection(items);
       highlightSelection();
+      return true;
     } else if (event.key === "Enter") {
-      event.preventDefault();
       pick(items[state.spotlightIndex]);
+      return true;
     }
+    return false;
   }
 
   function bind(root: ParentNode, mode: "modal" | "inline"): void {
@@ -765,10 +766,15 @@ export function createSpotlight(options: SpotlightOptions) {
         options.schedulePackageFetch();
         updateResults();
       });
-      input.addEventListener(
-        "keydown",
-        mode === "modal" ? handleModalKeys : handleInlineKeys,
-      );
+      options.keybindings.register({
+        id: mode === "modal"
+          ? "spotlight-modal.navigate"
+          : "spotlight-inline.navigate",
+        key: ["Escape", "Tab", "ArrowRight", "ArrowLeft", "ArrowUp", "ArrowDown", "Enter"],
+        allowExtraModifiers: true,
+        priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+        run: mode === "modal" ? handleModalKeys : handleInlineKeys,
+      }, input);
     }
     bindChipClicks(root);
     bindResultClicks(root);

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -1,4 +1,6 @@
 import { pdbSourceLimitationHtml } from "./data.ts";
+import type { KeybindingRegistry } from "./keybinding-registry.ts";
+import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
 
 // The type selector (the "PUBLIC TYPES" / "MEMBERS" nav pane) and the type viewer (the
 // type heading, metadata, and source sections shown for the "type" scope) as pure,
@@ -93,7 +95,7 @@ export interface TypePanelBindingActions {
   onCopySignature: () => void;
   onCopyTypeSource: () => void;
   onKindSelect: (kind: string) => void;
-  onListKeyDown: (event: KeyboardEvent) => void;
+  onListKeyDown: (event: KeyboardEvent) => boolean;
   onMemberAccessibilityFilterSelect: (accessibility: string | undefined) => void;
   onMemberBack: () => void;
   onMemberCompositionAccessibilitySelect: (accessibility: string) => void;
@@ -101,7 +103,7 @@ export interface TypePanelBindingActions {
   onMemberCompositionTraitSelect: (trait: string) => void;
   onMemberFilterChange: (value: string) => void;
   onMemberFilterClear: () => void;
-  onMemberFilterKeyDown: (event: KeyboardEvent, value: string) => void;
+  onMemberFilterKeyDown: (event: KeyboardEvent, value: string) => boolean;
   onMemberGroupOpen: (memberKey: string) => void;
   onMemberKindFilterSelect: (kind: string | undefined) => void;
   onMemberOverloadOpen: (index: number) => void;
@@ -118,6 +120,7 @@ export interface TypePanelBindingActions {
 export function bindTypePanel(
   root: ParentNode,
   actions: TypePanelBindingActions,
+  keybindings: KeybindingRegistry,
 ) {
   root.querySelectorAll<HTMLElement>("[data-type]").forEach(button =>
     button.addEventListener(
@@ -223,28 +226,58 @@ export function bindTypePanel(
     () => actions.onNamespaceSelect(namespaceJump.value));
 
   const typeList = root.querySelector<HTMLElement>("#type-list");
-  typeList?.addEventListener("keydown", actions.onListKeyDown);
+  if (typeList) {
+    keybindings.register({
+      id: "type-list.navigate",
+      key: ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "j", "k", "/"],
+      allowExtraModifiers: true,
+      priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+      run: actions.onListKeyDown,
+    }, typeList);
+    keybindings.register({
+      id: "type-list.extent",
+      key: ["Home", "End"],
+      allowExtraModifiers: true,
+      preventDefault: false,
+      priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+      run: actions.onListKeyDown,
+    }, typeList);
+  }
   const memberFilter =
     root.querySelector<HTMLInputElement>("#member-filter");
   memberFilter?.addEventListener(
     "input",
     () => actions.onMemberFilterChange(memberFilter.value));
-  memberFilter?.addEventListener(
-    "keydown",
-    event => actions.onMemberFilterKeyDown(event, memberFilter.value));
+  if (memberFilter) {
+    keybindings.register({
+      id: "member-filter.navigate",
+      key: ["Escape", "ArrowUp", "ArrowDown"],
+      allowExtraModifiers: true,
+      priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+      run: event => actions.onMemberFilterKeyDown(event, memberFilter.value),
+    }, memberFilter);
+  }
   const filter = root.querySelector<HTMLInputElement>("#type-filter");
   filter?.addEventListener(
     "input",
     () => actions.onTypeFilterChange(filter.value));
-  filter?.addEventListener("keydown", event => {
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      typeList?.focus();
-    } else if (event.key === "Escape" && filter.value !== "") {
-      event.preventDefault();
-      actions.onTypeFilterEscape();
-    }
-  });
+  if (filter) {
+    keybindings.register({
+      id: "type-filter.navigate",
+      key: ["ArrowDown", "Escape"],
+      allowExtraModifiers: true,
+      priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+      run: event => {
+        if (event.key === "ArrowDown") {
+          typeList?.focus();
+          return true;
+        }
+        if (filter.value === "") return false;
+        actions.onTypeFilterEscape();
+        return true;
+      },
+    }, filter);
+  }
 }
 
 export interface TypeNavOptions {

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -232,6 +232,8 @@ export function bindTypePanel(
       key: ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "j", "k", "/"],
       allowExtraModifiers: true,
       priority: WORKBENCH_KEYBINDING_PRIORITY.element,
+      when: event => event.key.toLowerCase() !== "k"
+        || (!event.metaKey && !event.ctrlKey),
       run: actions.onListKeyDown,
     }, typeList);
     keybindings.register({

--- a/prototypes/inspect-web/src/workbench-keybindings.ts
+++ b/prototypes/inspect-web/src/workbench-keybindings.ts
@@ -1,0 +1,25 @@
+import {
+  KeybindingRegistry,
+  type KeybindingConflict,
+} from "./keybinding-registry.ts";
+
+export const WORKBENCH_KEYBINDING_PRIORITY = {
+  workspace: 100,
+  popover: 150,
+  element: 200,
+  spotlight: 300,
+  documentViewer: 310,
+  graphSource: 320,
+  unavailableWorkspace: 330,
+  settings: 340,
+  metadataExplorer: 350,
+} as const;
+
+function reportConflict(conflict: KeybindingConflict): void {
+  const ids = conflict.bindings.map(binding => binding.id).join(", ");
+  console.error(`Ambiguous keybinding '${conflict.event.key}': ${ids}`);
+}
+
+export function createWorkbenchKeybindings(): KeybindingRegistry {
+  return new KeybindingRegistry({ onConflict: reportConflict });
+}

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -6,6 +6,7 @@ import {
   bindGraphPanZoom,
   bindTypeGraphNodes,
 } from "../src/graph-interactions.ts";
+import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 class FakeClassList {
@@ -178,6 +179,30 @@ function graphTransform(element: FakeElement) {
   };
 }
 
+function dispatchKey(
+  keybindings: KeybindingRegistry,
+  target: FakeElement,
+  values: Record<string, unknown>,
+) {
+  let prevented = false;
+  const event = fakeDom.keyboardEvent({
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    metaKey: false,
+    shiftKey: false,
+    target,
+    composedPath: () => [target],
+    preventDefault: () => prevented = true,
+    ...values,
+  });
+  const result = keybindings.dispatch(event);
+  return {
+    prevented,
+    result,
+  };
+}
+
 test("graph back binding dispatches only from the rendered control", () => {
   const back = new FakeElement();
   let calls = 0;
@@ -254,11 +279,13 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
   reset.dataset.zoom = "reset";
   const container = new FakeContainer([zoomIn, zoomOut, reset]);
   const calls: string[] = [];
+  const keybindings = new KeybindingRegistry();
 
   bindGraphPanZoom(
     fakeDom.parentNode(container),
     fakeDom.htmlElement(viewport),
     {
+      keybindings,
       resolveCallGraphNode: nodeId => nodeId
         ? {
             onSelect: () => calls.push(nodeId),
@@ -282,7 +309,11 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
   assert.equal(platform.style.cursor, "not-allowed");
   regular.dispatch("click");
   assert.deepEqual(calls, ["n1"]);
-  assert.equal(platform.dispatch("keydown", { key: "Enter" }), true);
+  assert.equal(dispatchKey(
+    keybindings,
+    platform,
+    { key: "Enter" },
+  ).prevented, true);
   assert.deepEqual(calls, ["n1", "n2"]);
 
   assert.equal(viewport.dispatch("wheel", {
@@ -303,15 +334,23 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
   const fitted = "translate(50px, 25px) scale(1)";
   assert.equal(svg.style.transform, fitted);
   for (const key of ["+", "="]) {
-    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.equal(dispatchKey(keybindings, viewport, { key }).prevented, true);
     assert.ok(graphTransform(svg).scale > 1);
-    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(dispatchKey(
+      keybindings,
+      viewport,
+      { key: "0" },
+    ).prevented, true);
     assert.equal(svg.style.transform, fitted);
   }
   for (const key of ["-", "_"]) {
-    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.equal(dispatchKey(keybindings, viewport, { key }).prevented, true);
     assert.ok(graphTransform(svg).scale < 1);
-    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(dispatchKey(
+      keybindings,
+      viewport,
+      { key: "0" },
+    ).prevented, true);
     assert.equal(svg.style.transform, fitted);
   }
   const arrowPositions = new Map([
@@ -321,11 +360,26 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
     ["ArrowDown", { x: 50, y: -20 }],
   ]);
   for (const [key, expected] of arrowPositions) {
-    assert.equal(viewport.dispatch("keydown", { key }), true);
+    assert.equal(dispatchKey(keybindings, viewport, { key }).prevented, true);
     assert.deepEqual(graphTransform(svg), { ...expected, scale: 1 });
-    assert.equal(viewport.dispatch("keydown", { key: "0" }), true);
+    assert.equal(dispatchKey(
+      keybindings,
+      viewport,
+      { key: "0" },
+    ).prevented, true);
   }
-  assert.equal(viewport.dispatch("keydown", { key: "x" }), false);
+  assert.equal(
+    dispatchKey(keybindings, viewport, { key: "x" }).result.handled,
+    false,
+  );
+  assert.equal(dispatchKey(keybindings, viewport, {
+    key: "ArrowLeft",
+    shiftKey: true,
+  }).result.handled, false);
+  assert.equal(dispatchKey(keybindings, viewport, {
+    altKey: true,
+    key: "ArrowRight",
+  }).result.handled, false);
 
   viewport.dispatch("pointerdown", {
     button: 1,
@@ -397,6 +451,7 @@ test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated
 });
 
 test("graph bindings tolerate missing rendered surfaces", () => {
+  const keybindings = new KeybindingRegistry();
   const root = fakeDom.parentNode(new FakeNodeRoot([]));
   assert.doesNotThrow(() => bindTypeGraphNodes(root, () => null));
   assert.doesNotThrow(() => bindDependencyGraphNodes(root, () => null));
@@ -407,5 +462,6 @@ test("graph bindings tolerate missing rendered surfaces", () => {
     fakeDom.parentNode(new FakeContainer([])),
     fakeDom.htmlElement({
       querySelector: () => null,
-    })));
+    }),
+    { keybindings }));
 });

--- a/prototypes/inspect-web/test/keybinding-registry.test.ts
+++ b/prototypes/inspect-web/test/keybinding-registry.test.ts
@@ -1,0 +1,369 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  KeybindingRegistry,
+  type KeybindingConflict,
+} from "../src/keybinding-registry.ts";
+import { fakeDom } from "./fake-dom.ts";
+
+interface KeyboardEventOptions {
+  altKey?: boolean;
+  ctrlKey?: boolean;
+  defaultPrevented?: boolean;
+  key?: string;
+  metaKey?: boolean;
+  path?: readonly EventTarget[];
+  shiftKey?: boolean;
+  target?: EventTarget | null;
+}
+
+function keyboardEvent(options: KeyboardEventOptions = {}) {
+  let prevented = options.defaultPrevented ?? false;
+  const target = options.target ?? null;
+  const event = fakeDom.keyboardEvent({
+    altKey: options.altKey ?? false,
+    ctrlKey: options.ctrlKey ?? false,
+    get defaultPrevented() {
+      return prevented;
+    },
+    key: options.key ?? "k",
+    metaKey: options.metaKey ?? false,
+    shiftKey: options.shiftKey ?? false,
+    target,
+    composedPath: () => options.path ?? (target ? [target] : []),
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+  return {
+    event,
+    prevented: () => prevented,
+  };
+}
+
+test("a higher-priority active binding is the single winner", () => {
+  const calls: string[] = [];
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "fallback",
+    key: "k",
+    priority: 10,
+    run: () => {
+      calls.push("fallback");
+      return true;
+    },
+  });
+  registry.register({
+    id: "winner",
+    key: "k",
+    priority: 20,
+    run: () => {
+      calls.push("winner");
+      return true;
+    },
+  });
+  const input = keyboardEvent();
+
+  assert.deepEqual(registry.dispatch(input.event), {
+    handled: true,
+    bindingId: "winner",
+  });
+  assert.deepEqual(calls, ["winner"]);
+  assert.equal(input.prevented(), true);
+});
+
+test("matched but unhandled bindings fall through", () => {
+  const calls: string[] = [];
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "conditional",
+    key: "Escape",
+    priority: 20,
+    run: () => {
+      calls.push("conditional");
+      return false;
+    },
+  });
+  registry.register({
+    id: "fallback",
+    key: "Escape",
+    priority: 10,
+    run: () => {
+      calls.push("fallback");
+      return true;
+    },
+  });
+
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "Escape" }).event).bindingId,
+    "fallback",
+  );
+  assert.deepEqual(calls, ["conditional", "fallback"]);
+});
+
+test("context predicates remove inactive bindings from arbitration", () => {
+  let active = false;
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "scoped",
+    key: "p",
+    when: () => active,
+    run: () => true,
+  });
+
+  assert.equal(registry.dispatch(keyboardEvent({ key: "p" }).event).handled, false);
+  active = true;
+  assert.equal(registry.dispatch(keyboardEvent({ key: "p" }).event).handled, true);
+});
+
+test("the closest event-path scope wins at equal priority", () => {
+  const parent = fakeDom.eventTarget({});
+  const child = fakeDom.eventTarget({});
+  const calls: string[] = [];
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "parent",
+    key: "ArrowDown",
+    run: () => {
+      calls.push("parent");
+      return true;
+    },
+  }, parent);
+  registry.register({
+    id: "child",
+    key: "ArrowDown",
+    run: () => {
+      calls.push("child");
+      return true;
+    },
+  }, child);
+
+  const result = registry.dispatch(keyboardEvent({
+    key: "ArrowDown",
+    target: child,
+    path: [child, parent],
+  }).event);
+
+  assert.equal(result.bindingId, "child");
+  assert.deepEqual(calls, ["child"]);
+});
+
+test("a scoped gesture arbitrates the stack-navigation collision", () => {
+  const list = fakeDom.eventTarget({});
+  const calls: string[] = [];
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "history.back",
+    key: "ArrowLeft",
+    modifiers: { shift: true },
+    priority: 100,
+    run: () => {
+      calls.push("history");
+      return true;
+    },
+  });
+  const disposeList = registry.register({
+    id: "list.step",
+    key: "ArrowLeft",
+    modifiers: { shift: true },
+    priority: 200,
+    run: () => {
+      calls.push("list");
+      return true;
+    },
+  }, list);
+  const input = () => keyboardEvent({
+    key: "ArrowLeft",
+    shiftKey: true,
+    target: list,
+    path: [list],
+  }).event;
+
+  assert.equal(registry.dispatch(input()).bindingId, "list.step");
+  assert.deepEqual(calls, ["list"]);
+
+  disposeList();
+  registry.register({
+    id: "list.disabled-step",
+    key: "ArrowLeft",
+    modifiers: { shift: true },
+    priority: 200,
+    run: () => false,
+  }, list);
+  assert.equal(registry.dispatch(input()).bindingId, "history.back");
+  assert.deepEqual(calls, ["list", "history"]);
+});
+
+test("exact modifiers prevent shifted arrows from matching plain arrows", () => {
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "plain",
+    key: "ArrowLeft",
+    run: () => true,
+  });
+  registry.register({
+    id: "shifted",
+    key: "ArrowLeft",
+    modifiers: { shift: true },
+    run: () => true,
+  });
+
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "ArrowLeft" }).event).bindingId,
+    "plain",
+  );
+  assert.equal(registry.dispatch(keyboardEvent({
+    key: "ArrowLeft",
+    shiftKey: true,
+  }).event).bindingId, "shifted");
+});
+
+test("commandOrControl matches either platform modifier and excludes plain input", () => {
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "palette",
+    key: "K",
+    modifiers: { commandOrControl: true },
+    run: () => true,
+  });
+
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "k", ctrlKey: true }).event).handled,
+    true,
+  );
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "K", metaKey: true }).event).handled,
+    true,
+  );
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "k" }).event).handled,
+    false,
+  );
+});
+
+test("aliases and explicitly allowed extra modifiers are supported", () => {
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "zoom",
+    key: ["+", "="],
+    allowExtraModifiers: true,
+    run: () => true,
+  });
+
+  assert.equal(registry.dispatch(keyboardEvent({
+    key: "+",
+    shiftKey: true,
+  }).event).handled, true);
+  assert.equal(registry.dispatch(keyboardEvent({
+    key: "=",
+    altKey: true,
+  }).event).handled, true);
+});
+
+test("equal-precedence ambiguity is reported and remains deterministic", () => {
+  const conflicts: KeybindingConflict[] = [];
+  const registry = new KeybindingRegistry({
+    onConflict: conflict => conflicts.push(conflict),
+  });
+  registry.register({ id: "first", key: "x", run: () => true });
+  registry.register({ id: "second", key: "x", run: () => true });
+
+  assert.equal(
+    registry.dispatch(keyboardEvent({ key: "x" }).event).bindingId,
+    "first",
+  );
+  assert.deepEqual(
+    conflicts[0]?.bindings.map(binding => binding.id),
+    ["first", "second"],
+  );
+});
+
+test("disposal, introspection, default behavior, and validation are explicit", () => {
+  const scope = fakeDom.eventTarget({});
+  const registry = new KeybindingRegistry();
+  const dispose = registry.register({
+    id: "native",
+    key: "Enter",
+    preventDefault: false,
+    run: () => true,
+  }, scope);
+
+  assert.deepEqual(registry.bindingsFor(scope), [{
+    id: "native",
+    keys: ["Enter"],
+    modifiers: {},
+    allowExtraModifiers: false,
+    priority: 0,
+    preventDefault: false,
+  }]);
+  const input = keyboardEvent({
+    key: "Enter",
+    target: scope,
+    path: [scope],
+  });
+  assert.equal(registry.dispatch(input.event).handled, true);
+  assert.equal(input.prevented(), false);
+  dispose();
+  assert.deepEqual(registry.bindingsFor(scope), []);
+  assert.equal(registry.dispatch(input.event).handled, false);
+
+  assert.throws(
+    () => registry.register({ id: "", key: "x", run: () => true }),
+    /id cannot be empty/,
+  );
+  assert.throws(
+    () => registry.register({ id: "missing", key: [], run: () => true }),
+    /must declare a key/,
+  );
+  assert.throws(
+    () => registry.register({
+      id: "mixed",
+      key: "x",
+      modifiers: { commandOrControl: true, control: true },
+      run: () => true,
+    }),
+    /combines commandOrControl/,
+  );
+});
+
+test("already-handled events are respected by default", () => {
+  const registry = new KeybindingRegistry();
+  registry.register({ id: "late", key: "x", run: () => true });
+
+  assert.equal(registry.dispatch(keyboardEvent({
+    key: "x",
+    defaultPrevented: true,
+  }).event).handled, false);
+});
+
+test("attach owns one keydown listener and returns its teardown", () => {
+  const listeners: EventListener[] = [];
+  let removed: EventListener | null = null;
+  const target = fakeDom.eventTarget({
+    addEventListener(type: string, listener: EventListener) {
+      assert.equal(type, "keydown");
+      listeners.push(listener);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      assert.equal(type, "keydown");
+      removed = listener;
+    },
+  });
+  let calls = 0;
+  const registry = new KeybindingRegistry();
+  registry.register({
+    id: "attached",
+    key: "x",
+    run: () => {
+      calls++;
+      return true;
+    },
+  });
+
+  const detach = registry.attach(target);
+  assert.equal(listeners.length, 1);
+  listeners[0](keyboardEvent({ key: "x" }).event);
+  assert.equal(calls, 1);
+  detach();
+  assert.equal(removed, listeners[0]);
+});

--- a/prototypes/inspect-web/test/package-bar.test.ts
+++ b/prototypes/inspect-web/test/package-bar.test.ts
@@ -15,6 +15,7 @@ import type {
   PackageBarPackage,
   ParsedPackageQuery,
 } from "../src/package-bar.ts";
+import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 function escapeHtml(value: unknown) {
@@ -149,6 +150,7 @@ test("package bar connects package selection controls to its typed options", () 
   root.add("#package-query", new FakeElement());
   const calls: string[] = [];
   const packageBar = createPackageBar({
+    keybindings: new KeybindingRegistry(),
     state: { packages: [], package: null },
     escapeHtml,
     packageIdentityKey,
@@ -177,6 +179,50 @@ test("package bar connects package selection controls to its typed options", () 
     "framework:net10.0",
     "version:10.0.1",
   ]);
+});
+
+test("package tabs register keyboard activation with the shared dispatcher", () => {
+  const root = new FakeRoot();
+  const tab = new FakeElement();
+  const packageModel = pkg("System.Text.Json");
+  tab.dataset.packageKey = packageIdentityKey(packageModel);
+  root.addAll("[data-package-key]", tab);
+  root.add("#package-query", new FakeElement());
+  const selected: PackageBarPackage[] = [];
+  const keybindings = new KeybindingRegistry();
+  const packageBar = createPackageBar({
+    keybindings,
+    state: { packages: [packageModel], package: null },
+    escapeHtml,
+    packageIdentityKey,
+    runtimePackPackage: () => null,
+    selectPackageTab: item => selected.push(item),
+    closePackageTab: () => {},
+    openRuntimePack: () => {},
+    openPackage: () => {},
+    selectFramework: () => {},
+    selectVersion: () => {},
+    showToast: () => {},
+  });
+  packageBar.bind(fakeDom.parentNode(root));
+
+  const target = fakeDom.eventTarget(tab);
+  let prevented = false;
+  const result = keybindings.dispatch(fakeDom.keyboardEvent({
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    key: "Enter",
+    metaKey: false,
+    shiftKey: false,
+    target,
+    composedPath: () => [target],
+    preventDefault: () => prevented = true,
+  }));
+
+  assert.equal(result.bindingId, "package-tab.activate");
+  assert.equal(prevented, true);
+  assert.deepEqual(selected, [packageModel]);
 });
 
 test("package identity equality compares the full coordinate", () => {
@@ -317,6 +363,7 @@ test("the package bar preserves whether the submitted version was explicit", () 
   const input = root.add("#package-query-input", new FakeElement());
   const queries: ParsedPackageQuery[] = [];
   const packageBar = createPackageBar({
+    keybindings: new KeybindingRegistry(),
     state: { packages: [], package: null },
     escapeHtml,
     packageIdentityKey,

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -368,6 +368,12 @@ const annotatedSourceModule = readFileSync(
 const typePanelSource = readFileSync(
   new URL("../src/type-panel.ts", import.meta.url),
   "utf8");
+const keybindingRegistrySource = readFileSync(
+  new URL("../src/keybinding-registry.ts", import.meta.url),
+  "utf8");
+const workbenchKeybindingsSource = readFileSync(
+  new URL("../src/workbench-keybindings.ts", import.meta.url),
+  "utf8");
 const scopeBarSource = readFileSync(
   new URL("../src/scope-bar.ts", import.meta.url),
   "utf8");
@@ -997,7 +1003,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /function mermaidNodeId\([\s\S]*data-id[\s\S]*flowchart-/);
   assert.match(
     graphInteractionsSource,
-    /export function bindGraphPanZoom\([\s\S]*"wheel"[\s\S]*"pointerdown"[\s\S]*"pointermove"[\s\S]*"pointerup"[\s\S]*"pointercancel"[\s\S]*\.graph-controls button[\s\S]*"keydown"[\s\S]*resolveCallGraphNode/);
+    /export function bindGraphPanZoom\([\s\S]*"wheel"[\s\S]*"pointerdown"[\s\S]*"pointermove"[\s\S]*"pointerup"[\s\S]*"pointercancel"[\s\S]*\.graph-controls button[\s\S]*id: "graph\.zoom"[\s\S]*id: "graph\.pan-horizontal"[\s\S]*id: "graph\.pan-vertical"[\s\S]*resolveCallGraphNode/);
   assert.match(
     graphInteractionsSource,
     /export function bindTypeGraphNodes\([\s\S]*"t"[\s\S]*nav-node[\s\S]*non-nav[\s\S]*createElementNS/);
@@ -1012,13 +1018,13 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /bindGraphBack\(document, graphBackActions\)/);
   assert.match(
     typeGraph,
-    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindTypeGraphNodes\(viewport, nodeId => \{[\s\S]*graphNodeOf\.get\(nodeId\)[\s\S]*onSelect: \(\) => navigateToType\(target\)[\s\S]*unavailableLabel/);
+    /bindGraphPanZoom\(container, viewport, \{ keybindings \}\);[\s\S]*bindTypeGraphNodes\(viewport, nodeId => \{[\s\S]*graphNodeOf\.get\(nodeId\)[\s\S]*onSelect: \(\) => navigateToType\(target\)[\s\S]*unavailableLabel/);
   assert.match(
     typeGraph,
     /const target = graphNode\.role === "self"\s*\? selectedType\(\)\s*: uniqueTypeByQueryId\(pkg\.types, fullName\)/);
   assert.match(
     dependencyGraph,
-    /bindGraphPanZoom\(container, viewport\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
+    /bindGraphPanZoom\(container, viewport, \{ keybindings \}\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
   assert.match(
     dependencyGraph,
     /const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null;\s*if \(!info \|\| info\.kind === "self"\) return null/);
@@ -1042,7 +1048,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /if \(loaded\) \{[\s\S]*navigateToGraphMember\(loaded, target\)[\s\S]*\} else if \(disposition === "resident"\) \{[\s\S]*startPlatformDrill\(target\)[\s\S]*\} else if \(platform\) \{[\s\S]*navigateOrDrillPlatform\(target\)/);
   assert.match(
     graphInteractionsSource,
-    /resolveCallGraphNode[\s\S]*setAttribute\("tabindex", "0"\)[\s\S]*setAttribute\("role", "button"\)[\s\S]*setAttribute\("aria-label", binding\.label\)[\s\S]*addEventListener\("click"[\s\S]*addEventListener\("keydown"/);
+    /resolveCallGraphNode[\s\S]*setAttribute\("tabindex", "0"\)[\s\S]*setAttribute\("role", "button"\)[\s\S]*setAttribute\("aria-label", binding\.label\)[\s\S]*addEventListener\("click"[\s\S]*id: "call-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);
@@ -1057,7 +1063,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
   assert.doesNotMatch(
     appSource,
     /document\.querySelector\("\[data-graph-back\]"\)/);
-  assert.equal(appSource.match(/\.addEventListener\(/g)?.length, 4);
+  assert.equal(appSource.match(/\.addEventListener\(/g)?.length, 3);
 });
 
 test("typed document inspection owns package document request coordination", () => {
@@ -1206,7 +1212,10 @@ test("typed type panel owns its rendered control bindings", () => {
     /onMemberFilterClear: \(\) => \{[\s\S]*resetMemberFilters\(\);[\s\S]*renderMemberFilterAndRestoreFocus\("#clear-member-filter"\)/);
   assert.match(
     binding,
-    /onMemberFilterKeyDown: \(event, value\) => \{\s*if \(event\.key === "Escape"\) \{\s*if \(navMode\(\) !== "member" && value === ""\) return;\s*event\.preventDefault\(\);[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"[\s\S]*event\.preventDefault\(\);\s*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\)/);
+    /onMemberFilterKeyDown: \(event, value\) => \{\s*if \(event\.key === "Escape"\) \{\s*if \(navMode\(\) !== "member" && value === ""\) return false;[\s\S]*navMode\(\) === "member"[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*return true;[\s\S]*event\.key !== "ArrowUp" && event\.key !== "ArrowDown"\) return false;\s*stepMemberNav\(event\.key === "ArrowDown" \? 1 : -1, true\);\s*return true/);
+  assert.match(
+    binding,
+    /bindTypePanel\(document, \{[\s\S]*}, keybindings\);/);
   const selectorCount = selector =>
     appSource.split(selector).length - 1;
   assert.deepEqual(
@@ -1791,7 +1800,7 @@ test("leaving package search clears its pending loading state", () => {
     /state\.spotlightScope !== "all"[\s\S]*state\.spotlightPkgLoading = false;[\s\S]*return;/);
   assert.match(
     appSource,
-    /event\.key === "Escape" && !event\.defaultPrevented && !typing/);
+    /id: "workspace\.drill-out-escape"[\s\S]*key: "Escape"[\s\S]*!isTextEntry\(\)/);
   assert.match(
     spotlightPackageSearchSource,
     /query === state\.spotlightPkgQuery[\s\S]*generation\+\+;[\s\S]*state\.spotlightPkgLoading = false;[\s\S]*return;/);
@@ -1823,30 +1832,29 @@ test("global workbench shortcuts respect the topmost modal", () => {
   assert.match(
     appSource,
     /bindWorkspaceLinkNavigation\(document, \{[\s\S]*currentOrigin: \(\) => location\.origin,[\s\S]*resolve: href => new URL\(href, location\.href\),[\s\S]*navigate: navigateInAppUrl,/);
-  // The workspace-scoped modal layers (graph source, doc viewer, spotlight) are declared,
-  // in priority order, as one explicit list the keydown listener loops over — the single
-  // place that owns which layer Escape (and everything else) belongs to.
+  // Modal ownership is explicit priority policy, while the reusable registry remains
+  // independent of inspect-web state and attaches the only raw keydown listener.
+  assert.match(
+    workbenchKeybindingsSource,
+    /workspace: 100,[\s\S]*element: 200,[\s\S]*spotlight: 300,[\s\S]*documentViewer: 310,[\s\S]*graphSource: 320,[\s\S]*unavailableWorkspace: 330,[\s\S]*settings: 340,[\s\S]*metadataExplorer: 350/);
+  assert.match(
+    keybindingRegistrySource,
+    /dispatch\(event: KeyboardEvent\): KeybindingDispatchResult[\s\S]*candidates\.sort\([\s\S]*candidate\.binding\.run\(event\)[\s\S]*event\.preventDefault\(\)[\s\S]*target\.addEventListener\("keydown", listener\)/);
   assert.match(
     appSource,
-    /const workspaceKeydownLayers: readonly KeydownLayer\[\] = \[[\s\S]*active: \(\) => state\.graphSourceOpen[\s\S]*active: \(\) => state\.docViewerOpen[\s\S]*active: \(\) => state\.spotlightOpen/);
+    /id: "graph-source\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.graphSource[\s\S]*when: graphSourceContextIsActive[\s\S]*closeGraphSource\(\)/);
   assert.match(
     appSource,
-    /if \(state\.home\) return;[\s\S]*for \(const layer of workspaceKeydownLayers\)/);
+    /id: "document-viewer\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.documentViewer[\s\S]*when: documentViewerContextIsActive[\s\S]*closeDocViewer\(\)/);
   assert.match(
     appSource,
-    /state\.spotlightOpen[\s\S]*event\.key\.toLowerCase\(\) === "k"[\s\S]*event\.preventDefault\(\);[\s\S]*openSpotlight\("", "commands"\)/);
+    /id: "spotlight\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.spotlight[\s\S]*when: spotlightContextIsActive[\s\S]*closeSpotlight\(\)/);
   assert.match(
     appSource,
-    /state\.spotlightOpen[\s\S]*event\.key\.toLowerCase\(\) === "p"[\s\S]*event\.preventDefault\(\);[\s\S]*openSpotlight\(\)/);
+    /id: "spotlight\.open-commands"[\s\S]*commandOrControl: true[\s\S]*openSpotlight\("", "commands"\)[\s\S]*id: "spotlight\.open-all"[\s\S]*openSpotlight\(\)[\s\S]*id: "spotlight\.contain-browser-find"/);
   assert.match(
     appSource,
-    /state\.spotlightOpen[\s\S]*event\.key\.toLowerCase\(\) === "f"[\s\S]*event\.preventDefault\(\)/);
-  assert.match(
-    appSource,
-    /state\.spotlightOpen[\s\S]*event\.key === "Escape"[\s\S]*closeSpotlight\(\)/);
-  assert.match(
-    appSource,
-    /event\.key === "Escape" && !event\.defaultPrevented && state\.tasteOpen/);
+    /id: "taste\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.popover[\s\S]*state\.tasteOpen = false/);
   assert.match(
     appSource,
     /function openSpotlight\(seed = "", spotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*state\.tasteOpen = false;/);
@@ -1855,16 +1863,32 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(\);/);
   assert.match(
     appSource,
-    /active: \(\) => Boolean\(state\.explorer\?\.open\)[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
+    /id: "metadata-explorer\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.metadataExplorer[\s\S]*Boolean\(state\.explorer\?\.open\)[\s\S]*metadata-explorer\.contain-browser-shortcut/);
   assert.match(
     appSource,
-    /active: \(\) => state\.settings[\s\S]*isContainedBrowserShortcut\(event\)[\s\S]*event\.preventDefault\(\)/);
+    /id: "settings\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.settings[\s\S]*when: \(\) => state\.settings[\s\S]*settings\.contain-browser-shortcut/);
   assert.match(
     spotlightSource,
     /aria-activedescendant="spotlight-result-\$\{state\.spotlightIndex\}"[\s\S]*syncActiveDescendant\(items\.length\)/);
   assert.match(
     appSource,
-    /if \(state\.loading \|\| state\.error\) \{\s*if \(isContainedBrowserShortcut\(event\) \|\| event\.key === "\/"\)[\s\S]*event\.preventDefault\(\);[\s\S]*return;/);
+    /const unavailableWorkspaceContext = \(\) =>[\s\S]*!state\.home && \(state\.loading \|\| Boolean\(state\.error\)\)[\s\S]*unavailable-workspace\.contain-browser-shortcut[\s\S]*unavailable-workspace\.contain-filter-shortcut/);
+  assert.match(
+    appSource,
+    /function workspaceKeyboardContextIsActive\(\)[\s\S]*!state\.explorer\?\.open[\s\S]*!state\.settings[\s\S]*!state\.home[\s\S]*!state\.loading[\s\S]*!state\.error[\s\S]*!state\.graphSourceOpen[\s\S]*!state\.docViewerOpen[\s\S]*!state\.spotlightOpen/);
+  assert.equal(
+    keybindingRegistrySource.match(/addEventListener\("keydown"/g)?.length,
+    1);
+  assert.equal(
+    [
+      appSource,
+      graphInteractionsSource,
+      packageBarSource,
+      spotlightSource,
+      typePanelSource,
+    ].join("\n").match(/addEventListener\(\s*"keydown"/g)?.length ?? 0,
+    0);
+  assert.match(appSource, /keybindings\.attach\(document\)/);
   assert.match(
     appSource,
     /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) \{\s*focus\(\);\s*return;\s*}\s*requestAnimationFrame\(focus\);/);
@@ -2044,13 +2068,13 @@ test("member filters retain accessible controls and focus across rerenders", () 
     /onMemberFilterChange: value => \{[\s\S]*state\.memberTextFilter = value;[\s\S]*renderPreservingMemberFocus\(\)/);
   assert.match(
     typePanelSource,
-    /memberFilter\?\.addEventListener\(\s*"keydown",\s*event => actions\.onMemberFilterKeyDown\(event, memberFilter\.value\)\)/);
+    /id: "member-filter\.navigate"[\s\S]*key: \["Escape", "ArrowUp", "ArrowDown"\][\s\S]*run: event => actions\.onMemberFilterKeyDown\(event, memberFilter\.value\)/);
   assert.match(
     binding,
-    /onMemberFilterKeyDown: \(event, value\) => \{[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) !== "member" && value === ""\) return;[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*stepMemberNav/);
+    /onMemberFilterKeyDown: \(event, value\) => \{[\s\S]*event\.key === "Escape"[\s\S]*if \(navMode\(\) !== "member" && value === ""\) return false;[\s\S]*if \(navMode\(\) === "member"\)[\s\S]*exitMemberScope\(\)[\s\S]*state\.memberTextFilter = ""[\s\S]*renderMemberFilterAndRestoreFocus\("#member-filter"\)[\s\S]*return true[\s\S]*stepMemberNav/);
   assert.match(
     appSource,
-    /event\.key === "Escape" && !event\.defaultPrevented && !typing[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);
+    /id: "workspace\.drill-out-escape"[\s\S]*key: "Escape"[\s\S]*!isTextEntry\(\)[\s\S]*if \(navMode\(\) === "member"\) exitMemberScope\(\)/);
   assert.match(
     appSource,
     /onShowTypes: exitMemberScope/);
@@ -2395,7 +2419,7 @@ test("Type Source completion settles behind workbench overlays", () => {
     /const ownsRequest = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\)/);
   assert.match(
     appSource,
-    /function isInteractiveElement\(element: Element \| null\)[\s\S]*"button, a\[href\], input, select, textarea, summary, "[\s\S]*\[role=button\][\s\S]*!isInteractiveElement\([\s\S]*event\.target instanceof Element \? event\.target : null\)[\s\S]*event\.key === "Enter"/);
+    /function isInteractiveElement\(element: Element \| null\)[\s\S]*"button, a\[href\], input, select, textarea, summary, "[\s\S]*\[role=button\][\s\S]*id: "workspace\.drill-in"[\s\S]*key: "Enter"[\s\S]*!isInteractiveElement\([\s\S]*event\.target instanceof Element \? event\.target : null\)/);
 });
 
 test("member-less Metadata omits the empty composition call to action", () => {
@@ -3926,7 +3950,7 @@ test("ambiguous call graph targets expose a visible refusal", () => {
     /invalidateGraphMemberNavigation\(\);\s*state\.memberCallGraphSeq\+\+;[\s\S]*?showPlatformTargetError\(target, reason\)/);
   assert.match(
     graphInteractionsSource,
-    /node\.setAttribute\("tabindex", "0"\);[\s\S]*node\.setAttribute\("role", "button"\)[\s\S]*node\.addEventListener\("click"[\s\S]*node\.addEventListener\("keydown", event => \{[\s\S]*event\.key !== "Enter" && event\.key !== " "/);
+    /node\.setAttribute\("tabindex", "0"\);[\s\S]*node\.setAttribute\("role", "button"\)[\s\S]*node\.addEventListener\("click"[\s\S]*id: "call-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
 });
 
 test("navigable call graph targets share mouse and keyboard activation", () => {

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../src/spotlight.ts";
 import type { SpotlightResult, SpotlightState } from "../src/spotlight.ts";
 import type { CommandContext } from "../src/command-bar.ts";
+import { KeybindingRegistry } from "../src/keybinding-registry.ts";
+import { fakeDom } from "./fake-dom.ts";
 
 function escapeHtml(value: unknown) {
   return String(value)
@@ -74,7 +76,9 @@ function createHarness({
     spotlightFocus: "input",
     spotlightChipIndex: 0,
   };
+  const keybindings = new KeybindingRegistry();
   const spotlight = createSpotlight({
+    keybindings,
     state,
     lenses,
     escapeHtml,
@@ -93,7 +97,7 @@ function createHarness({
     render: () => {},
     focusAfterDismiss,
   });
-  return { spotlight, state };
+  return { keybindings, spotlight, state };
 }
 
 const packageContext: CommandContext["package"] = {
@@ -170,7 +174,7 @@ test("modal arrow navigation reuses rendered results", () => {
     ranges: [],
   }));
   let searchCount = 0;
-  const { spotlight, state } = createHarness({
+  const { keybindings, spotlight, state } = createHarness({
     query: "Example",
     searchResults: () => {
       searchCount++;
@@ -230,12 +234,19 @@ test("modal arrow navigation reuses rendered results", () => {
     // The root implements the exact ParentNode query surface Spotlight consumes.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     spotlight.bind(root as unknown as ParentNode, "modal");
+    const target = fakeDom.eventTarget(input);
     for (let index = 0; index < 4; index++) {
-      listeners.get("keydown")!({
+      keybindings.dispatch(fakeDom.keyboardEvent({
+        altKey: false,
+        ctrlKey: false,
+        defaultPrevented: false,
         key: "ArrowDown",
-        currentTarget: input,
+        metaKey: false,
+        shiftKey: false,
+        target,
+        composedPath: () => [target],
         preventDefault: () => {},
-      });
+      }));
     }
   } finally {
     if (previousDocument === undefined) delete globals.document;

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -16,6 +16,7 @@ import type {
   TypePanelBindingActions,
   TypeSummary,
 } from "../src/type-panel.ts";
+import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
@@ -77,6 +78,33 @@ function keyboardEvent(key: string) {
     },
   });
   return { event, state };
+}
+
+function bindPanel(
+  root: FakeRoot,
+  actions: TypePanelBindingActions,
+): KeybindingRegistry {
+  const keybindings = new KeybindingRegistry();
+  bindTypePanel(fakeDom.parentNode(root), actions, keybindings);
+  return keybindings;
+}
+
+function dispatchKey(
+  keybindings: KeybindingRegistry,
+  target: FakeElement,
+  input: ReturnType<typeof keyboardEvent>,
+) {
+  const scopedTarget = fakeDom.eventTarget(target);
+  Object.assign(input.event, {
+    altKey: false,
+    ctrlKey: false,
+    defaultPrevented: false,
+    metaKey: false,
+    shiftKey: false,
+    target: scopedTarget,
+    composedPath: () => [scopedTarget],
+  });
+  return keybindings.dispatch(input.event);
 }
 
 function escapeHtml(value: unknown) {
@@ -156,7 +184,10 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
       calls.push("copy-type-source");
     },
     onKindSelect: value => calls.push(`kind:${value}`),
-    onListKeyDown: event => calls.push(`list:${event.key}`),
+    onListKeyDown: event => {
+      calls.push(`list:${event.key}`);
+      return true;
+    },
     onMemberAccessibilityFilterSelect: value =>
       calls.push(`member-access:${value}`),
     onMemberBack: () => calls.push("member-back"),
@@ -168,8 +199,10 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
       calls.push(`member-jump-trait:${value}`),
     onMemberFilterChange: value => calls.push(`member-filter:${value}`),
     onMemberFilterClear: () => calls.push("member-filter-clear"),
-    onMemberFilterKeyDown: (event, value) =>
-      calls.push(`member-filter-key:${event.key}:${value}`),
+    onMemberFilterKeyDown: (event, value) => {
+      calls.push(`member-filter-key:${event.key}:${value}`);
+      return true;
+    },
     onMemberGroupOpen: value => calls.push(`member-open:${value}`),
     onMemberKindFilterSelect: value => calls.push(`member-kind:${value}`),
     onMemberOverloadOpen: value => calls.push(`member-overload:${value}`),
@@ -205,9 +238,7 @@ test("type panel bindings dispatch member filters without eager work", () => {
   const clear = root.add("#clear-member-filter", new FakeElement());
   const calls: string[] = [];
 
-  bindTypePanel(
-    fakeDom.parentNode(root),
-    recordingActions(calls));
+  const keybindings = bindPanel(root, recordingActions(calls));
 
   assert.deepEqual(calls, []);
   kind.dispatch("click");
@@ -225,7 +256,7 @@ test("type panel bindings dispatch member filters without eager work", () => {
   ]);
   filter.dispatch("input");
   const arrow = keyboardEvent("ArrowDown");
-  filter.dispatch("keydown", arrow.event);
+  dispatchKey(keybindings, filter, arrow);
   clear.dispatch("click");
   assert.deepEqual(calls, [
     "member-kind:method",
@@ -258,10 +289,10 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
   const actions = recordingActions(calls);
   actions.onListKeyDown = event => {
     forwardedListEvent = event;
-    event.preventDefault();
     calls.push(`list:${event.key}`);
+    return true;
   };
-  bindTypePanel(fakeDom.parentNode(root), actions);
+  const keybindings = bindPanel(root, actions);
   namespaceJump.value = "System.Text";
   filter.value = "json";
 
@@ -275,7 +306,7 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
   clear.dispatch("click");
   filter.dispatch("input");
   const listKey = keyboardEvent("End");
-  typeList.dispatch("keydown", listKey.event);
+  dispatchKey(keybindings, typeList, listKey);
 
   assert.deepEqual(calls, [
     "type:System.String",
@@ -290,7 +321,7 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
     "list:End",
   ]);
   assert.equal(forwardedListEvent, listKey.event);
-  assert.equal(listKey.state.prevented, true);
+  assert.equal(listKey.state.prevented, false);
 });
 
 test("type panel bindings dispatch the rendered member navigation controls", () => {
@@ -304,16 +335,14 @@ test("type panel bindings dispatch the rendered member navigation controls", () 
   const showTypes = root.add("#nav-to-types", new FakeElement());
   const typeList = root.add("#type-list", new FakeElement());
   const calls: string[] = [];
-  bindTypePanel(
-    fakeDom.parentNode(root),
-    recordingActions(calls));
+  const keybindings = bindPanel(root, recordingActions(calls));
 
   member.dispatch("click");
   secondMember.dispatch("click");
   overload.dispatch("click");
   secondOverload.dispatch("click");
   showTypes.dispatch("click");
-  typeList.dispatch("keydown", keyboardEvent("Home").event);
+  dispatchKey(keybindings, typeList, keyboardEvent("Home"));
 
   assert.deepEqual(calls, [
     "member:M:Length",
@@ -352,9 +381,7 @@ test("type panel bindings dispatch member composition and detail controls", () =
   const copyTypeSource = root.add("#copy-type-source", new FakeElement());
   const calls: string[] = [];
 
-  bindTypePanel(
-    fakeDom.parentNode(root),
-    recordingActions(calls));
+  bindPanel(root, recordingActions(calls));
 
   assert.deepEqual(calls, []);
   jumpKind.dispatch("click");
@@ -402,10 +429,11 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   const typeList = root.add("#type-list", new FakeElement());
   let escapes = 0;
   let listKeys = 0;
-  bindTypePanel(fakeDom.parentNode(root), {
+  const keybindings = bindPanel(root, {
     ...recordingActions([]),
     onListKeyDown: () => {
       listKeys++;
+      return true;
     },
     onTypeFilterEscape: () => {
       escapes++;
@@ -413,14 +441,14 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   });
 
   const ignored = keyboardEvent("a");
-  filter.dispatch("keydown", ignored.event);
+  dispatchKey(keybindings, filter, ignored);
   assert.equal(typeList.focused, false);
   assert.equal(ignored.state.prevented, false);
   assert.equal(escapes, 0);
   assert.equal(listKeys, 0);
 
   const down = keyboardEvent("ArrowDown");
-  filter.dispatch("keydown", down.event);
+  dispatchKey(keybindings, filter, down);
   assert.equal(typeList.focused, true);
   assert.equal(down.state.prevented, true);
   assert.equal(escapes, 0);
@@ -429,7 +457,7 @@ test("type filter keys preserve list focus and Escape behavior", () => {
   typeList.focused = false;
   filter.value = "json";
   const escape = keyboardEvent("Escape");
-  filter.dispatch("keydown", escape.event);
+  dispatchKey(keybindings, filter, escape);
   assert.equal(escapes, 1);
   assert.equal(escape.state.prevented, true);
   assert.equal(typeList.focused, false);
@@ -437,16 +465,14 @@ test("type filter keys preserve list focus and Escape behavior", () => {
 
   filter.value = "";
   const emptyEscape = keyboardEvent("Escape");
-  filter.dispatch("keydown", emptyEscape.event);
+  dispatchKey(keybindings, filter, emptyEscape);
   assert.equal(escapes, 1);
   assert.equal(emptyEscape.state.prevented, false);
 });
 
 test("type panel binding tolerates controls from the inactive nav being absent", () => {
   const root = new FakeRoot();
-  assert.doesNotThrow(() => bindTypePanel(
-    fakeDom.parentNode(root),
-    recordingActions([])));
+  assert.doesNotThrow(() => bindPanel(root, recordingActions([])));
 });
 
 test("the type nav lists namespace groups with the current type selected", () => {

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -17,6 +17,7 @@ import type {
   TypeSummary,
 } from "../src/type-panel.ts";
 import { KeybindingRegistry } from "../src/keybinding-registry.ts";
+import { WORKBENCH_KEYBINDING_PRIORITY } from "../src/workbench-keybindings.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 class FakeElement {
@@ -69,13 +70,23 @@ class FakeRoot {
   }
 }
 
-function keyboardEvent(key: string) {
+function keyboardEvent(
+  key: string,
+  modifiers: Partial<Pick<
+    KeyboardEvent,
+    "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+  >> = {},
+) {
   const state = { prevented: false };
   const event = fakeDom.keyboardEvent({
+    altKey: modifiers.altKey ?? false,
+    ctrlKey: modifiers.ctrlKey ?? false,
     key,
+    metaKey: modifiers.metaKey ?? false,
     preventDefault: () => {
       state.prevented = true;
     },
+    shiftKey: modifiers.shiftKey ?? false,
   });
   return { event, state };
 }
@@ -96,11 +107,7 @@ function dispatchKey(
 ) {
   const scopedTarget = fakeDom.eventTarget(target);
   Object.assign(input.event, {
-    altKey: false,
-    ctrlKey: false,
     defaultPrevented: false,
-    metaKey: false,
-    shiftKey: false,
     target: scopedTarget,
     composedPath: () => [scopedTarget],
   });
@@ -322,6 +329,50 @@ test("type panel bindings dispatch the rendered type navigation controls", () =>
   ]);
   assert.equal(forwardedListEvent, listKey.event);
   assert.equal(listKey.state.prevented, false);
+});
+
+test("type list navigation yields Cmd/Ctrl+K to the command palette", () => {
+  const root = new FakeRoot();
+  const typeList = root.add("#type-list", new FakeElement());
+  const calls: string[] = [];
+  const keybindings = bindPanel(root, recordingActions(calls));
+  keybindings.register({
+    id: "workspace.open-commands",
+    key: "k",
+    modifiers: { commandOrControl: true },
+    allowExtraModifiers: true,
+    priority: WORKBENCH_KEYBINDING_PRIORITY.workspace,
+    run: () => {
+      calls.push("commands");
+      return true;
+    },
+  });
+
+  const controlK = keyboardEvent("k", { ctrlKey: true });
+  assert.equal(
+    dispatchKey(keybindings, typeList, controlK).bindingId,
+    "workspace.open-commands",
+  );
+  const metaK = keyboardEvent("k", { metaKey: true });
+  assert.equal(
+    dispatchKey(keybindings, typeList, metaK).bindingId,
+    "workspace.open-commands",
+  );
+  assert.deepEqual(calls, ["commands", "commands"]);
+
+  assert.equal(
+    dispatchKey(keybindings, typeList, keyboardEvent("k")).bindingId,
+    "type-list.navigate",
+  );
+  assert.equal(
+    dispatchKey(
+      keybindings,
+      typeList,
+      keyboardEvent("j", { ctrlKey: true }),
+    ).bindingId,
+    "type-list.navigate",
+  );
+  assert.deepEqual(calls, ["commands", "commands", "list:k", "list:j"]);
 });
 
 test("type panel bindings dispatch the rendered member navigation controls", () => {


### PR DESCRIPTION
## Summary

Centralize inspect-web keyboard gesture arbitration behind one dispatcher.

- add a dependency-free `KeybindingRegistry` with exact modifier matching,
  priority, event-path scopes, context predicates, handled fallthrough,
  conflict reporting, and explicit disposal
- keep inspect-web priorities and diagnostics in a separate workbench adapter
- migrate document, Spotlight, type/member, graph, package-tab, and call-node
  keyboard owners without changing their intended behavior
- gate the original Shift+Arrow stack-navigation collision and enforce that the
  registry owns the only raw application `keydown` listener

This is a standalone PR because #4644 has landed. Chords, remapping, command
catalogs, and editor infrastructure remain out of scope.

Closes #4646

## Demo

Before, element and document listeners independently handled the same event:
the type list or graph viewport had to call `preventDefault()`, and the
document history branch had to remember to observe it. A missed check allowed
both in-page navigation and stack navigation to fire.

After, the scoped gesture is the single winner; if it reports that it did not
handle the event, the same dispatch falls through to workspace history. The
neighboring modifier test proves plain and shifted arrows remain distinct.

```console
$ cd prototypes/inspect-web
$ node --test --test-name-pattern="stack-navigation collision|exact modifiers prevent" test/keybinding-registry.test.ts
✔ a scoped gesture arbitrates the stack-navigation collision
✔ exact modifiers prevent shifted arrows from matching plain arrows
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

## Validation

Run with Node.js 24:

```console
npm test
npm run lint
./node_modules/.bin/knip
npm run build
npx markdownlint-cli README.md
```
