### PR TITLE
Document network-accessible inspect-web demos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 | Skills | `taste/skill-guidance.md` |
 | Stacked PRs and restacking | `docs/stacked-prs.md` |
 | Running a review round, or checking PR status | `docs/round-orchestration.md` |
-| Hosting a network-accessible inspect-web demo | `docs/inspect-web-demo-hosting.md` |
+| Hosting a network-accessible inspect-web demo | `docs/runbooks/inspect-web-demo-hosting.md` |
 | Release and publishing | `docs/release-workflow.md` |
 | Changes spanning Markout and this repo | `docs/markout-co-development.md` |
 
@@ -744,8 +744,8 @@ Validation proves correctness; a demo shows value. Post the intended demo early
 enough to change the implementation.
 
 For a network-accessible inspect-web demo, follow
-[`docs/inspect-web-demo-hosting.md`](docs/inspect-web-demo-hosting.md). A local
-HTTP listener or successful `curl` is not a user-visible demo.
+[`docs/runbooks/inspect-web-demo-hosting.md`](docs/runbooks/inspect-web-demo-hosting.md).
+A local HTTP listener or successful `curl` is not a user-visible demo.
 
 A useful demo:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 | Skills | `taste/skill-guidance.md` |
 | Stacked PRs and restacking | `docs/stacked-prs.md` |
 | Running a review round, or checking PR status | `docs/round-orchestration.md` |
+| Hosting a network-accessible inspect-web demo | `docs/inspect-web-demo-hosting.md` |
 | Release and publishing | `docs/release-workflow.md` |
 | Changes spanning Markout and this repo | `docs/markout-co-development.md` |
 
@@ -741,6 +742,10 @@ must not contain the checkpoint itself.
 
 Validation proves correctness; a demo shows value. Post the intended demo early
 enough to change the implementation.
+
+For a network-accessible inspect-web demo, follow
+[`docs/inspect-web-demo-hosting.md`](docs/inspect-web-demo-hosting.md). A local
+HTTP listener or successful `curl` is not a user-visible demo.
 
 A useful demo:
 

--- a/docs/inspect-web-demo-hosting.md
+++ b/docs/inspect-web-demo-hosting.md
@@ -1,0 +1,288 @@
+# Hosting an inspect-web demo
+
+This runbook describes how to publish a worktree's inspect-web site so a user
+on another tailnet-connected machine can validate in-progress work.
+
+The repository-standard demo topology has two roles:
+
+1. The **build host** publishes the exact worktree and serves the resulting
+   static site on loopback.
+2. A stable **HTTPS gateway** receives that loopback service through an SSH
+   reverse tunnel and exposes it with Tailscale Serve.
+
+```text
+user browser
+  -> HTTPS over the tailnet
+  -> Tailscale Serve on the gateway
+  -> gateway loopback port
+  -> SSH reverse tunnel
+  -> build-host loopback static server
+  -> published wwwroot for one exact Git head
+```
+
+This is a review demo, not a production deployment. The production site follows
+the release workflow instead.
+
+## Why this topology
+
+- Remote .NET WebAssembly requires HTTPS because its loader uses secure-context
+  browser APIs.
+- The published `wwwroot` is the artifact users will eventually receive. Vite
+  and `dotnet run` are development hosts and are not substitutes for it.
+- Both origin ports bind to loopback. The tailnet gateway is the only
+  network-facing listener.
+- The gateway URL remains stable while the implementation worktree and build
+  host can change.
+- Tailscale Serve is tailnet-only. Do not use Tailscale Funnel for a review
+  demo.
+
+The gateway route is shared infrastructure. It can present only one demo on a
+given origin port at a time. Inspect its current owner before taking it over,
+and never reset or replace an unknown route.
+
+## Prerequisites
+
+The build host needs:
+
+- the exact branch in its own clean development worktree;
+- the repository-selected .NET SDK and WebAssembly workload;
+- Node.js at the version required by `prototypes/inspect-web/package.json`;
+- Python 3 for the static server;
+- SSH access to the gateway; and
+- Tailscale connectivity.
+
+The gateway needs Tailscale Serve configured once by its operator. The examples
+below use these variables so hostnames remain environment configuration rather
+than repository policy:
+
+```bash
+export DEMO_GATEWAY_HOST="<gateway SSH host>"
+export DEMO_PUBLIC_HOST="<gateway tailnet DNS name>"
+export DEMO_HTTPS_PORT=8443
+export DEMO_GATEWAY_ORIGIN_PORT=5199
+export DEMO_BUILD_ORIGIN_PORT=5198
+```
+
+Use the gateway values supplied for the current environment. Do not infer a
+gateway from an arbitrary machine name or commit private network configuration
+to the repository.
+
+## 1. Establish the exact candidate
+
+Run from the implementation worktree:
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+head="$(git rev-parse HEAD)"
+short_head="$(git rev-parse --short=12 HEAD)"
+git status --short --branch
+```
+
+Do not demo an uncommitted tree unless the user explicitly asks to inspect
+uncommitted work. In that exceptional case, say so beside the URL; a Git SHA
+cannot identify the content they are seeing.
+
+Before replacing the shared demo, inspect the gateway:
+
+```bash
+ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
+  "tailscale serve status; ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
+```
+
+An occupied gateway origin may belong to another demo. Coordinate its teardown;
+do not kill an unknown process or run `tailscale serve reset`.
+
+## 2. Build the production artifact
+
+Build the frontend and publish the WebAssembly engine from the same worktree:
+
+```bash
+cd "$repo_root/prototypes/inspect-web"
+npm ci
+npm run build
+
+cd "$repo_root"
+dotnet publish prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+  -c Release \
+  --disable-build-servers \
+  -p:UseSharedCompilation=false \
+  -p:BuildInParallel=false \
+  -m:1 \
+  -nr:false
+```
+
+Derive the target framework from the project rather than embedding today's
+framework in scripts:
+
+```bash
+target_framework="$(
+  dotnet msbuild prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+    -nologo -getProperty:TargetFramework
+)"
+site_root="$repo_root/prototypes/inspect-web/engine/bin/Release/$target_framework/publish/wwwroot"
+
+test -f "$site_root/index.html"
+test -f "$site_root/manifest.json"
+test -f "$site_root/inspect-web-engine.js"
+test -f "$site_root/_framework/dotnet.js"
+```
+
+Publish before starting the static server. For a later update, stop the server,
+publish the replacement completely, and restart it; do not serve a directory
+while `dotnet publish` is rewriting it.
+
+Do not use:
+
+- `vite` or `vite preview` — the demo must include the published .NET engine,
+  and Vite also applies host allow-list behavior;
+- `dotnet run` as the remote proof — the WebAssembly development host has
+  previously served fingerprinted assets incorrectly in this workflow; or
+- the frontend `dist/` directory — it does not contain the complete published
+  WebAssembly site.
+
+## 3. Serve the published site on loopback
+
+Keep this process in a dedicated persistent terminal or tmux window:
+
+```bash
+python3 -m http.server "$DEMO_BUILD_ORIGIN_PORT" \
+  --bind 127.0.0.1 \
+  --directory "$site_root"
+```
+
+Record the window or exact PID. Do not use a name-based process kill during
+cleanup.
+
+From another terminal on the build host:
+
+```bash
+curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/"
+curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/inspect-web-engine.js"
+curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/_framework/dotnet.js"
+```
+
+The simple static host supports the root and query-string workspace links used
+for demos. It does not implement Azure Static Web Apps route fallback; do not
+claim direct-path routes such as `/credits` as validated through this host.
+
+## 4. Open the reverse tunnel
+
+Keep the tunnel in a second dedicated persistent terminal or tmux window:
+
+```bash
+ssh -N -T \
+  -o BatchMode=yes \
+  -o ExitOnForwardFailure=yes \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -R "127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}:127.0.0.1:${DEMO_BUILD_ORIGIN_PORT}" \
+  "$DEMO_GATEWAY_HOST"
+```
+
+`ExitOnForwardFailure` is required. Without it, SSH can remain alive after
+failing to claim the gateway port, leaving a success-shaped tunnel process that
+serves nothing.
+
+Verify the origin from the gateway:
+
+```bash
+ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
+  "curl -fsSI http://127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}/"
+```
+
+## 5. Confirm the HTTPS route
+
+The gateway operator configures the route once:
+
+```bash
+tailscale serve --bg \
+  --https="$DEMO_HTTPS_PORT" \
+  "http://127.0.0.1:$DEMO_GATEWAY_ORIGIN_PORT"
+```
+
+Normal demo publication must reuse the existing matching route, not rewrite it.
+Confirm it from the gateway:
+
+```bash
+ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
+  "tailscale serve status"
+
+ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
+  "curl -fsSI https://${DEMO_PUBLIC_HOST}:${DEMO_HTTPS_PORT}/"
+```
+
+The build host may be unable to reach the gateway's public tailnet listener
+because of ACL or routing policy even while the gateway and user can. A timeout
+from the build host does not justify falling back to insecure HTTP. Check each
+hop separately and obtain the external browser proof below.
+
+## 6. Give the user an identifiable URL
+
+Start with the application-generated workspace link, then append the candidate
+head as a cache-busting build parameter:
+
+```text
+https://<DEMO_PUBLIC_HOST>:<DEMO_HTTPS_PORT>/?package=...&w=...&build=<short-head>
+```
+
+Use `?build=` for a bare root URL and `&build=` when the URL already has a
+query. The build value identifies the intended candidate and forces a distinct
+document URL; it is not a substitute for confirming the running artifact.
+
+State all three:
+
+- the complete clickable URL;
+- the exact full Git head; and
+- what interaction or output the user should validate.
+
+## 7. Validate from a user-equivalent browser
+
+An origin returning HTTP 200 is necessary but insufficient. The demo is ready
+only after a separate tailnet-connected browser proves that:
+
+1. HTTPS loads without a certificate or secure-context error.
+2. The .NET engine reaches its ready state.
+3. The exact changed scenario works through real pointer and keyboard input.
+4. A hard refresh of the complete workspace URL restores the same view.
+5. Browser back and forward work when navigation is part of the change.
+6. The browser console has no startup or module-loading error.
+
+Prefer the user's machine for final acceptance. An automated browser on another
+tailnet peer is useful preflight evidence, but it does not replace the user's
+validation when the purpose of the demo is UX feedback.
+
+## Updating and teardown
+
+For a new head:
+
+1. Stop the build-host static server.
+2. Build and publish the new head completely.
+3. Restart the static server against the new `wwwroot`.
+4. Keep or re-establish the reverse tunnel.
+5. Re-run the origin, gateway, HTTPS, and browser checks.
+6. Send a new URL with the new short head.
+
+When the demo is no longer needed:
+
+1. Stop the reverse tunnel by its terminal or exact PID.
+2. Stop the build-host static server by its terminal or exact PID.
+3. Verify the gateway origin no longer answers.
+4. Leave the shared Tailscale Serve mapping in place unless its operator
+   explicitly asks for removal.
+
+Never leave a URL advertised after its tunnel or exact artifact is gone. Never
+silently repoint an existing build-tagged URL to unrelated work.
+
+## Failure guide
+
+| Symptom | Likely boundary | Response |
+| --- | --- | --- |
+| Local origin fails | Publish or static server | Check `site_root`, process, and the four required files |
+| SSH exits immediately | Gateway port or authentication | Keep `ExitOnForwardFailure`; inspect ownership instead of choosing random processes to kill |
+| Gateway origin fails | Reverse tunnel | Check the tunnel terminal and both loopback ports |
+| HTTPS returns 502/503 | Serve mapping reaches no origin | Restore the tunnel; do not replace the HTTPS route |
+| HTTPS times out only on build host | Tailnet ACL/routing | Validate on the gateway and a user-equivalent peer |
+| Vite reports a disallowed host | Wrong server | Serve the published `wwwroot`, not Vite |
+| `dotnet.js` or bundled assets are empty/missing | Wrong artifact or host | Re-publish and use the static `wwwroot` host |
+| Page paints but controls remain inert | Wasm engine did not initialize | Inspect framework requests and browser console; HTTP 200 alone is not success |
+| User sees an older build | Stale URL or wrong served worktree | Confirm full head, restart from its `wwwroot`, and issue a new `build=<short-head>` URL |

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -223,8 +223,8 @@ secure-context treatment.
 
 ## Pattern B: Tailscale Serve through a stable gateway
 
-Use this pattern when the viewer already has tailnet access and needs a stable
-shared HTTPS URL. It has three hops:
+Use this pattern when the user has indicated that a Tailscale Serve session is
+available. It has three hops:
 
 ```text
 viewer browser

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -235,36 +235,37 @@ viewer browser
   -> build-host loopback static server
 ```
 
-The gateway route is a standing, tailnet-only slot. Keep its Serve
-configuration in place between web-development demos so its URL and certificate
-remain stable, but attach the reverse tunnel and origin only while a demo is
-active. The slot can present only one demo at a time. Inspect its current owner
-before taking it over, and never reset or replace an unknown route.
+One Serve session can contain multiple path mappings and can be reconfigured
+after it starts. This runbook deliberately treats the user-provided mapping as
+fixed: one tailnet HTTPS URL and path proxies to one assigned gateway loopback
+port. Keep that mapping configured between web-development demos, but attach
+the reverse tunnel and origin only while a demo is active.
 
-An existing gateway operator must own Tailscale Serve changes. Do not grant an
-agent account Tailscale operator access merely to publish or test one demo; that
-permission controls more than Serve. When no authorized operator is available,
-the Serve pattern is unavailable and the viewer-side SSH pattern remains the
-safe default.
+The agent does not inspect or change the Serve session and needs no Tailscale
+operator access. Never reset, replace, or add mappings to the session. When the
+user has not indicated that a session is available, use viewer-side SSH
+forwarding instead.
 
 On the build host, set the environment-specific gateway values:
 
 ```bash
 export DEMO_GATEWAY_HOST="<gateway SSH host>"
 export DEMO_PUBLIC_HOST="<gateway tailnet DNS name>"
-export DEMO_HTTPS_PORT=8443
-export DEMO_GATEWAY_ORIGIN_PORT=5199
+export DEMO_HTTPS_PORT="<assigned HTTPS port>"
+export DEMO_GATEWAY_ORIGIN_PORT="<assigned gateway loopback port>"
 export DEMO_BUILD_ORIGIN_PORT=5198
 ```
 
-Do not infer a gateway from an arbitrary machine name or commit private network
-configuration to the repository.
+Use the values supplied with the available session. Do not discover alternative
+gateways or routes, and do not commit private network configuration to the
+repository.
 
-Before replacing the shared demo, inspect the gateway:
+Before attaching the tunnel, confirm that no process already owns the assigned
+gateway loopback port:
 
 ```bash
 ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "tailscale serve status; ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
+  "ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
 ```
 
 An occupied gateway origin may belong to another demo. Coordinate its teardown;
@@ -289,21 +290,9 @@ ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
   "curl -fsSI http://127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}/"
 ```
 
-The gateway operator configures the private Serve route once:
+Confirm the existing HTTPS mapping from the gateway without changing it:
 
 ```bash
-tailscale serve --bg \
-  --https="$DEMO_HTTPS_PORT" \
-  "http://127.0.0.1:$DEMO_GATEWAY_ORIGIN_PORT"
-```
-
-Normal demo publication must reuse the existing matching route, not rewrite it.
-Confirm it from the gateway:
-
-```bash
-ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "tailscale serve status"
-
 ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
   "curl -fsSI https://${DEMO_PUBLIC_HOST}:${DEMO_HTTPS_PORT}/"
 ```

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -33,8 +33,18 @@ the release workflow instead.
   network-facing listener.
 - The gateway URL remains stable while the implementation worktree and build
   host can change.
-- Tailscale Serve is tailnet-only. Do not use Tailscale Funnel for a review
-  demo.
+- Tailscale Serve obtains and renews the certificate for the gateway's tailnet
+  DNS name, terminates HTTPS, and proxies to the loopback origin. It remains
+  tailnet-only; do not use Tailscale Funnel for a review demo.
+
+Tailscale Serve is the repository-standard HTTPS terminator, not a technical
+requirement. A gateway operator could instead obtain a certificate with
+`tailscale cert` and configure Caddy, nginx, or another TLS server. That
+alternative adds private-key handling, certificate renewal, and server
+configuration that Serve owns for this workflow. A directly reachable build
+host could also terminate HTTPS under its own tailnet DNS name, but would give
+up the stable gateway URL and change the network-exposure model. Keep those
+alternatives operator decisions rather than improvising them during a demo.
 
 The gateway route is shared infrastructure. It can present only one demo on a
 given origin port at a time. Inspect its current owner before taking it over,
@@ -51,9 +61,9 @@ The build host needs:
 - SSH access to the gateway; and
 - Tailscale connectivity.
 
-The gateway needs Tailscale Serve configured once by its operator. The examples
-below use these variables so hostnames remain environment configuration rather
-than repository policy:
+The gateway needs the repository-standard Tailscale Serve route configured once
+by its operator. The examples below use these variables so hostnames remain
+environment configuration rather than repository policy:
 
 ```bash
 export DEMO_GATEWAY_HOST="<gateway SSH host>"

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -54,7 +54,6 @@ The build host needs:
 - the exact branch in its own clean development worktree;
 - the repository-selected .NET SDK and WebAssembly workload;
 - Node.js at the version required by `prototypes/inspect-web/package.json`;
-- Python 3 for the loopback static server; and
 - SSH access from the viewer or gateway, depending on the selected pattern.
 
 Use these build-host variables:
@@ -127,8 +126,9 @@ while `dotnet publish` is rewriting it.
 
 Do not use:
 
-- `vite` or `vite preview` - the demo must include the published .NET engine,
-  and Vite also applies host allow-list behavior;
+- the Vite development server - it does not serve the published .NET engine;
+- the default `npm run preview` command - it targets the frontend `dist/`
+  directory rather than the complete published WebAssembly site;
 - `dotnet run` as the remote proof - the WebAssembly development host has
   previously served fingerprinted assets incorrectly in this workflow; or
 - the frontend `dist/` directory - it does not contain the complete published
@@ -139,10 +139,24 @@ Do not use:
 Keep this process in a dedicated persistent terminal or tmux window:
 
 ```bash
-python3 -m http.server "$DEMO_BUILD_ORIGIN_PORT" \
-  --bind 127.0.0.1 \
-  --directory "$site_root"
+cd "$repo_root/prototypes/inspect-web"
+
+if [ -n "${DEMO_PUBLIC_HOST:-}" ]; then
+  export __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS="$DEMO_PUBLIC_HOST"
+fi
+
+npm run preview -- \
+  --host 127.0.0.1 \
+  --port "$DEMO_BUILD_ORIGIN_PORT" \
+  --strictPort \
+  --outDir "$site_root"
 ```
+
+This uses the already-pinned Vite dependency as a static server while
+overriding its default output directory with the published `wwwroot`.
+`--strictPort` keeps an occupied port from silently selecting a different one.
+For the Serve pattern, allow only the exact tailnet DNS hostname; do not disable
+Vite's host check globally.
 
 Record the window or exact PID. Do not use a name-based process kill during
 cleanup.
@@ -221,9 +235,11 @@ viewer browser
   -> build-host loopback static server
 ```
 
-The gateway route is shared infrastructure. It can present only one demo on a
-given origin port at a time. Inspect its current owner before taking it over,
-and never reset or replace an unknown route.
+The gateway route is a standing, tailnet-only slot. Keep its Serve
+configuration in place between web-development demos so its URL and certificate
+remain stable, but attach the reverse tunnel and origin only while a demo is
+active. The slot can present only one demo at a time. Inspect its current owner
+before taking it over, and never reset or replace an unknown route.
 
 An existing gateway operator must own Tailscale Serve changes. Do not grant an
 agent account Tailscale operator access merely to publish or test one demo; that
@@ -371,7 +387,7 @@ silently repoint an existing build-tagged URL to unrelated work.
 | Gateway origin fails | Reverse tunnel | Check the tunnel terminal and both loopback ports |
 | Serve returns 502/503 | Serve cannot reach its origin | Restore the reverse tunnel; do not replace the Serve route |
 | Serve times out only on the build host | Tailnet policy | Validate on the gateway and an authorized viewer |
-| Vite reports a disallowed host | Wrong server | Serve the published `wwwroot`, not Vite |
-| `dotnet.js` or bundled assets are empty or missing | Wrong artifact or host | Re-publish and use the static `wwwroot` |
+| Vite reports a disallowed host | Missing exact Serve hostname | Restart with `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` set to the tailnet DNS name |
+| Fingerprinted loader or bundled assets are empty or missing | Wrong artifact or host | Re-publish and serve the complete `wwwroot` |
 | Page paints but controls remain inert | Wasm engine did not initialize | Inspect framework requests and browser console; HTTP 200 alone is not success |
 | User sees an older build | Stale URL or wrong served worktree | Confirm full head, restart from its `wwwroot`, and issue a new `build=<short-head>` URL |

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -7,14 +7,14 @@ Use one of two private hosting patterns:
 
 1. **Viewer-side SSH forwarding (preferred):** the viewer forwards a local
    loopback port over SSH to the build host's loopback static server.
-2. **Tailscale Serve:** a stable gateway receives the static server through an
-   SSH reverse tunnel and exposes it to authenticated tailnet clients over
-   HTTPS.
+2. **Tailscale Serve:** a standing Serve mapping on the build host exposes its
+   loopback static server to authenticated tailnet clients over HTTPS.
 
-Both patterns keep the static server bound to loopback. The preferred pattern
-opens no application port on either network; it reuses the build host's
-existing SSH access. Use Tailscale Serve when a stable shared URL is more
-important than the additional gateway and tailnet dependencies.
+Both patterns use one build-and-host machine; the only second machine is the
+viewer. Both keep the static server bound to build-host loopback. The preferred
+pattern opens no application port on either network and reuses the build host's
+existing SSH access. Use Tailscale Serve when the user has indicated that a
+standing session is available.
 
 This is a review demo, not a production deployment. The production site follows
 the release workflow instead.
@@ -32,8 +32,9 @@ The two supported patterns satisfy that requirement differently:
 
 - A viewer-side SSH forward gives the browser a loopback URL. SSH protects the
   connection to the build host, so no browser certificate is needed.
-- Tailscale Serve obtains and renews the certificate for the gateway's tailnet
-  DNS name, terminates HTTPS, and proxies to a gateway loopback origin.
+- Tailscale Serve obtains and renews the certificate for the build host's
+  tailnet DNS name, terminates HTTPS, and proxies to the build-host loopback
+  origin.
 
 **Tailscale Serve is private to the tailnet.** The viewer must be authenticated
 to the tailnet, and tailnet policy must permit access. **Tailscale Funnel is
@@ -42,10 +43,10 @@ public Internet exposure and must not be used for review demos.** Do not run
 public ingress without explicit user approval.
 
 Serve is the repository-standard shared HTTPS terminator, not the only way to
-obtain HTTPS. A gateway operator could instead use `tailscale cert` with a
-custom TLS server, or a LAN operator could provide another certificate trusted
-by the viewer. Those alternatives add private-key handling, certificate
-renewal, and server configuration that Serve owns in this workflow.
+obtain HTTPS. A build-host operator could instead use `tailscale cert` with a
+custom TLS server, or provide another certificate trusted by the viewer. Those
+alternatives add private-key handling, certificate renewal, and server
+configuration that Serve owns in this workflow.
 
 ## Common prerequisites
 
@@ -54,7 +55,8 @@ The build host needs:
 - the exact branch in its own clean development worktree;
 - the repository-selected .NET SDK and WebAssembly workload;
 - Node.js at the version required by `prototypes/inspect-web/package.json`;
-- SSH access from the viewer or gateway, depending on the selected pattern.
+- SSH access from the viewer when using viewer-side forwarding; or
+- a user-provided standing Serve session on the build host when using Serve.
 
 Use these build-host variables:
 
@@ -62,8 +64,9 @@ Use these build-host variables:
 export DEMO_BUILD_ORIGIN_PORT=5198
 ```
 
-Choose a different port only when `5198` is already owned. Inspect the current
-listener instead of killing an unknown process.
+For viewer-side SSH, choose a different port only when `5198` is already owned.
+For Serve, use the build-host loopback origin port supplied with the session.
+Inspect the current listener instead of killing an unknown process.
 
 ## 1. Establish the exact candidate
 
@@ -176,8 +179,8 @@ claim direct-path routes such as `/credits` as validated through this host.
 ## Pattern A: viewer-side SSH forwarding
 
 Use this pattern by default. It requires the viewer to have SSH access to the
-build host but requires no gateway, tailnet, certificate, or network-facing
-application listener.
+build host but requires no tailnet, certificate, or network-facing application
+listener.
 
 On the viewer machine, choose an unused loopback port and start the forward:
 
@@ -221,86 +224,41 @@ The loopback URL belongs to the viewer machine. Do not replace it with the
 build host's LAN address or tailnet name; doing so loses the browser's loopback
 secure-context treatment.
 
-## Pattern B: Tailscale Serve through a stable gateway
+## Pattern B: Tailscale Serve on the build host
 
 Use this pattern when the user has indicated that a Tailscale Serve session is
-available. It has three hops:
+available on the build host:
 
 ```text
 viewer browser
   -> HTTPS over the private tailnet
-  -> Tailscale Serve on the gateway
-  -> gateway loopback port
-  -> SSH reverse tunnel
+  -> Tailscale Serve on the build host
   -> build-host loopback static server
 ```
 
 One Serve session can contain multiple path mappings and can be reconfigured
 after it starts. This runbook deliberately treats the user-provided mapping as
-fixed: one tailnet HTTPS URL and path proxies to one assigned gateway loopback
-port. Keep that mapping configured between web-development demos, but attach
-the reverse tunnel and origin only while a demo is active.
+fixed: one tailnet HTTPS URL and path proxies to one assigned build-host
+loopback port. Keep that mapping configured between web-development demos, but
+run the Vite origin only while a demo is active.
 
 The agent does not inspect or change the Serve session and needs no Tailscale
 operator access. Never reset, replace, or add mappings to the session. When the
 user has not indicated that a session is available, use viewer-side SSH
 forwarding instead.
 
-On the build host, set the environment-specific gateway values:
+Before starting Vite in step 3, set the values supplied with the session:
 
 ```bash
-export DEMO_GATEWAY_HOST="<gateway SSH host>"
-export DEMO_PUBLIC_HOST="<gateway tailnet DNS name>"
+export DEMO_PUBLIC_HOST="<build-host tailnet DNS name>"
 export DEMO_HTTPS_PORT="<assigned HTTPS port>"
-export DEMO_GATEWAY_ORIGIN_PORT="<assigned gateway loopback port>"
-export DEMO_BUILD_ORIGIN_PORT=5198
+export DEMO_BUILD_ORIGIN_PORT="<assigned build-host loopback port>"
 ```
 
-Use the values supplied with the available session. Do not discover alternative
-gateways or routes, and do not commit private network configuration to the
-repository.
-
-Before attaching the tunnel, confirm that no process already owns the assigned
-gateway loopback port:
-
-```bash
-ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
-```
-
-An occupied gateway origin may belong to another demo. Coordinate its teardown;
-do not kill an unknown process or run `tailscale serve reset`.
-
-Keep the reverse tunnel in a dedicated persistent terminal or tmux window:
-
-```bash
-ssh -N -T \
-  -o BatchMode=yes \
-  -o ExitOnForwardFailure=yes \
-  -o ServerAliveInterval=30 \
-  -o ServerAliveCountMax=3 \
-  -R "127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}:127.0.0.1:${DEMO_BUILD_ORIGIN_PORT}" \
-  "$DEMO_GATEWAY_HOST"
-```
-
-Verify the forwarded origin from the gateway:
-
-```bash
-ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "curl -fsSI http://127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}/"
-```
-
-Confirm the existing HTTPS mapping from the gateway without changing it:
-
-```bash
-ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "curl -fsSI https://${DEMO_PUBLIC_HOST}:${DEMO_HTTPS_PORT}/"
-```
-
-The build host may be unable to reach the gateway's tailnet listener because of
-tailnet policy even while the gateway and viewer can. A timeout from the build
-host does not justify falling back to an insecure network URL. Check each hop
-separately and obtain the viewer-browser proof below.
+Do not discover alternative machines or routes, and do not commit private
+network configuration to the repository. Starting Vite on the assigned
+loopback port connects the existing Serve mapping directly; no SSH tunnel or
+other proxy process is involved.
 
 The browser URL is:
 
@@ -346,7 +304,7 @@ For a new head:
 1. Stop the build-host static server.
 2. Build and publish the new head completely.
 3. Restart the static server against the new `wwwroot`.
-4. Re-establish the selected tunnel.
+4. Re-establish the viewer-side tunnel when using SSH; leave Serve unchanged.
 5. Re-run the origin, end-to-end HTTP or HTTPS, and browser checks.
 6. Send a new URL with the new short head.
 
@@ -357,10 +315,9 @@ For viewer-side SSH forwarding:
 
 For Tailscale Serve:
 
-1. Stop the reverse tunnel by its terminal or exact PID.
-2. Stop the build-host static server by its terminal or exact PID.
-3. Verify the gateway origin no longer answers.
-4. Leave the shared Serve mapping in place unless its operator explicitly asks
+1. Stop the build-host static server by its terminal or exact PID.
+2. Verify the build-host loopback origin no longer answers.
+3. Leave the shared Serve mapping in place unless its operator explicitly asks
    for removal.
 
 Never leave a URL advertised after its tunnel or exact artifact is gone. Never
@@ -373,9 +330,8 @@ silently repoint an existing build-tagged URL to unrelated work.
 | Build-host origin fails | Publish or static server | Check `site_root`, process, and the required published files |
 | SSH exits immediately | Port ownership or authentication | Keep `ExitOnForwardFailure`; inspect the named port and SSH access |
 | Viewer HTTP works but browser reports insecure context | Wrong URL | Use viewer loopback, not the build host's LAN or tailnet address |
-| Gateway origin fails | Reverse tunnel | Check the tunnel terminal and both loopback ports |
-| Serve returns 502/503 | Serve cannot reach its origin | Restore the reverse tunnel; do not replace the Serve route |
-| Serve times out only on the build host | Tailnet policy | Validate on the gateway and an authorized viewer |
+| Serve returns 502/503 | Vite is absent or on the wrong loopback port | Start Vite on the session's assigned origin; do not change Serve |
+| Serve is unavailable to the viewer | Session or tailnet policy | Report the failure; do not discover another route or enable Funnel |
 | Vite reports a disallowed host | Missing exact Serve hostname | Restart with `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` set to the tailnet DNS name |
 | Fingerprinted loader or bundled assets are empty or missing | Wrong artifact or host | Re-publish and serve the complete `wwwroot` |
 | Page paints but controls remain inert | Wasm engine did not initialize | Inspect framework requests and browser console; HTTP 200 alone is not success |

--- a/docs/runbooks/inspect-web-demo-hosting.md
+++ b/docs/runbooks/inspect-web-demo-hosting.md
@@ -1,81 +1,70 @@
 # Hosting an inspect-web demo
 
 This runbook describes how to publish a worktree's inspect-web site so a user
-on another tailnet-connected machine can validate in-progress work.
+on another network-connected machine can validate in-progress work.
 
-The repository-standard demo topology has two roles:
+Use one of two private hosting patterns:
 
-1. The **build host** publishes the exact worktree and serves the resulting
-   static site on loopback.
-2. A stable **HTTPS gateway** receives that loopback service through an SSH
-   reverse tunnel and exposes it with Tailscale Serve.
+1. **Viewer-side SSH forwarding (preferred):** the viewer forwards a local
+   loopback port over SSH to the build host's loopback static server.
+2. **Tailscale Serve:** a stable gateway receives the static server through an
+   SSH reverse tunnel and exposes it to authenticated tailnet clients over
+   HTTPS.
 
-```text
-user browser
-  -> HTTPS over the tailnet
-  -> Tailscale Serve on the gateway
-  -> gateway loopback port
-  -> SSH reverse tunnel
-  -> build-host loopback static server
-  -> published wwwroot for one exact Git head
-```
+Both patterns keep the static server bound to loopback. The preferred pattern
+opens no application port on either network; it reuses the build host's
+existing SSH access. Use Tailscale Serve when a stable shared URL is more
+important than the additional gateway and tailnet dependencies.
 
 This is a review demo, not a production deployment. The production site follows
 the release workflow instead.
 
-## Why this topology
+## Browser security and network scope
 
-- Remote .NET WebAssembly requires HTTPS because its loader uses secure-context
-  browser APIs.
-- The published `wwwroot` is the artifact users will eventually receive. Vite
-  and `dotnet run` are development hosts and are not substitutes for it.
-- Both origin ports bind to loopback. The tailnet gateway is the only
-  network-facing listener.
-- The gateway URL remains stable while the implementation worktree and build
-  host can change.
+The .NET browser runtime requires secure-context browser APIs. Browsers treat
+HTTP loopback origins such as `http://127.0.0.1` as potentially trustworthy,
+but do not extend that exception to an ordinary LAN address. Proxying a
+loopback server to `http://<lan-address>` therefore does not solve the
+secure-context requirement: the browser judges the URL it loaded, not the
+proxy's upstream.
+
+The two supported patterns satisfy that requirement differently:
+
+- A viewer-side SSH forward gives the browser a loopback URL. SSH protects the
+  connection to the build host, so no browser certificate is needed.
 - Tailscale Serve obtains and renews the certificate for the gateway's tailnet
-  DNS name, terminates HTTPS, and proxies to the loopback origin. It remains
-  tailnet-only; do not use Tailscale Funnel for a review demo.
+  DNS name, terminates HTTPS, and proxies to a gateway loopback origin.
 
-Tailscale Serve is the repository-standard HTTPS terminator, not a technical
-requirement. A gateway operator could instead obtain a certificate with
-`tailscale cert` and configure Caddy, nginx, or another TLS server. That
-alternative adds private-key handling, certificate renewal, and server
-configuration that Serve owns for this workflow. A directly reachable build
-host could also terminate HTTPS under its own tailnet DNS name, but would give
-up the stable gateway URL and change the network-exposure model. Keep those
-alternatives operator decisions rather than improvising them during a demo.
+**Tailscale Serve is private to the tailnet.** The viewer must be authenticated
+to the tailnet, and tailnet policy must permit access. **Tailscale Funnel is
+public Internet exposure and must not be used for review demos.** Do not run
+`tailscale funnel`, enable Funnel for a Serve route, or substitute another
+public ingress without explicit user approval.
 
-The gateway route is shared infrastructure. It can present only one demo on a
-given origin port at a time. Inspect its current owner before taking it over,
-and never reset or replace an unknown route.
+Serve is the repository-standard shared HTTPS terminator, not the only way to
+obtain HTTPS. A gateway operator could instead use `tailscale cert` with a
+custom TLS server, or a LAN operator could provide another certificate trusted
+by the viewer. Those alternatives add private-key handling, certificate
+renewal, and server configuration that Serve owns in this workflow.
 
-## Prerequisites
+## Common prerequisites
 
 The build host needs:
 
 - the exact branch in its own clean development worktree;
 - the repository-selected .NET SDK and WebAssembly workload;
 - Node.js at the version required by `prototypes/inspect-web/package.json`;
-- Python 3 for the static server;
-- SSH access to the gateway; and
-- Tailscale connectivity.
+- Python 3 for the loopback static server; and
+- SSH access from the viewer or gateway, depending on the selected pattern.
 
-The gateway needs the repository-standard Tailscale Serve route configured once
-by its operator. The examples below use these variables so hostnames remain
-environment configuration rather than repository policy:
+Use these build-host variables:
 
 ```bash
-export DEMO_GATEWAY_HOST="<gateway SSH host>"
-export DEMO_PUBLIC_HOST="<gateway tailnet DNS name>"
-export DEMO_HTTPS_PORT=8443
-export DEMO_GATEWAY_ORIGIN_PORT=5199
 export DEMO_BUILD_ORIGIN_PORT=5198
 ```
 
-Use the gateway values supplied for the current environment. Do not infer a
-gateway from an arbitrary machine name or commit private network configuration
-to the repository.
+Choose a different port only when `5198` is already owned. Inspect the current
+listener instead of killing an unknown process.
 
 ## 1. Establish the exact candidate
 
@@ -91,16 +80,6 @@ git status --short --branch
 Do not demo an uncommitted tree unless the user explicitly asks to inspect
 uncommitted work. In that exceptional case, say so beside the URL; a Git SHA
 cannot identify the content they are seeing.
-
-Before replacing the shared demo, inspect the gateway:
-
-```bash
-ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
-  "tailscale serve status; ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
-```
-
-An occupied gateway origin may belong to another demo. Coordinate its teardown;
-do not kill an unknown process or run `tailscale serve reset`.
 
 ## 2. Build the production artifact
 
@@ -130,11 +109,16 @@ target_framework="$(
     -nologo -getProperty:TargetFramework
 )"
 site_root="$repo_root/prototypes/inspect-web/engine/bin/Release/$target_framework/publish/wwwroot"
+dotnet_loader="$(
+  grep -oE '_framework/dotnet\.[a-z0-9]+\.js' "$site_root/index.html" |
+    head -n 1
+)"
 
 test -f "$site_root/index.html"
 test -f "$site_root/manifest.json"
 test -f "$site_root/inspect-web-engine.js"
-test -f "$site_root/_framework/dotnet.js"
+test -n "$dotnet_loader"
+test -f "$site_root/$dotnet_loader"
 ```
 
 Publish before starting the static server. For a later update, stop the server,
@@ -143,14 +127,14 @@ while `dotnet publish` is rewriting it.
 
 Do not use:
 
-- `vite` or `vite preview` — the demo must include the published .NET engine,
+- `vite` or `vite preview` - the demo must include the published .NET engine,
   and Vite also applies host allow-list behavior;
-- `dotnet run` as the remote proof — the WebAssembly development host has
+- `dotnet run` as the remote proof - the WebAssembly development host has
   previously served fingerprinted assets incorrectly in this workflow; or
-- the frontend `dist/` directory — it does not contain the complete published
+- the frontend `dist/` directory - it does not contain the complete published
   WebAssembly site.
 
-## 3. Serve the published site on loopback
+## 3. Serve the published site on build-host loopback
 
 Keep this process in a dedicated persistent terminal or tmux window:
 
@@ -168,16 +152,109 @@ From another terminal on the build host:
 ```bash
 curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/"
 curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/inspect-web-engine.js"
-curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/_framework/dotnet.js"
+curl -fsSI "http://127.0.0.1:$DEMO_BUILD_ORIGIN_PORT/$dotnet_loader"
 ```
 
 The simple static host supports the root and query-string workspace links used
 for demos. It does not implement Azure Static Web Apps route fallback; do not
 claim direct-path routes such as `/credits` as validated through this host.
 
-## 4. Open the reverse tunnel
+## Pattern A: viewer-side SSH forwarding
 
-Keep the tunnel in a second dedicated persistent terminal or tmux window:
+Use this pattern by default. It requires the viewer to have SSH access to the
+build host but requires no gateway, tailnet, certificate, or network-facing
+application listener.
+
+On the viewer machine, choose an unused loopback port and start the forward:
+
+```bash
+export DEMO_BUILD_HOST="<build-host SSH name>"
+export DEMO_BUILD_ORIGIN_PORT=5198
+export DEMO_VIEWER_PORT=5198
+
+ssh -N -T \
+  -o ExitOnForwardFailure=yes \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -L "127.0.0.1:${DEMO_VIEWER_PORT}:127.0.0.1:${DEMO_BUILD_ORIGIN_PORT}" \
+  "$DEMO_BUILD_HOST"
+```
+
+`ExitOnForwardFailure` is required. Without it, SSH can remain alive after
+failing to claim the viewer port, leaving a success-shaped process that serves
+nothing.
+
+Keep the tunnel in a dedicated terminal. From another viewer terminal, verify
+the complete path:
+
+```bash
+curl -fsSI "http://127.0.0.1:$DEMO_VIEWER_PORT/"
+dotnet_loader="$(
+  curl -fsS "http://127.0.0.1:$DEMO_VIEWER_PORT/" |
+    grep -oE '_framework/dotnet\.[a-z0-9]+\.js' |
+    head -n 1
+)"
+curl -fsSI "http://127.0.0.1:$DEMO_VIEWER_PORT/$dotnet_loader"
+```
+
+The browser URL is:
+
+```text
+http://127.0.0.1:<DEMO_VIEWER_PORT>/?package=...&w=...&build=<short-head>
+```
+
+The loopback URL belongs to the viewer machine. Do not replace it with the
+build host's LAN address or tailnet name; doing so loses the browser's loopback
+secure-context treatment.
+
+## Pattern B: Tailscale Serve through a stable gateway
+
+Use this pattern when the viewer already has tailnet access and needs a stable
+shared HTTPS URL. It has three hops:
+
+```text
+viewer browser
+  -> HTTPS over the private tailnet
+  -> Tailscale Serve on the gateway
+  -> gateway loopback port
+  -> SSH reverse tunnel
+  -> build-host loopback static server
+```
+
+The gateway route is shared infrastructure. It can present only one demo on a
+given origin port at a time. Inspect its current owner before taking it over,
+and never reset or replace an unknown route.
+
+An existing gateway operator must own Tailscale Serve changes. Do not grant an
+agent account Tailscale operator access merely to publish or test one demo; that
+permission controls more than Serve. When no authorized operator is available,
+the Serve pattern is unavailable and the viewer-side SSH pattern remains the
+safe default.
+
+On the build host, set the environment-specific gateway values:
+
+```bash
+export DEMO_GATEWAY_HOST="<gateway SSH host>"
+export DEMO_PUBLIC_HOST="<gateway tailnet DNS name>"
+export DEMO_HTTPS_PORT=8443
+export DEMO_GATEWAY_ORIGIN_PORT=5199
+export DEMO_BUILD_ORIGIN_PORT=5198
+```
+
+Do not infer a gateway from an arbitrary machine name or commit private network
+configuration to the repository.
+
+Before replacing the shared demo, inspect the gateway:
+
+```bash
+ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
+  "tailscale serve status; ss -ltn | grep ':${DEMO_GATEWAY_ORIGIN_PORT} ' || true"
+```
+
+An occupied gateway origin may belong to another demo. Coordinate its teardown;
+do not kill an unknown process or run `tailscale serve reset`.
+
+Keep the reverse tunnel in a dedicated persistent terminal or tmux window:
 
 ```bash
 ssh -N -T \
@@ -189,20 +266,14 @@ ssh -N -T \
   "$DEMO_GATEWAY_HOST"
 ```
 
-`ExitOnForwardFailure` is required. Without it, SSH can remain alive after
-failing to claim the gateway port, leaving a success-shaped tunnel process that
-serves nothing.
-
-Verify the origin from the gateway:
+Verify the forwarded origin from the gateway:
 
 ```bash
 ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
   "curl -fsSI http://127.0.0.1:${DEMO_GATEWAY_ORIGIN_PORT}/"
 ```
 
-## 5. Confirm the HTTPS route
-
-The gateway operator configures the route once:
+The gateway operator configures the private Serve route once:
 
 ```bash
 tailscale serve --bg \
@@ -221,19 +292,21 @@ ssh -o BatchMode=yes "$DEMO_GATEWAY_HOST" \
   "curl -fsSI https://${DEMO_PUBLIC_HOST}:${DEMO_HTTPS_PORT}/"
 ```
 
-The build host may be unable to reach the gateway's public tailnet listener
-because of ACL or routing policy even while the gateway and user can. A timeout
-from the build host does not justify falling back to insecure HTTP. Check each
-hop separately and obtain the external browser proof below.
+The build host may be unable to reach the gateway's tailnet listener because of
+tailnet policy even while the gateway and viewer can. A timeout from the build
+host does not justify falling back to an insecure network URL. Check each hop
+separately and obtain the viewer-browser proof below.
 
-## 6. Give the user an identifiable URL
-
-Start with the application-generated workspace link, then append the candidate
-head as a cache-busting build parameter:
+The browser URL is:
 
 ```text
 https://<DEMO_PUBLIC_HOST>:<DEMO_HTTPS_PORT>/?package=...&w=...&build=<short-head>
 ```
+
+## Give the user an identifiable URL
+
+Start with the application-generated workspace link for the selected pattern,
+then append the candidate head as a cache-busting `build` parameter.
 
 Use `?build=` for a bare root URL and `&build=` when the URL already has a
 query. The build value identifies the intended candidate and forces a distinct
@@ -245,21 +318,21 @@ State all three:
 - the exact full Git head; and
 - what interaction or output the user should validate.
 
-## 7. Validate from a user-equivalent browser
+## Validate from the viewer's browser
 
 An origin returning HTTP 200 is necessary but insufficient. The demo is ready
-only after a separate tailnet-connected browser proves that:
+only after the viewer's browser proves that:
 
-1. HTTPS loads without a certificate or secure-context error.
+1. The page loads without a certificate or secure-context error.
 2. The .NET engine reaches its ready state.
 3. The exact changed scenario works through real pointer and keyboard input.
 4. A hard refresh of the complete workspace URL restores the same view.
 5. Browser back and forward work when navigation is part of the change.
 6. The browser console has no startup or module-loading error.
 
-Prefer the user's machine for final acceptance. An automated browser on another
-tailnet peer is useful preflight evidence, but it does not replace the user's
-validation when the purpose of the demo is UX feedback.
+Prefer the user's machine for final acceptance. An automated browser exercising
+the same URL shape is useful preflight evidence, but it does not replace the
+user's validation when the purpose of the demo is UX feedback.
 
 ## Updating and teardown
 
@@ -268,17 +341,22 @@ For a new head:
 1. Stop the build-host static server.
 2. Build and publish the new head completely.
 3. Restart the static server against the new `wwwroot`.
-4. Keep or re-establish the reverse tunnel.
-5. Re-run the origin, gateway, HTTPS, and browser checks.
+4. Re-establish the selected tunnel.
+5. Re-run the origin, end-to-end HTTP or HTTPS, and browser checks.
 6. Send a new URL with the new short head.
 
-When the demo is no longer needed:
+For viewer-side SSH forwarding:
+
+1. Stop the viewer-side tunnel by its terminal or exact PID.
+2. Stop the build-host static server by its terminal or exact PID.
+
+For Tailscale Serve:
 
 1. Stop the reverse tunnel by its terminal or exact PID.
 2. Stop the build-host static server by its terminal or exact PID.
 3. Verify the gateway origin no longer answers.
-4. Leave the shared Tailscale Serve mapping in place unless its operator
-   explicitly asks for removal.
+4. Leave the shared Serve mapping in place unless its operator explicitly asks
+   for removal.
 
 Never leave a URL advertised after its tunnel or exact artifact is gone. Never
 silently repoint an existing build-tagged URL to unrelated work.
@@ -287,12 +365,13 @@ silently repoint an existing build-tagged URL to unrelated work.
 
 | Symptom | Likely boundary | Response |
 | --- | --- | --- |
-| Local origin fails | Publish or static server | Check `site_root`, process, and the four required files |
-| SSH exits immediately | Gateway port or authentication | Keep `ExitOnForwardFailure`; inspect ownership instead of choosing random processes to kill |
+| Build-host origin fails | Publish or static server | Check `site_root`, process, and the required published files |
+| SSH exits immediately | Port ownership or authentication | Keep `ExitOnForwardFailure`; inspect the named port and SSH access |
+| Viewer HTTP works but browser reports insecure context | Wrong URL | Use viewer loopback, not the build host's LAN or tailnet address |
 | Gateway origin fails | Reverse tunnel | Check the tunnel terminal and both loopback ports |
-| HTTPS returns 502/503 | Serve mapping reaches no origin | Restore the tunnel; do not replace the HTTPS route |
-| HTTPS times out only on build host | Tailnet ACL/routing | Validate on the gateway and a user-equivalent peer |
+| Serve returns 502/503 | Serve cannot reach its origin | Restore the reverse tunnel; do not replace the Serve route |
+| Serve times out only on the build host | Tailnet policy | Validate on the gateway and an authorized viewer |
 | Vite reports a disallowed host | Wrong server | Serve the published `wwwroot`, not Vite |
-| `dotnet.js` or bundled assets are empty/missing | Wrong artifact or host | Re-publish and use the static `wwwroot` host |
+| `dotnet.js` or bundled assets are empty or missing | Wrong artifact or host | Re-publish and use the static `wwwroot` |
 | Page paints but controls remain inert | Wasm engine did not initialize | Inspect framework requests and browser console; HTTP 200 alone is not success |
 | User sees an older build | Stale URL or wrong served worktree | Confirm full head, restart from its `wwwroot`, and issue a new `build=<short-head>` URL |

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -570,7 +570,10 @@ Open `http://127.0.0.1:5198`. Create a deployable static bundle with
 `npm run build && dotnet publish -c Release` from the same directories shown
 above. The TypeScript check is part of both `npm run build` and `npm test`.
 Remote addresses require HTTPS because the .NET loader uses secure-context
-browser APIs.
+browser APIs. For private cross-machine demos, follow
+[`docs/runbooks/inspect-web-demo-hosting.md`](../../docs/runbooks/inspect-web-demo-hosting.md);
+the preferred SSH-forwarding pattern preserves a browser-loopback URL without
+exposing an application port.
 
 On a bare visit, `dotnet-inspect.ts` waits for the home page's first contentful paint
 before dynamically importing `inspect-web-engine.js`. Search and demo controls


### PR DESCRIPTION
## Summary

- define two private, single-host demo patterns; the only second machine is the viewer
- prefer viewer-side SSH forwarding, where the viewer browses its own forwarded loopback URL
- support a user-provided standing Tailscale Serve mapping directly to Vite on the same host loopback; agents never inspect or reconfigure Serve
- use the repository-pinned Vite preview server over the complete published `wwwroot`; Python is not required
- explicitly prohibit Tailscale Funnel and other public ingress for review demos
- document publication, fingerprinted loader checks, browser validation, update, teardown, and failure diagnosis
- register the runbook in `AGENTS.md` and link it from the inspect-web README

## Validation

- `npx markdownlint-cli AGENTS.md docs/runbooks/inspect-web-demo-hosting.md prototypes/inspect-web/README.md`
- `git diff --check`
- rebuilt the frontend and republished the Release Wasm artifact
- viewer-side SSH path: Chromium reached `browser wasm ready` with no console, page, or request failures
- single-host Serve path: Vite and the existing unchanged tailnet-only Serve mapping ran on the same host; loopback and HTTPS returned 200 and Chromium reached `browser wasm ready`
- exact test origins and viewer tunnels were stopped; the pre-existing Serve mapping remains configured with no live origin

Docs-only change; no product behavior changes. PR #4710 separately makes Markdown-only inspect-web changes skip the expensive web CI lane.