### PR TITLE
Fix metadata test nullability warnings

### DIFF
--- a/tests/ILInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
@@ -33,8 +33,8 @@ public class ApiDiffAnalyzerTests
             IsAbstract = isAbstract,
             IsStatic = isSealed && isAbstract,
             BaseType = baseType,
-            Interfaces = interfaces,
-            TypeParameters = typeParameters,
+            Interfaces = interfaces ?? [],
+            TypeParameters = typeParameters ?? [],
             Members = members ?? []
         };
     }

--- a/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
@@ -23,9 +23,9 @@ public sealed class DefaultValueRenderingTests
         Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
     }
 
-    static string Signature(string method) => Surface.Types
+    static string Signature(string method) => Assert.IsType<string>(Surface.Types
         .First(t => t.Name == nameof(DefaultValueFixtures))
-        .Members.First(m => m.Name == method).Signature;
+        .Members.First(m => m.Name == method).Signature);
 
     static ApiParameter Parameter(string method, int index = 0) => Surface.Types
         .First(t => t.Name == nameof(DefaultValueFixtures))


### PR DESCRIPTION
## Summary

- default optional API-diff fixture lists to empty collections instead of assigning null
- assert that extracted default-value fixture signatures are strings
- remove all three nullable warnings from the Release solution build

**Owner:** Metadata  
**Owning document:** `docs/design/assembly-inspection-query.md`

## Demo

```text
$ dotnet build dotnet-inspect.slnx -c Release

Before: 3 Warning(s), 0 Error(s)
After:  0 Warning(s), 0 Error(s)
```

The preview-SDK `NETSDK1057` entries remain informational messages, not warnings.

## Validation

- `source eng/activate-iltools.sh --mdv && dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 2,152 passed
- `dotnet build dotnet-inspect.slnx -c Release` — 0 warnings, 0 errors

## Compatibility

Test-only cleanup; no product behavior or public contract changes.