### PR TITLE
Convert the last inspect-web tests to TypeScript

### DIFF
--- a/prototypes/inspect-web/knip.json
+++ b/prototypes/inspect-web/knip.json
@@ -2,12 +2,11 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": [
     "test/**/*.test.ts",
-    "test/*.test.js",
     "scripts/*.js"
   ],
   "project": [
     "src/**/*.ts",
-    "test/**/*.{ts,js}",
+    "test/**/*.ts",
     "scripts/*.js"
   ],
   "ignore": ["engine/wwwroot/inspect-web-engine.js"]

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -6,6 +6,21 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { parseSync, visitorKeys } from "oxc-parser";
+import type {
+  Argument,
+  ArrowFunctionExpression,
+  CallExpression,
+  Directive,
+  Expression,
+  Function as SyntaxFunction,
+  FunctionBody,
+  ImportDeclaration,
+  Node,
+  ObjectExpression,
+  ObjectProperty,
+  Span,
+  Statement,
+} from "oxc-parser";
 
 import {
   accessibilityFilterIncludingType,
@@ -85,12 +100,19 @@ import {
   uniqueTypeByQueryId,
   workspaceCoordinatesMatch
 } from "../src/data.ts";
+import type {
+  CallGraphDiagnostics,
+  CallGraphTarget,
+  GraphMemberShareIdentity,
+  NavigationState,
+  SourceWorkbenchState,
+} from "../src/data.ts";
 import {
   buildDependencyGraphMermaid,
   buildTypeGraphMermaid
 } from "../src/graph-mermaid.ts";
 
-const packageAt = (version, framework, types = 1) => ({
+const packageAt = (version: string, framework: string, types = 1) => ({
   id: "Example.Package",
   version,
   activeFramework: framework,
@@ -138,7 +160,7 @@ test("dependency graph keys preserve complete coordinates and declared ranges", 
 });
 
 test("dependency graph node insertion is bounded", () => {
-  const nodes = new Map();
+  const nodes = new Map<string, { index: number }>();
   let truncated = false;
   for (let index = 0; index < 8000; index++) {
     const result = ensureBoundedGraphNode(
@@ -199,84 +221,226 @@ const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.u
 const parsedAppSource = parseSync("dotnet-inspect.ts", appSource);
 const appSyntax = parsedAppSource.program;
 
-function walkSyntax(node, visit) {
-  if (!node) return;
+// The helpers below read `dotnet-inspect.ts` as syntax rather than as text, so the tests
+// can assert on structure. `Node` is oxc's discriminated union over every AST shape, so
+// narrowing through `node.type` keeps each helper checked against the real grammar rather
+// than against `any`.
+type SyntaxVisitor = (node: Node) => void;
+
+// `visitorKeys` is a runtime map from a node type to that node's child keys, which is
+// what makes the walk data-driven instead of a switch over a union with hundreds of
+// members. Indexing a node by a key chosen at runtime is the one operation the union
+// cannot express, so the assertion is confined to this helper and every caller below
+// stays narrowed.
+const syntaxChildren = (node: Node): Record<string, unknown> =>
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  node as unknown as Record<string, unknown>;
+
+// The walk only relies on a node carrying a string `type`, which is what `visitorKeys` is
+// keyed by; anything else reached through a child key is skipped rather than trusted.
+function isSyntaxNode(value: unknown): value is Node {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && typeof value.type === "string";
+}
+
+function walkSyntax(node: Node, visit: SyntaxVisitor): void {
   visit(node);
+  const children = syntaxChildren(node);
   for (const key of visitorKeys[node.type] ?? []) {
-    const child = node[key];
+    const child = children[key];
     if (Array.isArray(child)) {
-      for (const item of child) walkSyntax(item, visit);
-    } else if (child) {
+      for (const item of child as readonly unknown[]) {
+        if (isSyntaxNode(item)) walkSyntax(item, visit);
+      }
+    } else if (isSyntaxNode(child)) {
       walkSyntax(child, visit);
     }
   }
 }
 
-function syntaxNodes(root, predicate) {
-  const matches = [];
+function syntaxNodes(root: Node, predicate: (node: Node) => boolean): Node[] {
+  const matches: Node[] = [];
   walkSyntax(root, node => {
     if (predicate(node)) matches.push(node);
   });
   return matches;
 }
 
-function onlySyntaxNode(nodes, description) {
+function onlySyntaxNode<T>(nodes: readonly T[], description: string): T {
   assert.equal(nodes.length, 1, description);
-  return nodes[0];
+  const only = nodes[0];
+  assert.ok(only !== undefined, description);
+  return only;
 }
 
-function functionDeclaration(name) {
-  return onlySyntaxNode(
+// oxc models every function form with one `Function` interface whose `type` is a union,
+// so a declaration is that interface with the `type` narrowed. These aliases add the two
+// facts the tests below rely on and the union cannot state: a declaration that was found
+// has a body, and a callback property holds an arrow function with a block body.
+type DeclaredFunction = SyntaxFunction & { body: FunctionBody };
+type BlockArrowFunction = ArrowFunctionExpression & { body: FunctionBody };
+
+function hasFunctionBody(declaration: SyntaxFunction): declaration is DeclaredFunction {
+  return declaration.body !== null && declaration.body !== undefined;
+}
+
+function isBlockArrowFunction(value: Expression): value is BlockArrowFunction {
+  return value.type === "ArrowFunctionExpression"
+    && value.body.type === "BlockStatement";
+}
+
+function functionDeclaration(name: string): DeclaredFunction {
+  const declaration = onlySyntaxNode(
     appSyntax.body.filter(
-      node => node.type === "FunctionDeclaration" && node.id?.name === name),
+      (node): node is SyntaxFunction =>
+        node.type === "FunctionDeclaration" && node.id?.name === name),
     `${name} declaration`);
+  // `assert.fail` returns `never`, so this narrows the declaration rather than merely
+  // reporting; `assert.ok` on a predicate call would assert the boolean, not the value.
+  if (!hasFunctionBody(declaration)) assert.fail(`${name} declaration must have a body`);
+  return declaration;
 }
 
-function callExpressionsNamed(root, name) {
-  return syntaxNodes(
-    root,
-    node => node.type === "CallExpression"
-      && node.callee?.type === "Identifier"
-      && node.callee.name === name);
+function onlyCallExpressionNamed(root: Node, name: string): CallExpression {
+  return onlySyntaxNode(callExpressionsNamed(root, name), `${name} call`);
 }
 
-function sourceText(node) {
+function callArgument(
+  call: CallExpression,
+  index: number,
+  description: string,
+): Argument {
+  const argument = call.arguments[index];
+  assert.ok(argument !== undefined, `${description} argument ${index}`);
+  return argument;
+}
+
+function objectArgument(
+  call: CallExpression,
+  index: number,
+  description: string,
+): ObjectExpression {
+  const argument = callArgument(call, index, description);
+  assert.ok(
+    argument.type === "ObjectExpression",
+    `${description} argument ${index} must be an object literal, `
+      + `found ${argument.type}`);
+  return argument;
+}
+
+function statementAt(
+  statements: readonly (Statement | Directive)[],
+  index: number,
+  description: string,
+): Statement | Directive {
+  const statement = statements[index];
+  assert.ok(statement !== undefined, `${description} statement ${index}`);
+  return statement;
+}
+
+// Several tests pin that a binder is handed a specific identifier, such as `document`.
+function assertIdentifierArgument(
+  call: CallExpression,
+  index: number,
+  name: string,
+  description: string,
+): void {
+  const argument = callArgument(call, index, description);
+  assert.ok(
+    argument.type === "Identifier",
+    `${description} argument ${index} must be an identifier, `
+      + `found ${argument.type}`);
+  assert.equal(argument.name, name);
+}
+
+function callExpressionsNamed(root: Node, name: string): CallExpression[] {
+  const matches: CallExpression[] = [];
+  walkSyntax(root, node => {
+    if (node.type === "CallExpression"
+      && node.callee.type === "Identifier"
+      && node.callee.name === name) {
+      matches.push(node);
+    }
+  });
+  return matches;
+}
+
+// Every AST node extends `Span`, so this accepts the span rather than the node union and
+// works for expressions, statements and arguments alike.
+function sourceText(node: Span): string {
   return appSource.slice(node.start, node.end).replace(/\s+/g, " ");
 }
 
-function callbackProperty(actions, name) {
-  const property = onlySyntaxNode(
+function namedProperty(actions: ObjectExpression, name: string): ObjectProperty {
+  return onlySyntaxNode(
     actions.properties.filter(
-      item => item.type === "Property"
+      (item): item is ObjectProperty =>
+        item.type === "Property"
         && item.key.type === "Identifier"
         && item.key.name === name),
-    `${name} callback`);
-  assert.equal(property.value.type, "ArrowFunctionExpression");
-  assert.equal(property.value.body.type, "BlockStatement");
-  return property.value;
+    `${name} property`);
 }
 
-function directCallExpression(statement, name) {
+function callbackProperty(actions: ObjectExpression, name: string): BlockArrowFunction {
+  const value = namedProperty(actions, name).value;
+  if (!isBlockArrowFunction(value)) {
+    assert.fail(
+      `${name} callback must be an arrow function with a block body, `
+        + `found ${value.type}`);
+  }
+  return value;
+}
+
+function directCallExpression(
+  statement: Statement | Directive,
+  name: string,
+): CallExpression | null {
   if (statement.type !== "ExpressionStatement") return null;
   const expression = statement.expression;
   return expression.type === "CallExpression"
-    && expression.callee?.type === "Identifier"
+    && expression.callee.type === "Identifier"
     && expression.callee.name === name
     ? expression
     : null;
 }
 
-function statementSignatures(statements) {
-  return statements.map(statementSignature);
+// The name of a statement's direct call, or `null` when the statement is not a bare call.
+// Three tests compare the order of binder calls and each carried its own copy of this.
+function directCallName(statement: Statement | Directive): string | null {
+  if (statement.type !== "ExpressionStatement") return null;
+  const expression = statement.expression;
+  return expression.type === "CallExpression"
+    && expression.callee.type === "Identifier"
+    ? expression.callee.name
+    : null;
 }
 
-function branchSignatures(branch) {
+interface IfSignature {
+  readonly if: string;
+  readonly whenTrue: readonly StatementSignature[];
+  readonly whenFalse: readonly StatementSignature[];
+}
+
+// A statement is summarised either as a single line of text or, for a branch, as the
+// condition plus the summaries of each arm, so the tests can compare control flow without
+// depending on formatting.
+type StatementSignature = string | IfSignature;
+
+function statementSignatures(
+  statements: readonly (Statement | Directive)[],
+): StatementSignature[] {
+  return statements.map(statement => statementSignature(statement));
+}
+
+function branchSignatures(branch: Statement): StatementSignature[] {
   return branch.type === "BlockStatement"
     ? statementSignatures(branch.body)
     : [statementSignature(branch)];
 }
 
-function statementSignature(statement) {
+function statementSignature(statement: Statement | Directive): StatementSignature {
   if (statement.type === "ExpressionStatement") {
     const expression = statement.expression;
     if (expression.type === "AssignmentExpression") {
@@ -297,7 +461,7 @@ function statementSignature(statement) {
   if (statement.type === "VariableDeclaration"
       && statement.declarations.length === 1) {
     const declaration = statement.declarations[0];
-    if (declaration.id.type === "Identifier" && declaration.init) {
+    if (declaration && declaration.id.type === "Identifier" && declaration.init) {
       return `declare:${statement.kind} ${declaration.id.name} = ${sourceText(declaration.init)}`;
     }
   }
@@ -305,7 +469,12 @@ function statementSignature(statement) {
 }
 
 const sourceRoot = fileURLToPath(new URL("../src/", import.meta.url));
-const productionTypeScriptSources = readdirSync(sourceRoot, { recursive: true })
+// `readdirSync` without an encoding is typed as returning buffers as well as strings, so
+// the encoding is explicit here to keep the entries `string`.
+const productionTypeScriptSources = readdirSync(sourceRoot, {
+  recursive: true,
+  encoding: "utf8",
+})
   .filter(path => path.endsWith(".ts"))
   .map(path => ({
     path,
@@ -447,7 +616,6 @@ test("platform call graphs carry the target pack into lazy acquisition", () => {
     platformPackFromAcquiredProvenance(
       "Microsoft.AspNetCore.Http",
       null,
-      [],
       []),
     null);
   const acquiredRuntime = {
@@ -809,7 +977,7 @@ test("typed package view owns package navigation bindings", () => {
   const dependencyPatch =
     appSource.match(/function patchDependenciesGroup\(\) \{[\s\S]*?\n}/)?.[0]
     ?? "";
-  const actionSource = name =>
+  const actionSource = (name: string) =>
     binding.match(
       new RegExp(`  ${name}: [\\s\\S]*?(?=\\n  on[A-Z])`))?.[0]
       ?? "";
@@ -1217,7 +1385,7 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     binding,
     /const enterMemberNavigation = \(action: \(\) => void\) => \{[\s\S]*beginSpotlightNavigation\(\);[\s\S]*action\(\);[\s\S]*focusTypeList\(focusGeneration\)/);
-  const callbackSource = name =>
+  const callbackSource = (name: string) =>
     binding.match(
       new RegExp(`    ${name}: [\\s\\S]*?(?=\\n    on[A-Z])`))?.[0]
       ?? "";
@@ -1225,7 +1393,7 @@ test("typed type panel owns its rendered control bindings", () => {
     ["onMemberCompositionAccessibilitySelect", "memberAccessibilityFilter"],
     ["onMemberCompositionKindSelect", "memberKindFilter"],
     ["onMemberCompositionTraitSelect", "memberTraitFilter"],
-  ]) {
+  ] as const) {
     const source = callbackSource(name);
     assert.match(
       source,
@@ -1262,7 +1430,7 @@ test("typed type panel owns its rendered control bindings", () => {
   assert.match(
     binding,
     /bindTypePanel\(document, \{[\s\S]*}, keybindings\);/);
-  const selectorCount = selector =>
+  const selectorCount = (selector: string) =>
     appSource.split(selector).length - 1;
   assert.deepEqual(
     Object.fromEntries([
@@ -1293,38 +1461,28 @@ test("typed scope bar owns its rendered control bindings", () => {
   assert.deepEqual(parsedAppSource.errors, []);
   const rootEventBinder = functionDeclaration("bindEvents");
   const scopeEventBinder = functionDeclaration("bindScopeBarEvents");
-  const rootScopeCalls = callExpressionsNamed(appSyntax, "bindScopeBarEvents");
-  const innerScopeCalls = callExpressionsNamed(appSyntax, "bindScopeBar");
-  assert.equal(rootScopeCalls.length, 1);
-  assert.equal(rootScopeCalls[0].arguments.length, 0);
-  assert.equal(innerScopeCalls.length, 1);
-  const innerScopeCall = innerScopeCalls[0];
+  const rootScopeCall = onlyCallExpressionNamed(appSyntax, "bindScopeBarEvents");
+  assert.equal(rootScopeCall.arguments.length, 0);
+  const innerScopeCall = onlyCallExpressionNamed(appSyntax, "bindScopeBar");
   assert.equal(innerScopeCall.arguments.length, 2);
-  assert.equal(innerScopeCall.arguments[0].type, "Identifier");
-  assert.equal(innerScopeCall.arguments[0].name, "document");
-  assert.equal(innerScopeCall.arguments[1].type, "ObjectExpression");
+  assertIdentifierArgument(innerScopeCall, 0, "document", "bindScopeBar");
   assert.equal(
     callExpressionsNamed(scopeEventBinder, "bindScopeBar").length,
     1);
-  assert.equal(scopeEventBinder.body.body.length, 1);
   assert.equal(
-    directCallExpression(scopeEventBinder.body.body[0], "bindScopeBar"),
+    directCallExpression(
+      onlySyntaxNode(scopeEventBinder.body.body, "bindScopeBarEvents body"),
+      "bindScopeBar"),
     innerScopeCall);
   assert.equal(
     callExpressionsNamed(rootEventBinder, "bindScopeBarEvents").length,
     1);
-  const directCallName = statement =>
-    statement.type === "ExpressionStatement"
-      && statement.expression.type === "CallExpression"
-      && statement.expression.callee?.type === "Identifier"
-      ? statement.expression.callee.name
-      : null;
   const directRootCalls = rootEventBinder.body.body.map(directCallName);
   const typePanelIndex = directRootCalls.indexOf("bindTypePanelEvents");
   assert.notEqual(typePanelIndex, -1);
   assert.equal(directRootCalls[typePanelIndex + 1], "bindScopeBarEvents");
 
-  const actions = innerScopeCall.arguments[1];
+  const actions = objectArgument(innerScopeCall, 1, "bindScopeBar");
   const memberSection = callbackProperty(actions, "onMemberSectionSelect");
   assert.deepEqual(
     statementSignatures(memberSection.body.body),
@@ -1411,11 +1569,12 @@ test("typed settings panel owns its rendered control bindings", () => {
   const settingsEventBinder = functionDeclaration("bindSettingsPanelEvents");
   const settingsPanelImport = onlySyntaxNode(
     appSyntax.body.filter(
-      node => node.type === "ImportDeclaration"
+      (node): node is ImportDeclaration =>
+        node.type === "ImportDeclaration"
         && node.source.value === "./settings-panel.ts"),
     "settings panel import");
   assert.equal(
-    settingsPanelImport.specifiers.filter(
+    (settingsPanelImport.specifiers ?? []).filter(
       specifier => specifier.type === "ImportSpecifier"
         && specifier.imported.type === "Identifier"
         && specifier.imported.name === "bindSettingsPanel"
@@ -1435,11 +1594,16 @@ test("typed settings panel owns its rendered control bindings", () => {
       node => node.type === "Identifier"
         && node.name === "bindSettingsPanelEvents").length,
     4);
-  for (const [owner, description, predecessor] of [
+  const settingsBinders: readonly (readonly [
+    DeclaredFunction,
+    string,
+    string | null,
+  ])[] = [
     [bindEvents, "workbench settings binder", "bindScopeBarEvents"],
     [bindHomeEvents, "home settings binder", "bindStatusBarEvents"],
     [renderSettings, "settings view binder", null],
-  ]) {
+  ];
+  for (const [owner, description, predecessor] of settingsBinders) {
     assert.equal(
       callExpressionsNamed(owner, "bindSettingsPanelEvents").length,
       1,
@@ -1452,73 +1616,62 @@ test("typed settings panel owns its rendered control bindings", () => {
       1,
       `${description} direct call`);
     if (predecessor) {
-      const directCallNames = owner.body.body.map(statement => {
-        if (statement.type !== "ExpressionStatement") return null;
-        const expression = statement.expression;
-        return expression.type === "CallExpression"
-          && expression.callee?.type === "Identifier"
-          ? expression.callee.name
-          : null;
-      });
+      const directCallNames = owner.body.body.map(directCallName);
       assert.equal(
         directCallNames.indexOf("bindSettingsPanelEvents"),
         directCallNames.indexOf(predecessor) + 1,
         `${description} order`);
     }
   }
-  const directWorkbenchCalls = bindEvents.body.body.map(statement => {
-    if (statement.type !== "ExpressionStatement") return null;
-    const expression = statement.expression;
-    return expression.type === "CallExpression"
-      && expression.callee?.type === "Identifier"
-      ? expression.callee.name
-      : null;
-  });
+  const directWorkbenchCalls = bindEvents.body.body.map(directCallName);
   assert.equal(
     directWorkbenchCalls.indexOf("bindSettingsPanelEvents"),
     directWorkbenchCalls.indexOf("bindScopeBarEvents") + 1);
   assert.equal(renderSettings.body.body.length, 2);
-  const renderStatement = renderSettings.body.body[0];
-  assert.equal(renderStatement.type, "ExpressionStatement");
-  assert.equal(renderStatement.expression.type, "AssignmentExpression");
-  assert.equal(renderStatement.expression.operator, "=");
-  assert.equal(sourceText(renderStatement.expression.left), "app.innerHTML");
-  assert.equal(renderStatement.expression.right.type, "CallExpression");
-  assert.equal(renderStatement.expression.right.callee.type, "Identifier");
-  assert.equal(renderStatement.expression.right.callee.name, "renderSettingsView");
+  const [renderStatement, bindStatement] = renderSettings.body.body;
+  assert.ok(renderStatement !== undefined && bindStatement !== undefined);
   assert.ok(
-    directCallExpression(
-      renderSettings.body.body[1],
-      "bindSettingsPanelEvents"));
+    renderStatement.type === "ExpressionStatement",
+    `settings view must render first, found ${renderStatement.type}`);
+  const renderExpression = renderStatement.expression;
+  assert.ok(
+    renderExpression.type === "AssignmentExpression",
+    `settings view render must be an assignment, found ${renderExpression.type}`);
+  assert.equal(renderExpression.operator, "=");
+  assert.equal(sourceText(renderExpression.left), "app.innerHTML");
+  const renderCall = renderExpression.right;
+  assert.ok(
+    renderCall.type === "CallExpression",
+    `settings view must assign a call, found ${renderCall.type}`);
+  assert.ok(
+    renderCall.callee.type === "Identifier",
+    `settings view call must name a function, found ${renderCall.callee.type}`);
+  assert.equal(renderCall.callee.name, "renderSettingsView");
+  assert.ok(directCallExpression(bindStatement, "bindSettingsPanelEvents"));
 
-  const innerSettingsCalls = callExpressionsNamed(appSyntax, "bindSettingsPanel");
-  assert.equal(innerSettingsCalls.length, 1);
-  const innerSettingsCall = innerSettingsCalls[0];
-  assert.equal(settingsEventBinder.body.body.length, 1);
+  const innerSettingsCall = onlyCallExpressionNamed(appSyntax, "bindSettingsPanel");
   assert.equal(
-    directCallExpression(settingsEventBinder.body.body[0], "bindSettingsPanel"),
+    directCallExpression(
+      onlySyntaxNode(settingsEventBinder.body.body, "bindSettingsPanelEvents body"),
+      "bindSettingsPanel"),
     innerSettingsCall);
   assert.equal(innerSettingsCall.arguments.length, 2);
-  assert.equal(innerSettingsCall.arguments[0].type, "Identifier");
-  assert.equal(innerSettingsCall.arguments[0].name, "document");
-  const actions = innerSettingsCall.arguments[1];
-  assert.equal(actions.type, "ObjectExpression");
+  assertIdentifierArgument(innerSettingsCall, 0, "document", "bindSettingsPanel");
+  const actions = objectArgument(innerSettingsCall, 1, "bindSettingsPanel");
   assert.equal(actions.properties.length, 6);
-  for (const [name, value] of [
+  const settingsActions: readonly (readonly [string, string])[] = [
     ["onClose", "closeSettings"],
     ["onOpen", "openSettings"],
     ["onTasteClear", "clearTaste"],
     ["onTasteToggle", "toggleTaste"],
     ["onThemeSelect", "setTheme"],
-  ]) {
-    const property = onlySyntaxNode(
-      actions.properties.filter(
-        item => item.type === "Property"
-          && item.key.type === "Identifier"
-          && item.key.name === name),
-      `${name} settings action`);
-    assert.equal(property.value.type, "Identifier");
-    assert.equal(property.value.name, value);
+  ];
+  for (const [name, value] of settingsActions) {
+    const target = namedProperty(actions, name).value;
+    assert.ok(
+      target.type === "Identifier",
+      `${name} settings action must be an identifier, found ${target.type}`);
+    assert.equal(target.name, value);
   }
   const tasteOpenToggle = callbackProperty(actions, "onTasteOpenToggle");
   assert.deepEqual(
@@ -1590,10 +1743,11 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
       node => node.type === "Identifier"
         && node.name === "bindMetadataViewerEvents").length,
     3);
-  for (const [owner, description] of [
+  const metadataBinders: readonly (readonly [DeclaredFunction, string])[] = [
     [bindEvents, "workbench metadata binder"],
     [renderMetadata, "metadata explorer binder"],
-  ]) {
+  ];
+  for (const [owner, description] of metadataBinders) {
     assert.equal(
       callExpressionsNamed(owner, "bindMetadataViewerEvents").length,
       1,
@@ -1606,14 +1760,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
       1,
       `${description} direct call`);
   }
-  const directWorkbenchCalls = bindEvents.body.body.map(statement => {
-    if (statement.type !== "ExpressionStatement") return null;
-    const expression = statement.expression;
-    return expression.type === "CallExpression"
-      && expression.callee?.type === "Identifier"
-      ? expression.callee.name
-      : null;
-  });
+  const directWorkbenchCalls = bindEvents.body.body.map(directCallName);
   assert.equal(
     directWorkbenchCalls.indexOf("bindMetadataViewerEvents"),
     directWorkbenchCalls.indexOf("bindSettingsPanelEvents") + 1);
@@ -1628,9 +1775,7 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
   assert.notEqual(replacementIndex, -1);
   assert.equal(binderIndex, replacementIndex + 1);
 
-  const innerCalls = callExpressionsNamed(appSyntax, "bindMetadataExplorer");
-  assert.equal(innerCalls.length, 1);
-  const innerCall = innerCalls[0];
+  const innerCall = onlyCallExpressionNamed(appSyntax, "bindMetadataExplorer");
   assert.equal(
     metadataEventBinder.body.body
       .map(statement => directCallExpression(statement, "bindMetadataExplorer"))
@@ -1641,7 +1786,9 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
     statementSignatures(metadataEventBinder.body.body.slice(0, 1)),
     ["declare:const ex = state.explorer"]);
   assert.equal(
-    directCallExpression(metadataEventBinder.body.body[1], "bindMetadataExplorer"),
+    directCallExpression(
+      statementAt(metadataEventBinder.body.body, 1, "bindMetadataExplorerEvents"),
+      "bindMetadataExplorer"),
     innerCall);
   assert.deepEqual(
     statementSignatures(metadataEventBinder.body.body.slice(2, 3)),
@@ -1653,12 +1800,9 @@ test("metadata viewer owns its rendered explorer control bindings", () => {
       },
     ]);
   assert.equal(innerCall.arguments.length, 3);
-  assert.equal(innerCall.arguments[0].type, "Identifier");
-  assert.equal(innerCall.arguments[0].name, "document");
-  assert.equal(innerCall.arguments[1].type, "Identifier");
-  assert.equal(innerCall.arguments[1].name, "ex");
-  const actions = innerCall.arguments[2];
-  assert.equal(actions.type, "ObjectExpression");
+  assertIdentifierArgument(innerCall, 0, "document", "bindMetadataExplorer");
+  assertIdentifierArgument(innerCall, 1, "ex", "bindMetadataExplorer");
+  const actions = objectArgument(innerCall, 2, "bindMetadataExplorer");
   assert.equal(actions.properties.length, 11);
   const rowFocus = callbackProperty(actions, "onRowFocus");
   assert.deepEqual(
@@ -1782,7 +1926,7 @@ test("modal viewers own their rendered close bindings", () => {
     ["bindDocViewerEvents", 2],
     ["bindGraphSource", 2],
     ["bindDocViewer", 2],
-  ]) {
+  ] as const) {
     assert.equal(
       appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
       count,
@@ -1819,7 +1963,7 @@ test("annotated source owns its rendered control bindings", () => {
   for (const [identifier, count] of [
     ["bindAnnotatedSourceEvents", 2],
     ["bindAnnotatedSource", 2],
-  ]) {
+  ] as const) {
     assert.equal(
       appSource.match(new RegExp(`\\b${identifier}\\b`, "g"))?.length,
       count,
@@ -1988,6 +2132,8 @@ test("dependency graph render identity includes truncation and navigation", () =
   assert.notEqual(
     signature,
     dependencyGraphRenderSignature({ ...graph, truncated: true }));
+  const rootNodeInfo = graph.nodeInfoById.get("d0");
+  assert.ok(rootNodeInfo, "the graph fixture must describe node d0");
   assert.notEqual(
     signature,
     dependencyGraphRenderSignature({
@@ -1995,7 +2141,7 @@ test("dependency graph render identity includes truncation and navigation", () =
       nodeInfoById: new Map([[
         "d0",
         {
-          ...graph.nodeInfoById.get("d0"),
+          ...rootNodeInfo,
           packageKey: "Example.Package|2.0.0|net8.0"
         }
       ]])
@@ -2757,9 +2903,13 @@ test("annotated source request identity includes the selected body", () => {
     "Example.Outer+Inner",
     "M:Run"
   ];
+  // The product stringifies the metadata token before building the key
+  // (`dotnet-inspect.ts` pushes `String(state.selectedBodyTarget?.metadataToken ?? "")`),
+  // so the fixture spells the token the same way rather than relying on `join` to coerce
+  // a raw number.
   assert.notEqual(
-    memberRequestKey([...request, 0x06000001, "M:Run"]),
-    memberRequestKey([...request, 0x06000002, "M:<Run>b__0_0"]));
+    memberRequestKey([...request, String(0x06000001), "M:Run"]),
+    memberRequestKey([...request, String(0x06000002), "M:<Run>b__0_0"]));
 });
 
 test("member detail adapters preserve exact engine coordinates", () => {
@@ -2873,7 +3023,9 @@ test("source operations cancel when superseded or hidden", () => {
     memberDetailInspectionSource,
     /async loadAnnotated\(request\)[\s\S]*sourceRequestNeedsLoad\([\s\S]*state\.memberAnnotatedLoading[\s\S]*state\.memberAnnotatedError/);
 
-  const visible = {
+  // Annotating the fixture contextually types `lens` and `memberSection` against their
+  // literal unions instead of widening them to `string`.
+  const visible: SourceWorkbenchState = {
     settings: false,
     explorer: null,
     loading: false,
@@ -2887,7 +3039,7 @@ test("source operations cancel when superseded or hidden", () => {
     memberSection: "overview"
   };
   assert.equal(sourceSurfaceIsVisible(visible), true);
-  for (const hidden of [
+  const hiddenOverrides: readonly SourceWorkbenchState[] = [
     { home: true },
     { atPackageRoot: true },
     { settings: true },
@@ -2895,7 +3047,8 @@ test("source operations cancel when superseded or hidden", () => {
     { error: "failed" },
     { explorer: { open: true } },
     { package: null }
-  ]) {
+  ];
+  for (const hidden of hiddenOverrides) {
     assert.equal(sourceSurfaceIsVisible({ ...visible, ...hidden }), false);
   }
   assert.equal(
@@ -2986,7 +3139,7 @@ test("generated browser engine module is syntactically valid", () => {
 });
 
 test("generated source wrappers parse their JSON envelopes", () => {
-  const wrapper = name => {
+  const wrapper = (name: string) => {
     const start = generatedEngineSource.search(
       new RegExp(`\\nexport (?:async )?function ${name}\\(`));
     assert.notEqual(start, -1, `missing generated wrapper ${name}`);
@@ -3129,15 +3282,25 @@ test("history restores the complete saved workspace coordinate set", () => {
   assert.equal(workspaceCoordinatesMatch([second, first], tabs), false);
 });
 
+// A real call-graph node carries more than the identity view in `data.ts` declares:
+// `typeFullName` is part of the engine's own DTO in `inspect-web-engine.d.ts`. Passing the
+// wider payload is exactly what the product does, so the fixtures below keep the field --
+// it is what makes "prefers metadata identity over the display name" a real claim -- and
+// this widening keeps the excess property check, which only fires on fresh object
+// literals, from rejecting it.
+const engineCallGraphTarget = (
+  fixture: CallGraphTarget & { typeFullName?: string },
+): CallGraphTarget => fixture;
+
 test("call graph navigation prefers exact metadata type identity", () => {
   assert.equal(
-    callGraphTargetTypeId({
+    callGraphTargetTypeId(engineCallGraphTarget({
       typeFullName: "Example.Outer.Inner",
       typeMetadataId: "Example.Outer`1+Inner`1"
-    }),
+    })),
     "Example.Outer`1+Inner`1");
   assert.equal(
-    callGraphTargetTypeId({ typeFullName: "Example.Legacy" }),
+    callGraphTargetTypeId(engineCallGraphTarget({ typeFullName: "Example.Legacy" })),
     "");
 });
 
@@ -3232,6 +3395,7 @@ test("graph-only member targets round-trip through shared URLs", () => {
     metadataToken: 0x06000001
   };
   const encoded = graphMemberShareTarget(target);
+  assert.ok(encoded, "the fixture target must encode to a share tuple");
 
   assert.deepEqual(graphMemberTargetFromShare(encoded), target);
   assert.equal(graphMemberShareTarget({
@@ -3281,14 +3445,14 @@ test("graph-only member targets round-trip through shared URLs", () => {
       m: "method:Run",
       o: 0,
       g: [...encoded.slice(0, 8), "not-a-token"]
-    }).error,
+    }).error ?? "",
     /shared graph member target is invalid/);
   assert.match(
     graphMemberTargetFromPacket({
       y: "Example.Widget",
       m: "method:Run",
       g: encoded
-    }).error,
+    }).error ?? "",
     /shared graph member target is invalid/);
 });
 
@@ -3318,10 +3482,10 @@ test("shared graph targets require explicit assembly version provenance", () => 
     ...target,
     assemblyVersion: null
   };
-  assert.equal(
-    graphMemberTargetFromShare(
-      graphMemberShareTarget(explicitUnknown)).assemblyVersion,
-    null);
+  const explicitUnknownRoundTrip = graphMemberTargetFromShare(
+    graphMemberShareTarget(explicitUnknown));
+  assert.ok(explicitUnknownRoundTrip, "an explicit unknown version must round-trip");
+  assert.equal(explicitUnknownRoundTrip.assemblyVersion, null);
 });
 
 test("graph-only members open through the typed member surface", () => {
@@ -3351,11 +3515,20 @@ test("graph-only members open through the typed member surface", () => {
 test("graph-only deep links win over colliding public member groups", () => {
   const selectedType = { id: "Example.Widget" };
   const publicGroup = { key: "method:Run", overloads: [{ name: "Run" }] };
+  const deepLinkGraphTarget = (
+    selectorKey: string,
+  ): GraphMemberShareIdentity => ({
+    assembly: "Example.dll",
+    typeDefinitionId: "Example.Widget",
+    memberName: "Run",
+    selectorKey,
+    metadataToken: 0x06000001
+  });
   assert.equal(
     graphMemberDeepLinkDisposition(
       {
         member: publicGroup.key,
-        graphTarget: { memberName: "Run", selectorKey: "private-overload" }
+        graphTarget: deepLinkGraphTarget("private-overload")
       },
       { status: "unique", type: selectedType },
       selectedType,
@@ -3366,7 +3539,7 @@ test("graph-only deep links win over colliding public member groups", () => {
       {
         member: publicGroup.key,
         overload: "99",
-        graphTarget: { memberName: "Run", selectorKey: "public-overload" }
+        graphTarget: deepLinkGraphTarget("public-overload")
       },
       { status: "unique", type: selectedType },
       selectedType,
@@ -3940,10 +4113,8 @@ test("member filters retain an exact selected graph target", () => {
       /memberSelectionIsAvailable\(type, visible\)/);
   }
 
-  const typePanelCalls = callExpressionsNamed(appSyntax, "bindTypePanel");
-  assert.equal(typePanelCalls.length, 1);
-  const actions = typePanelCalls[0].arguments[1];
-  assert.equal(actions.type, "ObjectExpression");
+  const typePanelCall = onlyCallExpressionNamed(appSyntax, "bindTypePanel");
+  const actions = objectArgument(typePanelCall, 1, "bindTypePanel");
   for (const name of [
     "onMemberAccessibilityFilterSelect",
     "onMemberFilterChange",
@@ -3976,11 +4147,13 @@ test("pending graph restoration replaces its current history entry", () => {
   assert.equal(navigation.index, 0);
   assert.equal(navigation.stack.length, 2);
   assert.deepEqual(navigation.stack[0], resolved);
-  assert.equal(navigation.stack[1].sig, "forward");
+  assert.deepEqual(
+    navigation.stack.map(entry => entry.sig),
+    ["resolved", "forward"]);
 });
 
 test("history normalization preserves the current index and forward entries", () => {
-  const navigation = {
+  const navigation: NavigationState<{ selectedOverloadIndex?: number }> = {
     stack: [
       { sig: "older", view: {} },
       { sig: "recorded", view: { selectedOverloadIndex: 0 } },
@@ -4223,7 +4396,7 @@ test("an exact resident runtime target wins over package identity skew", () => {
   assert.equal(
     combinedGraphTargetNavigationDisposition(
       { status: "skew" },
-      { status: "unique" },
+      { status: "unique", pkg: null, type: null },
       target,
       true),
     "resident");
@@ -4256,7 +4429,7 @@ test("an exact resident runtime target wins over package identity skew", () => {
   assert.equal(
     combinedGraphTargetNavigationDisposition(
       { status: "missing" },
-      { status: "unique" },
+      { status: "unique", pkg: null, type: null },
       { ...target, assemblyVersion: null },
       true),
     "none");
@@ -4574,37 +4747,50 @@ test("relationship navigation rejects ambiguous dotted identities", () => {
   assert.equal(uniqueTypeByQueryId([], "N.T"), null);
 });
 
+// Same widening as `engineCallGraphTarget`: the engine's diagnostics payload also carries
+// `isIncomplete` and `hasUnexploredTraversalBoundary`, which the message view in `data.ts`
+// deliberately ignores in favour of the counted evidence. Keeping them in the fixtures is
+// what proves the message is driven by the counts rather than by the summary flag.
+const engineCallGraphDiagnostics = (
+  fixture: CallGraphDiagnostics & {
+    isIncomplete?: boolean;
+    hasUnexploredTraversalBoundary?: boolean;
+  },
+): CallGraphDiagnostics => fixture;
+
 test("call graph diagnostics distinguish failures from expected bounds", () => {
-  assert.equal(callGraphDiagnosticsMessage({
+  assert.equal(callGraphDiagnosticsMessage(engineCallGraphDiagnostics({
     isIncomplete: true,
     incompleteNodes: 2,
     incompleteEdges: 1,
     bindingIdentityConflicts: 3,
     hasUnexploredTraversalBoundary: true
-  }), "Partial call graph: 2 incomplete nodes, 1 incomplete edge, and 3 binding identity conflicts.");
-  assert.equal(callGraphDiagnosticsMessage({
+  })), "Partial call graph: 2 incomplete nodes, 1 incomplete edge, and 3 binding identity conflicts.");
+  assert.equal(callGraphDiagnosticsMessage(engineCallGraphDiagnostics({
     isIncomplete: true,
     incompleteNodes: 0,
     incompleteEdges: 0,
     bindingIdentityConflicts: 0,
     hasUnexploredTraversalBoundary: true
-  }), "");
-  assert.equal(callGraphDiagnosticsMessage({
+  })), "");
+  assert.equal(callGraphDiagnosticsMessage(engineCallGraphDiagnostics({
     isIncomplete: true,
     incompleteNodes: 0,
     incompleteEdges: 0,
     bindingIdentityConflicts: 0,
     hasAnalysisFailureBoundary: true
-  }), "Partial call graph: one or more method bodies could not be analyzed.");
-  assert.equal(callGraphDiagnosticsMessage({
+  })), "Partial call graph: one or more method bodies could not be analyzed.");
+  assert.equal(callGraphDiagnosticsMessage(engineCallGraphDiagnostics({
     isIncomplete: true,
     incompleteNodes: 1,
     incompleteEdges: 0,
     bindingIdentityConflicts: 0,
     hasUnexploredTraversalBoundary: true,
     hasAnalysisFailureBoundary: true
-  }), "Partial call graph: 1 incomplete node and one or more method bodies could not be analyzed.");
-  assert.equal(callGraphDiagnosticsMessage({ isIncomplete: false }), "");
+  })), "Partial call graph: 1 incomplete node and one or more method bodies could not be analyzed.");
+  assert.equal(
+    callGraphDiagnosticsMessage(engineCallGraphDiagnostics({ isIncomplete: false })),
+    "");
 });
 
 test("parameter titles preserve generic identities and contain metadata text", () => {
@@ -4653,6 +4839,7 @@ test("workspace package models retain the active and newest coordinates within t
     { length: MAX_WORKSPACE_PACKAGES },
     (_, index) => packageAt(`${index}.0.0`, "net10.0"));
   const active = packages[0];
+  assert.ok(active, "the workspace fixture must hold at least one package");
   const incoming = packageAt("13.0.0", "net10.0");
 
   const retained = retainWorkspacePackage(packages, active, incoming);
@@ -4668,6 +4855,7 @@ test("workspace package replacement reuses its slot at the package limit", () =>
     { length: MAX_WORKSPACE_PACKAGES },
     (_, index) => packageAt(`${index}.0.0`, "net10.0"));
   const active = packages[0];
+  assert.ok(active, "the workspace fixture must hold at least one package");
   const replacement = packageAt("99.0.0", "net10.0");
 
   const retained = retainWorkspacePackage(
@@ -4810,6 +4998,7 @@ test("missing exact dependency groups never create graph edges", () => {
   const data = {
     dependencyGroupError: "No exact dependency group.",
     dependencyGroups: [{
+      index: 0,
       framework: "net9.0",
       isActive: false,
       dependencies: [{ id: "Wrong.Dependency", versionRange: "1.0.0" }]
@@ -4912,6 +5101,7 @@ test("type graph rendering contains artifact labels", () => {
     ],
     graphEdges: [{ fromId: "self", toId: "base" }]
   });
+  assert.ok(definition, "the fixture graph must render a mermaid definition");
 
   assert.match(
     definition,
@@ -4942,6 +5132,7 @@ test("dependency graph rendering contains artifact labels", () => {
       workspaceDependencies: {}
     },
     () => null);
+  assert.ok(definition, "the fixture graph must render a mermaid definition");
 
   assert.match(
     definition.definition,

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -210,7 +210,7 @@ for (const [name, project] of [
 // report itself, and excluding this file would leave a hole in the one test that closes
 // the per-file vector. Assembling keeps this file in scope and the scan exactly as
 // strict, which is why the prose above names the directives only in the abstract.
-test("no source file suppresses type checking", () => {
+function checkedSourceFiles(extensions: readonly string[]): string[] {
   const root = new URL("../", import.meta.url);
   const files: string[] = [];
   for (const directory of ["src", "test"]) {
@@ -218,11 +218,18 @@ test("no source file suppresses type checking", () => {
       recursive: true,
       withFileTypes: true,
     })) {
-      if (entry.isFile() && entry.name.endsWith(".ts")) {
+      if (entry.isFile()
+          && extensions.some(extension => entry.name.endsWith(extension))) {
         files.push(join(entry.parentPath, entry.name));
       }
     }
   }
+  return files;
+}
+
+test("no source file suppresses type checking", () => {
+  const root = new URL("../", import.meta.url);
+  const files = checkedSourceFiles([".ts"]);
 
   assert.ok(files.length > 50, `expected the TypeScript sources, found ${files.length}`);
   const suppressionPattern = new RegExp(
@@ -239,6 +246,23 @@ test("no source file suppresses type checking", () => {
     suppressed.map(file => file.slice(fileURLToPath(root).length)),
     [],
     "these files opt out of type checking; use a narrowing guard or @ts-expect-error");
+});
+
+// The third way out of type checking is to not write TypeScript at all. The oxlint config
+// turns the `no-unsafe-*` family off for `**/*.js`, which is right for the build script,
+// the generated engine wrapper, and the Vite config, but would silently exempt a new
+// JavaScript file dropped into the application or its tests. Both directories are now
+// wholly TypeScript, so the cheapest way to keep the exemption scoped to the files that
+// need it is to assert that neither directory has any JavaScript to exempt.
+test("the application and its tests are wholly TypeScript", () => {
+  const root = new URL("../", import.meta.url);
+  const unchecked = checkedSourceFiles([".js", ".jsx", ".mjs", ".cjs"]);
+
+  assert.deepEqual(
+    unchecked.map(file => file.slice(fileURLToPath(root).length)),
+    [],
+    "src and test are TypeScript-only; the oxlint `**/*.js` override would exempt these "
+      + "files from the no-unsafe rules that the rest of the application is held to");
 });
 
 test("static hosting serves credits links through the application entry point", () => {

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -19,24 +19,74 @@ import {
 } from "../scripts/verify-analysis-host.js";
 import { verifySiteArtifact } from "../scripts/verify-site-artifact.js";
 
-const packageLock = JSON.parse(
-  readFileSync(new URL("../package-lock.json", import.meta.url), "utf8"),
-);
-const packageJson = JSON.parse(
-  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-);
-const oxlintConfig = JSON.parse(
-  readFileSync(new URL("../.oxlintrc.json", import.meta.url), "utf8"),
-);
-const browserTsconfig = JSON.parse(
-  readFileSync(new URL("../tsconfig.json", import.meta.url), "utf8"),
-);
-const testTsconfig = JSON.parse(
-  readFileSync(new URL("tsconfig.json", import.meta.url), "utf8"),
-);
-const staticWebAppConfig = JSON.parse(
-  readFileSync(new URL("../staticwebapp.config.json", import.meta.url), "utf8"),
-);
+interface PackageLockEntry {
+  readonly link?: boolean;
+  readonly resolved?: string;
+  readonly integrity?: string;
+  readonly optionalDependencies?: Readonly<Record<string, string>>;
+  readonly os?: readonly string[];
+  readonly cpu?: readonly string[];
+  readonly libc?: readonly string[];
+}
+
+interface PackageLock {
+  readonly packages: Readonly<Record<string, PackageLockEntry>>;
+}
+
+interface PackageJson {
+  readonly scripts: Readonly<Record<string, string>>;
+}
+
+interface OxlintConfig {
+  readonly ignorePatterns?: readonly string[];
+}
+
+interface TsconfigFile {
+  readonly extends?: string;
+  readonly compilerOptions: Readonly<Record<string, unknown>>;
+  readonly include?: readonly string[];
+}
+
+interface StaticWebAppRoute {
+  readonly route: string;
+  readonly rewrite?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+}
+
+interface StaticWebAppConfig {
+  readonly routes: readonly StaticWebAppRoute[];
+  readonly navigationFallback: {
+    readonly rewrite: string;
+    readonly exclude: readonly string[];
+  };
+}
+
+// `JSON.parse` is typed `any`, and an `any` here would silently switch off checking for
+// every config read below -- the same defeat this file's own strictness tests guard
+// against. Naming the shape each test relies on keeps those reads checked, so a renamed
+// config key becomes a compile error rather than an `undefined` comparison.
+//
+// These are repo-owned files rather than untrusted input, and a shape that stops matching
+// fails the assertion that reads it, so this asserts the shape instead of validating it.
+// That mirrors `parseEngineJson` in `src/dotnet-inspect.ts`, including the two targeted
+// disables it needs. `reportUnusedDisableDirectives` is an error here, so these directives
+// cannot outlive the rules they suppress.
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters
+function readJson<T>(specifier: string): T {
+  const parsed: unknown = JSON.parse(
+    readFileSync(new URL(specifier, import.meta.url), "utf8"),
+  );
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return parsed as T;
+}
+
+const packageLock = readJson<PackageLock>("../package-lock.json");
+const packageJson = readJson<PackageJson>("../package.json");
+const oxlintConfig = readJson<OxlintConfig>("../.oxlintrc.json");
+const browserTsconfig = readJson<TsconfigFile>("../tsconfig.json");
+const testTsconfig = readJson<TsconfigFile>("tsconfig.json");
+const staticWebAppConfig
+  = readJson<StaticWebAppConfig>("../staticwebapp.config.json");
 const siteIndexHtml = readFileSync(
   new URL("../index.html", import.meta.url),
   "utf8",
@@ -88,8 +138,8 @@ test("the strictness options this project relies on stay enabled", () => {
 // Round 6 review (GPT-5.6 Sol, converging with Claude Opus 5) defeated the pin above
 // without touching any value it reads: adding `"noCheck": true` leaves every pinned
 // option literally `true` while TypeScript stops checking anything at all, and the suite
-// stayed green with a genuinely unsafe indexed read restored. A per-file `// @ts-nocheck`
-// walked past it the same way.
+// stayed green with a genuinely unsafe indexed read restored. A per-file suppression
+// directive walked past it the same way.
 //
 // Enumerating the neutering options is the losing move -- `noCheck` was already the
 // second one found, and the compiler keeps adding surface. So this asserts the property
@@ -100,7 +150,10 @@ test("the strictness options this project relies on stay enabled", () => {
 // Opus established that the remaining vector, narrowing `include`/`exclude` to drop files
 // from the program, is already caught by `npm run analyze`: oxlint's type-aware rules
 // lose their type information and fail. So this covers the vectors that gate leaves open.
-for (const [name, project] of [["browser", "tsconfig.json"], ["test", "test/tsconfig.json"]]) {
+for (const [name, project] of [
+  ["browser", "tsconfig.json"],
+  ["test", "test/tsconfig.json"],
+] as const) {
   test(`the ${name} project rejects an unchecked indexed read`, () => {
     const root = new URL("../", import.meta.url);
     const probe = mkdtempSync(join(tmpdir(), "inspect-web-strictness-"));
@@ -147,13 +200,19 @@ for (const [name, project] of [["browser", "tsconfig.json"], ["test", "test/tsco
 }
 
 // The other half of the same vector: `noCheck` turns the compiler off for a project, and
-// `@ts-nocheck` turns it off for a file. The fixture above cannot see the second, because
-// it compiles a file of its own. Unlike a naming or roster ban, the set of suppression
-// directives is closed and owned by the compiler rather than by us, so listing them here
-// is not a restatement that can drift out of date.
+// the per-file suppression directives turn it off for a single file. The fixture above
+// cannot see the second, because it compiles a file of its own. Unlike a naming or roster
+// ban, the set of suppression directives is closed and owned by the compiler rather than
+// by us, so listing them here is not a restatement that can drift out of date.
+//
+// Converting this file from JavaScript put it inside its own scan. The directives are
+// therefore assembled from parts rather than spelled out: a literal would make this gate
+// report itself, and excluding this file would leave a hole in the one test that closes
+// the per-file vector. Assembling keeps this file in scope and the scan exactly as
+// strict, which is why the prose above names the directives only in the abstract.
 test("no source file suppresses type checking", () => {
   const root = new URL("../", import.meta.url);
-  const files = [];
+  const files: string[] = [];
   for (const directory of ["src", "test"]) {
     for (const entry of readdirSync(new URL(directory, root), {
       recursive: true,
@@ -166,8 +225,16 @@ test("no source file suppresses type checking", () => {
   }
 
   assert.ok(files.length > 50, `expected the TypeScript sources, found ${files.length}`);
+  const suppressionPattern = new RegExp(
+    ["nocheck", "ignore"].map(directive => `@ts-${directive}`).join("|"),
+  );
+  // This file is one of the scanned files, so the assembly above is load-bearing rather
+  // than stylistic; a literal pattern would fail this assertion on this very file.
+  assert.ok(
+    files.includes(fileURLToPath(import.meta.url)),
+    "the scan must cover the file that defines it");
   const suppressed = files.filter(file =>
-    /@ts-nocheck|@ts-ignore/.test(readFileSync(file, "utf8")));
+    suppressionPattern.test(readFileSync(file, "utf8")));
   assert.deepEqual(
     suppressed.map(file => file.slice(fileURLToPath(root).length)),
     [],
@@ -197,24 +264,34 @@ test("static hosting serves credits links through the application entry point", 
 
 const linuxLibcs = ["glibc", "musl"];
 
-function optionalNativeVariants(packagePath, dependencyPrefix) {
+function optionalNativeVariants(
+  packagePath: string,
+  dependencyPrefix: string,
+): Set<string> {
   const packageEntry = packageLock.packages[packagePath];
   assert.ok(packageEntry);
   const dependencies = Object.keys(packageEntry.optionalDependencies ?? {})
     .filter(dependency => dependency.startsWith(dependencyPrefix));
   assert.notEqual(dependencies.length, 0);
 
-  const variants = new Set();
+  const variants = new Set<string>();
   for (const dependency of dependencies) {
     const nativeEntry = packageLock.packages[`node_modules/${dependency}`];
     assert.ok(nativeEntry);
-    assert.equal(nativeEntry.os?.length, 1);
-    assert.equal(nativeEntry.cpu?.length, 1);
+    const { os, cpu } = nativeEntry;
+    assert.equal(os?.length, 1);
+    assert.equal(cpu?.length, 1);
     assert.ok(nativeEntry.libc === undefined || nativeEntry.libc.length === 1);
 
-    const host = `${nativeEntry.os[0]}-${nativeEntry.cpu[0]}`;
+    // The length assertions above already establish these, but they are `assert` calls
+    // rather than narrowing, so the indexed reads still need a guard to compile.
+    const osName = os?.[0];
+    const cpuName = cpu?.[0];
+    assert.ok(osName !== undefined && cpuName !== undefined);
+
+    const host = `${osName}-${cpuName}`;
     const libcs = nativeEntry.libc
-      ?? (nativeEntry.os[0] === "linux" ? linuxLibcs : ["none"]);
+      ?? (osName === "linux" ? linuxLibcs : ["none"]);
     for (const libc of libcs) {
       variants.add(`${host}/${libc}`);
     }
@@ -222,7 +299,10 @@ function optionalNativeVariants(packagePath, dependencyPrefix) {
   return variants;
 }
 
-function completeAnalyzerHosts(oxlintVariants, tsgolintVariants) {
+function completeAnalyzerHosts(
+  oxlintVariants: ReadonlySet<string>,
+  tsgolintVariants: ReadonlySet<string>,
+): Set<string> {
   const sharedVariants = new Set(
     [...tsgolintVariants].filter(variant => oxlintVariants.has(variant)),
   );
@@ -276,24 +356,42 @@ test("the lint gate includes both generated tsbindgen outputs", () => {
   assert.ok(
     !(oxlintConfig.ignorePatterns ?? []).includes("src/inspect-web-engine.d.ts"),
   );
-  assert.match(packageJson.scripts.lint, /(?:^| )src(?: |$)/);
+  // Reading the script through an index signature makes its absence a real possibility
+  // rather than a silent `undefined` handed to `assert.match`, which would fail with a
+  // type error about the argument instead of naming the missing script.
+  const lintScript = packageJson.scripts.lint;
+  assert.ok(lintScript !== undefined, "package.json must define a lint script");
+  assert.match(lintScript, /(?:^| )src(?: |$)/);
   assert.match(
-    packageJson.scripts.lint,
+    lintScript,
     /(?:^| )engine\/wwwroot\/inspect-web-engine\.js(?: |$)/,
   );
 });
+
+// The fixture below is mutated in place across the assertions, so it is typed rather than
+// inferred: an inferred object literal makes every key required, which forbids `delete`,
+// and an indexed read back would be `ManifestEntry | undefined`. Holding the entry that
+// the test mutates in its own binding keeps those mutations checked and undefined-free.
+interface ManifestEntry {
+  file: string;
+  css?: readonly string[];
+  dynamicImports?: readonly string[];
+  isEntry?: boolean;
+  isDynamicEntry?: boolean;
+}
 
 test("the site artifact rejects a missing Vite output", (context) => {
   const site = mkdtempSync(join(tmpdir(), "inspect-web-artifact-"));
   context.after(() => rmSync(site, { recursive: true, force: true }));
   mkdirSync(join(site, "assets"));
-  const manifest = {
-    "index.html": {
-      file: "assets/index.js",
-      css: ["assets/index.css"],
-      dynamicImports: ["src/dotnet-inspect.ts"],
-      isEntry: true,
-    },
+  const indexEntry: ManifestEntry = {
+    file: "assets/index.js",
+    css: ["assets/index.css"],
+    dynamicImports: ["src/dotnet-inspect.ts"],
+    isEntry: true,
+  };
+  const manifest: Record<string, ManifestEntry> = {
+    "index.html": indexEntry,
     "src/dotnet-inspect.ts": {
       file: "assets/app.js",
       isDynamicEntry: true,
@@ -366,14 +464,14 @@ test("the site artifact rejects a missing Vite output", (context) => {
     file: "assets/app.js",
     isDynamicEntry: true,
   };
-  manifest["index.html"].file = "assets/../index.html";
+  indexEntry.file = "assets/../index.html";
   writeFileSync(join(site, "manifest.json"), JSON.stringify(manifest));
   assert.throws(
     () => verifySiteArtifact(site),
     /manifest contains invalid asset 'assets\/\.\.\/index\.html'/,
   );
 
-  manifest["index.html"].file = "assets/index.js";
+  indexEntry.file = "assets/index.js";
   writeFileSync(join(site, "manifest.json"), JSON.stringify(manifest));
   unlinkSync(join(site, "assets/index.js"));
   assert.throws(


### PR DESCRIPTION
The inspect-web application and its tests are now wholly TypeScript, and a new
toolchain gate keeps them that way. Converting the last two test files opts 660
tests into the strict compiler options and the type-aware lint rules the rest of
the application is already held to, and the compiler found three fixtures that
had drifted from the code they exercise.

The oxlint config turns the `no-unsafe-*` family off for `**/*.js`. That is
correct for the build script, the generated engine wrapper, and the Vite config,
but it also exempted every test. The conversion removes the exemption for tests;
the new gate keeps it scoped to the three files that still need it.

## Demo

The clearest value here is what the type checker sees that the test run cannot.
`platformPackFromAcquiredProvenance` takes three parameters. The test passed
four — a copy-paste from its five-parameter sibling `platformPackFromProvenance`
that had been sitting in the suite silently. Restoring the pre-conversion call
shape on the converted file:

```console
$ npx tsc --noEmit -p test/tsconfig.json
test/spotlight-identity.test.ts(620,7): error TS2554: Expected 3 arguments, but got 4.

$ node --test test/spotlight-identity.test.ts
ℹ tests 149
ℹ pass 149
ℹ fail 0
```

Notice that the test run is green either way. JavaScript discards the extra
argument, so no assertion in the file could ever have noticed. Only the compiler
reports it, and only once the file is TypeScript.

A neighboring drift of a different class behaves the same way. A fixture built a
`unique` graph target candidate without the package and type that status
carries, because the function under test only reads `.status`:

```console
$ npx tsc --noEmit -p test/tsconfig.json
test/spotlight-identity.test.ts(4399,7): error TS2345: Argument of type '{ status: "unique"; }'
  is not assignable to parameter of type 'GraphTargetCandidate<unknown, unknown> | null'.

$ node --test test/spotlight-identity.test.ts
ℹ pass 149
ℹ fail 0
```

Both fixtures now match the real call shape. Neither change alters what its test
asserts.

## What changed

**`test/toolchain.test.js` → `.ts`.** This file owns the gate that scans `src`
and `test` for per-file type-checking suppressions, so converting it put the
file inside its own scan. A literal `@ts-nocheck` pattern would make the gate
report itself, and excluding the file would leave a hole in the one test that
closes the per-file vector. The directives are assembled from parts instead, and
a new assertion pins that the scan covers the file that defines it, so the
assembly stays load-bearing rather than stylistic.

**`test/spotlight-identity.test.js` → `.ts`.** 149 tests. Several assert on
application syntax through an oxc walk, which needed refinement types rather
than casts: oxc models every function form with a single `Function` interface,
so `hasFunctionBody` and `isBlockArrowFunction` narrow through `assert.fail`,
which returns `never`. Dynamic child indexing is the one operation the `Node`
union cannot express and is confined to a single helper with one targeted
disable, which `reportUnusedDisableDirectives: "error"` keeps honest.

**Three fixture drifts fixed.** The arity drift and the incomplete candidate
above, plus a fixture passing raw numbers where the product stringifies metadata
tokens — verified against the real call site in `dotnet-inspect.ts`, which does
`String(state.selectedBodyTarget?.metadataToken ?? "")`. The replacement is
byte-identical in effect and now matches how the function is actually called.

**Widening helpers for engine payloads.** Some fixtures legitimately carry more
than the narrow view types in `data.ts` declare — `typeFullName`,
`isIncomplete`, and `hasUnexploredTraversalBoundary` are real fields on the
generated engine DTOs. Rather than delete them, those fixtures route through
`engineCallGraphTarget` / `engineCallGraphDiagnostics`, so they keep documenting
the real payload without tripping the excess-property check that only fires on
fresh object literals.

**A new gate: "the application and its tests are wholly TypeScript."**
Mutation-tested — adding a `.js` file under `src` fails that test and nothing
else (10 pass / 1 fail).

## Non-action boundary

No product code changes. No test was added, removed, or weakened: 149 tests
before and after in the spotlight file, and the only new test is the
TypeScript-only gate. `vite.config.js`, `scripts/verify-site-artifact.js`,
`scripts/verify-analysis-host.js`, and the generated
`engine/wwwroot/inspect-web-engine.js` stay JavaScript by design and remain
covered by the `**/*.js` lint override.

`knip.json` drops its now-dead `test/*.test.js` entry pattern, which knip
reported as an unmatched configuration hint.

## Validation

At `20d6892bb`, after integrating `origin/main` at `f50fde3c7`:

- `npm test` — 660 pass / 0 fail
- `npm run typecheck` — clean (both the browser and test projects)
- `npm run analyze` (oxlint + knip) — clean
- Both new gates mutation-tested: restoring a literal suppression directive
  fails the suppression scan on that file alone; adding a `.js` file under `src`
  fails the TypeScript-only gate alone.
