### PR TITLE
Add reusable static query catalogs

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -81,14 +81,13 @@ extension-method, custom-attribute, manifest-resource, type-forwarder,
 union-type, method-classification, audit-metadata, unsafe-evidence,
 top-leverage, optimization-opportunity, and resource-triage queries, plus the
 Research-backed
-switch query through a typed,
-content-shaped registry
+switch query through a typed, immutable, content-shaped catalog
 over a host-owned `AssemblyInspectionSession`. The `References`, `Extension
 Methods`, `Custom Attributes`, `Resources`, `Switches`, `Type Forwarders`,
 `Union Types`, `P/Invoke Methods`, `Async Methods`, `Unsafe Members`, `Signals`,
 `Top Leverage`, `Body Shapes`, the Performance section family, and `Library
 Info` sections bind to concrete query definitions, and the CLI and package
-convenience route lower section selection into that same registry.
+convenience route lower section selection into that same catalog.
 Library and package SourceLink sections
 execute a shared document prerequisite plus availability or integrity query
 over a host-owned `SourceLinkService`. The library CLI and package
@@ -148,9 +147,11 @@ MethodDef scope. `LibraryMetadataService` still projects query results into the
 mutable `LibraryInspection` compatibility aggregate, and transitive reference
 resolution remains host-owned. The SourceLink document query delegates PDB
 acquisition to shared Services while the host supplies trusted symbol and
-SSRF-hardened source clients. The registry supports deterministic synchronous
-and asynchronous execution and passes each query's maximum transitive cost
-into the host execution scope.
+SSRF-hardened source clients. The catalog supports stable enumeration plus
+deterministic synchronous and asynchronous execution. It precomputes each
+query's required closure, transitive cost, and single-query execution plan, and
+passes that cost into the host execution scope. Commands compile multi-query
+plans once and may reuse them across assembly contexts.
 
 `DotnetInspector.Artifacts` now provides the source-neutral floor below these
 layers: generation-scoped identity and registration, adapter-owned typed
@@ -414,7 +415,7 @@ canaries:
   as `InspectionQueryException`; cancellation and cost-declaration failures
   retain their specific exception types. The `ProductionQueryCatchBoundary_*`
   tests gate this fail-visible boundary.
-- The query registry exposes each executor's maximum transitive
+- The query catalog exposes each executor's maximum transitive
   `InspectionCost` to a host execution scope. The CLI adapter maps it to
   `SectionCost` and enforces body-index and drill-map acquisition through
   `InspectionQueryContext`; the

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -15,8 +15,9 @@ user gesture
 ```
 
 The command owns the gesture and budget. `SectionPipeline<TModel>` owns section
-and category planning. `InspectionQueryRegistry` owns typed query cost,
-prerequisites, optional composition, and execution.
+and category planning. `InspectionQueryRegistry` authors typed query
+declarations; its immutable `InspectionQueryCatalog` owns query cost,
+prerequisites, optional composition, planning, and execution.
 
 ## Section descriptors
 
@@ -109,8 +110,8 @@ sections now bind typed queries or consume baseline command facts.
 ## Query-owned cost
 
 Production cost belongs to the query because multiple sections can be views
-over the same work. `UseQueryCosts(registry.CostOf)` binds a pipeline to the
-registry before any section is added.
+over the same work. `UseQueryCosts(catalog.CostOf)` binds a pipeline to the catalog before any
+section is added.
 
 A section's effective cost is:
 
@@ -134,10 +135,21 @@ The three production tiers are:
 An unbounded section remains reachable through exact selection, explicit
 category selection, or effective category discovery.
 
-`LibrarySectionCatalog` constructs per-assembly and group typed-query
-registries plus one cost-bound pipeline. Commands use that catalog for planning
-and execution so the pipeline cannot snapshot costs from one registry while
-another performs the work.
+`LibrarySections` retains one process-wide immutable per-assembly query catalog
+and one assembly-group catalog. Catalog construction validates the complete
+required graph and precomputes each query's closure, transitive cost, and
+single-query execution plan. Repeated catalog acquisition and single-query
+planning allocate no memory after static initialization; the
+`LibraryQueryCatalog_RepeatedAcquisitionAndPlanningAllocateNothing` gate
+enforces that property.
+
+`LibrarySectionCatalog` binds each request's section pipeline to those shared
+catalogs. Commands compile arbitrary multi-query demand once and reuse the
+resulting immutable plan for every assembly in that request, so package
+inspection does not rebuild dependency state per assembly. The mutable
+`InspectionQueryRegistry` remains the authoring surface for dynamic hosts and
+focused extensions; `Compile` snapshots it into a catalog without allowing
+later registrations to mutate that snapshot.
 
 ## Resource declarations
 
@@ -150,15 +162,15 @@ that calls one throws at the acquisition boundary. Production
 catch boundaries do not convert that declaration violation into a
 success-shaped result.
 
-Typed queries use the same host-side resource guard. The query registry enters
+Typed queries use the same host-side resource guard. The query catalog enters
 an execution scope with each query's maximum transitive `InspectionCost`; the
 CLI adapter maps that cost to `SectionCost`. Query planning, contract, and
 executor failures remain fail-visible, while cancellation and cost-declaration
 failures retain their specific exception types.
 
-Declarations are scoped to one registry run and cannot leak into later work.
-This is a correctness mechanism for well-behaved product-owned query wiring,
-not an in-process security boundary.
+Declarations are scoped to one catalog execution and cannot leak into later
+work. This is a correctness mechanism for well-behaved product-owned query
+wiring, not an in-process security boundary.
 
 Metadata query adapters share the command's open inspection session. They do not
 reopen the target independently, and they continue to observe the image the

--- a/src/DotnetInspector.Queries/InspectionQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionQuery.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace DotnetInspector.Queries;
@@ -126,6 +125,7 @@ public sealed class InspectionQueryResults
 public sealed class InspectionQueryRegistry<TContext>
 {
     private readonly Dictionary<InspectionQueryDefinition, Registration> _registrations = [];
+    private InspectionQueryCatalog<TContext>? _compiled;
     private readonly Func<
         TContext,
         InspectionQueryDefinition,
@@ -145,6 +145,16 @@ public sealed class InspectionQueryRegistry<TContext>
             enterExecutionScope = null)
     {
         _enterExecutionScope = enterExecutionScope;
+    }
+
+    internal InspectionQueryRegistry(
+        IEnumerable<Registration> registrations,
+        Func<TContext, InspectionQueryDefinition, InspectionCost, IDisposable>?
+            enterExecutionScope)
+        : this(enterExecutionScope)
+    {
+        foreach (Registration registration in registrations)
+            _registrations.Add(registration.Query, registration);
     }
 
     /// <summary>Every registered query, in registration order.</summary>
@@ -193,6 +203,7 @@ public sealed class InspectionQueryRegistry<TContext>
                 execute,
                 required,
                 optionalDependencies));
+        _compiled = null;
         return this;
     }
 
@@ -260,6 +271,7 @@ public sealed class InspectionQueryRegistry<TContext>
                 execute,
                 required,
                 optionalDependencies));
+        _compiled = null;
         return this;
     }
 
@@ -328,32 +340,21 @@ public sealed class InspectionQueryRegistry<TContext>
     /// Returns the maximum cost over <paramref name="query"/>'s prerequisite closure.
     /// </summary>
     public InspectionCost CostOf(InspectionQueryDefinition query)
-    {
-        ArgumentNullException.ThrowIfNull(query);
-        EnsureRegistered(query);
+        => Compile().CostOf(query);
 
-        InspectionCost cost = InspectionCost.NetworkFree;
-        foreach (InspectionQueryDefinition member in ExpandRequired([query]))
-        {
-            if (member.Cost > cost)
-                cost = member.Cost;
-        }
-
-        return cost;
-    }
+    /// <summary>
+    /// Compiles the current registrations into an immutable reusable catalog. Repeated calls
+    /// return the same catalog until another query is registered.
+    /// </summary>
+    public InspectionQueryCatalog<TContext> Compile()
+        => _compiled ??= new InspectionQueryCatalog<TContext>(
+            _registrations.Values,
+            _enterExecutionScope);
 
     /// <summary>Expands queries to include every transitively required query.</summary>
     public HashSet<InspectionQueryDefinition> ExpandRequired(
         IEnumerable<InspectionQueryDefinition> requested)
-    {
-        ArgumentNullException.ThrowIfNull(requested);
-
-        HashSet<InspectionQueryDefinition> closure = [];
-        HashSet<InspectionQueryDefinition> visiting = [];
-        foreach (InspectionQueryDefinition query in requested)
-            AddWithRequirements(query, closure, visiting);
-        return closure;
-    }
+        => Compile().ExpandRequired(requested);
 
     /// <summary>
     /// Executes the requested queries and their prerequisites once, in deterministic order.
@@ -362,29 +363,7 @@ public sealed class InspectionQueryRegistry<TContext>
         IEnumerable<InspectionQueryDefinition> requested,
         TContext context,
         Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null)
-    {
-        HashSet<InspectionQueryDefinition> required = ExpandRequired(requested);
-        HashSet<InspectionQueryDefinition> ran = [];
-        HashSet<InspectionQueryDefinition> running = [];
-        var results = new InspectionQueryResults();
-
-        foreach (InspectionQueryDefinition query in _registrations.Keys)
-        {
-            if (required.Contains(query))
-            {
-                RunWithRequirements(
-                    query,
-                    context,
-                    results,
-                    required,
-                    ran,
-                    running,
-                    recordExecution);
-            }
-        }
-
-        return results;
-    }
+        => Compile().Run(requested, context, recordExecution);
 
     /// <summary>
     /// Executes synchronous and asynchronous queries and their prerequisites once, in
@@ -395,213 +374,13 @@ public sealed class InspectionQueryRegistry<TContext>
         TContext context,
         Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null,
         CancellationToken cancellationToken = default)
-    {
-        HashSet<InspectionQueryDefinition> required = ExpandRequired(requested);
-        HashSet<InspectionQueryDefinition> ran = [];
-        HashSet<InspectionQueryDefinition> running = [];
-        var results = new InspectionQueryResults();
+        => await Compile().RunAsync(
+            requested,
+            context,
+            recordExecution,
+            cancellationToken).ConfigureAwait(false);
 
-        foreach (InspectionQueryDefinition query in _registrations.Keys)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (required.Contains(query))
-            {
-                await RunWithRequirementsAsync(
-                    query,
-                    context,
-                    results,
-                    required,
-                    ran,
-                    running,
-                    recordExecution,
-                    cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        return results;
-    }
-
-    private void AddWithRequirements(
-        InspectionQueryDefinition query,
-        HashSet<InspectionQueryDefinition> closure,
-        HashSet<InspectionQueryDefinition> visiting)
-    {
-        EnsureRegistered(query);
-        if (!visiting.Add(query))
-            throw new InspectionQueryException(
-                $"Inspection query prerequisite cycle detected at '{query.Name}'.");
-
-        if (closure.Add(query))
-        {
-            Registration registration = _registrations[query];
-            foreach (InspectionQueryDefinition optional in registration.Optional)
-                EnsureRegistered(optional);
-            foreach (InspectionQueryDefinition required in registration.Requires)
-                AddWithRequirements(required, closure, visiting);
-        }
-
-        visiting.Remove(query);
-    }
-
-    private void RunWithRequirements(
-        InspectionQueryDefinition query,
-        TContext context,
-        InspectionQueryResults results,
-        IReadOnlySet<InspectionQueryDefinition> active,
-        HashSet<InspectionQueryDefinition> ran,
-        HashSet<InspectionQueryDefinition> running,
-        Action<InspectionQueryDefinition, TimeSpan>? recordExecution)
-    {
-        if (ran.Contains(query))
-            return;
-        if (!running.Add(query))
-        {
-            throw new InspectionQueryException(
-                $"Inspection query active dependency cycle detected at '{query.Name}'.");
-        }
-
-        Registration registration = _registrations[query];
-        foreach (InspectionQueryDefinition required in registration.Requires)
-        {
-            RunWithRequirements(
-                required,
-                context,
-                results,
-                active,
-                ran,
-                running,
-                recordExecution);
-        }
-        foreach (InspectionQueryDefinition optional in registration.Optional)
-        {
-            if (active.Contains(optional))
-            {
-                RunWithRequirements(
-                    optional,
-                    context,
-                    results,
-                    active,
-                    ran,
-                    running,
-                    recordExecution);
-            }
-        }
-
-        running.Remove(query);
-        ran.Add(query);
-        long start = Stopwatch.GetTimestamp();
-        try
-        {
-            HashSet<InspectionQueryDefinition> prerequisites =
-                AccessibleDependencies(registration, active);
-            using IDisposable? scope = _enterExecutionScope?.Invoke(
-                context,
-                query,
-                CostOf(query));
-            registration.Execute(
-                context,
-                results,
-                results.RestrictTo(prerequisites));
-        }
-        finally
-        {
-            recordExecution?.Invoke(query, Stopwatch.GetElapsedTime(start));
-        }
-    }
-
-    private async ValueTask RunWithRequirementsAsync(
-        InspectionQueryDefinition query,
-        TContext context,
-        InspectionQueryResults results,
-        IReadOnlySet<InspectionQueryDefinition> active,
-        HashSet<InspectionQueryDefinition> ran,
-        HashSet<InspectionQueryDefinition> running,
-        Action<InspectionQueryDefinition, TimeSpan>? recordExecution,
-        CancellationToken cancellationToken)
-    {
-        if (ran.Contains(query))
-            return;
-        if (!running.Add(query))
-        {
-            throw new InspectionQueryException(
-                $"Inspection query active dependency cycle detected at '{query.Name}'.");
-        }
-
-        Registration registration = _registrations[query];
-        foreach (InspectionQueryDefinition required in registration.Requires)
-        {
-            await RunWithRequirementsAsync(
-                required,
-                context,
-                results,
-                active,
-                ran,
-                running,
-                recordExecution,
-                cancellationToken).ConfigureAwait(false);
-        }
-        foreach (InspectionQueryDefinition optional in registration.Optional)
-        {
-            if (active.Contains(optional))
-            {
-                await RunWithRequirementsAsync(
-                    optional,
-                    context,
-                    results,
-                    active,
-                    ran,
-                    running,
-                    recordExecution,
-                    cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        cancellationToken.ThrowIfCancellationRequested();
-        running.Remove(query);
-        ran.Add(query);
-        long start = Stopwatch.GetTimestamp();
-        try
-        {
-            HashSet<InspectionQueryDefinition> prerequisites =
-                AccessibleDependencies(registration, active);
-            using IDisposable? scope = _enterExecutionScope?.Invoke(
-                context,
-                query,
-                CostOf(query));
-            await registration.ExecuteAsync(
-                context,
-                results,
-                results.RestrictTo(prerequisites),
-                cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            recordExecution?.Invoke(query, Stopwatch.GetElapsedTime(start));
-        }
-    }
-
-    private HashSet<InspectionQueryDefinition> AccessibleDependencies(
-        Registration registration,
-        IReadOnlySet<InspectionQueryDefinition> active)
-    {
-        HashSet<InspectionQueryDefinition> accessible =
-            ExpandRequired(registration.Requires);
-        foreach (InspectionQueryDefinition optional in registration.Optional)
-        {
-            accessible.Add(optional);
-            if (active.Contains(optional))
-                accessible.UnionWith(ExpandRequired([optional]));
-        }
-        return accessible;
-    }
-
-    private void EnsureRegistered(InspectionQueryDefinition query)
-    {
-        if (!_registrations.ContainsKey(query))
-            throw new InspectionQueryException($"Query '{query.Name}' is not registered.");
-    }
-
-    private abstract class Registration(
+    internal abstract class Registration(
         InspectionQueryDefinition query,
         ImmutableArray<InspectionQueryDefinition> requires,
         ImmutableArray<InspectionQueryDefinition> optional)
@@ -609,11 +388,11 @@ public sealed class InspectionQueryRegistry<TContext>
         public InspectionQueryDefinition Query { get; } = query;
         public ImmutableArray<InspectionQueryDefinition> Requires { get; } = requires;
         public ImmutableArray<InspectionQueryDefinition> Optional { get; } = optional;
-        public abstract void Execute(
+        internal abstract void Execute(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults);
-        public abstract ValueTask ExecuteAsync(
+        internal abstract ValueTask ExecuteAsync(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults,
@@ -627,13 +406,13 @@ public sealed class InspectionQueryRegistry<TContext>
         ImmutableArray<InspectionQueryDefinition> optional)
         : Registration(query, requires, optional)
     {
-        public override void Execute(
+        internal override void Execute(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults)
             => results.Set(query, execute(context, prerequisiteResults));
 
-        public override ValueTask ExecuteAsync(
+        internal override ValueTask ExecuteAsync(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults,
@@ -656,14 +435,14 @@ public sealed class InspectionQueryRegistry<TContext>
         ImmutableArray<InspectionQueryDefinition> optional)
         : Registration(query, requires, optional)
     {
-        public override void Execute(
+        internal override void Execute(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults)
             => throw new InspectionQueryException(
                 $"Query '{query.Name}' is asynchronous and must be executed with RunAsync.");
 
-        public override async ValueTask ExecuteAsync(
+        internal override async ValueTask ExecuteAsync(
             TContext context,
             InspectionQueryResults results,
             InspectionQueryResults prerequisiteResults,

--- a/src/DotnetInspector.Queries/InspectionQueryCatalog.cs
+++ b/src/DotnetInspector.Queries/InspectionQueryCatalog.cs
@@ -1,0 +1,446 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// An immutable fixed-domain catalog of typed inspection queries.
+/// </summary>
+/// <remarks>
+/// Catalog construction validates the complete required-dependency graph and precomputes each
+/// query's closure, cost, and single-query execution plan. Hosts with a fixed query domain can
+/// retain one catalog for the process lifetime; per-run state remains in the supplied context
+/// and returned <see cref="InspectionQueryResults"/>.
+/// </remarks>
+public sealed class InspectionQueryCatalog<TContext>
+{
+    private readonly ImmutableArray<InspectionQueryRegistry<TContext>.Registration>
+        _registrations;
+    private readonly Dictionary<InspectionQueryDefinition, int> _indexes;
+    private readonly ImmutableArray<QueryMetadata> _metadata;
+    private readonly ImmutableArray<InspectionQueryPlan<TContext>> _singleQueryPlans;
+    private readonly InspectionQueryPlan<TContext> _emptyPlan;
+    private readonly Func<
+        TContext,
+        InspectionQueryDefinition,
+        InspectionCost,
+        IDisposable>? _enterExecutionScope;
+
+    internal InspectionQueryCatalog(
+        IEnumerable<InspectionQueryRegistry<TContext>.Registration> registrations,
+        Func<
+            TContext,
+            InspectionQueryDefinition,
+            InspectionCost,
+            IDisposable>? enterExecutionScope)
+    {
+        _registrations = [.. registrations];
+        _enterExecutionScope = enterExecutionScope;
+        _indexes = new Dictionary<InspectionQueryDefinition, int>(_registrations.Length);
+
+        var registeredQueries =
+            ImmutableArray.CreateBuilder<InspectionQueryDefinition>(_registrations.Length);
+        for (int index = 0; index < _registrations.Length; index++)
+        {
+            var registration = _registrations[index];
+            if (!_indexes.TryAdd(registration.Query, index))
+            {
+                throw new InspectionQueryException(
+                    $"Query '{registration.Query.Name}' is already registered.");
+            }
+            registeredQueries.Add(registration.Query);
+        }
+        RegisteredQueries = registeredQueries.MoveToImmutable();
+
+        var metadata =
+            ImmutableArray.CreateBuilder<QueryMetadata>(_registrations.Length);
+        for (int index = 0; index < _registrations.Length; index++)
+        {
+            bool[] closure = new bool[_registrations.Length];
+            byte[] state = new byte[_registrations.Length];
+            AddRequiredClosure(index, closure, state);
+
+            InspectionCost cost = InspectionCost.NetworkFree;
+            for (int member = 0; member < closure.Length; member++)
+            {
+                if (closure[member] && _registrations[member].Query.Cost > cost)
+                    cost = _registrations[member].Query.Cost;
+            }
+
+            metadata.Add(new QueryMetadata(closure, cost));
+        }
+        _metadata = metadata.MoveToImmutable();
+
+        _emptyPlan = new InspectionQueryPlan<TContext>(this, []);
+        var plans =
+            ImmutableArray.CreateBuilder<InspectionQueryPlan<TContext>>(
+                _registrations.Length);
+        for (int index = 0; index < _registrations.Length; index++)
+            plans.Add(CompilePlan((bool[])_metadata[index].RequiredClosure.Clone()));
+        _singleQueryPlans = plans.MoveToImmutable();
+    }
+
+    /// <summary>Every registered query, in stable registration order.</summary>
+    public ImmutableArray<InspectionQueryDefinition> RegisteredQueries { get; }
+
+    /// <summary>The queries directly required by <paramref name="query"/>.</summary>
+    public ImmutableArray<InspectionQueryDefinition> RequirementsOf(
+        InspectionQueryDefinition query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return RegistrationOf(query).Requires;
+    }
+
+    /// <summary>
+    /// Queries whose results this query may consume when independently requested.
+    /// </summary>
+    public ImmutableArray<InspectionQueryDefinition> OptionalDependenciesOf(
+        InspectionQueryDefinition query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return RegistrationOf(query).Optional;
+    }
+
+    /// <summary>
+    /// Returns the maximum cost over <paramref name="query"/>'s required closure.
+    /// </summary>
+    public InspectionCost CostOf(InspectionQueryDefinition query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return _metadata[IndexOf(query)].Cost;
+    }
+
+    /// <summary>
+    /// Creates a mutable builder initialized from this catalog. The returned builder and catalogs
+    /// subsequently compiled from it do not mutate this instance.
+    /// </summary>
+    public InspectionQueryRegistry<TContext> ToBuilder()
+        => new(_registrations, _enterExecutionScope);
+
+    /// <summary>
+    /// Returns the precomputed execution plan for one query and its required closure.
+    /// Repeated calls return the same plan instance.
+    /// </summary>
+    public InspectionQueryPlan<TContext> Plan(InspectionQueryDefinition query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        return _singleQueryPlans[IndexOf(query)];
+    }
+
+    /// <summary>
+    /// Returns a deterministic plan for the requested queries and their required closures.
+    /// Single-query requests use the precomputed plan; arbitrary combinations are compiled
+    /// explicitly.
+    /// </summary>
+    public InspectionQueryPlan<TContext> Plan(
+        IEnumerable<InspectionQueryDefinition> requested)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+
+        if (requested is InspectionQueryDefinition[] { Length: 0 })
+            return _emptyPlan;
+        if (requested is InspectionQueryDefinition[] { Length: 1 } single)
+            return Plan(single[0]);
+        if (requested is ImmutableArray<InspectionQueryDefinition> immutable)
+        {
+            if (immutable.IsEmpty)
+                return _emptyPlan;
+            if (immutable.Length == 1)
+                return Plan(immutable[0]);
+        }
+
+        bool[] active = new bool[_registrations.Length];
+        int onlyRequested = -1;
+        bool hasMultipleRequested = false;
+        foreach (InspectionQueryDefinition query in requested)
+        {
+            ArgumentNullException.ThrowIfNull(query);
+            int index = IndexOf(query);
+            if (onlyRequested < 0)
+                onlyRequested = index;
+            else if (onlyRequested != index)
+                hasMultipleRequested = true;
+
+            Union(active, _metadata[index].RequiredClosure);
+        }
+
+        if (onlyRequested < 0)
+            return _emptyPlan;
+        if (!hasMultipleRequested)
+            return _singleQueryPlans[onlyRequested];
+        return CompilePlan(active);
+    }
+
+    /// <summary>Expands queries to include every transitively required query.</summary>
+    public HashSet<InspectionQueryDefinition> ExpandRequired(
+        IEnumerable<InspectionQueryDefinition> requested)
+        => [.. Plan(requested).Queries];
+
+    /// <summary>Executes a request through its immutable plan.</summary>
+    public InspectionQueryResults Run(
+        IEnumerable<InspectionQueryDefinition> requested,
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null)
+        => Plan(requested).Run(context, recordExecution);
+
+    /// <summary>Executes a request through its immutable asynchronous plan.</summary>
+    public Task<InspectionQueryResults> RunAsync(
+        IEnumerable<InspectionQueryDefinition> requested,
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null,
+        CancellationToken cancellationToken = default)
+        => Plan(requested).RunAsync(
+            context,
+            recordExecution,
+            cancellationToken);
+
+    internal InspectionQueryResults Execute(
+        ImmutableArray<InspectionQueryPlan<TContext>.Entry> entries,
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution)
+    {
+        var results = new InspectionQueryResults();
+        foreach (InspectionQueryPlan<TContext>.Entry entry in entries)
+        {
+            long start = Stopwatch.GetTimestamp();
+            try
+            {
+                using IDisposable? scope = _enterExecutionScope?.Invoke(
+                    context,
+                    entry.Registration.Query,
+                    entry.Cost);
+                entry.Registration.Execute(
+                    context,
+                    results,
+                    results.RestrictTo(entry.AccessibleDependencies));
+            }
+            finally
+            {
+                recordExecution?.Invoke(
+                    entry.Registration.Query,
+                    Stopwatch.GetElapsedTime(start));
+            }
+        }
+        return results;
+    }
+
+    internal async Task<InspectionQueryResults> ExecuteAsync(
+        ImmutableArray<InspectionQueryPlan<TContext>.Entry> entries,
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution,
+        CancellationToken cancellationToken)
+    {
+        var results = new InspectionQueryResults();
+        foreach (InspectionQueryPlan<TContext>.Entry entry in entries)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            long start = Stopwatch.GetTimestamp();
+            try
+            {
+                using IDisposable? scope = _enterExecutionScope?.Invoke(
+                    context,
+                    entry.Registration.Query,
+                    entry.Cost);
+                await entry.Registration.ExecuteAsync(
+                    context,
+                    results,
+                    results.RestrictTo(entry.AccessibleDependencies),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recordExecution?.Invoke(
+                    entry.Registration.Query,
+                    Stopwatch.GetElapsedTime(start));
+            }
+        }
+        return results;
+    }
+
+    private InspectionQueryPlan<TContext> CompilePlan(bool[] active)
+    {
+        byte[] state = new byte[_registrations.Length];
+        var order =
+            ImmutableArray.CreateBuilder<int>(_registrations.Length);
+        for (int index = 0; index < _registrations.Length; index++)
+        {
+            if (active[index])
+                AddExecutionOrder(index, active, state, order);
+        }
+
+        var entries =
+            ImmutableArray.CreateBuilder<InspectionQueryPlan<TContext>.Entry>(
+                order.Count);
+        foreach (int index in order)
+        {
+            var registration = _registrations[index];
+            var accessible =
+                ImmutableHashSet.CreateBuilder<InspectionQueryDefinition>();
+            foreach (InspectionQueryDefinition required in registration.Requires)
+            {
+                int requiredIndex = IndexOf(required);
+                AddDefinitions(
+                    accessible,
+                    _metadata[requiredIndex].RequiredClosure);
+            }
+            foreach (InspectionQueryDefinition optional in registration.Optional)
+            {
+                int optionalIndex = IndexOf(optional);
+                accessible.Add(optional);
+                if (active[optionalIndex])
+                {
+                    AddDefinitions(
+                        accessible,
+                        _metadata[optionalIndex].RequiredClosure);
+                }
+            }
+
+            entries.Add(
+                new InspectionQueryPlan<TContext>.Entry(
+                    registration,
+                    accessible.ToImmutable(),
+                    _metadata[index].Cost));
+        }
+        return new InspectionQueryPlan<TContext>(
+            this,
+            entries.MoveToImmutable());
+    }
+
+    private void AddRequiredClosure(
+        int index,
+        bool[] closure,
+        byte[] state)
+    {
+        if (state[index] == 1)
+        {
+            throw new InspectionQueryException(
+                $"Inspection query prerequisite cycle detected at "
+                    + $"'{_registrations[index].Query.Name}'.");
+        }
+        if (state[index] == 2)
+            return;
+
+        state[index] = 1;
+        var registration = _registrations[index];
+        foreach (InspectionQueryDefinition optional in registration.Optional)
+            _ = IndexOf(optional);
+        foreach (InspectionQueryDefinition required in registration.Requires)
+            AddRequiredClosure(IndexOf(required), closure, state);
+        closure[index] = true;
+        state[index] = 2;
+    }
+
+    private void AddExecutionOrder(
+        int index,
+        bool[] active,
+        byte[] state,
+        ImmutableArray<int>.Builder order)
+    {
+        if (state[index] == 1)
+        {
+            throw new InspectionQueryException(
+                $"Inspection query active dependency cycle detected at "
+                    + $"'{_registrations[index].Query.Name}'.");
+        }
+        if (state[index] == 2)
+            return;
+
+        state[index] = 1;
+        var registration = _registrations[index];
+        foreach (InspectionQueryDefinition required in registration.Requires)
+            AddExecutionOrder(IndexOf(required), active, state, order);
+        foreach (InspectionQueryDefinition optional in registration.Optional)
+        {
+            int optionalIndex = IndexOf(optional);
+            if (active[optionalIndex])
+                AddExecutionOrder(optionalIndex, active, state, order);
+        }
+        state[index] = 2;
+        order.Add(index);
+    }
+
+    private void AddDefinitions(
+        ImmutableHashSet<InspectionQueryDefinition>.Builder destination,
+        bool[] members)
+    {
+        for (int index = 0; index < members.Length; index++)
+        {
+            if (members[index])
+                destination.Add(_registrations[index].Query);
+        }
+    }
+
+    private static void Union(bool[] destination, bool[] source)
+    {
+        for (int index = 0; index < destination.Length; index++)
+            destination[index] |= source[index];
+    }
+
+    private InspectionQueryRegistry<TContext>.Registration RegistrationOf(
+        InspectionQueryDefinition query)
+        => _registrations[IndexOf(query)];
+
+    private int IndexOf(InspectionQueryDefinition query)
+        => _indexes.TryGetValue(query, out int index)
+            ? index
+            : throw new InspectionQueryException(
+                $"Query '{query.Name}' is not registered.");
+
+    private sealed record QueryMetadata(
+        bool[] RequiredClosure,
+        InspectionCost Cost);
+}
+
+/// <summary>
+/// A dependency-ordered immutable execution plan over one fixed query catalog.
+/// </summary>
+public sealed class InspectionQueryPlan<TContext>
+{
+    private readonly InspectionQueryCatalog<TContext> _catalog;
+    private readonly ImmutableArray<Entry> _entries;
+
+    internal InspectionQueryPlan(
+        InspectionQueryCatalog<TContext> catalog,
+        ImmutableArray<Entry> entries)
+    {
+        _catalog = catalog;
+        _entries = entries;
+        Queries = [.. entries.Select(static entry => entry.Registration.Query)];
+
+        InspectionCost cost = InspectionCost.NetworkFree;
+        foreach (Entry entry in entries)
+        {
+            if (entry.Cost > cost)
+                cost = entry.Cost;
+        }
+        Cost = cost;
+    }
+
+    /// <summary>Queries in deterministic execution order.</summary>
+    public ImmutableArray<InspectionQueryDefinition> Queries { get; }
+
+    /// <summary>The maximum transitive cost of all queries in the plan.</summary>
+    public InspectionCost Cost { get; }
+
+    /// <summary>Executes this plan synchronously.</summary>
+    public InspectionQueryResults Run(
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null)
+        => _catalog.Execute(_entries, context, recordExecution);
+
+    /// <summary>Executes this plan asynchronously.</summary>
+    public Task<InspectionQueryResults> RunAsync(
+        TContext context,
+        Action<InspectionQueryDefinition, TimeSpan>? recordExecution = null,
+        CancellationToken cancellationToken = default)
+        => _catalog.ExecuteAsync(
+            _entries,
+            context,
+            recordExecution,
+            cancellationToken);
+
+    internal sealed record Entry(
+        InspectionQueryRegistry<TContext>.Registration Registration,
+        IReadOnlySet<InspectionQueryDefinition> AccessibleDependencies,
+        InspectionCost Cost);
+}

--- a/src/DotnetInspector.Queries/InspectionQueryCatalog.cs
+++ b/src/DotnetInspector.Queries/InspectionQueryCatalog.cs
@@ -230,6 +230,7 @@ public sealed class InspectionQueryCatalog<TContext>
         Action<InspectionQueryDefinition, TimeSpan>? recordExecution,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var results = new InspectionQueryResults();
         foreach (InspectionQueryPlan<TContext>.Entry entry in entries)
         {

--- a/src/dotnet-inspect.Tests/AuditSignalRefreshTests.cs
+++ b/src/dotnet-inspect.Tests/AuditSignalRefreshTests.cs
@@ -68,7 +68,7 @@ public class AuditSignalRefreshTests
                 packageVersion: null,
                 httpClient,
                 queries: [retarget],
-                queryRegistry: registry);
+                queryCatalog: registry.Compile());
 
             Assert.NotNull(inspection);
             Assert.Equal(expectedB, PInvokeCount(linkedAssembly));

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -4085,6 +4085,24 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public async Task TypedQueryRegistry_RunAsync_EmptyDemandPropagatesCancellation()
+    {
+        var registered = new InspectionQuery<int>(
+            "registered",
+            InspectionCost.NetworkFree);
+        var registry = new InspectionQueryRegistry<object?>()
+            .Add(registered, _ => 1);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => registry.RunAsync(
+                [],
+                context: null,
+                cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
     public async Task TypedQueryRegistry_RunAsync_RejectsUndeclaredResultDependencies()
     {
         var hidden = new InspectionQuery<int>("hidden", InspectionCost.Unbounded);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1686,26 +1686,26 @@ public class SectionPipelineTests
         HashSet<InspectionQueryDefinition> perAssemblyQueries =
         [
             .. pipeline.DeclaredQueries.Where(
-                catalog.QueryRegistry.RegisteredQueries.Contains),
+                catalog.QueryCatalog.RegisteredQueries.Contains),
         ];
         HashSet<InspectionQueryDefinition> groupQueries =
         [
             .. pipeline.DeclaredQueries.Where(
-                catalog.GroupQueryRegistry.RegisteredQueries.Contains),
+                catalog.GroupQueryCatalog.RegisteredQueries.Contains),
         ];
         HashSet<InspectionQueryDefinition> closure =
-            catalog.QueryRegistry.ExpandRequired(perAssemblyQueries);
+            catalog.QueryCatalog.ExpandRequired(perAssemblyQueries);
         closure.UnionWith(
-            catalog.GroupQueryRegistry.ExpandRequired(groupQueries));
+            catalog.GroupQueryCatalog.ExpandRequired(groupQueries));
         HashSet<InspectionQueryDefinition> registered =
         [
-            .. catalog.QueryRegistry.RegisteredQueries,
-            .. catalog.GroupQueryRegistry.RegisteredQueries,
+            .. catalog.QueryCatalog.RegisteredQueries,
+            .. catalog.GroupQueryCatalog.RegisteredQueries,
         ];
 
         Assert.Empty(
-            catalog.QueryRegistry.RegisteredQueries.Intersect(
-                catalog.GroupQueryRegistry.RegisteredQueries));
+            catalog.QueryCatalog.RegisteredQueries.Intersect(
+                catalog.GroupQueryCatalog.RegisteredQueries));
         Assert.Equal(
             closure.OrderBy(q => q.Name, StringComparer.Ordinal),
             registered.OrderBy(q => q.Name, StringComparer.Ordinal));
@@ -1741,7 +1741,7 @@ public class SectionPipelineTests
             pipeline.DeclaredQueries.OrderBy(q => q.Name, StringComparer.Ordinal));
         Assert.Equal(
             [OptimizationOpportunitiesQuery.Definition],
-            catalog.QueryRegistry.OptionalDependenciesOf(
+            catalog.QueryCatalog.OptionalDependenciesOf(
                 BodyShapesQuery.Definition));
     }
 
@@ -3722,6 +3722,101 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void TypedQueryRegistry_CompileProducesImmutableCatalogSnapshot()
+    {
+        var first = new InspectionQuery<int>("first", InspectionCost.NetworkFree);
+        var later = new InspectionQuery<int>("later", InspectionCost.Moderated);
+        var registry = new InspectionQueryRegistry<object?>()
+            .Add(first, _ => 1);
+
+        InspectionQueryCatalog<object?> catalog = registry.Compile();
+
+        Assert.Same(catalog, registry.Compile());
+        Assert.Equal([first], catalog.RegisteredQueries);
+
+        registry.Add(later, _ => 2);
+        InspectionQueryCatalog<object?> extended = registry.Compile();
+
+        Assert.NotSame(catalog, extended);
+        Assert.Equal([first], catalog.RegisteredQueries);
+        Assert.Equal([first, later], extended.RegisteredQueries);
+    }
+
+    [Fact]
+    public void TypedQueryCatalog_PrecomputesSingleQueryPlan()
+    {
+        var prerequisite = new InspectionQuery<int>(
+            "prerequisite",
+            InspectionCost.Moderated);
+        var query = new InspectionQuery<int>("query", InspectionCost.NetworkFree);
+        InspectionQueryCatalog<object?> catalog =
+            new InspectionQueryRegistry<object?>()
+                .Add(prerequisite, _ => 41)
+                .Add(
+                    query,
+                    (_, results) => results.Get(prerequisite) + 1,
+                    prerequisite)
+                .Compile();
+
+        InspectionQueryPlan<object?> plan = catalog.Plan(query);
+
+        Assert.Same(plan, catalog.Plan(query));
+        Assert.Equal([prerequisite, query], plan.Queries);
+        Assert.Equal(InspectionCost.Moderated, plan.Cost);
+        Assert.Equal(42, plan.Run(context: null).Get(query));
+    }
+
+    [Fact]
+    public void TypedQueryPlan_ReusesPlanWithoutSharingRunState()
+    {
+        var query = new InspectionQuery<string>(
+            "query",
+            InspectionCost.NetworkFree);
+        InspectionQueryPlan<string> plan =
+            new InspectionQueryRegistry<string>()
+                .Add(query, context => context)
+                .Compile()
+                .Plan(query);
+
+        InspectionQueryResults first = plan.Run("first");
+        InspectionQueryResults second = plan.Run("second");
+
+        Assert.NotSame(first, second);
+        Assert.Equal("first", first.Get(query));
+        Assert.Equal("second", second.Get(query));
+    }
+
+    [Fact]
+    public void LibraryQueryCatalog_RepeatedAcquisitionAndPlanningAllocateNothing()
+    {
+        InspectionQueryCatalog<InspectionQueryContext> queryCatalog =
+            LibrarySections.QueryCatalog;
+        InspectionQueryCatalog<AssemblyContextGroup> groupQueryCatalog =
+            LibrarySections.GroupQueryCatalog;
+        InspectionQueryPlan<InspectionQueryContext> plan =
+            queryCatalog.Plan(BodyShapesQuery.Definition);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int iteration = 0; iteration < 1_000; iteration++)
+        {
+            if (!ReferenceEquals(queryCatalog, LibrarySections.QueryCatalog)
+                || !ReferenceEquals(
+                    groupQueryCatalog,
+                    LibrarySections.GroupQueryCatalog)
+                || !ReferenceEquals(
+                    plan,
+                    queryCatalog.Plan(BodyShapesQuery.Definition)))
+            {
+                throw new InvalidOperationException(
+                    "The library query catalog or its precomputed plan changed identity.");
+            }
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
     public void QueryBackedSection_InheritsDependencyClosureCost()
     {
         var prerequisite = new InspectionQuery<int>(
@@ -4208,7 +4303,7 @@ public class SectionPipelineTests
                 packageVersion: null,
                 httpClient,
                 queries: [query],
-                queryRegistry: registry));
+                queryCatalog: registry.Compile()));
     }
 
     [Fact]
@@ -4228,7 +4323,7 @@ public class SectionPipelineTests
                 packageVersion: null,
                 httpClient,
                 queries: [query],
-                queryRegistry: registry));
+                queryCatalog: registry.Compile()));
 
         Assert.Contains("query execution", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.IsType<IOException>(ex.InnerException);
@@ -4251,7 +4346,7 @@ public class SectionPipelineTests
                 packageVersion: null,
                 httpClient,
                 queries: [query],
-                queryRegistry: registry));
+                queryCatalog: registry.Compile()));
     }
 
     [Fact]
@@ -4269,7 +4364,7 @@ public class SectionPipelineTests
                 packageVersion: null,
                 httpClient,
                 queries: [query],
-                queryRegistry: LibrarySections.CreateQueryRegistry()));
+                queryCatalog: LibrarySections.QueryCatalog));
 
         Assert.Contains("unregistered", ex.Message, StringComparison.Ordinal);
     }
@@ -4397,13 +4492,13 @@ public class SectionPipelineTests
         SectionPipeline<LibraryInspection> pipeline = catalog.Pipeline;
         Assert.Contains(
             AssemblyContextIntegrationsQuery.Definition,
-            catalog.GroupQueryRegistry.RegisteredQueries);
+            catalog.GroupQueryCatalog.RegisteredQueries);
         Assert.Contains(
             AssemblyContextIntegrationOpportunitiesQuery.Definition,
-            catalog.GroupQueryRegistry.RegisteredQueries);
+            catalog.GroupQueryCatalog.RegisteredQueries);
         Assert.DoesNotContain(
             AssemblyContextIntegrationsQuery.Definition,
-            catalog.QueryRegistry.RegisteredQueries);
+            catalog.QueryCatalog.RegisteredQueries);
 
         foreach (string section in LibraryIntegrationCatalog.CategorySections)
         {
@@ -4433,11 +4528,11 @@ public class SectionPipelineTests
             pipeline.GetRequiredQueries(Verbosity.Minimal, opportunities));
         Assert.Equal(
             [AssemblyContextIntegrationsQuery.Definition],
-            catalog.GroupQueryRegistry.RequirementsOf(
+            catalog.GroupQueryCatalog.RequirementsOf(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition));
         Assert.Equal(
             InspectionCost.Unbounded,
-            catalog.GroupQueryRegistry.CostOf(
+            catalog.GroupQueryCatalog.CostOf(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition));
     }
 
@@ -4856,7 +4951,7 @@ public class SectionPipelineTests
                     BodyShapesQuery.Definition,
                     OptimizationOpportunitiesQuery.Definition,
                 ],
-                queryRegistry: registry));
+                queryCatalog: registry.Compile()));
 
         Assert.IsType<BodyShapesResult.DependencyUnavailable>(
             inspection.BodyShapesQueryResult);

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -107,8 +107,8 @@ public class LibraryCommand
         var assemblyPath = options.AssemblyName;
         var catalog = LibrarySections.CreateCatalog();
         var pipeline = catalog.Pipeline;
-        var queryRegistry = catalog.QueryRegistry;
-        var groupQueryRegistry = catalog.GroupQueryRegistry;
+        var queryCatalog = catalog.QueryCatalog;
+        var groupQueryCatalog = catalog.GroupQueryCatalog;
 
         var schemaMap = MetadataSectionNames.AugmentSchema(
             InspectionContext.Default.GetSchemaInfo<LibraryInspectionView>()!.ToDocumentSchema());
@@ -604,7 +604,7 @@ public class LibraryCommand
                 AssemblyContextIntegrationsBatch? integrations =
                     AssemblyContextIntegrationsRunner.RunIfRequested(
                         queries,
-                        groupQueryRegistry,
+                        groupQueryCatalog,
                         [
                             new AssemblyContextIntegrationsInput(
                                 resolvedPath!,
@@ -614,10 +614,12 @@ public class LibraryCommand
                                     "library --platform")),
                         ],
                         trace);
+                InspectionQueryPlan<InspectionQueryContext> queryPlan =
+                    queryCatalog.Plan(queries);
                 var inspection = await LibraryMetadataService.InspectAsync(
                     resolvedPath!, inspectionOptions, logger, null, null, context.HttpClient,
                     isPlatformAssembly: true,
-                    queries: queries,                     queryRegistry: queryRegistry,
+                    queryPlan: queryPlan,
                     assemblyReference: integrations?.AssemblyForInspection(resolvedPath!),
                     integrationsEntry: integrations?.EntryFor(resolvedPath!),
                     integrationOpportunitiesEntry:
@@ -733,7 +735,7 @@ public class LibraryCommand
                 AssemblyContextIntegrationsBatch? integrations =
                     AssemblyContextIntegrationsRunner.RunIfRequested(
                         queries,
-                        groupQueryRegistry,
+                        groupQueryCatalog,
                         inspectionPaths.Select(path =>
                             new AssemblyContextIntegrationsInput(
                                 path,
@@ -743,11 +745,13 @@ public class LibraryCommand
                                     packageName,
                                     packageVersion))),
                         trace);
+                InspectionQueryPlan<InspectionQueryContext> queryPlan =
+                    queryCatalog.Plan(queries);
                 PackageInspectionCollection collection =
                     await CollectPackageInspectionsAsync(
                     inspectionPaths, inspectionOptions, logger, packageName, packageVersion,
                     extractPath, context.HttpClient, signatureResult,
-                    queries, queryRegistry, integrations,
+                    queryPlan, integrations,
                     discoveryInspection && !fullEffectiveDiscovery, trace);
                 List<LibraryInspection> inspections =
                     collection.Inspections;
@@ -889,7 +893,7 @@ public class LibraryCommand
                 AssemblyContextIntegrationsBatch? integrations =
                     AssemblyContextIntegrationsRunner.RunIfRequested(
                         queries,
-                        groupQueryRegistry,
+                        groupQueryCatalog,
                         [
                             new AssemblyContextIntegrationsInput(
                                 assemblyPath!,
@@ -897,9 +901,11 @@ public class LibraryCommand
                                     "library path")),
                         ],
                         trace);
+                InspectionQueryPlan<InspectionQueryContext> queryPlan =
+                    queryCatalog.Plan(queries);
                 var inspection = await LibraryMetadataService.InspectAsync(
                     assemblyPath!, inspectionOptions, logger, null, null, context.HttpClient,
-                    queries: queries,                     queryRegistry: queryRegistry,
+                    queryPlan: queryPlan,
                     assemblyReference: integrations?.AssemblyForInspection(assemblyPath!),
                     integrationsEntry: integrations?.EntryFor(assemblyPath!),
                     integrationOpportunitiesEntry:
@@ -2756,8 +2762,7 @@ public class LibraryCommand
         List<string> assemblyPaths, LibraryOptions options, VerboseLogger logger,
         string? packageName, string? packageVersion, string extractPath,
         HttpClient httpClient, SignatureVerificationResult? signatureResult,
-        HashSet<InspectionQueryDefinition>? queries = null,
-        InspectionQueryRegistry<InspectionQueryContext>? queryRegistry = null,
+        InspectionQueryPlan<InspectionQueryContext>? queryPlan = null,
         AssemblyContextIntegrationsBatch? integrations = null,
         bool discoveryOnly = false, InspectionTrace? trace = null)
     {
@@ -2785,8 +2790,7 @@ public class LibraryCommand
                     packageName,
                     version,
                     httpClient,
-                    queries: queries,
-                    queryRegistry: queryRegistry,
+                    queryPlan: queryPlan,
                     assemblyReference:
                         integrations?.AssemblyForInspection(targetPath),
                     integrationsEntry:

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3777,7 +3777,7 @@ public class PackageCommand
 
         var catalog = LibrarySections.CreateCatalog();
         var pipeline = catalog.Pipeline;
-        var queryRegistry = catalog.QueryRegistry;
+        var queryCatalog = catalog.QueryCatalog;
         var libraryOptions = CreateLibraryOptions(assemblyName: null, packageReference, options);
 
         libraryOptions = LibraryCommand.NormalizeBareSelect(libraryOptions);
@@ -3854,6 +3854,8 @@ public class PackageCommand
             RequiresGroupedIntegrations(
                 queries,
                 out bool includeIntegrationOpportunities);
+        InspectionQueryPlan<InspectionQueryContext> queryPlan =
+            queryCatalog.Plan(queries);
         using PackageIntegrationsWorkspace? integrationsWorkspace =
             requiresGroupedIntegrations
                 ? PackageIntegrationsWorkspace.Create(
@@ -3894,8 +3896,7 @@ public class PackageCommand
                     packageName,
                     version,
                     context.HttpClient,
-                    queries: queries,
-                    queryRegistry: queryRegistry,
+                    queryPlan: queryPlan,
                     assemblyReference: assemblyReference,
                     integrationsEntry: integrations,
                     integrationOpportunitiesEntry: opportunities);

--- a/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyContextIntegrationsRunner.cs
@@ -57,16 +57,16 @@ internal static class AssemblyContextIntegrationsRunner
 {
     internal static AssemblyContextIntegrationsBatch? RunIfRequested(
         HashSet<InspectionQueryDefinition>? requestedQueries,
-        InspectionQueryRegistry<AssemblyContextGroup> queryRegistry,
+        InspectionQueryCatalog<AssemblyContextGroup> queryCatalog,
         IEnumerable<AssemblyContextIntegrationsInput> inputs,
         InspectionTrace? trace = null,
         AssemblyContextGroupOptions? groupOptions = null)
     {
-        ArgumentNullException.ThrowIfNull(queryRegistry);
+        ArgumentNullException.ThrowIfNull(queryCatalog);
         HashSet<InspectionQueryDefinition> requested = requestedQueries?
             .Where(
                 query =>
-                    queryRegistry.RegisteredQueries.Contains(query))
+                    queryCatalog.RegisteredQueries.Contains(query))
             .ToHashSet() ?? [];
         if (requested.Count == 0)
         {
@@ -116,13 +116,12 @@ internal static class AssemblyContextIntegrationsRunner
         using var workspace = new InspectionWorkspace();
         using AssemblyContextGroup group =
             workspace.CreateAssemblyContextGroup(participants, groupOptions);
-        HashSet<InspectionQueryDefinition> closure =
-            queryRegistry.ExpandRequired(requested);
-        trace?.RecordQueryClosure(closure);
+        InspectionQueryPlan<AssemblyContextGroup> plan =
+            queryCatalog.Plan(requested);
+        trace?.RecordQueryClosure(plan.Queries);
         Action<InspectionQueryDefinition, TimeSpan>? recordExecution =
             trace is null ? null : trace.RecordQueryExecution;
-        InspectionQueryResults queryResults = queryRegistry.Run(
-            requested,
+        InspectionQueryResults queryResults = plan.Run(
             group,
             recordExecution);
         AssemblyContextIntegrationsResult integrationsResult = queryResults.Get(

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -40,7 +40,8 @@ internal static class LibraryMetadataService
         HttpClient httpClient,
         bool isPlatformAssembly = false,
         HashSet<InspectionQueryDefinition>? queries = null,
-        InspectionQueryRegistry<InspectionQueryContext>? queryRegistry = null,
+        InspectionQueryCatalog<InspectionQueryContext>? queryCatalog = null,
+        InspectionQueryPlan<InspectionQueryContext>? queryPlan = null,
         ResolvedAssemblyReference? assemblyReference = null,
         AssemblyIntegrationsEntry? integrationsEntry = null,
         AssemblyIntegrationOpportunitiesEntry?
@@ -52,9 +53,13 @@ internal static class LibraryMetadataService
 
         try
         {
-            var requiredQueries = queryRegistry is not null && queries is not null
-                ? queryRegistry.ExpandRequired(queries)
-                : queries;
+            queryPlan ??= queryCatalog is not null && queries is not null
+                ? queryCatalog.Plan(queries)
+                : null;
+            IReadOnlyCollection<InspectionQueryDefinition>? requiredQueries =
+                queryPlan is null
+                    ? queries
+                    : queryPlan.Queries;
             if (requiredQueries is not null)
                 trace?.RecordQueryClosure(requiredQueries);
             var bodyAnalysisFeatures = SelectBodyAnalysisFeatures(requiredQueries);
@@ -135,7 +140,7 @@ internal static class LibraryMetadataService
                 nativeAudit.HasReproducibleFlag = pdbContext.HasReproducibleFlag;
                 nativeAudit.IsDeterministic = pdbContext.HasReproducibleFlag;
 
-                if (queryRegistry is not null && requiredQueries is not null)
+                if (queryPlan is not null)
                 {
                     using var queryContext = new Sections.InspectionQueryContext
                     {
@@ -153,8 +158,7 @@ internal static class LibraryMetadataService
                         path,
                         nativeAudit,
                         logger,
-                        queryRegistry,
-                        requiredQueries,
+                        queryPlan,
                         queryContext,
                         projectOptimizationOpportunities,
                         trace).ConfigureAwait(false);
@@ -260,7 +264,7 @@ internal static class LibraryMetadataService
             // Run typed queries against one shared assembly context.
             var collectReferenceTree = options.CollectReferenceTree;
             var referencesWillRun =
-                queryRegistry is not null
+                queryPlan is not null
                 && requiredQueries?.Contains(AssemblyReferencesQuery.Definition) == true;
             if ((collectReferenceTree || needsAuditSignals) && !referencesWillRun)
             {
@@ -272,7 +276,7 @@ internal static class LibraryMetadataService
                     AssemblyReferencesQuery.Execute(session));
             }
 
-            if (queryRegistry is not null && requiredQueries is not null)
+            if (queryPlan is not null)
             {
                 using var queryContext = new Sections.InspectionQueryContext
                 {
@@ -291,8 +295,7 @@ internal static class LibraryMetadataService
                     path,
                     inspection,
                     logger,
-                    queryRegistry,
-                    requiredQueries,
+                    queryPlan,
                     queryContext,
                     projectOptimizationOpportunities,
                     trace).ConfigureAwait(false);
@@ -504,7 +507,7 @@ internal static class LibraryMetadataService
     }
 
     static Analysis.LibraryBodyAnalysisFeatures SelectBodyAnalysisFeatures(
-        IReadOnlySet<InspectionQueryDefinition>? queries)
+        IReadOnlyCollection<InspectionQueryDefinition>? queries)
     {
         var features = Analysis.LibraryBodyAnalysisFeatures.None;
         if (queries?.Contains(TopLeverageQuery.Definition) == true
@@ -2905,8 +2908,7 @@ internal static class LibraryMetadataService
         string path,
         LibraryInspection inspection,
         VerboseLogger logger,
-        InspectionQueryRegistry<InspectionQueryContext> queryRegistry,
-        HashSet<InspectionQueryDefinition> requiredQueries,
+        InspectionQueryPlan<InspectionQueryContext> queryPlan,
         InspectionQueryContext queryContext,
         bool projectOptimizationOpportunities,
         Sections.InspectionTrace? trace)
@@ -2917,8 +2919,7 @@ internal static class LibraryMetadataService
         InspectionQueryResults results;
         try
         {
-            results = await queryRegistry.RunAsync(
-                requiredQueries,
+            results = await queryPlan.RunAsync(
                 queryContext,
                 recordQuery).ConfigureAwait(false);
         }

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -8,8 +8,8 @@ namespace DotnetInspector.Sections;
 
 public sealed record LibrarySectionCatalog(
     SectionPipeline<LibraryInspection> Pipeline,
-    InspectionQueryRegistry<InspectionQueryContext> QueryRegistry,
-    InspectionQueryRegistry<AssemblyContextGroup> GroupQueryRegistry);
+    InspectionQueryCatalog<InspectionQueryContext> QueryCatalog,
+    InspectionQueryCatalog<AssemblyContextGroup> GroupQueryCatalog);
 
 /// <summary>
 /// Section descriptors for the library command.
@@ -18,33 +18,49 @@ public sealed record LibrarySectionCatalog(
 /// </summary>
 public static class LibrarySections
 {
+    /// <summary>The reusable fixed-domain catalog for per-assembly library queries.</summary>
+    public static InspectionQueryCatalog<InspectionQueryContext> QueryCatalog { get; } =
+        BuildQueryCatalog();
+
+    /// <summary>The reusable fixed-domain catalog for assembly-context group queries.</summary>
+    public static InspectionQueryCatalog<AssemblyContextGroup> GroupQueryCatalog { get; } =
+        BuildGroupQueryCatalog();
+
     /// <summary>
     /// Builds the library catalog from typed query catalogs, so section costs, demand, and
     /// execution use the same immutable declarations.
     /// </summary>
     public static LibrarySectionCatalog CreateCatalog()
     {
-        var queryRegistry = CreateQueryRegistry();
-        var groupQueryRegistry = CreateGroupQueryRegistry();
         return new LibrarySectionCatalog(
             CreatePipeline(
-                query => groupQueryRegistry.RegisteredQueries.Contains(query)
-                    ? groupQueryRegistry.CostOf(query)
-                    : queryRegistry.CostOf(query)),
-            queryRegistry,
-            groupQueryRegistry);
+                query => GroupQueryCatalog.RegisteredQueries.Contains(query)
+                    ? GroupQueryCatalog.CostOf(query)
+                    : QueryCatalog.CostOf(query)),
+            QueryCatalog,
+            GroupQueryCatalog);
     }
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()
-    {
-        var queryRegistry = CreateQueryRegistry();
-        var groupQueryRegistry = CreateGroupQueryRegistry();
-        return CreatePipeline(
-            query => groupQueryRegistry.RegisteredQueries.Contains(query)
-                ? groupQueryRegistry.CostOf(query)
-                : queryRegistry.CostOf(query));
-    }
+        => CreatePipeline(
+            query => GroupQueryCatalog.RegisteredQueries.Contains(query)
+                ? GroupQueryCatalog.CostOf(query)
+                : QueryCatalog.CostOf(query));
+
+    /// <summary>
+    /// Creates an independently mutable builder initialized from the production query catalog.
+    /// Intended for focused host tests and extensions; production execution uses
+    /// <see cref="QueryCatalog"/>.
+    /// </summary>
+    public static InspectionQueryRegistry<InspectionQueryContext> CreateQueryRegistry()
+        => QueryCatalog.ToBuilder();
+
+    /// <summary>
+    /// Returns the reusable assembly-context group catalog.
+    /// </summary>
+    public static InspectionQueryCatalog<AssemblyContextGroup> CreateGroupQueryRegistry()
+        => GroupQueryCatalog;
 
     private static SectionPipeline<LibraryInspection> CreatePipeline(
         Func<InspectionQueryDefinition, InspectionCost> queryCost)
@@ -197,8 +213,7 @@ public static class LibrarySections
                 SectionNames.CostContext);
     }
 
-    /// <summary>Builds the typed query registry used by library sections.</summary>
-    public static InspectionQueryRegistry<InspectionQueryContext> CreateQueryRegistry()
+    private static InspectionQueryCatalog<InspectionQueryContext> BuildQueryCatalog()
     {
         return new InspectionQueryRegistry<InspectionQueryContext>(
             static (context, query, cost) =>
@@ -308,7 +323,8 @@ public static class LibrarySections
             .Add(
                 TopLeverageQuery.Definition,
                 ExecuteTopLeverageQuery)
-            .AddSourceLinkQueries(RequireSourceLinkContext);
+            .AddSourceLinkQueries(RequireSourceLinkContext)
+            .Compile();
     }
 
     internal static UnsafeEvidenceResult ExecuteUnsafeEvidenceQuery(
@@ -514,9 +530,8 @@ public static class LibrarySections
         }
     }
 
-    /// <summary>Builds the typed query registry for assembly-context group sections.</summary>
-    public static InspectionQueryRegistry<AssemblyContextGroup>
-        CreateGroupQueryRegistry()
+    private static InspectionQueryCatalog<AssemblyContextGroup>
+        BuildGroupQueryCatalog()
         => new InspectionQueryRegistry<AssemblyContextGroup>()
             .Add(
                 AssemblyContextIntegrationsQuery.Definition,
@@ -524,7 +539,8 @@ public static class LibrarySections
             .Add(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition,
                 AssemblyContextIntegrationOpportunitiesQuery.Execute,
-                AssemblyContextIntegrationsQuery.Definition);
+                AssemblyContextIntegrationsQuery.Definition)
+            .Compile();
 
     private static SourceLinkQueryContext RequireSourceLinkContext(InspectionQueryContext context)
         => context.SourceLinkContext


### PR DESCRIPTION
## Summary

Adds an immutable, reusable typed-query catalog so fixed query domains recover ScannerRegistry's useful static properties without restoring string keys or weakening typed query-to-sink currency.

- Compiles mutable `InspectionQueryRegistry<TContext>` declarations into immutable `InspectionQueryCatalog<TContext>` snapshots.
- Precomputes stable enumeration, dependency closures, transitive costs, and reusable single-query plans.
- Adds immutable multi-query plans that can be reused across assembly contexts without sharing run state.
- Moves library and assembly-group queries to process-wide catalogs and compiles per-request demand once for package/library loops.
- Preserves required/optional dependency behavior, sync/async execution, typed result access, and host cost enforcement.

## Evidence

- `SectionPipelineTests` + `AuditSignalRefreshTests`: 297 passed
- `LibraryQueryCatalog_RepeatedAcquisitionAndPlanningAllocateNothing`: 0 B after initialization
- `dotnet build dotnet-inspect.slnx -c Release`: succeeded
- `markdownlint` on changed architecture docs: passed

## Non-goals

- No restoration of string scanner keys or lower-level scanner APIs.
- No output, section-selection, rendering, or source/PDB acquisition-policy change.
- Intentionally mutable host-owned registries remain mutable.

Closes #4685