### PR TITLE
Raise Windows CI timeout budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,10 +537,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
     runs-on: windows-latest
-    # Raised from 40 after #4350 measured a 29-minute CLI run followed by the
-    # expected six remaining suites. The lane needed about 42 minutes to report
-    # every result; 55 preserves that evidence with measured runner variance.
-    timeout-minutes: 55
+    # Raised again after #4350 recurred at 55 minutes: two runs spent 40-41
+    # minutes in the CLI suite and reached Metadata near minute 54, while an
+    # adjacent healthy lane needed 53 minutes. The failed runs project to
+    # 56-57 minutes, so 70 restores about 13 minutes of runner-variance margin.
+    timeout-minutes: 70
     env:
       DOTNET_INSPECT_TIPS: q
     steps:

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -743,7 +743,7 @@ public class IlToolsActivationTests
             "\n    steps:\n",
             StringComparison.Ordinal);
         Assert.True(stepsStart >= 0);
-        Assert.Contains("timeout-minutes: 55", job[..stepsStart]);
+        Assert.Contains("timeout-minutes: 70", job[..stepsStart]);
 
         int install = job.IndexOf(
             "- name: Install ilasm/ildasm",


### PR DESCRIPTION
Raises the Windows `test-windows` job timeout from 55 to 70 minutes so the complete reduced Windows suite can report instead of being cancelled near Metadata. Closes #4350.

## Demo

Two runs of PR #4263 reached Metadata near minute 54 after 40-41 minute CLI runs, then were cancelled at 55 minutes with every completed suite green. The adjacent PR #4262 lane completed in 53:27; projecting its remaining suites onto the cancelled runs yields 56-57 minutes. A 70-minute budget restores approximately 13 minutes of measured runner-variance margin.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*WindowsWorkflow_RestoresOraclesAndExposesGitBashBeforeCliTests*'`\n- `dotnet run eng/test-ci-change-detection.cs`\n\nNo tests, ordering, or Windows behavior changes; only the job budget and its workflow contract assertion move.