### PR TITLE
docs: reconcile package-query-cli.md with merged #4551

### DIFF
--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -8,15 +8,21 @@ document's vocabulary as canonical rather than inventing its own.
 
 ## Status
 
-Design proposal. `find --package-prefix`'s corpus-streaming mechanism is
-proposed in the still-open #4551; the facet/predicate layer, the
-row-declaration step, and the tier capability gate described here do not exist
-even there. Nothing in this document is a claim about behavior that is merged
-today unless stated otherwise; #4551's own identifiers and mechanism are cited
-from its current diff, not from `main`. The corpus-limit flag used below is the
-settled `-n` target from
-[Item and line limits](item-and-line-limits.md), which resolves the
-repository-wide flag-numbering problem this document surfaced.
+Design proposal, partially landed. `find --package-prefix`'s corpus-streaming
+mechanism, its typed L1 queries (`PackageProfileQuery`,
+`PackageDependencyGroupsQuery`), and — further than this document originally
+recommended as a follow-up slice — its rendering path already merged in #4551
+onto the shared `Sections`/shape-ladder registry (`PackageProfileSections`,
+`SectionPipeline<PackageProfileView>`), the same registry `library`, `member`,
+and `package` use. See
+[Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
+for what shipped and what did not.
+
+Still proposal-only, not present on `main`: the facet/predicate layer, the
+tier capability gate, and — despite the Sections migration landing —
+`find --package-prefix`'s corpus limit is still spelled `-t`, not the settled
+`-n` target from [Item and line limits](item-and-line-limits.md), which
+resolves the repository-wide flag-numbering problem this document surfaced.
 
 Related docs:
 
@@ -36,8 +42,8 @@ Related docs:
   package row must follow.
 - [Package source model](package-source-model.md) and
   [browser package sources](browser-package-sources.md) — own the source
-  clients and manifest acquisition `find --package-prefix`'s #4551 diff
-  streams from.
+  clients and manifest acquisition `find --package-prefix` streams from
+  (merged in #4551).
 - [Progressive disclosure](progressive-disclosure.md) — owns the
   capability-gated, explicit-cost pattern the promoted tier's IL evaluation
   must follow.
@@ -47,10 +53,13 @@ Related docs:
 
 ## Thesis
 
-`find --package-prefix`'s #4551 diff already makes it the right CLI verb: it
-streams typed manifests over a corpus, with an explicit bound and honest
-truncation and partial-source failure. Its current `-t` spelling is replaced by
-the target `-n` vocabulary before landing. What it does not have yet is a way to
+`find --package-prefix` (#4551, merged) is the right CLI verb: it streams
+typed manifests over a corpus, with an explicit bound and honest truncation
+and partial-source failure, rendered through the shared Sections registry
+just as `library`/`member`/`package` are. Its corpus-limit spelling is still
+`-t`, not yet the target `-n` vocabulary — see
+[Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
+What it does not have yet is a way to
 ask "and does each package satisfy *this*" — a facet predicate — cheaply for
 nuspec-derived facts and, on explicit request, expensively for facts that
 require opening IL. This document proposes that predicate layer, and where each piece of it
@@ -63,8 +72,8 @@ split existed.
 Core. Concretely:
 
 - **L1 — `DotnetInspector.Queries`.** The facet-matching engine belongs here,
-  next to `PackageProfileQuery` and `PackageDependencyGroupsQuery`, which the
-  still-open #4551 places in this layer rather than in the CLI project. A typed
+  next to `PackageProfileQuery` and `PackageDependencyGroupsQuery`, which
+  #4551 places in this layer rather than in the CLI project. A typed
   query that evaluates nuspec-tier facets over a streamed manifest, and a
   second typed query that evaluates promoted-tier (IL) facets over an
   explicitly bounded package/version set, both return typed results and
@@ -89,47 +98,59 @@ Core. Concretely:
 
 ## Is there a reason to start by changing `find`'s layering?
 
-Not for the corpus-fetch mechanism — that part is already correctly designed
-in #4551's diff, even though the PR has not merged. #4551 puts
-`PackageProfileQuery` and `PackageDependencyGroupsQuery` in L1, and its diff
-makes the row-declaration call correctly: as its README addition states,
-"`-t` limits packages rather than flattened dependency rows." That is the
-same "declared row unit, not rendered row count" discipline
+Not for the corpus-fetch mechanism — that part is correctly designed and
+merged. #4551 puts `PackageProfileQuery` and `PackageDependencyGroupsQuery` in
+L1, and makes the row-declaration call correctly: as its README addition
+states, "`-t` limits packages rather than flattened dependency rows." That is
+the same "declared row unit, not rendered row count" discipline
 [output-shapes.md](output-shapes.md) requires of call-graph edges, applied
 correctly to package rows a version early.
 
-There is a real, narrower gap worth closing first, though:
-`find --package-prefix`'s *rendering* path — `PackageProfileFindOutputFormatter`
-and friends, as proposed in #4551's diff — is bespoke CLI-side code, not
-routed through the shared Sections registry the way `library`, `member`, and
-`package` already are (see [section-model.md](section-model.md), "first made
-coherent for the library command and then adopted by the package command").
-Concretely, this means `find --package-prefix` would not get `-S`, `--where`,
-`--count`, and `--rows` "for free" and consistently with those other
-commands — each would need its own bespoke implementation in the
-`find`-specific formatter if this gap isn't closed first.
+### Sections migration: already landed, ahead of this document's sequencing
 
-**Recommendation:** migrate `find --package-prefix` row rendering onto the
-shared Sections/shape-ladder registry as a preparatory slice, before adding
-facet predicates on top of it — mostly behavior-preserving except for the
-one deliberate flag change named just below. Doing the facet work first
-would mean either duplicating `--where`'s row-predicate semantics a second
-time inside the bespoke formatter, or building the facet feature on a
-foundation that has to be migrated out from under it immediately after.
-This migration is orthogonal to and does not require changing anything about
-where `PackageProfileQuery` itself lives (L1 is already right in #4551's
-diff); it only moves *rendering* onto the shared L2 path.
+This document originally identified a real, narrower gap and recommended
+closing it as a preparatory slice before adding facet predicates: routing
+`find --package-prefix`'s rendering path through the shared Sections registry
+the way `library`, `member`, and `package` already are (see
+[section-model.md](section-model.md), "first made coherent for the library
+command and then adopted by the package command"), rather than leaving it as
+bespoke CLI-side code.
+
+**That migration already happened, inside #4551 itself, rather than as a
+follow-up slice.** `find --package-prefix` is built directly on
+`PackageProfileSections` and `SectionPipeline<PackageProfileView>` — there was
+no intermediate bespoke formatter to migrate away from. Concretely, on `main`
+today: `--count`, `--rows`, `-D`/`--discover` (with section cost annotations
+and category maps), and the JSON/TSV/JSONL/projected-JSON output formats all
+route through the shared pipeline, the same infrastructure `library`/`member`/
+`package` use.
+
+**What did not land alongside it:** the flag-numbering half of this
+recommendation. This document's own "one deliberate, called-out behavior
+change" for this migration step was retiring `-t`-as-package-limit in favor of
+the settled `-n` contract — but `find --package-prefix`'s corpus limit is
+still spelled `-t` on `main` (`FindOptions.Limit`, validated as "`-t` must be
+between 1 and..."). `-S` and `--where` are also not yet wired (there is
+currently exactly one section, `Packages`, so `-S` selection is moot until the
+facet layer adds more to select between).
+
+**Interaction concern for the next slice:** the Sections migration and the
+`-t`→`-n` flag rename were assumed to be one atomic step; in practice they
+decoupled, and the migration landed first. The next slice (wiring nuspec-tier
+`--where`, [Landing sequence](#landing-sequence) step 3) should not silently
+inherit `-t` as precedent — it should either retire `-t` for `-n` itself, or
+explicitly hand that retirement to whatever implements #4677 across the CLI,
+naming which PR owns it so it does not fall through the gap a second time.
 
 ### `-t` is the wrong flag to build on; `-n` owns the corpus limit
 
-The `-t 100` #4551's diff uses for `find --package-prefix` reuses `find`'s
-own pre-existing `-t`, whose description that diff widens from "Limit type
-count (`-t 5`) or filter by glob (`-t *Json*`)" to "Limit result count... or
-filter API types by glob." That reuse is real in #4551's open diff, though
-not yet merged, and it is not a precedent this document should build a new
-predicate/limit flag on: `-t` already means a type name or glob filter
-everywhere else in the CLI (`library`, `type`, `member`,
-`package -S "SourceLink: Files"`) — a
+The `-t 100` `find --package-prefix` uses reuses `find`'s own pre-existing
+`-t`, whose description #4551 widens from "Limit type count (`-t 5`) or
+filter by glob (`-t *Json*`)" to "Limit result count... or filter API types
+by glob." That reuse is real and merged, and it is not a precedent this
+document should build a new predicate/limit flag on: `-t` already means a
+type name or glob filter everywhere else in the CLI (`library`, `type`,
+`member`, `package -S "SourceLink: Files"`) — a
 different noun than "how many rows" — and `find` only overloads it as
 count-or-glob because `find`'s own type search predates a dedicated
 row-count flag.
@@ -149,10 +170,11 @@ A corpus-match query that names a ranking field (for example, "top 500 by
 download count") uses `--top 500 --order-by "DownloadCount desc"`; a plain
 "first 500 that match" uses `-n 500`.
 
-The Sections-registry migration recommended above is the right moment to apply
-the settled contract. Once `find --package-prefix` rows are declared sections,
-`-n` applies through the same row path as `library`/`member`/`package`, and the
-migration retires `-t` rather than carrying its overload forward.
+The Sections-registry migration was the right moment to apply the settled
+contract, but it landed without that part: `find --package-prefix` rows are
+now declared sections, yet the corpus limit is still `-t`, not `-n`. See
+[Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
+for the resulting follow-up.
 
 ## Two-tier facets, reusing `--where`
 
@@ -160,8 +182,8 @@ The web design's nuspec/promoted split maps directly onto capability, not
 vocabulary:
 
 - **`nuspec` tier.** Free, always evaluated, over every streamed package —
-  backed entirely by fields `PackageProfileQuery` already surfaces in #4551's
-  open diff (target frameworks, declared dependencies, owners, metadata
+  backed entirely by fields `PackageProfileQuery` already surfaces (#4551,
+  merged; target frameworks, declared dependencies, owners, metadata
   fields). No new grammar:
   `RowPredicateSyntaxParser`'s existing `Field=value` / `!=` / `>=` / `<=`
   grammar, ANDed via repeated `--where` flags exactly as it works today for
@@ -202,7 +224,7 @@ A facet-matched package is not naturally one flat row: it may match zero or
 more facets, each with its own evidence, and evaluating a promoted-tier facet
 may add fields a nuspec-only row never had. Before this can be a Table,
 something has to decide the row grain — the same "declared row unit"
-decision #4551's diff already makes once for package/dependency pairs. This
+decision #4551 already makes once for package/dependency pairs. This
 document proposes:
 
 - **Default grain: one row per package.** Multiple matched facets collapse
@@ -217,7 +239,7 @@ document proposes:
   facet whose answer is inherently per-sub-item (for example, "which of this
   package's target frameworks are out of support" when a package targets
   several) may choose to emit one row per package × sub-item, the same
-  explicit choice #4551's diff already makes for package × dependency.
+  explicit choice #4551 already makes for package × dependency.
   Markout does not decide this cardinality — the producer does, same as a
   call-graph producer decides edges, not nodes, are the row.
 - **Relational questions are out of scope for this row model.** "Which
@@ -232,7 +254,7 @@ document proposes:
 
 ## Completion and bound honesty parity with the browser
 
-`find --package-prefix`'s #4551 diff already reports truncation
+`find --package-prefix` (#4551, merged) already reports truncation
 ("Package discovery reached the requested package limit" /
 "Package discovery was truncated by a pagination limit; narrow the prefix.")
 and visible per-source failures. That is the same completion vocabulary
@@ -302,16 +324,19 @@ the CLI's named facets as canonical for the browser's facet rail.
 
 1. **This document** — layering and vocabulary, reviewable independently of
    any implementation.
-2. **Migrate `find --package-prefix` rendering onto the shared Sections
-   registry** — a mostly behavior-preserving prerequisite so `-S`/`--where`/
-   `--count`/`-n`/`--rows` work the same way they do for
-   `library`/`member`/`package`, without a second bespoke implementation
-   inside `PackageProfileFindOutputFormatter`. Its one deliberate, called-out
-   behavior change is retiring `-t`-as-package-limit in favor of the settled
-   `-n` contract described above.
-3. **Wire nuspec-tier `--where`** onto package-profile rows, deciding and
-   documenting the filter-before-bound ordering from
+2. **Sections migration — done, via #4551, but not as its own slice.**
+   `find --package-prefix` rendering already routes through the shared
+   Sections registry (`PackageProfileSections`,
+   `SectionPipeline<PackageProfileView>`), so `-S`/`--where`/`--count`/
+   `--rows` work the same way they do for `library`/`member`/`package`
+   without a second bespoke implementation. What did not land: retiring
+   `-t`-as-package-limit for the settled `-n` contract. See
+   [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
+3. **Retire `-t` for `-n` on `find --package-prefix`**, closing the gap step
+   2 left open, and **wire nuspec-tier `--where`** onto package-profile rows,
+   deciding and documenting the filter-before-bound ordering from
    [Completion and bound honesty parity](#completion-and-bound-honesty-parity-with-the-browser).
+   Neither sub-goal has landed yet.
 4. **Add the promoted-tier capability gate and `--deepen`-bounded IL
    evaluation**, including the L2 tier-gating error for an ungated
    promoted-tier field.

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -327,10 +327,11 @@ the CLI's named facets as canonical for the browser's facet rail.
 2. **Sections migration — done, via #4551, but not as its own slice.**
    `find --package-prefix` rendering already routes through the shared
    Sections registry (`PackageProfileSections`,
-   `SectionPipeline<PackageProfileView>`), so `-S`/`--where`/`--count`/
-   `--rows` work the same way they do for `library`/`member`/`package`
-   without a second bespoke implementation. What did not land: retiring
-   `-t`-as-package-limit for the settled `-n` contract. See
+   `SectionPipeline<PackageProfileView>`), so `--count`/`--rows` work the
+   same way they do for `library`/`member`/`package`, without a second
+   bespoke implementation. What did not land alongside it: retiring
+   `-t`-as-package-limit for the settled `-n` contract, and `-S`/`--where`
+   remain unwired. See
    [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
 3. **Retire `-t` for `-n` on `find --package-prefix`**, closing the gap step
    2 left open, and **wire nuspec-tier `--where`** onto package-profile rows,

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -9,12 +9,14 @@ document's vocabulary as canonical rather than inventing its own.
 ## Status
 
 Design proposal, partially landed. `find --package-prefix`'s corpus-streaming
-mechanism, its typed L1 queries (`PackageProfileQuery`,
-`PackageDependencyGroupsQuery`), and — further than this document originally
-recommended as a follow-up slice — its rendering path already merged in #4551
-onto the shared `Sections`/shape-ladder registry (`PackageProfileSections`,
-`SectionPipeline<PackageProfileView>`), the same registry `library`, `member`,
-and `package` use. See
+mechanism and typed L1 query (`PackageProfileQuery`) — plus, further than
+this document originally recommended as a follow-up slice, its rendering
+path — already merged in #4551 onto the shared `Sections`/shape-ladder
+registry (`PackageProfileSections`, `SectionPipeline<PackageProfileView>`),
+the same registry `library`, `member`, and `package` use. `PackageDependencyGroupsQuery`
+also landed in #4551, in the same L1 layer, but backs the browser's
+single-package dependency view (`InspectionEngine.QueryPackageDependencies`),
+not `find --package-prefix`'s corpus-streaming query. See
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
 for what shipped and what did not.
 


### PR DESCRIPTION
## Summary

`docs/design/package-query-cli.md` described `find --package-prefix`'s
corpus-streaming and Sections-registry migration as `#4551`'s still-open
plan. `#4551` and `#4690` (item/line limits) have both since merged; this
PR reconciles the doc with what actually shipped on `main` and raises one
real interaction concern found while verifying it.

## What changed

- Corrected all present-tense "#4551 still open" / "not yet merged"
  language throughout the doc.
- Rewrote "Is there a reason to start by changing `find`'s layering?" —
  the doc recommended the Sections-registry migration as a *future*
  preparatory slice. It already happened, inside `#4551` itself:
  `find --package-prefix` is built directly on `PackageProfileSections` /
  `SectionPipeline<PackageProfileView>`; there was no bespoke
  `PackageProfileFindOutputFormatter` to migrate away from.
- **Interaction concern:** the doc's plan bundled that Sections migration
  with retiring `-t`-as-package-limit for `-n` as one atomic step. In
  practice they decoupled — the migration landed, but
  `find --package-prefix`'s corpus limit is still `-t` on `main`
  (`FindOptions.Limit`). Flagged explicitly so the next slice (or #4677's
  CLI-wide rollout) doesn't silently inherit `-t` as precedent.
- Updated the landing sequence: step 2 (Sections migration) is done with
  that caveat; step 3 now folds in retiring `-t` for `-n` alongside wiring
  nuspec-tier `--where`.

## Demo

Before, the doc claimed:

> Not for the corpus-fetch mechanism — that part is already correctly
> designed in #4551's diff, even though the PR has not merged.

`main` today (verified):

```console
$ grep -n "PackageProfileSections\|SectionPipeline<PackageProfileView>" \
    src/dotnet-inspect/Commands/FindCommand.cs | head -3
```

confirms `find --package-prefix` already routes through the shared
Sections registry. But:

```console
$ grep -n "Limit result count" \
    src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
```

confirms the corpus limit is still spelled `-t`, not `-n` — the divergence
this PR calls out.

## Validation

- `npx markdownlint-cli docs/design/package-query-cli.md` — clean.
- Documentation-only change; no product build/tests required per
  AGENTS.md.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
