### PR TITLE
Add typed package manifest failures

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -179,6 +179,25 @@ flag — decide between eager and lazy acquisition.
 L1 takes **content**, not filesystem paths. A consumer without a filesystem must
 be able to call it. See [Seam rules](#seam-rules).
 
+Package-manifest facts return `PackageManifestFailure`, not parser or validation
+exceptions. Its stable reason distinguishes malformed XML, unsupported document
+shape or namespace, identity mismatch, invalid dependency declarations, and
+query-owned configured limits. The message is derived only from that reason and
+optional numeric XML location; package-authored text never becomes diagnostic
+text. Package profiles retain the reason on their failure event, and L2 projects
+it into the row status while keeping the safe message visible. Dependency-group
+selection retains the same manifest failure alongside its legacy
+exception-shaped package-content failure. These contracts are gated by
+`PackageManifestFactsQueryTests.FailureMessage_IsStableForEveryReason`,
+`PackageManifestFactsQueryTests.FailureMessage_IsSafeForUnknownFutureReason`,
+`PackageProfileQueryTests.ExecuteAsync_ReportsInvalidManifestAndContinues`, and
+`FindCommandTests.PackageProfileSection_KeepsFailuresAndTruncationVisible`.
+
+The Services parser currently reports decoded-character exhaustion through its
+malformed-XML outcome. L1 preserves that classification rather than inferring a
+resource-limit reason from exception text; distinguishing it requires an
+explicit parser-owned contract.
+
 L1 does not reference Markout.
 
 ### L2 — `DotnetInspector.Sections`

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -2048,10 +2048,15 @@ only ordinary compiler output.
    rejected value; that same handler returns an empty result, which is the
    success-shaped failure this document forbids elsewhere.
    `ValidatePathComponent` does not reject control characters other than
-   `NUL`, so an `ESC` passes it outright. The nuspec boundary now rejects
-   malformed XML with a typed, content-free diagnostic and carries descriptions
-   as `InertString`; package-coordinate validation and the two graph-resolution
-   leaks remain the next application of the hardened-entrypoint pattern.
+   `NUL`, so an `ESC` passes it outright. The nuspec projection boundary now
+   rejects malformed XML, unsupported structure, identity mismatch, dependency
+   contract violations, and query-owned resource limits with typed,
+   content-free reasons, and carries descriptions as `InertString`.
+   `PackageManifestFactsQueryTests.FailureMessage_IsStableForEveryReason`,
+   `FailureMessage_IsSafeForUnknownFutureReason`, and the hostile-input
+   execution tests gate that diagnostic contract. Package-coordinate validation
+   and the two graph-resolution leaks remain the next application of the
+   hardened-entrypoint pattern.
 10. Establish fuzzing over the PE, metadata, PDB, nuspec, and archive entry
     points. The domain-matched precedent is `binutils`, whose parsers are
     continuously fuzzed and have repeatedly yielded CVEs that way. Most of

--- a/src/DotnetInspector.Queries.Tests/PackageDependencyGroupsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageDependencyGroupsQueryTests.cs
@@ -306,13 +306,19 @@ public sealed class PackageDependencyGroupsQueryTests
         InMemoryPackageContent content = Content(
             ("Example.Package.nuspec", Manifest("", "Different.Package")));
 
-        Exception error = Failed(
+        PackageDependencyGroupsResult.Failed failure = FailedResult(
             await ExecuteAsync(
                 content,
                 "Example.Package"));
 
-        Assert.IsType<InvalidDataException>(error);
-        Assert.DoesNotContain("Different.Package", error.Message, StringComparison.Ordinal);
+        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.IdentityMismatch,
+            failure.ManifestFailure?.Reason);
+        Assert.DoesNotContain(
+            "Different.Package",
+            failure.Error.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -352,15 +358,18 @@ public sealed class PackageDependencyGroupsQueryTests
             </package>
             """;
 
-        Exception error = Failed(
+        PackageDependencyGroupsResult.Failed failure = FailedResult(
             await ExecuteAsync(
                 Content(("Example.Package.nuspec", manifest)),
                 "Example.Package"));
 
-        Assert.IsType<NuspecParseException>(error);
+        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.MalformedXml,
+            failure.ManifestFailure?.Reason);
         Assert.DoesNotContain(
             "SHOULD-NOT-REACH-THE-DIAGNOSTIC",
-            error.Message,
+            failure.Error.Message,
             StringComparison.Ordinal);
     }
 
@@ -435,12 +444,15 @@ public sealed class PackageDependencyGroupsQueryTests
             Manifest(""),
             PackageManifestFactsQuery.MaxManifestCharacters + 1);
 
-        Exception error = Failed(
+        PackageDependencyGroupsResult.Failed failure = FailedResult(
             await ExecuteAsync(
                 Content(("Example.Package.nuspec", manifest)),
                 "Example.Package"));
 
-        Assert.IsType<NuspecParseException>(error);
+        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.MalformedXml,
+            failure.ManifestFailure?.Reason);
     }
 
     static PackageDependencyGroups Available(PackageDependencyGroupsResult result) =>
@@ -459,7 +471,11 @@ public sealed class PackageDependencyGroupsQueryTests
             TestContext.Current.CancellationToken);
 
     static Exception Failed(PackageDependencyGroupsResult result) =>
-        Assert.IsType<PackageDependencyGroupsResult.Failed>(result).Error;
+        FailedResult(result).Error;
+
+    static PackageDependencyGroupsResult.Failed FailedResult(
+        PackageDependencyGroupsResult result) =>
+        Assert.IsType<PackageDependencyGroupsResult.Failed>(result);
 
     static string Manifest(
         string dependencies,

--- a/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
@@ -79,10 +79,12 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.IdentityMismatch,
+            failure.Failure.Reason);
         Assert.DoesNotContain(
             "SHOULD-NOT-REACH-THE-DIAGNOSTIC",
-            failure.Error.Message,
+            failure.Failure.Message,
             StringComparison.Ordinal);
     }
 
@@ -136,11 +138,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "invalid document root",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.UnsupportedDocumentShape,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -164,11 +164,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "identity does not match",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.UnsupportedDocumentShape,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -193,10 +191,71 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.InvalidDependencyContract,
+            failure.Failure.Reason);
         Assert.DoesNotContain(
             "evil/../other",
-            failure.Error.Message,
+            failure.Failure.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsInvalidDependencyRangeWithTypedReason()
+    {
+        PackageManifestFactsResult.Failed failure = Assert.IsType<
+            PackageManifestFactsResult.Failed>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(
+                        """
+                        <package>
+                          <metadata>
+                            <id>Example.Package</id>
+                            <version>1.0.0</version>
+                            <dependencies>
+                              <dependency id="Example.Dependency" version="SHOULD-NOT-REACH-THE-DIAGNOSTIC" />
+                            </dependencies>
+                          </metadata>
+                        </package>
+                        """),
+                    PackageSourceCoordinate.Create(
+                        "Example.Package",
+                        "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFailureReason.InvalidDependencyContract,
+            failure.Failure.Reason);
+        Assert.DoesNotContain(
+            "SHOULD-NOT-REACH-THE-DIAGNOSTIC",
+            failure.Failure.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ReportsMalformedXmlWithSafeLocation()
+    {
+        PackageManifestFactsResult.Failed failure = Assert.IsType<
+            PackageManifestFactsResult.Failed>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(
+                        """
+                        <package>
+                          <metadata>
+                            <id>SHOULD-NOT-REACH-THE-DIAGNOSTIC</id>
+                          </package>
+                        """),
+                    PackageSourceCoordinate.Create(
+                        "Example.Package",
+                        "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFailureReason.MalformedXml,
+            failure.Failure.Reason);
+        Assert.True(failure.Failure.LineNumber > 0);
+        Assert.True(failure.Failure.LinePosition > 0);
+        Assert.DoesNotContain(
+            "SHOULD-NOT-REACH-THE-DIAGNOSTIC",
+            failure.Failure.Message,
             StringComparison.Ordinal);
     }
 
@@ -212,7 +271,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
+        Assert.Equal(
+            PackageManifestFailureReason.ConfiguredLimitExceeded,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -238,11 +299,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "scalar value",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.ConfiguredLimitExceeded,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -274,11 +333,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "too many dependencies",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.ConfiguredLimitExceeded,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -310,11 +367,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "too many dependency groups",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.ConfiguredLimitExceeded,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -346,11 +401,9 @@ public sealed class PackageManifestFactsQueryTests
                         "Example.Package",
                         "1.0.0")));
 
-        Assert.IsType<InvalidDataException>(failure.Error);
-        Assert.Contains(
-            "too many package types",
-            failure.Error.Message,
-            StringComparison.Ordinal);
+        Assert.Equal(
+            PackageManifestFailureReason.ConfiguredLimitExceeded,
+            failure.Failure.Reason);
     }
 
     [Fact]
@@ -420,6 +473,42 @@ public sealed class PackageManifestFactsQueryTests
             PackageManifestFactsQuery.MaxDependencies,
             facts.DependencyGroups.Sum(group =>
                 group.Dependencies.Length));
+    }
+
+    [Theory]
+    [InlineData(
+        PackageManifestFailureReason.MalformedXml,
+        "Package manifest is not well-formed XML.")]
+    [InlineData(
+        PackageManifestFailureReason.UnsupportedDocumentShape,
+        "The package manifest has an unsupported document shape or namespace.")]
+    [InlineData(
+        PackageManifestFailureReason.IdentityMismatch,
+        "The package manifest identity does not match the requested package.")]
+    [InlineData(
+        PackageManifestFailureReason.InvalidDependencyContract,
+        "The package manifest contains an invalid dependency declaration.")]
+    [InlineData(
+        PackageManifestFailureReason.ConfiguredLimitExceeded,
+        "The package manifest exceeds a configured resource limit.")]
+    public void FailureMessage_IsStableForEveryReason(
+        PackageManifestFailureReason reason,
+        string expectedMessage)
+    {
+        var failure = new PackageManifestFailure(reason);
+
+        Assert.Equal(expectedMessage, failure.Message);
+    }
+
+    [Fact]
+    public void FailureMessage_IsSafeForUnknownFutureReason()
+    {
+        var failure = new PackageManifestFailure(
+            (PackageManifestFailureReason)int.MaxValue);
+
+        Assert.Equal(
+            "The package manifest could not be projected.",
+            failure.Message);
     }
 
     private static PackageManifestFacts Available(

--- a/src/DotnetInspector.Queries.Tests/PackageProfileQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageProfileQueryTests.cs
@@ -99,6 +99,16 @@ public sealed class PackageProfileQueryTests
         Assert.Equal(
             PackageProfileFailureKind.InvalidManifest,
             failure.Kind);
+        Assert.Equal(
+            PackageManifestFailureReason.IdentityMismatch,
+            failure.ManifestFailureReason);
+        Assert.Equal(
+            "The package manifest identity does not match the requested package.",
+            failure.Message);
+        Assert.DoesNotContain(
+            "Other.Package",
+            failure.Message,
+            StringComparison.Ordinal);
         Assert.Equal("Contoso.Broken", failure.PackageId);
         Assert.IsType<PackageProfileEvent.Match>(events[1]);
         PackageProfileSummary summary =

--- a/src/DotnetInspector.Queries/PackageDependencyGroupsQuery.cs
+++ b/src/DotnetInspector.Queries/PackageDependencyGroupsQuery.cs
@@ -133,7 +133,9 @@ public abstract record PackageDependencyGroupsResult
     public sealed record NoManifest : PackageDependencyGroupsResult;
 
     public sealed record Failed(
-        Exception Error) : PackageDependencyGroupsResult;
+        Exception Error,
+        PackageManifestFailure? ManifestFailure = null) :
+        PackageDependencyGroupsResult;
 }
 
 /// <summary>
@@ -198,7 +200,11 @@ public static class PackageDependencyGroupsQuery
                     manifestBytes,
                     coordinate);
             if (facts is PackageManifestFactsResult.Failed failed)
-                return new PackageDependencyGroupsResult.Failed(failed.Error);
+            {
+                return new PackageDependencyGroupsResult.Failed(
+                    new InvalidDataException(failed.Failure.Message),
+                    failed.Failure);
+            }
 
             string? requested = string.IsNullOrWhiteSpace(requestedTargetFramework)
                 ? null

--- a/src/DotnetInspector.Queries/PackageManifestFactsQuery.cs
+++ b/src/DotnetInspector.Queries/PackageManifestFactsQuery.cs
@@ -26,6 +26,71 @@ public sealed record PackageManifestFacts(
     ImmutableArray<DeclaredPackageDependencyGroup> DependencyGroups);
 
 /// <summary>
+/// The stable reason one package manifest could not be projected.
+/// </summary>
+public enum PackageManifestFailureReason
+{
+    MalformedXml,
+    UnsupportedDocumentShape,
+    IdentityMismatch,
+    InvalidDependencyContract,
+    ConfiguredLimitExceeded,
+}
+
+/// <summary>
+/// A content-free package-manifest projection failure.
+/// </summary>
+/// <remarks>
+/// <c>FailureMessage_IsStableForEveryReason</c>,
+/// <c>FailureMessage_IsSafeForUnknownFutureReason</c>, and the hostile-input
+/// execution tests gate this diagnostic contract.
+/// </remarks>
+public sealed record PackageManifestFailure
+{
+    public PackageManifestFailure(
+        PackageManifestFailureReason reason,
+        int lineNumber = 0,
+        int linePosition = 0)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(lineNumber);
+        ArgumentOutOfRangeException.ThrowIfNegative(linePosition);
+        Reason = reason;
+        LineNumber = lineNumber;
+        LinePosition = linePosition;
+    }
+
+    public PackageManifestFailureReason Reason { get; }
+
+    /// <summary>
+    /// The one-based XML line where parsing failed, or zero when unavailable.
+    /// </summary>
+    public int LineNumber { get; }
+
+    /// <summary>
+    /// The one-based XML position where parsing failed, or zero when unavailable.
+    /// </summary>
+    public int LinePosition { get; }
+
+    public string Message => Reason switch
+    {
+        PackageManifestFailureReason.MalformedXml
+            when LineNumber > 0 && LinePosition > 0 =>
+            $"Package manifest is not well-formed XML at line {LineNumber}, position {LinePosition}.",
+        PackageManifestFailureReason.MalformedXml =>
+            "Package manifest is not well-formed XML.",
+        PackageManifestFailureReason.UnsupportedDocumentShape =>
+            "The package manifest has an unsupported document shape or namespace.",
+        PackageManifestFailureReason.IdentityMismatch =>
+            "The package manifest identity does not match the requested package.",
+        PackageManifestFailureReason.InvalidDependencyContract =>
+            "The package manifest contains an invalid dependency declaration.",
+        PackageManifestFailureReason.ConfiguredLimitExceeded =>
+            "The package manifest exceeds a configured resource limit.",
+        _ => "The package manifest could not be projected.",
+    };
+}
+
+/// <summary>
 /// The typed outcome of projecting facts from one exact package manifest.
 /// </summary>
 public abstract record PackageManifestFactsResult
@@ -38,7 +103,7 @@ public abstract record PackageManifestFactsResult
         PackageManifestFacts Value) : PackageManifestFactsResult;
 
     public sealed record Failed(
-        Exception Error) : PackageManifestFactsResult;
+        PackageManifestFailure Failure) : PackageManifestFactsResult;
 }
 
 /// <summary>
@@ -73,8 +138,8 @@ public static class PackageManifestFactsQuery
         {
             if (manifestBytes.Length > MaxManifestBytes)
             {
-                throw new InvalidDataException(
-                    "The package manifest exceeds the configured size limit.");
+                throw Failure(
+                    PackageManifestFailureReason.ConfiguredLimitExceeded);
             }
 
             using var buffer = new MemoryStream(
@@ -104,11 +169,21 @@ public static class PackageManifestFactsQuery
                     nuspec.ReadmeFile,
                     dependencyGroups));
         }
-        catch (Exception exception) when (
-            exception is InvalidDataException
-                or NuspecParseException)
+        catch (ManifestValidationException exception)
         {
-            return new PackageManifestFactsResult.Failed(exception);
+            return Failed(exception.Reason);
+        }
+        catch (NuspecParseException exception)
+        {
+            return Failed(
+                PackageManifestFailureReason.MalformedXml,
+                exception.LineNumber,
+                exception.LinePosition);
+        }
+        catch (InvalidDataException)
+        {
+            return Failed(
+                PackageManifestFailureReason.UnsupportedDocumentShape);
         }
     }
 
@@ -117,15 +192,21 @@ public static class PackageManifestFactsQuery
         PackageSourceCoordinate expectedCoordinate)
     {
         if (string.IsNullOrWhiteSpace(nuspec.PackageName)
-            || !nuspec.PackageName.Equals(
+            || string.IsNullOrWhiteSpace(nuspec.Version))
+        {
+            throw Failure(
+                PackageManifestFailureReason.UnsupportedDocumentShape);
+        }
+
+        if (!nuspec.PackageName.Equals(
                 expectedCoordinate.PackageId,
                 StringComparison.OrdinalIgnoreCase)
             || !VersionsEqual(
                 nuspec.Version,
                 expectedCoordinate.Version))
         {
-            throw new InvalidDataException(
-                "The package manifest identity does not match the requested package.");
+            throw Failure(
+                PackageManifestFailureReason.IdentityMismatch);
         }
     }
 
@@ -136,8 +217,8 @@ public static class PackageManifestFactsQuery
             return [];
         if (groups.Count > MaxDependencyGroups)
         {
-            throw new InvalidDataException(
-                "The package manifest contains too many dependency groups.");
+            throw Failure(
+                PackageManifestFailureReason.ConfiguredLimitExceeded);
         }
 
         var builder =
@@ -155,20 +236,29 @@ public static class PackageManifestFactsQuery
                 dependencyCount++;
                 if (dependencyCount > MaxDependencies)
                 {
-                    throw new InvalidDataException(
-                        "The package manifest contains too many dependencies.");
-                }
-
-                if (!PackageCoordinateResolver.IsCanonicalPackageId(
-                        dependency.Id))
-                {
-                    throw new InvalidDataException(
-                        "The package manifest contains an invalid dependency id.");
+                    throw Failure(
+                        PackageManifestFailureReason.ConfiguredLimitExceeded);
                 }
 
                 ValidateScalar(dependency.Id);
                 ValidateScalar(dependency.Version);
-                PackageDependencyVersionRange.Validate(dependency.Version);
+                if (!PackageCoordinateResolver.IsCanonicalPackageId(
+                        dependency.Id))
+                {
+                    throw Failure(
+                        PackageManifestFailureReason.InvalidDependencyContract);
+                }
+
+                try
+                {
+                    PackageDependencyVersionRange.Validate(dependency.Version);
+                }
+                catch (InvalidDataException)
+                {
+                    throw Failure(
+                        PackageManifestFailureReason
+                            .InvalidDependencyContract);
+                }
                 dependencies.Add(
                     new DeclaredPackageDependency(
                         dependency.Id,
@@ -199,8 +289,8 @@ public static class PackageManifestFactsQuery
 
         if (nuspec.PackageTypes is { Count: > MaxPackageTypes })
         {
-            throw new InvalidDataException(
-                "The package manifest contains too many package types.");
+            throw Failure(
+                PackageManifestFailureReason.ConfiguredLimitExceeded);
         }
 
         foreach (string packageType in nuspec.PackageTypes ?? [])
@@ -211,10 +301,23 @@ public static class PackageManifestFactsQuery
     {
         if (value is { Length: > MaxScalarCharacters })
         {
-            throw new InvalidDataException(
-                "The package manifest contains a scalar value that exceeds the configured limit.");
+            throw Failure(
+                PackageManifestFailureReason.ConfiguredLimitExceeded);
         }
     }
+
+    private static PackageManifestFactsResult.Failed Failed(
+        PackageManifestFailureReason reason,
+        int lineNumber = 0,
+        int linePosition = 0) =>
+        new(new PackageManifestFailure(
+            reason,
+            lineNumber,
+            linePosition));
+
+    private static ManifestValidationException Failure(
+        PackageManifestFailureReason reason) =>
+        new(reason);
 
     private static bool VersionsEqual(
         string? declaredVersion,
@@ -228,4 +331,10 @@ public static class PackageManifestFactsQuery
         && declared.ToNormalizedString().Equals(
             requested.ToNormalizedString(),
             StringComparison.OrdinalIgnoreCase);
+
+    private sealed class ManifestValidationException(
+        PackageManifestFailureReason reason) : Exception
+    {
+        public PackageManifestFailureReason Reason { get; } = reason;
+    }
 }

--- a/src/DotnetInspector.Queries/PackageProfileQuery.cs
+++ b/src/DotnetInspector.Queries/PackageProfileQuery.cs
@@ -49,7 +49,8 @@ public sealed record PackageProfileFailure(
     string? Version,
     PackageSourceIdentity Producer,
     PackageProfileFailureKind Kind,
-    string Message);
+    string Message,
+    PackageManifestFailureReason? ManifestFailureReason = null);
 
 /// <summary>
 /// Terminal accounting for a completed package-profile stream.
@@ -283,7 +284,8 @@ public static class PackageProfileQuery
                 yield return Failure(
                     candidate,
                     PackageProfileFailureKind.InvalidManifest,
-                    manifestFailureResult.Error.Message);
+                    manifestFailureResult.Failure.Message,
+                    manifestFailureResult.Failure.Reason);
                 continue;
             }
 
@@ -317,14 +319,16 @@ public static class PackageProfileQuery
     private static PackageProfileEvent.Failure Failure(
         PackageSearchMatch candidate,
         PackageProfileFailureKind kind,
-        string message) =>
+        string message,
+        PackageManifestFailureReason? manifestFailureReason = null) =>
         new(
             new PackageProfileFailure(
                 candidate.Metadata.Id,
                 candidate.Metadata.Version,
                 candidate.Candidate.Producer,
                 kind,
-                message));
+                message,
+                manifestFailureReason));
 
     private static void Validate(PackagePrefixProfileRequest request)
     {

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -364,7 +364,8 @@ public class FindCommandTests
                     "1.0.0",
                     PackageSourceIdentity.NuGetOrg,
                     PackageProfileFailureKind.InvalidManifest,
-                    "The manifest was invalid.")),
+                    "The manifest was invalid.",
+                    PackageManifestFailureReason.IdentityMismatch)),
             new PackageProfileEvent.Completed(
                 new PackageProfileSummary(
                     "Contoso.",
@@ -379,7 +380,9 @@ public class FindCommandTests
             events);
 
         Assert.Equal(2, view.Results!.Count);
-        Assert.Equal("InvalidManifest", view.Results[0].Status);
+        Assert.Equal(
+            "InvalidManifest:IdentityMismatch",
+            view.Results[0].Status);
         Assert.Equal("The manifest was invalid.", view.Results[0].Error);
         Assert.Equal("truncated", view.Results[1].Status);
         Assert.Contains(

--- a/src/dotnet-inspect/Sections/PackageProfileSections.cs
+++ b/src/dotnet-inspect/Sections/PackageProfileSections.cs
@@ -292,8 +292,13 @@ public static class PackageProfileSections
             EmptyCell,
             EmptyCell,
             Cell(failure.Producer.Value),
-            Cell(failure.Kind.ToString()),
+            Cell(FailureStatus(failure)),
             Cell(failure.Message));
+
+    private static string FailureStatus(PackageProfileFailure failure) =>
+        failure.ManifestFailureReason is { } manifestReason
+            ? $"{failure.Kind}:{manifestReason}"
+            : failure.Kind.ToString();
 
     private static int MatchRowCount(PackageProfileMatch match)
     {


### PR DESCRIPTION
## Summary

- replace `PackageManifestFactsResult.Failed(Exception)` with a stable
  `PackageManifestFailure` contract
- classify malformed XML, unsupported document shape or namespace, identity
  mismatch, invalid dependency declarations, and query-owned configured limits
- derive every visible message from the typed reason plus optional numeric XML
  location, never package-authored text
- retain the reason through package-profile events, L2 row status, and
  dependency-group selection

## Evidence

- `PackageManifestFactsQueryTests` gates every reason, the unknown/future-reason
  path, hostile identity/dependency/XML inputs, and exact resource boundaries
- `PackageProfileQueryTests` gates typed event propagation and safe visible
  wording
- `FindCommandTests` gates the L2 `InvalidManifest:<reason>` row status
- 60 focused Queries tests pass in Release
- 22 focused CLI/L2 tests pass in Release
- changed design documents pass `markdownlint`

## Compatibility

Accepted nuspec shapes and query acquisition capabilities are unchanged.
`PackageDependencyGroupsResult` retains its legacy exception-shaped
package-content failure while exposing the typed manifest failure alongside it.
The Services parser currently reports decoded-character exhaustion through its
malformed-XML outcome; this PR preserves that owner-issued classification rather
than inferring from exception text.

## Non-claims

- nuspec structural compatibility policy remains #4722
- the pinned real-manifest corpus and independent oracle remain #4724
- Browser/Wasm and measured resource/request canaries remain #4723

Closes #4725
Part of #4714
