### PR TITLE
Update residual containment census

### DIFF
--- a/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
@@ -387,11 +387,11 @@ public class MarkoutRowContainmentTests
     ];
 
     [Fact]
-    public void ResidualCensus_IsPinnedAt269MembersAcross59Types()
+    public void ResidualCensus_IsPinnedAt267MembersAcross58Types()
     {
-        Assert.Equal(269, NotSelfContaining.Length);
+        Assert.Equal(267, NotSelfContaining.Length);
         Assert.Equal(
-            59,
+            58,
             NotSelfContaining
                 .Select(entry => entry[..entry.IndexOf('.')])
                 .Distinct(StringComparer.Ordinal)


### PR DESCRIPTION
## Summary

- update the residual Markout containment census from 269 members across 59 types to 267 members across 58 types
- align the pin with #4430, which made both `MethodAttributeRow` columns self-containing and removed the type from the residual set
- restore the current `main` CLI test gate without changing product behavior

Fixes #4671.

## Demo

Before:

```text
ResidualCensus_IsPinnedAt269MembersAcross59Types
Expected: 269
Actual:   267
```

After:

```text
MarkoutRowContainmentTests: 2 passed, 0 failed
```

The type count also moves from 59 to 58 because `MethodAttributeRow` has no remaining residual members.

## Validation

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- -class '*MarkoutRowContainmentTests*'\nTotal: 2, Failed: 0\n```\n\n## Review\n\nTrivial test-only correction: the expected member/type totals are mechanically derived from the adjacent literal residual set, and the unfixed exact test fails on current `main` with the two observed deltas.