### PR TITLE
Remove stale containment census totals

### DIFF
--- a/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/MarkoutRowContainmentTests.cs
@@ -58,8 +58,9 @@ namespace DotnetInspector.Tests;
 /// had to be corrected for. It is the exact complement of the set that contains
 /// <i>in the row</i>. Membership is a fact about which idiom a column uses; some
 /// entries are producer-contained and correct as they stand, and the remainder
-/// are the residual tracked by issue #3463 -- which this measures at 269 members
-/// across 59 types after the library-inspection boundary moved to typed inert text.</para>
+/// are the residual tracked by issue #3463. The census below pins the current
+/// member and type totals after the library-inspection boundary moved to typed
+/// inert text.</para>
 ///
 /// <para>Asserting it as a set is what makes the weaker property still bite. A
 /// column cannot leave the self-containing set without failing here, which is


### PR DESCRIPTION
## Summary

- remove the stale 269-member/59-type totals left in the containment-test remarks after #4672
- make the adjacent executable census the single source of truth for current member and type totals
- preserve all product and test behavior

## Demo

Before, the remarks reported 269 members across 59 types while the adjacent gate correctly pinned 267 across 58. After this change, the remarks describe the invariant and defer current totals to the executable census.

## Validation

`git diff --check origin/main...HEAD`

## Review

Trivial documentation-only correction: one stale numeric statement is removed from a test doc comment; executable behavior is unchanged.