### PR TITLE
Ban UnsafeEvidencePresenceQuery from the browser engine

### DIFF
--- a/prototypes/inspect-web/engine/BannedSymbols.txt
+++ b/prototypes/inspect-web/engine/BannedSymbols.txt
@@ -16,6 +16,7 @@ T:ILInspector.Metadata.AssemblyInspectionSession;Inspect through a public produc
 T:ILInspector.Metadata.AssemblyImage;Raw assembly images belong to product queries; the browser host must not open one from a descriptor or path.
 T:ILInspector.Metadata.AssemblyImageSnapshot;A group's immutable image belongs to the query layer; hand the group to a query instead.
 T:ILInspector.Metadata.PdbContext;PDB and metadata inspection belong to product queries, not transitive descriptor openers in the browser host.
+T:DotnetInspector.Queries.UnsafeEvidencePresenceQuery;The presence probe consumes a borrowed PdbContext and raw path directly; product realization that already owns metadata inspection may call it, not the browser host.
 T:ILInspector.Metadata.AssemblyTypeDeclarationInventoryReader;Assembly inventory projection belongs to product queries, not transitive descriptor openers in the browser host.
 T:ILInspector.Metadata.AssemblySurfaceClassifier;Assembly surface classification belongs to product queries, not transitive path or descriptor openers in the browser host.
 T:ILInspector.Metadata.AssemblyInspector;Assembly metadata extraction belongs to product queries, not transitive path or descriptor openers in the browser host.


### PR DESCRIPTION
## Problem

`EveryPublicPathMethodOwnerIsBannedOrApprovedNonInspectionSurface` in `BrowserEngineLayeringTests` failed because `DotnetInspector.Queries.UnsafeEvidencePresenceQuery` is an unclassified public path-method owner: its `Execute(string path, PdbContext context)` overload takes a raw path parameter alongside a borrowed `PdbContext`.

## Fix

Classify the query on the deny list in `prototypes/inspect-web/engine/BannedSymbols.txt`, alongside its sibling entries for `PdbContext` and `LibraryBodyIndex`. This presence probe is meant to be called by product realization that already owns metadata inspection (see `LibrarySections.cs`), not reached directly from the browser host.

## Validation

```
dotnet run --project prototypes/inspect-web/engine.Tests -c Release
=== TEST EXECUTION SUMMARY ===
   InspectWeb.Engine.Tests  Total: 131, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 26.125s
```

Trivial, config-only change (deny-list entry); no product behavior change. No review round required.

Fixes #4703