### PR TITLE
Skip inspect-web CI for Markdown-only changes

### DIFF
--- a/eng/CiChangeDetection/DetectionTestSuite.cs
+++ b/eng/CiChangeDetection/DetectionTestSuite.cs
@@ -353,6 +353,70 @@ internal static class DetectionTestSuite
             throw new InvalidOperationException(
                 $"Web canary did not select only web: {FormatValues(web)}");
         }
+        foreach (string webDocumentation in new[]
+        {
+            "prototypes/inspect-web/README.md",
+            "prototypes/inspect-web/docs/hosting.md",
+        })
+        {
+            Dictionary<string, string> webDocs = RunDetection(
+                repository,
+                body,
+                "pull_request",
+                webDocumentation,
+                outputs);
+            if (webDocs["code"] != "false"
+                || webDocs["docs"] != "true"
+                || webDocs["web"] != "false")
+            {
+                throw new InvalidOperationException(
+                    $"Web documentation {webDocumentation} selected the wrong " +
+                    $"lanes: {FormatValues(webDocs)}");
+            }
+        }
+        Dictionary<string, string> webDocsAndSource = RunDetection(
+            repository,
+            body,
+            "pull_request",
+            """
+            prototypes/inspect-web/README.md
+            prototypes/inspect-web/src/dotnet-inspect.ts
+            """,
+            outputs);
+        if (webDocsAndSource["docs"] != "true"
+            || webDocsAndSource["web"] != "true")
+        {
+            throw new InvalidOperationException(
+                "Mixed web documentation and source did not select both lanes: "
+                + FormatValues(webDocsAndSource));
+        }
+        Dictionary<string, string> webSourceRenamedToDocs = RunDetection(
+            repository,
+            body,
+            "pull_request",
+            "prototypes/inspect-web/archived-design.md",
+            outputs,
+            previousFiles: "prototypes/inspect-web/src/archived-design.ts");
+        if (webSourceRenamedToDocs["docs"] != "true"
+            || webSourceRenamedToDocs["web"] != "true")
+        {
+            throw new InvalidOperationException(
+                "Web source renamed to documentation escaped the web lane: "
+                + FormatValues(webSourceRenamedToDocs));
+        }
+        Dictionary<string, string> webTextFixture = RunDetection(
+            repository,
+            body,
+            "pull_request",
+            "prototypes/inspect-web/test/fixture.txt",
+            outputs);
+        if (webTextFixture["docs"] != "true"
+            || webTextFixture["web"] != "true")
+        {
+            throw new InvalidOperationException(
+                "Non-Markdown web fixture escaped the web lane: "
+                + FormatValues(webTextFixture));
+        }
         Dictionary<string, string> webGenerator = RunDetection(
             repository,
             body,

--- a/eng/ci-detect-changes.sh
+++ b/eng/ci-detect-changes.sh
@@ -330,6 +330,9 @@ while IFS= read -r -d '' file; do
     # thing keeping this file honest against the pre-merge preset, so
     # editing the file must run the lane that validates it.
     eng/decompiler-gate-expected-classes.txt) CODE=true ;;
+    # Markdown under the browser prototype is documentation, not a browser
+    # build input. Keep non-Markdown fixtures and configuration gated.
+    prototypes/inspect-web/*.md) ;;
     prototypes/inspect-web/*) WEB=true ;;
     prototypes/annotated-source-viewer/*) WEB=true ;;
     *.props|*.targets|*.sln|*.slnx) CODE=true; WEB=true ;;


### PR DESCRIPTION
## Summary

- classify Markdown files under `prototypes/inspect-web/` as documentation without scheduling the inspect-web lane
- preserve inspect-web validation for mixed source/documentation changes, source-to-Markdown renames, and non-Markdown fixtures
- add executable change-detection canaries for each boundary

## Validation

- `dotnet run eng/test-ci-change-detection.cs`
- `bash -n eng/ci-detect-changes.sh`
- `git diff --check`

This is intentionally separate from the demo-hosting documentation PR.