### PR TITLE
Clarify metadata keybinding ownership comment

### DIFF
--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -11,8 +11,8 @@
 // stack (`openExplorer`, `pushExplorerFocus`, `applyExplorerFocus`,
 // `explorerHistoryBack/Forward`, `explorerShowOverview`, `closeExplorer`), the
 // `IntersectionObserver` that hydrates cards lazily, the resize listener, and the global
-// keydown handler. This module owns the markup and its interaction mapping given explicit
-// state and action callbacks.
+// gesture effects registered with the shared keybinding dispatcher. This module owns the
+// markup and its interaction mapping given explicit state and action callbacks.
 //
 // The shared text helpers used well beyond these views (`escapeHtml`, `fmtBytes`) and the
 // shared lens chrome (`platformLensPicker`, `scopedPlatformLibrary`, `packageScopeSignature`,


### PR DESCRIPTION
## Summary

Update the Metadata Explorer ownership comment to describe global gesture effects registered with the shared keybinding dispatcher, rather than the removed global `keydown` handler.

This is a trivial comment-only correction with no behavior or contract change; no adversarial review is required.

## Demo

```diff
-// keydown handler.
+// gesture effects registered with the shared keybinding dispatcher.
```

## Validation

```console
git diff --check
git grep "global keydown handler" -- prototypes/inspect-web/src  # no matches
```