### PR TITLE
Trust "CI is ready", authorize pre-CI rounds, and add 12-round design/hardening check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,11 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
   the user may authorize auto-merge for the intended final head; the agent may
   ask. If the head moves after arming, disarm, review the new head, and ask
   again.
+- **"CI is ready":** the user's statement that CI has no failures and the PR is
+  mergeable. Trust it without re-checking and move to the next task, such as
+  dispatching the next round's reviewers.
+- **Authorizing the next round before CI completes:** the agent does not need
+  to check CI status first; proceed with the authorized round.
 
 ## Before changing files
 
@@ -823,6 +828,14 @@ Before requesting another block, answer:
 5. **If design work was skipped last block, why skip it again?** The prior
    decision is not standing authorization; identify the new evidence that makes
    implementation rounds the better investment.
+
+At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
+
+1. **Would a design doc better define the design space?** Foundational APIs
+   weigh heavily toward yes.
+2. **Can hardening move to followups?** State whether deferring remaining
+   hardening to followup work would unlock this PR's value for other agent
+   work sooner.
 
 State the proposed remedy and end with one recommendation: approve the next
 implementation block, switch to a docs-only design PR, or stop. If consecutive


### PR DESCRIPTION
## Summary

Two AGENTS.md guidance additions per user direction:

1. **Standing adjustments**: the user may say "CI is ready" (no failures, mergeable) and the agent trusts it without re-checking, moving straight to the next task (e.g. dispatching the next round). Likewise, the user may authorize the next round before CI completes; the agent proceeds without checking CI status first.
2. **Round-boundary checklist**: at round 12 and every 6-round boundary after (18, 24, ...), agents also answer whether a design doc would better define the design space, and whether hardening can move to followups to unlock the PR value for other agent work — weighted toward yes for foundational APIs. Answered as regular session output before the approval prompt, same as the existing checklist items.

## Demo

Before: an agent receiving "CI is ready" would still re-poll GitHub status before starting the next round. After: it proceeds directly to dispatching reviewers. At round 12 (and 18, 24, ...) the checkpoint now includes the design-doc/hardening-followup questions alongside the existing five.

## Validation

Documentation-only change.

    npx markdownlint-cli AGENTS.md

No findings.