### PR TITLE
Defer browser workspace packet resolution until engine startup

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -753,12 +753,17 @@ state: changing either resolves a different workspace. Lenses this engine does
 not answer report the engine's failure rather than fixture results.
 
 `src/workspace-navigation.ts` owns the in-memory view history, monotonic
-navigation generation, share-packet encoding and decoding, URL parsing and
+navigation generation, share-packet encoding and decoding, URL routing and
 building, the browser-history port, and the single delegated click listener
 that intercepts same-origin in-app anchor clicks
 (`bindWorkspaceLinkNavigation`/`shouldInterceptLinkClick`) — a modified click,
 `target`-scoped link, `download` link, or cross-origin href keeps native
-browser behavior. `dotnet-inspect.ts` remains the sole mutable
+browser behavior. Initial routing records the opaque `w=` value without decoding
+it, which preserves the bare-home paint before WebAssembly while allowing shared
+workspace resolution to run only after the engine is ready.
+`test/workspace-navigation.test.ts` gates that the route preflight cannot decode
+the packet and that later resolution invokes exactly one decoder.
+`dotnet-inspect.ts` remains the sole mutable
 application-state owner: it supplies typed snapshots and explicit transition
 callbacks, calls the one link-navigation binder instead of adding its own
 click listener, and registers application-level gestures and context

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1144,14 +1144,15 @@ function parseLocation() {
 
 type ParsedLocation = ParsedWorkspaceLocation;
 
-const initialLocation = parseLocation();
+const initialRoute = workspaceLocation.routeCurrent();
+const initialLocation = initialRoute.visible;
 // A bare visit (no package, no shared workspace packet) lands on the intro/home page
 // instead of auto-loading a package. Any deep link or shared link skips home and restores
 // its workspace directly.
 state.credits = isCreditsPath(location.pathname);
 state.home = state.credits
-  || (!initialLocation.package && !(initialLocation.tabs && initialLocation.tabs.length));
-state.queryNotice = initialLocation.workspaceNotice || "";
+  || (!initialLocation.package && !initialRoute.hasWorkspaceState);
+state.queryNotice = "";
 if (initialLocation.package) {
   state.requestedPackage = initialLocation.package;
   state.requestedVersion = initialLocation.version || "latest";
@@ -1163,21 +1164,21 @@ if (initialLocation.atPackageRoot) {
   state.packageLens = initialLocation.packageLens || "overview";
 }
 
-// Deep-link selection to restore once the first package model is available. Consumed
-// (and cleared) by the first loadPackage so later package switches start fresh.
-const initialDeepLink = {
-  type: initialLocation.type,
-  member: initialLocation.member,
-  overload: initialLocation.overload,
-  section: initialLocation.section,
-  bodyTarget: initialLocation.bodyTarget,
-  memberBrowse: initialLocation.memberBrowse,
-  memberTextFilter: initialLocation.memberTextFilter,
-  memberKindFilter: initialLocation.memberKindFilter,
-  memberAccessibilityFilter: initialLocation.memberAccessibilityFilter,
-  memberTraitFilter: initialLocation.memberTraitFilter,
-  graphTarget: initialLocation.graphTarget
-};
+function deepLinkFromLocation(loc: ParsedLocation): DeepLink {
+  return {
+    type: loc.type,
+    member: loc.member,
+    overload: loc.overload,
+    section: loc.section,
+    bodyTarget: loc.bodyTarget,
+    memberBrowse: loc.memberBrowse,
+    memberTextFilter: loc.memberTextFilter,
+    memberKindFilter: loc.memberKindFilter,
+    memberAccessibilityFilter: loc.memberAccessibilityFilter,
+    memberTraitFilter: loc.memberTraitFilter,
+    graphTarget: loc.graphTarget
+  };
+}
 
 function requireElement(selector: string): HTMLElement {
   const element = document.querySelector<HTMLElement>(selector);
@@ -8558,13 +8559,15 @@ function applyLocationView(loc: ParsedLocation) {
 // target for a lone/legacy link), loading each tab in order so the tab bar and any
 // cross-package dependency edges come back. Only the focused target restores its deep-link.
 async function restoreInitialWorkspace() {
-  const loc = {
-    ...initialLocation,
-    package: state.requestedPackage,
-    version: state.requestedVersion,
-    framework: state.requestedFramework
-  };
-  await restoreWorkspaceFromLocation(loc, initialDeepLink);
+  const loc = workspaceLocation.resolve(initialRoute);
+  if (!loc.package) {
+    state.loading = false;
+    state.home = true;
+    state.queryNotice = loc.workspaceNotice || "";
+    render();
+    return;
+  }
+  await restoreWorkspaceFromLocation(loc, deepLinkFromLocation(loc));
 }
 
 function isStyleTier(value: unknown): value is StyleTier {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -1144,14 +1144,14 @@ function parseLocation() {
 
 type ParsedLocation = ParsedWorkspaceLocation;
 
-const initialRoute = workspaceLocation.routeCurrent();
-const initialLocation = initialRoute.visible;
+const initialWorkspace = workspaceLocation.preflightCurrent();
+const initialLocation = initialWorkspace.visible;
 // A bare visit (no package, no shared workspace packet) lands on the intro/home page
 // instead of auto-loading a package. Any deep link or shared link skips home and restores
 // its workspace directly.
 state.credits = isCreditsPath(location.pathname);
 state.home = state.credits
-  || (!initialLocation.package && !initialRoute.hasWorkspaceState);
+  || (!initialLocation.package && !initialWorkspace.hasWorkspaceState);
 state.queryNotice = "";
 if (initialLocation.package) {
   state.requestedPackage = initialLocation.package;
@@ -8559,7 +8559,7 @@ function applyLocationView(loc: ParsedLocation) {
 // target for a lone/legacy link), loading each tab in order so the tab bar and any
 // cross-package dependency edges come back. Only the focused target restores its deep-link.
 async function restoreInitialWorkspace() {
-  const loc = workspaceLocation.resolve(initialRoute);
+  const loc = initialWorkspace.resolve();
   if (!loc.package) {
     state.loading = false;
     state.home = true;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -529,6 +529,7 @@ function isAnnotatedMedium(value: string): value is (typeof MEDIA)[number] {
 
 let spotlightCache: SpotlightCache | null = null;
 const HOME_BOT_ANIMATION_DURATION_MS = 5500;
+const DEFAULT_REQUESTED_FRAMEWORK = "net10.0";
 let homeBotAnimationStartedAt: number | null = null;
 let homeReadyGlintPending = true;
 const initialState = {
@@ -543,7 +544,7 @@ const initialState = {
   queryNoticeRetryAction: null,
   requestedPackage: "System.Text.Json",
   requestedVersion: "10.0.0",
-  requestedFramework: "net10.0",
+  requestedFramework: DEFAULT_REQUESTED_FRAMEWORK,
   selectedTypeId: "",
   selectedMemberKey: "",
   memberBrowseTypeId: "",
@@ -8572,7 +8573,7 @@ async function restoreInitialWorkspace() {
     ...loc,
     package: packageId,
     version: loc.version || "latest",
-    framework: loc.framework || state.requestedFramework
+    framework: loc.framework || DEFAULT_REQUESTED_FRAMEWORK
   };
   state.requestedPackage = resolvedLocation.package;
   state.requestedVersion = resolvedLocation.version;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -8560,14 +8560,26 @@ function applyLocationView(loc: ParsedLocation) {
 // cross-package dependency edges come back. Only the focused target restores its deep-link.
 async function restoreInitialWorkspace() {
   const loc = initialWorkspace.resolve();
-  if (!loc.package) {
+  const packageId = loc.package;
+  if (!packageId) {
     state.loading = false;
     state.home = true;
     state.queryNotice = loc.workspaceNotice || "";
     render();
     return;
   }
-  await restoreWorkspaceFromLocation(loc, deepLinkFromLocation(loc));
+  const resolvedLocation = {
+    ...loc,
+    package: packageId,
+    version: loc.version || "latest",
+    framework: loc.framework || state.requestedFramework
+  };
+  state.requestedPackage = resolvedLocation.package;
+  state.requestedVersion = resolvedLocation.version;
+  state.requestedFramework = resolvedLocation.framework;
+  await restoreWorkspaceFromLocation(
+    resolvedLocation,
+    deepLinkFromLocation(resolvedLocation));
 }
 
 function isStyleTier(value: unknown): value is StyleTier {

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -677,14 +677,18 @@ export function buildWorkspaceStateUrl(
 
 export interface WorkspaceLocationPersistence {
   parseCurrent(): ParsedWorkspaceLocation;
-  routeCurrent(): WorkspaceLocationRoute;
-  resolve(
-    route: WorkspaceLocationRoute,
-    decode?: WorkspaceShareDecoder,
-  ): ParsedWorkspaceLocation;
+  preflightCurrent(): WorkspaceLocationPreflight;
   build(state: WorkspaceUrlState, base?: string): URL;
   sync(state: WorkspaceUrlState): void;
   push(url: string): void;
+}
+
+export interface WorkspaceLocationPreflight {
+  visible: ParsedWorkspaceLocation;
+  hasWorkspaceState: boolean;
+  resolve(
+    decode?: WorkspaceShareDecoder,
+  ): ParsedWorkspaceLocation;
 }
 
 export interface WorkspaceLocationDependencies {
@@ -704,10 +708,7 @@ export function createWorkspaceLocationPersistence(
     parseCurrent() {
       return parseWorkspaceLocation(dependencies.current());
     },
-    routeCurrent() {
-      return parseWorkspaceRoute(dependencies.current());
-    },
-    resolve,
+    preflightCurrent,
     build,
     sync(state) {
       try {
@@ -725,10 +726,14 @@ export function createWorkspaceLocationPersistence(
     },
   };
 
-  function resolve(
-    route: WorkspaceLocationRoute,
-    decode?: WorkspaceShareDecoder,
-  ) {
-    return resolveWorkspaceRoute(route, decode);
+  function preflightCurrent(): WorkspaceLocationPreflight {
+    const route = parseWorkspaceRoute(dependencies.current());
+    return {
+      visible: route.visible,
+      hasWorkspaceState: route.hasWorkspaceState,
+      resolve(decode?: WorkspaceShareDecoder) {
+        return resolveWorkspaceRoute(route, decode);
+      },
+    };
   }
 }

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -308,7 +308,7 @@ interface SharePacket {
   g?: GraphMemberShareTarget;
 }
 
-interface DecodedShareState {
+export interface DecodedShareState {
   tabs: WorkspaceTab[];
   active: number;
   view: string;
@@ -328,7 +328,8 @@ interface DecodedShareState {
   graphTarget: GraphMemberShareIdentity | null;
 }
 
-type ShareStateResult = DecodedShareState | { error: string } | null;
+export type ShareStateResult = DecodedShareState | { error: string } | null;
+export type WorkspaceShareDecoder = (value: string) => ShareStateResult;
 
 const invalidShareState =
   "The shared workspace state is invalid and was ignored.";
@@ -516,11 +517,20 @@ export interface WorkspaceLocationSnapshot {
   hash: string;
 }
 
-export function parseWorkspaceLocation(location: WorkspaceLocationSnapshot) {
+export interface WorkspaceLocationRoute {
+  location: WorkspaceLocationSnapshot;
+  encodedWorkspaceState: string | null;
+  hasWorkspaceState: boolean;
+  visible: ParsedWorkspaceLocation;
+}
+
+function resolveWorkspaceLocation(
+  location: WorkspaceLocationSnapshot,
+  share: ShareStateResult,
+) {
   const params = new URLSearchParams(location.search);
   const route = location.pathname.split("/").filter(Boolean);
   const packageAt = route.findIndex(part => part.toLowerCase() === "packages");
-  const share = decodeWorkspaceShareState(params.get("w"));
 
   let pkg = packageAt >= 0
     ? decodeURIComponent(route[packageAt + 1] || "")
@@ -616,7 +626,37 @@ export function parseWorkspaceLocation(location: WorkspaceLocationSnapshot) {
   };
 }
 
-export type ParsedWorkspaceLocation = ReturnType<typeof parseWorkspaceLocation>;
+export type ParsedWorkspaceLocation = ReturnType<typeof resolveWorkspaceLocation>;
+
+export function parseWorkspaceRoute(
+  location: WorkspaceLocationSnapshot,
+): WorkspaceLocationRoute {
+  const encodedWorkspaceState = new URLSearchParams(location.search).get("w");
+  return {
+    location,
+    encodedWorkspaceState,
+    hasWorkspaceState: Boolean(encodedWorkspaceState),
+    visible: resolveWorkspaceLocation(location, null),
+  };
+}
+
+export function resolveWorkspaceRoute(
+  route: WorkspaceLocationRoute,
+  decode: WorkspaceShareDecoder = decodeWorkspaceShareState,
+): ParsedWorkspaceLocation {
+  const encodedWorkspaceState = route.encodedWorkspaceState;
+  return resolveWorkspaceLocation(
+    route.location,
+    encodedWorkspaceState
+      ? decode(encodedWorkspaceState)
+      : null);
+}
+
+export function parseWorkspaceLocation(
+  location: WorkspaceLocationSnapshot,
+): ParsedWorkspaceLocation {
+  return resolveWorkspaceRoute(parseWorkspaceRoute(location));
+}
 
 export function buildWorkspaceStateUrl(
   base: string,
@@ -637,6 +677,11 @@ export function buildWorkspaceStateUrl(
 
 export interface WorkspaceLocationPersistence {
   parseCurrent(): ParsedWorkspaceLocation;
+  routeCurrent(): WorkspaceLocationRoute;
+  resolve(
+    route: WorkspaceLocationRoute,
+    decode?: WorkspaceShareDecoder,
+  ): ParsedWorkspaceLocation;
   build(state: WorkspaceUrlState, base?: string): URL;
   sync(state: WorkspaceUrlState): void;
   push(url: string): void;
@@ -659,6 +704,10 @@ export function createWorkspaceLocationPersistence(
     parseCurrent() {
       return parseWorkspaceLocation(dependencies.current());
     },
+    routeCurrent() {
+      return parseWorkspaceRoute(dependencies.current());
+    },
+    resolve,
     build,
     sync(state) {
       try {
@@ -675,4 +724,11 @@ export function createWorkspaceLocationPersistence(
       }
     },
   };
+
+  function resolve(
+    route: WorkspaceLocationRoute,
+    decode?: WorkspaceShareDecoder,
+  ) {
+    return resolveWorkspaceRoute(route, decode);
+  }
 }

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2191,6 +2191,24 @@ test("shared member views retain scope and filter state", () => {
     /window\.addEventListener\("popstate"[\s\S]*const deep = loc;[\s\S]*restoreWorkspaceFromLocation\(loc, deep, navigationSeq\)/);
 });
 
+test("initial workspace packet resolution waits for the engine phase", () => {
+  assert.match(
+    appSource,
+    /const initialRoute = workspaceLocation\.routeCurrent\(\);\s*const initialLocation = initialRoute\.visible/);
+  assert.match(
+    appSource,
+    /state\.home = state\.credits\s*\|\| \(!initialLocation\.package && !initialRoute\.hasWorkspaceState\)/);
+  const restore = appSource.match(
+    /async function restoreInitialWorkspace\(\)[\s\S]*?\n}\n\nfunction isStyleTier/)?.[0]
+    ?? "";
+  assert.match(
+    restore,
+    /const loc = workspaceLocation\.resolve\(initialRoute\);[\s\S]*restoreWorkspaceFromLocation\(loc, deepLinkFromLocation\(loc\)\)/);
+  assert.match(
+    appSource,
+    /await initializeEngine\(reportEngineStatus\);[\s\S]*await restoreInitialWorkspace\(\)/);
+});
+
 test("member entry controls move focus into the resulting member navigation", () => {
   const bindings =
     appSource.match(/function bindTypePanelEvents\(\) \{[\s\S]*?\n}(?=\n\nfunction )/)?.[0]

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2203,7 +2203,7 @@ test("initial workspace packet resolution waits for the engine phase", () => {
     ?? "";
   assert.match(
     restore,
-    /const loc = initialWorkspace\.resolve\(\);[\s\S]*restoreWorkspaceFromLocation\(loc, deepLinkFromLocation\(loc\)\)/);
+    /const loc = initialWorkspace\.resolve\(\);[\s\S]*framework: loc\.framework \|\| state\.requestedFramework[\s\S]*state\.requestedPackage = resolvedLocation\.package;[\s\S]*state\.requestedVersion = resolvedLocation\.version;[\s\S]*state\.requestedFramework = resolvedLocation\.framework;[\s\S]*restoreWorkspaceFromLocation\(\s*resolvedLocation,\s*deepLinkFromLocation\(resolvedLocation\)\)/);
   const bootstrap = appSource.match(
     /async function bootstrap\(\)[\s\S]*?\n}\n\nobserveAsync\(bootstrap\(\)/)?.[0]
     ?? "";

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2194,19 +2194,24 @@ test("shared member views retain scope and filter state", () => {
 test("initial workspace packet resolution waits for the engine phase", () => {
   assert.match(
     appSource,
-    /const initialRoute = workspaceLocation\.routeCurrent\(\);\s*const initialLocation = initialRoute\.visible/);
+    /const initialWorkspace = workspaceLocation\.preflightCurrent\(\);\s*const initialLocation = initialWorkspace\.visible/);
   assert.match(
     appSource,
-    /state\.home = state\.credits\s*\|\| \(!initialLocation\.package && !initialRoute\.hasWorkspaceState\)/);
+    /state\.home = state\.credits\s*\|\| \(!initialLocation\.package && !initialWorkspace\.hasWorkspaceState\)/);
   const restore = appSource.match(
     /async function restoreInitialWorkspace\(\)[\s\S]*?\n}\n\nfunction isStyleTier/)?.[0]
     ?? "";
   assert.match(
     restore,
-    /const loc = workspaceLocation\.resolve\(initialRoute\);[\s\S]*restoreWorkspaceFromLocation\(loc, deepLinkFromLocation\(loc\)\)/);
-  assert.match(
-    appSource,
-    /await initializeEngine\(reportEngineStatus\);[\s\S]*await restoreInitialWorkspace\(\)/);
+    /const loc = initialWorkspace\.resolve\(\);[\s\S]*restoreWorkspaceFromLocation\(loc, deepLinkFromLocation\(loc\)\)/);
+  const bootstrap = appSource.match(
+    /async function bootstrap\(\)[\s\S]*?\n}\n\nobserveAsync\(bootstrap\(\)/)?.[0]
+    ?? "";
+  const initializeAt = bootstrap.indexOf("await initializeEngine(reportEngineStatus);");
+  const restoreAt = bootstrap.indexOf("await restoreInitialWorkspace();");
+  assert.notEqual(initializeAt, -1);
+  assert.notEqual(restoreAt, -1);
+  assert.ok(initializeAt < restoreAt);
 });
 
 test("member entry controls move focus into the resulting member navigation", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.js
+++ b/prototypes/inspect-web/test/spotlight-identity.test.js
@@ -2203,7 +2203,7 @@ test("initial workspace packet resolution waits for the engine phase", () => {
     ?? "";
   assert.match(
     restore,
-    /const loc = initialWorkspace\.resolve\(\);[\s\S]*framework: loc\.framework \|\| state\.requestedFramework[\s\S]*state\.requestedPackage = resolvedLocation\.package;[\s\S]*state\.requestedVersion = resolvedLocation\.version;[\s\S]*state\.requestedFramework = resolvedLocation\.framework;[\s\S]*restoreWorkspaceFromLocation\(\s*resolvedLocation,\s*deepLinkFromLocation\(resolvedLocation\)\)/);
+    /const loc = initialWorkspace\.resolve\(\);[\s\S]*framework: loc\.framework \|\| DEFAULT_REQUESTED_FRAMEWORK[\s\S]*state\.requestedPackage = resolvedLocation\.package;[\s\S]*state\.requestedVersion = resolvedLocation\.version;[\s\S]*state\.requestedFramework = resolvedLocation\.framework;[\s\S]*restoreWorkspaceFromLocation\(\s*resolvedLocation,\s*deepLinkFromLocation\(resolvedLocation\)\)/);
   const bootstrap = appSource.match(
     /async function bootstrap\(\)[\s\S]*?\n}\n\nobserveAsync\(bootstrap\(\)/)?.[0]
     ?? "";

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -7,6 +7,8 @@ import {
   createNavigationSequence,
   createWorkspaceLocationPersistence,
   parseWorkspaceLocation,
+  parseWorkspaceRoute,
+  resolveWorkspaceRoute,
   shouldInterceptLinkClick,
   workspaceViewSignature,
   type LinkNavigationClick,
@@ -291,6 +293,48 @@ test("rich workspace URLs round-trip coordinates, scope, and member selection", 
   assert.equal(parsed.memberAccessibilityFilter, "public");
   assert.equal(parsed.memberTraitFilter, "isStatic");
   assert.equal(parsed.workspaceNotice, "");
+});
+
+test("workspace route preflight defers packet decoding", () => {
+  const location = locationSnapshot(
+    "https://inspect.example/?package=Visible.Package&w=opaque#metadata");
+  const route = parseWorkspaceRoute(location);
+
+  assert.equal(route.encodedWorkspaceState, "opaque");
+  assert.equal(route.hasWorkspaceState, true);
+  assert.equal(route.visible.package, "Visible.Package");
+  assert.deepEqual(route.visible.tabs, []);
+  assert.equal(route.visible.workspaceNotice, "");
+
+  let decodeCalls = 0;
+  const resolved = resolveWorkspaceRoute(route, value => {
+    decodeCalls++;
+    assert.equal(value, "opaque");
+    return { error: "The product decoder rejected this packet." };
+  });
+
+  assert.equal(decodeCalls, 1);
+  assert.equal(resolved.package, "Visible.Package");
+  assert.deepEqual(resolved.tabs, []);
+  assert.equal(
+    resolved.workspaceNotice,
+    "The product decoder rejected this packet.");
+});
+
+test("workspace route resolution skips the decoder without packet state", () => {
+  const route = parseWorkspaceRoute(locationSnapshot(
+    "https://inspect.example/packages/Example.Package/1.0.0#source"));
+  let decodeCalls = 0;
+  const resolved = resolveWorkspaceRoute(route, () => {
+    decodeCalls++;
+    return { error: "unexpected" };
+  });
+
+  assert.equal(route.encodedWorkspaceState, null);
+  assert.equal(route.hasWorkspaceState, false);
+  assert.equal(decodeCalls, 0);
+  assert.equal(resolved.package, "Example.Package");
+  assert.equal(resolved.workspaceNotice, "");
 });
 
 test("graph member URLs retain exact identity instead of a lossy body target", () => {

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -337,6 +337,38 @@ test("workspace route resolution skips the decoder without packet state", () => 
   assert.equal(resolved.workspaceNotice, "");
 });
 
+test("location preflight snapshots once and defers decoding", () => {
+  let currentCalls = 0;
+  let decodeCalls = 0;
+  const persistence = createWorkspaceLocationPersistence({
+    current() {
+      currentCalls++;
+      return locationSnapshot(
+        "https://inspect.example/?package=Visible.Package&w=opaque");
+    },
+    replace() {},
+    push() {},
+  });
+
+  const preflight = persistence.preflightCurrent();
+  assert.equal(currentCalls, 1);
+  assert.equal(decodeCalls, 0);
+  assert.equal(preflight.visible.package, "Visible.Package");
+  assert.equal(preflight.hasWorkspaceState, true);
+
+  const resolved = preflight.resolve(value => {
+    decodeCalls++;
+    assert.equal(value, "opaque");
+    return { error: "The product decoder rejected this packet." };
+  });
+
+  assert.equal(currentCalls, 1);
+  assert.equal(decodeCalls, 1);
+  assert.equal(
+    resolved.workspaceNotice,
+    "The product decoder rejected this packet.");
+});
+
 test("graph member URLs retain exact identity instead of a lossy body target", () => {
   const graphTarget = {
     assembly: "Example.Second",


### PR DESCRIPTION
Part of #4647.

## Summary

- Split inspect-web location handling into an inert route preflight and an explicit workspace-state resolution phase.
- Capture `w=` opaquely during module initialization, preserving the bare-home paint while allowing the product-owned decoder to replace the prototype decoder after WebAssembly startup.
- Resolve the captured packet exactly once inside `restoreInitialWorkspace`, after `initializeEngine`, and return invalid packet-only visits to a visible home state instead of leaving the loading overlay active.
- Gate the production startup wiring and the deferred decoder boundary with behavioral and structural non-vacuity tests.

## Demo

The real frontend module now exposes the two startup phases directly:

```console
$ node --input-type=module -e 'import { parseWorkspaceRoute, resolveWorkspaceRoute } from "./src/workspace-navigation.ts"; const u = new URL("https://dotnet-inspect.net/?package=System.Text.Json&w=opaque"); const route = parseWorkspaceRoute({ href:u.href, pathname:u.pathname, search:u.search, hash:u.hash }); let calls=0; console.log(JSON.stringify({phase:"preflight",hasWorkspaceState:route.hasWorkspaceState,visiblePackage:route.visible.package,decoderCalls:calls})); const resolved=resolveWorkspaceRoute(route, value => { calls++; return {error:`rejected:${value}`}; }); console.log(JSON.stringify({phase:"engine-ready",visiblePackage:resolved.package,notice:resolved.workspaceNotice,decoderCalls:calls}));'
{"phase":"preflight","hasWorkspaceState":true,"visiblePackage":"System.Text.Json","decoderCalls":0}
{"phase":"engine-ready","visiblePackage":"System.Text.Json","notice":"rejected:opaque","decoderCalls":1}
```

Notice that startup can identify a shared workspace without reading its bytes; the decoder runs only in the engine-ready phase, and its failure remains visible alongside the explicit package coordinate. A neighboring package URL without `w=` never invokes the decoder.

## Compatibility and non-action boundary

This slice deliberately does not change the current prototype packet format or claim canonical v1 browser adoption. Full replacement still requires a product-owned Browser context model that can preserve required `g`/`x` binding state, canonical `:Platform` group identity instead of the `Microsoft.NETCore.App` pseudo-package, and an explicit disposition for current transient deep-link fields absent from v1. It adds the startup seam needed to adopt that decoder without a second parser or delaying bare-home paint.

## Validation

- `npm test` in `prototypes/inspect-web`
- `npm run lint` in `prototypes/inspect-web`
- `npm run build` in `prototypes/inspect-web`
- `npx markdownlint-cli prototypes/inspect-web/README.md`
