### PR TITLE
Apply PR readiness labels in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,30 @@ Do not repeat or move the round report, architectural checkpoint, carry-forward
 analysis, evidence, or recommendation into the prompt. The prompt is a control,
 not the record.
 
+### Keep PR readiness labels current
+
+`ready-to-merge` and `carry-forward` are mutually exclusive live state, not
+historical milestones. Reconcile them after every resume and whenever the head,
+review result, base, draft state, or mergeability changes. Remove a stale label
+before reporting the new state. Neither label authorizes a merge.
+
+- **`ready-to-merge`:** add it when, and only when, the current head satisfies
+  the repository's `Ready to merge` claim: every required review is
+  review-clean and GitHub reports positive mergeability. Remove it before a new
+  round, author change, conflict recovery, restack, unresolved finding, draft
+  transition, or non-positive mergeability. When base movement enters the
+  carry-forward path, replace it with `carry-forward`.
+- **`carry-forward`:** add it when the
+  [clean-review carry-forward rule](#clean-reviews-are-not-spent-by-main-moving)
+  applies and analysis or approval is the next action. Keep it while that
+  analysis or decision is pending, including when another base movement requires
+  re-analysis. Remove it when carry-forward is unavailable or declined, before
+  integrating an approved tip, or when the review-clean evidence is otherwise
+  invalidated.
+
+Never leave both labels on a PR. A successful approved carry-forward may restore
+`ready-to-merge` only after the new head again satisfies its conditions.
+
 ### Publish your state where tooling can read it
 
 Update both window-scoped options whenever state changes:

--- a/agents/burndown-curator.md
+++ b/agents/burndown-curator.md
@@ -53,7 +53,9 @@ issue.
 Runners must post an explicit `Ready to merge` PR comment after all
 merge-blocking validation, CI, and required review are complete. If an agent keeps
 running extra tests or review after that point, the PR comment or follow-up
-status must label that work as non-blocking.
+status must label that work as non-blocking. Keep the `ready-to-merge` and
+`carry-forward` PR labels synchronized with
+[repository guidance](../AGENTS.md#keep-pr-readiness-labels-current).
 
 For every open PR mentioned in a report, state either:
 

--- a/agents/burndown-runner.md
+++ b/agents/burndown-runner.md
@@ -32,7 +32,9 @@ row at a time and drives it to a PR, explicit blocker, or pivot issue.
 6. Open a PR and update the row to `In review — #PR`.
 7. When all merge-blocking validation, CI, and required review are complete,
    post a PR comment that clearly says `Ready to merge`. Label any later tests
-   or review as non-blocking follow-up work.
+   or review as non-blocking follow-up work. Keep the `ready-to-merge` and
+   `carry-forward` PR labels synchronized with
+   [repository guidance](../AGENTS.md#keep-pr-readiness-labels-current).
 8. When merged, the curator or runner updates the row to `Done — #PR`.
 
 ## If blocked

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -943,7 +943,9 @@ raise code.
 When the decision is **Go** and all merge-blocking validation, CI, and required
 review are complete, post a PR comment that clearly says `Ready to merge`. If
 extra tests or review continue after that point, mark them as non-blocking
-follow-up work so the PR state remains unambiguous.
+follow-up work so the PR state remains unambiguous. Keep the `ready-to-merge`
+and `carry-forward` PR labels synchronized with
+[repository guidance](../AGENTS.md#keep-pr-readiness-labels-current).
 
 ## Naming the harnesses by role
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -255,6 +255,11 @@ normal session output. Then open a separate prompt containing only the concise
 decision question and answer labels. Do not repeat the report or its evidence
 inside the prompt.
 
+Before emitting the report or opening its approval prompt, synchronize the PR's
+`ready-to-merge` and `carry-forward` labels with
+[Keep PR readiness labels current](../AGENTS.md#keep-pr-readiness-labels-current).
+The labels describe the state the report records; they must not lag behind it.
+
 The same report may also be posted on the PR; the public reconciliation may
 include more detail when the findings or fixes warrant it.
 
@@ -266,19 +271,23 @@ path applies and when it does not. This is the procedure once it does.
 
 1. **Detect movement.** Compare the candidate's recorded base tip with the live
    tip in `baseRef.target.oid`. `baseRefOid` is the base commit recorded for the
-   PR, not the live branch tip.
+   PR, not the live branch tip. Replace `ready-to-merge` with `carry-forward`
+   before beginning the analysis.
 2. **Inspect without integrating.** A non-mutating fetch is permitted solely to
    read the exact landed range.
 3. **Report, then ask.** As normal session output, report which commits touch
    files this change touches, which relied-on behavior they alter, and any
    conflict a textual merge would resolve silently but wrongly. Say plainly
-   when nothing interacts. After that output is visible, open a separate prompt
-   that asks only whether to carry the clean reviews forward to the named tip.
+   when nothing interacts. Remove `carry-forward` before reporting an outcome
+   where the path is unavailable. After that output is visible, open a separate
+   prompt that asks only whether to carry the clean reviews forward to the named
+   tip.
 4. **Execute the rule's decision.** Exactly one of its outcomes runs here: when
-   it authorizes carry-forward, integrate that exact analyzed tip by SHA, not a
-   moving branch ref, and re-run the claimed validation and current-head CI.
-   Every other outcome — declined, interacting, or that re-run failing — returns
-   to the rule for its terminal action, which this document does not restate.
+   it authorizes carry-forward, remove `carry-forward`, integrate that exact
+   analyzed tip by SHA, not a moving branch ref, and re-run the claimed
+   validation and current-head CI. Remove `carry-forward` when the user declines.
+   Every other outcome — interacting or that re-run failing — returns to the
+   rule for its terminal action, which this document does not restate.
 
 For an approved carry-forward, record the reviewed head, the old and approved
 new tips, the non-interaction analysis, and the user's decision on the PR.


### PR DESCRIPTION
## Summary

- define `ready-to-merge` and `carry-forward` as mutually exclusive live PR state
- specify when agents add, replace, and remove each label
- link focused burndown and decompiler workflows to the repository-wide rule

## Demo

Agents now mark review-clean, mergeable PRs with `ready-to-merge` and switch them to `carry-forward` when base movement requires analysis or approval. Stale labels are removed before reporting state, and neither label grants merge authorization.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md docs/decompiler-correctness-pipeline.md agents/burndown-runner.md agents/burndown-curator.md`

This is a trivial documentation-only workflow clarification: it changes no product code or executable behavior.