### PR TITLE
Hoist nested member focus test

### DIFF
--- a/prototypes/inspect-web/test/member-focus.test.ts
+++ b/prototypes/inspect-web/test/member-focus.test.ts
@@ -358,29 +358,29 @@ test("member and overload rows survive activation renders", () => {
       return 1;
     });
 
-    test("taste controls survive source completion renders", () => {
-      const { document: tasteDocument, element: tasteElement } = createDocument();
-      const tasteSelector = "[data-taste=\"prefer-var\"]";
-      const initialCheckbox = tasteElement(tasteSelector, {
-        dataset: { taste: "prefer-var" },
-      });
-      tasteDocument.activeElement = initialCheckbox;
-      const tasteSnapshot = captureMemberFocus(tasteDocument);
-
-      const replacementCheckbox = tasteElement(tasteSelector, {
-        dataset: { taste: "prefer-var" },
-      });
-      tasteDocument.activeElement = tasteDocument.body;
-      restoreMemberFocus(tasteDocument, tasteSnapshot, callback => {
-        callback(0);
-        return 1;
-      });
-
-      assert.equal(tasteDocument.activeElement, replacementCheckbox);
-    });
-
     assert.equal(document.activeElement, replacementButton);
   }
+});
+
+test("taste controls survive source completion renders", () => {
+  const { document, element } = createDocument();
+  const selector = "[data-taste=\"prefer-var\"]";
+  const initialCheckbox = element(selector, {
+    dataset: { taste: "prefer-var" },
+  });
+  document.activeElement = initialCheckbox;
+  const snapshot = captureMemberFocus(document);
+
+  const replacementCheckbox = element(selector, {
+    dataset: { taste: "prefer-var" },
+  });
+  document.activeElement = document.body;
+  restoreMemberFocus(document, snapshot, callback => {
+    callback(0);
+    return 1;
+  });
+
+  assert.equal(document.activeElement, replacementCheckbox);
 });
 
 test("deferred restoration does not steal intentionally moved focus", () => {


### PR DESCRIPTION
## Summary

Hoist the taste-control focus test out of the member/overload loop so Node registers it once as an independent top-level test. The two existing focus-restoration assertions are unchanged.

## Demo

```console
$ npx --yes node@24 --test test/member-focus.test.ts
# before
▶ member and overload rows survive activation renders
  ✔ taste controls survive source completion renders
  ✔ taste controls survive source completion renders
✔ member and overload rows survive activation renders
ℹ tests 16

# after
✔ member and overload rows survive activation renders
✔ taste controls survive source completion renders
ℹ tests 15
```

The neighboring member/overload focus case still passes; the taste case now appears once at top level.

## Validation

- `npx --yes node@24 --test test/member-focus.test.ts` — 15/15 passed
- `npm test` under Node 24 — 591/591 passed, including TypeScript checks
- `npm run analyze` under Node 24 — passed
- `git diff --check` — passed

## Non-action boundary

This changes test registration only. It does not change inspect-web focus behavior or production code.

Closes #4542.