### PR TITLE
Define the desktop typed package-source client boundary

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -155,6 +155,8 @@ contains:
   source policy;
 - the ordered runtime transport profiles for that producer;
 - an owner-issued typed source-client factory for each profile;
+- the owner-issued compatibility-request credential policy tracked by
+  [NuGet feed authentication](https://github.com/richlander/dotnet-inspect/issues/4776);
 - the network capability selected for the public package operation;
 - the public operation context issued by the
   [operation-deadline owner](https://github.com/richlander/dotnet-inspect/issues/4770):
@@ -170,13 +172,21 @@ credentials are not part of durable identity.
 The package layer passes the network capability unchanged and cannot turn an
 offline operation into permission to contact a source.
 
-The source client returns one of three typed outcomes:
+An owner-issued source operation returns either its typed value or a
+`PackageSourceFailure`. `DotnetInspector.Packages` wraps that result in one
+package-owned route outcome with these variants:
 
-- candidate observations with producer and discovery provenance;
-- an exact payload with coordinate, producer, transport profile, payload kind,
-  and a caller-owned stream; or
-- a content-free source failure with source identity, coordinate when known,
-  failure kind, and typed timeout identity when applicable.
+- a successful candidate or payload value, with its producer provenance and
+  the selected transport profile;
+- a source-operation failure, retaining the owner-issued failure and selected
+  transport profile; or
+- a pre-client classification failure, retaining a safe configured-source
+  reference, syntactic source kind, and reason without a producer identity.
+
+The classification-failure variant cannot authorize a cache entry, contribute
+candidate provenance, or assert package absence. A safe configured-source
+reference is a configured source name or redacted display, never a raw signed
+URL.
 
 Raw resource URLs, response bodies, and credentials are not package-layer
 failure data. Caller cancellation propagates with the caller token instead of
@@ -191,7 +201,7 @@ selected:
 | --- | --- |
 | HTTP endpoint | Ask the owner-issued factory for the endpoint's typed capability. A syntactically valid HTTP URL is not assumed to be a valid NuGet v3 source. |
 | Local path or `file://` directory | Retain the local-source identity and use only local-store capabilities implemented by the package layer. Until [local-feed acquisition](https://github.com/richlander/dotnet-inspect/issues/3759) supplies a capability, report it as unsupported explicitly and never rewrite the source as HTTP. |
-| Unsupported URI scheme or malformed runtime endpoint | Return a typed unsupported-source failure without constructing an HTTP request or exposing a raw argument exception. |
+| Unsupported URI scheme or malformed runtime endpoint | Return the package-owned classification-failure variant without constructing an HTTP request, minting a producer identity, or exposing a raw argument exception. |
 
 An unsupported local capability is not an unreadable remote source. It is
 reported with its own source kind rather than an HTTP failure. When an
@@ -213,9 +223,9 @@ redacted network diagnostics.
 The package layer does not reconstruct v3 resource URLs or add a second retry
 loop around a typed operation. A compatibility request that still must follow
 a feed-discovered resource remains part of the same producer route and uses
-the request-policy hook issued by NuGetFetch. This prevents a fallback from
-bypassing policy merely because it has not yet migrated to the typed protocol
-operation.
+the request-policy hook issued by the NuGetFetch-owned #4776 prerequisite. This
+prevents a fallback from bypassing policy merely because it has not yet
+migrated to the typed protocol operation.
 
 This boundary does not prescribe whether an adjacent source-client
 implementation owns an isolated transport or receives policy through another
@@ -234,14 +244,14 @@ The package layer consumes the source client's declared credential-origin
 contract; it does not redefine how typed protocol requests or redirects enforce
 that contract. For a compatibility request the package layer still constructs,
 the configured producer origin is compared with the feed-derived target before
-the request reaches authentication. A cross-origin request carries the
-owner-issued suppression marker; a same-origin request remains eligible for
-authentication.
+the request reaches authentication. The owner-issued policy from #4776 marks a
+cross-origin request as ineligible for plugin authentication; a same-origin
+request remains eligible.
 
 The package layer does not discover plugins, cache credentials, construct
 authorization headers, or infer authorization from URL text. Those mechanisms
 remain adjacent-owner responsibilities. The package layer's obligation is to
-preserve the producer origin and apply the owner-issued request policy to every
+preserve the producer origin and apply the #4776 request policy to every
 compatibility request it constructs.
 
 ### Routes, deadlines, and projection
@@ -308,14 +318,16 @@ projects contain non-vacuous gates for these outcomes.
 
 - `PackageSourceClientProvider_LocalSourcesNeverSelectHttpTransport` proves
   plain paths and `file://` directories do not enter HTTP selection.
-- `PackageSourceClientProvider_UnsupportedSchemesBecomeTypedFailures` proves an
-  unsupported scheme returns the declared failure shape without a request.
+- `PackageSourceClientProvider_UnsupportedSchemesBecomeRouteClassificationFailures`
+  proves an unsupported scheme returns the package-owned pre-client variant
+  without a request or producer identity.
 - `PackageRoutePreservesOfflineNetworkCapability` proves route adaptation does
   not construct or invoke an HTTP source client, and observes no request, when
   the operation lacks network permission.
 - `PackageCompatibilityRecoverySuppressesPluginAuthenticationCrossOrigin`
   proves compatibility recovery suppresses plugin acquisition for a
-  feed-declared foreign origin, with a same-origin positive control.
+  feed-declared foreign origin, with a same-origin positive control. This gate
+  depends on the owner-issued policy from #4776.
 - `PackageSourceFailureDataExcludesResourceUrlsAndCredentials` proves
   package-layer failure projection does not retain signed queries, response
   text, or authorization data.
@@ -743,8 +755,9 @@ package-base-relative symbol download contract.
 
 The [desktop typed source-client
 boundary](#desktop-typed-source-client-boundary) is not a current-behavior
-claim. #4653 is the implementation candidate, and the named Release gates
-define when that candidate may claim the boundary.
+claim. #4653 is the implementation candidate; #4770 and #4776 supply its
+adjacent owner-issued prerequisites, and the named Release gates define when
+that candidate may claim the boundary.
 
 The current implementation source-scopes downloaded package content and
 candidate metadata, aggregates versions across sources while retaining the

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -3,12 +3,19 @@
 This document defines what it means for dotnet-inspect to support NuGet package
 sources. It covers source configuration, package source mapping, local stores,
 source-bound caches, package discovery, exact payload acquisition, and
-NuGet.org-specific enrichment.
+NuGet.org-specific enrichment. It also owns the composition boundary that turns
+an eligible desktop producer route into typed source operations and projects
+their results back into package-source outcomes.
 
 Browser source implementations, NuGet Gallery access without the v3 service
 index, portable source bundles, ephemeral credentials, and library-owned
 timeouts are defined by
 [browser package sources](browser-package-sources.md).
+For the desktop composition boundary introduced below, protocol discovery and
+request mechanics remain owned by NuGetFetch. Host HTTP pipeline construction,
+offline enforcement, and network diagnostic rendering remain owned by
+DotnetInspector.Core. That boundary consumes those adjacent contracts without
+redefining them.
 
 It is the target contract. The
 [implementation boundaries](#implementation-boundaries) section distinguishes
@@ -42,6 +49,7 @@ package id, and source provenance protects downloaded content after acquisition.
 | Payload location | Where the inspected bytes were opened: an explicit file, global packages, the dotnet-inspect cache, a local feed, or a network response. |
 | Enrichment endpoint | A service such as a symbol server or NuGet.org aggregate metadata API that is not itself a package source. |
 | Source client | A protocol-specific implementation that supplies package-source capabilities behind the common candidate and payload contracts. |
+| Producer route | One stable producer identity together with its source kind and ordered runtime transport profiles. |
 | Candidate observation | A normalized coordinate together with the producer that reported it, the discovery contract, and source-relative listing state. |
 | Availability observation | A transient environment- and transport-scoped result describing whether an authorized producer can currently supply a coordinate. |
 
@@ -127,6 +135,239 @@ collapses them by producer identity before candidate queries. A transport
 failure falls through to another applicable profile and does not create a
 second candidate source or a partial aggregate; the producer fails only when
 all of its applicable transports fail.
+
+## Desktop typed source-client boundary
+
+This section defines one package-source-owned responsibility: adapting an
+eligible desktop producer route to an owner-issued typed source client.
+`DotnetInspector.Packages` owns that composition. It is a target contract. Its
+safety properties remain unverified until the
+[required implementation gates](#required-implementation-gates) run in a
+Release suite.
+
+### Immediate input and output
+
+For each eligible producer, the package layer forms one typed route input that
+contains:
+
+- the syntactic source kind: HTTP endpoint, local folder, or unsupported;
+- the configured source aliases and stable producer identity selected by
+  source policy;
+- the ordered runtime transport profiles for that producer;
+- an owner-issued typed source-client factory for each profile;
+- the network capability selected for the public package operation;
+- the public operation context issued by the
+  [operation-deadline owner](https://github.com/richlander/dotnet-inspect/issues/4770):
+  caller cancellation, request deadline, and operation ceiling; and
+- the package coordinate or candidate capability requested by the operation.
+
+The stable producer identity authorizes payload caches and records provenance.
+Candidate-cache identity adds the discovery contract and version. Runtime
+transport-profile order controls failover but does not create another content
+identity or invalidate candidate evidence for the same immutable producer and
+discovery contract. A signed query may distinguish runtime transports, but
+credentials are not part of durable identity.
+The package layer passes the network capability unchanged and cannot turn an
+offline operation into permission to contact a source.
+
+The source client returns one of three typed outcomes:
+
+- candidate observations with producer and discovery provenance;
+- an exact payload with coordinate, producer, transport profile, payload kind,
+  and a caller-owned stream; or
+- a content-free source failure with source identity, coordinate when known,
+  failure kind, and typed timeout identity when applicable.
+
+Raw resource URLs, response bodies, and credentials are not package-layer
+failure data. Caller cancellation propagates with the caller token instead of
+becoming a source failure.
+
+### Classify before selecting a transport
+
+Source kind is decided before any HTTP client or service-index normalization is
+selected:
+
+| Source kind | Package-layer action |
+| --- | --- |
+| HTTP endpoint | Ask the owner-issued factory for the endpoint's typed capability. A syntactically valid HTTP URL is not assumed to be a valid NuGet v3 source. |
+| Local path or `file://` directory | Retain the local-source identity and use only local-store capabilities implemented by the package layer. Until [local-feed acquisition](https://github.com/richlander/dotnet-inspect/issues/3759) supplies a capability, report it as unsupported explicitly and never rewrite the source as HTTP. |
+| Unsupported URI scheme or malformed runtime endpoint | Return a typed unsupported-source failure without constructing an HTTP request or exposing a raw argument exception. |
+
+An unsupported local capability is not an unreadable remote source. It is
+reported with its own source kind rather than an HTTP failure. When an
+aggregate requires every eligible source, that observation makes the result
+non-authoritative: the operation must fail or explicitly report a partial
+result. It cannot silently grant authority to a cache or another source.
+
+### Protocol and host handoff
+
+The package layer decides which producer may be queried, obtains the typed
+source client from the owner-issued factory, and invokes its operations with
+the operation context issued by #4770. NuGetFetch owns service-index discovery,
+endpoint construction and validation, protocol-level retry, bounded body
+reading, source-client transport construction and lifetime, and the typed
+source-operation result.
+DotnetInspector.Core owns its host HTTP pipeline, offline enforcement, and
+redacted network diagnostics.
+
+The package layer does not reconstruct v3 resource URLs or add a second retry
+loop around a typed operation. A compatibility request that still must follow
+a feed-discovered resource remains part of the same producer route and uses
+the request-policy hook issued by NuGetFetch. This prevents a fallback from
+bypassing policy merely because it has not yet migrated to the typed protocol
+operation.
+
+This boundary does not prescribe whether an adjacent source-client
+implementation owns an isolated transport or receives policy through another
+owner-issued factory. Transport construction, mutability, and disposal remain
+part of that adjacent owner's contract.
+
+DotnetInspector.Packages owns the typed client handle it obtains. It retains
+that handle until a returned payload stream is consumed or disposed, or
+transfers both into one wrapper with the same lifetime. It disposes the handle
+on every path that returns no payload. This is client-handle orchestration, not
+a claim about how the adjacent client owns its transport.
+
+### Credential and origin boundary
+
+The package layer consumes the source client's declared credential-origin
+contract; it does not redefine how typed protocol requests or redirects enforce
+that contract. For a compatibility request the package layer still constructs,
+the configured producer origin is compared with the feed-derived target before
+the request reaches authentication. A cross-origin request carries the
+owner-issued suppression marker; a same-origin request remains eligible for
+authentication.
+
+The package layer does not discover plugins, cache credentials, construct
+authorization headers, or infer authorization from URL text. Those mechanisms
+remain adjacent-owner responsibilities. The package layer's obligation is to
+preserve the producer origin and apply the owner-issued request policy to every
+compatibility request it constructs.
+
+### Routes, deadlines, and projection
+
+Configured source aliases collapse by producer identity after mapping.
+Transport profiles for one producer form one ordered route rather than
+separate candidate sources. Source declaration order between different
+producers is not precedence and cannot make one source's candidate
+authoritative over another.
+
+The request deadline and operation ceiling are the library-owned bounds defined
+by [browser package sources](browser-package-sources.md#timeout-ownership).
+The owner-issued carrier required to compose that rule across typed clients is
+tracked by #4770. One public operation ceiling spans every selected producer,
+transport-profile failover, retry, and payload read. The package layer passes
+the same operation context through every route; neither a new producer nor
+another transport profile resets it.
+
+Package-layer projection preserves:
+
+- producer identity and transport-profile diagnostics;
+- source-failure kind;
+- timeout kind and configured duration;
+- caller cancellation as cancellation rather than timeout; and
+- payload-stream ownership and the deadline that remains active through
+  consumption.
+
+If a source returns a payload after the public operation ceiling, the package
+layer disposes the unreturned stream before producing a typed operation
+timeout. If consuming an already returned payload raises an expected request
+timeout, the package acquisition layer projects a new content-free failure
+with the same timeout kind and duration; another authorized producer may be
+tried only while the public operation ceiling remains. An operation-ceiling
+timeout terminates the public operation and cannot enable producer failover.
+Archive validation and store failures remain payload-policy outcomes rather
+than transport failures.
+
+### Aggregation and completeness
+
+Typed clients report one producer at a time; the package layer owns
+multi-source composition. Exact pinned acquisition may succeed from one
+eligible producer. An aggregate that selects latest or wildcard versions,
+claims authoritative absence, or otherwise depends on the complete candidate
+set requires a terminal observation from every eligible producer. A capability
+gap is itself non-terminal for completeness: the operation must fail or
+explicitly report partial authority. A healthy subset cannot silently become
+the whole authority.
+
+Candidate caches remain producer- and discovery-contract-scoped observations.
+They may replace a request only for the producer and discovery contract that
+produced them, and every aggregate is recomposed against the current eligible
+set.
+Local sources without the operation capability remain explicit
+unsupported-capability observations. They are not rewritten as failed HTTP
+feeds, but they prevent an authoritative all-source aggregate unless the
+result shape explicitly represents partial authority.
+
+### Required implementation gates
+
+An implementation may claim this boundary only when the named Release test
+projects contain non-vacuous gates for these outcomes.
+
+`src/dotnet-inspect.Tests` owns the package-layer composition gates:
+
+- `PackageSourceClientProvider_LocalSourcesNeverSelectHttpTransport` proves
+  plain paths and `file://` directories do not enter HTTP selection.
+- `PackageSourceClientProvider_UnsupportedSchemesBecomeTypedFailures` proves an
+  unsupported scheme returns the declared failure shape without a request.
+- `PackageRoutePreservesOfflineNetworkCapability` proves route adaptation does
+  not construct or invoke an HTTP source client, and observes no request, when
+  the operation lacks network permission.
+- `PackageCompatibilityRecoverySuppressesPluginAuthenticationCrossOrigin`
+  proves compatibility recovery suppresses plugin acquisition for a
+  feed-declared foreign origin, with a same-origin positive control.
+- `PackageSourceFailureDataExcludesResourceUrlsAndCredentials` proves
+  package-layer failure projection does not retain signed queries, response
+  text, or authorization data.
+
+`src/DotnetInspector.Services.Tests` owns aggregation, acquisition, and
+projection gates:
+
+- `TransportProfilesShareThePublicOperationCeiling` proves neither another
+  profile nor another producer resets the operation ceiling. This gate depends
+  on the owner-issued carrier from #4770.
+- `PackageStreamTimeoutPreservesKindAndDuration` and
+  `RouteTimeoutPreservesKindAndDuration` prove request and operation timeout
+  identity survives package-layer projection. These gates depend on the typed
+  failure shape from #4770.
+- `PackagePayloadCallerCancellationRetainsToken` proves caller cancellation is
+  not projected as a source timeout.
+- `PayloadKeepsSourceClientAliveThroughConsumption` proves client-handle
+  disposal cannot invalidate a caller-owned payload stream.
+- `FailedRouteDisposesSourceClientHandle` proves every path without a returned
+  payload releases the package layer's client handle.
+- `LatePayloadAfterOperationCeilingIsDisposed` proves the package layer does not
+  leak an unreturned stream.
+- `ProducerRouteCollapsesTransportProfilesIntoOneCandidateSource` proves
+  transport failover does not create duplicate source authority.
+- `WildcardResolutionRequiresEveryEligibleSource` proves a healthy subset or
+  capability gap cannot produce an authoritative aggregate.
+- `LocalUnsupportedCapabilityPreventsAuthoritativeAggregateWithoutHttpFailure`
+  proves a filesystem-free operation keeps local-source handling visible,
+  prevents an authoritative aggregate, and does not route the source through
+  HTTP diagnostics.
+- `CandidateCacheUsesProducerAndDiscoveryContractIdentity` proves transport
+  profile changes do not become content identity while incompatible discovery
+  contracts remain isolated.
+
+These gates must fail when the corresponding classification, request-policy
+hook, timeout field, shared operation context, or completeness check is
+removed. A test that only observes a generic failure kind or an empty result is
+insufficient.
+
+### Non-claims
+
+This boundary does not define:
+
+- NuGet protocol resource parsing, endpoint normalization, or internal retry;
+- source-client transport construction or lifetime;
+- host HTTP handler construction, offline exception rendering, or credential
+  provider lifecycle;
+- browser source profiles, portable source bundles, or browser persistence;
+- local-folder package discovery and acquisition;
+- CLI wording or output layout; or
+- enrichment endpoint policy beyond consuming the producer eligibility already
+  defined by this document.
 
 ## Resolving active and eligible sources
 
@@ -499,6 +740,11 @@ version-index, exact-manifest, and exact-package URL construction. The legacy
 compatibility choice to bypass canonical NuGet.org service-index discovery.
 V3 symbol payload remains unsupported because the protocol has no
 package-base-relative symbol download contract.
+
+The [desktop typed source-client
+boundary](#desktop-typed-source-client-boundary) is not a current-behavior
+claim. #4653 is the implementation candidate, and the named Release gates
+define when that candidate may claim the boundary.
 
 The current implementation source-scopes downloaded package content and
 candidate metadata, aggregates versions across sources while retaining the

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -147,23 +147,31 @@ Release suite.
 
 ### Immediate input and output
 
-For each eligible producer, the package layer forms one typed route input that
-contains:
+For each eligible configured source, the package layer first forms an
+identity-free classification input containing:
 
-- the syntactic source kind: HTTP endpoint, local folder, or unsupported;
-- the configured source aliases and stable producer identity selected by
-  source policy;
+- the configured source aliases and configured source value selected by source
+  policy;
+- the package coordinate or candidate capability requested by the operation;
+  and
+- the network capability selected for the public package operation.
+
+Classification either returns the package-owned classification-failure variant
+or constructs one producer-bearing route input containing:
+
+- the classified source kind: HTTP endpoint or local folder;
+- the stable producer identity;
 - the ordered runtime transport profiles for that producer;
 - an owner-issued typed source-client factory for each profile;
 - the owner-issued compatibility-request credential policy tracked by
   [NuGet feed authentication](https://github.com/richlander/dotnet-inspect/issues/4776);
-- the network capability selected for the public package operation;
 - the public operation context issued by the
   [operation-deadline owner](https://github.com/richlander/dotnet-inspect/issues/4770):
-  caller cancellation, request deadline, and operation ceiling; and
-- the package coordinate or candidate capability requested by the operation.
+  caller cancellation, request deadline, and operation ceiling.
 
-The stable producer identity authorizes payload caches and records provenance.
+The stable producer identity selects the typed route and records provenance. It
+does not replace the canonical HTTP endpoint or local-directory identity used
+for payload-cache authorization.
 Candidate-cache identity adds the discovery contract and version. Runtime
 transport-profile order controls failover but does not create another content
 identity or invalidate candidate evidence for the same immutable producer and
@@ -176,7 +184,8 @@ An owner-issued source operation returns either its typed value or a
 `PackageSourceFailure`. `DotnetInspector.Packages` wraps that result in one
 package-owned route outcome with these variants:
 
-- a successful candidate or payload value, with its producer provenance and
+- a successful owner-issued operation value, including search or version
+  candidates, an exact manifest, or a payload, with its producer provenance and
   the selected transport profile;
 - a source-operation failure, retaining the owner-issued failure and selected
   transport profile; or
@@ -319,8 +328,9 @@ projects contain non-vacuous gates for these outcomes.
 - `PackageSourceClientProvider_LocalSourcesNeverSelectHttpTransport` proves
   plain paths and `file://` directories do not enter HTTP selection.
 - `PackageSourceClientProvider_UnsupportedSchemesBecomeRouteClassificationFailures`
-  proves an unsupported scheme returns the package-owned pre-client variant
-  without a request or producer identity.
+  proves the identity-free configured source is classified before route
+  construction and an unsupported scheme returns the package-owned pre-client
+  variant without a request or producer identity.
 - `PackageRoutePreservesOfflineNetworkCapability` proves route adaptation does
   not construct or invoke an HTTP source client, and observes no request, when
   the operation lacks network permission.
@@ -344,6 +354,8 @@ projection gates:
   failure shape from #4770.
 - `PackagePayloadCallerCancellationRetainsToken` proves caller cancellation is
   not projected as a source timeout.
+- `PackageRouteOutcomeCarriesManifestWithoutPayloadProjection` proves the
+  generic success variant retains an exact manifest as its owner-issued type.
 - `PayloadKeepsSourceClientAliveThroughConsumption` proves client-handle
   disposal cannot invalidate a caller-owned payload stream.
 - `FailedRouteDisposesSourceClientHandle` proves every path without a returned
@@ -361,6 +373,9 @@ projection gates:
 - `CandidateCacheUsesProducerAndDiscoveryContractIdentity` proves transport
   profile changes do not become content identity while incompatible discovery
   contracts remain isolated.
+- `PayloadCacheAuthorizationRetainsCanonicalEndpointIdentity` proves
+  query-distinct configured endpoints remain distinct cache authorities even
+  when their typed producer identities match.
 
 These gates must fail when the corresponding classification, request-policy
 hook, timeout field, shared operation context, or completeness check is

--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -50,6 +50,7 @@ package id, and source provenance protects downloaded content after acquisition.
 | Enrichment endpoint | A service such as a symbol server or NuGet.org aggregate metadata API that is not itself a package source. |
 | Source client | A protocol-specific implementation that supplies package-source capabilities behind the common candidate and payload contracts. |
 | Producer route | One stable producer identity together with its source kind and ordered runtime transport profiles. |
+| Typed source identity | The NuGetFetch HTTP identity carried by owner-issued protocol results. It may fold runtime query credentials and does not replace package cache or provenance identity. |
 | Candidate observation | A normalized coordinate together with the producer that reported it, the discovery contract, and source-relative listing state. |
 | Availability observation | A transient environment- and transport-scoped result describing whether an authorized producer can currently supply a coordinate. |
 
@@ -107,13 +108,14 @@ This is gated by
 `MalformedRedirectTargetIsInvalidResponse`, and the `NuGetFetch`
 `browser-wasm` build.
 
-The typed source-client compatibility adapter therefore derives producer
-identity from a query-bearing legacy service index's origin and path while
-retaining its query and fragment only in runtime transport configuration. This
-does not change the stricter endpoint identity used for credential adoption or
-legacy caches. Portable descriptors reject queries and fragments. Two immutable
-content domains that need distinct producer identities require distinct
-endpoint paths rather than a query-only distinction.
+The typed source-client compatibility adapter therefore derives its typed
+source identity from a query-bearing legacy service index's origin and path
+while retaining its query and fragment only in runtime transport configuration.
+This does not change the stricter package producer endpoint identity used for
+credential adoption, payload provenance, or legacy caches. Portable descriptors
+reject queries and fragments. Two immutable content domains that need distinct
+typed source identities require distinct endpoint paths rather than a
+query-only distinction.
 
 Package-source identity is broader than a NuGet v3 service-index URL. A
 standard v3 feed, the built-in NuGet Gallery browser implementation, and a
@@ -157,26 +159,24 @@ identity-free classification input containing:
 - the network capability selected for the public package operation.
 
 Classification either returns the package-owned classification-failure variant
-or constructs one producer-bearing route input containing:
+or constructs one of two producer-bearing route inputs:
 
-- the classified source kind: HTTP endpoint or local folder;
-- the stable producer identity;
-- the ordered runtime transport profiles for that producer;
-- an owner-issued typed source-client factory for each profile;
-- the owner-issued compatibility-request credential policy tracked by
-  [NuGet feed authentication](https://github.com/richlander/dotnet-inspect/issues/4776);
-- the public operation context issued by the
-  [operation-deadline owner](https://github.com/richlander/dotnet-inspect/issues/4770):
-  caller cancellation, request deadline, and operation ceiling.
+| Route input | Required fields |
+| --- | --- |
+| HTTP | Canonical endpoint producer identity; typed source identity; ordered runtime transport profiles; owner-issued source-client factory for each profile; the #4776 compatibility-request credential policy; and the #4770 public operation context. |
+| Local folder | Canonical local-directory producer identity; local source kind; implemented package-layer local-store capabilities; and caller cancellation. It has no typed source identity, HTTP transport profile, or source-client factory. |
 
-The stable producer identity selects the typed route and records provenance. It
-does not replace the canonical HTTP endpoint or local-directory identity used
-for payload-cache authorization.
-Candidate-cache identity adds the discovery contract and version. Runtime
-transport-profile order controls failover but does not create another content
-identity or invalidate candidate evidence for the same immutable producer and
-discovery contract. A signed query may distinguish runtime transports, but
-credentials are not part of durable identity.
+The package producer identity owns configured-alias collapse after mapping,
+route authority, recorded payload provenance, payload-cache slot identity, and
+payload-cache authorization. Candidate-cache identity adds the discovery
+contract and version. The typed source identity selects and labels HTTP
+protocol operations only.
+
+Runtime transport-profile order controls failover but does not create another
+content identity or invalidate candidate evidence for the same immutable
+producer and discovery contract. A signed query remains part of canonical HTTP
+producer identity even when the typed source identity folds it; raw query text
+is hashed in cache keys and redacted in diagnostics.
 The package layer passes the network capability unchanged and cannot turn an
 offline operation into permission to contact a source.
 
@@ -184,18 +184,22 @@ An owner-issued source operation returns either its typed value or a
 `PackageSourceFailure`. `DotnetInspector.Packages` wraps that result in one
 package-owned route outcome with these variants:
 
-- a successful owner-issued operation value, including search or version
-  candidates, an exact manifest, or a payload, with its producer provenance and
-  the selected transport profile;
-- a source-operation failure, retaining the owner-issued failure and selected
-  transport profile; or
+- a successful HTTP operation, retaining the owner-issued search or version
+  candidates, exact manifest, or payload value together with package producer
+  identity, typed source identity, and selected transport profile;
+- a failed HTTP operation, retaining the owner-issued failure, package producer
+  identity, typed source identity, and selected transport profile;
+- a local-route observation, retaining canonical local producer identity and
+  either a package-layer local-store value or an unsupported-capability reason,
+  with no typed source identity or transport profile; or
 - a pre-client classification failure, retaining a safe configured-source
   reference, syntactic source kind, and reason without a producer identity.
 
 The classification-failure variant cannot authorize a cache entry, contribute
-candidate provenance, or assert package absence. A safe configured-source
-reference is a configured source name or redacted display, never a raw signed
-URL.
+candidate provenance, or assert package absence. Its safe source reference is
+the contained, redacted display produced by
+`PackageSourceDisplay.ForDiagnostics`; a configured source name is never used
+directly because an unmatched URL override uses its URL as the name.
 
 Raw resource URLs, response bodies, and credentials are not package-layer
 failure data. Caller cancellation propagates with the caller token instead of
@@ -209,7 +213,7 @@ selected:
 | Source kind | Package-layer action |
 | --- | --- |
 | HTTP endpoint | Ask the owner-issued factory for the endpoint's typed capability. A syntactically valid HTTP URL is not assumed to be a valid NuGet v3 source. |
-| Local path or `file://` directory | Retain the local-source identity and use only local-store capabilities implemented by the package layer. Until [local-feed acquisition](https://github.com/richlander/dotnet-inspect/issues/3759) supplies a capability, report it as unsupported explicitly and never rewrite the source as HTTP. |
+| Local path or `file://` directory | Construct the local-route input and return a local-route observation. Until [local-feed acquisition](https://github.com/richlander/dotnet-inspect/issues/3759) supplies a requested capability, retain canonical directory identity with an unsupported-capability reason and never rewrite the source as HTTP. |
 | Unsupported URI scheme or malformed runtime endpoint | Return the package-owned classification-failure variant without constructing an HTTP request, minting a producer identity, or exposing a raw argument exception. |
 
 An unsupported local capability is not an unreadable remote source. It is
@@ -220,11 +224,12 @@ result. It cannot silently grant authority to a cache or another source.
 
 ### Protocol and host handoff
 
-The package layer decides which producer may be queried, obtains the typed
-source client from the owner-issued factory, and invokes its operations with
-the operation context issued by #4770. NuGetFetch owns service-index discovery,
-endpoint construction and validation, protocol-level retry, bounded body
-reading, source-client transport construction and lifetime, and the typed
+The package layer decides which producer may be queried. For an HTTP route, it
+obtains the typed source client from the owner-issued factory and invokes its
+operations with the context issued by #4770. A local route remains within the
+package layer and never constructs that client. NuGetFetch owns service-index
+discovery, endpoint construction and validation, protocol-level retry, bounded
+body reading, source-client transport construction and lifetime, and the typed
 source-operation result.
 DotnetInspector.Core owns its host HTTP pipeline, offline enforcement, and
 redacted network diagnostics.
@@ -241,11 +246,11 @@ implementation owns an isolated transport or receives policy through another
 owner-issued factory. Transport construction, mutability, and disposal remain
 part of that adjacent owner's contract.
 
-DotnetInspector.Packages owns the typed client handle it obtains. It retains
-that handle until a returned payload stream is consumed or disposed, or
-transfers both into one wrapper with the same lifetime. It disposes the handle
-on every path that returns no payload. This is client-handle orchestration, not
-a claim about how the adjacent client owns its transport.
+DotnetInspector.Packages owns each typed HTTP client handle it obtains. It
+retains that handle until a returned payload stream is consumed or disposed,
+or transfers both into one wrapper with the same lifetime. It disposes the
+handle on every path that returns no payload. This is client-handle
+orchestration, not a claim about how the adjacent client owns its transport.
 
 ### Credential and origin boundary
 
@@ -265,7 +270,8 @@ compatibility request it constructs.
 
 ### Routes, deadlines, and projection
 
-Configured source aliases collapse by producer identity after mapping.
+Configured source aliases collapse by canonical endpoint or local-directory
+producer identity after mapping.
 Transport profiles for one producer form one ordered route rather than
 separate candidate sources. Source declaration order between different
 producers is not precedence and cannot make one source's candidate
@@ -281,7 +287,8 @@ another transport profile resets it.
 
 Package-layer projection preserves:
 
-- producer identity and transport-profile diagnostics;
+- package producer identity, typed source identity, and transport-profile
+  diagnostics without substituting one identity for another;
 - source-failure kind;
 - timeout kind and configured duration;
 - caller cancellation as cancellation rather than timeout; and
@@ -300,14 +307,14 @@ than transport failures.
 
 ### Aggregation and completeness
 
-Typed clients report one producer at a time; the package layer owns
-multi-source composition. Exact pinned acquisition may succeed from one
-eligible producer. An aggregate that selects latest or wildcard versions,
-claims authoritative absence, or otherwise depends on the complete candidate
-set requires a terminal observation from every eligible producer. A capability
-gap is itself non-terminal for completeness: the operation must fail or
-explicitly report partial authority. A healthy subset cannot silently become
-the whole authority.
+Each typed HTTP client or local-store adapter reports one producer at a time;
+the package layer owns multi-source composition. Exact pinned acquisition may
+succeed from one eligible producer. An aggregate that selects latest or
+wildcard versions, claims authoritative absence, or otherwise depends on the
+complete candidate set requires a terminal observation from every eligible
+producer. A capability gap is itself non-terminal for completeness: the
+operation must fail or explicitly report partial authority. A healthy subset
+cannot silently become the whole authority.
 
 Candidate caches remain producer- and discovery-contract-scoped observations.
 They may replace a request only for the producer and discovery contract that
@@ -330,7 +337,8 @@ projects contain non-vacuous gates for these outcomes.
 - `PackageSourceClientProvider_UnsupportedSchemesBecomeRouteClassificationFailures`
   proves the identity-free configured source is classified before route
   construction and an unsupported scheme returns the package-owned pre-client
-  variant without a request or producer identity.
+  variant without a request or producer identity, using only the contained
+  redacted source display.
 - `PackageRoutePreservesOfflineNetworkCapability` proves route adaptation does
   not construct or invoke an HTTP source client, and observes no request, when
   the operation lacks network permission.
@@ -340,7 +348,8 @@ projects contain non-vacuous gates for these outcomes.
   depends on the owner-issued policy from #4776.
 - `PackageSourceFailureDataExcludesResourceUrlsAndCredentials` proves
   package-layer failure projection does not retain signed queries, response
-  text, or authorization data.
+  text, or authorization data, including when an unmatched signed URL is also
+  the configured source name.
 
 `src/DotnetInspector.Services.Tests` owns aggregation, acquisition, and
 projection gates:
@@ -364,12 +373,16 @@ projection gates:
   leak an unreturned stream.
 - `ProducerRouteCollapsesTransportProfilesIntoOneCandidateSource` proves
   transport failover does not create duplicate source authority.
+- `ProducerAliasesCollapseByCanonicalEndpointIdentity` proves query-distinct
+  configured endpoints do not collapse merely because their typed source
+  identities match.
 - `WildcardResolutionRequiresEveryEligibleSource` proves a healthy subset or
   capability gap cannot produce an authoritative aggregate.
 - `LocalUnsupportedCapabilityPreventsAuthoritativeAggregateWithoutHttpFailure`
-  proves a filesystem-free operation keeps local-source handling visible,
-  prevents an authoritative aggregate, and does not route the source through
-  HTTP diagnostics.
+  proves a filesystem-free operation returns the local-route variant with
+  canonical directory identity and no typed source identity or transport
+  profile, prevents an authoritative aggregate, and does not route the source
+  through HTTP diagnostics.
 - `CandidateCacheUsesProducerAndDiscoveryContractIdentity` proves transport
   profile changes do not become content identity while incompatible discovery
   contracts remain isolated.


### PR DESCRIPTION
Closes #4765. Docs-only successor selected after round 18 of #4653.

## Summary

- Define the `DotnetInspector.Packages` composition boundary that turns one eligible producer route into typed source operations.
- Classify HTTP, local-directory, `file://`, and unsupported sources before protocol or transport selection.
- Separate stable producer and discovery-contract identity from ordered runtime transport profiles.
- Preserve credential-origin policy on package-layer compatibility requests, client-handle and payload-stream lifetime, typed timeout projection, caller cancellation, and complete-source authority.
- Name the Release gates required before #4653 may claim the target contract.

## Owner and boundaries

**Owner:** Package source model  
**Owning document:** `docs/design/package-source-model.md`

The design specifies only this owner's immediate route input, typed outcomes, package-layer projection, aggregation, and gates. NuGetFetch retains protocol discovery, request mechanics, source-client transport construction, and lifetime. DotnetInspector.Core retains host HTTP construction, offline enforcement, and network diagnostic rendering. Browser source profiles, local-feed acquisition, and CLI presentation remain out of scope.

## Dependencies and residuals

- #4770 supplies the NuGetFetch-owned reusable public-operation context and typed request-versus-operation timeout identity consumed by this boundary.
- #4776 supplies the NuGetFetch-owned per-request plugin-authentication eligibility policy consumed by package-layer compatibility requests.
- #4766 owns signed-URL redaction at the Core offline boundary.
- #3759 remains the owner for local-folder package discovery and acquisition.
- #4653 remains the implementation candidate and cannot claim this contract until the named non-vacuous Release gates exist.

## Compatibility and non-action boundary

This PR changes no product behavior, output, API, source selection, cache entry, credential flow, or network request. It does not copy the broad implementation contract from #4653; it re-derives one focused owner boundary and records adjacent prerequisites separately.

## Validation

- `npx markdownlint-cli docs/design/package-source-model.md`
- `git diff --check`
