### PR TITLE
Remove duplicate UnsafeEvidencePresenceQuery bans

### DIFF
--- a/prototypes/inspect-web/engine/BannedSymbols.txt
+++ b/prototypes/inspect-web/engine/BannedSymbols.txt
@@ -29,11 +29,9 @@ T:ILInspector.SourceLink.SourceLinkService;SourceLink and PDB inspection open de
 T:ILInspector.SourceLink.SourceLinkInspector;Path-based SourceLink inspection belongs to product queries, not the browser host.
 T:ILInspector.Analysis.CallerScopeReachabilityPlan;Caller-scope metadata inspection belongs to product queries, not transitive descriptor openers in the browser host.
 T:ILInspector.Analysis.LibraryBodyIndex;Analysis lifetimes belong to the query that needs them, not to the browser host.
-T:DotnetInspector.Queries.UnsafeEvidencePresenceQuery;Path-based unsafe-evidence inspection belongs to product queries, not the browser host.
 T:ILInspector.Analysis.LibraryBodyAnalysisResult;Body analysis is reached through a query result, never built here.
 T:ILInspector.Analysis.LeakTriageAnalyzer;Path-based body analysis belongs to product queries, not the browser host.
 T:ILInspector.Analysis.ResourceLifecycleAnalysis;Path-based lifecycle analysis belongs to product queries, not the browser host.
-T:DotnetInspector.Queries.UnsafeEvidencePresenceQuery;Path-based unsafe-evidence inspection belongs behind a workspace-owned query entry point, not the browser host.
 T:ILInspector.Instructions.IlAssemblyDiff;Raw IL stream comparison belongs to product queries, not the browser host.
 T:ILInspector.Decompiler.CSharpBodyDiff;Path-based decompiler comparison belongs to product queries, not the browser host.
 T:ILInspector.Decompiler.CSharpFindings;Path-based decompiler Finding comparison belongs to product queries, not the browser host.


### PR DESCRIPTION
## Summary

`DotnetInspector.Queries.UnsafeEvidencePresenceQuery` is banned from the browser
engine three times. Two of the three copies are removed; the ban itself is
unchanged.

## Why there are three

The type arrived with #4453 and was not classified in either the path-method
approved list or `BannedSymbols.txt`, so
`BrowserEngineLayeringTests.EveryPublicPathMethodOwnerIsBannedOrApprovedNonInspectionSurface`
started failing on `main`. Three PRs then fixed it independently:

| Commit | PR | Rationale text |
| --- | --- | --- |
| `0e4fd4498` | #4708 | "The presence probe consumes a borrowed PdbContext and raw path directly..." |
| `00b7963a4` | -- | "Path-based unsafe-evidence inspection belongs to product queries..." |
| `6ca99b0cd` | #4563 | "...belongs behind a workspace-owned query entry point..." |

Each inserted its line at a different point in the file, so no two merges
conflicted and all three survived.

## What noticed, and what did not

The guard test did not: it asks whether each path-method owner is banned *or*
approved, and three bans satisfy that as well as one. The analyzer did:

```text
BannedSymbols.txt(32,1): warning RS0031: The symbol
'DotnetInspector.Queries.UnsafeEvidencePresenceQuery' is listed multiple times
in the list of banned APIs
BannedSymbols.txt(36,1): warning RS0031: ...
```

## Change

Keep #4708's entry -- the PR that existed to add this ban, carrying the fullest
rationale and sitting beside the `PdbContext` ban it derives from -- and drop the
two incidental copies.

## Validation

```text
$ dotnet run --project prototypes/inspect-web/engine.Tests -c Release
InspectWeb.Engine.Tests  Total: 144, Errors: 0, Failed: 0, Skipped: 0
```

No RS0031 in the build output. A `uniq -d` over the symbol column of the whole
ban list reports no remaining duplicates, so this is the only instance.

## Non-action boundary

The ban's scope, rationale, and every other entry are untouched. This does not
address the CI gap that let `main` go red in the first place -- `inspect-web`
carries `github.event_name == 'pull_request'`, so it never runs on push to
`main` -- which is tracked by #4729.
