### PR TITLE
Enable noUncheckedIndexedAccess for inspect-web

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -606,13 +606,18 @@ npm run analyze
 ```
 
 The TypeScript gate checks product and test projects with `strict`,
-`exactOptionalPropertyTypes`, and `noImplicitReturns`. `npm run analyze` then
-runs Oxlint with its tsgolint backend against the same TypeScript 7.0.2
-toolchain used to build the product. Correctness and suspicious diagnostics,
-type-aware promise and unsafe-operation checks, warnings, and unused
-suppression directives all fail the gate. Browser/background promises must
-either preserve sequencing or surface unexpected rejection visibly. The exact
-`node:test` `test` call is the only configured safe promise-returning call
+`exactOptionalPropertyTypes`, `noImplicitReturns`, and
+`noUncheckedIndexedAccess`. Indexed reads must prove that an entry exists or
+preserve absence as an explicit result. The `npm test` cases `closing a package
+removes its coordinate and selects the adjacent tab` and `call graph navigation
+resolves accessor selectors across image-local token differences` provide
+close negative coverage for sparse workspace packages and graph member groups.
+`npm run analyze` then runs Oxlint with its tsgolint backend against the same
+TypeScript 7.0.2 toolchain used to build the product. Correctness and suspicious
+diagnostics, type-aware promise and unsafe-operation checks, warnings, and
+unused suppression directives all fail the gate. Browser/background promises
+must either preserve sequencing or surface unexpected rejection visibly. The
+exact `node:test` `test` call is the only configured safe promise-returning call
 because the test runner owns and observes that returned promise.
 
 Oxlint checks both checked-in tsbindgen outputs as consumer contracts:
@@ -650,13 +655,6 @@ unit test derives the supported intersection from the locked Oxlint and
 tsgolint package metadata, requires both Linux libc variants, and pins the npm
 preflight wiring; `npm run analyze` on macOS arm64 and the Linux x64 CI host
 gates the supported paths.
-
-`noUncheckedIndexedAccess` is not enabled yet. A TypeScript 7.0.2 migration
-probe reports 77 findings across 15 files: 65 in nine product files and 12 in
-six test files. [Issue #4549](https://github.com/richlander/dotnet-inspect/issues/4549)
-records the probe commands, file distribution, and migration discipline; the
-set should be migrated with close negative tests for indexing behavior rather
-than hidden behind assertions.
 
 ## Test
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -610,7 +610,7 @@ The TypeScript gate checks product and test projects with `strict`,
 `noUncheckedIndexedAccess`. Indexed reads must prove that an entry exists or
 preserve absence as an explicit result. The `npm test` cases `closing a package
 removes its coordinate and selects the adjacent tab` and `call graph navigation
-resolves accessor selectors across image-local token differences` provide
+resolves accessor selectors across image-local token skew` provide
 close negative coverage for sparse workspace packages and graph member groups.
 `npm run analyze` then runs Oxlint with its tsgolint backend against the same
 TypeScript 7.0.2 toolchain used to build the product. Correctness and suspicious

--- a/prototypes/inspect-web/src/data.ts
+++ b/prototypes/inspect-web/src/data.ts
@@ -467,11 +467,12 @@ export function removeWorkspacePackage<T extends RemoveWorkspacePackageInput>(
   packageKey: string,
 ): RemoveWorkspacePackageResult<T> {
   const index = packages.findIndex(item => packageIdentityKey(item) === packageKey);
-  if (index < 0 || packages[index].isRuntimePack) {
+  const packageToClose = packages[index];
+  if (!packageToClose || packageToClose.isRuntimePack) {
     return { packages: [...packages], active: activePackage, closed: null };
   }
 
-  const closed = packages[index];
+  const closed = packageToClose;
   const remaining = packages.filter((_, candidate) => candidate !== index);
   const active = packageIdentityKey(activePackage) === packageKey
     ? remaining[Math.min(index, remaining.length - 1)] ?? null
@@ -860,7 +861,7 @@ export function uniqueTypeByQueryId<T extends QueryIdentifiedType>(
 ): T | null {
   const matches = (types ?? []).filter(type =>
     (type.queryId ?? type.id) === queryId);
-  return matches.length === 1 ? matches[0] : null;
+  return matches.length === 1 ? matches[0] ?? null : null;
 }
 
 export interface CallGraphAssembly {
@@ -976,8 +977,9 @@ function resolveGraphTargetCandidate<
       if (matches.length > 1) return { status: "ambiguous" };
     }
   }
-  return matches.length === 1
-    ? { status: "unique", ...matches[0] }
+  const match = matches[0];
+  return matches.length === 1 && match
+    ? { status: "unique", ...match }
     : exactAssemblyResident
       ? { status: "resident" }
       : identitySkew
@@ -1276,8 +1278,10 @@ export function graphMemberSelection(
   )[] = [];
   for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
     const group = groups[groupIndex];
+    if (!group) continue;
     for (let overloadIndex = 0; overloadIndex < group.overloads.length; overloadIndex++) {
       const overload = group.overloads[overloadIndex];
+      if (!overload) continue;
       for (const body of overload.bodySelectors ?? []) {
         if (body.memberName === target.memberName
           && body.selectorKey === target.selectorKey) {
@@ -1288,6 +1292,7 @@ export function graphMemberSelection(
   }
   if (bodyMatches.length > 0) {
     const [first] = bodyMatches;
+    if (!first) return null;
     if (bodyMatches.length === 1
       || (first.token != null
         && bodyMatches.every(match => match.token === first.token))) {
@@ -1302,12 +1307,13 @@ export function graphMemberSelection(
   const ownerMatches: GraphMemberSelection[] = [];
   for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
     const group = groups[groupIndex];
+    if (!group) continue;
     for (let overloadIndex = 0; overloadIndex < group.overloads.length; overloadIndex++) {
-      if (group.overloads[overloadIndex].graphSelectorKey === target.selectorKey)
+      if (group.overloads[overloadIndex]?.graphSelectorKey === target.selectorKey)
         ownerMatches.push({ groupIndex, overloadIndex });
     }
   }
-  return ownerMatches.length === 1 ? ownerMatches[0] : null;
+  return ownerMatches.length === 1 ? ownerMatches[0] ?? null : null;
 }
 
 export function searchableMemberGroups<

--- a/prototypes/inspect-web/src/document-inspection.ts
+++ b/prototypes/inspect-web/src/document-inspection.ts
@@ -43,22 +43,34 @@ function splitFrontmatter(text: string) {
   const source = text;
   const match = /^\uFEFF?---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(source);
   if (!match) return { meta: null, body: source };
+  const frontmatter = match[1];
+  if (frontmatter === undefined) return { meta: null, body: source };
   const meta: DocumentFrontmatter = {};
-  const lines = match[1].split(/\r?\n/);
+  const lines = frontmatter.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    const kv = /^([A-Za-z0-9_-]+):\s?(.*)$/.exec(lines[i]);
+    const line = lines[i];
+    if (line === undefined) continue;
+    const kv = /^([A-Za-z0-9_-]+):\s?(.*)$/.exec(line);
     if (!kv) continue;
-    let value = kv[2];
+    const key = kv[1];
+    const rawValue = kv[2];
+    if (key === undefined || rawValue === undefined) continue;
+    let value = rawValue;
     if (value === ">" || value === ">-" || value === "|" || value === "|-") {
       const folded = value.startsWith(">");
       const buffer = [];
-      while (i + 1 < lines.length
-        && (/^\s+\S/.test(lines[i + 1]) || lines[i + 1].trim() === "")) {
-        buffer.push(lines[++i].trim());
+      while (i + 1 < lines.length) {
+        const nextLine = lines[i + 1];
+        if (nextLine === undefined
+          || (!/^\s+\S/.test(nextLine) && nextLine.trim() !== "")) {
+          break;
+        }
+        buffer.push(nextLine.trim());
+        i++;
       }
       value = buffer.join(folded ? " " : "\n").trim();
     }
-    meta[kv[1]] = value.trim();
+    meta[key] = value.trim();
   }
   return { meta, body: source.slice(match[0].length) };
 }

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -382,7 +382,7 @@ interface AppMemberGroup {
   key: string;
   name: string;
   kind: string;
-  overloads: AppMemberSurface[];
+  overloads: [AppMemberSurface, ...AppMemberSurface[]];
 }
 
 interface AppMemberSurface extends BrowserMemberSurface {
@@ -1787,10 +1787,11 @@ function memberGroups(
       `${member.graphOnly ? "graph:" : ""}${member.kind}:${member.name}`;
     let group = groups.get(key);
     if (!group) {
-      group = { key, name: member.name, kind: member.kind, overloads: [] };
+      group = { key, name: member.name, kind: member.kind, overloads: [member] };
       groups.set(key, group);
+    } else {
+      group.overloads.push(member);
     }
-    group.overloads.push(member);
   }
   return [...groups.values()];
 }
@@ -1952,10 +1953,15 @@ function packageLensesFor(pkg: AppPackage | null) {
 // The single platform library the Integrations/Opportunities/Analysis lenses scan: whatever
 // is currently scoped (one library), else none — the lens then prompts the user to pick one.
 // Identity is the bare assembly key (no .dll), matching libraryScope and the platform roster.
+function singleLibraryScope() {
+  if (state.libraryScope?.size !== 1) return null;
+  const candidate = state.libraryScope.values().next();
+  return candidate.done ? null : candidate.value;
+}
+
 function scopedPlatformLibrary() {
   if (!state.package?.isRuntimePack) return null;
-  if (state.libraryScope && state.libraryScope.size === 1) return [...state.libraryScope][0];
-  return null;
+  return singleLibraryScope();
 }
 
 function activeLenses() {
@@ -2018,7 +2024,8 @@ function enterMemberScope() {
   state.memberBrowseTypeId = type.id;
   const visible = visibleMemberGroups(type);
   if (!memberSelectionIsAvailable(type, visible)) {
-    if (visible.length) openMemberGroup(visible[0].key);
+    const first = visible[0];
+    if (first) openMemberGroup(first.key);
     else {
       state.selectedMemberKey = "";
       state.selectedOverloadIndex = null;
@@ -2136,7 +2143,8 @@ function stepMemberNav(delta: number, focusList: boolean) {
   const entries = memberNavEntries(type);
   if (!entries.length) return;
   const cursor = memberNavTargetIndex(memberNavCursor(entries), entries.length, delta);
-  selectMemberNavEntry(entries[cursor], focusList);
+  const entry = entries[cursor];
+  if (entry) selectMemberNavEntry(entry, focusList);
 }
 
 // ↑/↓ always act on the visible nav list, whatever depth you are at.
@@ -2151,7 +2159,9 @@ function stepHorizontal(delta: number) {
   if (state.atPackageRoot) {
     const strip = packageLensesFor(state.package);
     const index = strip.findIndex(([id]) => id === state.packageLens);
-    state.packageLens = strip[(index + delta + strip.length) % strip.length][0];
+    const lens = strip[(index + delta + strip.length) % strip.length];
+    if (!lens) return;
+    state.packageLens = lens[0];
     render();
     return;
   }
@@ -2163,12 +2173,14 @@ function stepHorizontal(delta: number) {
     const order = memberSectionsFor(member).map(([id]) => id);
     let index = order.indexOf(state.memberSection);
     if (index < 0) index = 0;
-    applyMemberSection(order[(index + delta + order.length) % order.length]);
+    const section = order[(index + delta + order.length) % order.length];
+    if (section) applyMemberSection(section);
   } else {
     const available = typeLensesFor(state.package);
     const index = available.findIndex(([id]) => id === state.lens);
-    state.lens = available[
-      (index + delta + available.length) % available.length][0];
+    const lens = available[(index + delta + available.length) % available.length];
+    if (!lens) return;
+    state.lens = lens[0];
     render();
   }
 }
@@ -2697,6 +2709,9 @@ function dependencyListSectionHtml(
   selectedGroupIndex: number | null,
 ) {
   const group = groups.find(candidate => candidate.index === selectedGroupIndex) || groups[0];
+  if (!group) {
+    throw new Error("Cannot render a dependency list without a dependency group.");
+  }
   const deps = group.dependencies || [];
   return `
     <section class="document-section" id="dep-list-section">
@@ -4578,7 +4593,8 @@ function bindAnnotatedSourceEvents() {
       const owning = node
         ? factsForNode(state.memberAnnotated.document, node.id)
         : [];
-      if (owning.length === 1) state.memberAnnotatedFactId = owning[0].id;
+      const fact = owning[0];
+      if (owning.length === 1 && fact) state.memberAnnotatedFactId = fact.id;
       render();
     },
   });
@@ -4705,8 +4721,10 @@ function selectTypeByCursor(
   items: readonly BrowserTypeSurface[],
   focusList: boolean,
 ) {
+  const item = items[cursor];
+  if (!item) return;
   state.typeCursor = cursor;
-  state.selectedTypeId = items[cursor].id;
+  state.selectedTypeId = item.id;
   state.selectedMemberKey = "";
   state.memberBrowseTypeId = "";
   resetMemberFilters();
@@ -5752,8 +5770,7 @@ function captureWorkspaceUrlState(): WorkspaceUrlState | null {
     }
   }
   const library = isRuntimePackId(state.package.id)
-    && state.libraryScope?.size === 1
-    ? [...state.libraryScope][0]
+    ? singleLibraryScope()
     : null;
   return {
     package: state.package.id,
@@ -7126,9 +7143,8 @@ function blockedCallGraphNodeBinding(
 }
 
 function currentCallGraph() {
-  return state.platformStack.length > 0
-    ? state.platformStack[state.platformStack.length - 1].graph
-    : state.memberCallGraph;
+  const current = state.platformStack.at(-1);
+  return current ? current.graph : state.memberCallGraph;
 }
 
 function platformCrumbTrail() {
@@ -7174,12 +7190,10 @@ function findGraphMemberSelection(
 ) {
   const groups = memberGroups(type);
   const selection = graphMemberSelection(groups, target);
-  return selection
-    ? {
-        group: groups[selection.groupIndex],
-        overloadIndex: selection.overloadIndex
-      }
-    : null;
+  if (!selection) return null;
+  const group = groups[selection.groupIndex];
+  if (!group?.overloads[selection.overloadIndex]) return null;
+  return { group, overloadIndex: selection.overloadIndex };
 }
 
 async function loadGraphMemberSurface(
@@ -7664,13 +7678,10 @@ function findRuntimeMemberSelection(
   const type = candidate.type;
   const groups = memberGroups(type);
   const selection = graphMemberSelection(groups, node);
-  return selection
-    ? {
-        type,
-        group: groups[selection.groupIndex],
-        overloadIndex: selection.overloadIndex
-      }
-    : null;
+  if (!selection) return null;
+  const group = groups[selection.groupIndex];
+  if (!group?.overloads[selection.overloadIndex]) return null;
+  return { type, group, overloadIndex: selection.overloadIndex };
 }
 
 function stripArity(name: string) {
@@ -8274,6 +8285,11 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
       throw new Error(
         "The engine-run demo selection was not present in its returned package surfaces.");
     }
+    const overload = member.overloads[overloadIndex];
+    if (!overload) {
+      throw new Error(
+        "The engine-run demo overload was not present in its returned member surface.");
+    }
 
     for (const packageModel of packages) {
       retainPackageModel(packageModel);
@@ -8308,7 +8324,7 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
     state.memberCallGraphExpanding = false;
     state.memberCallGraphKey = memberRequestSignature(
       type,
-      member.overloads[overloadIndex],
+      overload,
       true);
     state.loading = false;
     render();
@@ -8907,15 +8923,16 @@ keybindings.register({
   run: event => {
     const set = activeLenses();
     const index = Number(event.key) - 1;
-    if (index < set.length) {
+    const selected = set[index];
+    if (selected) {
       const sc = scope();
       if (sc === "package") {
-        state.packageLens = set[index][0];
+        state.packageLens = selected[0];
         render();
-      } else if (sc === "member" && isMemberSection(set[index][0])) {
-        applyMemberSection(set[index][0]);
+      } else if (sc === "member" && isMemberSection(selected[0])) {
+        applyMemberSection(selected[0]);
       } else {
-        state.lens = set[index][0];
+        state.lens = selected[0];
         render();
       }
     }

--- a/prototypes/inspect-web/src/keybinding-registry.ts
+++ b/prototypes/inspect-web/src/keybinding-registry.ts
@@ -203,7 +203,9 @@ export class KeybindingRegistry {
     const candidates: Candidate[] = [];
     const path = eventPath(event);
     for (let scopeDepth = 0; scopeDepth < path.length; scopeDepth++) {
-      const bindings = this.#scopedBindings.get(path[scopeDepth]);
+      const target = path[scopeDepth];
+      if (target === undefined) continue;
+      const bindings = this.#scopedBindings.get(target);
       if (!bindings) continue;
       for (const binding of bindings) {
         if (matches(binding, event)) {
@@ -224,11 +226,16 @@ export class KeybindingRegistry {
 
     for (let index = 0; index < candidates.length;) {
       const first = candidates[index];
+      if (first === undefined) break;
       let end = index + 1;
-      while (end < candidates.length
-        && candidates[end].binding.description.priority
-          === first.binding.description.priority
-        && candidates[end].scopeDepth === first.scopeDepth) {
+      while (end < candidates.length) {
+        const next = candidates[end];
+        if (next === undefined
+          || next.binding.description.priority
+            !== first.binding.description.priority
+          || next.scopeDepth !== first.scopeDepth) {
+          break;
+        }
         end++;
       }
       const group = candidates.slice(index, end);

--- a/prototypes/inspect-web/src/member-filtering.ts
+++ b/prototypes/inspect-web/src/member-filtering.ts
@@ -59,10 +59,10 @@ export function memberGroupMatches(
   });
 }
 
-export function filterMemberGroups(
-  groups: readonly FilterableMemberGroup[],
+export function filterMemberGroups<T extends FilterableMemberGroup>(
+  groups: readonly T[],
   filters: MemberGroupFilters,
-): FilterableMemberGroup[] {
+): T[] {
   return groups.filter(group => memberGroupMatches(group, filters));
 }
 

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -211,6 +211,25 @@ export interface MetadataExplorerBindingActions {
   onTableFocus: (index: number, rowId: number) => void;
 }
 
+function parseMetadataExplorerIndex(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const index = Number(value);
+  return Number.isSafeInteger(index) ? index : null;
+}
+
+function parseMetadataExplorerPair(
+  value: string | undefined,
+): [number, number] | null {
+  if (value === undefined) return null;
+  const [indexText, rowIdText] = value.split(":");
+  if (indexText === undefined || rowIdText === undefined) return null;
+  const index = Number(indexText);
+  const rowId = Number(rowIdText);
+  return Number.isSafeInteger(index) && Number.isSafeInteger(rowId)
+    ? [index, rowId]
+    : null;
+}
+
 export function bindMetadataExplorer(
   root: ParentNode,
   explorer: Pick<ExplorerState, "overview"> | null,
@@ -242,13 +261,15 @@ export function bindMetadataExplorer(
   root.querySelectorAll<HTMLElement>("[data-mde-chip]").forEach(chip =>
     chip.addEventListener(
       "click",
-      () => actions.onTableFocus(Number(chip.dataset.mdeChip), 0)));
+      () => {
+        const index = parseMetadataExplorerIndex(chip.dataset.mdeChip);
+        if (index !== null) actions.onTableFocus(index, 0);
+      }));
   root.querySelectorAll<HTMLElement>("[data-mde-jump]").forEach(button =>
     button.addEventListener("click", event => {
       event.stopPropagation();
-      const [index, rowId] =
-        (button.dataset.mdeJump ?? "").split(":").map(Number);
-      actions.onJump(index, rowId);
+      const ref = parseMetadataExplorerPair(button.dataset.mdeJump);
+      if (ref) actions.onJump(ref[0], ref[1]);
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-overview]").forEach(button =>
     button.addEventListener("click", event => {
@@ -257,9 +278,8 @@ export function bindMetadataExplorer(
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-page]").forEach(button =>
     button.addEventListener("click", () => {
-      const [index, startRowId] =
-        (button.dataset.mdePage ?? "").split(":").map(Number);
-      actions.onPage(index, startRowId);
+      const ref = parseMetadataExplorerPair(button.dataset.mdePage);
+      if (ref) actions.onPage(ref[0], ref[1]);
     }));
   root.querySelectorAll<HTMLElement>("[data-mde-heap-chip]").forEach(chip =>
     chip.addEventListener("click", () => {
@@ -272,7 +292,10 @@ export function bindMetadataExplorer(
       ".mde-wall .mde-card[data-mde-index] .mde-card-head",
     ).forEach(head => head.addEventListener("click", () => {
       const card = head.closest<HTMLElement>(".mde-card");
-      if (card) actions.onTableFocus(Number(card.dataset.mdeIndex), 0);
+      if (card) {
+        const index = parseMetadataExplorerIndex(card.dataset.mdeIndex);
+        if (index !== null) actions.onTableFocus(index, 0);
+      }
     }));
     root.querySelectorAll<HTMLElement>(
       ".mde-wall .mde-heap-card[data-mde-heap] .mde-card-head",
@@ -284,9 +307,8 @@ export function bindMetadataExplorer(
     root.querySelectorAll<HTMLElement>(
       ".mde-wall .mde-row[data-mde-row]",
     ).forEach(row => row.addEventListener("click", () => {
-      const [index, rowId] =
-        (row.dataset.mdeRow ?? "").split(":").map(Number);
-      actions.onTableFocus(index, rowId);
+      const ref = parseMetadataExplorerPair(row.dataset.mdeRow);
+      if (ref) actions.onTableFocus(ref[0], ref[1]);
     }));
   } else {
     root.querySelector("#mde-canvas")?.addEventListener(
@@ -295,9 +317,8 @@ export function bindMetadataExplorer(
     root.querySelectorAll<HTMLElement>(
       ".mde-focus .mde-row[data-mde-row]",
     ).forEach(row => row.addEventListener("click", () => {
-      const [index, rowId] =
-        (row.dataset.mdeRow ?? "").split(":").map(Number);
-      actions.onRowFocus(index, rowId);
+      const ref = parseMetadataExplorerPair(row.dataset.mdeRow);
+      if (ref) actions.onRowFocus(ref[0], ref[1]);
     }));
   }
 }

--- a/prototypes/inspect-web/src/metadata-viewer.ts
+++ b/prototypes/inspect-web/src/metadata-viewer.ts
@@ -212,7 +212,7 @@ export interface MetadataExplorerBindingActions {
 }
 
 function parseMetadataExplorerIndex(value: string | undefined): number | null {
-  if (value === undefined) return null;
+  if (value === undefined || !/^\d+$/.test(value)) return null;
   const index = Number(value);
   return Number.isSafeInteger(index) ? index : null;
 }
@@ -221,11 +221,11 @@ function parseMetadataExplorerPair(
   value: string | undefined,
 ): [number, number] | null {
   if (value === undefined) return null;
-  const [indexText, rowIdText] = value.split(":");
-  if (indexText === undefined || rowIdText === undefined) return null;
-  const index = Number(indexText);
-  const rowId = Number(rowIdText);
-  return Number.isSafeInteger(index) && Number.isSafeInteger(rowId)
+  const separator = value.indexOf(":");
+  if (separator <= 0 || separator !== value.lastIndexOf(":")) return null;
+  const index = parseMetadataExplorerIndex(value.slice(0, separator));
+  const rowId = parseMetadataExplorerIndex(value.slice(separator + 1));
+  return index !== null && rowId !== null && rowId > 0
     ? [index, rowId]
     : null;
 }

--- a/prototypes/inspect-web/src/package-opportunities.ts
+++ b/prototypes/inspect-web/src/package-opportunities.ts
@@ -89,7 +89,13 @@ function splitApiName(fullName: string): { short: string; qualifier: string } {
 // with no dotted prefix (e.g. "IServiceCollection registration") stay as plain muted text.
 function splitOpportunityKind(integrationType: string): { package: string | null; text: string } {
   const match = integrationType.match(/^([A-Z][A-Za-z0-9]+(?:\.[A-Z][A-Za-z0-9]+)+)\b\s*(.*)$/);
-  return match ? { package: match[1], text: match[2].trim() } : { package: null, text: integrationType };
+  if (!match) return { package: null, text: integrationType };
+  const packageName = match[1];
+  const text = match[2];
+  if (packageName === undefined || text === undefined) {
+    return { package: null, text: integrationType };
+  }
+  return { package: packageName, text: text.trim() };
 }
 
 // Turns the comma-separated "look for" hint into chips. Concrete identifiers open a spotlight

--- a/prototypes/inspect-web/src/platform-index.ts
+++ b/prototypes/inspect-web/src/platform-index.ts
@@ -58,21 +58,37 @@ function parseTsv(text: string): ParsedIndex {
     if (!line) continue;
     const parts = line.split("\t");
     if (parts.length < 8) continue;
+    const tfm = parts[0];
     const pack = parts[1];
+    const assembly = parts[2];
+    const file = parts[3];
     const kind = parts[4];
+    const forwardsTo = parts[5];
+    const version = parts[6];
+    const publicTypesText = parts[7];
+    if (tfm === undefined
+      || pack === undefined
+      || assembly === undefined
+      || file === undefined
+      || kind === undefined
+      || forwardsTo === undefined
+      || version === undefined
+      || publicTypesText === undefined) {
+      continue;
+    }
     if (pack !== "netcore.app" && pack !== "aspnetcore.app" && pack !== "netstandard")
       throw new Error(`Invalid platform pack '${pack}' on index line ${i + 1}.`);
     if (kind !== "impl" && kind !== "facade" && kind !== "ref")
       throw new Error(`Invalid platform assembly kind '${kind}' on index line ${i + 1}.`);
     const row: PlatformAssemblyRow = {
-      tfm: parts[0],
+      tfm,
       pack,
-      assembly: parts[2],
-      file: parts[3],
+      assembly,
+      file,
       kind,
-      forwardsTo: parts[5] || null,
-      version: parts[6],
-      publicTypes: Number(parts[7]) || 0
+      forwardsTo: forwardsTo || null,
+      version,
+      publicTypes: Number(publicTypesText) || 0
     };
     rows.push(row);
     let bucket = byTfm.get(row.tfm);

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -139,7 +139,11 @@ export function productHomeDemoLocationHref(
   const active = Math.min(
     Math.max(demo.focusTabIndex, 0),
     tabs.length - 1);
-  const focusPackage = tabs[active].id;
+  const focusTab = tabs[active];
+  if (!focusTab) {
+    throw new Error(`Product home demo '${demo.id}' has no focus tab.`);
+  }
+  const focusPackage = focusTab.id;
   return locationHref(workspaceUrlState({
     package: focusPackage,
     tabs,

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -244,6 +244,11 @@ function hasElementId(value: EventTarget | null): value is EventTarget & { id: s
   return value !== null && "id" in value && typeof value.id === "string";
 }
 
+function itemAt<T>(items: readonly T[], index: number): T | null {
+  const item = items[index];
+  return item === undefined ? null : item;
+}
+
 export function createSpotlight(options: SpotlightOptions) {
   const { state, escapeHtml } = options;
   let interactionGeneration = 0;
@@ -402,8 +407,9 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function rememberSelection(items: readonly SpotlightResult[]): void {
-    selectedResultIdentity = items[state.spotlightIndex]
-      ? spotlightResultIdentity(items[state.spotlightIndex])
+    const selectedResult = itemAt(items, state.spotlightIndex);
+    selectedResultIdentity = selectedResult
+      ? spotlightResultIdentity(selectedResult)
       : null;
   }
 
@@ -671,7 +677,9 @@ export function createSpotlight(options: SpotlightOptions) {
         event.shiftKey,
       );
       state.spotlightChipIndex = next;
-      setScope(available[next].id);
+      const scope = itemAt(available, next);
+      if (!scope) return true;
+      setScope(scope.id);
       return true;
     }
 

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -410,10 +410,17 @@ export function renderMemberNav(options: MemberNavOptions): string {
               <small>${graphOnly ? `graph target · ${escapeHtml(shortKind(group.kind))}` : (isMulti ? `${group.overloads.length}×` : escapeHtml(shortKind(group.kind)))}</small>
             </button>`;
           }
+          const overload = entry.group.overloads[entry.index];
+          if (!overload) {
+            return `<button class="type-row overload-nav-row unavailable" data-nav-overload="${entry.index}" role="option" aria-disabled="true" disabled>
+              <span class="overload-branch">↳</span>
+              <code>Unavailable overload</code>
+            </button>`;
+          }
           const selected = entry.group.key === selectedMemberKey && selectedOverloadIndex === entry.index;
           return `<button class="type-row overload-nav-row ${selected ? "selected" : ""}" data-nav-overload="${entry.index}" role="option" aria-selected="${selected}">
             <span class="overload-branch">↳</span>
-            <code>${highlight(entry.group.overloads[entry.index].signature)}</code>
+            <code>${highlight(overload.signature)}</code>
           </button>`;
         }).join("") || '<div class="empty-list">No members match these filters.</div>'}
       </div>

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -196,9 +196,9 @@ export function createNavigationHistory<TView>(
       const view = dependencies.capture();
       if (!view) return;
       const sig = dependencies.signature(view);
-      if (navigation.index >= 0
-        && navigation.stack[navigation.index]?.sig === sig) {
-        navigation.stack[navigation.index].view = view;
+      const current = itemAt(navigation.stack, navigation.index);
+      if (current && current.sig === sig) {
+        current.view = view;
         return;
       }
       navigation.stack = navigation.stack.slice(0, navigation.index + 1);
@@ -225,7 +225,11 @@ export function createNavigationHistory<TView>(
       while (navigation.index > 0) {
         const candidate = navigation.index - 1;
         navigation.index = candidate;
-        if (dependencies.apply(navigation.stack[candidate].view)) return true;
+        const candidateEntry = itemAt(navigation.stack, candidate);
+        if (!candidateEntry) {
+          throw new Error("The current navigation entry is unavailable.");
+        }
+        if (dependencies.apply(candidateEntry.view)) return true;
         navigation.stack.splice(candidate, 1);
       }
       dependencies.onExhausted();
@@ -235,7 +239,11 @@ export function createNavigationHistory<TView>(
       while (navigation.index < navigation.stack.length - 1) {
         const candidate = navigation.index + 1;
         navigation.index = candidate;
-        if (dependencies.apply(navigation.stack[candidate].view)) return true;
+        const candidateEntry = itemAt(navigation.stack, candidate);
+        if (!candidateEntry) {
+          throw new Error("The current navigation entry is unavailable.");
+        }
+        if (dependencies.apply(candidateEntry.view)) return true;
         navigation.stack.splice(candidate, 1);
         navigation.index--;
       }
@@ -324,6 +332,11 @@ type ShareStateResult = DecodedShareState | { error: string } | null;
 
 const invalidShareState =
   "The shared workspace state is invalid and was ignored.";
+
+function itemAt<T>(items: readonly T[], index: number): T | null {
+  const item = items[index];
+  return item === undefined ? null : item;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -451,9 +464,11 @@ function decodeWorkspaceShareState(value: string | null): ShareStateResult {
       if (graphMember.error) return { error: graphMember.error };
       if (!richSharePacketIsValid(raw, normalized.sourceIndexes))
         return { error: invalidShareState };
+      const active = itemAt(normalized.sourceIndexes, raw.a);
+      if (active === null) return { error: invalidShareState };
       return {
         tabs: normalized.tabs,
-        active: normalized.sourceIndexes[raw.a],
+        active,
         view: typeof raw.v === "string" ? raw.v : "",
         rich: true,
         type: typeof raw.y === "string" ? raw.y : null,
@@ -562,6 +577,9 @@ export function parseWorkspaceLocation(location: WorkspaceLocationSnapshot) {
   }
   if (!pkg && tabs.length) {
     const target = tabs[Math.min(Math.max(0, active), tabs.length - 1)];
+    if (!target) {
+      throw new Error(invalidShareState);
+    }
     pkg = target.id;
     version = target.version;
     framework = target.framework;

--- a/prototypes/inspect-web/test/annotated-source-view.test.ts
+++ b/prototypes/inspect-web/test/annotated-source-view.test.ts
@@ -42,9 +42,12 @@ test("hiding a medium drops only that medium's lines and rebases no coordinate",
 
   assert.deepEqual(view.lines.map(line => line.number), [1, 3, 4, 6]);
   assert.equal(view.hiddenLines, 2);
-  assert.equal(view.lines[0].start, 0);
+  const [firstLine, , thirdLine] = view.lines;
+  assert.ok(firstLine);
+  assert.ok(thirdLine);
+  assert.equal(firstLine.start, 0);
   assert.equal(
-    view.lines[2].segments.map(segment => segment.text).join(""),
+    thirdLine.segments.map(segment => segment.text).join(""),
     "    return new object();",
   );
 });
@@ -97,17 +100,26 @@ test("facts with no targets stay visible as explicitly unanchored", () => {
 
   assert.deepEqual(view.facts.map(fact => fact.id), [0, 1, 2]);
   assert.deepEqual(view.unanchoredFactIds, [2]);
-  assert.equal(view.facts[2].anchored, false);
-  assert.deepEqual(view.facts[2].nodeIds, []);
-  assert.equal(view.facts[2].origin, "MemberHeader");
+  const unanchoredFact = view.facts[2];
+  assert.ok(unanchoredFact);
+  assert.equal(unanchoredFact.anchored, false);
+  assert.deepEqual(unanchoredFact.nodeIds, []);
+  assert.equal(unanchoredFact.origin, "MemberHeader");
 });
 
 test("clicking text selects the tightest node and its facts", () => {
   const offset = sampleDocument.text.indexOf("new object()");
+  assert.notEqual(offset, -1);
 
-  assert.equal(nodeAtOffset(sampleDocument, offset)!.id, 1);
+  const selectedNode = nodeAtOffset(sampleDocument, offset);
+  assert.ok(selectedNode);
+  assert.equal(selectedNode.id, 1);
   assert.deepEqual(factsForNode(sampleDocument, 1).map(fact => fact.descriptor), ["alloc.new"]);
-  assert.equal(nodeAtOffset(sampleDocument, sampleDocument.text.indexOf("for ("))!.id, 0);
+  const forOffset = sampleDocument.text.indexOf("for (");
+  assert.notEqual(forOffset, -1);
+  const forNode = nodeAtOffset(sampleDocument, forOffset);
+  assert.ok(forNode);
+  assert.equal(forNode.id, 0);
   assert.equal(nodeAtOffset(sampleDocument, sampleDocument.text.length), null);
 });
 

--- a/prototypes/inspect-web/test/command-bar.test.ts
+++ b/prototypes/inspect-web/test/command-bar.test.ts
@@ -189,7 +189,7 @@ test("trailing whitespace preserves completed command arguments", () => {
     ["types kind ", "types kind"],
     ["clear ", "clear"],
     ["share ", "share"],
-  ]) {
+  ] as const) {
     assert.deepEqual(
       commandPaletteResults(commandContext(command), lenses)
         .map(result => [result.command, result.action]),

--- a/prototypes/inspect-web/test/keybinding-registry.test.ts
+++ b/prototypes/inspect-web/test/keybinding-registry.test.ts
@@ -362,7 +362,9 @@ test("attach owns one keydown listener and returns its teardown", () => {
 
   const detach = registry.attach(target);
   assert.equal(listeners.length, 1);
-  listeners[0](keyboardEvent({ key: "x" }).event);
+  const listener = listeners[0];
+  assert.ok(listener);
+  listener(keyboardEvent({ key: "x" }).event);
   assert.equal(calls, 1);
   detach();
   assert.equal(removed, listeners[0]);

--- a/prototypes/inspect-web/test/member-filtering.test.ts
+++ b/prototypes/inspect-web/test/member-filtering.test.ts
@@ -165,14 +165,17 @@ const groups = [
 ];
 
 test("member filters compose on one matching overload", () => {
-  assert.equal(memberGroupMatches(groups[0], {
+  const buildGroup = groups[0];
+  assert.ok(buildGroup);
+
+  assert.equal(memberGroupMatches(buildGroup, {
     kind: "method",
     accessibility: "public",
     trait: "isStatic",
     query: "path",
   }), true);
 
-  assert.equal(memberGroupMatches(groups[0], {
+  assert.equal(memberGroupMatches(buildGroup, {
     kind: "method",
     accessibility: "protected",
     trait: "isStatic",

--- a/prototypes/inspect-web/test/metadata-viewer.test.ts
+++ b/prototypes/inspect-web/test/metadata-viewer.test.ts
@@ -232,6 +232,44 @@ test("focus bindings dispatch lightbox controls and keep inner clicks contained"
   }
 });
 
+test("metadata explorer ignores malformed table and row indexes", () => {
+  const root = new FakeRoot();
+  const chips = [
+    new FakeElement({ mdeChip: "-1" }),
+    new FakeElement({ mdeChip: "1.5" }),
+    new FakeElement({ mdeChip: "9007199254740992" }),
+  ];
+  root.addAll("[data-mde-chip]", ...chips);
+  const jumps = [
+    new FakeElement({ mdeJump: "2:4:garbage" }),
+    new FakeElement({ mdeJump: "-1:4" }),
+    new FakeElement({ mdeJump: "2:-4" }),
+    new FakeElement({ mdeJump: "2:0" }),
+  ];
+  root.addAll("[data-mde-jump]", ...jumps);
+  const pages = [
+    new FakeElement({ mdePage: "2" }),
+    new FakeElement({ mdePage: "2:" }),
+  ];
+  root.addAll("[data-mde-page]", ...pages);
+  const rows = [
+    new FakeElement({ mdeRow: "-3:-9" }),
+    new FakeElement({ mdeRow: ":9" }),
+  ];
+  root.addAll(".mde-focus .mde-row[data-mde-row]", ...rows);
+  const calls: string[] = [];
+  bindMetadataExplorer(
+    fakeDom.parentNode(root),
+    { overview: false },
+    recordingActions(calls));
+
+  for (const element of [...chips, ...jumps, ...pages, ...rows]) {
+    element.dispatch("click", fakeDom.event({ stopPropagation: () => {} }));
+  }
+
+  assert.deepEqual(calls, []);
+});
+
 test("metadata lens bindings open table and heap explorer views", () => {
   const root = new FakeRoot();
   const table = new FakeElement({

--- a/prototypes/inspect-web/test/package-acquisition.test.ts
+++ b/prototypes/inspect-web/test/package-acquisition.test.ts
@@ -282,7 +282,9 @@ test("runtime acquisition serializes and merges full-pack and assembly requests"
     mergedModel.types.map(candidate => candidate.id),
     ["System.Object", "System.Text.Json.JsonDocument"]);
   assert.equal(mergedModel.totalMembers, 5);
-  assert.equal(mergedModel.accessibility[0].count, 2);
+  const [primaryAccessibility] = mergedModel.accessibility;
+  assert.ok(primaryAccessibility);
+  assert.equal(primaryAccessibility.count, 2);
   assert.equal(mergedModel.assembly, "System.Private.CoreLib");
   assert.equal(mergedModel.assemblyId, "corelib");
   assert.equal(

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -651,17 +651,22 @@ test("workspace dependency loading records failures and ignores runtime packs", 
     "Example.Dependency");
   assert.equal(Object.hasOwn(state.workspaceDependencyErrors, goodKey), false);
   const partialKey = workspaceDependencyKey(partial);
+  const partialWorkspace = state.workspaceDependencies[partialKey];
+  assert.ok(partialWorkspace);
   assert.equal(
-    state.workspaceDependencies[partialKey].dependencyGroupError,
+    partialWorkspace.dependencyGroupError,
     "no dependency group matches net10.0");
   assert.equal(
     state.workspaceDependencyErrors[partialKey],
     "no dependency group matches net10.0");
+  const badKey = workspaceDependencyKey(bad);
+  const badWorkspace = state.workspaceDependencies[badKey];
+  assert.ok(badWorkspace);
   assert.deepEqual(
-    state.workspaceDependencies[workspaceDependencyKey(bad)].dependencyGroups,
+    badWorkspace.dependencyGroups,
     []);
   assert.equal(
-    state.workspaceDependencyErrors[workspaceDependencyKey(bad)],
+    state.workspaceDependencyErrors[badKey],
     "dependency feed unavailable");
   assert.equal(
     Object.hasOwn(state.workspaceDependencies, workspaceDependencyKey(runtime)),

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -215,10 +215,12 @@ test("extensions-callgraph delegates execution to the engine instead of encoding
 });
 
 test("platform residual rejects pinned runtime coordinates", () => {
+  const stjTab = unversionedRuntimeResolved.tabs[0];
+  assert.ok(stjTab);
   const pinned = {
     ...unversionedRuntimeResolved,
     tabs: [
-      unversionedRuntimeResolved.tabs[0],
+      stjTab,
       {
         id: "runtime",
         member: {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -3124,6 +3124,16 @@ test("call graph navigation resolves accessor selectors across image-local token
       selectorKey: "getter-selector"
     }),
     null);
+  const sparseGroups = [];
+  sparseGroups.length = 2;
+  sparseGroups[1] = group;
+  assert.deepEqual(
+    graphMemberSelection(sparseGroups, {
+      metadataToken: 456,
+      memberName: "get_P",
+      selectorKey: "getter-selector"
+    }),
+    { groupIndex: 1, overloadIndex: 0 });
 
   const runtimeResolver =
     appSource.match(/function findRuntimeMemberSelection[\s\S]*?\n\}/)?.[0]
@@ -4615,6 +4625,13 @@ test("closing a package removes its coordinate and selects the adjacent tab", ()
     packageIdentityKey(active));
   assert.deepEqual(only.packages, []);
   assert.equal(only.active, null);
+
+  const sparse = [];
+  sparse.length = 1;
+  const malformed = removeWorkspacePackage(sparse, active, "");
+  assert.equal(malformed.packages.length, 1);
+  assert.equal(malformed.active, active);
+  assert.equal(malformed.closed, null);
 });
 
 test("workspace UI routes replacements and restore notices through bounded paths", () => {

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -456,7 +456,9 @@ test("malformed rich packet fields cannot override the visible package", () => {
     ...[null, 0, true, "1"]
       .map(b => ({ ...base, b })),
   ];
-  delete invalidPackets[0].a;
+  const firstInvalidPacket = invalidPackets[0];
+  assert.ok(firstInvalidPacket);
+  delete firstInvalidPacket.a;
 
   for (const packet of invalidPackets) {
     const encoded = Buffer.from(JSON.stringify(packet)).toString("base64url");
@@ -555,7 +557,10 @@ test("location persistence contains sync failures but leaves direct build failur
 
   persistence.sync(workspaceState());
   persistence.push("/");
-  assert.equal(new URL(replaced[0]).searchParams.get("package"), "Example.Second");
+  assert.equal(replaced.length, 1);
+  const firstReplacement = replaced[0];
+  assert.ok(firstReplacement);
+  assert.equal(new URL(firstReplacement).searchParams.get("package"), "Example.Second");
   assert.deepEqual(pushed, ["/"]);
   const replacedCount = replaced.length;
   assert.doesNotThrow(() => persistence.sync(workspaceState({

--- a/prototypes/inspect-web/tsconfig.json
+++ b/prototypes/inspect-web/tsconfig.json
@@ -10,6 +10,7 @@
     "exactOptionalPropertyTypes": true,
     "noEmit": true,
     "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
     "paths": {
       "/inspect-web-engine.js": ["./src/inspect-web-engine.d.ts"]
     },


### PR DESCRIPTION
## Summary

- enable `noUncheckedIndexedAccess` for inspect-web product and test TypeScript
- encode non-empty member groups and validate indexed navigation, metadata,
  decoded state, and graph selections at their owning boundaries
- add close negative coverage for sparse workspace packages and graph member
  groups without broad assertions or casts

Closes #4549

## Demo

Before, the TypeScript 7.0.2 migration probe reported 99 current diagnostics
across product and test sources when `noUncheckedIndexedAccess` was supplied
only on the command line.

After, the repository gate enforces the option directly:

```console
$ npm run typecheck
> tsc --noEmit && tsc --noEmit -p test/tsconfig.json
```

The command exits successfully with no diagnostics. Notice that callers now
either prove an indexed value exists or preserve absence explicitly. The
neighboring sparse-input tests also pass: package close remains a no-op for a
missing package entry, while graph-member resolution skips a missing group and
still resolves the valid target.

## Validation

- `npm run typecheck`
- `npm run analyze`
- `npm test` — 593 passed
- `npm run build`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
