### PR TITLE
Add all-access type filter chip

### DIFF
--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1695,10 +1695,15 @@ function isDefaultAccessibility(type: BrowserTypeSurface) {
     descriptor => descriptor.isDefault && descriptor.id === type.accessibilityId));
 }
 
-// Multi-select chip toggle for the accessibility filter. Flips a bucket in the
-// active set; an empty result falls back to the "public" default so the type
-// list is never blanked out.
+// Multi-select chip toggle for the accessibility filter. An empty bucket
+// selects every bucket; otherwise, an empty result falls back to the "public"
+// default so the type list is never blanked out.
 function toggleAccessibilityChip(bucket: string) {
+  if (!bucket) {
+    state.accessibilityFilter =
+      new Set(accessibilityBuckets().map(descriptor => descriptor.id));
+    return;
+  }
   const next = new Set(state.accessibilityFilter);
   if (next.has(bucket)) next.delete(bucket); else next.add(bucket);
   if (next.size === 0) {
@@ -1713,10 +1718,15 @@ function toggleAccessibilityChip(bucket: string) {
 function accessibilityControl() {
   const buckets = accessibilityBuckets();
   if (buckets.length <= 1) return "";
+  const allOn = buckets.every(
+    bucket => state.accessibilityFilter.has(bucket.id));
   const chips = buckets
     .map(bucket => `<button class="${state.accessibilityFilter.has(bucket.id) ? "active" : ""}" data-access-chip="${escapeHtml(bucket.id)}">${escapeHtml(bucket.label)}</button>`)
     .join("");
-  return `<div class="namespace-chips access-chips" aria-label="Accessibility filters">${chips}</div>`;
+  return `<div class="namespace-chips access-chips" aria-label="Accessibility filters">
+    <button class="${allOn ? "active" : ""}" data-access-chip="">all access</button>
+    ${chips}
+  </div>`;
 }
 
 // Options for the namespace picker dropdown: every namespace in the active

--- a/prototypes/inspect-web/test/library-controls.test.ts
+++ b/prototypes/inspect-web/test/library-controls.test.ts
@@ -73,12 +73,12 @@ test("library controls decode every rendered selector without eager work", () =>
   const libraryChip = new FakeElement({ libraryChip: "System.Text.Json" });
   const defaultLibraryChip = new FakeElement();
   const accessChip = new FakeElement({ accessChip: "public" });
-  const defaultAccessChip = new FakeElement();
+  const allAccessChip = new FakeElement();
   root.addAll(
     "[data-library-chip]",
     libraryChip,
     defaultLibraryChip);
-  root.addAll("[data-access-chip]", accessChip, defaultAccessChip);
+  root.addAll("[data-access-chip]", accessChip, allAccessChip);
 
   const libraryJump = root.add("#library-jump", new FakeElement());
   libraryJump.value = "System.Collections";
@@ -122,7 +122,7 @@ test("library controls decode every rendered selector without eager work", () =>
   libraryChip.dispatch("click");
   defaultLibraryChip.dispatch("click");
   accessChip.dispatch("click");
-  defaultAccessChip.dispatch("click");
+  allAccessChip.dispatch("click");
   libraryJump.dispatch("change");
   libraryJump.value = "";
   libraryJump.dispatch("change");

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -906,6 +906,22 @@ test("typed library controls own library and Platform picker bindings", () => {
   assert.doesNotMatch(appSource, /bindPlatformLensPicker/);
 });
 
+test("type accessibility controls offer an all-access selection", () => {
+  const toggle =
+    appSource.match(/function toggleAccessibilityChip\([\s\S]*?\n}(?=\n\n\/\/ The accessibility selector)/)?.[0]
+    ?? "";
+  const control =
+    appSource.match(/function accessibilityControl\(\) \{[\s\S]*?\n}(?=\n\n\/\/ Options for the namespace picker)/)?.[0]
+    ?? "";
+
+  assert.match(
+    toggle,
+    /if \(!bucket\) \{[\s\S]*new Set\(accessibilityBuckets\(\)\.map\(descriptor => descriptor\.id\)\);[\s\S]*return;/);
+  assert.match(
+    control,
+    /const allOn = buckets\.every\([\s\S]*data-access-chip="">all access<\/button>/);
+});
+
 test("typed shell controls own workbench, home, and load-error bindings", () => {
   const workbenchActions =
     appSource.match(/const workbenchShellActions: WorkbenchShellBindingActions = \{[\s\S]*?\n};/)?.[0]


### PR DESCRIPTION
Type accessibility filters now include the same **all access** chip already available for member filters. Selecting it enables every advertised accessibility bucket; the chip is highlighted only while the full set is active.

Related to #3865.

## Demo

Before, the type filter row began with individual accessibility buckets:

```text
[public] [protected] [internal] ...
```

After, users can restore the complete type set in one click:

```text
[all access] [public] [protected] [internal] ...
```

The neighboring member filter keeps its existing **all access** behavior.

## Validation

```text
npm run analyze
npm run build
npm test
```

All passed with Node.js 24.19.0.