### PR TITLE
Extract a shared compiler-generated name/shape grammar

### DIFF
--- a/src/ILInspector.Analysis/CompilerGeneratedNames.cs
+++ b/src/ILInspector.Analysis/CompilerGeneratedNames.cs
@@ -10,10 +10,10 @@ namespace ILInspector.Analysis;
 public static class CompilerGeneratedNames
 {
     /// <summary>Closure environment types: <c>&lt;&gt;c__DisplayClass...</c>.</summary>
-    internal const string DisplayClassPrefix = "<>c__DisplayClass";
+    internal const string DisplayClassPrefix = GeneratedNameGrammar.DisplayClassPrefix;
 
     /// <summary>Iterator/async state-machine types: <c>&lt;...&gt;d__...</c>.</summary>
-    internal const string StateMachineInfix = ">d__";
+    internal const string StateMachineInfix = GeneratedNameGrammar.StateMachineInfix;
 
     /// <summary>
     /// The innermost segment of a type's metadata name, with any
@@ -25,8 +25,7 @@ public static class CompilerGeneratedNames
         string name = type.Kind == TypeRefKind.GenericInstance
             ? type.ElementType?.Name ?? ""
             : type.Name;
-        int nested = name.LastIndexOf('+');
-        return nested < 0 ? name : name[(nested + 1)..];
+        return GeneratedNameGrammar.LeafSegment(name);
     }
 
     /// <summary>
@@ -36,13 +35,12 @@ public static class CompilerGeneratedNames
     /// </summary>
     internal static bool IsDisplayClass(TypeRef? type)
         => type is not null
-            && LeafName(type)
-                .StartsWith(DisplayClassPrefix, StringComparison.Ordinal);
+            && GeneratedNameGrammar.IsDisplayClassLeaf(LeafName(type));
 
     /// <summary>Source-authored local-function and lambda method bodies.</summary>
     internal static bool IsLocalFunctionOrLambda(string methodName)
-        => methodName.Contains(">g__", StringComparison.Ordinal)
-            || methodName.Contains(">b__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsLocalFunctionMethodName(methodName)
+            || GeneratedNameGrammar.IsLambdaMethodName(methodName);
 
     /// <summary>
     /// Returns the qualified display name of the immediate containing type for
@@ -101,15 +99,12 @@ public static class CompilerGeneratedNames
     }
 
     static bool IsGeneratedTypeName(string name)
-        => name.StartsWith('<')
-            || name.StartsWith("__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsGeneratedName(name);
 
     internal static bool RequiresDeclaredOwner(
         MethodIdentity method)
         => IsLocalFunctionOrLambda(method.Name)
             || method.Name == "MoveNext"
-                && LeafName(method.DeclaringType)
-                    .Contains(
-                        StateMachineInfix,
-                        StringComparison.Ordinal);
+                && GeneratedNameGrammar.IsStateMachineLeaf(
+                    LeafName(method.DeclaringType));
 }

--- a/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/GeneratedCodeIdentity.cs
@@ -1,3 +1,5 @@
+using ILInspector.Metadata;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -23,14 +25,13 @@ public static class GeneratedCodeIdentity
             && IsSynthesizedLambdaMethodName(method.Name);
 
     public static bool IsStaticLambdaClosureHolderName(TypeRef type)
-        => LeafTypeName(type.Name) == "<>c";
+        => LeafTypeName(type.Name) == GeneratedNameGrammar.NonCapturingLambdaHolderName;
 
     public static bool IsDisplayClassName(TypeRef type)
-        => LeafTypeName(type.Name).StartsWith("<>c__DisplayClass", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsDisplayClassLeaf(LeafTypeName(type.Name));
 
     public static bool IsSynthesizedLambdaMethodName(string name)
-        => name.StartsWith("<", StringComparison.Ordinal)
-            && name.Contains(">b__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsSynthesizedLambdaMethodName(name);
 
     /// <summary>
     /// A synthesized local-function method: <c>&lt;Enclosing&gt;g__Name|N_M</c>,
@@ -58,7 +59,7 @@ public static class GeneratedCodeIdentity
         => method.DeclaringTypeCompilerGenerated == MetadataFactState.Yes
             && !method.HasThis
             && method.Name == "ComputeStringHash"
-            && LeafTypeName(MetadataTypeName(method.DeclaringType)) == "<PrivateImplementationDetails>"
+            && LeafTypeName(MetadataTypeName(method.DeclaringType)) == GeneratedNameGrammar.PrivateImplementationDetailsTypeName
             && method.ReturnType.Equals(TypeRef.CoreLib("System", "UInt32"))
             && method.ParameterTypes is [var parameter]
             && parameter.Equals(TypeRef.CoreLib("System", "String"));
@@ -80,7 +81,7 @@ public static class GeneratedCodeIdentity
         readOnly = false;
         if (method.DeclaringTypeCompilerGenerated != MetadataFactState.Yes
             || method.HasThis
-            || LeafTypeName(MetadataTypeName(method.DeclaringType)) != "<PrivateImplementationDetails>")
+            || LeafTypeName(MetadataTypeName(method.DeclaringType)) != GeneratedNameGrammar.PrivateImplementationDetailsTypeName)
         {
             return false;
         }
@@ -104,14 +105,13 @@ public static class GeneratedCodeIdentity
     }
 
     public static bool IsDynamicCallSiteContainerType(TypeRef type)
-        => LeafTypeName(MetadataTypeName(type)).StartsWith("<>o__", StringComparison.Ordinal);
+        => LeafTypeName(MetadataTypeName(type)).StartsWith(GeneratedNameGrammar.DynamicCallSiteContainerPrefix, StringComparison.Ordinal);
 
     public static bool IsIteratorStateMachineTypeName(TypeRef type)
-        => LeafTypeName(MetadataTypeName(type)).Contains(">d__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsStateMachineLeaf(LeafTypeName(MetadataTypeName(type)));
 
     public static bool IsSynthesizedLocalFunctionName(string name)
-        => name.StartsWith("<", StringComparison.Ordinal)
-            && name.Contains(">g__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsSynthesizedLocalFunctionName(name);
 
     /// <summary>
     /// A compiler-generated field name. The leading <c>&lt;</c> is unspeakable in
@@ -122,7 +122,7 @@ public static class GeneratedCodeIdentity
     /// field a rewrite failed to remap.
     /// </summary>
     public static bool IsGeneratedFieldName(string name)
-        => name.StartsWith("<", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsGeneratedFieldName(name);
 
     /// <summary>
     /// A hoisted user-local field — <c>&lt;name&gt;5__N</c>, the lifted form of a
@@ -135,15 +135,10 @@ public static class GeneratedCodeIdentity
     /// those passes materialize back into kickoff locals and parameters.
     /// </summary>
     public static bool IsHoistedLocalFieldName(string name)
-        => IsGeneratedFieldName(name)
-            && !name.StartsWith("<>", StringComparison.Ordinal)
-            && name.Contains(">5__", StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsHoistedLocalFieldName(name);
 
     static string LeafTypeName(string name)
-    {
-        int plus = name.LastIndexOf('+');
-        return plus < 0 ? name : name[(plus + 1)..];
-    }
+        => GeneratedNameGrammar.LeafSegment(name);
 
     static string MetadataTypeName(TypeRef type)
         => type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -93,7 +93,7 @@ internal static class CSharpNaming
     /// <summary>The property name an auto-property backing field <c>&lt;Prop&gt;k__BackingField</c> backs, or null for an ordinary field.</summary>
     public static string? BackingFieldProperty(string fieldName)
     {
-        const string suffix = ">k__BackingField";
+        const string suffix = GeneratedNameGrammar.BackingFieldSuffix;
         return fieldName.Length > suffix.Length + 1 && fieldName[0] == '<' && fieldName.EndsWith(suffix, StringComparison.Ordinal)
             ? fieldName[1..^suffix.Length]
             : null;
@@ -127,10 +127,10 @@ internal static class CSharpNaming
     {
         if (!name.StartsWith('<'))
             return name;
-        int marker = name.IndexOf(">g__", StringComparison.Ordinal);
+        int marker = name.IndexOf(GeneratedNameGrammar.LocalFunctionInfix, StringComparison.Ordinal);
         if (marker < 0)
             return name;
-        int start = marker + 4;
+        int start = marker + GeneratedNameGrammar.LocalFunctionInfix.Length;
         int bar = name.IndexOf('|', start);
         return bar > start ? name[start..bar] : name[start..];
     }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2572,7 +2572,7 @@ public static class ApiSurfaceExtractor
             }
 
             (descriptors ??= new Dictionary<string, AutoPropertyBackingField>(StringComparer.Ordinal))
-                [$"<{propertyName}>k__BackingField"]
+                [$"<{propertyName}{GeneratedNameGrammar.BackingFieldSuffix}"]
                     = new AutoPropertyBackingField(propertyType, isStatic);
         }
 

--- a/src/ILInspector.Metadata/TypeFilters.cs
+++ b/src/ILInspector.Metadata/TypeFilters.cs
@@ -12,7 +12,7 @@ public static class TypeFilters
     /// rule appropriate for member names.
     /// </summary>
     public static bool IsCompilerGenerated(string typeName)
-        => typeName.StartsWith('<') || typeName.StartsWith("__", System.StringComparison.Ordinal);
+        => GeneratedNameGrammar.IsGeneratedName(typeName);
 
     /// <summary>
     /// True when any segment of a possibly nested-qualified, <c>+</c>-separated

--- a/src/ILInspector.MetadataPrimitives/GeneratedNameGrammar.cs
+++ b/src/ILInspector.MetadataPrimitives/GeneratedNameGrammar.cs
@@ -1,0 +1,145 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The raw, metadata-free string shapes Roslyn and the runtime use for
+/// compiler-synthesized names: closure environments, state machines, local
+/// functions, lambdas, and hoisted/backing fields. This is shape parsing
+/// only — whether a name carrying one of these shapes should be <em>trusted</em>
+/// is a separate, consumer-owned policy (for example, requiring
+/// <c>[CompilerGenerated]</c> attribute evidence before acting on a name), and
+/// is intentionally not decided here. See
+/// <see cref="MetadataNameArity"/> for the analogous generic-arity grammar this
+/// follows the shape of.
+/// </summary>
+/// <remarks>
+/// Before this type existed, the same shapes were independently re-derived in
+/// Analysis (<c>CompilerGeneratedNames</c>), the decompiler
+/// (<c>GeneratedCodeIdentity</c>), and Metadata (<c>TypeFilters</c> /
+/// <c>MemberFilters</c>), and had already drifted — see issue #4692. Each of
+/// those keeps its own policy (attribute gating, declared-owner requirements,
+/// API-surface visibility) layered on top of these shared primitives.
+/// </remarks>
+public static class GeneratedNameGrammar
+{
+    /// <summary>Closure environment types: <c>&lt;&gt;c__DisplayClass...</c>.</summary>
+    public const string DisplayClassPrefix = "<>c__DisplayClass";
+
+    /// <summary>
+    /// The non-capturing lambda cache singleton type, named exactly this —
+    /// distinct from a display class, which additionally captures state.
+    /// </summary>
+    public const string NonCapturingLambdaHolderName = "<>c";
+
+    /// <summary>
+    /// The static holder type for compiler-synthesized helpers such as string-switch
+    /// hash computation and inline-array element-ref intrinsics.
+    /// </summary>
+    public const string PrivateImplementationDetailsTypeName = "<PrivateImplementationDetails>";
+
+    /// <summary>Dynamic call-site storage container types: <c>&lt;&gt;o__...</c>.</summary>
+    public const string DynamicCallSiteContainerPrefix = "<>o__";
+
+    /// <summary>Iterator/async state-machine types: <c>&lt;...&gt;d__...</c>.</summary>
+    public const string StateMachineInfix = ">d__";
+
+    /// <summary>Synthesized local-function methods: <c>&lt;...&gt;g__...</c>.</summary>
+    public const string LocalFunctionInfix = ">g__";
+
+    /// <summary>Synthesized lambda-body methods: <c>&lt;...&gt;b__...</c>.</summary>
+    public const string LambdaInfix = ">b__";
+
+    /// <summary>
+    /// Hoisted user-local fields — the lifted form of a source local or
+    /// parameter inside a state machine: <c>&lt;name&gt;5__N</c>.
+    /// </summary>
+    public const string HoistedLocalInfix = ">5__";
+
+    /// <summary>Auto-property backing fields: <c>&lt;Prop&gt;k__BackingField</c>.</summary>
+    public const string BackingFieldSuffix = ">k__BackingField";
+
+    /// <summary>
+    /// True when a single (non-nested) metadata name uses one of the reserved
+    /// prefixes the runtime/Roslyn use for synthesized names: <c>&lt;</c>
+    /// (closures, state machines, display classes, hoisted/plumbing fields) or
+    /// <c>__</c> (e.g. <c>__StaticArrayInitTypeSize=...</c>).
+    /// </summary>
+    public static bool IsGeneratedName(string name)
+        => name.StartsWith('<') || name.StartsWith("__", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The innermost segment of a possibly nested-qualified (<c>+</c>-separated)
+    /// metadata name. Metadata readers qualify a nested type as
+    /// <c>Outer+Inner</c>, so a synthesized display class or state machine
+    /// nested under ordinary types appears as <c>Outer+&lt;Method&gt;d__0</c>;
+    /// this returns just <c>&lt;Method&gt;d__0</c>.
+    /// </summary>
+    public static string LeafSegment(string name)
+    {
+        int nested = name.LastIndexOf('+');
+        return nested < 0 ? name : name[(nested + 1)..];
+    }
+
+    /// <summary>
+    /// True when a leaf (already-unqualified) type name is a closure
+    /// environment: <c>&lt;&gt;c__DisplayClass...</c>. The non-capturing lambda
+    /// cache singleton is named exactly <see cref="NonCapturingLambdaHolderName"/>
+    /// and does not match this prefix.
+    /// </summary>
+    public static bool IsDisplayClassLeaf(string leafTypeName)
+        => leafTypeName.StartsWith(DisplayClassPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when a leaf (already-unqualified) type name is an iterator or
+    /// async state machine: <c>&lt;...&gt;d__...</c>.
+    /// </summary>
+    public static bool IsStateMachineLeaf(string leafTypeName)
+        => leafTypeName.Contains(StateMachineInfix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when a method name carries the synthesized local-function infix
+    /// <c>&gt;g__</c>, regardless of a leading <c>&lt;</c>.
+    /// </summary>
+    public static bool IsLocalFunctionMethodName(string methodName)
+        => methodName.Contains(LocalFunctionInfix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// True when a method name carries the synthesized lambda-body infix
+    /// <c>&gt;b__</c>, regardless of a leading <c>&lt;</c>.
+    /// </summary>
+    public static bool IsLambdaMethodName(string methodName)
+        => methodName.Contains(LambdaInfix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// A synthesized local-function method name: <c>&lt;Enclosing&gt;g__Name|N_M</c>.
+    /// </summary>
+    public static bool IsSynthesizedLocalFunctionName(string name)
+        => name.StartsWith('<') && IsLocalFunctionMethodName(name);
+
+    /// <summary>
+    /// A synthesized lambda-body method name: <c>&lt;Enclosing&gt;b__N_M</c>.
+    /// </summary>
+    public static bool IsSynthesizedLambdaMethodName(string name)
+        => name.StartsWith('<') && IsLambdaMethodName(name);
+
+    /// <summary>
+    /// True for any compiler-generated field name — state-machine plumbing
+    /// (<c>&lt;&gt;1__state</c>, <c>&lt;&gt;2__current</c>) or a hoisted local
+    /// (<c>&lt;i&gt;5__2</c>) alike. The leading <c>&lt;</c> is unspeakable in
+    /// C# source, so it alone is reliable evidence a field was synthesized.
+    /// </summary>
+    public static bool IsGeneratedFieldName(string name)
+        => name.StartsWith('<');
+
+    /// <summary>
+    /// A hoisted user-local field — <c>&lt;name&gt;5__N</c>, the lifted form of
+    /// a source local or parameter inside a state machine. The single
+    /// <c>&lt;</c> marks it generated; the absent <c>&lt;&gt;</c> double prefix
+    /// and the <see cref="HoistedLocalInfix"/> infix together distinguish it
+    /// from pure state-machine plumbing (<c>&lt;&gt;1__state</c>,
+    /// <c>&lt;&gt;2__current</c>).
+    /// </summary>
+    public static bool IsHoistedLocalFieldName(string name)
+        => IsGeneratedFieldName(name)
+            && !name.StartsWith("<>", StringComparison.Ordinal)
+            && name.Contains(HoistedLocalInfix, StringComparison.Ordinal);
+}

--- a/tests/ILInspector.Metadata.Tests/GeneratedNameGrammarTests.cs
+++ b/tests/ILInspector.Metadata.Tests/GeneratedNameGrammarTests.cs
@@ -1,0 +1,100 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// The shared compiler-generated name/shape grammar (#4692), extracted after
+/// Analysis, the decompiler, and Metadata independently re-derived the same
+/// shapes and drifted. This is shape parsing only; trust policy (attribute
+/// gating, declared-owner requirements, API-surface visibility) is layered on
+/// top by each consumer and is out of scope here.
+/// </summary>
+public class GeneratedNameGrammarTests
+{
+    [Theory]
+    [InlineData("<>c__DisplayClass6_2", true)]
+    [InlineData("<GetRegisteredTypes>d__10", true)]
+    [InlineData("__StaticArrayInitTypeSize=16", true)]
+    [InlineData("Outer", false)]
+    [InlineData("ApiOutputFormatter", false)]
+    public void IsGeneratedName_matches_leading_reserved_prefixes(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsGeneratedName(name));
+
+    [Theory]
+    [InlineData("Outer+<M>d__0", "<M>d__0")]
+    [InlineData("Outer+Middle+<>c__DisplayClass0_0", "<>c__DisplayClass0_0")]
+    [InlineData("Outer", "Outer")]
+    [InlineData("", "")]
+    public void LeafSegment_strips_everything_up_to_the_last_plus(string name, string expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.LeafSegment(name));
+
+    [Theory]
+    [InlineData("<>c__DisplayClass0_0", true)]
+    [InlineData("<>c", false)] // the non-capturing lambda holder, not a display class
+    [InlineData("<M>d__0", false)]
+    [InlineData("Outer", false)]
+    public void IsDisplayClassLeaf_requires_the_display_class_prefix(string leaf, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsDisplayClassLeaf(leaf));
+
+    [Theory]
+    [InlineData("<M>d__0", true)]
+    [InlineData("<M>d__0`1", true)] // generic iterator/async state machine
+    [InlineData("<>c__DisplayClass0_0", false)]
+    [InlineData("Outer", false)]
+    public void IsStateMachineLeaf_requires_the_state_machine_infix(string leaf, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsStateMachineLeaf(leaf));
+
+    [Theory]
+    [InlineData("<M>g__Helper|0_0", true)]
+    [InlineData("M", false)]
+    [InlineData("<M>b__0_0", false)]
+    public void IsLocalFunctionMethodName_requires_the_local_function_infix(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsLocalFunctionMethodName(name));
+
+    [Theory]
+    [InlineData("<M>b__0_0", true)]
+    [InlineData("M", false)]
+    [InlineData("<M>g__Helper|0_0", false)]
+    public void IsLambdaMethodName_requires_the_lambda_infix(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsLambdaMethodName(name));
+
+    [Theory]
+    // A leading '<' plus the matching infix is required together; either alone is not enough.
+    [InlineData("<M>g__Helper|0_0", true)]
+    [InlineData("M_g__Helper|0_0", false)] // carries the infix, but not the leading '<'
+    [InlineData("<M>b__0_0", false)] // leading '<', but the lambda infix, not local-function
+    public void IsSynthesizedLocalFunctionName_requires_both_marks(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsSynthesizedLocalFunctionName(name));
+
+    [Theory]
+    [InlineData("<M>b__0_0", true)]
+    [InlineData("M_b__0_0", false)]
+    [InlineData("<M>g__Helper|0_0", false)]
+    public void IsSynthesizedLambdaMethodName_requires_both_marks(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsSynthesizedLambdaMethodName(name));
+
+    [Theory]
+    [InlineData("<>1__state", true)]
+    [InlineData("<>2__current", true)]
+    [InlineData("<i>5__2", true)]
+    [InlineData("<>9__0_0", true)]
+    [InlineData("count", false)]
+    [InlineData("", false)]
+    public void IsGeneratedFieldName_matches_any_leading_angle_bracket(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsGeneratedFieldName(name));
+
+    [Theory]
+    // A hoisted local carries a single '<' plus the hoist infix.
+    [InlineData("<i>5__2", true)]
+    [InlineData("<text>5__1", true)]
+    // Pure state-machine plumbing wears the '<>' double prefix, not a hoist.
+    [InlineData("<>1__state", false)]
+    [InlineData("<>2__current", false)]
+    [InlineData("<>9__0_0", false)]
+    // A single-angle generated name without the hoist infix is not a hoisted local.
+    [InlineData("<M>b__0_0", false)]
+    [InlineData("<M>d__0", false)]
+    [InlineData("count", false)]
+    public void IsHoistedLocalFieldName_requires_single_angle_prefix_and_hoist_infix(string name, bool expected)
+        => Assert.Equal(expected, GeneratedNameGrammar.IsHoistedLocalFieldName(name));
+}


### PR DESCRIPTION
## Result

Extracts the raw compiler-generated name/shape grammar that Analysis, the
decompiler, and Metadata each independently re-derived — and had already
drifted — into one shared, dependency-free primitive.

## Demo

Before: three separate re-derivations of the same shape, already inconsistent.

```csharp
// ILInspector.Analysis.CompilerGeneratedNames
internal static bool IsLocalFunctionOrLambda(string methodName)
    => methodName.Contains(">g__", StringComparison.Ordinal)
        || methodName.Contains(">b__", StringComparison.Ordinal);

// ILInspector.Decompiler.Pipeline.GeneratedCodeIdentity
public static bool IsSynthesizedLocalFunctionName(string name)
    => name.StartsWith("<", StringComparison.Ordinal)
        && name.Contains(">g__", StringComparison.Ordinal);

// ILInspector.Metadata.TypeFilters (a *different* rule again)
public static bool IsCompilerGenerated(string typeName)
    => typeName.StartsWith('<') || typeName.StartsWith("__", ...);
```

After: one shared grammar; each consumer keeps only its own policy on top.

```csharp
// ILInspector.MetadataPrimitives.GeneratedNameGrammar (new, SRM-only, no project references)
public static bool IsSynthesizedLocalFunctionName(string name)
    => name.StartsWith('<') && IsLocalFunctionMethodName(name);

// Analysis.CompilerGeneratedNames
internal static bool IsLocalFunctionOrLambda(string methodName)
    => GeneratedNameGrammar.IsLocalFunctionMethodName(methodName)
        || GeneratedNameGrammar.IsLambdaMethodName(methodName);

// Decompiler.GeneratedCodeIdentity — same primitive, same answer
public static bool IsSynthesizedLocalFunctionName(string name)
    => GeneratedNameGrammar.IsSynthesizedLocalFunctionName(name);

// Metadata.TypeFilters — its own, deliberately broader admission rule,
// but built on the same base prefix test
public static bool IsCompilerGenerated(string typeName)
    => GeneratedNameGrammar.IsGeneratedName(typeName);
```

## Change

- Adds `GeneratedNameGrammar` to `ILInspector.MetadataPrimitives` — the project
  already referenced by Analysis, Decompiler, ILDiff, and Metadata — following
  the precedent set by `MetadataNameArity` (#4233). It owns only raw shape
  parsing (prefix/infix/suffix tests, leaf-segment extraction across `+`
  nesting): closure environments, iterator/async state machines, local
  functions, lambdas, hoisted/plumbing fields, and the auto-property
  backing-field suffix.
- `ILInspector.Analysis.CompilerGeneratedNames`, `ILInspector.Decompiler.Pipeline.GeneratedCodeIdentity`,
  `ILInspector.Decompiler.Pipeline.Ir.CSharpNaming`, and `ILInspector.Metadata.TypeFilters`
  now delegate their raw shape classification to it.
- `ILInspector.Metadata.ApiSurfaceExtractor` builds its backing-field name from
  the same shared constant instead of a separately spelled string literal.
- Adds `GeneratedNameGrammarTests` (43 cases) covering every primitive and its
  adjacent negative shape (e.g. the non-capturing lambda holder `<>c` vs. a
  display class, single-angle hoisted locals vs. double-angle plumbing
  fields).

## Scope and safety

- Grammar only: no consumer's *trust policy* moved. The decompiler's
  `[CompilerGenerated]`-attribute gating before acting on a name,
  `Metadata.MemberFilters`' deliberately broader member-name rule (`s_`,
  `value__`, bare `__BackingField` substring), and `ILDiff.CompilerGeneratedOrdinals`'
  ordinal-correspondence algorithm are all untouched — they are consumer
  policy or a materially different algorithm, not duplicated grammar (see
  #4692 for the reasoning on why ILDiff is out of scope here).
- Every changed call site is a behavior-preserving delegation; no
  classification outcome changes.

Closes #4692.

## Evidence

- `dotnet build dotnet-inspect.slnx -c Release`: 0 errors.
- `ILInspector.Analysis.Tests`: 1147 passed, 0 failed, 8 skipped (pre-existing,
  require an unpinned CoreLib corpus artifact).
- `ILInspector.Metadata.Tests`: 2028 passed (1985 existing + 43 new), 0
  failed.
- `ILInspector.Decompiler.Tests --gate fast`: 5620 total, 1 failed, 1 skipped —
  the failure (`RetainedMergeStructuringTests.CoreLibOrdinalCasingCrossArmPredecessorPreservesFallbackPath`)
  is confirmed pre-existing and unrelated: reproduced identically on `main`
  before this change (CoreLib-version-dependent, untouched by this PR).
