### PR TITLE
Grow home demo catalog with Call Graph shapes

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -1002,8 +1002,9 @@ Definition records and product demos (this slice):
   `WorkspaceMemberCoordinate` for `WorkspaceContextLoader` (group `subscribe`
   expressions and filesystem coordinates are typed failures in this slice);
 - `ProductInspectionDemos` is a static id→factory registry (smooth-markdown-table
-  `RendererRegistry` style) of the two home scenarios; listing is metadata-only
-  and `ResolveHomeScenario` allocates only that demo's peer records and enforces
+  `RendererRegistry` style) of the product home scenarios (Methods tour plus
+  multiple Call Graph shapes); listing is metadata-only and
+  `ResolveHomeScenario` allocates only that demo's peer records and enforces
   `ProductDemoSections` binding; JSON remains the portable load path for external
   definitions;
 - `ProductDemoRunPlan` lowers the resolved context, focus, type/member
@@ -1018,7 +1019,7 @@ Definition records and product demos (this slice):
   including `--mermaid` and fail-closed Call Graph `--json`;
 - `InspectionDefinitionTests` / `DemoCommandTests` gate round-trip, separation,
   demo-parity, section binding, CLI lowering, and real section output for the
-  two home demos; inspect-web's generated `RunHomeDemo` binding runs the
+  product home demos; inspect-web's generated `RunHomeDemo` binding runs the
   member-bound Call Graph preset from its product scenario id;
 - `WorkspaceSharePacketCodec` decodes and canonically re-emits the bounded v1
   base64url packet into an immutable product-owned semantic model. It rejects

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -414,14 +414,16 @@ resolved scenario into its selected context, navigation focus, type/member
 selection, and section; CLI and browser encodings consume that plan rather than
 parsing the member selection independently. **Home demos now bind product
 section display names**
-through `ProductDemoSections` (today: `Methods` for STJ; `Call Graph` primary
-bind for the extensions member, expanded at run via `ExpandRunSections` /
-`DemoScenarioRunner` so the closed preset matches the multi-package
-`--caller-package` companion rule: Markdown keeps `Call Graph` + `Callers`;
-table/tsv/jsonl select `Callers` alone (MemberCommand re-adds Callers under
-caller scope, so Call Graph-only tabular silently fell back to a member
-inventory); standalone `--mermaid` keeps `Call Graph`; document `--json` fails
-closed for Call Graph demos until graph sections project into that payload.
+through `ProductDemoSections` (today: `Methods` for the STJ API tour; `Call
+Graph` primary bind for multi-package and package-local graph demos, expanded
+at run via `ExpandRunSections` / `DemoScenarioRunner`: Markdown keeps
+`Call Graph` + `Callers`; table/tsv/jsonl select `Callers` when the demo has
+caller scope — MemberCommand re-adds Callers under caller scope, so
+Call Graph-only tabular would silently fall back to a member inventory — and
+select `Call Graph` when it does not, so package-local entry points with empty
+Callers still emit rows; standalone `--mermaid` keeps `Call Graph`; document
+`--json` fails closed for Call Graph demos until graph sections project into
+that payload.
 `ResolveHomeScenario` fails when a home demo omits `View.Section` or names a
 section outside that allow list (`ProductHomeDemos_AllBindKnownProductSections`,
 `ProductDemoSections_AreProductSectionNames`). Methods demos reject standalone
@@ -1012,7 +1014,7 @@ Definition records and product demos (this slice):
 - `ProductDemoSections` is the closed allow list of product section display names
   home demos may select until minted view-facet ids land; `ExpandRunSections`
   expands Call Graph binds format-aware (Markdown: Call Graph + Callers;
-  table/tsv/jsonl: Callers);
+  table/tsv/jsonl: Callers with caller scope, Call Graph without);
 - CLI `demo list` / `demo <id>` (`DemoCommand` + `DemoScenarioRunner`) lists
   metadata and **runs** the bound section through `TypeCommand` /
   `MemberCommand` (not a resolve-only plan dump), with orthogonal formats

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -672,7 +672,8 @@ peer records and requires a `ProductDemoSections` binding. Home demos are closed
 presets over the open query/section product: the registry fixes inputs and names
 **existing product section(s)** (`ProductDemoSections.ExpandRunSections` expands
 Call Graph presets format-aware: Markdown keeps Call Graph + Callers;
-table/tsv/jsonl keep Callers alone so caller-scope re-add stays one section;
+table/tsv/jsonl keep Callers when the demo has caller scope so the re-add stays
+one section, otherwise Call Graph so package-local entry points still emit rows;
 mermaid keeps Call Graph; document JSON fails closed until graph projection
 lands); the CLI host runs them through the normal type/member section pipelines
 (`DemoScenarioRunner` → `TypeCommand` / `MemberCommand`) and returns those

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -8213,7 +8213,7 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
   state.error = "";
   state.errorDetail = "";
   state.retryAction = null;
-  state.loadingMessage = "Loading cross-package call graph demo…";
+  state.loadingMessage = "Loading call graph demo…";
   state.loadingSubtitle =
     "Resolving the product workspace and anchored member…";
   render();

--- a/prototypes/inspect-web/src/product-home-demos.ts
+++ b/prototypes/inspect-web/src/product-home-demos.ts
@@ -153,7 +153,7 @@ export function productHomeDemoLocationHref(
  * Pending home-row paint while the Wasm engine catalog is not yet installed.
  * Layout-only placeholders — titles come from `ListHomeDemos` after bootstrap.
  */
-export const HOME_DEMO_PENDING_SLOT_COUNT = 2;
+export const HOME_DEMO_PENDING_SLOT_COUNT = 5;
 
 export function homeDemoRowHtml(
   enginePending: boolean,

--- a/prototypes/inspect-web/test/product-home-demos.test.ts
+++ b/prototypes/inspect-web/test/product-home-demos.test.ts
@@ -165,9 +165,15 @@ test("isProductHomeDemoId uses the installed engine catalog", () => {
   setProductHomeDemoCatalog([
     { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
     { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
+    { id: "stj-serialize-callgraph", title: "Serialize call graph", summary: "Dense package-local STJ graph" },
+    { id: "config-bind-callgraph", title: "Configuration Bind", summary: "Recursive binder call graph" },
+    { id: "options-add-callgraph", title: "Options hub", summary: "Inbound fan-in at AddOptions" },
   ]);
   assert.equal(isProductHomeDemoId("stj-serializer"), true);
   assert.equal(isProductHomeDemoId("extensions-callgraph"), true);
+  assert.equal(isProductHomeDemoId("stj-serialize-callgraph"), true);
+  assert.equal(isProductHomeDemoId("config-bind-callgraph"), true);
+  assert.equal(isProductHomeDemoId("options-add-callgraph"), true);
   assert.equal(isProductHomeDemoId("platform-list"), false);
   assert.equal(isProductHomeDemoId("stj"), false);
   assert.equal(isProductHomeDemoId("runtime"), false);
@@ -212,6 +218,44 @@ test("unversioned platform residual maps to the browser runtime pack", () => {
 
 test("extensions-callgraph delegates execution to the engine instead of encoding a location", () => {
   assert.equal(productHomeDemoLocationHref(callGraphResolved), null);
+});
+
+test("single-package Call Graph demos also delegate to the engine", () => {
+  const serializeResolved: BrowserHomeDemoResolved = {
+    id: "stj-serialize-callgraph",
+    title: "Serialize call graph",
+    summary: "Dense package-local STJ graph",
+    workspaceMembers: [
+      {
+        kind: "package",
+        id: "System.Text.Json",
+        version: "10.0.0",
+        framework: "net10.0",
+        assembly: null,
+      },
+    ],
+    tabs: [
+      {
+        id: "stj",
+        member: {
+          kind: "package",
+          id: "System.Text.Json",
+          version: "10.0.0",
+          framework: "net10.0",
+          assembly: null,
+        },
+      },
+    ],
+    focusTabIndex: 0,
+    view: {
+      library: null,
+      type: "System.Text.Json.JsonSerializer",
+      memberAnchor: "1dc14dd1fb",
+      memberKey: "method:Serialize",
+      section: "Call Graph",
+    },
+  };
+  assert.equal(productHomeDemoLocationHref(serializeResolved), null);
 });
 
 test("platform residual rejects pinned runtime coordinates", () => {

--- a/prototypes/inspect-web/test/shell-controls.test.ts
+++ b/prototypes/inspect-web/test/shell-controls.test.ts
@@ -11,6 +11,9 @@ import { fakeDom } from "./fake-dom.ts";
 setProductHomeDemoCatalog([
   { id: "stj-serializer", title: "System.Text.Json", summary: "Browse a real package API" },
   { id: "extensions-callgraph", title: "Cross-package call graph", summary: "Trace calls across three packages" },
+  { id: "stj-serialize-callgraph", title: "Serialize call graph", summary: "Dense package-local STJ graph" },
+  { id: "config-bind-callgraph", title: "Configuration Bind", summary: "Recursive binder call graph" },
+  { id: "options-add-callgraph", title: "Options hub", summary: "Inbound fan-in at AddOptions" },
 ]);
 
 class FakeElement {
@@ -109,6 +112,7 @@ test("home shell accepts only known demos", () => {
   const credits = new FakeElement();
   const stj = new FakeElement({ homeDemo: "stj-serializer" });
   const callgraph = new FakeElement({ homeDemo: "extensions-callgraph" });
+  const serializeGraph = new FakeElement({ homeDemo: "stj-serialize-callgraph" });
   const unknown = new FakeElement({ homeDemo: "other" });
   const absent = new FakeElement();
   root.add("#home-theme", theme);
@@ -118,6 +122,7 @@ test("home shell accepts only known demos", () => {
     "[data-home-demo]",
     stj,
     callgraph,
+    serializeGraph,
     unknown,
     absent,
   );
@@ -139,6 +144,7 @@ test("home shell accepts only known demos", () => {
   assert.equal(credits.dispatch("click"), true);
   stj.dispatch("click");
   callgraph.dispatch("click");
+  serializeGraph.dispatch("click");
   unknown.dispatch("click");
   absent.dispatch("click");
   assert.deepEqual(calls, [
@@ -147,6 +153,7 @@ test("home shell accepts only known demos", () => {
     "credits",
     "demo:stj-serializer",
     "demo:extensions-callgraph",
+    "demo:stj-serialize-callgraph",
   ]);
 });
 

--- a/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
@@ -809,10 +809,19 @@ public class InspectionDefinitionTests
     public void ProductHomeDemos_ResolveCallGraphByMemberAnchor()
     {
         Assert.Equal(
-            ["stj-serializer", "extensions-callgraph"],
+            [
+                "stj-serializer",
+                "extensions-callgraph",
+                "stj-serialize-callgraph",
+                "config-bind-callgraph",
+                "options-add-callgraph",
+            ],
             ProductInspectionDemos.HomeScenarioIds);
-        Assert.Equal(2, ProductInspectionDemos.Entries.Count);
+        Assert.Equal(5, ProductInspectionDemos.Entries.Count);
         Assert.True(ProductInspectionDemos.HasScenario("extensions-callgraph"));
+        Assert.True(ProductInspectionDemos.HasScenario("stj-serialize-callgraph"));
+        Assert.True(ProductInspectionDemos.HasScenario("config-bind-callgraph"));
+        Assert.True(ProductInspectionDemos.HasScenario("options-add-callgraph"));
 
         // Per-demo resolve — does not require materializing the other home demos.
         var callGraph = ProductInspectionDemos.ResolveHomeScenario("extensions-callgraph");
@@ -864,6 +873,41 @@ public class InspectionDefinitionTests
     }
 
     [Fact]
+    public void ProductHomeDemos_SinglePackageCallGraphShapes()
+    {
+        // Three complementary Call Graph demos: dense outbound STJ Serialize,
+        // recursive ConfigurationBinder.Bind, and inbound Options.AddOptions hub.
+        var serialize = ProductInspectionDemos.ResolveHomeScenario(
+            ProductInspectionDemos.StjSerializeCallGraphScenarioId);
+        Assert.Equal(ProductDemoSections.CallGraph, serialize.View!.Section);
+        Assert.Equal("1dc14dd1fb", serialize.View.MemberAnchor);
+        Assert.Equal("method:Serialize", serialize.View.MemberKey);
+        Assert.Single(serialize.SelectedContext!.Members);
+        var serializePlan = ProductDemoRunPlan.Create(serialize);
+        Assert.Equal("Serialize", serializePlan.Member!.Name);
+        Assert.Equal("1dc14dd1fb", serializePlan.Member.Anchor);
+
+        var bind = ProductInspectionDemos.ResolveHomeScenario(
+            ProductInspectionDemos.ConfigBindCallGraphScenarioId);
+        Assert.Equal("Microsoft.Extensions.Configuration.ConfigurationBinder", bind.View!.Type);
+        Assert.Equal("a6a6257f65", bind.View.MemberAnchor);
+        Assert.Equal("method:Bind", bind.View.MemberKey);
+        Assert.Equal(
+            "Microsoft.Extensions.Configuration.Binder",
+            Assert.IsType<WorkspaceMemberCoordinate.PackageMember>(
+                bind.SelectedContext!.Members[0]).PackageId);
+
+        var options = ProductInspectionDemos.ResolveHomeScenario(
+            ProductInspectionDemos.OptionsAddCallGraphScenarioId);
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions",
+            options.View!.Type);
+        Assert.Equal("1e6bfaf2ae", options.View.MemberAnchor);
+        Assert.Equal("method:AddOptions", options.View.MemberKey);
+        Assert.Single(options.SelectedContext!.Members);
+    }
+
+    [Fact]
     public void ProductHomeDemos_AllBindKnownProductSections()
     {
         foreach (var entry in ProductInspectionDemos.Entries)
@@ -878,8 +922,8 @@ public class InspectionDefinitionTests
     [Fact]
     public void ProductHomeDemos_FactoryRegistry_IsMetadataOnlyUntilResolved()
     {
-        // Catalog surface is two entries; factories are not invoked by listing.
-        Assert.Equal(2, ProductInspectionDemos.Entries.Count);
+        // Catalog surface is five entries; factories are not invoked by listing.
+        Assert.Equal(5, ProductInspectionDemos.Entries.Count);
         Assert.All(
             ProductInspectionDemos.Entries,
             entry =>
@@ -889,9 +933,9 @@ public class InspectionDefinitionTests
                 Assert.NotNull(entry.CreateRecords);
             });
 
-        // Full materialization is opt-in (4 records × 2 demos).
+        // Full materialization is opt-in (4 records × 5 demos).
         var all = ProductInspectionDemos.CreateRegistry();
-        Assert.Equal(8, all.Records.Count);
+        Assert.Equal(20, all.Records.Count);
 
         // Each factory owns exactly one scenario composition.
         foreach (var entry in ProductInspectionDemos.Entries)

--- a/src/DotnetInspector.Queries/Definitions/ProductDemoSections.cs
+++ b/src/DotnetInspector.Queries/Definitions/ProductDemoSections.cs
@@ -37,22 +37,37 @@ public static class ProductDemoSections
     /// rule instead of silently gaining a second section at run time.
     /// </summary>
     /// <param name="singleSectionFormat">
-    /// When true (table/tsv/jsonl), multi-package Call Graph demos select
-    /// <see cref="Callers"/> only. MemberCommand re-adds Callers whenever
-    /// caller-scope packages are set; starting from Call Graph alone therefore
-    /// becomes {Call Graph, Callers} and the tabular path falls back to a member
-    /// inventory. Callers alone survives that re-add as a true one-section
-    /// projection. Standalone mermaid is not this path — it keeps Call Graph
-    /// only (validated before the Callers inject) and is resolved by the CLI
-    /// runner.
+    /// When true (table/tsv/jsonl), Call Graph demos must pick exactly one
+    /// section. With caller scope, that is <see cref="Callers"/>: MemberCommand
+    /// re-adds Callers whenever caller-scope packages are set, so starting from
+    /// Call Graph alone becomes {Call Graph, Callers} and the tabular path falls
+    /// back to a member inventory. Callers alone survives that re-add.
+    /// Without caller scope the re-add does not fire, so Call Graph alone stays
+    /// a true one-section projection — required for package-local entry points
+    /// that have outbound callees but no inbound callers (empty Callers would
+    /// silently succeed with zero rows). Standalone mermaid is not this path —
+    /// it keeps Call Graph only (validated before any Callers inject) and is
+    /// resolved by the CLI runner.
+    /// </param>
+    /// <param name="hasCallerScope">
+    /// True when the run encodes extra packages as caller-scope
+    /// (<c>--caller-package</c>). Defaults to true so legacy multi-package
+    /// callers keep the Callers tabular path without an extra argument.
     /// </param>
     public static IReadOnlyList<string> ExpandRunSections(
         string boundSection,
-        bool singleSectionFormat = false)
+        bool singleSectionFormat = false,
+        bool hasCallerScope = true)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(boundSection);
         if (string.Equals(boundSection, CallGraph, StringComparison.Ordinal))
-            return singleSectionFormat ? [Callers] : [CallGraph, Callers];
+        {
+            if (!singleSectionFormat)
+                return [CallGraph, Callers];
+            // Caller-scope re-add forces Callers; no-scope keeps Call Graph.
+            return hasCallerScope ? [Callers] : [CallGraph];
+        }
+
         return [boundSection];
     }
 

--- a/src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs
+++ b/src/DotnetInspector.Queries/Definitions/ProductInspectionDemos.cs
@@ -22,6 +22,12 @@ public static class ProductInspectionDemos
 
     public const string ExtensionsCallGraphScenarioId = "extensions-callgraph";
 
+    public const string StjSerializeCallGraphScenarioId = "stj-serialize-callgraph";
+
+    public const string ConfigBindCallGraphScenarioId = "config-bind-callgraph";
+
+    public const string OptionsAddCallGraphScenarioId = "options-add-callgraph";
+
     private static readonly Entry[] s_entries =
     [
         new(
@@ -34,6 +40,21 @@ public static class ProductInspectionDemos
             "Cross-package call graph",
             "Trace calls across three packages",
             CreateExtensionsCallGraphRecords),
+        new(
+            StjSerializeCallGraphScenarioId,
+            "Serialize call graph",
+            "Dense package-local STJ graph",
+            CreateStjSerializeCallGraphRecords),
+        new(
+            ConfigBindCallGraphScenarioId,
+            "Configuration Bind",
+            "Recursive binder call graph",
+            CreateConfigBindCallGraphRecords),
+        new(
+            OptionsAddCallGraphScenarioId,
+            "Options hub",
+            "Inbound fan-in at AddOptions",
+            CreateOptionsAddCallGraphRecords),
     ];
 
     /// <summary>
@@ -214,6 +235,141 @@ public static class ProductInspectionDemos
                 context: "extensions",
                 view: "try-add-enumerable-call-graph",
                 navigation: "extensions-callgraph-navigation"),
+        ];
+    }
+
+    /// <summary>
+    /// Single-package outbound graph: <c>JsonSerializer.Serialize&lt;T&gt;(T, options)</c>.
+    /// Complements the Methods STJ tour with a dense package-local Call Graph.
+    /// </summary>
+    private static InspectionDefinitionRecord[] CreateStjSerializeCallGraphRecords()
+    {
+        const int v = InspectionDefinitionJson.CurrentSchemaVersion;
+        var stjPackage = Package("System.Text.Json", "10.0.0", "net10.0");
+        return
+        [
+            new WorkspaceDefinition(
+                v,
+                "stj-serialize-callgraph-workspace",
+                [
+                    new WorkspaceContextDefinition(
+                        "stj",
+                        framework: "net10.0",
+                        members: [stjPackage]),
+                ],
+                title: "System.Text.Json Serialize call graph",
+                description: "Package-local Call Graph for JsonSerializer.Serialize."),
+            new ViewDefinition(
+                v,
+                "stj-serialize-call-graph",
+                type: "System.Text.Json.JsonSerializer",
+                memberAnchor: "1dc14dd1fb",
+                memberKey: "method:Serialize",
+                section: ProductDemoSections.CallGraph),
+            new NavigationDefinition(
+                v,
+                "stj-serialize-callgraph-navigation",
+                [new NavigationTabDefinition("stj", coordinate: stjPackage)],
+                focus: "stj"),
+            new ScenarioDefinition(
+                v,
+                StjSerializeCallGraphScenarioId,
+                title: "Serialize call graph",
+                description: "Dense package-local STJ graph",
+                workspace: "stj-serialize-callgraph-workspace",
+                context: "stj",
+                view: "stj-serialize-call-graph",
+                navigation: "stj-serialize-callgraph-navigation"),
+        ];
+    }
+
+    /// <summary>
+    /// Single-package dense recursive graph: <c>ConfigurationBinder.Bind</c>.
+    /// High fan-out into binder internals (arrays, conversion, BindingPoint).
+    /// </summary>
+    private static InspectionDefinitionRecord[] CreateConfigBindCallGraphRecords()
+    {
+        const int v = InspectionDefinitionJson.CurrentSchemaVersion;
+        var binder = Package("Microsoft.Extensions.Configuration.Binder", "10.0.0", "net10.0");
+        return
+        [
+            new WorkspaceDefinition(
+                v,
+                "config-bind-callgraph-workspace",
+                [
+                    new WorkspaceContextDefinition(
+                        "binder",
+                        framework: "net10.0",
+                        members: [binder]),
+                ],
+                title: "Configuration Binder call graph",
+                description: "Recursive ConfigurationBinder.Bind Call Graph."),
+            new ViewDefinition(
+                v,
+                "config-bind-call-graph",
+                type: "Microsoft.Extensions.Configuration.ConfigurationBinder",
+                memberAnchor: "a6a6257f65",
+                memberKey: "method:Bind",
+                section: ProductDemoSections.CallGraph),
+            new NavigationDefinition(
+                v,
+                "config-bind-callgraph-navigation",
+                [new NavigationTabDefinition("binder", coordinate: binder)],
+                focus: "binder"),
+            new ScenarioDefinition(
+                v,
+                ConfigBindCallGraphScenarioId,
+                title: "Configuration Bind",
+                description: "Recursive binder call graph",
+                workspace: "config-bind-callgraph-workspace",
+                context: "binder",
+                view: "config-bind-call-graph",
+                navigation: "config-bind-callgraph-navigation"),
+        ];
+    }
+
+    /// <summary>
+    /// Single-package inbound hub: <c>AddOptions(IServiceCollection)</c>.
+    /// Sibling Configure/PostConfigure/ValidateOnStart methods fan into the hub.
+    /// </summary>
+    private static InspectionDefinitionRecord[] CreateOptionsAddCallGraphRecords()
+    {
+        const int v = InspectionDefinitionJson.CurrentSchemaVersion;
+        var options = Package("Microsoft.Extensions.Options", "10.0.0", "net10.0");
+        return
+        [
+            new WorkspaceDefinition(
+                v,
+                "options-add-callgraph-workspace",
+                [
+                    new WorkspaceContextDefinition(
+                        "options",
+                        framework: "net10.0",
+                        members: [options]),
+                ],
+                title: "Options AddOptions call graph",
+                description: "Inbound fan-in Call Graph at Options.AddOptions."),
+            new ViewDefinition(
+                v,
+                "options-add-call-graph",
+                type: "Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions",
+                memberAnchor: "1e6bfaf2ae",
+                memberKey: "method:AddOptions",
+                section: ProductDemoSections.CallGraph),
+            new NavigationDefinition(
+                v,
+                "options-add-callgraph-navigation",
+                [new NavigationTabDefinition("options", coordinate: options)],
+                focus: "options"),
+            new ScenarioDefinition(
+                v,
+                OptionsAddCallGraphScenarioId,
+                title: "Options hub",
+                description: "Inbound fan-in at AddOptions",
+                workspace: "options-add-callgraph-workspace",
+                context: "options",
+                view: "options-add-call-graph",
+                navigation: "options-add-callgraph-navigation"),
         ];
     }
 

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -147,6 +147,27 @@ public class DemoCommandTests
     }
 
     [Fact]
+    public void Runner_LowersSinglePackageCallGraphWithoutCallerPackages()
+    {
+        var resolved = ProductInspectionDemos.ResolveHomeScenario(
+            ProductInspectionDemos.StjSerializeCallGraphScenarioId);
+        Assert.True(
+            DemoScenarioRunner.TryCreateOptions(
+                resolved, OutputFormat.Mermaid, noHeader: false, out var options, out var error),
+            error);
+        var member = Assert.IsType<MemberOptions>(options);
+        Assert.Equal("System.Text.Json.JsonSerializer", member.TypeName);
+        Assert.Equal("System.Text.Json@10.0.0", member.PackagePath);
+        Assert.Equal("1dc14dd1fb", member.MemberDigest);
+        Assert.Contains("Serialize", member.MemberFilter);
+        Assert.True(member.MermaidOutput);
+        Assert.Empty(member.CallerScopePackages);
+        Assert.Equal(
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.CallGraph },
+            member.IncludeSections);
+    }
+
+    [Fact]
     public void Runner_Mermaid_SetsMermaidOutputAndSingleGraphSection()
     {
         var resolved = ProductInspectionDemos.ResolveHomeScenario(ProductInspectionDemos.ExtensionsCallGraphScenarioId);

--- a/src/dotnet-inspect.Tests/DemoCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DemoCommandTests.cs
@@ -95,11 +95,20 @@ public class DemoCommandTests
         Assert.Equal(
             [SectionNames.CallGraph, SectionNames.Callers],
             ProductDemoSections.ExpandRunSections(ProductDemoSections.CallGraph));
-        // Tabular single-section path selects Callers so MemberCommand's
-        // caller-scope re-add stays one section (not Call Graph+Callers).
+        // Tabular + caller scope: Callers so MemberCommand's re-add stays one section.
         Assert.Equal(
             [SectionNames.Callers],
-            ProductDemoSections.ExpandRunSections(ProductDemoSections.CallGraph, singleSectionFormat: true));
+            ProductDemoSections.ExpandRunSections(
+                ProductDemoSections.CallGraph,
+                singleSectionFormat: true,
+                hasCallerScope: true));
+        // Tabular without caller scope: Call Graph (no re-add; empty Callers would ship silence).
+        Assert.Equal(
+            [SectionNames.CallGraph],
+            ProductDemoSections.ExpandRunSections(
+                ProductDemoSections.CallGraph,
+                singleSectionFormat: true,
+                hasCallerScope: false));
         Assert.Equal(
             [SectionNames.Methods],
             ProductDemoSections.ExpandRunSections(ProductDemoSections.Methods));
@@ -165,6 +174,25 @@ public class DemoCommandTests
         Assert.Equal(
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.CallGraph },
             member.IncludeSections);
+    }
+
+    [Fact]
+    public void Runner_SinglePackageCallGraph_Table_UsesCallGraphSection()
+    {
+        var resolved = ProductInspectionDemos.ResolveHomeScenario(
+            ProductInspectionDemos.StjSerializeCallGraphScenarioId);
+        Assert.True(
+            DemoScenarioRunner.TryCreateOptions(
+                resolved, OutputFormat.Table, noHeader: false, out var options, out var error),
+            error);
+        var member = Assert.IsType<MemberOptions>(options);
+        Assert.Empty(member.CallerScopePackages);
+        // Call Graph alone: no caller-scope re-add, so tabular keeps the graph.
+        Assert.Equal(
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.CallGraph },
+            member.IncludeSections);
+        Assert.Equal([SectionNames.CallGraph], Assert.IsType<string[]>(member.Select));
+        Assert.True(member.Tabular);
     }
 
     [Fact]
@@ -405,6 +433,53 @@ public class DemoCommandTests
         Assert.Contains("Caller", output, StringComparison.Ordinal);
         Assert.DoesNotContain("Return Type", output, StringComparison.Ordinal);
         Assert.Contains("TryAddEnumerable", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Cli_EveryCallGraphDemo_Mermaid_EmitsNonEmptyGraph()
+    {
+        foreach (var entry in ProductInspectionDemos.Entries)
+        {
+            var resolved = ProductInspectionDemos.ResolveHomeScenario(entry.Id);
+            if (!string.Equals(
+                    resolved.View?.Section,
+                    ProductDemoSections.CallGraph,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var (exitCode, output, error) = await RunCliAsync("demo", entry.Id, "--mermaid");
+            Assert.True(exitCode == 0, $"{entry.Id}: {error}\n{output}");
+            Assert.Contains("graph TD", output, StringComparison.Ordinal);
+            Assert.True(
+                output.Length > 80,
+                $"{entry.Id}: mermaid output too short ({output.Length} bytes).");
+        }
+    }
+
+    [Fact]
+    public async Task Cli_EveryCallGraphDemo_Table_EmitsNonEmptyRows()
+    {
+        foreach (var entry in ProductInspectionDemos.Entries)
+        {
+            var resolved = ProductInspectionDemos.ResolveHomeScenario(entry.Id);
+            if (!string.Equals(
+                    resolved.View?.Section,
+                    ProductDemoSections.CallGraph,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var (exitCode, output, error) = await RunCliAsync("demo", entry.Id, "--table");
+            Assert.True(exitCode == 0, $"{entry.Id}: {error}\n{output}");
+            Assert.False(
+                string.IsNullOrWhiteSpace(output),
+                $"{entry.Id}: tabular Call Graph demo produced empty stdout.");
+            // Must not fall through to the member inventory Kind/Name table.
+            Assert.DoesNotContain("Return Type", output, StringComparison.Ordinal);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/DemoCommand.cs
+++ b/src/dotnet-inspect/Commands/DemoCommand.cs
@@ -236,7 +236,14 @@ public static class DemoScenarioRunner
         if (!TryResolveSource(resolved, view, context, out var source, out error))
             return false;
 
-        if (!TryResolveRunSections(section, format, embeddedMermaid, out var runSections, out error))
+        // Methods demos have no caller scope.
+        if (!TryResolveRunSections(
+                section,
+                format,
+                embeddedMermaid,
+                hasCallerScope: false,
+                out var runSections,
+                out error))
             return false;
 
         // Select mirrors -S so HasSectionQuery is true and TypeCommand cannot
@@ -293,7 +300,13 @@ public static class DemoScenarioRunner
         if (!TryCollectCallerPackages(resolved, context, source.PackagePath, out var callers, out error))
             return false;
 
-        if (!TryResolveRunSections(section, format, embeddedMermaid, out var runSections, out error))
+        if (!TryResolveRunSections(
+                section,
+                format,
+                embeddedMermaid,
+                hasCallerScope: callers.Length > 0,
+                out var runSections,
+                out error))
             return false;
 
         MemberOptions member = new()
@@ -321,16 +334,19 @@ public static class DemoScenarioRunner
 
     /// <summary>
     /// Format-aware section expansion for a closed home-demo binding.
-    /// Markdown: Call Graph + Callers. Table/tsv/jsonl: Callers only (survives
-    /// MemberCommand's caller-scope Callers inject). Standalone mermaid: Call
-    /// Graph only. Embedded mermaid requires a Call Graph bind (member pipeline)
-    /// and keeps the Markdown companion set. Structured document JSON is rejected
-    /// for Call Graph/Callers binds until those sections project into that payload.
+    /// Markdown: Call Graph + Callers. Table/tsv/jsonl: Callers when the demo
+    /// has caller scope (survives MemberCommand's Callers inject); Call Graph
+    /// when it does not (package-local entry points with empty Callers).
+    /// Standalone mermaid: Call Graph only. Embedded mermaid requires a Call
+    /// Graph bind (member pipeline) and keeps the Markdown companion set.
+    /// Structured document JSON is rejected for Call Graph/Callers binds until
+    /// those sections project into that payload.
     /// </summary>
     private static bool TryResolveRunSections(
         string boundSection,
         OutputFormat format,
         bool embeddedMermaid,
+        bool hasCallerScope,
         out IReadOnlyList<string> runSections,
         out string? error)
     {
@@ -361,12 +377,15 @@ public static class DemoScenarioRunner
         {
             error =
                 "--json cannot represent Call Graph/Callers section output yet. "
-                + "Use default Markdown, --mermaid, or --table/--tsv/--jsonl (Callers rows).";
+                + "Use default Markdown, --mermaid, or --table/--tsv/--jsonl.";
             return false;
         }
 
         var singleSectionFormat = format is OutputFormat.Table or OutputFormat.Tsv or OutputFormat.Jsonl;
-        runSections = ProductDemoSections.ExpandRunSections(boundSection, singleSectionFormat);
+        runSections = ProductDemoSections.ExpandRunSections(
+            boundSection,
+            singleSectionFormat,
+            hasCallerScope);
         return true;
     }
 


### PR DESCRIPTION
## Summary

Grow the product home-demo catalog with three additional Call Graph demos so the catalog shows distinct graph shapes beyond the existing multi-package Extensions hub.

- **`stj-serialize-callgraph`** — dense package-local outbound graph from `JsonSerializer.Serialize`
- **`config-bind-callgraph`** — recursive `ConfigurationBinder.Bind` (high fan-out binder internals)
- **`options-add-callgraph`** — inbound fan-in hub at `Options.AddOptions`

C# `ProductInspectionDemos` remains the sole catalog source. Host pending slots bump 2→5. No TS twin demos.

Informed by recent call-graph work (multi-package callers, package-local projection density, inbound vs outbound shapes).

## Demo

```bash
dotnet run --project src/dotnet-inspect -c Release -- demo list
```

| Id | Title | Summary |
| -- | ----- | ------- |
| stj-serializer | System.Text.Json | Browse a real package API |
| extensions-callgraph | Cross-package call graph | Trace calls across three packages |
| stj-serialize-callgraph | Serialize call graph | Dense package-local STJ graph |
| config-bind-callgraph | Configuration Bind | Recursive binder call graph |
| options-add-callgraph | Options hub | Inbound fan-in at AddOptions |

```bash
dotnet run --project src/dotnet-inspect -c Release -- demo stj-serialize-callgraph --mermaid
dotnet run --project src/dotnet-inspect -c Release -- demo config-bind-callgraph --mermaid
dotnet run --project src/dotnet-inspect -c Release -- demo options-add-callgraph --mermaid
```

Each emits a focused Mermaid graph (STJ depth-4 Serialize path; BindInstance fanout 83; AddOptions inbound Configure/PostConfigure hub).

## Non-action boundary

- Does not add a dedicated demo page (still #4596 / home-row residual).
- Does not change Call Graph projection or browser residual encoding.
- Does not twin demos in TypeScript.

## Validation

- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -method '*ProductHomeDemos*'` → 6 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*DemoCommand*'` → 27 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -- -method '*BrowserProductHomeDemos*'` → 7 passed
- `node --test test/product-home-demos.test.ts test/shell-controls.test.ts` → 11 passed
- Real CLI demos above