### PR TITLE
Compile reusable library section catalog

### DIFF
--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -155,20 +155,43 @@ An unbounded section remains reachable through exact selection, explicit
 category selection, or effective category discovery.
 
 `LibrarySections` retains one process-wide immutable per-assembly query catalog
-and one assembly-group catalog. Catalog construction validates the complete
-required graph and precomputes each query's closure, transitive cost, and
-single-query execution plan. Repeated catalog acquisition and single-query
-planning allocate no memory after static initialization; the
-`LibraryQueryCatalog_RepeatedAcquisitionAndPlanningAllocateNothing` gate
-enforces that property.
+and one assembly-group catalog. Query catalog construction validates the
+complete required graph and precomputes each query's closure, transitive cost,
+and single-query execution plan. Repeated catalog acquisition and single-query
+planning allocate no memory after static initialization;
+`LibraryQueryCatalog_RepeatedAcquisitionAndPlanningAllocateNothing` gates that
+property.
 
-`LibrarySectionCatalog` binds each request's section pipeline to those shared
-catalogs. Commands compile arbitrary multi-query demand once and reuse the
-resulting immutable plan for every assembly in that request, so package
-inspection does not rebuild dependency state per assembly. The mutable
-`InspectionQueryRegistry` remains the authoring surface for dynamic hosts and
-focused extensions; `Compile` snapshots it into a catalog without allowing
-later registrations to mutate that snapshot.
+`SectionPipeline<TModel>` remains the mutable section-authoring API.
+`Compile()` freezes it and returns an immutable `SectionCatalog<TModel>` that
+snapshots stable section and category enumeration. Compilation also preserves
+the frozen pipeline for candidate, effectiveness, and rendering APIs rather
+than introducing a parallel selection implementation. A compiled builder
+rejects later section, category, cost, or pole changes;
+`CompiledSectionCatalog_FreezesBuilderAndSnapshotsEnumeration` gates that
+boundary.
+
+The library retains one process-wide compiled section catalog. It precomputes
+query-demand plans for every automatic verbosity/fixed-overview combination,
+exact single-section selection, category selection, and the base-category
+union, with bounded and unbounded variants. An uncommon arbitrary section set
+is compiled once for that request. Each immutable plan retains both unique
+queries in section-registration order and section-to-query demand pairs for
+`InspectionTrace`; activation creates the request-owned mutable demand set and
+adds attributed command demand. `LibrarySectionCatalog_QueryPlansMatchMutablePipeline`
+and `CompiledSectionQueryPlan_PreservesTraceAttributionAndCommandDemand` gate
+equivalence. Repeated library catalog acquisition and common plan lookup
+allocate no memory after static initialization;
+`LibrarySectionCatalog_RepeatedAcquisitionAndCommonPlanningAllocateNothing`
+gates that narrower claim. `LibrarySections.CreatePipeline()` remains a fresh
+mutable compatibility builder for focused tests and extensions.
+
+Commands compile arbitrary multi-query demand once and reuse the resulting
+immutable query plan for every assembly in that request, so package inspection
+does not rebuild dependency state per assembly. The mutable
+`InspectionQueryRegistry` remains the query-authoring surface for dynamic hosts
+and focused extensions; its `Compile` method snapshots it into a catalog
+without allowing later registrations to mutate that snapshot.
 
 ## Resource declarations
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -3820,6 +3820,197 @@ public class SectionPipelineTests
     }
 
     [Fact]
+    public void CompiledSectionCatalog_FreezesBuilderAndSnapshotsEnumeration()
+    {
+        string[] categoryMembers = [AlwaysSection.Name];
+        var pipeline = CreateTestPipeline()
+            .AddCategory("@Core", categoryMembers);
+        categoryMembers[0] = DetailedSection.Name;
+
+        SectionCatalog<TestModel> catalog = pipeline.Compile();
+
+        Assert.Same(catalog, pipeline.Compile());
+        Assert.Equal(
+            [AlwaysSection.Name, NormalSection.Name, DetailedSection.Name],
+            catalog.AllSectionNames);
+        Assert.Equal([AlwaysSection.Name], catalog.CategoryMap["@Core"]);
+        Assert.Equal(["@All", "@Core"], catalog.CategoryNames);
+        Assert.Throws<InvalidOperationException>(
+            () => pipeline.Add<QueryBackedSection>());
+        Assert.Throws<InvalidOperationException>(
+            () => pipeline.AddCategory("@More", AlwaysSection.Name));
+        Assert.Throws<InvalidOperationException>(
+            () => pipeline.UseCuratedCatalog());
+        Assert.Throws<InvalidOperationException>(
+            () => pipeline.UseQueryCosts(
+                _ => InspectionCost.NetworkFree));
+        Assert.Throws<InvalidOperationException>(
+            () => pipeline.WithoutComputedPoles());
+    }
+
+    [Fact]
+    public void LibrarySectionCatalog_QueryPlansMatchMutablePipeline()
+    {
+        LibrarySectionCatalog libraryCatalog = LibrarySections.CreateCatalog();
+        SectionCatalog<LibraryInspection> catalog = libraryCatalog.Sections;
+        SectionPipeline<LibraryInspection> pipeline = catalog.Pipeline;
+
+        foreach (Verbosity verbosity in Enum.GetValues<Verbosity>())
+        {
+            AssertPlansMatch(verbosity, include: null, fixedOverview: false);
+            AssertPlansMatch(verbosity, include: null, fixedOverview: true);
+            AssertPlansMatch(
+                verbosity,
+                include: null,
+                fixedOverview: false,
+                excludeUnbounded: true);
+            AssertPlansMatch(
+                verbosity,
+                include: null,
+                fixedOverview: true,
+                excludeUnbounded: true);
+        }
+
+        foreach (string section in catalog.SelectableSectionNames)
+        {
+            AssertPlansMatch(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section },
+                fixedOverview: false);
+            AssertPlansMatch(
+                Verbosity.Minimal,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase) { section },
+                fixedOverview: false,
+                excludeUnbounded: true);
+        }
+
+        foreach (ImmutableArray<string> sections in catalog.CategoryMap.Values)
+        {
+            AssertPlansMatch(
+                Verbosity.Normal,
+                new HashSet<string>(sections, StringComparer.OrdinalIgnoreCase),
+                fixedOverview: false);
+            AssertPlansMatch(
+                Verbosity.Normal,
+                new HashSet<string>(sections, StringComparer.OrdinalIgnoreCase),
+                fixedOverview: false,
+                excludeUnbounded: true);
+        }
+
+        AssertPlansMatch(
+            Verbosity.Detailed,
+            [catalog.SelectableSectionNames[0], catalog.SelectableSectionNames[^1]],
+            fixedOverview: false);
+        AssertPlansMatch(
+            Verbosity.Normal,
+            new HashSet<string>
+            {
+                catalog.SelectableSectionNames[0].ToLowerInvariant(),
+            },
+            fixedOverview: false);
+
+        void AssertPlansMatch(
+            Verbosity verbosity,
+            HashSet<string>? include,
+            bool fixedOverview,
+            bool excludeUnbounded = false)
+        {
+            HashSet<InspectionQueryDefinition> expected = pipeline.GetRequiredQueries(
+                verbosity,
+                include,
+                fixedOverview,
+                excludeUnbounded: excludeUnbounded);
+            SectionQueryPlan actual = catalog.PlanQueries(
+                verbosity,
+                include,
+                fixedOverview,
+                excludeUnbounded);
+
+            Assert.True(expected.SetEquals(actual.Queries));
+        }
+    }
+
+    [Fact]
+    public void LibrarySectionCatalog_RepeatedAcquisitionAndCommonPlanningAllocateNothing()
+    {
+        LibrarySectionCatalog libraryCatalog = LibrarySections.CreateCatalog();
+        SectionCatalog<LibraryInspection> catalog = libraryCatalog.Sections;
+        SectionQueryPlan automaticPlan = catalog.PlanQueries(Verbosity.Normal);
+        HashSet<string> exactSelection = new(StringComparer.OrdinalIgnoreCase)
+        {
+            catalog.SelectableSectionNames[0],
+        };
+        SectionQueryPlan exactPlan =
+            catalog.PlanQueries(Verbosity.Normal, exactSelection);
+        ImmutableArray<string> categoryMembers = catalog.CategoryMap.Values.First();
+        HashSet<string> categorySelection =
+            new(categoryMembers, StringComparer.OrdinalIgnoreCase);
+        SectionQueryPlan categoryPlan =
+            catalog.PlanQueries(Verbosity.Normal, categorySelection);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int iteration = 0; iteration < 1_000; iteration++)
+        {
+            if (!ReferenceEquals(libraryCatalog, LibrarySections.CreateCatalog())
+                || !ReferenceEquals(catalog, LibrarySections.SectionCatalog)
+                || !ReferenceEquals(
+                    automaticPlan,
+                    catalog.PlanQueries(Verbosity.Normal))
+                || !ReferenceEquals(
+                    exactPlan,
+                    catalog.PlanQueries(Verbosity.Normal, exactSelection))
+                || !ReferenceEquals(
+                    categoryPlan,
+                    catalog.PlanQueries(Verbosity.Normal, categorySelection)))
+            {
+                throw new InvalidOperationException(
+                    "The library section catalog or a precomputed plan changed identity.");
+            }
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void CompiledSectionQueryPlan_PreservesTraceAttributionAndCommandDemand()
+    {
+        var sectionQuery = new InspectionQuery<int>(
+            "section query",
+            InspectionCost.NetworkFree);
+        var commandQuery = new InspectionQuery<int>(
+            "command query",
+            InspectionCost.NetworkFree);
+        var pipeline = new SectionPipeline<TestModel>()
+            .Add<QueryBackedSection>(sectionQuery);
+        SectionCatalog<TestModel> catalog = pipeline.Compile();
+        var include = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            QueryBackedSection.Name,
+        };
+        List<(string Reason, InspectionQueryDefinition Query)> commandDemand =
+        [
+            ("test command", commandQuery),
+        ];
+        var expectedTrace = new InspectionTrace();
+        var actualTrace = new InspectionTrace();
+
+        HashSet<InspectionQueryDefinition> expected = pipeline.GetRequiredQueries(
+            Verbosity.Normal,
+            include,
+            trace: expectedTrace,
+            commandDemand: commandDemand);
+        HashSet<InspectionQueryDefinition> actual = catalog
+            .PlanQueries(Verbosity.Normal, include)
+            .Activate(actualTrace, commandDemand);
+
+        Assert.True(expected.SetEquals(actual));
+        Assert.Equal(expectedTrace.QueryDemand, actualTrace.QueryDemand);
+        Assert.Equal(expectedTrace.CommandQueryDemand, actualTrace.CommandQueryDemand);
+        Assert.Equal(expectedTrace.RequestedQueries, actualTrace.RequestedQueries);
+    }
+
+    [Fact]
     public void QueryBackedSection_InheritsDependencyClosureCost()
     {
         var prerequisite = new InspectionQuery<int>(

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -113,6 +113,7 @@ public class LibraryCommand
     {
         var assemblyPath = options.AssemblyName;
         var catalog = LibrarySections.CreateCatalog();
+        var sections = catalog.Sections;
         var pipeline = catalog.Pipeline;
         var queryCatalog = catalog.QueryCatalog;
         var groupQueryCatalog = catalog.GroupQueryCatalog;
@@ -170,7 +171,7 @@ public class LibraryCommand
                     tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
                     verbosity: (int)options.Verbosity,
                     sectionCostAnnotations: pipeline.GetCostAnnotations(),
-                    sectionCategories: pipeline.GetCategoryMap(),
+                    sectionCategories: sections.SelectionCategoryMap,
                     // --schema reveals every registered section. Structural category drill-down
                     // keeps the curated top-level scope when no target inspection is requested.
                     catalogHiddenSections: options.Schema ? null : pipeline.GetCatalogHiddenSections(),
@@ -220,8 +221,8 @@ public class LibraryCommand
         if (fullEffectiveDiscovery && options.Discover is { Length: > 0 })
         {
             var discoverResult = SelectResolver.ResolveSelectAsSections(
-                options.Discover, pipeline.SelectableSectionNames, pipeline.InfoSectionNames,
-                pipeline.GetCategoryMap(), selectDefault: false);
+                options.Discover, sections.SelectableSectionNames, sections.InfoSectionNames,
+                sections.SelectionCategoryMap, selectDefault: false);
             if (SelectOutput.WriteUnresolved(discoverResult))
                 return 1;
             options = options with { IncludeSections = discoverResult.Sections };
@@ -229,7 +230,8 @@ public class LibraryCommand
 
         // -S/--select with values: resolve as section filter for backpressure
         var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap(),
+            options.Select, sections.SelectableSectionNames, sections.InfoSectionNames,
+            sections.SelectionCategoryMap,
             selectDefault: options.SelectDefault);
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
@@ -496,7 +498,7 @@ public class LibraryCommand
         // requested sections; bare full discovery is bounded to the base-category union.
         HashSet<string>? discoveryExecutionScope = options.IncludeSections;
         if (fullEffectiveDiscovery && discoveryExecutionScope is not { Count: > 0 })
-            discoveryExecutionScope = [.. pipeline.BaseSectionNames];
+            discoveryExecutionScope = [.. sections.BaseSectionNames];
         bool useEffectiveDiscoveryCache = fullEffectiveDiscovery
             && options.Discover is { Length: 0 }
             && options.UserIncludeSections is not { Count: > 0 }
@@ -514,7 +516,7 @@ public class LibraryCommand
         }
         if (options.CollectReferenceTree)
             commandQueryDemand.Add(("reference tree", AssemblyReferencesQuery.Definition));
-        HashSet<InspectionQueryDefinition> sectionQueries = pipeline.GetRequiredQueries(
+        SectionQueryPlan sectionPlan = sections.PlanQueries(
             discoveryInspection && !fullEffectiveDiscovery
                 ? Verbosity.Quiet
                 : options.Verbosity,
@@ -523,9 +525,8 @@ public class LibraryCommand
                 : discoveryExecutionScope,
             discoveryInspection && !fullEffectiveDiscovery
                 ? false
-                : options.FixedOverview,
-            trace);
-        if (sectionQueries.Contains(BodyShapesQuery.Definition)
+                : options.FixedOverview);
+        if (sectionPlan.Queries.Contains(BodyShapesQuery.Definition)
             && options.BodyKindQuery.HasFilter
             && options.PerformanceTriage.HasCandidateFilters)
         {
@@ -534,13 +535,8 @@ public class LibraryCommand
                     OptimizationOpportunitiesQuery.Definition));
         }
 
-        HashSet<InspectionQueryDefinition> queries = sectionQueries;
-        foreach ((string reason, InspectionQueryDefinition query) in commandQueryDemand)
-        {
-            queries.Add(query);
-            trace?.RecordCommandQueryDemand(reason, query);
-        }
-        trace?.RecordRequestedQueries(queries);
+        HashSet<InspectionQueryDefinition> queries =
+            sectionPlan.Activate(trace, commandQueryDemand);
         var inspectionOptions = fullEffectiveDiscovery
             && options.IncludeSections is not { Count: > 0 }
             ? options with { IncludeSections = discoveryExecutionScope }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -4091,6 +4091,7 @@ public class PackageCommand
                 : packageName;
 
         var catalog = LibrarySections.CreateCatalog();
+        var sectionCatalog = catalog.Sections;
         var pipeline = catalog.Pipeline;
         var queryCatalog = catalog.QueryCatalog;
         var libraryOptions = CreateLibraryOptions(assemblyName: null, packageReference, options);
@@ -4103,9 +4104,9 @@ public class PackageCommand
 
         var selectResult = SelectResolver.ResolveSelectAsSections(
             libraryOptions.Select,
-            pipeline.SelectableSectionNames,
-            pipeline.InfoSectionNames,
-            pipeline.GetCategoryMap(),
+            sectionCatalog.SelectableSectionNames,
+            sectionCatalog.InfoSectionNames,
+            sectionCatalog.SelectionCategoryMap,
             selectDefault: libraryOptions.SelectDefault);
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
@@ -4162,14 +4163,14 @@ public class PackageCommand
                 candidates.Contains(SectionNames.IdentifierConfusion),
         };
 
-        HashSet<InspectionQueryDefinition> sectionQueries = pipeline.GetRequiredQueries(
+        SectionQueryPlan sectionPlan = sectionCatalog.PlanQueries(
             libraryOptions.Verbosity,
             libraryOptions.IncludeSections,
             libraryOptions.FixedOverview);
         List<(string Reason, InspectionQueryDefinition Query)> commandQueryDemand = [];
         if (libraryOptions.CollectReferenceTree)
             commandQueryDemand.Add(("reference tree", AssemblyReferencesQuery.Definition));
-        if (sectionQueries.Contains(BodyShapesQuery.Definition)
+        if (sectionPlan.Queries.Contains(BodyShapesQuery.Definition)
             && libraryOptions.BodyKindQuery.HasFilter
             && libraryOptions.PerformanceTriage.HasCandidateFilters)
         {
@@ -4177,9 +4178,8 @@ public class PackageCommand
                 ("Body Shapes performance predicates",
                     OptimizationOpportunitiesQuery.Definition));
         }
-        HashSet<InspectionQueryDefinition> queries = sectionQueries;
-        foreach ((_, InspectionQueryDefinition query) in commandQueryDemand)
-            queries.Add(query);
+        HashSet<InspectionQueryDefinition> queries =
+            sectionPlan.Activate(commandDemand: commandQueryDemand);
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
         bool requiresGroupedIntegrations =
@@ -4319,8 +4319,8 @@ public class PackageCommand
             && libraryOptions.Select?.Any(
                 value => SelectResolver.TryResolveCategory(
                     value,
-                    pipeline.GetCategoryMap(),
-                    pipeline.SelectableSectionNames,
+                    sectionCatalog.SelectionCategoryMap,
+                    sectionCatalog.SelectableSectionNames,
                     out _,
                     out _)) == true)
         {

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -167,7 +167,7 @@ public static class SelectResolver
     /// (discover semantics); otherwise all glob matches are returned.
     /// </summary>
     public static (List<string> Matches, SelectMiss? Miss) ResolveSingle(
-        string name, string[] knownSections, bool singleGlob = false)
+        string name, IReadOnlyList<string> knownSections, bool singleGlob = false)
     {
         var (matches, miss, _) = ResolveSingleWithProvenance(name, knownSections, singleGlob);
         return (matches, miss);
@@ -175,7 +175,7 @@ public static class SelectResolver
 
     private static (List<string> Matches, SelectMiss? Miss, bool IsExact)
         ResolveSingleWithProvenance(
-            string name, string[] knownSections, bool singleGlob = false)
+            string name, IReadOnlyList<string> knownSections, bool singleGlob = false)
     {
         // Exact match (case-insensitive)
         var exact = knownSections.FirstOrDefault(s =>
@@ -234,8 +234,8 @@ public static class SelectResolver
     /// </param>
     public static SelectResult ResolveSelectAsSections(
         string[]? select,
-        string[] knownSections,
-        string[]? infoSections = null,
+        IReadOnlyList<string> knownSections,
+        IReadOnlyList<string>? infoSections = null,
         IReadOnlyDictionary<string, string[]>? categories = null,
         bool selectDefault = false)
     {
@@ -313,11 +313,12 @@ public static class SelectResolver
         };
     }
 
-    private static IReadOnlyDictionary<string, string[]> BuildFallbackCategories(string[] knownSections)
+    private static IReadOnlyDictionary<string, string[]> BuildFallbackCategories(
+        IReadOnlyList<string> knownSections)
     {
         Dictionary<string, string[]> categories = new(StringComparer.OrdinalIgnoreCase)
         {
-            [AllSelector] = knownSections
+            [AllSelector] = [.. knownSections]
         };
         return categories;
     }
@@ -326,7 +327,10 @@ public static class SelectResolver
     /// Generates suggestions using prefix + fuzzy matching, ranked by similarity.
     /// Same strategy as TypeMatcher.LookupMembers.
     /// </summary>
-    private static List<string> GetSuggestions(string value, string[] allNames, int maxResults = 6)
+    private static List<string> GetSuggestions(
+        string value,
+        IReadOnlyList<string> allNames,
+        int maxResults = 6)
     {
         var suggestions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var valueKey = SuggestionKey(value);

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -7,9 +7,12 @@ using ILInspector.Metadata;
 namespace DotnetInspector.Sections;
 
 public sealed record LibrarySectionCatalog(
-    SectionPipeline<LibraryInspection> Pipeline,
+    SectionCatalog<LibraryInspection> Sections,
     InspectionQueryCatalog<InspectionQueryContext> QueryCatalog,
-    InspectionQueryCatalog<AssemblyContextGroup> GroupQueryCatalog);
+    InspectionQueryCatalog<AssemblyContextGroup> GroupQueryCatalog)
+{
+    public SectionPipeline<LibraryInspection> Pipeline => Sections.Pipeline;
+}
 
 /// <summary>
 /// Section descriptors for the library command.
@@ -26,20 +29,19 @@ public static class LibrarySections
     public static InspectionQueryCatalog<AssemblyContextGroup> GroupQueryCatalog { get; } =
         BuildGroupQueryCatalog();
 
+    /// <summary>The reusable fixed-domain catalog for library sections and query-demand plans.</summary>
+    public static SectionCatalog<LibraryInspection> SectionCatalog { get; } =
+        CreatePipeline().Compile();
+
+    /// <summary>The complete reusable library section and query catalog.</summary>
+    public static LibrarySectionCatalog Catalog { get; } =
+        new(SectionCatalog, QueryCatalog, GroupQueryCatalog);
+
     /// <summary>
     /// Builds the library catalog from typed query catalogs, so section costs, demand, and
     /// execution use the same immutable declarations.
     /// </summary>
-    public static LibrarySectionCatalog CreateCatalog()
-    {
-        return new LibrarySectionCatalog(
-            CreatePipeline(
-                query => GroupQueryCatalog.RegisteredQueries.Contains(query)
-                    ? GroupQueryCatalog.CostOf(query)
-                    : QueryCatalog.CostOf(query)),
-            QueryCatalog,
-            GroupQueryCatalog);
-    }
+    public static LibrarySectionCatalog CreateCatalog() => Catalog;
 
     /// <summary>Builds the section pipeline with all library sections registered.</summary>
     public static SectionPipeline<LibraryInspection> CreatePipeline()

--- a/src/dotnet-inspect/Sections/SectionCatalog.cs
+++ b/src/dotnet-inspect/Sections/SectionCatalog.cs
@@ -1,0 +1,263 @@
+using System.Collections.Immutable;
+using DotnetInspector.Options;
+using DotnetInspector.Queries;
+
+namespace DotnetInspector.Sections;
+
+public readonly record struct SectionQueryDemand(
+    string Section,
+    InspectionQueryDefinition Query);
+
+public sealed record CompiledSectionCategory(
+    string Name,
+    SectionCategoryRole Role,
+    ImmutableArray<string> Sections);
+
+public sealed class SectionQueryPlan
+{
+    internal SectionQueryPlan(
+        ImmutableArray<InspectionQueryDefinition> queries,
+        ImmutableArray<SectionQueryDemand> demands)
+    {
+        Queries = queries;
+        Demands = demands;
+    }
+
+    public ImmutableArray<InspectionQueryDefinition> Queries { get; }
+
+    public ImmutableArray<SectionQueryDemand> Demands { get; }
+
+    public HashSet<InspectionQueryDefinition> Activate(
+        InspectionTrace? trace = null,
+        IReadOnlyList<(string Reason, InspectionQueryDefinition Query)>? commandDemand = null)
+    {
+        HashSet<InspectionQueryDefinition> queries = [.. Queries];
+
+        if (trace is not null)
+        {
+            foreach (SectionQueryDemand demand in Demands)
+                trace.RecordQueryDemand(demand.Section, demand.Query);
+        }
+
+        if (commandDemand is not null)
+        {
+            foreach ((string reason, InspectionQueryDefinition query) in commandDemand)
+            {
+                queries.Add(query);
+                trace?.RecordCommandQueryDemand(reason, query);
+            }
+        }
+
+        trace?.RecordRequestedQueries(queries);
+        return queries;
+    }
+}
+
+public sealed class SectionCatalog<TModel>
+{
+    private const int PlanVariantCount = 4;
+
+    private readonly SectionQueryPlan[] _automaticPlans;
+    private readonly Dictionary<string, PrecomputedSelection> _singleSectionPlans;
+    private readonly ImmutableArray<PrecomputedSelection> _selectionPlans;
+
+    internal SectionCatalog(SectionPipeline<TModel> pipeline)
+    {
+        Pipeline = pipeline;
+        AllSectionNames = [.. pipeline.AllSectionNames];
+        AlphabeticalSectionOrder = [.. pipeline.AlphabeticalSectionOrder];
+        DeclaredQueries = [.. pipeline.DeclaredQueries];
+        SelectableSectionNames = [.. pipeline.SelectableSectionNames];
+        InfoSectionNames = [.. pipeline.InfoSectionNames];
+        BaseSectionNames = [.. pipeline.BaseSectionNames];
+        FixedOverviewSectionNames = [.. pipeline.FixedOverviewSectionNames];
+        BareSelectSectionNames = [.. pipeline.BareSelectSectionNames];
+        AuthoredCategories =
+            [.. pipeline.RegisteredCategories.Select(static category =>
+                new CompiledSectionCategory(
+                    category.Name,
+                    category.Role,
+                    [.. category.Sections]))];
+
+        ImmutableDictionary<string, ImmutableArray<string>>.Builder categories =
+            ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(
+                StringComparer.OrdinalIgnoreCase);
+        IReadOnlyDictionary<string, string[]> categoryMap = pipeline.GetCategoryMap();
+        SelectionCategoryMap = categoryMap;
+        CategoryNames = [.. categoryMap.Keys];
+        foreach ((string name, string[] sections) in categoryMap)
+            categories.Add(name, [.. sections]);
+
+        CategoryMap = categories.ToImmutable();
+
+        Verbosity[] verbosityValues = Enum.GetValues<Verbosity>();
+        _automaticPlans = new SectionQueryPlan[verbosityValues.Length * PlanVariantCount];
+        foreach (Verbosity verbosity in verbosityValues)
+        {
+            for (int fixedOverview = 0; fixedOverview <= 1; fixedOverview++)
+            {
+                for (int excludeUnbounded = 0; excludeUnbounded <= 1; excludeUnbounded++)
+                {
+                    _automaticPlans[GetAutomaticIndex(
+                        verbosity,
+                        fixedOverview != 0,
+                        excludeUnbounded != 0)] = pipeline.CreateQueryPlan(
+                            verbosity,
+                            include: null,
+                            fixedOverview != 0,
+                            excludeUnbounded != 0);
+                }
+            }
+        }
+
+        _singleSectionPlans = new Dictionary<string, PrecomputedSelection>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (string section in SelectableSectionNames)
+        {
+            HashSet<string> include = new(StringComparer.OrdinalIgnoreCase) { section };
+            _singleSectionPlans.Add(
+                section,
+                new PrecomputedSelection(
+                    [section],
+                    CreateExplicitSelectionPlans(pipeline, include)));
+        }
+
+        ImmutableArray<PrecomputedSelection>.Builder selections =
+            ImmutableArray.CreateBuilder<PrecomputedSelection>();
+        foreach (ImmutableArray<string> categorySections in CategoryMap.Values)
+            AddSelection(pipeline, selections, categorySections);
+
+        AddSelection(pipeline, selections, BaseSectionNames);
+        _selectionPlans = selections.ToImmutable();
+    }
+
+    public SectionPipeline<TModel> Pipeline { get; }
+
+    public ImmutableArray<string> AllSectionNames { get; }
+
+    public ImmutableArray<string> AlphabeticalSectionOrder { get; }
+
+    public ImmutableArray<InspectionQueryDefinition> DeclaredQueries { get; }
+
+    public ImmutableArray<string> SelectableSectionNames { get; }
+
+    public ImmutableArray<string> InfoSectionNames { get; }
+
+    public ImmutableArray<string> BaseSectionNames { get; }
+
+    public ImmutableArray<string> FixedOverviewSectionNames { get; }
+
+    public ImmutableArray<string> BareSelectSectionNames { get; }
+
+    public ImmutableArray<CompiledSectionCategory> AuthoredCategories { get; }
+
+    public ImmutableArray<string> CategoryNames { get; }
+
+    public ImmutableDictionary<string, ImmutableArray<string>> CategoryMap { get; }
+
+    internal IReadOnlyDictionary<string, string[]> SelectionCategoryMap { get; }
+
+    public SectionQueryPlan PlanQueries(
+        Verbosity verbosity,
+        HashSet<string>? include = null,
+        bool fixedOverview = false,
+        bool excludeUnbounded = false)
+    {
+        if (include is null || include.Count == 0)
+        {
+            return _automaticPlans[GetAutomaticIndex(
+                verbosity,
+                fixedOverview,
+                excludeUnbounded)];
+        }
+
+        if (include.Count == 1)
+        {
+            foreach (string section in include)
+            {
+                if (_singleSectionPlans.TryGetValue(
+                        section,
+                        out PrecomputedSelection? selection)
+                    && SelectionEquals(include, selection.Sections))
+                {
+                    return selection.Plans[excludeUnbounded ? 1 : 0];
+                }
+            }
+        }
+
+        foreach (PrecomputedSelection selection in _selectionPlans)
+        {
+            if (SelectionEquals(include, selection.Sections))
+                return selection.Plans[excludeUnbounded ? 1 : 0];
+        }
+
+        return Pipeline.CreateQueryPlan(
+            verbosity,
+            include,
+            fixedOverview,
+            excludeUnbounded);
+    }
+
+    private static SectionQueryPlan[] CreateExplicitSelectionPlans(
+        SectionPipeline<TModel> pipeline,
+        HashSet<string> include) =>
+    [
+        pipeline.CreateQueryPlan(
+            Verbosity.Normal,
+            include,
+            fixedOverview: false,
+            excludeUnbounded: false),
+        pipeline.CreateQueryPlan(
+            Verbosity.Normal,
+            include,
+            fixedOverview: false,
+            excludeUnbounded: true)
+    ];
+
+    private static void AddSelection(
+        SectionPipeline<TModel> pipeline,
+        ImmutableArray<PrecomputedSelection>.Builder selections,
+        ImmutableArray<string> sections)
+    {
+        if (sections.IsEmpty ||
+            selections.Any(selection => selection.Sections.SequenceEqual(
+                sections,
+                StringComparer.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        HashSet<string> include = new(sections, StringComparer.OrdinalIgnoreCase);
+        selections.Add(new PrecomputedSelection(
+            sections,
+            CreateExplicitSelectionPlans(pipeline, include)));
+    }
+
+    private static bool SelectionEquals(
+        HashSet<string> include,
+        ImmutableArray<string> sections)
+    {
+        if (include.Count != sections.Length)
+            return false;
+
+        foreach (string section in sections)
+        {
+            if (!include.Contains(section))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static int GetAutomaticIndex(
+        Verbosity verbosity,
+        bool fixedOverview,
+        bool excludeUnbounded) =>
+        ((int)verbosity * PlanVariantCount) |
+        (fixedOverview ? 2 : 0) |
+        (excludeUnbounded ? 1 : 0);
+
+    private sealed record PrecomputedSelection(
+        ImmutableArray<string> Sections,
+        SectionQueryPlan[] Plans);
+}

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -59,9 +59,27 @@ public sealed class SectionPipeline<TModel>
     private bool _curatedCatalog;
     private bool _computedPoles = true;
     private Func<InspectionQueryDefinition, InspectionCost>? _queryCost;
+    private SectionCatalog<TModel>? _compiledCatalog;
 
     public const string AllCategory = "@All";
     public const string HiddenCategory = "@Hidden";
+
+    internal IReadOnlyList<SectionCategory> RegisteredCategories => _categories;
+
+    public SectionCatalog<TModel> Compile()
+    {
+        if (_compiledCatalog is not null)
+            return _compiledCatalog;
+
+        for (int i = 0; i < _categories.Count; i++)
+        {
+            SectionCategory category = _categories[i];
+            _categories[i] = category with { Sections = [.. category.Sections] };
+        }
+
+        _compiledCatalog = new SectionCatalog<TModel>(this);
+        return _compiledCatalog;
+    }
 
     /// <summary>
     /// Opts this pipeline into the curated-catalog taxonomy: <c>@All</c> is the visible pole
@@ -73,6 +91,7 @@ public sealed class SectionPipeline<TModel>
     /// </summary>
     public SectionPipeline<TModel> UseCuratedCatalog()
     {
+        EnsureMutable();
         _curatedCatalog = true;
         return this;
     }
@@ -84,6 +103,7 @@ public sealed class SectionPipeline<TModel>
     public SectionPipeline<TModel> UseQueryCosts(
         Func<InspectionQueryDefinition, InspectionCost> costOf)
     {
+        EnsureMutable();
         if (_entries.Count > 0)
             throw new InvalidOperationException(
                 "UseQueryCosts must be called before any section is registered; " +
@@ -103,6 +123,7 @@ public sealed class SectionPipeline<TModel>
     /// </summary>
     public SectionPipeline<TModel> WithoutComputedPoles()
     {
+        EnsureMutable();
         _computedPoles = false;
         return this;
     }
@@ -204,6 +225,7 @@ public sealed class SectionPipeline<TModel>
     /// </summary>
     public SectionPipeline<TModel> Add(SectionEntry<TModel> entry)
     {
+        EnsureMutable();
         if (entry.Queries.IsDefault)
             throw new InvalidOperationException($"{entry.Name} has an uninitialized query set.");
         if (entry.Queries.Any(query => query is null))
@@ -264,6 +286,7 @@ public sealed class SectionPipeline<TModel>
         SectionCategoryRole role,
         params string[] sections)
     {
+        EnsureMutable();
         if (!name.StartsWith("@", StringComparison.Ordinal))
             throw new ArgumentException("Section category names must start with '@'.", nameof(name));
 
@@ -275,7 +298,7 @@ public sealed class SectionPipeline<TModel>
                 "Category membership must name a registered section; use the SectionNames constant " +
                 "the descriptor returns so renames move both together.");
 
-        _categories.Add(new SectionCategory(name, role, sections));
+        _categories.Add(new SectionCategory(name, role, [.. sections]));
         return this;
     }
 
@@ -425,7 +448,7 @@ public sealed class SectionPipeline<TModel>
         }
 
         foreach (var category in _categories)
-            categories[category.Name] = category.Sections;
+            categories[category.Name] = [.. category.Sections];
 
         if (_curatedCatalog && _computedPoles)
             categories[HiddenCategory] = GetHiddenSections().ToArray();
@@ -787,22 +810,15 @@ public sealed class SectionPipeline<TModel>
         bool excludeUnbounded = false)
     {
         HashSet<InspectionQueryDefinition> queries = [];
-        for (int i = 0; i < _entries.Count; i++)
-        {
-            SectionEntry<TModel> entry = _entries[i];
-            if (entry.Queries.IsDefaultOrEmpty)
-                continue;
-            if (excludeUnbounded && entry.Cost == SectionCost.Unbounded)
-                continue;
-            if (IsRequested(entry, i, verbosity, include, fixedOverview))
-            {
-                foreach (InspectionQueryDefinition query in entry.Queries)
-                {
-                    queries.Add(query);
-                    trace?.RecordQueryDemand(entry.Name, query);
-                }
-            }
-        }
+        CollectRequiredQueries(
+            verbosity,
+            include,
+            fixedOverview,
+            excludeUnbounded,
+            queries,
+            orderedQueries: null,
+            demands: null,
+            trace);
 
         if (commandDemand is not null)
         {
@@ -815,6 +831,62 @@ public sealed class SectionPipeline<TModel>
 
         trace?.RecordRequestedQueries(queries);
         return queries;
+    }
+
+    internal SectionQueryPlan CreateQueryPlan(
+        Verbosity verbosity,
+        HashSet<string>? include,
+        bool fixedOverview,
+        bool excludeUnbounded)
+    {
+        HashSet<InspectionQueryDefinition> queries = [];
+        ImmutableArray<InspectionQueryDefinition>.Builder orderedQueries =
+            ImmutableArray.CreateBuilder<InspectionQueryDefinition>();
+        ImmutableArray<SectionQueryDemand>.Builder demands =
+            ImmutableArray.CreateBuilder<SectionQueryDemand>();
+
+        CollectRequiredQueries(
+            verbosity,
+            include,
+            fixedOverview,
+            excludeUnbounded,
+            queries,
+            orderedQueries,
+            demands,
+            trace: null);
+
+        return new SectionQueryPlan(orderedQueries.ToImmutable(), demands.ToImmutable());
+    }
+
+    private void CollectRequiredQueries(
+        Verbosity verbosity,
+        HashSet<string>? include,
+        bool fixedOverview,
+        bool excludeUnbounded,
+        HashSet<InspectionQueryDefinition> queries,
+        ImmutableArray<InspectionQueryDefinition>.Builder? orderedQueries,
+        ImmutableArray<SectionQueryDemand>.Builder? demands,
+        InspectionTrace? trace)
+    {
+        for (int i = 0; i < _entries.Count; i++)
+        {
+            SectionEntry<TModel> entry = _entries[i];
+            if (entry.Queries.IsDefaultOrEmpty)
+                continue;
+            if (excludeUnbounded && entry.Cost == SectionCost.Unbounded)
+                continue;
+            if (IsRequested(entry, i, verbosity, include, fixedOverview))
+            {
+                foreach (InspectionQueryDefinition query in entry.Queries)
+                {
+                    if (queries.Add(query))
+                        orderedQueries?.Add(query);
+
+                    demands?.Add(new SectionQueryDemand(entry.Name, query));
+                    trace?.RecordQueryDemand(entry.Name, query);
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -842,6 +914,15 @@ public sealed class SectionPipeline<TModel>
 
         // No expensive entries: all are primary
         return _entries.Count - 1;
+    }
+
+    private void EnsureMutable()
+    {
+        if (_compiledCatalog is not null)
+        {
+            throw new InvalidOperationException(
+                "A compiled section pipeline is immutable. Create a new pipeline to author another catalog.");
+        }
     }
 
     private bool IsRequested(SectionEntry<TModel> entry, int index, Verbosity verbosity,


### PR DESCRIPTION
## Summary

- freeze mutable section declarations into an immutable catalog with stable section/category snapshots
- precompute automatic, exact-section, category, base-scope, and bounded query-demand plans while preserving trace attribution
- reuse one process-wide library section catalog in library and package `--all-libraries` execution

## Behavior

Selection, verbosity, cost, discovery, output, query identity, and resource policy are unchanged. Request activation still owns its mutable query set; uncommon arbitrary selection combinations compile once for that request.

Package, Diff, and Package Profile catalogs remain outside this slice. `LibrarySourcePlans` remains the separate resource-authorization table.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `SectionPipelineTests` and `SelectResolverTests`
- affected `CommandExecutionTests.Library_*` and `Package_AllLibraries_*` tests
- `npx markdownlint-cli docs/design/section-pipeline.md`

The full CLI suite was also attempted locally; unrelated platform-catalog availability failures prevented a clean aggregate result. The changed and directly affected test surfaces are green.

Closes #4728
