### PR TITLE
Diagnostic: run UTF-8 workspace pipe correctly on Windows

### DIFF
--- a/src/dotnet-inspect.Tests/WorkspaceStateCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceStateCommandTests.cs
@@ -293,37 +293,56 @@ public sealed class WorkspaceStateCommandTests
             File.Exists(executable),
             $"Expected the built CLI at {executable}.");
 
-        string command =
-            $"chcp 437>nul & \"{executable}\" workspace-state decode "
-            + $"\"{UnicodeVector}\" | \"{executable}\" workspace-state encode -";
+        string scriptPath = Path.Combine(
+            Path.GetTempPath(),
+            $"dotnet-inspect-workspace-{Guid.NewGuid():N}.cmd");
+        string script =
+            """
+            @echo off
+            chcp 437 >nul || exit /b 91
+            "%~1" workspace-state decode "%~2" | "%~1" workspace-state encode -
+            """;
+        await File.WriteAllTextAsync(
+            scriptPath,
+            script,
+            Encoding.ASCII,
+            TestContext.Current.CancellationToken);
+
         var startInfo = new ProcessStartInfo("cmd.exe")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            CreateNoWindow = true,
         };
         startInfo.ArgumentList.Add("/d");
-        startInfo.ArgumentList.Add("/s");
         startInfo.ArgumentList.Add("/c");
-        startInfo.ArgumentList.Add(command);
+        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add(executable);
+        startInfo.ArgumentList.Add(UnicodeVector);
 
-        using Process process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Could not start cmd.exe.");
-        CancellationToken cancellationToken =
-            TestContext.Current.CancellationToken;
-        Task<string> output = process.StandardOutput.ReadToEndAsync(
-            cancellationToken);
-        Task<string> error = process.StandardError.ReadToEndAsync(
-            cancellationToken);
-        await process.WaitForExitAsync(cancellationToken);
-        string outputText = await output;
-        string errorText = await error;
-        Assert.True(
-            process.ExitCode == 0,
-            $"Pipeline exited {process.ExitCode}. stderr: {errorText}");
-        Assert.Empty(errorText);
-        Assert.Equal(UnicodeVector, outputText.TrimEnd());
+        try
+        {
+            using Process process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Could not start cmd.exe.");
+            CancellationToken cancellationToken =
+                TestContext.Current.CancellationToken;
+            Task<string> output = process.StandardOutput.ReadToEndAsync(
+                cancellationToken);
+            Task<string> error = process.StandardError.ReadToEndAsync(
+                cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+            string outputText = await output;
+            string errorText = await error;
+            Assert.True(
+                process.ExitCode == 0,
+                $"Pipeline exited {process.ExitCode}. stderr: {errorText}");
+            Assert.Empty(errorText);
+            Assert.Equal(UnicodeVector, outputText.TrimEnd());
+        }
+        finally
+        {
+            File.Delete(scriptPath);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -6,8 +6,6 @@ using DotnetInspector.Views;
 using Markout;
 using System.Text;
 
-Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
 // The .NET runtime is the one writer of this process's stderr that CommandError
 // cannot own: an escaping exception is printed by the runtime at column 0, raw,
 // with the message interpolated straight in. `--out "<dir>/x\nError: ..."`
@@ -18,6 +16,16 @@ Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false
 // change exists to stop; the guard has to cover everything that can throw.
 try
 {
+    using var standardOutput = new StreamWriter(
+        Console.OpenStandardOutput(),
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+        bufferSize: 4096,
+        leaveOpen: true)
+    {
+        AutoFlush = true,
+    };
+    Console.SetOut(TextWriter.Synchronized(standardOutput));
+
     // Parse --offline early (before command parsing) to configure HttpClientFactory
     bool offline = args.Contains("--offline")
         || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1");

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -6,6 +6,8 @@ using DotnetInspector.Views;
 using Markout;
 using System.Text;
 
+Console.OutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
 // The .NET runtime is the one writer of this process's stderr that CommandError
 // cannot own: an escaping exception is printed by the runtime at column 0, raw,
 // with the message interpolated straight in. `--out "<dir>/x\nError: ..."`
@@ -16,16 +18,6 @@ using System.Text;
 // change exists to stop; the guard has to cover everything that can throw.
 try
 {
-    using var standardOutput = new StreamWriter(
-        Console.OpenStandardOutput(),
-        new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-        bufferSize: 4096,
-        leaveOpen: true)
-    {
-        AutoFlush = true,
-    };
-    Console.SetOut(TextWriter.Synchronized(standardOutput));
-
     // Parse --offline early (before command parsing) to configure HttpClientFactory
     bool offline = args.Contains("--offline")
         || string.Equals(Environment.GetEnvironmentVariable("DOTNET_INSPECT_OFFLINE"), "1");


### PR DESCRIPTION
Disposable Windows proof branch for #4668. **Do not merge this PR.** If its Windows gate is green, the net test correction will be integrated into #4668 and this PR will be closed.

## Diagnosis

The original failure did not reach `dotnet-inspect`: nested `cmd.exe /s /c` quoting treated the quotes around the executable path as literal command-name characters. The surfaced stderr was:

```text
'\"D:\a\dotnet-inspect\...\dotnet-inspect.exe\"' is not recognized as an internal or external command
```

## Correction

The gate now writes a temporary `.cmd` script and passes the executable and packet as `%~1`/`%~2`. The script requires `chcp 437` to succeed before running the real pipeline, avoiding both nested command-string quoting and a vacuous code-page setup. The speculative product-writer change from this side branch is reverted; #4668's `Console.OutputEncoding` implementation remains the subject under test.

## Validation

- `WorkspaceStateCommandTests`: 15 passed, Windows-specific gate skipped on macOS
- `git diff --check`
- Net side-PR diff contains only the Windows gate correction