### PR TITLE
Run inspect-web home demos through product plans

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -446,14 +446,16 @@ the workspace, focus, section, and optional member anchor, opens one aggregate
 browser workspace, and returns its package surfaces plus exact activation
 identity. The focused `BrowserTypeSurface.Api` rows are the browser's ordinary
 Methods-section output; a member-bound run additionally returns the ordinary
-Call Graph projection. The engine rejects other product sections and
-library-scoped views until Browser has explicit execution support rather than
-silently dropping either binding. These properties are gated by
+Call Graph projection. The engine rejects other product sections,
+library-scoped views, and runtime-identifier-scoped package workspaces until
+Browser has explicit execution support rather than silently dropping those
+bindings. These properties are gated by
 `ToRunPlan_AllProductHomeDemosHaveSupportedBrowserShape`,
 `StjSerializer_RunPlanOwnsTypeOnlyMethodsSelection`,
 `ToRunPlan_DerivesNonFirstFocusForTypeOnlyMethodsView`,
 `ToRunPlan_RejectsUnsupportedBrowserSection`,
 `ToRunPlan_RejectsLibraryScopedView`,
+`ToRunPlan_RejectsRuntimeIdentifierScopes`,
 `ToRunPlan_RejectsFocusOutsideSelectedContext`,
 `HomeDemoRunCore_ProjectsTypeOnlyMethodsSurface`, and
 `HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`.

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -440,23 +440,43 @@ output from the existing pipelines; multi-package workspaces encode extra
 package members as `--caller-package` for the call-graph demo. **inspect-web**
 loads home-demo catalog and coordinates from the product registry through the
 browser engine (`ListHomeDemos` / `ResolveHomeDemo` /
-`RunHomeDemo` over `ProductInspectionDemos`); host-only share encoding and the
-residual platform → `Microsoft.NETCore.App` runtime-pack mapping (for future
-platform members) live in
-`prototypes/inspect-web/src/product-home-demos.ts`. STJ restores via share deep
-links built from the resolved projection. The member-bound Call Graph button
-passes only the product scenario id to `RunHomeDemo`; the engine resolves the
-workspace, focus, member anchor, and section, opens one aggregate browser
-workspace, and returns its package surfaces, exact activation identity, and
-ordinary Call Graph projection. TypeScript applies that typed result to the UI
-without parsing definition member keys or reconstructing package/query inputs.
+`RunHomeDemo` over `ProductInspectionDemos`). `RunHomeDemo` accepts both
+type-only `Methods` and member-bound `Call Graph` presets: the engine resolves
+the workspace, focus, section, and optional member anchor, opens one aggregate
+browser workspace, and returns its package surfaces plus exact activation
+identity. The focused `BrowserTypeSurface.Api` rows are the browser's ordinary
+Methods-section output; a member-bound run additionally returns the ordinary
+Call Graph projection. The engine rejects other product sections and
+library-scoped views until Browser has explicit execution support rather than
+silently dropping either binding. These properties are gated by
+`ToRunPlan_AllProductHomeDemosHaveSupportedBrowserShape`,
+`StjSerializer_RunPlanOwnsTypeOnlyMethodsSelection`,
+`ToRunPlan_DerivesNonFirstFocusForTypeOnlyMethodsView`,
+`ToRunPlan_RejectsUnsupportedBrowserSection`,
+`ToRunPlan_RejectsLibraryScopedView`,
+`ToRunPlan_RejectsFocusOutsideSelectedContext`,
+`HomeDemoRunCore_ProjectsTypeOnlyMethodsSurface`, and
+`HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`.
+
+This engine capability does not yet change the home buttons. The current
+TypeScript still restores STJ through a share deep link built from the resolved
+projection and invokes `RunHomeDemo` for Call Graph. The frontend follow-up
+must apply the typed Methods result and then push a canonical shareable
+location; calling the engine without updating location would regress refresh
+and sharing. That follow-up can then delete the host-owned share encoding and
+the residual platform → `Microsoft.NETCore.App` runtime-pack mapping (for
+future platform members) from
+`prototypes/inspect-web/src/product-home-demos.ts`. TypeScript applies the
+current Call Graph result without parsing definition member keys or
+reconstructing package/query inputs.
 Browser package scopes now adapt product-selected, product-realized package
 participants into Browser coordinate/asset provenance; Browser still owns Wasm
 transport, cache/deadline/lifetime policy, and its resource-limit values.
 Residual: (1) minted facet ids replacing display-name allow list; (2) realize
 definitions via `WorkspaceContextLoader` instead of CLI package/
-`--caller-package` encoding and the browser runtime-pack share encoding for
-platform; (3) Call Graph / Callers structured JSON projection remains the
+`--caller-package` encoding; (3) canonical frontend activation of every home
+demo, including share-location projection and deletion of browser-owned packet
+construction; (4) Call Graph / Callers structured JSON projection remains the
 shared member-pipeline gap (Markdown/Mermaid are the faithful graph formats
 today).
 
@@ -1077,8 +1097,11 @@ Definition records and product demos (this slice):
   including `--mermaid` and fail-closed Call Graph `--json`;
 - `InspectionDefinitionTests` / `DemoCommandTests` gate round-trip, separation,
   demo-parity, section binding, CLI lowering, and real section output for the
-  product home demos; inspect-web's generated `RunHomeDemo` binding runs the
-  member-bound Call Graph preset from its product scenario id;
+  product home demos; inspect-web's generated `RunHomeDemo` binding runs both
+  type-only Methods and member-bound Call Graph presets from their product
+  scenario ids. `BrowserProductHomeDemosTests` gates host-plan lowering and
+  unsupported bindings; `BrowserEngineBoundaryTests` gates nonempty Methods
+  projection and anchored Call Graph execution;
 - `WorkspaceSharePacketCodec` decodes and canonically re-emits the bounded v1
   base64url packet into an immutable product-owned semantic model. It rejects
   legacy prototype packets, malformed or non-canonical encoding and JSON,

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -1048,8 +1048,11 @@ Implementation must add, at minimum:
   resolve the static product-registry scenario to `WorkspaceMemberCoordinate`
   plans, member anchor `74b6b4b321`, browser workspace requests, and exact
   activation identity;
-  `BrowserProductHomeDemosTests.ToCallGraphRunPlan_DerivesNonFirstFocusFromNavigation`
-  gates non-first focus derivation from the product navigation plan;
+  `BrowserProductHomeDemosTests.ToRunPlan_DerivesNonFirstFocusForTypeOnlyMethodsView`
+  gates type-only Methods lowering and non-first focus derivation from the
+  product navigation plan;
+  `BrowserEngineBoundaryTests.HomeDemoRunCore_ProjectsTypeOnlyMethodsSurface`
+  gates the real projected type/member surface and expected fixture methods;
   `BrowserEngineBoundaryTests.HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`
   gates aggregate workspace projection, non-first focus consumption,
   digest-prefix selection, and graph execution;

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -10,6 +10,7 @@ using System.Xml;
 using System.Text.Json;
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
+using DotnetInspector.Queries.Definitions;
 using DotnetInspector.Services;
 using ILInspector.Analysis;
 using ILInspector.CallGraph;
@@ -2853,6 +2854,74 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void HomeDemoRunCore_ProjectsTypeOnlyMethodsSurface()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string packageId = $"Home.Demo.Methods.{suffix}";
+        string peerPackageId = $"Home.Demo.Methods.Peer.{suffix}";
+        string assemblyPath =
+            typeof(BrowserEngineBoundaryTests).Assembly.Location;
+        string peerAssemblyPath = typeof(BrowserPackage).Assembly.Location;
+        BrowserPackageCoordinate coordinate = Coordinate(
+            packageId,
+            Package(
+                File.ReadAllBytes(assemblyPath),
+                $"lib/net11.0/{Path.GetFileName(assemblyPath)}"));
+        BrowserPackageCoordinate peerCoordinate = Coordinate(
+            peerPackageId,
+            Package(
+                File.ReadAllBytes(peerAssemblyPath),
+                $"lib/net11.0/{Path.GetFileName(peerAssemblyPath)}"));
+        BrowserInspectionScope scope =
+            BrowserPackageWorkspace.OpenScope(
+                [peerCoordinate, coordinate]);
+        try
+        {
+            var plan = new BrowserHomeDemoRunPlan(
+                [
+                    new BrowserPackageRequest(
+                        peerPackageId,
+                        "1.0.0",
+                        "net11.0"),
+                    new BrowserPackageRequest(
+                        packageId,
+                        "1.0.0",
+                        "net11.0"),
+                ],
+                FocusRequestIndex: 1,
+                typeof(BrowserEngineBoundaryTests).FullName!,
+                ProductDemoSections.Methods,
+                Member: null);
+            var resolution = new BrowserScopeResolution(
+                scope,
+                [peerCoordinate, coordinate]);
+
+            BrowserHomeDemoRunResult result =
+                InspectionEngine.RunHomeDemoCore(plan, resolution);
+
+            Assert.True(result.Found);
+            Assert.Equal(2, result.Packages.Length);
+            Assert.Equal(ProductDemoSections.Methods, result.Activation?.Section);
+            Assert.Null(result.Activation?.MemberName);
+            Assert.Null(result.Activation?.MemberSection);
+            Assert.Null(result.CallGraph);
+            BrowserTypeSurface type = Assert.Single(
+                result.Packages[1].Types,
+                candidate => candidate.Id
+                    == typeof(BrowserEngineBoundaryTests).FullName);
+            Assert.NotEmpty(type.Api);
+            Assert.Equal(
+                2,
+                type.Api.Count(member =>
+                    member.Name == nameof(HomeDemoRunFixture)));
+        }
+        finally
+        {
+            BrowserPackageWorkspace.RemoveScope(scope);
+        }
+    }
+
+    [Fact]
     public void HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph()
     {
         string suffix = Guid.NewGuid().ToString("N");
@@ -2902,10 +2971,12 @@ public sealed class BrowserEngineBoundaryTests
                 ],
                 FocusRequestIndex: 1,
                 type.Id,
-                member.Name,
-                member.Kind,
-                member.AnchorDigest[..6],
-                MemberSection: "call-graph");
+                ProductDemoSections.CallGraph,
+                new BrowserHomeDemoRunMember(
+                    member.Name,
+                    member.Kind,
+                    member.AnchorDigest[..6],
+                    MemberSection: "call-graph"));
             var resolution = new BrowserScopeResolution(
                 scope,
                 [peerCoordinate, coordinate]);
@@ -2915,6 +2986,7 @@ public sealed class BrowserEngineBoundaryTests
 
             Assert.True(result.Found);
             Assert.Equal(2, result.Packages.Length);
+            Assert.Equal(ProductDemoSections.CallGraph, result.Activation?.Section);
             Assert.Equal(member.AnchorDigest, result.Activation?.MemberAnchorDigest);
             Assert.Equal("call-graph", result.Activation?.MemberSection);
             Assert.NotNull(result.CallGraph);

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2901,9 +2901,17 @@ public sealed class BrowserEngineBoundaryTests
 
             Assert.True(result.Found);
             Assert.Equal(2, result.Packages.Length);
-            Assert.Equal(ProductDemoSections.Methods, result.Activation?.Section);
-            Assert.Null(result.Activation?.MemberName);
-            Assert.Null(result.Activation?.MemberSection);
+            BrowserHomeDemoRunActivation activation =
+                Assert.IsType<BrowserHomeDemoRunActivation>(result.Activation);
+            Assert.Equal(packageId, activation.FocusPackage);
+            Assert.Equal("1.0.0", activation.FocusVersion);
+            Assert.Equal("net11.0", activation.FocusFramework);
+            Assert.Equal(
+                typeof(BrowserEngineBoundaryTests).FullName,
+                activation.TypeId);
+            Assert.Equal(ProductDemoSections.Methods, activation.Section);
+            Assert.Null(activation.MemberName);
+            Assert.Null(activation.MemberSection);
             Assert.Null(result.CallGraph);
             BrowserTypeSurface type = Assert.Single(
                 result.Packages[1].Types,
@@ -2986,9 +2994,15 @@ public sealed class BrowserEngineBoundaryTests
 
             Assert.True(result.Found);
             Assert.Equal(2, result.Packages.Length);
-            Assert.Equal(ProductDemoSections.CallGraph, result.Activation?.Section);
-            Assert.Equal(member.AnchorDigest, result.Activation?.MemberAnchorDigest);
-            Assert.Equal("call-graph", result.Activation?.MemberSection);
+            BrowserHomeDemoRunActivation activation =
+                Assert.IsType<BrowserHomeDemoRunActivation>(result.Activation);
+            Assert.Equal(packageId, activation.FocusPackage);
+            Assert.Equal("1.0.0", activation.FocusVersion);
+            Assert.Equal("net11.0", activation.FocusFramework);
+            Assert.Equal(type.Id, activation.TypeId);
+            Assert.Equal(ProductDemoSections.CallGraph, activation.Section);
+            Assert.Equal(member.AnchorDigest, activation.MemberAnchorDigest);
+            Assert.Equal("call-graph", activation.MemberSection);
             Assert.NotNull(result.CallGraph);
             Assert.False(result.CallGraph.NoBody);
             Assert.Equal(2, result.CallGraph.Scope.Packages);

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -186,6 +186,31 @@ public sealed class BrowserProductHomeDemosTests
         Assert.Contains("does not support library-scoped views", error.Message);
     }
 
+    [Theory]
+    [InlineData("context")]
+    [InlineData("package")]
+    [InlineData("navigation")]
+    public void ToRunPlan_RejectsRuntimeIdentifierScopes(string source)
+    {
+        InspectionDefinitionException error = Assert.Throws<InspectionDefinitionException>(
+            () => BrowserProductHomeDemos.ToRunPlan(
+                ResolveSyntheticScenario(
+                    ProductDemoSections.Methods,
+                    contextRuntimeIdentifier: source == "context"
+                        ? "linux-x64"
+                        : null,
+                    packageRuntimeIdentifier: source == "package"
+                        ? "linux-x64"
+                        : null,
+                    navigationRuntimeIdentifier: source == "navigation"
+                        ? "linux-x64"
+                        : null)));
+
+        Assert.Contains(
+            "does not support runtime-identifier-scoped package workspaces",
+            error.Message);
+    }
+
     [Fact]
     public void ToRunPlan_RejectsFocusOutsideSelectedContext()
     {
@@ -219,6 +244,9 @@ public sealed class BrowserProductHomeDemosTests
     private static ResolvedScenario ResolveSyntheticScenario(
         string section,
         string? library = null,
+        string? contextRuntimeIdentifier = null,
+        string? packageRuntimeIdentifier = null,
+        string? navigationRuntimeIdentifier = null,
         bool includeFocusedPackageInContext = true)
     {
         const int version = InspectionDefinitionJson.CurrentSchemaVersion;
@@ -229,7 +257,8 @@ public sealed class BrowserProductHomeDemosTests
         var second = new DefinitionMemberCoordinate.PackageCoordinate(
             "Demo.Second",
             "2.0.0",
-            "net11.0");
+            "net11.0",
+            packageRuntimeIdentifier);
         DefinitionMemberCoordinate[] contextMembers =
             includeFocusedPackageInContext ? [first, second] : [first];
         var registry = new InspectionDefinitionRegistry();
@@ -240,6 +269,7 @@ public sealed class BrowserProductHomeDemosTests
                 new WorkspaceContextDefinition(
                     "context",
                     framework: "net11.0",
+                    runtimeIdentifier: contextRuntimeIdentifier,
                     members: contextMembers),
             ]));
         registry.Add(new ViewDefinition(
@@ -253,7 +283,10 @@ public sealed class BrowserProductHomeDemosTests
             "navigation",
             [
                 new NavigationTabDefinition("first", coordinate: first),
-                new NavigationTabDefinition("second", coordinate: second),
+                new NavigationTabDefinition(
+                    "second",
+                    coordinate: second,
+                    runtimeIdentifier: navigationRuntimeIdentifier),
             ],
             focus: "second"));
         registry.Add(new ScenarioDefinition(

--- a/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserProductHomeDemosTests.cs
@@ -85,10 +85,49 @@ public sealed class BrowserProductHomeDemosTests
     }
 
     [Fact]
+    public void ToRunPlan_AllProductHomeDemosHaveSupportedBrowserShape()
+    {
+        foreach (var entry in ProductInspectionDemos.Entries)
+        {
+            BrowserHomeDemoRunPlan plan = BrowserProductHomeDemos.ToRunPlan(
+                ProductInspectionDemos.ResolveHomeScenario(entry.Id));
+
+            Assert.InRange(plan.FocusRequestIndex, 0, plan.Requests.Length - 1);
+            if (plan.Section == ProductDemoSections.Methods)
+            {
+                Assert.Null(plan.Member);
+            }
+            else
+            {
+                Assert.Equal(ProductDemoSections.CallGraph, plan.Section);
+                Assert.NotNull(plan.Member);
+            }
+        }
+    }
+
+    [Fact]
+    public void StjSerializer_RunPlanOwnsTypeOnlyMethodsSelection()
+    {
+        BrowserHomeDemoRunPlan plan =
+            BrowserProductHomeDemos.ToRunPlan(
+                ProductInspectionDemos.ResolveHomeScenario(
+                    ProductInspectionDemos.StjSerializerScenarioId));
+
+        Assert.Single(plan.Requests);
+        Assert.Equal("System.Text.Json", plan.Requests[0].PackageId);
+        Assert.Equal("10.0.0", plan.Requests[0].Version);
+        Assert.Equal("net10.0", plan.Requests[0].TargetFramework);
+        Assert.Equal(0, plan.FocusRequestIndex);
+        Assert.Equal("System.Text.Json.JsonSerializer", plan.TypeId);
+        Assert.Equal(ProductDemoSections.Methods, plan.Section);
+        Assert.Null(plan.Member);
+    }
+
+    [Fact]
     public void ExtensionsCallGraph_RunPlanOwnsWorkspaceFocusAndMemberSelection()
     {
         BrowserHomeDemoRunPlan plan =
-            BrowserProductHomeDemos.ToCallGraphRunPlan(
+            BrowserProductHomeDemos.ToRunPlan(
                 ProductInspectionDemos.ResolveHomeScenario(
                     ProductInspectionDemos.ExtensionsCallGraphScenarioId));
 
@@ -102,64 +141,63 @@ public sealed class BrowserProductHomeDemosTests
         Assert.Equal(
             "Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions",
             plan.TypeId);
-        Assert.Equal("TryAddEnumerable", plan.MemberName);
-        Assert.Equal("method", plan.MemberKind);
-        Assert.Equal("74b6b4b321", plan.MemberAnchorDigest);
-        Assert.Equal("call-graph", plan.MemberSection);
+        Assert.Equal(ProductDemoSections.CallGraph, plan.Section);
+        BrowserHomeDemoRunMember member = Assert.IsType<BrowserHomeDemoRunMember>(plan.Member);
+        Assert.Equal("TryAddEnumerable", member.Name);
+        Assert.Equal("method", member.MemberKind);
+        Assert.Equal("74b6b4b321", member.AnchorDigest);
+        Assert.Equal("call-graph", member.MemberSection);
     }
 
     [Fact]
-    public void ToCallGraphRunPlan_DerivesNonFirstFocusFromNavigation()
+    public void ToRunPlan_DerivesNonFirstFocusForTypeOnlyMethodsView()
     {
-        const int version = InspectionDefinitionJson.CurrentSchemaVersion;
-        var first = new DefinitionMemberCoordinate.PackageCoordinate(
-            "Demo.First",
-            "1.0.0",
-            "net11.0");
-        var second = new DefinitionMemberCoordinate.PackageCoordinate(
-            "Demo.Second",
-            "2.0.0",
-            "net11.0");
-        var registry = new InspectionDefinitionRegistry();
-        registry.Add(new WorkspaceDefinition(
-            version,
-            "workspace",
-            [
-                new WorkspaceContextDefinition(
-                    "context",
-                    framework: "net11.0",
-                    members: [first, second]),
-            ]));
-        registry.Add(new ViewDefinition(
-            version,
-            "view",
-            type: "Demo.Second.Target",
-            memberAnchor: "1234567890",
-            memberKey: "method:Run",
-            section: ProductDemoSections.CallGraph));
-        registry.Add(new NavigationDefinition(
-            version,
-            "navigation",
-            [
-                new NavigationTabDefinition("first", coordinate: first),
-                new NavigationTabDefinition("second", coordinate: second),
-            ],
-            focus: "second"));
-        registry.Add(new ScenarioDefinition(
-            version,
-            "scenario",
-            workspace: "workspace",
-            context: "context",
-            view: "view",
-            navigation: "navigation"));
-
-        BrowserHomeDemoRunPlan plan = BrowserProductHomeDemos.ToCallGraphRunPlan(
-            registry.ResolveScenario("scenario"));
+        BrowserHomeDemoRunPlan plan = BrowserProductHomeDemos.ToRunPlan(
+            ResolveSyntheticScenario(ProductDemoSections.Methods));
 
         Assert.Equal(1, plan.FocusRequestIndex);
         Assert.Equal(
             "Demo.Second",
             plan.Requests[plan.FocusRequestIndex].PackageId);
+        Assert.Equal("Demo.Second.Target", plan.TypeId);
+        Assert.Equal(ProductDemoSections.Methods, plan.Section);
+        Assert.Null(plan.Member);
+    }
+
+    [Fact]
+    public void ToRunPlan_RejectsUnsupportedBrowserSection()
+    {
+        InspectionDefinitionException error = Assert.Throws<InspectionDefinitionException>(
+            () => BrowserProductHomeDemos.ToRunPlan(
+                ResolveSyntheticScenario(ProductDemoSections.Callers)));
+
+        Assert.Contains("does not implement section 'Callers'", error.Message);
+    }
+
+    [Fact]
+    public void ToRunPlan_RejectsLibraryScopedView()
+    {
+        InspectionDefinitionException error = Assert.Throws<InspectionDefinitionException>(
+            () => BrowserProductHomeDemos.ToRunPlan(
+                ResolveSyntheticScenario(
+                    ProductDemoSections.Methods,
+                    library: "Demo.Second")));
+
+        Assert.Contains("does not support library-scoped views", error.Message);
+    }
+
+    [Fact]
+    public void ToRunPlan_RejectsFocusOutsideSelectedContext()
+    {
+        InspectionDefinitionException error = Assert.Throws<InspectionDefinitionException>(
+            () => BrowserProductHomeDemos.ToRunPlan(
+                ResolveSyntheticScenario(
+                    ProductDemoSections.Methods,
+                    includeFocusedPackageInContext: false)));
+
+        Assert.Contains(
+            "navigation focus is not a member of its selected workspace context",
+            error.Message);
     }
 
     [Fact]
@@ -178,4 +216,53 @@ public sealed class BrowserProductHomeDemosTests
             document.RootElement.GetProperty("callGraph").ValueKind);
     }
 
+    private static ResolvedScenario ResolveSyntheticScenario(
+        string section,
+        string? library = null,
+        bool includeFocusedPackageInContext = true)
+    {
+        const int version = InspectionDefinitionJson.CurrentSchemaVersion;
+        var first = new DefinitionMemberCoordinate.PackageCoordinate(
+            "Demo.First",
+            "1.0.0",
+            "net11.0");
+        var second = new DefinitionMemberCoordinate.PackageCoordinate(
+            "Demo.Second",
+            "2.0.0",
+            "net11.0");
+        DefinitionMemberCoordinate[] contextMembers =
+            includeFocusedPackageInContext ? [first, second] : [first];
+        var registry = new InspectionDefinitionRegistry();
+        registry.Add(new WorkspaceDefinition(
+            version,
+            "workspace",
+            [
+                new WorkspaceContextDefinition(
+                    "context",
+                    framework: "net11.0",
+                    members: contextMembers),
+            ]));
+        registry.Add(new ViewDefinition(
+            version,
+            "view",
+            type: "Demo.Second.Target",
+            section: section,
+            library: library));
+        registry.Add(new NavigationDefinition(
+            version,
+            "navigation",
+            [
+                new NavigationTabDefinition("first", coordinate: first),
+                new NavigationTabDefinition("second", coordinate: second),
+            ],
+            focus: "second"));
+        registry.Add(new ScenarioDefinition(
+            version,
+            "scenario",
+            workspace: "workspace",
+            context: "context",
+            view: "view",
+            navigation: "navigation"));
+        return registry.ResolveScenario("scenario");
+    }
 }

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -281,10 +281,11 @@ public sealed record BrowserHomeDemoRunActivation(
     string FocusVersion,
     string FocusFramework,
     string TypeId,
-    string MemberName,
-    string MemberKind,
-    string MemberAnchorDigest,
-    string MemberSection);
+    string Section,
+    string? MemberName,
+    string? MemberKind,
+    string? MemberAnchorDigest,
+    string? MemberSection);
 
 /// <summary>
 /// Browser result of running one product home demo through the normal package

--- a/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
+++ b/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
@@ -47,27 +47,29 @@ internal static class BrowserProductHomeDemos
                 view.Section));
     }
 
-    internal static BrowserHomeDemoRunPlan ToCallGraphRunPlan(
+    internal static BrowserHomeDemoRunPlan ToRunPlan(
         ResolvedScenario scenario)
     {
         ProductDemoRunPlan productPlan = ProductDemoRunPlan.Create(scenario);
-        if (!string.Equals(
-                productPlan.Section,
-                ProductDemoSections.CallGraph,
-                StringComparison.Ordinal))
+        if (productPlan.Scenario.View?.Libraries.Count > 0)
         {
             throw new InspectionDefinitionException(
-                $"Home demo '{scenario.ScenarioId}' does not select the Call Graph section.");
+                $"Home demo '{scenario.ScenarioId}' browser execution does not support library-scoped views.");
         }
 
-        if (productPlan.Member is not
-            {
-                Anchor: { Length: > 0 } memberAnchor,
-            } member)
+        BrowserHomeDemoRunMember? member = productPlan.Section switch
         {
-            throw new InspectionDefinitionException(
-                $"Home demo '{scenario.ScenarioId}' Call Graph view must select a member anchor.");
-        }
+            ProductDemoSections.Methods when productPlan.Member is null => null,
+            ProductDemoSections.Methods =>
+                throw new InspectionDefinitionException(
+                    $"Home demo '{scenario.ScenarioId}' Methods view must not select a member."),
+            ProductDemoSections.CallGraph =>
+                ToCallGraphMember(scenario.ScenarioId, productPlan.Member),
+            _ => throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' browser execution does not implement "
+                + $"section '{productPlan.Section}' (supported: "
+                + $"{ProductDemoSections.Methods}, {ProductDemoSections.CallGraph})."),
+        };
 
         BrowserPackageRequest[] requests =
         [
@@ -87,11 +89,34 @@ internal static class BrowserProductHomeDemos
         int focusIndex = Array.FindIndex(
             requests,
             request => request == focus);
+        if (focusIndex < 0)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenario.ScenarioId}' navigation focus is not present in its browser workspace requests.");
+        }
 
         return new BrowserHomeDemoRunPlan(
             requests,
             focusIndex,
             productPlan.TypeName,
+            productPlan.Section,
+            member);
+    }
+
+    private static BrowserHomeDemoRunMember ToCallGraphMember(
+        string scenarioId,
+        ProductDemoMemberSelection? selection)
+    {
+        if (selection is not
+            {
+                Anchor: { Length: > 0 } memberAnchor,
+            } member)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{scenarioId}' Call Graph view must select a member anchor.");
+        }
+
+        return new BrowserHomeDemoRunMember(
             member.Name,
             member.Kind,
             memberAnchor,
@@ -148,7 +173,11 @@ internal sealed record BrowserHomeDemoRunPlan(
     BrowserPackageRequest[] Requests,
     int FocusRequestIndex,
     string TypeId,
-    string MemberName,
+    string Section,
+    BrowserHomeDemoRunMember? Member);
+
+internal sealed record BrowserHomeDemoRunMember(
+    string Name,
     string? MemberKind,
-    string MemberAnchorDigest,
+    string AnchorDigest,
     string MemberSection);

--- a/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
+++ b/prototypes/inspect-web/engine/BrowserProductHomeDemos.cs
@@ -56,6 +56,7 @@ internal static class BrowserProductHomeDemos
             throw new InspectionDefinitionException(
                 $"Home demo '{scenario.ScenarioId}' browser execution does not support library-scoped views.");
         }
+        EnsureNoRuntimeIdentifier(productPlan);
 
         BrowserHomeDemoRunMember? member = productPlan.Section switch
         {
@@ -101,6 +102,23 @@ internal static class BrowserProductHomeDemos
             productPlan.TypeName,
             productPlan.Section,
             member);
+    }
+
+    private static void EnsureNoRuntimeIdentifier(ProductDemoRunPlan plan)
+    {
+        bool hasRuntimeIdentifier =
+            plan.Context.RuntimeIdentifier is not null
+            || plan.Context.Members.Any(member =>
+                member is WorkspaceMemberCoordinate.PackageMember
+                {
+                    RuntimeIdentifier: not null,
+                })
+            || plan.Focus?.RuntimeIdentifier is not null;
+        if (hasRuntimeIdentifier)
+        {
+            throw new InspectionDefinitionException(
+                $"Home demo '{plan.Scenario.ScenarioId}' browser execution does not support runtime-identifier-scoped package workspaces.");
+        }
     }
 
     private static BrowserHomeDemoRunMember ToCallGraphMember(

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -1048,10 +1048,10 @@ public static partial class InspectionEngine
     }
 
     /// <summary>
-    /// Runs one member-bound Call Graph home demo from its product definition.
+    /// Runs one supported home demo from its product definition.
     /// The browser supplies only the scenario id: workspace coordinates,
-    /// navigation focus, member-anchor selection, and query execution remain
-    /// on the engine side.
+    /// navigation focus, section selection, optional member selection, and
+    /// query execution remain on the engine side.
     /// </summary>
     [JSExport]
     public static async Task<string> RunHomeDemo(string scenarioId)
@@ -1064,7 +1064,7 @@ public static partial class InspectionEngine
         }
 
         BrowserHomeDemoRunPlan plan =
-            BrowserProductHomeDemos.ToCallGraphRunPlan(resolved);
+            BrowserProductHomeDemos.ToRunPlan(resolved);
         BrowserScopeResolution resolution =
             await BrowserPackageWorkspace.RunPackageOperationAsync(
                 deadline => BrowserPackageWorkspace.ResolveAndOpenScopeAsync(
@@ -1096,6 +1096,11 @@ public static partial class InspectionEngine
             throw new InvalidOperationException(
                 "The product home demo workspace did not preserve its distinct request ordering.");
         }
+        if ((uint)plan.FocusRequestIndex >= (uint)resolution.RequestedCoordinates.Length)
+        {
+            throw new InvalidOperationException(
+                "The product home demo focus is outside its resolved browser workspace.");
+        }
 
         BrowserPackageCoordinate focusCoordinate =
             scope.Coordinate(
@@ -1119,6 +1124,25 @@ public static partial class InspectionEngine
         }
 
         BrowserTypeSurface type = types[0];
+        BrowserHomeDemoRunMember? memberPlan = plan.Member;
+        if (memberPlan is null)
+        {
+            return new BrowserHomeDemoRunResult(
+                true,
+                [.. projections.Select(projection => projection.Surface)],
+                new BrowserHomeDemoRunActivation(
+                    focusCoordinate.PackageId,
+                    focusCoordinate.Version,
+                    focusCoordinate.Framework,
+                    type.Id,
+                    plan.Section,
+                    MemberName: null,
+                    MemberKind: null,
+                    MemberAnchorDigest: null,
+                    MemberSection: null),
+                null);
+        }
+
         (ApiType Type, AssemblyContextSubject Subject)[] apiTypes =
         [
             .. focusProjection.ApiSurfaces.Assemblies.Assemblies
@@ -1140,10 +1164,10 @@ public static partial class InspectionEngine
 
         (ApiType apiType, AssemblyContextSubject subject) = apiTypes[0];
         var selector = new MemberTargetSelector(
-            $"{plan.MemberName}~{plan.MemberAnchorDigest}",
-            plan.MemberName,
-            DigestPrefix: plan.MemberAnchorDigest,
-            Kind: plan.MemberKind);
+            $"{memberPlan.Name}~{memberPlan.AnchorDigest}",
+            memberPlan.Name,
+            DigestPrefix: memberPlan.AnchorDigest,
+            Kind: memberPlan.MemberKind);
         MemberTargetResolution target =
             MemberTargetResolver.Resolve(apiType, selector);
         if (target.Diagnostic is { } diagnostic)
@@ -1210,10 +1234,11 @@ public static partial class InspectionEngine
                 focusCoordinate.Version,
                 focusCoordinate.Framework,
                 type.Id,
+                plan.Section,
                 member.Name,
                 member.Kind,
                 member.AnchorDigest,
-                plan.MemberSection),
+                memberPlan.MemberSection),
             ProjectCallGraph(scope, view));
     }
 

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -165,10 +165,11 @@ export interface BrowserHomeDemoRunActivation {
   focusVersion: string;
   focusFramework: string;
   typeId: string;
-  memberName: string;
-  memberKind: string;
-  memberAnchorDigest: string;
-  memberSection: string;
+  section: string;
+  memberName: string | null;
+  memberKind: string | null;
+  memberAnchorDigest: string | null;
+  memberSection: string | null;
 }
 
 export interface BrowserHomeDemoRunResult {


### PR DESCRIPTION
## Summary

Make inspect-web's existing `RunHomeDemo` engine operation execute every
current product home-demo shape through `ProductDemoRunPlan`: type-only
`Methods` and member-bound `Call Graph`.

The engine now returns a required product section plus optional member
activation, preserves exact workspace focus, projects the ordinary Browser
type/member surface for Methods, and explicitly rejects unsupported sections
or library-scoped views. This is an engine-side capability with no home-button
behavior change; the frontend follow-up remains isolated from the concurrent
#4647 work.

## Design scope

- **Owner:** product-demo scenario activation
- **Owning document:** `docs/design/workspace-definitions.md`
- **Immediate boundary:** consume the product-owned `ProductDemoRunPlan` and
  return Browser engine package/type/member activation plus optional graph
  projection.
- **Non-claims:** frontend routing and presentation, canonical share-location
  projection, general Browser workspace/packet execution, and platform demo
  realization remain separate work.

## Demo

Before this change, the real product STJ scenario failed at the engine boundary
because `RunHomeDemo("stj-serializer")` accepted only Call Graph definitions:

```text
Home demo 'stj-serializer' does not select the Call Graph section.
```

After this change, invoking the same engine operation against the real package
coordinate produces:

```text
found=True
focus=System.Text.Json@10.0.0/net10.0
type=System.Text.Json.JsonSerializer section=Methods
members=104 DeserializeAsync=10 callGraph=Null
```

Notice that the engine realizes the product-owned coordinate and returns real
`JsonSerializer` API rows without inventing a demo-only payload. A neighboring
two-package, non-first-focus Methods fixture and the existing anchored Call
Graph fixture exercise the same generalized path.

## Compatibility

The generated TypeScript contract adds required `section` and makes member
fields nullable. Existing Call Graph frontend code remains type-compatible and
behavior is unchanged. RID-scoped package workspaces fail explicitly until the
Browser acquisition contract can preserve that identity. The later frontend
slice must apply the typed Methods activation and push a canonical shareable
location before deleting host-owned packet construction.

## Validation

- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -- -method '*HomeDemo*'` — 17 passed
- Current-head `ci-required` — passed, including the Browser engine lane
- `npm test`
- `npm run lint`
- `eng/generate-inspect-web-engine-dts.sh --check`
- `npx markdownlint-cli docs/design/workspace-definitions.md`

Part of #4700
