### PR TITLE
Coordinate package and site releases

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -28,9 +28,27 @@ From `main`, collect:
 Compare the full CI and staging SHAs before dispatching:
 
 ```bash
+set -euo pipefail
+: "${ci_run_id:?set ci_run_id to the successful main CI run ID}"
+: "${staging_run_id:?set staging_run_id to the matching staging run ID}"
+
 ci_sha=$(gh run view "$ci_run_id" --json headSha --jq .headSha)
 site_sha=$(gh run view "$staging_run_id" --json headSha --jq .headSha)
-test "$ci_sha" = "$site_sha"
+
+[[ "$ci_sha" =~ ^[0-9a-f]{40}$ ]] || {
+  printf 'invalid CI SHA: %s\n' "$ci_sha" >&2
+  exit 1
+}
+[[ "$site_sha" =~ ^[0-9a-f]{40}$ ]] || {
+  printf 'invalid staging SHA: %s\n' "$site_sha" >&2
+  exit 1
+}
+if [ "$ci_sha" != "$site_sha" ]; then
+  printf 'release SHA mismatch: CI=%s staging=%s\n' \
+    "$ci_sha" "$site_sha" >&2
+  exit 1
+fi
+
 printf 'release SHA: %s\n' "$ci_sha"
 ```
 
@@ -50,7 +68,9 @@ Open `release.yml` and `promote-inspect-web.yml` together:
 2. Dispatch `promote-inspect-web.yml` with the matching staging run ID and
    `confirm=promote`.
 3. Confirm that both resolve jobs report the same full release SHA.
-4. Only then approve the protected NuGet and production-site environments.
+4. Wait for every package build to succeed, then approve the NuGet environment.
+5. Wait for the package workflow and GitHub release to succeed, then approve
+   the production-site environment. Never promote the site first.
 
 Do not substitute a newer run after the SHA comparison. The release is complete
 only when both workflows succeed.
@@ -60,8 +80,9 @@ only when both workflows succeed.
 Verify the package version and commit in NuGet and the GitHub release. Then
 check the production site's status bar for the same version and linked commit.
 
-If one workflow fails after the other publishes, retry the failed workflow with
-the same run IDs. Package retries tolerate already-published artifacts with
-`--skip-duplicate`; site retries revalidate and promote the same staged
-artifact. A different SHA, ancestry-only relationship, or matching version
-string is not a valid substitute.
+If the package workflow fails, leave site production unapproved and retry with
+the same CI and certification run IDs. Package retries tolerate
+already-published artifacts with `--skip-duplicate`. If site promotion fails
+after package publication, retry with the same staging run ID; site retries
+revalidate and promote the same staged artifact. A different SHA, ancestry-only
+relationship, or matching version string is not a valid substitute.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: release
+description: Use when shipping a new dotnet-inspect version; coordinate certification, NuGet and GitHub publication, and the matching dotnet-inspect.net production deployment.
+---
+
+# Release dotnet-inspect
+
+Use this maintainer skill when the user asks to ship, publish, or release a new
+dotnet-inspect version. Read
+[`docs/release-workflow.md`](../../../docs/release-workflow.md) first; it owns
+the release contract and failure handling. This skill is an operator playbook,
+not a substitute for that document or the workflows.
+
+A release is one exact `(commit SHA, VersionPrefix)` pair shared by the NuGet
+packages, GitHub release, and `https://dotnet-inspect.net`. Never advance only
+the packages or only the site.
+
+## Collect the release evidence
+
+From `main`, collect:
+
+1. The successful `ci.yml` main-push run ID that selects the release commit.
+2. A fresh successful Deep Inspect `test` run ID that certifies that commit or
+   an explicitly accepted ancestor.
+3. The successful `deploy-inspect-web.yml` **push** run ID for the exact release
+   commit. A manual staging run cannot be promoted.
+
+Compare the full CI and staging SHAs before dispatching:
+
+```bash
+ci_sha=$(gh run view "$ci_run_id" --json headSha --jq .headSha)
+site_sha=$(gh run view "$staging_run_id" --json headSha --jq .headSha)
+test "$ci_sha" = "$site_sha"
+printf 'release SHA: %s\n' "$ci_sha"
+```
+
+`allow_later_commit` changes the package target; it never relaxes site
+identity. When using it, select a staging run for the later exact SHA.
+
+Confirm that the release commit contains the intended `VersionPrefix`, release
+notes, package `README.md`, and embedded product skills. Record the documentation
+checkpoint even when no edits were required.
+
+## Publish package and site together
+
+Open `release.yml` and `promote-inspect-web.yml` together:
+
+1. Dispatch `release.yml` with the CI run ID, certification run ID, the intended
+   `allow_later_commit` value, and `confirm=publish`.
+2. Dispatch `promote-inspect-web.yml` with the matching staging run ID and
+   `confirm=promote`.
+3. Confirm that both resolve jobs report the same full release SHA.
+4. Only then approve the protected NuGet and production-site environments.
+
+Do not substitute a newer run after the SHA comparison. The release is complete
+only when both workflows succeed.
+
+## Verify and recover
+
+Verify the package version and commit in NuGet and the GitHub release. Then
+check the production site's status bar for the same version and linked commit.
+
+If one workflow fails after the other publishes, retry the failed workflow with
+the same run IDs. Package retries tolerate already-published artifacts with
+`--skip-duplicate`; site retries revalidate and promote the same staged
+artifact. A different SHA, ancestry-only relationship, or matching version
+string is not a valid substitute.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -22,8 +22,9 @@ From `main`, collect:
 1. The successful `ci.yml` main-push run ID that selects the release commit.
 2. A fresh successful Deep Inspect `test` run ID that certifies that commit or
    an explicitly accepted ancestor.
-3. The successful `deploy-inspect-web.yml` **push** run ID for the exact release
-   commit. A manual staging run cannot be promoted.
+3. The successful `deploy-inspect-web.yml` run ID for the exact release commit.
+   Use the main-push run by default. An operator-dispatched main staging run
+   requires explicit authorization during promotion.
 
 Compare the full CI and staging SHAs before dispatching:
 
@@ -52,8 +53,15 @@ fi
 printf 'release SHA: %s\n' "$ci_sha"
 ```
 
-`allow_later_commit` changes the package target; it never relaxes site
-identity. When using it, select a staging run for the later exact SHA.
+The standard path uses exact certification and leaves both overrides disabled.
+For urgent relief, a person may set `allow_later_commit` to ship a later `main`
+descendant whose target commit is not itself certified. This never relaxes site
+identity: select a staging run for that same exact SHA. If that staging run was
+operator-dispatched, the person must also set `allow_manual_staging`.
+
+After relief ships, keep package and site together on that commit and wait for
+the next exact certification before the next ordinary release. Neither override
+is standing authorization.
 
 The SHA comparison is the last dependable veto before dispatch. The `nuget`
 environment has no approval gate; package publication proceeds automatically
@@ -70,7 +78,8 @@ Open `release.yml` and `promote-inspect-web.yml` together:
 1. Dispatch `release.yml` with the CI run ID, certification run ID, the intended
    `allow_later_commit` value, and `confirm=publish`.
 2. Dispatch `promote-inspect-web.yml` with the matching staging run ID and
-   `confirm=promote`.
+   `confirm=promote`. Leave `allow_manual_staging=false` for a push run; set it
+   only with explicit authorization for an operator-dispatched staging run.
 3. Confirm immediately that both resolve jobs report the same full release SHA.
    If either is wrong, cancel both workflow runs before package publication
    starts. Do not leave a stale promotion run waiting for approval.
@@ -105,4 +114,6 @@ while deployment retries. If GitHub reruns a cancelled build after upload, the
 workflow replaces the retained same-name artifact;
 `PromotionWorkflowContract` gates that promotion still sees exactly one.
 Promote the successful failed-job rerun. Do not substitute a manual staging
-dispatch; promotion rejects non-push runs.
+dispatch by default. If exceptional circumstances require one, obtain explicit
+authorization, confirm its SHA still equals the package target, and enable
+`allow_manual_staging` during promotion.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -72,8 +72,8 @@ Open `release.yml` and `promote-inspect-web.yml` together:
 2. Dispatch `promote-inspect-web.yml` with the matching staging run ID and
    `confirm=promote`.
 3. Confirm immediately that both resolve jobs report the same full release SHA.
-   If either is wrong, cancel package publication before its publish job starts
-   and leave site production unapproved.
+   If either is wrong, cancel both workflow runs before package publication
+   starts. Do not leave a stale promotion run waiting for approval.
 4. Monitor the package builds and automatic NuGet publication.
 5. Wait for the package workflow and GitHub release to succeed, then approve
    the production-site environment. Never promote the site first.
@@ -100,8 +100,9 @@ staging work to finish and rerun the original push-triggered run:
 gh run rerun "$staging_run_id" --failed
 ```
 
-Rerun only failed or cancelled jobs so a successful build keeps its single
-uploaded artifact while deployment retries. Do not rerun all jobs, which can
-upload another artifact that promotion rejects. Promote the successful
-failed-job rerun. Do not substitute a manual staging dispatch; promotion rejects
-non-push runs.
+Rerun only failed or cancelled jobs so a successful build keeps its artifact
+while deployment retries. If GitHub reruns a cancelled build after upload, the
+workflow replaces the retained same-name artifact;
+`PromotionWorkflowContract` gates that promotion still sees exactly one.
+Promote the successful failed-job rerun. Do not substitute a manual staging
+dispatch; promotion rejects non-push runs.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -55,6 +55,10 @@ printf 'release SHA: %s\n' "$ci_sha"
 `allow_later_commit` changes the package target; it never relaxes site
 identity. When using it, select a staging run for the later exact SHA.
 
+The SHA comparison is the last dependable veto before dispatch. The `nuget`
+environment has no approval gate; package publication proceeds automatically
+after its builds.
+
 Confirm that the release commit contains the intended `VersionPrefix`, release
 notes, package `README.md`, and embedded product skills. Record the documentation
 checkpoint even when no edits were required.
@@ -67,8 +71,10 @@ Open `release.yml` and `promote-inspect-web.yml` together:
    `allow_later_commit` value, and `confirm=publish`.
 2. Dispatch `promote-inspect-web.yml` with the matching staging run ID and
    `confirm=promote`.
-3. Confirm that both resolve jobs report the same full release SHA.
-4. Wait for every package build to succeed, then approve the NuGet environment.
+3. Confirm immediately that both resolve jobs report the same full release SHA.
+   If either is wrong, cancel package publication before its publish job starts
+   and leave site production unapproved.
+4. Monitor the package builds and automatic NuGet publication.
 5. Wait for the package workflow and GitHub release to succeed, then approve
    the production-site environment. Never promote the site first.
 
@@ -86,3 +92,13 @@ already-published artifacts with `--skip-duplicate`. If site promotion fails
 after package publication, retry with the same staging run ID; site retries
 revalidate and promote the same staged artifact. A different SHA, ancestry-only
 relationship, or matching version string is not a valid substitute.
+
+If a newer `main` push cancels the release commit's staging run, wait for active
+staging work to finish and rerun the original push-triggered run:
+
+```bash
+gh run rerun "$staging_run_id"
+```
+
+Promote that successful rerun. Do not substitute a manual staging dispatch;
+promotion rejects non-push runs.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -97,8 +97,11 @@ If a newer `main` push cancels the release commit's staging run, wait for active
 staging work to finish and rerun the original push-triggered run:
 
 ```bash
-gh run rerun "$staging_run_id"
+gh run rerun "$staging_run_id" --failed
 ```
 
-Promote that successful rerun. Do not substitute a manual staging dispatch;
-promotion rejects non-push runs.
+Rerun only failed or cancelled jobs so a successful build keeps its single
+uploaded artifact while deployment retries. Do not rerun all jobs, which can
+upload another artifact that promotion rejects. Promote the successful
+failed-job rerun. Do not substitute a manual staging dispatch; promotion rejects
+non-push runs.

--- a/.github/workflows/deploy-inspect-web.yml
+++ b/.github/workflows/deploy-inspect-web.yml
@@ -111,6 +111,7 @@ jobs:
           name: inspect-web-site
           path: artifacts/inspect-web-publish
           if-no-files-found: error
+          overwrite: true
           retention-days: 30
           include-hidden-files: true
 

--- a/.github/workflows/promote-inspect-web.yml
+++ b/.github/workflows/promote-inspect-web.yml
@@ -6,6 +6,11 @@ on:
       staging_run_id:
         description: 'Successful main staging run whose site artifact will be promoted'
         required: true
+      allow_manual_staging:
+        description: 'Allow an operator-dispatched staging run instead of a main-push run'
+        required: true
+        default: false
+        type: boolean
       confirm:
         description: 'Type "promote" to confirm production deployment'
         required: true
@@ -57,11 +62,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+          ALLOW_MANUAL_STAGING: ${{ inputs.allow_manual_staging }}
         run: |
           bash eng/validate-inspect-web-promotion.sh \
             "$STAGING_RUN_ID" \
             720 \
-            "$GITHUB_OUTPUT"
+            "$GITHUB_OUTPUT" \
+            "$ALLOW_MANUAL_STAGING"
 
   deploy:
     name: Promote to production
@@ -84,6 +91,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STAGING_RUN_ID: ${{ inputs.staging_run_id }}
+          ALLOW_MANUAL_STAGING: ${{ inputs.allow_manual_staging }}
           EXPECTED_SHA: ${{ needs.resolve.outputs.sha }}
           EXPECTED_ATTEMPT: ${{ needs.resolve.outputs.run_attempt }}
           EXPECTED_ARTIFACT_ID: ${{ needs.resolve.outputs.artifact_id }}
@@ -93,6 +101,7 @@ jobs:
             "$STAGING_RUN_ID" \
             720 \
             "$RUNNER_TEMP/revalidated-inspect-web" \
+            "$ALLOW_MANUAL_STAGING" \
             "$EXPECTED_SHA" \
             "$EXPECTED_ATTEMPT" \
             "$EXPECTED_ARTIFACT_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         description: 'Fresh successful Deep Inspect test run certifying this commit or an ancestor'
         required: true
       allow_later_commit:
-        description: 'Allow publishing a later main commit than the certified commit'
+        description: 'Allow publishing a later main commit without exact certification'
         required: true
         default: false
         type: boolean

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+# Repository-maintainer skills are source, not build output.
+!.github/skills/release/
+!.github/skills/release/SKILL.md
 x64/
 x86/
 [Ww][Ii][Nn]32/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,10 @@ choosing one.
 Keep user-facing product skills and repository-maintainer skills separate:
 
 - `skills/` contains user-facing guidance shipped in the dotnet-inspect binary.
+  Use these skills when consuming the published tool or when a product change
+  needs its user-facing commands, examples, and expectations reviewed. Do not
+  select them merely because an agent is maintaining this repository; they are
+  product artifacts, not contributor runbooks.
   When adding a focused product skill, register it in `SkillCommand.Skills` and
   add an `EmbeddedResource` line for it in
   `src/dotnet-inspect/dotnet-inspect.csproj`; the embeds are enumerated per
@@ -235,9 +239,35 @@ Keep user-facing product skills and repository-maintainer skills separate:
   frontmatter `description:` is the single source of truth for the generated
   skill listing.
 - `.github/skills/` and `.claude/skills/` contain repo-local guidance for
-  contributors and agents. Do not register or embed them in the product. Keep
-  release, CI, corpus maintenance, and other repository operations out of the
+  contributors and agents. Use the matching repo-local skill for release, CI,
+  corpus maintenance, and other repository operations. Do not register or
+  embed these skills in the product, and keep repository operations out of the
   user-facing `skills/` tree.
+
+### Which dotnet-inspect to run
+
+For routine repository development and investigation, use the latest production
+dotnet-inspect:
+
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+The production tool is normally current and its Native AOT executable starts
+much faster than `dotnet run`. Prefer it for inspecting packages, platform
+libraries, local artifacts, and existing product behavior while developing.
+
+Use the source version primarily to test behavior from the current worktree:
+
+```bash
+dotnet run --project src/dotnet-inspect -c Release -- <command>
+```
+
+The source command is required when the evidence depends on an unmerged change,
+when reproducing or validating a source-only fix, or when checking output that
+the production release does not yet contain. Do not cite the production tool as
+evidence for worktree behavior, and do not pay the source-build startup cost for
+routine development queries that the production tool can answer.
 
 ## Repository-wide engineering constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,13 +224,20 @@ current product behavior and tests over design history. When current sources
 disagree, stop and resolve which owner is authoritative rather than silently
 choosing one.
 
-When adding a focused skill, register it in `SkillCommand.Skills` **and** add an
-`EmbeddedResource` line for it in `src/dotnet-inspect/dotnet-inspect.csproj`;
-the embeds are enumerated per skill.
-`FocusedSkillFilesRegistryAndEmbeddedResourcesAgree` keeps the skill
-directories, runtime registry, and embedded resources equal. Its YAML
-frontmatter `description:` is the single source of truth for the generated
-skill listing.
+Keep user-facing product skills and repository-maintainer skills separate:
+
+- `skills/` contains user-facing guidance shipped in the dotnet-inspect binary.
+  When adding a focused product skill, register it in `SkillCommand.Skills` and
+  add an `EmbeddedResource` line for it in
+  `src/dotnet-inspect/dotnet-inspect.csproj`; the embeds are enumerated per
+  skill. `FocusedSkillFilesRegistryAndEmbeddedResourcesAgree` keeps the skill
+  directories, runtime registry, and embedded resources equal. Its YAML
+  frontmatter `description:` is the single source of truth for the generated
+  skill listing.
+- `.github/skills/` and `.claude/skills/` contain repo-local guidance for
+  contributors and agents. Do not register or embed them in the product. Keep
+  release, CI, corpus maintenance, and other repository operations out of the
+  user-facing `skills/` tree.
 
 ## Repository-wide engineering constraints
 
@@ -354,8 +361,10 @@ per-change targeting advice live in `docs/decompiler-correctness-pipeline.md`.
 
 Only tool projects set `IsPackable=true`; `IsTool` also makes them available to
 solution-level publish. Internal library APIs are not external compatibility
-surfaces. Changing `VersionPrefix` is a release: follow
-`docs/release-workflow.md` and update the shipped `README.md` and skills.
+surfaces. Changing `VersionPrefix` is a coordinated package-and-site release:
+follow `docs/release-workflow.md`, publish dotnet-inspect and
+`https://dotnet-inspect.net` from the same commit, and update the shipped
+`README.md` and skills.
 
 ### Package acquisition when nuget.org is disabled
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -212,8 +212,9 @@ both before dispatching, and expect to update them:
 9. Dispatch both workflows as one operator action. Do not substitute a newer
    run for either side after the exact-SHA comparison.
 10. Confirm immediately that both resolve jobs report the expected release SHA.
-    If either is wrong, cancel the package workflow before its publish job
-    starts and leave the production-site environment unapproved.
+    If either is wrong, cancel both the package and promotion workflow runs
+    before package publication starts. Do not leave a stale promotion run
+    waiting for approval.
 11. Monitor the package builds and automatic NuGet publication. There is no
     NuGet environment approval after dispatch.
 12. Wait for the package workflow and GitHub release to succeed, then approve
@@ -275,13 +276,16 @@ check the production site's status bar for the same version and linked commit.
   certification run IDs.
 - **The release commit's staging run was cancelled by a newer push:** wait for
   active staging work to finish, then rerun only the failed or cancelled jobs
-  with `gh run rerun <staging-run-id> --failed`. This preserves a successful
-  build's single uploaded artifact while retrying deployment; do not rerun all
-  jobs. Use that successful rerun for promotion. A manually dispatched staging
-  run is still not promotable.
+  with `gh run rerun <staging-run-id> --failed`. A successful build keeps its
+  artifact; if GitHub reruns a cancelled build after its upload completed, the
+  upload replaces the retained same-name artifact. `PromotionWorkflowContract`
+  gates this rerun-safe wiring so promotion still sees exactly one artifact.
+  Use the successful rerun for promotion. A manually dispatched staging run is
+  still not promotable.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
 - **Either side resolves a different SHA:** cancel the package workflow
-  immediately, leave the site unapproved, and select matching evidence. If
+  and the promotion workflow immediately, then select matching evidence. If
   package publication already started, audit the partial immutable package set
-  before retrying. Do not treat ancestry or an equal version string as a match.
+  before retrying. Do not leave a stale promotion run waiting for approval, and
+  do not treat ancestry or an equal version string as a match.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,10 +1,15 @@
 # Release workflow
 
-This document explains how a tested commit becomes published packages.
-Repository development, worktree, build, and test rules live in
-[AGENTS.md](../AGENTS.md). The executable source of truth for publishing is
-[release.yml](../.github/workflows/release.yml); update this document when that
-workflow changes.
+This document explains how a tested commit becomes one coordinated release of
+the dotnet-inspect packages and the production site at
+`https://dotnet-inspect.net`. Repository development, worktree, build, and test
+rules live in [AGENTS.md](../AGENTS.md). The executable sources of truth are
+[release.yml](../.github/workflows/release.yml),
+[deploy-inspect-web.yml](../.github/workflows/deploy-inspect-web.yml), and
+[promote-inspect-web.yml](../.github/workflows/promote-inspect-web.yml); update
+this document when those workflows change. The repo-local
+[release skill](../.github/skills/release/SKILL.md) is the operator playbook and
+must stay aligned with this contract.
 
 ## Release boundary
 
@@ -16,6 +21,8 @@ responsibilities:
 | `ci.yml` | Pull requests and pushes to `main` | Validate the changed commit |
 | `deep-inspect.yml` | Daily schedule or manual `lane=test` dispatch | Certify one `main` commit with the full slow test and corpus gates |
 | `release.yml` | Manual dispatch | Verify certification, rebuild packages, and publish one selected commit |
+| `deploy-inspect-web.yml` | Pushes to `main` | Build and deploy a staging site artifact for the pushed commit |
+| `promote-inspect-web.yml` | Manual dispatch | Verify and promote one staged artifact to `https://dotnet-inspect.net` |
 
 The publish workflow accepts a successful `main` CI run ID to resolve the exact
 commit SHA and a Deep Inspect run ID as its heavy-validation evidence. It does
@@ -34,6 +41,33 @@ test jobs are PR-only, so it does not certify the intervening changes. The
 workflow proves that the target descends from the certified commit, but the
 operator owns the decision that those changes do not require another slow run.
 Divergent and older commits are never accepted.
+
+## Lockstep release identity
+
+A release is one exact pair: the full commit SHA and the `VersionPrefix` read
+from that commit. The packages, GitHub release, and production site are one
+release unit:
+
+- `release.yml` rebuilds and publishes the packages from the commit selected by
+  the successful `main` CI run.
+- `deploy-inspect-web.yml` builds the staging site from a `main` push, embedding
+  that commit's `VersionPrefix`, full source SHA, and build timestamp.
+- `promote-inspect-web.yml` promotes that exact staged artifact without
+  rebuilding it.
+
+Publish and promote together. Do not publish a new package version without
+promoting its matching site, and do not promote a site from a commit that is
+not the package release commit. The staging run's `head_sha` must exactly equal
+the target CI run's `head_sha`; ancestry is not sufficient. Enabling
+`allow_later_commit` changes the package target and therefore requires a
+staging run for that later exact commit.
+
+The individual workflows validate their own evidence:
+`validate-release-evidence.sh` fixes the package target SHA, and
+`validate-inspect-web-promotion.sh` fixes the staging SHA, run attempt,
+artifact ID, and digest. Comparing the two resolved SHAs remains an explicit
+operator gate; no single workflow currently verifies the cross-workflow
+equality.
 
 ## Packages
 
@@ -77,12 +111,16 @@ Before dispatching a release:
 1. Select a successful CI run for the exact commit to publish.
 2. Select a successful Deep Inspect `test` run completed within the last 36
    hours. Prefer an exact-SHA match.
-3. If publishing a later commit, review every intervening commit and decide
+3. Select the successful `deploy-inspect-web.yml` **push** run for the exact
+   commit to publish. Manual staging runs are not promotable.
+4. Compare the CI and staging runs' full 40-character `head_sha` values. Stop
+   if they differ.
+5. If publishing a later commit, review every intervening commit and decide
    whether carrying the ancestor's certification is justified.
-4. Confirm that the commit contains the intended `VersionPrefix` and release
+6. Confirm that the commit contains the intended `VersionPrefix` and release
    notes.
-5. Confirm that the version has not already been published.
-6. Reconcile the shipped documentation with what the release actually does —
+7. Confirm that the version has not already been published.
+8. Reconcile the shipped documentation with what the release actually does —
    see [Shipped documentation](#shipped-documentation).
 
 ## Shipped documentation
@@ -127,14 +165,32 @@ both before dispatching, and expect to update them:
 1. Open the selected successful `main` CI run and copy its run ID.
 2. Open the daily or manually dispatched Deep Inspect `test` run and copy its
    run ID.
-3. Open the **Publish** workflow and choose **Run workflow**.
-4. Enter both run IDs and type `publish` in the confirmation field.
-5. Leave `allow_later_commit` disabled for an exact certification. Enable it
-   only after reviewing the commits between the certified and target SHAs.
-6. Confirm that the resolve job reports both expected SHAs before the package
-   jobs proceed.
+3. Open the matching successful `deploy-inspect-web.yml` push run and copy its
+   run ID.
+4. Compare the CI and staging run `head_sha` values. Both must name the exact
+   release commit:
 
-The workflow then:
+   ```bash
+   ci_sha=$(gh run view "$ci_run_id" --json headSha --jq .headSha)
+   site_sha=$(gh run view "$staging_run_id" --json headSha --jq .headSha)
+   test "$ci_sha" = "$site_sha"
+   printf 'release SHA: %s\n' "$ci_sha"
+   ```
+
+5. Open the **Publish** and **Promote inspect-web** workflows in separate tabs
+   and choose **Run workflow** for both.
+6. In **Publish**, enter the CI and certification run IDs and type `publish` in
+   the confirmation field.
+7. In **Promote inspect-web**, enter the staging run ID and type `promote` in
+   the confirmation field.
+8. Leave `allow_later_commit` disabled for an exact certification. Enable it
+   only after reviewing the commits between the certified and target SHAs.
+9. Dispatch both workflows as one operator action. Do not substitute a newer
+   run for either side after the exact-SHA comparison.
+10. Confirm that both resolve jobs report the expected release SHA before
+    approving either protected publishing environment.
+
+The package workflow then:
 
 1. Verifies the normal CI run, the fresh Deep Inspect certification, and their
    commit relationship.
@@ -152,6 +208,14 @@ The workflow then:
 
 The pointer is deliberately published last because it references the
 runtime-specific packages.
+
+In parallel, the site promotion workflow revalidates the staging run and
+artifact identity, downloads the exact staged artifact with digest verification,
+and deploys it to `https://dotnet-inspect.net`.
+
+The release is complete only when both workflows succeed. Verify that the
+published package and GitHub release use the intended version and commit, then
+check the production site's status bar for the same version and linked commit.
 
 ## Failure handling
 
@@ -175,3 +239,10 @@ runtime-specific packages.
 - **A partially published release is retried:** the workflow uses
   `--skip-duplicate`, but verify the complete package set and GitHub release
   before treating the release as complete.
+- **The package workflow fails after site promotion:** retry package publication
+  with the same CI and certification run IDs. Do not promote a newer site.
+- **Site promotion fails after package publication:** retry promotion with the
+  same staging run ID. Do not advance the package version or staging SHA.
+- **Either side resolves a different SHA:** cancel before approving publication
+  and select matching evidence. Do not treat ancestry or an equal version string
+  as a match.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -125,8 +125,8 @@ Before dispatching a release:
 
 ## Shipped documentation
 
-`README.md` and the skills are not repository-side notes. They are release
-artifacts:
+`README.md` and the user-facing product skills under `skills/` are not
+repository-side notes. They are release artifacts:
 
 - `README.md` is the package readme (`PackageReadmeFile` in
   `src/dotnet-inspect/dotnet-inspect.csproj`, packed via the `None Include`
@@ -138,18 +138,22 @@ artifacts:
   enumerated one line per skill in `src/dotnet-inspect/dotnet-inspect.csproj`,
   not globbed.
 
+Repo-local maintainer skills under `.github/skills/` and `.claude/skills/` are
+not product release artifacts. Do not register or embed them.
+
 A change to `VersionPrefix` is therefore a documentation checkpoint. Consult
 both before dispatching, and expect to update them:
 
 - Do the commands, flags, defaults, and example output in `README.md` still
   match the tool? Re-run any example whose command surface changed rather than
   eyeballing it.
-- Does each `SKILL.md` still describe capabilities the release actually has,
-  and is a new capability discoverable from the skill that owns it? A skill's
-  YAML frontmatter `description:` is the single source of truth for the
-  generated listing, so a stale description ships as a stale listing.
-- **Does every skill added since the last release appear in both places?** A
-  skill needs an `EmbeddedResource` line in
+- Does each product `skills/*/SKILL.md` still describe capabilities the release
+  actually has, and is a new capability discoverable from the product skill
+  that owns it? A product skill's YAML frontmatter `description:` is the single
+  source of truth for the generated listing, so a stale description ships as a
+  stale listing.
+- **Does every product skill added under `skills/` since the last release appear
+  in both places?** A product skill needs an `EmbeddedResource` line in
   `src/dotnet-inspect/dotnet-inspect.csproj` *and* an entry in
   `SkillCommand.Skills`.
   `SkillCommandTests.FocusedSkillFilesRegistryAndEmbeddedResourcesAgree`
@@ -171,9 +175,27 @@ both before dispatching, and expect to update them:
    release commit:
 
    ```bash
+   set -euo pipefail
+   : "${ci_run_id:?set ci_run_id to the successful main CI run ID}"
+   : "${staging_run_id:?set staging_run_id to the matching staging run ID}"
+
    ci_sha=$(gh run view "$ci_run_id" --json headSha --jq .headSha)
    site_sha=$(gh run view "$staging_run_id" --json headSha --jq .headSha)
-   test "$ci_sha" = "$site_sha"
+
+   [[ "$ci_sha" =~ ^[0-9a-f]{40}$ ]] || {
+     printf 'invalid CI SHA: %s\n' "$ci_sha" >&2
+     exit 1
+   }
+   [[ "$site_sha" =~ ^[0-9a-f]{40}$ ]] || {
+     printf 'invalid staging SHA: %s\n' "$site_sha" >&2
+     exit 1
+   }
+   if [ "$ci_sha" != "$site_sha" ]; then
+     printf 'release SHA mismatch: CI=%s staging=%s\n' \
+       "$ci_sha" "$site_sha" >&2
+     exit 1
+   fi
+
    printf 'release SHA: %s\n' "$ci_sha"
    ```
 
@@ -187,8 +209,10 @@ both before dispatching, and expect to update them:
    only after reviewing the commits between the certified and target SHAs.
 9. Dispatch both workflows as one operator action. Do not substitute a newer
    run for either side after the exact-SHA comparison.
-10. Confirm that both resolve jobs report the expected release SHA before
-    approving either protected publishing environment.
+10. Confirm that both resolve jobs report the expected release SHA.
+11. Wait for every package build to succeed, then approve the NuGet environment.
+12. Wait for the package workflow and GitHub release to succeed, then approve
+    the production-site environment. Never promote the site first.
 
 The package workflow then:
 
@@ -209,9 +233,11 @@ The package workflow then:
 The pointer is deliberately published last because it references the
 runtime-specific packages.
 
-In parallel, the site promotion workflow revalidates the staging run and
-artifact identity, downloads the exact staged artifact with digest verification,
-and deploys it to `https://dotnet-inspect.net`.
+The site promotion workflow may validate its staging evidence while packages
+build, but its production environment remains unapproved. After package
+publication succeeds, approve the site workflow; it revalidates the staging run
+and artifact identity, downloads the exact staged artifact with digest
+verification, and deploys it to `https://dotnet-inspect.net`.
 
 The release is complete only when both workflows succeed. Verify that the
 published package and GitHub release use the intended version and commit, then
@@ -239,8 +265,9 @@ check the production site's status bar for the same version and linked commit.
 - **A partially published release is retried:** the workflow uses
   `--skip-duplicate`, but verify the complete package set and GitHub release
   before treating the release as complete.
-- **The package workflow fails after site promotion:** retry package publication
-  with the same CI and certification run IDs. Do not promote a newer site.
+- **The package workflow fails before site approval:** leave the production-site
+  environment unapproved and retry package publication with the same CI and
+  certification run IDs.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
 - **Either side resolves a different SHA:** cancel before approving publication

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -67,7 +67,9 @@ The individual workflows validate their own evidence:
 `validate-inspect-web-promotion.sh` fixes the staging SHA, run attempt,
 artifact ID, and digest. Comparing the two resolved SHAs remains an explicit
 operator gate; no single workflow currently verifies the cross-workflow
-equality.
+equality. Perform that comparison before dispatch: the `nuget` environment has
+no approval gate, so package publication proceeds automatically after its
+builds.
 
 ## Packages
 
@@ -209,8 +211,11 @@ both before dispatching, and expect to update them:
    only after reviewing the commits between the certified and target SHAs.
 9. Dispatch both workflows as one operator action. Do not substitute a newer
    run for either side after the exact-SHA comparison.
-10. Confirm that both resolve jobs report the expected release SHA.
-11. Wait for every package build to succeed, then approve the NuGet environment.
+10. Confirm immediately that both resolve jobs report the expected release SHA.
+    If either is wrong, cancel the package workflow before its publish job
+    starts and leave the production-site environment unapproved.
+11. Monitor the package builds and automatic NuGet publication. There is no
+    NuGet environment approval after dispatch.
 12. Wait for the package workflow and GitHub release to succeed, then approve
     the production-site environment. Never promote the site first.
 
@@ -268,8 +273,13 @@ check the production site's status bar for the same version and linked commit.
 - **The package workflow fails before site approval:** leave the production-site
   environment unapproved and retry package publication with the same CI and
   certification run IDs.
+- **The release commit's staging run was cancelled by a newer push:** wait for
+  active staging work to finish, then rerun the original push-triggered run with
+  `gh run rerun <staging-run-id>`. Use that successful rerun for promotion; a
+  manually dispatched staging run is still not promotable.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
-- **Either side resolves a different SHA:** cancel before approving publication
-  and select matching evidence. Do not treat ancestry or an equal version string
-  as a match.
+- **Either side resolves a different SHA:** cancel the package workflow
+  immediately, leave the site unapproved, and select matching evidence. If
+  package publication already started, audit the partial immutable package set
+  before retrying. Do not treat ancestry or an equal version string as a match.

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -21,7 +21,7 @@ responsibilities:
 | `ci.yml` | Pull requests and pushes to `main` | Validate the changed commit |
 | `deep-inspect.yml` | Daily schedule or manual `lane=test` dispatch | Certify one `main` commit with the full slow test and corpus gates |
 | `release.yml` | Manual dispatch | Verify certification, rebuild packages, and publish one selected commit |
-| `deploy-inspect-web.yml` | Pushes to `main` | Build and deploy a staging site artifact for the pushed commit |
+| `deploy-inspect-web.yml` | Pushes to `main` or manual dispatch from `main` | Build and deploy a staging site artifact for that commit |
 | `promote-inspect-web.yml` | Manual dispatch | Verify and promote one staged artifact to `https://dotnet-inspect.net` |
 
 The publish workflow accepts a successful `main` CI run ID to resolve the exact
@@ -42,6 +42,13 @@ workflow proves that the target descends from the certified commit, but the
 operator owns the decision that those changes do not require another slow run.
 Divergent and older commits are never accepted.
 
+That override is the **relief release** path for an urgent fix whose target
+commit is not itself certified. Exact certification is normal practice, not an
+absolute prerequisite when a person explicitly accepts the gap. After a relief
+release, leave the published package and site together on the relief commit and
+wait for the next exact certification before the next ordinary release;
+`allow_later_commit` is not standing authorization.
+
 ## Lockstep release identity
 
 A release is one exact pair: the full commit SHA and the `VersionPrefix` read
@@ -50,8 +57,9 @@ release unit:
 
 - `release.yml` rebuilds and publishes the packages from the commit selected by
   the successful `main` CI run.
-- `deploy-inspect-web.yml` builds the staging site from a `main` push, embedding
-  that commit's `VersionPrefix`, full source SHA, and build timestamp.
+- `deploy-inspect-web.yml` builds the staging site from `main`, normally from
+  its push trigger and exceptionally from an operator dispatch, embedding that
+  commit's `VersionPrefix`, full source SHA, and build timestamp.
 - `promote-inspect-web.yml` promotes that exact staged artifact without
   rebuilding it.
 
@@ -113,8 +121,9 @@ Before dispatching a release:
 1. Select a successful CI run for the exact commit to publish.
 2. Select a successful Deep Inspect `test` run completed within the last 36
    hours. Prefer an exact-SHA match.
-3. Select the successful `deploy-inspect-web.yml` **push** run for the exact
-   commit to publish. Manual staging runs are not promotable.
+3. Select the successful `deploy-inspect-web.yml` run for the exact commit to
+   publish. Use its main-push run by default. A person may authorize a manual
+   main staging run as an explicit exception.
 4. Compare the CI and staging runs' full 40-character `head_sha` values. Stop
    if they differ.
 5. If publishing a later commit, review every intervening commit and decide
@@ -171,8 +180,8 @@ both before dispatching, and expect to update them:
 1. Open the selected successful `main` CI run and copy its run ID.
 2. Open the daily or manually dispatched Deep Inspect `test` run and copy its
    run ID.
-3. Open the matching successful `deploy-inspect-web.yml` push run and copy its
-   run ID.
+3. Open the matching successful `deploy-inspect-web.yml` run and copy its run
+   ID. Use the main-push run unless a person authorized manual staging.
 4. Compare the CI and staging run `head_sha` values. Both must name the exact
    release commit:
 
@@ -208,16 +217,20 @@ both before dispatching, and expect to update them:
 7. In **Promote inspect-web**, enter the staging run ID and type `promote` in
    the confirmation field.
 8. Leave `allow_later_commit` disabled for an exact certification. Enable it
-   only after reviewing the commits between the certified and target SHAs.
-9. Dispatch both workflows as one operator action. Do not substitute a newer
+   only after reviewing the commits between the certified and target SHAs and
+   explicitly authorizing a relief release.
+9. Leave `allow_manual_staging` disabled for a main-push staging run. Enable it
+   only when a person explicitly authorizes the selected operator-dispatched
+   staging run.
+10. Dispatch both workflows as one operator action. Do not substitute a newer
    run for either side after the exact-SHA comparison.
-10. Confirm immediately that both resolve jobs report the expected release SHA.
+11. Confirm immediately that both resolve jobs report the expected release SHA.
     If either is wrong, cancel both the package and promotion workflow runs
     before package publication starts. Do not leave a stale promotion run
     waiting for approval.
-11. Monitor the package builds and automatic NuGet publication. There is no
+12. Monitor the package builds and automatic NuGet publication. There is no
     NuGet environment approval after dispatch.
-12. Wait for the package workflow and GitHub release to succeed, then approve
+13. Wait for the package workflow and GitHub release to succeed, then approve
     the production-site environment. Never promote the site first.
 
 The package workflow then:
@@ -280,8 +293,14 @@ check the production site's status bar for the same version and linked commit.
   artifact; if GitHub reruns a cancelled build after its upload completed, the
   upload replaces the retained same-name artifact. `PromotionWorkflowContract`
   gates this rerun-safe wiring so promotion still sees exactly one artifact.
-  Use the successful rerun for promotion. A manually dispatched staging run is
-  still not promotable.
+  Use the successful rerun for promotion.
+- **A push staging run is unavailable:** prefer rerunning its failed jobs. When
+  exceptional circumstances require a new operator-dispatched staging build,
+  a person must explicitly authorize it and enable `allow_manual_staging` for
+  promotion. The exact package/site SHA comparison remains mandatory.
+- **A relief release shipped an uncertified target:** keep package and site on
+  that same relief commit. Return to the standard path by waiting for an exact
+  successful Deep Inspect certification before the next ordinary release.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
 - **Either side resolves a different SHA:** cancel the package workflow

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -274,9 +274,11 @@ check the production site's status bar for the same version and linked commit.
   environment unapproved and retry package publication with the same CI and
   certification run IDs.
 - **The release commit's staging run was cancelled by a newer push:** wait for
-  active staging work to finish, then rerun the original push-triggered run with
-  `gh run rerun <staging-run-id>`. Use that successful rerun for promotion; a
-  manually dispatched staging run is still not promotable.
+  active staging work to finish, then rerun only the failed or cancelled jobs
+  with `gh run rerun <staging-run-id> --failed`. This preserves a successful
+  build's single uploaded artifact while retrying deployment; do not rerun all
+  jobs. Use that successful rerun for promotion. A manually dispatched staging
+  run is still not promotable.
 - **Site promotion fails after package publication:** retry promotion with the
   same staging run ID. Do not advance the package version or staging SHA.
 - **Either side resolves a different SHA:** cancel the package workflow

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -222,6 +222,12 @@ internal static class PromotionWorkflowContract
             ValidateStaging,
             "Staging workflow contract accepted an artifact without hidden Function dependencies.");
         AssertMutationRejected(
+            stagingWorkflow,
+            "          overwrite: true\n",
+            "",
+            ValidateStaging,
+            "Staging workflow contract accepted a non-rerun-safe artifact upload.");
+        AssertMutationRejected(
             coreClrStagingWorkflow,
             "            -p:Features=runtime-async=on \\\n",
             "",
@@ -777,6 +783,7 @@ internal static class PromotionWorkflowContract
                 ["name"] = "inspect-web-site",
                 ["path"] = "artifacts/inspect-web-publish",
                 ["if-no-files-found"] = "error",
+                ["overwrite"] = "true",
                 ["retention-days"] = "30",
                 ["include-hidden-files"] = "true",
             },

--- a/eng/CiChangeDetection/PromotionWorkflowContract.cs
+++ b/eng/CiChangeDetection/PromotionWorkflowContract.cs
@@ -187,6 +187,12 @@ internal static class PromotionWorkflowContract
             "Promotion workflow contract accepted disabled revalidation.");
         AssertMutationRejected(
             promotionWorkflow,
+            "          ALLOW_MANUAL_STAGING: ${{ inputs.allow_manual_staging }}\n",
+            "",
+            ValidatePromotion,
+            "Promotion workflow contract accepted an unpinned manual-staging override.");
+        AssertMutationRejected(
+            promotionWorkflow,
             "      - name: Revalidate staged site\n",
             "      - name: Download staged site artifact\n",
             ValidatePromotion,
@@ -492,6 +498,7 @@ internal static class PromotionWorkflowContract
             {
                 ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
                 ["STAGING_RUN_ID"] = "${{ inputs.staging_run_id }}",
+                ["ALLOW_MANUAL_STAGING"] = "${{ inputs.allow_manual_staging }}",
                 ["EXPECTED_SHA"] = "${{ needs.resolve.outputs.sha }}",
                 ["EXPECTED_ATTEMPT"] = "${{ needs.resolve.outputs.run_attempt }}",
                 ["EXPECTED_ARTIFACT_ID"] =
@@ -510,6 +517,7 @@ internal static class PromotionWorkflowContract
               "$STAGING_RUN_ID" \
               720 \
               "$RUNNER_TEMP/revalidated-inspect-web" \
+              "$ALLOW_MANUAL_STAGING" \
               "$EXPECTED_SHA" \
               "$EXPECTED_ATTEMPT" \
               "$EXPECTED_ARTIFACT_ID" \
@@ -1311,7 +1319,7 @@ internal static class PromotionWorkflowContract
             GetRequiredMapping(dispatch, "inputs", "promotion workflow_dispatch");
         RequireExactKeys(
             inputs,
-            ["staging_run_id", "confirm"],
+            ["staging_run_id", "allow_manual_staging", "confirm"],
             "promotion workflow_dispatch.inputs");
         RequireExactScalarValues(
             GetRequiredMapping(
@@ -1325,6 +1333,20 @@ internal static class PromotionWorkflowContract
                 ["required"] = "true",
             },
             "promotion staging_run_id input");
+        RequireExactScalarValues(
+            GetRequiredMapping(
+                inputs,
+                "allow_manual_staging",
+                "promotion workflow_dispatch.inputs"),
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["description"] =
+                    "Allow an operator-dispatched staging run instead of a main-push run",
+                ["required"] = "true",
+                ["default"] = "false",
+                ["type"] = "boolean",
+            },
+            "promotion allow_manual_staging input");
         RequireExactScalarValues(
             GetRequiredMapping(
                 inputs,
@@ -1444,6 +1466,7 @@ internal static class PromotionWorkflowContract
             {
                 ["GH_TOKEN"] = "${{ secrets.GITHUB_TOKEN }}",
                 ["STAGING_RUN_ID"] = "${{ inputs.staging_run_id }}",
+                ["ALLOW_MANUAL_STAGING"] = "${{ inputs.allow_manual_staging }}",
             },
             "staging evidence step.env");
         const string ExpectedValidation =
@@ -1451,7 +1474,8 @@ internal static class PromotionWorkflowContract
             bash eng/validate-inspect-web-promotion.sh \
               "$STAGING_RUN_ID" \
               720 \
-              "$GITHUB_OUTPUT"
+              "$GITHUB_OUTPUT" \
+              "$ALLOW_MANUAL_STAGING"
             """;
         if (GetRequiredScalar(validate, "run", "staging evidence step").TrimEnd() !=
             ExpectedValidation)

--- a/eng/validate-inspect-web-promotion.cs
+++ b/eng/validate-inspect-web-promotion.cs
@@ -18,6 +18,9 @@ try
     JobInfo[] jobs = ReadJobs(Required(options, "--jobs"));
     ArtifactInfo[] artifacts = ReadArtifacts(Required(options, "--artifacts"));
     string repository = Required(options, "--repository");
+    bool allowManualStaging = ParseBoolean(
+        Required(options, "--allow-manual-staging"),
+        "--allow-manual-staging");
     double maxAgeHours = double.Parse(
         Required(options, "--max-age-hours"),
         CultureInfo.InvariantCulture);
@@ -28,6 +31,7 @@ try
         jobs,
         artifacts,
         repository,
+        allowManualStaging,
         TimeSpan.FromHours(maxAgeHours),
         DateTimeOffset.UtcNow);
 
@@ -53,6 +57,7 @@ static ValidationResult Validate(
     IReadOnlyList<JobInfo> jobs,
     IReadOnlyList<ArtifactInfo> artifacts,
     string repository,
+    bool allowManualStaging,
     TimeSpan maxAge,
     DateTimeOffset now)
 {
@@ -61,8 +66,16 @@ static ValidationResult Validate(
         throw new InvalidOperationException(
             $"Staging run uses {run.WorkflowPath}, not {StagingWorkflow}.");
     }
-    if (run.Event != "push")
-        throw new InvalidOperationException($"Staging run event {run.Event} is not push.");
+    if (run.Event != "push" && run.Event != "workflow_dispatch")
+    {
+        throw new InvalidOperationException(
+            $"Staging run event {run.Event} is not push or workflow_dispatch.");
+    }
+    if (run.Event == "workflow_dispatch" && !allowManualStaging)
+    {
+        throw new InvalidOperationException(
+            "Manual staging promotion requires explicit operator authorization.");
+    }
     if (run.HeadBranch != "main")
         throw new InvalidOperationException($"Staging run targets {run.HeadBranch}, not main.");
     if (run.Repository != repository || run.HeadRepository != repository)
@@ -292,6 +305,14 @@ static string Required(IReadOnlyDictionary<string, string> options, string name)
         ? value
         : throw new ArgumentException($"Missing required option {name}.");
 
+static bool ParseBoolean(string value, string name) =>
+    value switch
+    {
+        "true" => true,
+        "false" => false,
+        _ => throw new ArgumentException($"{name} must be true or false."),
+    };
+
 static void RunSelfTest()
 {
     DateTimeOffset now = new(2026, 8, 17, 12, 0, 0, TimeSpan.Zero);
@@ -325,6 +346,7 @@ static void RunSelfTest()
         jobs,
         artifacts,
         repository,
+        allowManualStaging: false,
         TimeSpan.FromDays(30),
         now);
     Assert(result.Sha == sha, "Validated SHA should be preserved.");
@@ -336,6 +358,7 @@ static void RunSelfTest()
             jobs,
             artifacts,
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "not .github/workflows/deploy-inspect-web.yml");
@@ -345,15 +368,36 @@ static void RunSelfTest()
             jobs,
             artifacts,
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
-        "not push");
+        "requires explicit operator authorization");
+    ValidationResult manualResult = Validate(
+        run with { Event = "workflow_dispatch" },
+        jobs,
+        artifacts,
+        repository,
+        allowManualStaging: true,
+        TimeSpan.FromDays(30),
+        now);
+    Assert(manualResult.Sha == sha, "Authorized manual staging should preserve SHA.");
+    ExpectFailure(
+        () => Validate(
+            run with { Event = "pull_request" },
+            jobs,
+            artifacts,
+            repository,
+            allowManualStaging: true,
+            TimeSpan.FromDays(30),
+            now),
+        "not push or workflow_dispatch");
     ExpectFailure(
         () => Validate(
             run with { HeadRepository = "other/repository" },
             jobs,
             artifacts,
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "repository identity");
@@ -363,6 +407,7 @@ static void RunSelfTest()
             [new(StagingJob, "completed", "failure", now.AddMinutes(-5))],
             artifacts,
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "not completed/success");
@@ -372,6 +417,7 @@ static void RunSelfTest()
             jobs,
             [],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "contains 0 artifacts");
@@ -381,6 +427,7 @@ static void RunSelfTest()
             jobs,
             [artifacts[0], artifacts[0] with { Id = 203 }],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "contains 2 artifacts");
@@ -390,6 +437,7 @@ static void RunSelfTest()
             jobs,
             [artifacts[0], artifacts[0] with { Id = 203, Name = "other-artifact" }],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "contains 2 artifacts");
@@ -399,6 +447,7 @@ static void RunSelfTest()
             jobs,
             [artifacts[0] with { Name = "other-artifact" }],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "not inspect-web-site");
@@ -408,6 +457,7 @@ static void RunSelfTest()
             jobs,
             [artifacts[0] with { Expired = true }],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "expired");
@@ -417,6 +467,7 @@ static void RunSelfTest()
             jobs,
             [artifacts[0] with { WorkflowRunId = 999 }],
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "not 101");
@@ -426,6 +477,7 @@ static void RunSelfTest()
             [jobs[0] with { CompletedAt = now.AddDays(-31) }],
             artifacts,
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now),
         "maximum age");
@@ -478,6 +530,7 @@ static void RunSelfTest()
             ReadJobs(jobsPath),
             ReadArtifacts(artifactsPath),
             repository,
+            allowManualStaging: false,
             TimeSpan.FromDays(30),
             now);
         Assert(parsed.ArtifactDigest == digest, "API parsing should preserve artifact digest.");

--- a/eng/validate-inspect-web-promotion.sh
+++ b/eng/validate-inspect-web-promotion.sh
@@ -2,18 +2,19 @@
 
 set -euo pipefail
 
-if [ "$#" -lt 3 ] || [ "$#" -gt 7 ]; then
-  echo "usage: $0 <staging-run-id> <max-age-hours> <output> [expected-sha] [expected-attempt] [expected-artifact-id] [expected-digest]" >&2
+if [ "$#" -lt 4 ] || [ "$#" -gt 8 ]; then
+  echo "usage: $0 <staging-run-id> <max-age-hours> <output> <allow-manual-staging> [expected-sha] [expected-attempt] [expected-artifact-id] [expected-digest]" >&2
   exit 2
 fi
 
 staging_run_id=$1
 max_age_hours=$2
 output=$3
-expected_sha=${4:-}
-expected_attempt=${5:-}
-expected_artifact_id=${6:-}
-expected_digest=${7:-}
+allow_manual_staging=$4
+expected_sha=${5:-}
+expected_attempt=${6:-}
+expected_artifact_id=${7:-}
+expected_digest=${8:-}
 
 if [[ ! "$staging_run_id" =~ ^[1-9][0-9]*$ ]]; then
   echo "staging run ID must be a positive decimal run ID." >&2
@@ -21,6 +22,10 @@ if [[ ! "$staging_run_id" =~ ^[1-9][0-9]*$ ]]; then
 fi
 if [[ ! "$max_age_hours" =~ ^[1-9][0-9]*$ ]]; then
   echo "max-age-hours must be a positive integer." >&2
+  exit 1
+fi
+if [ "$allow_manual_staging" != true ] && [ "$allow_manual_staging" != false ]; then
+  echo "allow-manual-staging must be true or false." >&2
   exit 1
 fi
 if [ -n "$expected_sha" ] && [[ ! "$expected_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -65,6 +70,7 @@ dotnet run eng/validate-inspect-web-promotion.cs -- \
   --jobs "$jobs_json" \
   --artifacts "$artifacts_json" \
   --repository "$GITHUB_REPOSITORY" \
+  --allow-manual-staging "$allow_manual_staging" \
   --max-age-hours "$max_age_hours" \
   --github-output "$validator_output"
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1047,9 +1047,12 @@ archives the resulting `wwwroot` and prebuilt managed API as the run-scoped
 `inspect-web-site` GitHub artifact, then uses a fresh environment-gated job to
 download that artifact by ID with digest mismatch configured as an error and
 deploy it to the public staging site at `https://dotnet-inspect.ca`. The upload
-includes the managed API's hidden `.azurefunctions` dependencies, and the
-post-download gate requires its extension loader before deployment. Candidate
-build code never runs in the staging deployment job. The separate
+includes the managed API's hidden `.azurefunctions` dependencies and overwrites
+the same-name artifact on a rerun, so a cancelled attempt can be retried without
+leaving multiple artifacts that promotion rejects.
+`PromotionWorkflowContract` gates both properties. The post-download gate
+requires the extension loader before deployment. Candidate build code never
+runs in the staging deployment job. The separate
 `inspect-web-staging` GitHub environment accepts only `main` and holds a
 deployment token scoped to the staging Azure Static Web App.
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1074,18 +1074,20 @@ hook before and after artifact transfer.
 `.github/workflows/promote-inspect-web.yml` intentionally promotes one
 successful staging run to production at `https://dotnet-inspect.net`. The
 operator supplies the staging run ID and types `promote`; the workflow verifies
-that the run was a successful `main` push through the staging workflow, that
+that the run was a successful `main` build through the staging workflow, that
 its `Publish staging` job succeeded, and that it produced one unexpired,
-nonempty `inspect-web-site` artifact. After production approval it revalidates
-the run attempt, commit, artifact identity, and digest, downloads the exact
-artifact ID with digest mismatch configured as an error, and deploys the
-archived staging files. `validate-inspect-web-promotion.cs --self-test`, run
-by inspect-web CI, gates the evidence discriminator and close negative cases;
+nonempty `inspect-web-site` artifact. Main-push staging is the default. An
+operator-dispatched staging run is accepted only when the promotion dispatch
+explicitly enables `allow_manual_staging`; the validator rejects it otherwise.
+After production approval the workflow revalidates that same override, run
+attempt, commit, artifact identity, and digest, downloads the exact artifact ID
+with digest mismatch configured as an error, and deploys the archived staging
+files. `validate-inspect-web-promotion.cs --self-test`, run by inspect-web CI,
+gates the default rejection, explicit exception, and other close negative cases;
 the CI change-detection workflow contract gate keeps all deployment jobs free
 of candidate code, closes the CoreCLR runtime and credential contract, keeps
 production revalidation on the trusted dispatch revision, and orders each
-artifact download before only verification and deployment. Manual staging runs
-remain useful for recovery but are deliberately not promotable.
+artifact download before only verification and deployment.
 
 Production promotion uses the distinct `inspect-web-production-promotion`
 environment and `AZURE_STATIC_WEB_APPS_API_TOKEN_INSPECT_WEB_PRODUCTION`


### PR DESCRIPTION
## Summary

- define one release as the exact commit SHA and `VersionPrefix` shared by NuGet, the GitHub release, and `dotnet-inspect.net`
- add a repo-local release skill that dispatches package publication and site promotion together and keeps retries pinned to the same evidence
- document the boundary between shipped user-facing skills and repo-local maintainer skills

## Demo

Before this change, the release playbook ended after package publication and the existing Deep Inspect product skill was the closest release-adjacent guidance. Site promotion was a separate operator action with no documented requirement to match the package commit.

After this change, the release skill requires the CI and staging runs to resolve to the same full SHA before either protected environment is approved:

```bash
ci_sha=$(gh run view \"$ci_run_id\" --json headSha --jq .headSha)
site_sha=$(gh run view \"$staging_run_id\" --json headSha --jq .headSha)
test \"$ci_sha\" = \"$site_sha\"
printf 'release SHA: %s\\n' \"$ci_sha\"
```

The operator then dispatches `release.yml` and `promote-inspect-web.yml` as one release operation. A failure retries the same side with the same evidence instead of advancing package and site independently. The shipped `deep-inspect` skill remains certification-focused and unchanged.

## Compatibility

This changes maintainer guidance only. It does not alter either publishing workflow or any user-facing embedded skill. The exact-SHA comparison between the independent workflows remains an explicit operator gate.

## Validation

- `npx markdownlint-cli AGENTS.md docs/release-workflow.md .github/skills/release/SKILL.md`
- `git diff --check origin/main...HEAD`