### PR TITLE
Add canonical workspace share packet codec

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -920,7 +920,13 @@ Implementation must add, at minimum:
   non-ASCII metadata names, canonical signatures, lowercase C0 escapes, quotes,
   backslashes, raw U+007F/U+0085/U+2028/U+2029, and a valid supplementary-plane
   scalar such as U+E0074, with negative lone-high- and lone-low-surrogate cases
-  proving rejection rather than U+FFFD substitution;
+  proving rejection rather than U+FFFD substitution —
+  `WorkspaceSharePacketCodecTests.Decode_CanonicalVector_RoundTripsExactly`,
+  `Decode_UnicodeAndSignatureVector_RoundTripsExactly`,
+  `Encode_UsesPinnedCanonicalStringEscaping`, and the neighboring
+  `Decode_Rejects*` tests cover the product-owned .NET codec, semantic
+  validation, canonical writer, fixed vectors, and declared bounds; an
+  independent browser implementation consuming the same vectors remains open;
 - a session-closure gate asserting the packet grammar covers every
   interactively reachable v1 session state without inferring relationships
   across contexts, including library scope over non-platform packages;
@@ -1008,10 +1014,19 @@ Definition records and product demos (this slice):
   demo-parity, section binding, CLI lowering, and real section output for the
   two home demos; inspect-web's generated `RunHomeDemo` binding runs the
   member-bound Call Graph preset from its product scenario id; and
-- **not yet:** minted view-facet ids; `WorkspaceContextLoader` group realization
-  as the run substrate (CLI still uses package + `--caller-package` encoding;
-  inspect-web's package workspace remains its dual reference/body group owner,
-  and platform still uses the resident runtime-pack share encoding).
+- `WorkspaceSharePacketCodec` decodes and canonically re-emits the bounded v1
+  base64url packet into an immutable product-owned semantic model. It rejects
+  legacy prototype packets, malformed or non-canonical encoding and JSON,
+  invalid coordinate and context topology, and partial state through typed
+  outcomes. Its fixed .NET vectors cover composed package/platform contexts,
+  independent focus and context indexes, Unicode metadata and canonical
+  signatures, and the pinned scalar-escaping rules; and
+- **not yet:** packet-to-definition transposition, minted view-facet ids,
+  packet view/query binding, or CLI and browser use of the codec;
+  `WorkspaceContextLoader` group realization as the run substrate (CLI still
+  uses package + `--caller-package` encoding; inspect-web's package workspace
+  remains its dual reference/body group owner, and platform still uses the
+  resident runtime-pack share encoding).
 
 The coordinate-realization slice implements the `package`, `platform`, and
 `embedded` member coordinates

--- a/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
@@ -173,6 +173,10 @@ public sealed class WorkspaceSharePacketCodecTests
         AssertFailure(
             EncodeBytes([0x7B, 0x22, 0x66, 0x22, 0x3A, 0xC3, 0x28, 0x7D]),
             WorkspaceSharePacketFailureKind.InvalidJson);
+        AssertFailure(
+            "eyJmIjoxLCJ0IjpbWyJQIixudWxsLCJuZXQxMC4wIixudWxsXV0sImciOltbMF1d"
+            + "LCJhIjowLCJ4IjowLCKAIjoxfQ",
+            WorkspaceSharePacketFailureKind.InvalidJson);
     }
 
     [Theory]
@@ -184,6 +188,10 @@ public sealed class WorkspaceSharePacketCodecTests
     [InlineData("""[[":Custom","1.0.0","net10.0",null]]""")]
     [InlineData("""[[":PlatformX","1.0.0","net10.0",null]]""")]
     [InlineData("""[[":Platform@10.0.0",null,"net10.0",null]]""")]
+    [InlineData("""[[":Platform:",null,"net10.0",null]]""")]
+    [InlineData("""[[":Platform+",null,"net10.0",null]]""")]
+    [InlineData("""[[":Platform:+Extensions",null,"net10.0",null]]""")]
+    [InlineData("""[[":Platform+Extensions:",null,"net10.0",null]]""")]
     [InlineData("""[[":Platform++Extensions",null,"net10.0",null]]""")]
     [InlineData("""[["P",null,"net10.0",null],["p",null,"net10.0",null]]""")]
     public void Decode_RejectsInvalidOrDuplicateTabTuples(string tabs)
@@ -343,6 +351,18 @@ public sealed class WorkspaceSharePacketCodecTests
             EncodeJson(
                 """{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"v":"\uDC00"}"""),
             WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            "eyJcdUQ4MDAiOjAsImYiOjEsInQiOltbIlAiLG51bGwsIm5ldDEwLjAiLG51bGxdXSwi"
+            + "ZyI6W1swXV0sImEiOjAsIngiOjB9",
+            WorkspaceSharePacketFailureKind.InvalidJson);
+
+        WorkspaceSharePacketException exception = AssertFailure(
+            EncodeJson(
+                """{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"\u001b[2J\nspoof":1}"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        Assert.Equal(
+            "Workspace share state contains an unknown property.",
+            exception.Message);
 
         using var cancellation = new CancellationTokenSource();
         cancellation.Cancel();
@@ -366,7 +386,7 @@ public sealed class WorkspaceSharePacketCodecTests
     private static string PacketJson(string tabs, string contexts) =>
         $$"""{"f":1,"t":{{tabs}},"g":{{contexts}},"a":0,"x":0}""";
 
-    private static void AssertFailure(
+    private static WorkspaceSharePacketException AssertFailure(
         string encoded,
         WorkspaceSharePacketFailureKind expected)
     {
@@ -375,6 +395,7 @@ public sealed class WorkspaceSharePacketCodecTests
                 encoded,
                 TestContext.Current.CancellationToken));
         Assert.Equal(expected, exception.Kind);
+        return exception;
     }
 
     private static string EncodeJson(string json) =>

--- a/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
@@ -1,0 +1,395 @@
+using System.Text;
+using DotnetInspector.Queries.Definitions;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class WorkspaceSharePacketCodecTests
+{
+    private const string CanonicalVector =
+        "eyJmIjoxLCJ0IjpbWyI6UGxhdGZvcm0iLCIxMC4wLjEwIiwibmV0MTAuMCIsbnVsbF0s"
+        + "WyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCIsbnVsbF1dLCJnIjpb"
+        + "WzAsMV1dLCJhIjoxLCJ4IjowLCJ2IjoiYXBpIiwieSI6IlN5c3RlbS5UZXh0Lkpzb24u"
+        + "SnNvblNlcmlhbGl6ZXIiLCJsIjpbIlN5c3RlbS5UZXh0Lkpzb24iXX0";
+
+    private const string UnicodeVector =
+        "eyJmIjoxLCJ0IjpbWyJDb250b3NvLkpzb24iLCIyLjAuMCIsIm5ldDEwLjAiLCJsaW51"
+        + "eC14NjQiXV0sImciOltbMF1dLCJhIjowLCJ4IjowLCJ2IjoibWVtYmVyIiwieSI6IuS-"
+        + "iy5Kc29uU2VyaWFsaXplcjxUPiIsInMiOiJEZXNlcmlhbGl6ZUFzeW5jKFN5c3RlbS5T"
+        + "dHJpbmcsIFN5c3RlbS5UaHJlYWRpbmcuQ2FuY2VsbGF0aW9uVG9rZW4pIiwiYyI6IlNv"
+        + "dXJjZSIsImwiOlsiQ29udG9zby5Kc29uIl19";
+
+    private const string IndependentFocusVector =
+        "eyJmIjoxLCJ0IjpbWyJQIixudWxsLCJuZXQxMC4wIixudWxsXSxbIlEiLG51bGwsIm5l"
+        + "dDEwLjAiLG51bGxdXSwiZyI6W1swXSxbMV1dLCJhIjoxLCJ4IjowfQ";
+
+    [Fact]
+    public void Decode_CanonicalVector_RoundTripsExactly()
+    {
+        WorkspaceSharePacket packet = WorkspaceSharePacketCodec.Decode(
+            CanonicalVector,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, packet.FormatVersion);
+        Assert.Equal(2, packet.Tabs.Count);
+        Assert.Equal(WorkspaceShareSourceKind.Group, packet.Tabs[0].SourceKind);
+        Assert.Equal(":Platform", packet.Tabs[0].Source);
+        Assert.Equal("10.0.10", packet.Tabs[0].Version);
+        Assert.Equal(WorkspaceShareSourceKind.Package, packet.Tabs[1].SourceKind);
+        Assert.Equal("System.Text.Json", packet.Tabs[1].Source);
+        Assert.Single(packet.Contexts);
+        Assert.Equal([0, 1], packet.Contexts[0].TabIndexes);
+        Assert.Equal(1, packet.ActiveTabIndex);
+        Assert.Equal(0, packet.SelectedContextIndex);
+        Assert.Equal("api", packet.Lens);
+        Assert.Equal("System.Text.Json.JsonSerializer", packet.Type);
+        Assert.Null(packet.MemberAnchor);
+        Assert.Null(packet.MemberSignature);
+        Assert.Null(packet.Section);
+        Assert.Equal(["System.Text.Json"], packet.Libraries);
+        Assert.Equal(CanonicalVector, WorkspaceSharePacketCodec.Encode(packet));
+    }
+
+    [Fact]
+    public void Decode_UnicodeAndSignatureVector_RoundTripsExactly()
+    {
+        WorkspaceSharePacket packet = WorkspaceSharePacketCodec.Decode(
+            UnicodeVector,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("例.JsonSerializer<T>", packet.Type);
+        Assert.Equal(
+            "DeserializeAsync(System.String, System.Threading.CancellationToken)",
+            packet.MemberSignature);
+        Assert.Equal("linux-x64", packet.Tabs[0].RuntimeIdentifier);
+        Assert.Equal(UnicodeVector, WorkspaceSharePacketCodec.Encode(packet));
+    }
+
+    [Fact]
+    public void Decode_IndependentFocusVector_PreservesFocusOutsideSelectedContext()
+    {
+        WorkspaceSharePacket packet = WorkspaceSharePacketCodec.Decode(
+            IndependentFocusVector,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, packet.ActiveTabIndex);
+        Assert.Equal(0, packet.SelectedContextIndex);
+        Assert.Equal([0], packet.Contexts[packet.SelectedContextIndex].TabIndexes);
+        Assert.DoesNotContain(
+            packet.ActiveTabIndex,
+            packet.Contexts[packet.SelectedContextIndex].TabIndexes);
+        Assert.Equal(IndependentFocusVector, WorkspaceSharePacketCodec.Encode(packet));
+    }
+
+    [Fact]
+    public void Encode_UsesPinnedCanonicalStringEscaping()
+    {
+        const string value =
+            "\"\\\b\t\n\f\r\u0000\u001f\u007f\u0085\u2028\u2029\U000E0074";
+        var packet = new WorkspaceSharePacket(
+            [
+                new WorkspaceShareTab(
+                    WorkspaceShareSourceKind.Package,
+                    "P",
+                    version: null,
+                    framework: "net10.0",
+                    runtimeIdentifier: null),
+            ],
+            [new WorkspaceShareContext([0])],
+            activeTabIndex: 0,
+            selectedContextIndex: 0,
+            lens: value,
+            type: null,
+            memberAnchor: null,
+            memberSignature: null,
+            section: null,
+            libraries: []);
+
+        string encoded = WorkspaceSharePacketCodec.Encode(packet);
+        string json = DecodeJson(encoded);
+        Assert.Equal(
+            "{\"f\":1,\"t\":[[\"P\",null,\"net10.0\",null]],"
+            + "\"g\":[[0]],\"a\":0,\"x\":0,\"v\":\""
+            + "\\\"\\\\\\b\\t\\n\\f\\r\\u0000\\u001f"
+            + "\u007f\u0085\u2028\u2029\U000E0074\"}",
+            json);
+        Assert.Equal(
+            encoded,
+            WorkspaceSharePacketCodec.Encode(WorkspaceSharePacketCodec.Decode(
+                encoded,
+                TestContext.Current.CancellationToken)));
+    }
+
+    [Theory]
+    [InlineData(""" { "f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0}""")]
+    [InlineData("""{"t":[["P",null,"net10.0",null]],"f":1,"g":[[0]],"a":0,"x":0}""")]
+    [InlineData("""{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"v":"\u0061pi"}""")]
+    [InlineData("""{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"v":"\u001F"}""")]
+    public void Decode_RejectsValidButNonCanonicalJson(string json)
+    {
+        AssertFailure(
+            EncodeJson(json),
+            WorkspaceSharePacketFailureKind.NonCanonical);
+    }
+
+    [Theory]
+    [InlineData("=")]
+    [InlineData("+")]
+    [InlineData("/")]
+    [InlineData("A")]
+    [InlineData("not.base64")]
+    public void Decode_RejectsInvalidBase64Url(string encoded)
+    {
+        AssertFailure(
+            encoded,
+            WorkspaceSharePacketFailureKind.InvalidBase64Url);
+    }
+
+    [Fact]
+    public void Decode_RejectsLegacyAndUnsupportedFormats()
+    {
+        AssertFailure(
+            EncodeJson("""[["P","1.0.0","net10.0"]]"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(
+                """{"f":1.0,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0}"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(
+                """{"f":2,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0}"""),
+            WorkspaceSharePacketFailureKind.UnsupportedFormat);
+    }
+
+    [Fact]
+    public void Decode_RejectsMalformedAndDuplicateJson()
+    {
+        AssertFailure(
+            EncodeJson("""{"f":1"""),
+            WorkspaceSharePacketFailureKind.InvalidJson);
+        AssertFailure(
+            EncodeJson(
+                """{"f":1,"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0}"""),
+            WorkspaceSharePacketFailureKind.InvalidJson);
+        AssertFailure(
+            EncodeBytes([0x7B, 0x22, 0x66, 0x22, 0x3A, 0xC3, 0x28, 0x7D]),
+            WorkspaceSharePacketFailureKind.InvalidJson);
+    }
+
+    [Theory]
+    [InlineData("""[["bad/id",null,"net10.0",null]]""")]
+    [InlineData("""[["P","1.0","net10.0",null]]""")]
+    [InlineData("""[["P","1.0.0+build","net10.0",null]]""")]
+    [InlineData("""[["P",null,"NET10.0",null]]""")]
+    [InlineData("""[["P",null,"net10.0","Linux-X64"]]""")]
+    [InlineData("""[[":Custom","1.0.0","net10.0",null]]""")]
+    [InlineData("""[[":PlatformX","1.0.0","net10.0",null]]""")]
+    [InlineData("""[[":Platform@10.0.0",null,"net10.0",null]]""")]
+    [InlineData("""[[":Platform++Extensions",null,"net10.0",null]]""")]
+    [InlineData("""[["P",null,"net10.0",null],["p",null,"net10.0",null]]""")]
+    public void Decode_RejectsInvalidOrDuplicateTabTuples(string tabs)
+    {
+        string contexts = tabs.Contains("],[", StringComparison.Ordinal)
+            ? "[[0,1]]"
+            : "[[0]]";
+        AssertFailure(
+            EncodeJson(PacketJson(tabs, contexts)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+    }
+
+    [Theory]
+    [InlineData(
+        """[["P",null,"net10.0",null]]""",
+        """[[1]]""")]
+    [InlineData(
+        """[["P",null,"net10.0",null],["Q",null,"net10.0",null]]""",
+        """[[0]]""")]
+    [InlineData(
+        """[["P",null,"net10.0",null]]""",
+        """[[0,0]]""")]
+    [InlineData(
+        """[["P",null,"net10.0",null],[":Platform",null,"net10.0",null]]""",
+        """[[0,1]]""")]
+    [InlineData(
+        """[["P",null,"net10.0",null],["Q",null,"net9.0",null]]""",
+        """[[0,1]]""")]
+    [InlineData(
+        """[["P",null,"net10.0",null]]""",
+        """[[0],[0]]""")]
+    public void Decode_RejectsInvalidContextTopology(string tabs, string contexts)
+    {
+        AssertFailure(
+            EncodeJson(PacketJson(tabs, contexts)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+    }
+
+    [Theory]
+    [InlineData(",\"m\":\"anchor\"")]
+    [InlineData(",\"y\":\"T\",\"m\":\"anchor\",\"s\":\"signature\"")]
+    [InlineData(",\"l\":[]")]
+    [InlineData(",\"l\":[\"B\",\"A\"]")]
+    [InlineData(",\"l\":[\"A\",\"A\"]")]
+    [InlineData(",\"unknown\":1")]
+    public void Decode_RejectsInvalidViewAndLibraryShapes(string suffix)
+    {
+        string json =
+            """{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0"""
+            + suffix
+            + "}";
+        AssertFailure(
+            EncodeJson(json),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+    }
+
+    [Fact]
+    public void Decode_AcceptsPlatformSubgroupPin()
+    {
+        string json = PacketJson(
+            """[[":Platform:AspNetCore","10.0.10","net10.0",null]]""",
+            """[[0]]""");
+
+        WorkspaceSharePacket packet = WorkspaceSharePacketCodec.Decode(
+            EncodeJson(json),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(":Platform:AspNetCore", packet.Tabs[0].Source);
+        Assert.Equal("10.0.10", packet.Tabs[0].Version);
+    }
+
+    [Fact]
+    public void Decode_RejectsMissingFieldsBoundsAndTrailingContent()
+    {
+        AssertFailure("", WorkspaceSharePacketFailureKind.Empty);
+        AssertFailure(
+            EncodeJson(
+                """{"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0}"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(PacketJson(
+                """[["P",null,"net10.0",null]]""",
+                """[[0]]""").Replace("\"a\":0", "\"a\":1", StringComparison.Ordinal)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(PacketJson(
+                """[["P",null,"net10.0",null]]""",
+                """[[0]]""").Replace("\"x\":0", "\"x\":1", StringComparison.Ordinal)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(PacketJson(
+                """[["P",null,"net10.0",null]]""",
+                """[[0]]""") + "null"),
+            WorkspaceSharePacketFailureKind.InvalidJson);
+        AssertFailure(
+            CanonicalVector + "=",
+            WorkspaceSharePacketFailureKind.InvalidBase64Url);
+    }
+
+    [Fact]
+    public void Decode_RejectsOverLimitTables()
+    {
+        string tabs = "["
+            + string.Join(
+                ',',
+                Enumerable.Range(0, WorkspaceSharePacketCodec.MaxTabs + 1)
+                    .Select(index => $"[\"P{index}\",null,\"net10.0\",null]"))
+            + "]";
+        string allIndexes = "[["
+            + string.Join(',', Enumerable.Range(0, WorkspaceSharePacketCodec.MaxTabs + 1))
+            + "]]";
+        AssertFailure(
+            EncodeJson(PacketJson(tabs, allIndexes)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+
+        string contexts = "["
+            + string.Join(
+                ',',
+                Enumerable.Repeat("[0]", WorkspaceSharePacketCodec.MaxContexts + 1))
+            + "]";
+        AssertFailure(
+            EncodeJson(PacketJson(
+                """[["P",null,"net10.0",null]]""",
+                contexts)),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+    }
+
+    [Fact]
+    public void Decode_EnforcesEncodedValueAndDepthBoundsBeforeBinding()
+    {
+        AssertFailure(
+            new string('A', WorkspaceSharePacketCodec.MaxEncodedLength + 1),
+            WorkspaceSharePacketFailureKind.EncodedLimitExceeded);
+
+        string values = string.Join(',', Enumerable.Repeat("0", 1025));
+        AssertFailure(
+            EncodeJson(
+                $$"""{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"z":[{{values}}]}"""),
+            WorkspaceSharePacketFailureKind.JsonValueLimitExceeded);
+
+        string nested = new string('[', WorkspaceSharePacketCodec.MaxJsonDepth + 1)
+            + "0"
+            + new string(']', WorkspaceSharePacketCodec.MaxJsonDepth + 1);
+        AssertFailure(
+            EncodeJson(nested),
+            WorkspaceSharePacketFailureKind.InvalidJson);
+    }
+
+    [Fact]
+    public void Decode_RejectsInvalidUnicodeAndChecksCancellationFirst()
+    {
+        AssertFailure(
+            EncodeJson(
+                """{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"v":"\uD800"}"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+        AssertFailure(
+            EncodeJson(
+                """{"f":1,"t":[["P",null,"net10.0",null]],"g":[[0]],"a":0,"x":0,"v":"\uDC00"}"""),
+            WorkspaceSharePacketFailureKind.InvalidShape);
+
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.Throws<OperationCanceledException>(
+            () => WorkspaceSharePacketCodec.Decode("", cancellation.Token));
+    }
+
+    [Fact]
+    public void Decode_ReturnsMutationResistantCollections()
+    {
+        WorkspaceSharePacket packet = WorkspaceSharePacketCodec.Decode(
+            CanonicalVector,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(Assert.IsAssignableFrom<IList<WorkspaceShareTab>>(packet.Tabs).IsReadOnly);
+        Assert.True(Assert.IsAssignableFrom<IList<WorkspaceShareContext>>(packet.Contexts).IsReadOnly);
+        Assert.True(Assert.IsAssignableFrom<IList<int>>(packet.Contexts[0].TabIndexes).IsReadOnly);
+        Assert.True(Assert.IsAssignableFrom<IList<string>>(packet.Libraries).IsReadOnly);
+    }
+
+    private static string PacketJson(string tabs, string contexts) =>
+        $$"""{"f":1,"t":{{tabs}},"g":{{contexts}},"a":0,"x":0}""";
+
+    private static void AssertFailure(
+        string encoded,
+        WorkspaceSharePacketFailureKind expected)
+    {
+        WorkspaceSharePacketException exception = Assert.Throws<WorkspaceSharePacketException>(
+            () => WorkspaceSharePacketCodec.Decode(
+                encoded,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(expected, exception.Kind);
+    }
+
+    private static string EncodeJson(string json) =>
+        EncodeBytes(Encoding.UTF8.GetBytes(json));
+
+    private static string EncodeBytes(byte[] bytes) =>
+        Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+    private static string DecodeJson(string encoded)
+    {
+        string padded = encoded.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - padded.Length % 4) % 4);
+        return Encoding.UTF8.GetString(Convert.FromBase64String(padded));
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketCodecTests.cs
@@ -300,22 +300,36 @@ public sealed class WorkspaceSharePacketCodecTests
                 Enumerable.Range(0, WorkspaceSharePacketCodec.MaxTabs + 1)
                     .Select(index => $"[\"P{index}\",null,\"net10.0\",null]"))
             + "]";
-        string allIndexes = "[["
-            + string.Join(',', Enumerable.Range(0, WorkspaceSharePacketCodec.MaxTabs + 1))
-            + "]]";
+        string singletonContexts = "["
+            + string.Join(
+                ',',
+                Enumerable.Range(0, WorkspaceSharePacketCodec.MaxTabs + 1)
+                    .Select(index => $"[{index}]"))
+            + "]";
         AssertFailure(
-            EncodeJson(PacketJson(tabs, allIndexes)),
+            EncodeJson(PacketJson(tabs, singletonContexts)),
             WorkspaceSharePacketFailureKind.InvalidShape);
 
+        const int contextTabCount = 5;
+        string contextTabs = "["
+            + string.Join(
+                ',',
+                Enumerable.Range(0, contextTabCount)
+                    .Select(index => $"[\"P{index}\",null,\"net10.0\",null]"))
+            + "]";
         string contexts = "["
             + string.Join(
                 ',',
-                Enumerable.Repeat("[0]", WorkspaceSharePacketCodec.MaxContexts + 1))
+                Enumerable.Range(0, contextTabCount)
+                    .Select(index => $"[{index}]")
+                    .Concat(
+                        from first in Enumerable.Range(0, contextTabCount)
+                        from second in Enumerable.Range(0, contextTabCount)
+                        where first != second
+                        select $"[{first},{second}]"))
             + "]";
         AssertFailure(
-            EncodeJson(PacketJson(
-                """[["P",null,"net10.0",null]]""",
-                contexts)),
+            EncodeJson(PacketJson(contextTabs, contexts)),
             WorkspaceSharePacketFailureKind.InvalidShape);
     }
 

--- a/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacket.cs
+++ b/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacket.cs
@@ -1,0 +1,160 @@
+using System.Collections.ObjectModel;
+
+namespace DotnetInspector.Queries.Definitions;
+
+/// <summary>The acquisition-source kind carried by one workspace share tab.</summary>
+public enum WorkspaceShareSourceKind
+{
+    Package = 0,
+    Group = 1,
+}
+
+/// <summary>
+/// One navigation source in a versioned workspace share packet.
+/// </summary>
+public sealed record WorkspaceShareTab
+{
+    internal WorkspaceShareTab(
+        WorkspaceShareSourceKind sourceKind,
+        string source,
+        string? version,
+        string? framework,
+        string? runtimeIdentifier)
+    {
+        SourceKind = sourceKind;
+        Source = source;
+        Version = version;
+        Framework = framework;
+        RuntimeIdentifier = runtimeIdentifier;
+    }
+
+    public WorkspaceShareSourceKind SourceKind { get; }
+
+    /// <summary>A package id or a leading-colon group expression.</summary>
+    public string Source { get; }
+
+    /// <summary>
+    /// An exact package version or the base group segment's exact pin.
+    /// Null means the coordinate floats.
+    /// </summary>
+    public string? Version { get; }
+
+    public string? Framework { get; }
+
+    public string? RuntimeIdentifier { get; }
+}
+
+/// <summary>
+/// One binding-consistent context expressed as indexes into
+/// <see cref="WorkspaceSharePacket.Tabs"/>.
+/// </summary>
+public sealed class WorkspaceShareContext
+{
+    internal WorkspaceShareContext(int[] tabIndexes)
+    {
+        TabIndexes = new ReadOnlyCollection<int>((int[])tabIndexes.Clone());
+    }
+
+    /// <summary>
+    /// Ordered tab indexes. Order is member overlay and binding precedence,
+    /// not navigation order.
+    /// </summary>
+    public IReadOnlyList<int> TabIndexes { get; }
+}
+
+/// <summary>
+/// The validated semantic model for one canonical v1 <c>w</c> query value.
+/// </summary>
+/// <remarks>
+/// The packet separates coordinate/binding state from optional initial view
+/// state. This type does not resolve view ids, acquire artifacts, or execute a
+/// query. <c>WorkspaceSharePacketCodecTests.Decode_CanonicalVector_RoundTripsExactly</c>
+/// gates exact v1 decoding and canonical re-emission.
+/// </remarks>
+public sealed class WorkspaceSharePacket
+{
+    internal WorkspaceSharePacket(
+        WorkspaceShareTab[] tabs,
+        WorkspaceShareContext[] contexts,
+        int activeTabIndex,
+        int selectedContextIndex,
+        string? lens,
+        string? type,
+        string? memberAnchor,
+        string? memberSignature,
+        string? section,
+        string[] libraries)
+    {
+        Tabs = new ReadOnlyCollection<WorkspaceShareTab>(
+            (WorkspaceShareTab[])tabs.Clone());
+        Contexts = new ReadOnlyCollection<WorkspaceShareContext>(
+            (WorkspaceShareContext[])contexts.Clone());
+        ActiveTabIndex = activeTabIndex;
+        SelectedContextIndex = selectedContextIndex;
+        Lens = lens;
+        Type = type;
+        MemberAnchor = memberAnchor;
+        MemberSignature = memberSignature;
+        Section = section;
+        Libraries = new ReadOnlyCollection<string>((string[])libraries.Clone());
+    }
+
+    public int FormatVersion => WorkspaceSharePacketCodec.CurrentFormatVersion;
+
+    public IReadOnlyList<WorkspaceShareTab> Tabs { get; }
+
+    public IReadOnlyList<WorkspaceShareContext> Contexts { get; }
+
+    public int ActiveTabIndex { get; }
+
+    public int SelectedContextIndex { get; }
+
+    public string? Lens { get; }
+
+    public string? Type { get; }
+
+    public string? MemberAnchor { get; }
+
+    public string? MemberSignature { get; }
+
+    public string? Section { get; }
+
+    public IReadOnlyList<string> Libraries { get; }
+}
+
+/// <summary>Why a workspace share packet could not be decoded.</summary>
+public enum WorkspaceSharePacketFailureKind
+{
+    Empty,
+    EncodedLimitExceeded,
+    InvalidBase64Url,
+    DecodedLimitExceeded,
+    InvalidJson,
+    UnsupportedFormat,
+    InvalidShape,
+    JsonValueLimitExceeded,
+    NonCanonical,
+}
+
+/// <summary>Typed failure while decoding or emitting workspace share state.</summary>
+public sealed class WorkspaceSharePacketException : Exception
+{
+    public WorkspaceSharePacketException(
+        WorkspaceSharePacketFailureKind kind,
+        string message)
+        : base(message)
+    {
+        Kind = kind;
+    }
+
+    public WorkspaceSharePacketException(
+        WorkspaceSharePacketFailureKind kind,
+        string message,
+        Exception innerException)
+        : base(message, innerException)
+    {
+        Kind = kind;
+    }
+
+    public WorkspaceSharePacketFailureKind Kind { get; }
+}

--- a/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacketCodec.cs
+++ b/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacketCodec.cs
@@ -1,0 +1,795 @@
+using System.Buffers;
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Queries.Definitions;
+
+/// <summary>
+/// Decodes and canonically emits the versioned base64url workspace share
+/// packet used by the browser <c>w</c> query value.
+/// </summary>
+/// <remarks>
+/// Decoding is synchronous and bounded. It restores no partial state: malformed
+/// encoding, JSON, shape, identity, or topology produces one typed failure
+/// before artifact acquisition or query planning. The codec is host-neutral,
+/// NativeAOT-compatible, and safe for single-threaded Browser/Wasm.
+/// </remarks>
+public static class WorkspaceSharePacketCodec
+{
+    public const int CurrentFormatVersion = 1;
+    public const int MaxEncodedLength = 16 * 1024;
+    public const int MaxDecodedUtf8Length = 12 * 1024;
+    public const int MaxJsonDepth = 16;
+    public const int MaxJsonValues = 1024;
+    public const int MaxTabs = 12;
+    public const int MaxContexts = 24;
+
+    private static readonly UTF8Encoding s_utf8Strict = new(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// Decodes one complete canonical base64url packet.
+    /// </summary>
+    public static WorkspaceSharePacket Decode(
+        string encoded,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        ArgumentNullException.ThrowIfNull(encoded);
+
+        if (encoded.Length == 0)
+            throw Failure(WorkspaceSharePacketFailureKind.Empty, "Workspace share state is empty.");
+        if (encoded.Length > MaxEncodedLength)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.EncodedLimitExceeded,
+                $"Workspace share state exceeds the {MaxEncodedLength}-character limit.");
+        }
+
+        byte[] utf8Json = DecodeBase64Url(encoded);
+        if (utf8Json.Length > MaxDecodedUtf8Length)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.DecodedLimitExceeded,
+                $"Workspace share state exceeds the {MaxDecodedUtf8Length}-byte decoded limit.");
+        }
+
+        ValidateJsonBudget(utf8Json);
+
+        JsonDocument document;
+        try
+        {
+            document = HardenedJson.Parse(utf8Json);
+        }
+        catch (JsonException ex)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidJson,
+                "Workspace share state is not valid duplicate-free JSON.",
+                ex);
+        }
+
+        WorkspaceSharePacket packet;
+        using (document)
+            packet = Bind(document.RootElement);
+
+        string canonical = Encode(packet);
+        if (!string.Equals(encoded, canonical, StringComparison.Ordinal))
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.NonCanonical,
+                "Workspace share state is valid but not in canonical v1 form.");
+        }
+
+        return packet;
+    }
+
+    /// <summary>
+    /// Emits the one canonical base64url representation of a validated packet.
+    /// </summary>
+    public static string Encode(WorkspaceSharePacket packet)
+    {
+        ArgumentNullException.ThrowIfNull(packet);
+        byte[] utf8Json = WriteCanonicalJson(packet);
+        if (utf8Json.Length > MaxDecodedUtf8Length)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.DecodedLimitExceeded,
+                $"Workspace share state exceeds the {MaxDecodedUtf8Length}-byte decoded limit.");
+        }
+
+        string encoded = Convert.ToBase64String(utf8Json)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        if (encoded.Length > MaxEncodedLength)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.EncodedLimitExceeded,
+                $"Workspace share state exceeds the {MaxEncodedLength}-character limit.");
+        }
+
+        return encoded;
+    }
+
+    private static byte[] DecodeBase64Url(string encoded)
+    {
+        int remainder = encoded.Length % 4;
+        if (remainder == 1)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidBase64Url,
+                "Workspace share state is not valid canonical base64url.");
+        }
+
+        int padding = remainder == 0 ? 0 : 4 - remainder;
+        char[] base64 = new char[encoded.Length + padding];
+        for (int index = 0; index < encoded.Length; index++)
+        {
+            char character = encoded[index];
+            base64[index] = character switch
+            {
+                >= 'A' and <= 'Z' => character,
+                >= 'a' and <= 'z' => character,
+                >= '0' and <= '9' => character,
+                '-' => '+',
+                '_' => '/',
+                _ => throw Failure(
+                    WorkspaceSharePacketFailureKind.InvalidBase64Url,
+                    "Workspace share state is not valid canonical base64url."),
+            };
+        }
+
+        for (int index = encoded.Length; index < base64.Length; index++)
+            base64[index] = '=';
+
+        byte[] decoded = new byte[base64.Length / 4 * 3];
+        if (!Convert.TryFromBase64Chars(base64, decoded, out int written))
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidBase64Url,
+                "Workspace share state is not valid canonical base64url.");
+        }
+
+        if (written == decoded.Length)
+            return decoded;
+
+        return decoded.AsSpan(0, written).ToArray();
+    }
+
+    private static void ValidateJsonBudget(ReadOnlySpan<byte> utf8Json)
+    {
+        try
+        {
+            var reader = new Utf8JsonReader(
+                utf8Json,
+                new JsonReaderOptions
+                {
+                    AllowTrailingCommas = false,
+                    CommentHandling = JsonCommentHandling.Disallow,
+                    MaxDepth = MaxJsonDepth,
+                });
+            int values = 0;
+            while (reader.Read())
+            {
+                if (reader.TokenType is
+                    JsonTokenType.StartObject
+                    or JsonTokenType.StartArray
+                    or JsonTokenType.String
+                    or JsonTokenType.Number
+                    or JsonTokenType.True
+                    or JsonTokenType.False
+                    or JsonTokenType.Null)
+                {
+                    values++;
+                    if (values > MaxJsonValues)
+                    {
+                        throw Failure(
+                            WorkspaceSharePacketFailureKind.JsonValueLimitExceeded,
+                            $"Workspace share state exceeds the {MaxJsonValues}-value JSON limit.");
+                    }
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidJson,
+                $"Workspace share state is invalid JSON or exceeds depth {MaxJsonDepth}.",
+                ex);
+        }
+    }
+
+    private static WorkspaceSharePacket Bind(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+            throw InvalidShape("Workspace share state must be one JSON object.");
+
+        foreach (JsonProperty property in root.EnumerateObject())
+        {
+            if (property.Name is not ("f" or "t" or "g" or "a" or "x"
+                or "v" or "y" or "m" or "s" or "c" or "l"))
+            {
+                throw InvalidShape(
+                    $"Workspace share state must not set '{property.Name}'.");
+            }
+        }
+
+        JsonElement format = Required(root, "f");
+        if (format.ValueKind != JsonValueKind.Number || !format.TryGetInt32(out int version))
+            throw InvalidShape("Workspace share state requires integer format field 'f'.");
+        if (version != CurrentFormatVersion)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.UnsupportedFormat,
+                $"Unsupported workspace share format {version}; expected {CurrentFormatVersion}.");
+        }
+
+        WorkspaceShareTab[] tabs = ReadTabs(Required(root, "t"));
+        WorkspaceShareContext[] contexts = ReadContexts(
+            Required(root, "g"),
+            tabs);
+
+        int activeTab = ReadIndex(Required(root, "a"), "a", tabs.Length);
+        int selectedContext = ReadIndex(
+            Required(root, "x"),
+            "x",
+            contexts.Length);
+
+        string? lens = OptionalString(root, "v");
+        string? type = OptionalString(root, "y");
+        string? memberAnchor = OptionalString(root, "m");
+        string? memberSignature = OptionalString(root, "s");
+        string? section = OptionalString(root, "c");
+        string[] libraries = ReadLibraries(root);
+
+        if (memberAnchor is not null && memberSignature is not null)
+            throw InvalidShape("Workspace share state cannot set both 'm' and 's'.");
+        if ((memberAnchor is not null || memberSignature is not null) && type is null)
+            throw InvalidShape("Workspace share member selection requires type field 'y'.");
+
+        return new WorkspaceSharePacket(
+            tabs,
+            contexts,
+            activeTab,
+            selectedContext,
+            lens,
+            type,
+            memberAnchor,
+            memberSignature,
+            section,
+            libraries);
+    }
+
+    private static WorkspaceShareTab[] ReadTabs(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            throw InvalidShape("Workspace share field 't' must be an array.");
+
+        int count = element.GetArrayLength();
+        if (count is < 1 or > MaxTabs)
+        {
+            throw InvalidShape(
+                $"Workspace share field 't' requires between 1 and {MaxTabs} entries.");
+        }
+
+        var tabs = new WorkspaceShareTab[count];
+        var seen = new HashSet<TabIdentity>();
+        int tabIndex = 0;
+        foreach (JsonElement tuple in element.EnumerateArray())
+        {
+            if (tuple.ValueKind != JsonValueKind.Array || tuple.GetArrayLength() != 4)
+                throw InvalidShape("Every workspace share tab tuple must contain exactly four values.");
+
+            JsonElement.ArrayEnumerator values = tuple.EnumerateArray();
+            values.MoveNext();
+            string source = RequiredString(values.Current, "tab source");
+            values.MoveNext();
+            string? version = NullableString(values.Current, "tab version");
+            values.MoveNext();
+            string? framework = NullableString(values.Current, "tab framework");
+            values.MoveNext();
+            string? runtimeIdentifier = NullableString(values.Current, "tab runtime identifier");
+
+            WorkspaceShareSourceKind sourceKind;
+            string identitySource;
+            if (source[0] == ':')
+            {
+                sourceKind = WorkspaceShareSourceKind.Group;
+                if (!IsGroupExpression(source))
+                    throw InvalidShape("A workspace share group source is not a valid group expression.");
+                if (version is not null
+                    && !HasPlatformBase(source))
+                {
+                    throw InvalidShape("Only a well-known Platform group may carry a v1 group pin.");
+                }
+
+                identitySource = source;
+            }
+            else
+            {
+                sourceKind = WorkspaceShareSourceKind.Package;
+                if (!PackageCoordinateResolver.IsCanonicalPackageId(source))
+                    throw InvalidShape("A workspace share package source is not a valid NuGet package id.");
+                identitySource = source.ToLowerInvariant();
+            }
+
+            if (version is not null
+                && !RealizedMemberCoordinate.IsCanonicalPackageVersion(version))
+            {
+                throw InvalidShape(
+                    "A workspace share version must be one normalized lowercase concrete NuGet version.");
+            }
+
+            if (framework is not null
+                && !RealizedMemberCoordinate.IsCanonicalFramework(framework))
+            {
+                throw InvalidShape(
+                    "A workspace share framework must be one canonical lowercase acquisition target.");
+            }
+
+            if (runtimeIdentifier is not null
+                && !RealizedMemberCoordinate.IsCanonicalRuntimeIdentifier(runtimeIdentifier))
+            {
+                throw InvalidShape(
+                    "A workspace share runtime identifier must be canonical lowercase target text.");
+            }
+
+            var identity = new TabIdentity(
+                sourceKind,
+                identitySource,
+                version,
+                framework,
+                runtimeIdentifier);
+            if (!seen.Add(identity))
+                throw InvalidShape("Workspace share field 't' contains a duplicate source tuple.");
+
+            tabs[tabIndex++] = new WorkspaceShareTab(
+                sourceKind,
+                source,
+                version,
+                framework,
+                runtimeIdentifier);
+        }
+
+        return tabs;
+    }
+
+    private static WorkspaceShareContext[] ReadContexts(
+        JsonElement element,
+        WorkspaceShareTab[] tabs)
+    {
+        if (element.ValueKind != JsonValueKind.Array)
+            throw InvalidShape("Workspace share field 'g' must be an array.");
+
+        int count = element.GetArrayLength();
+        if (count is < 1 or > MaxContexts)
+        {
+            throw InvalidShape(
+                $"Workspace share field 'g' requires between 1 and {MaxContexts} entries.");
+        }
+
+        var contexts = new WorkspaceShareContext[count];
+        var referenced = new bool[tabs.Length];
+        var contextIdentities = new HashSet<string>(StringComparer.Ordinal);
+        int contextIndex = 0;
+        foreach (JsonElement context in element.EnumerateArray())
+        {
+            if (context.ValueKind != JsonValueKind.Array
+                || context.GetArrayLength() is < 1 or > MaxTabs)
+            {
+                throw InvalidShape(
+                    $"Every workspace share context requires between 1 and {MaxTabs} tab indexes.");
+            }
+
+            int[] indexes = new int[context.GetArrayLength()];
+            var local = new HashSet<int>();
+            string? framework = null;
+            string? runtimeIdentifier = null;
+            bool first = true;
+            bool sawGroup = false;
+            int indexOffset = 0;
+            foreach (JsonElement indexElement in context.EnumerateArray())
+            {
+                int index = ReadIndex(indexElement, "context tab", tabs.Length);
+                if (!local.Add(index))
+                    throw InvalidShape("A workspace share context repeats a tab index.");
+
+                WorkspaceShareTab tab = tabs[index];
+                if (tab.SourceKind == WorkspaceShareSourceKind.Group)
+                {
+                    if (!first || sawGroup)
+                    {
+                        throw InvalidShape(
+                            "A workspace share context may contain one group source, and it must be first.");
+                    }
+
+                    sawGroup = true;
+                }
+
+                if (first)
+                {
+                    framework = tab.Framework;
+                    runtimeIdentifier = tab.RuntimeIdentifier;
+                    first = false;
+                }
+                else if (!string.Equals(framework, tab.Framework, StringComparison.Ordinal)
+                    || !string.Equals(
+                        runtimeIdentifier,
+                        tab.RuntimeIdentifier,
+                        StringComparison.Ordinal))
+                {
+                    throw InvalidShape(
+                        "Every tab in one workspace share context must declare the same framework and runtime identifier.");
+                }
+
+                indexes[indexOffset++] = index;
+                referenced[index] = true;
+            }
+
+            string identity = string.Join(',', indexes);
+            if (!contextIdentities.Add(identity))
+                throw InvalidShape("Workspace share field 'g' contains a duplicate context.");
+
+            contexts[contextIndex++] = new WorkspaceShareContext(indexes);
+        }
+
+        if (referenced.Any(value => !value))
+            throw InvalidShape("Every workspace share tab must belong to at least one context.");
+
+        return contexts;
+    }
+
+    private static string[] ReadLibraries(JsonElement root)
+    {
+        if (!root.TryGetProperty("l", out JsonElement element))
+            return [];
+        if (element.ValueKind != JsonValueKind.Array || element.GetArrayLength() == 0)
+            throw InvalidShape("Workspace share field 'l' must be a nonempty array when present.");
+
+        var libraries = new string[element.GetArrayLength()];
+        string? previous = null;
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string library = RequiredString(item, "library identity");
+            if (previous is not null
+                && string.CompareOrdinal(previous, library) >= 0)
+            {
+                throw InvalidShape(
+                    "Workspace share library identities must be unique and in ascending ordinal order.");
+            }
+
+            libraries[index++] = library;
+            previous = library;
+        }
+
+        return libraries;
+    }
+
+    private static int ReadIndex(JsonElement element, string field, int count)
+    {
+        if (element.ValueKind != JsonValueKind.Number
+            || !element.TryGetInt32(out int value)
+            || value < 0
+            || value >= count)
+        {
+            throw InvalidShape(
+                $"Workspace share {field} index must be an integer from 0 through {count - 1}.");
+        }
+
+        return value;
+    }
+
+    private static JsonElement Required(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out JsonElement value))
+            throw InvalidShape($"Workspace share state requires field '{name}'.");
+        return value;
+    }
+
+    private static string? OptionalString(JsonElement root, string name)
+    {
+        if (!root.TryGetProperty(name, out JsonElement value))
+            return null;
+        return RequiredString(value, $"field '{name}'");
+    }
+
+    private static string? NullableString(JsonElement element, string owner) =>
+        element.ValueKind == JsonValueKind.Null
+            ? null
+            : RequiredString(element, owner);
+
+    private static string RequiredString(JsonElement element, string owner)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            throw InvalidShape($"Workspace share {owner} must be a string.");
+
+        string value;
+        try
+        {
+            value = element.GetString() ?? "";
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw InvalidShape(
+                $"Workspace share {owner} contains invalid Unicode.",
+                ex);
+        }
+
+        if (value.Length == 0)
+            throw InvalidShape($"Workspace share {owner} must not be empty.");
+        EnsureWellFormedUnicode(value, owner);
+        return value;
+    }
+
+    private static void EnsureWellFormedUnicode(string value, string owner)
+    {
+        ReadOnlySpan<char> remaining = value;
+        while (!remaining.IsEmpty)
+        {
+            OperationStatus status = Rune.DecodeFromUtf16(
+                remaining,
+                out _,
+                out int consumed);
+            if (status != OperationStatus.Done)
+                throw InvalidShape($"Workspace share {owner} contains invalid Unicode.");
+            remaining = remaining[consumed..];
+        }
+    }
+
+    private static bool IsGroupExpression(string value)
+    {
+        if (value.Length < 2 || value[0] != ':' || value.Contains('@', StringComparison.Ordinal))
+            return false;
+
+        ReadOnlySpan<char> remaining = value.AsSpan(1);
+        while (!remaining.IsEmpty)
+        {
+            int overlay = remaining.IndexOf('+');
+            ReadOnlySpan<char> path = overlay < 0 ? remaining : remaining[..overlay];
+            if (path.IsEmpty)
+                return false;
+
+            while (!path.IsEmpty)
+            {
+                int separator = path.IndexOf(':');
+                ReadOnlySpan<char> segment = separator < 0 ? path : path[..separator];
+                if (!IsGroupName(segment))
+                    return false;
+                path = separator < 0 ? [] : path[(separator + 1)..];
+            }
+
+            remaining = overlay < 0 ? [] : remaining[(overlay + 1)..];
+        }
+
+        return true;
+    }
+
+    private static bool HasPlatformBase(string value)
+    {
+        int end = value.AsSpan(1).IndexOfAny(':', '+');
+        ReadOnlySpan<char> baseSegment = end < 0
+            ? value.AsSpan(1)
+            : value.AsSpan(1, end);
+        return baseSegment.SequenceEqual("Platform");
+    }
+
+    private static bool IsGroupName(ReadOnlySpan<char> value)
+    {
+        if (value.IsEmpty)
+            return false;
+        foreach (char character in value)
+        {
+            if (!char.IsAsciiLetterOrDigit(character)
+                && character is not ('.' or '_' or '-'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static byte[] WriteCanonicalJson(WorkspaceSharePacket packet)
+    {
+        var writer = new CanonicalWriter();
+        writer.WriteAscii("{\"f\":1,\"t\":["u8);
+        for (int index = 0; index < packet.Tabs.Count; index++)
+        {
+            if (index > 0)
+                writer.WriteByte((byte)',');
+            WorkspaceShareTab tab = packet.Tabs[index];
+            writer.WriteByte((byte)'[');
+            writer.WriteString(tab.Source);
+            writer.WriteByte((byte)',');
+            writer.WriteNullableString(tab.Version);
+            writer.WriteByte((byte)',');
+            writer.WriteNullableString(tab.Framework);
+            writer.WriteByte((byte)',');
+            writer.WriteNullableString(tab.RuntimeIdentifier);
+            writer.WriteByte((byte)']');
+        }
+
+        writer.WriteAscii("],\"g\":["u8);
+        for (int contextIndex = 0; contextIndex < packet.Contexts.Count; contextIndex++)
+        {
+            if (contextIndex > 0)
+                writer.WriteByte((byte)',');
+            writer.WriteByte((byte)'[');
+            IReadOnlyList<int> indexes = packet.Contexts[contextIndex].TabIndexes;
+            for (int index = 0; index < indexes.Count; index++)
+            {
+                if (index > 0)
+                    writer.WriteByte((byte)',');
+                writer.WriteInteger(indexes[index]);
+            }
+
+            writer.WriteByte((byte)']');
+        }
+
+        writer.WriteAscii("],\"a\":"u8);
+        writer.WriteInteger(packet.ActiveTabIndex);
+        writer.WriteAscii(",\"x\":"u8);
+        writer.WriteInteger(packet.SelectedContextIndex);
+        writer.WriteOptionalProperty("v"u8, packet.Lens);
+        writer.WriteOptionalProperty("y"u8, packet.Type);
+        writer.WriteOptionalProperty("m"u8, packet.MemberAnchor);
+        writer.WriteOptionalProperty("s"u8, packet.MemberSignature);
+        writer.WriteOptionalProperty("c"u8, packet.Section);
+        if (packet.Libraries.Count > 0)
+        {
+            writer.WriteAscii(",\"l\":["u8);
+            for (int index = 0; index < packet.Libraries.Count; index++)
+            {
+                if (index > 0)
+                    writer.WriteByte((byte)',');
+                writer.WriteString(packet.Libraries[index]);
+            }
+
+            writer.WriteByte((byte)']');
+        }
+
+        writer.WriteByte((byte)'}');
+        return writer.ToArray();
+    }
+
+    private static WorkspaceSharePacketException Failure(
+        WorkspaceSharePacketFailureKind kind,
+        string message) =>
+        new(kind, message);
+
+    private static WorkspaceSharePacketException Failure(
+        WorkspaceSharePacketFailureKind kind,
+        string message,
+        Exception innerException) =>
+        new(kind, message, innerException);
+
+    private static WorkspaceSharePacketException InvalidShape(string message) =>
+        Failure(WorkspaceSharePacketFailureKind.InvalidShape, message);
+
+    private static WorkspaceSharePacketException InvalidShape(
+        string message,
+        Exception innerException) =>
+        Failure(WorkspaceSharePacketFailureKind.InvalidShape, message, innerException);
+
+    private readonly record struct TabIdentity(
+        WorkspaceShareSourceKind SourceKind,
+        string Source,
+        string? Version,
+        string? Framework,
+        string? RuntimeIdentifier);
+
+    private sealed class CanonicalWriter
+    {
+        private readonly ArrayBufferWriter<byte> _buffer = new(512);
+
+        public void WriteByte(byte value)
+        {
+            Span<byte> destination = _buffer.GetSpan(1);
+            destination[0] = value;
+            _buffer.Advance(1);
+        }
+
+        public void WriteAscii(ReadOnlySpan<byte> value)
+        {
+            value.CopyTo(_buffer.GetSpan(value.Length));
+            _buffer.Advance(value.Length);
+        }
+
+        public void WriteInteger(int value)
+        {
+            Span<byte> destination = _buffer.GetSpan(11);
+            if (!Utf8Formatter.TryFormat(value, destination, out int written))
+                throw new InvalidOperationException("Could not format a workspace share index.");
+            _buffer.Advance(written);
+        }
+
+        public void WriteOptionalProperty(ReadOnlySpan<byte> name, string? value)
+        {
+            if (value is null)
+                return;
+            WriteAscii(",\""u8);
+            WriteAscii(name);
+            WriteAscii("\":"u8);
+            WriteString(value);
+        }
+
+        public void WriteNullableString(string? value)
+        {
+            if (value is null)
+            {
+                WriteAscii("null"u8);
+                return;
+            }
+
+            WriteString(value);
+        }
+
+        public void WriteString(string value)
+        {
+            WriteByte((byte)'"');
+            Span<byte> utf8 = stackalloc byte[4];
+            ReadOnlySpan<char> remaining = value;
+            while (!remaining.IsEmpty)
+            {
+                OperationStatus status = Rune.DecodeFromUtf16(
+                    remaining,
+                    out Rune rune,
+                    out int consumed);
+                if (status != OperationStatus.Done)
+                {
+                    throw InvalidShape(
+                        "Workspace share state contains invalid Unicode.");
+                }
+
+                remaining = remaining[consumed..];
+                int scalar = rune.Value;
+                switch (scalar)
+                {
+                    case '"':
+                        WriteAscii("\\\""u8);
+                        break;
+                    case '\\':
+                        WriteAscii("\\\\"u8);
+                        break;
+                    case '\b':
+                        WriteAscii("\\b"u8);
+                        break;
+                    case '\t':
+                        WriteAscii("\\t"u8);
+                        break;
+                    case '\n':
+                        WriteAscii("\\n"u8);
+                        break;
+                    case '\f':
+                        WriteAscii("\\f"u8);
+                        break;
+                    case '\r':
+                        WriteAscii("\\r"u8);
+                        break;
+                    case < 0x20:
+                        WriteAscii("\\u00"u8);
+                        WriteByte(HexLower((scalar >> 4) & 0xF));
+                        WriteByte(HexLower(scalar & 0xF));
+                        break;
+                    default:
+                        int written = rune.EncodeToUtf8(utf8);
+                        WriteAscii(utf8[..written]);
+                        break;
+                }
+            }
+
+            WriteByte((byte)'"');
+        }
+
+        public byte[] ToArray() => _buffer.WrittenSpan.ToArray();
+
+        private static byte HexLower(int value) =>
+            (byte)(value < 10 ? '0' + value : 'a' + value - 10);
+    }
+}

--- a/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacketCodec.cs
+++ b/src/DotnetInspector.Queries/Definitions/WorkspaceSharePacketCodec.cs
@@ -58,6 +58,7 @@ public static class WorkspaceSharePacketCodec
                 $"Workspace share state exceeds the {MaxDecodedUtf8Length}-byte decoded limit.");
         }
 
+        ValidateUtf8(utf8Json);
         ValidateJsonBudget(utf8Json);
 
         JsonDocument document;
@@ -70,6 +71,13 @@ public static class WorkspaceSharePacketCodec
             throw Failure(
                 WorkspaceSharePacketFailureKind.InvalidJson,
                 "Workspace share state is not valid duplicate-free JSON.",
+                ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidJson,
+                "Workspace share state contains invalid JSON property text.",
                 ex);
         }
 
@@ -204,19 +212,43 @@ public static class WorkspaceSharePacketCodec
         }
     }
 
+    private static void ValidateUtf8(ReadOnlySpan<byte> utf8Json)
+    {
+        try
+        {
+            _ = s_utf8Strict.GetCharCount(utf8Json);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            throw Failure(
+                WorkspaceSharePacketFailureKind.InvalidJson,
+                "Workspace share state is not valid UTF-8 JSON.",
+                ex);
+        }
+    }
+
     private static WorkspaceSharePacket Bind(JsonElement root)
     {
         if (root.ValueKind != JsonValueKind.Object)
             throw InvalidShape("Workspace share state must be one JSON object.");
 
-        foreach (JsonProperty property in root.EnumerateObject())
+        try
         {
-            if (property.Name is not ("f" or "t" or "g" or "a" or "x"
-                or "v" or "y" or "m" or "s" or "c" or "l"))
+            foreach (JsonProperty property in root.EnumerateObject())
             {
-                throw InvalidShape(
-                    $"Workspace share state must not set '{property.Name}'.");
+                if (property.Name is not ("f" or "t" or "g" or "a" or "x"
+                    or "v" or "y" or "m" or "s" or "c" or "l"))
+                {
+                    throw InvalidShape(
+                        "Workspace share state contains an unknown property.");
+                }
             }
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw InvalidShape(
+                "Workspace share state contains an invalid property name.",
+                ex);
         }
 
         JsonElement format = Required(root, "f");
@@ -548,26 +580,19 @@ public static class WorkspaceSharePacketCodec
             return false;
 
         ReadOnlySpan<char> remaining = value.AsSpan(1);
-        while (!remaining.IsEmpty)
+        while (true)
         {
-            int overlay = remaining.IndexOf('+');
-            ReadOnlySpan<char> path = overlay < 0 ? remaining : remaining[..overlay];
-            if (path.IsEmpty)
+            int separator = remaining.IndexOfAny(':', '+');
+            ReadOnlySpan<char> segment = separator < 0
+                ? remaining
+                : remaining[..separator];
+            if (!IsGroupName(segment))
                 return false;
+            if (separator < 0)
+                return true;
 
-            while (!path.IsEmpty)
-            {
-                int separator = path.IndexOf(':');
-                ReadOnlySpan<char> segment = separator < 0 ? path : path[..separator];
-                if (!IsGroupName(segment))
-                    return false;
-                path = separator < 0 ? [] : path[(separator + 1)..];
-            }
-
-            remaining = overlay < 0 ? [] : remaining[(overlay + 1)..];
+            remaining = remaining[(separator + 1)..];
         }
-
-        return true;
     }
 
     private static bool HasPlatformBase(string value)


### PR DESCRIPTION
Part of #4647. This is the non-conflicting product-only foundation; it deliberately does not add CLI routing, browser wiring, packet transposition, or member planning.

## Demo

This PR stops below CLI binding, so an executable `-W` invocation does not
exist at this head. The intended downstream consumer syntax is:

```console
$ dotnet-inspect -W 'eyJmIjoxLCJ0IjpbLi4uXX0'
```

The actual demonstration in this foundation is the shared wire contract. The
fixed v1 packet decodes this browser/CLI-neutral state:

```json
{"f":1,"t":[[":Platform","10.0.10","net10.0",null],["System.Text.Json","10.0.0","net10.0",null]],"g":[[0,1]],"a":1,"x":0,"v":"api","y":"System.Text.Json.JsonSerializer","l":["System.Text.Json"]}
```

from this exact base64url `w` value:

```text
eyJmIjoxLCJ0IjpbWyI6UGxhdGZvcm0iLCIxMC4wLjEwIiwibmV0MTAuMCIsbnVsbF0sWyJTeXN0ZW0uVGV4dC5Kc29uIiwiMTAuMC4wIiwibmV0MTAuMCIsbnVsbF1dLCJnIjpbWzAsMV1dLCJhIjoxLCJ4IjowLCJ2IjoiYXBpIiwieSI6IlN5c3RlbS5UZXh0Lkpzb24uSnNvblNlcmlhbGl6ZXIiLCJsIjpbIlN5c3RlbS5UZXh0Lkpzb24iXX0
```

`WorkspaceSharePacketCodec.Decode` returns two typed tabs, the fused context,
active tab `1`, selected context `0`, and the API/type view. Re-encoding
produces the byte-identical value. A neighboring fixed vector proves that
active focus may remain outside the selected binding context; Unicode
metadata, canonical signatures, C0 controls, raw edge scalars, and a
supplementary scalar are pinned independently.

Packet-to-definition transposition and the actual `-W` CLI demo remain
downstream of this foundation and #4649.

## Summary

- Add an immutable product-owned v1 packet model and typed failure contract.
- Add bounded, duplicate-free base64url/JSON decoding with exact coordinate, topology, selection, and canonical-form validation.
- Add a purpose-built canonical UTF-8 writer and fixed vectors plus close-negative coverage for malformed, non-canonical, over-limit, and partial state.
- Record the implemented codec boundary and the remaining transposition/host work in the workspace design.

## Compatibility

V1 is the first supported wire contract, so the codec intentionally rejects today's unversioned prototype forms rather than guessing or partially restoring them. The packet carries coordinates only; acquisition authority remains with the receiving host. This PR changes no CLI or browser behavior and consumes none of the mutable member-routing surfaces being replaced by #4649.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build --no-restore` — 553 passed
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-restore -- -method '*WorkspaceSharePacket*'` — 47 passed
- `npx markdownlint-cli docs/design/workspace-definitions.md`
