### PR TITLE
Typecheck generated runtime wrappers

### DIFF
--- a/eng/generate-inspect-web-engine-dts.sh
+++ b/eng/generate-inspect-web-engine-dts.sh
@@ -41,8 +41,11 @@ cat > "$header_file" <<'EOF'
 EOF
 
 dotnet build "$engine_csproj" -c Release >&2
-dotnet run --project "$repo_root/src/tsbindgen" -c Release -- "$engine_dll" \
-  --emit-js "$js_generated_file.body" > "$dts_generated_file.body"
+# Prevent Git Bash from rewriting the public URL-like module name as a Windows path.
+MSYS2_ARG_CONV_EXCL="/inspect-web-engine.js" \
+  dotnet run --project "$repo_root/src/tsbindgen" -c Release -- "$engine_dll" \
+  --emit-js "$js_generated_file.body" \
+  --declaration-module "/inspect-web-engine.js" > "$dts_generated_file.body"
 cat "$header_file" "$dts_generated_file.body" > "$dts_generated_file"
 cat "$header_file" "$js_generated_file.body" > "$js_generated_file"
 

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
@@ -154,20 +154,20 @@ export async function initializeEngine(onStatus = () => {}) {
  * @returns {BrowserBuildIdentity}
  */
 export function buildIdentity() {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.BuildIdentity();
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.BuildIdentity();
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserBuildIdentity} */ (parsed);
+  return /** @type {BrowserBuildIdentity} */ ($parsed);
 }
 
 /**
  * @returns {void}
  */
 export function cancelSourceQuery() {
-  const exports = $requireManagedExports();
-  return exports.InspectionEngine.CancelSourceQuery();
+  const $exports = $requireManagedExports();
+  return $exports.InspectionEngine.CancelSourceQuery();
 }
 
 /**
@@ -175,8 +175,8 @@ export function cancelSourceQuery() {
  * @returns {void}
  */
 export function configureHost(origin) {
-  const exports = $requireManagedExports();
-  return exports.InspectionEngine.ConfigureHost(origin);
+  const $exports = $requireManagedExports();
+  return $exports.InspectionEngine.ConfigureHost(origin);
 }
 
 /**
@@ -184,12 +184,12 @@ export function configureHost(origin) {
  * @returns {BrowserWorkspaceShareDecodeResult}
  */
 export function decodeWorkspaceShareState(encoded) {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.DecodeWorkspaceShareState(encoded);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.DecodeWorkspaceShareState(encoded);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserWorkspaceShareDecodeResult} */ (parsed);
+  return /** @type {BrowserWorkspaceShareDecodeResult} */ ($parsed);
 }
 
 /**
@@ -197,12 +197,12 @@ export function decodeWorkspaceShareState(encoded) {
  * @returns {BrowserWorkspaceShareEncodeResult}
  */
 export function encodeWorkspaceShareState(stateJson) {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.EncodeWorkspaceShareState(stateJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.EncodeWorkspaceShareState(stateJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserWorkspaceShareEncodeResult} */ (parsed);
+  return /** @type {BrowserWorkspaceShareEncodeResult} */ ($parsed);
 }
 
 /**
@@ -220,12 +220,12 @@ export function encodeWorkspaceShareState(stateJson) {
  * @returns {Promise<BrowserCallGraph>}
  */
 export async function expandPlatformCallGraph(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.ExpandPlatformCallGraph(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.ExpandPlatformCallGraph(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserCallGraph} */ (parsed);
+  return /** @type {BrowserCallGraph} */ ($parsed);
 }
 
 /**
@@ -235,36 +235,36 @@ export async function expandPlatformCallGraph(targetFramework, platformVersion, 
  * @returns {Promise<BrowserPackageDocumentContent>}
  */
 export async function getPackageDocument(packageId, version, path) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.GetPackageDocument(packageId, version, path);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.GetPackageDocument(packageId, version, path);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageDocumentContent} */ (parsed);
+  return /** @type {BrowserPackageDocumentContent} */ ($parsed);
 }
 
 /**
  * @returns {BrowserHomeDemoCatalog}
  */
 export function listHomeDemos() {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.ListHomeDemos();
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.ListHomeDemos();
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserHomeDemoCatalog} */ (parsed);
+  return /** @type {BrowserHomeDemoCatalog} */ ($parsed);
 }
 
 /**
  * @returns {BrowserVocabularyDocument}
  */
 export function listVocabulary() {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.ListVocabulary();
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.ListVocabulary();
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserVocabularyDocument} */ (parsed);
+  return /** @type {BrowserVocabularyDocument} */ ($parsed);
 }
 
 /**
@@ -273,8 +273,8 @@ export function listVocabulary() {
  * @returns {Promise<string>}
  */
 export async function loadRuntimePack(targetFramework, platformVersion) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.LoadRuntimePack(targetFramework, platformVersion);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.LoadRuntimePack(targetFramework, platformVersion);
 }
 
 /**
@@ -285,8 +285,8 @@ export async function loadRuntimePack(targetFramework, platformVersion) {
  * @returns {Promise<string>}
  */
 export async function loadRuntimePackAssembly(targetFramework, platformVersion, assemblyFileName, pack) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.LoadRuntimePackAssembly(targetFramework, platformVersion, assemblyFileName, pack);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.LoadRuntimePackAssembly(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
 /**
@@ -296,24 +296,24 @@ export async function loadRuntimePackAssembly(targetFramework, platformVersion, 
  * @returns {BrowserDependencyCoordinateMatch}
  */
 export function matchPackageDependencyCoordinate(packageId, declaredRange, candidatesJson) {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.MatchPackageDependencyCoordinate(packageId, declaredRange, candidatesJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.MatchPackageDependencyCoordinate(packageId, declaredRange, candidatesJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserDependencyCoordinateMatch} */ (parsed);
+  return /** @type {BrowserDependencyCoordinateMatch} */ ($parsed);
 }
 
 /**
  * @returns {BrowserPackageCacheStats}
  */
 export function packageCacheStats() {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.PackageCacheStats();
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.PackageCacheStats();
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageCacheStats} */ (parsed);
+  return /** @type {BrowserPackageCacheStats} */ ($parsed);
 }
 
 /**
@@ -328,12 +328,12 @@ export function packageCacheStats() {
  * @returns {Promise<BrowserMemberSurface>}
  */
 export async function queryGraphMemberSurface(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryGraphMemberSurface(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryGraphMemberSurface(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserMemberSurface} */ (parsed);
+  return /** @type {BrowserMemberSurface} */ ($parsed);
 }
 
 /**
@@ -351,12 +351,12 @@ export async function queryGraphMemberSurface(packageId, version, targetFramewor
  * @returns {Promise<BrowserAnnotatedSource>}
  */
 export async function queryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserAnnotatedSource} */ (parsed);
+  return /** @type {BrowserAnnotatedSource} */ ($parsed);
 }
 
 /**
@@ -374,12 +374,12 @@ export async function queryMemberAnnotatedSource(packageId, version, targetFrame
  * @returns {Promise<BrowserCallGraph>}
  */
 export async function queryMemberCallGraph(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryMemberCallGraph(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryMemberCallGraph(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserCallGraph} */ (parsed);
+  return /** @type {BrowserCallGraph} */ ($parsed);
 }
 
 /**
@@ -391,12 +391,12 @@ export async function queryMemberCallGraph(packageId, version, targetFramework, 
  * @returns {Promise<BrowserMemberDocumentation>}
  */
 export async function queryMemberDocumentation(packageId, version, framework, assemblyName, documentationId) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryMemberDocumentation(packageId, version, framework, assemblyName, documentationId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryMemberDocumentation(packageId, version, framework, assemblyName, documentationId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserMemberDocumentation} */ (parsed);
+  return /** @type {BrowserMemberDocumentation} */ ($parsed);
 }
 
 /**
@@ -410,8 +410,8 @@ export async function queryMemberDocumentation(packageId, version, framework, as
  * @returns {Promise<string>}
  */
 export async function queryMemberFacts(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryMemberFacts(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryMemberFacts(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature);
 }
 
 /**
@@ -427,12 +427,12 @@ export async function queryMemberFacts(packageId, version, targetFramework, asse
  * @returns {Promise<BrowserSource>}
  */
 export async function queryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserSource} */ (parsed);
+  return /** @type {BrowserSource} */ ($parsed);
 }
 
 /**
@@ -442,12 +442,12 @@ export async function queryMemberSource(packageId, version, targetFramework, ass
  * @returns {Promise<BrowserPackageSurface>}
  */
 export async function queryPackage(packageId, version, targetFramework) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackage(packageId, version, targetFramework);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackage(packageId, version, targetFramework);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageSurface} */ (parsed);
+  return /** @type {BrowserPackageSurface} */ ($parsed);
 }
 
 /**
@@ -458,12 +458,12 @@ export async function queryPackage(packageId, version, targetFramework) {
  * @returns {Promise<BrowserPackageDependencies>}
  */
 export async function queryPackageDependencies(packageId, version, targetFramework, assemblyId) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackageDependencies(packageId, version, targetFramework, assemblyId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackageDependencies(packageId, version, targetFramework, assemblyId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageDependencies} */ (parsed);
+  return /** @type {BrowserPackageDependencies} */ ($parsed);
 }
 
 /**
@@ -475,8 +475,8 @@ export async function queryPackageDependencies(packageId, version, targetFramewo
  * @returns {Promise<string>}
  */
 export async function queryPackageHeapEntries(packageId, version, targetFramework, assemblyFileName, heap) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPackageHeapEntries(packageId, version, targetFramework, assemblyFileName, heap);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPackageHeapEntries(packageId, version, targetFramework, assemblyFileName, heap);
 }
 
 /**
@@ -486,12 +486,12 @@ export async function queryPackageHeapEntries(packageId, version, targetFramewor
  * @returns {Promise<BrowserPackageIntegrations>}
  */
 export async function queryPackageIntegrations(packageId, version, targetFramework) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackageIntegrations(packageId, version, targetFramework);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackageIntegrations(packageId, version, targetFramework);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageIntegrations} */ (parsed);
+  return /** @type {BrowserPackageIntegrations} */ ($parsed);
 }
 
 /**
@@ -501,8 +501,8 @@ export async function queryPackageIntegrations(packageId, version, targetFramewo
  * @returns {Promise<string>}
  */
 export async function queryPackageMetadata(packageId, version, targetFramework) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPackageMetadata(packageId, version, targetFramework);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPackageMetadata(packageId, version, targetFramework);
 }
 
 /**
@@ -516,8 +516,8 @@ export async function queryPackageMetadata(packageId, version, targetFramework) 
  * @returns {Promise<string>}
  */
 export async function queryPackageMetadataTable(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPackageMetadataTable(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPackageMetadataTable(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows);
 }
 
 /**
@@ -527,12 +527,12 @@ export async function queryPackageMetadataTable(packageId, version, targetFramew
  * @returns {Promise<BrowserPackageOpportunities>}
  */
 export async function queryPackageOpportunities(packageId, version, targetFramework) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackageOpportunities(packageId, version, targetFramework);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackageOpportunities(packageId, version, targetFramework);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageOpportunities} */ (parsed);
+  return /** @type {BrowserPackageOpportunities} */ ($parsed);
 }
 
 /**
@@ -542,12 +542,12 @@ export async function queryPackageOpportunities(packageId, version, targetFramew
  * @returns {Promise<BrowserPackagePerformance>}
  */
 export async function queryPackagePerformance(packageId, version, targetFramework) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackagePerformance(packageId, version, targetFramework);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackagePerformance(packageId, version, targetFramework);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackagePerformance} */ (parsed);
+  return /** @type {BrowserPackagePerformance} */ ($parsed);
 }
 
 /**
@@ -555,12 +555,12 @@ export async function queryPackagePerformance(packageId, version, targetFramewor
  * @returns {Promise<ReadonlyArray<string>>}
  */
 export async function queryPackageVersions(packageId) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPackageVersions(packageId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPackageVersions(packageId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {ReadonlyArray<string>} */ (parsed);
+  return /** @type {ReadonlyArray<string>} */ ($parsed);
 }
 
 /**
@@ -572,8 +572,8 @@ export async function queryPackageVersions(packageId) {
  * @returns {Promise<string>}
  */
 export async function queryPlatformHeapEntries(targetFramework, platformVersion, assemblyFileName, pack, heap) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPlatformHeapEntries(targetFramework, platformVersion, assemblyFileName, pack, heap);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPlatformHeapEntries(targetFramework, platformVersion, assemblyFileName, pack, heap);
 }
 
 /**
@@ -584,12 +584,12 @@ export async function queryPlatformHeapEntries(targetFramework, platformVersion,
  * @returns {Promise<BrowserPackageIntegrations>}
  */
 export async function queryPlatformIntegrations(targetFramework, platformVersion, assemblyFileName, pack) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPlatformIntegrations(targetFramework, platformVersion, assemblyFileName, pack);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPlatformIntegrations(targetFramework, platformVersion, assemblyFileName, pack);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageIntegrations} */ (parsed);
+  return /** @type {BrowserPackageIntegrations} */ ($parsed);
 }
 
 /**
@@ -600,8 +600,8 @@ export async function queryPlatformIntegrations(targetFramework, platformVersion
  * @returns {Promise<string>}
  */
 export async function queryPlatformMetadata(targetFramework, platformVersion, assemblyFileName, pack) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPlatformMetadata(targetFramework, platformVersion, assemblyFileName, pack);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPlatformMetadata(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
 /**
@@ -615,8 +615,8 @@ export async function queryPlatformMetadata(targetFramework, platformVersion, as
  * @returns {Promise<string>}
  */
 export async function queryPlatformMetadataTable(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPlatformMetadataTable(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPlatformMetadataTable(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows);
 }
 
 /**
@@ -627,12 +627,12 @@ export async function queryPlatformMetadataTable(targetFramework, platformVersio
  * @returns {Promise<BrowserPackageOpportunities>}
  */
 export async function queryPlatformOpportunities(targetFramework, platformVersion, assemblyFileName, pack) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryPlatformOpportunities(targetFramework, platformVersion, assemblyFileName, pack);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryPlatformOpportunities(targetFramework, platformVersion, assemblyFileName, pack);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserPackageOpportunities} */ (parsed);
+  return /** @type {BrowserPackageOpportunities} */ ($parsed);
 }
 
 /**
@@ -643,8 +643,8 @@ export async function queryPlatformOpportunities(targetFramework, platformVersio
  * @returns {Promise<string>}
  */
 export async function queryPlatformPerformance(targetFramework, platformVersion, assemblyFileName, pack) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.QueryPlatformPerformance(targetFramework, platformVersion, assemblyFileName, pack);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.QueryPlatformPerformance(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
 /**
@@ -660,12 +660,12 @@ export async function queryPlatformPerformance(targetFramework, platformVersion,
  * @returns {Promise<BrowserSource>}
  */
 export async function queryTypeMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryTypeMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryTypeMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserSource} */ (parsed);
+  return /** @type {BrowserSource} */ ($parsed);
 }
 
 /**
@@ -677,12 +677,12 @@ export async function queryTypeMemberSource(packageId, version, targetFramework,
  * @returns {Promise<BrowserTypeMetadata>}
  */
 export async function queryTypeProjection(packageId, version, targetFramework, assemblyName, typeId) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryTypeProjection(packageId, version, targetFramework, assemblyName, typeId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryTypeProjection(packageId, version, targetFramework, assemblyName, typeId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserTypeMetadata} */ (parsed);
+  return /** @type {BrowserTypeMetadata} */ ($parsed);
 }
 
 /**
@@ -695,12 +695,12 @@ export async function queryTypeProjection(packageId, version, targetFramework, a
  * @returns {Promise<BrowserSource>}
  */
 export async function queryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.QueryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.QueryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserSource} */ (parsed);
+  return /** @type {BrowserSource} */ ($parsed);
 }
 
 /**
@@ -708,12 +708,12 @@ export async function queryTypeSource(packageId, version, targetFramework, assem
  * @returns {BrowserHomeDemoResolveResult}
  */
 export function resolveHomeDemo(scenarioId) {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.ResolveHomeDemo(scenarioId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.ResolveHomeDemo(scenarioId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserHomeDemoResolveResult} */ (parsed);
+  return /** @type {BrowserHomeDemoResolveResult} */ ($parsed);
 }
 
 /**
@@ -722,8 +722,8 @@ export function resolveHomeDemo(scenarioId) {
  * @returns {Promise<string>}
  */
 export async function resolvePackageDependencyVersion(packageId, declaredRange) {
-  const exports = $requireManagedExports();
-  return await exports.InspectionEngine.ResolvePackageDependencyVersion(packageId, declaredRange);
+  const $exports = $requireManagedExports();
+  return await $exports.InspectionEngine.ResolvePackageDependencyVersion(packageId, declaredRange);
 }
 
 /**
@@ -731,12 +731,12 @@ export async function resolvePackageDependencyVersion(packageId, declaredRange) 
  * @returns {Promise<BrowserHomeDemoRunResult>}
  */
 export async function runHomeDemo(scenarioId) {
-  const exports = $requireManagedExports();
-  const result = await exports.InspectionEngine.RunHomeDemo(scenarioId);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = await $exports.InspectionEngine.RunHomeDemo(scenarioId);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {BrowserHomeDemoRunResult} */ (parsed);
+  return /** @type {BrowserHomeDemoRunResult} */ ($parsed);
 }
 
 /**
@@ -745,10 +745,10 @@ export async function runHomeDemo(scenarioId) {
  * @returns {ReadonlyArray<BrowserTypeSearchHit>}
  */
 export function searchTypes(query, candidatesJson) {
-  const exports = $requireManagedExports();
-  const result = exports.InspectionEngine.SearchTypes(query, candidatesJson);
-  const parsed = $parseJson(result);
+  const $exports = $requireManagedExports();
+  const $result = $exports.InspectionEngine.SearchTypes(query, candidatesJson);
+  const $parsed = $parseJson($result);
   // The authenticated serializer contract fixes this function's exact wire type.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-  return /** @type {ReadonlyArray<BrowserTypeSearchHit>} */ (parsed);
+  return /** @type {ReadonlyArray<BrowserTypeSearchHit>} */ ($parsed);
 }

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
@@ -6,327 +6,749 @@
 
 import { dotnet } from "./_framework/dotnet.js";
 
-let buildIdentityExport;
-let cancelSourceQueryExport;
-let configureHostExport;
-let decodeWorkspaceShareStateExport;
-let encodeWorkspaceShareStateExport;
-let expandPlatformCallGraphExport;
-let getPackageDocumentExport;
-let listHomeDemosExport;
-let listVocabularyExport;
-let loadRuntimePackExport;
-let loadRuntimePackAssemblyExport;
-let matchPackageDependencyCoordinateExport;
-let packageCacheStatsExport;
-let queryGraphMemberSurfaceExport;
-let queryMemberAnnotatedSourceExport;
-let queryMemberCallGraphExport;
-let queryMemberDocumentationExport;
-let queryMemberFactsExport;
-let queryMemberSourceExport;
-let queryPackageExport;
-let queryPackageDependenciesExport;
-let queryPackageHeapEntriesExport;
-let queryPackageIntegrationsExport;
-let queryPackageMetadataExport;
-let queryPackageMetadataTableExport;
-let queryPackageOpportunitiesExport;
-let queryPackagePerformanceExport;
-let queryPackageVersionsExport;
-let queryPlatformHeapEntriesExport;
-let queryPlatformIntegrationsExport;
-let queryPlatformMetadataExport;
-let queryPlatformMetadataTableExport;
-let queryPlatformOpportunitiesExport;
-let queryPlatformPerformanceExport;
-let queryTypeMemberSourceExport;
-let queryTypeProjectionExport;
-let queryTypeSourceExport;
-let resolveHomeDemoExport;
-let resolvePackageDependencyVersionExport;
-let runHomeDemoExport;
-let searchTypesExport;
+/** @typedef {import("/inspect-web-engine.js").BrowserAccessibilityDescriptor} BrowserAccessibilityDescriptor */
+/** @typedef {import("/inspect-web-engine.js").BrowserAnnotatedSource} BrowserAnnotatedSource */
+/** @typedef {import("/inspect-web-engine.js").BrowserAssemblyReference} BrowserAssemblyReference */
+/** @typedef {import("/inspect-web-engine.js").BrowserAssemblySurface} BrowserAssemblySurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserBuildIdentity} BrowserBuildIdentity */
+/** @typedef {import("/inspect-web-engine.js").BrowserCallGraph} BrowserCallGraph */
+/** @typedef {import("/inspect-web-engine.js").BrowserCallGraphDiagnostics} BrowserCallGraphDiagnostics */
+/** @typedef {import("/inspect-web-engine.js").BrowserCallGraphNode} BrowserCallGraphNode */
+/** @typedef {import("/inspect-web-engine.js").BrowserCallGraphScope} BrowserCallGraphScope */
+/** @typedef {import("/inspect-web-engine.js").BrowserCallGraphTarget} BrowserCallGraphTarget */
+/** @typedef {import("/inspect-web-engine.js").BrowserDependencyCoordinateCandidate} BrowserDependencyCoordinateCandidate */
+/** @typedef {import("/inspect-web-engine.js").BrowserDependencyCoordinateMatch} BrowserDependencyCoordinateMatch */
+/** @typedef {import("/inspect-web-engine.js").BrowserDependencyCoordinateMatchOutcome} BrowserDependencyCoordinateMatchOutcome */
+/** @typedef {import("/inspect-web-engine.js").BrowserDependencyCoordinateProvenance} BrowserDependencyCoordinateProvenance */
+/** @typedef {import("/inspect-web-engine.js").BrowserExceptionSurface} BrowserExceptionSurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoCatalog} BrowserHomeDemoCatalog */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoCatalogEntry} BrowserHomeDemoCatalogEntry */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoMember} BrowserHomeDemoMember */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoNavigationTab} BrowserHomeDemoNavigationTab */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoResolveResult} BrowserHomeDemoResolveResult */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoResolved} BrowserHomeDemoResolved */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoRunActivation} BrowserHomeDemoRunActivation */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoRunResult} BrowserHomeDemoRunResult */
+/** @typedef {import("/inspect-web-engine.js").BrowserHomeDemoView} BrowserHomeDemoView */
+/** @typedef {import("/inspect-web-engine.js").BrowserIntegrationCategory} BrowserIntegrationCategory */
+/** @typedef {import("/inspect-web-engine.js").BrowserIntegrationSignal} BrowserIntegrationSignal */
+/** @typedef {import("/inspect-web-engine.js").BrowserMemberBodySelector} BrowserMemberBodySelector */
+/** @typedef {import("/inspect-web-engine.js").BrowserMemberDocumentation} BrowserMemberDocumentation */
+/** @typedef {import("/inspect-web-engine.js").BrowserMemberSurface} BrowserMemberSurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserOpportunityCategory} BrowserOpportunityCategory */
+/** @typedef {import("/inspect-web-engine.js").BrowserOpportunityItem} BrowserOpportunityItem */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageCacheStats} BrowserPackageCacheStats */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageDependencies} BrowserPackageDependencies */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageDependency} BrowserPackageDependency */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageDependencyGroup} BrowserPackageDependencyGroup */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageDocument} BrowserPackageDocument */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageDocumentContent} BrowserPackageDocumentContent */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageIntegrations} BrowserPackageIntegrations */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageOpportunities} BrowserPackageOpportunities */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackagePerformance} BrowserPackagePerformance */
+/** @typedef {import("/inspect-web-engine.js").BrowserPackageSurface} BrowserPackageSurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserParameterSurface} BrowserParameterSurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserPerformanceMember} BrowserPerformanceMember */
+/** @typedef {import("/inspect-web-engine.js").BrowserSource} BrowserSource */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeCandidate} BrowserTypeCandidate */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeComposition} BrowserTypeComposition */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeGraphEdge} BrowserTypeGraphEdge */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeGraphNode} BrowserTypeGraphNode */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeMetadata} BrowserTypeMetadata */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeParameter} BrowserTypeParameter */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeSearchHit} BrowserTypeSearchHit */
+/** @typedef {import("/inspect-web-engine.js").BrowserTypeSurface} BrowserTypeSurface */
+/** @typedef {import("/inspect-web-engine.js").BrowserVocabularyDocument} BrowserVocabularyDocument */
+/** @typedef {import("/inspect-web-engine.js").BrowserVocabularyField} BrowserVocabularyField */
+/** @typedef {import("/inspect-web-engine.js").BrowserVocabularySection} BrowserVocabularySection */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareContext} BrowserWorkspaceShareContext */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareDecodeResult} BrowserWorkspaceShareDecodeResult */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareEncodeResult} BrowserWorkspaceShareEncodeResult */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareFailure} BrowserWorkspaceShareFailure */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareState} BrowserWorkspaceShareState */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareTab} BrowserWorkspaceShareTab */
+/** @typedef {import("/inspect-web-engine.js").BrowserWorkspaceShareView} BrowserWorkspaceShareView */
 
+/**
+ * @typedef {{
+ *   InspectionEngine: {
+ *     BuildIdentity: () => string,
+ *     CancelSourceQuery: () => void,
+ *     ConfigureHost: (origin: string) => void,
+ *     DecodeWorkspaceShareState: (encoded: string) => string,
+ *     EncodeWorkspaceShareState: (stateJson: string) => string,
+ *     ExpandPlatformCallGraph: (targetFramework: string, platformVersion: string, assembly: string, pack: string, assemblyVersion: string, assemblyCulture: string | null, assemblyPublicKeyToken: string | null, typeFullName: string, memberName: string, selectorKey: string, metadataToken: number) => Promise<string>,
+ *     GetPackageDocument: (packageId: string, version: string, path: string) => Promise<string>,
+ *     ListHomeDemos: () => string,
+ *     ListVocabulary: () => string,
+ *     LoadRuntimePack: (targetFramework: string, platformVersion: string) => Promise<string>,
+ *     LoadRuntimePackAssembly: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>,
+ *     MatchPackageDependencyCoordinate: (packageId: string, declaredRange: string | null, candidatesJson: string) => string,
+ *     PackageCacheStats: () => string,
+ *     QueryGraphMemberSurface: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number) => Promise<string>,
+ *     QueryMemberAnnotatedSource: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>,
+ *     QueryMemberCallGraph: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, workspaceJson: string) => Promise<string>,
+ *     QueryMemberDocumentation: (packageId: string, version: string, framework: string, assemblyName: string, documentationId: string) => Promise<string>,
+ *     QueryMemberFacts: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeId: string, memberName: string, memberSignature: string) => Promise<string>,
+ *     QueryMemberSource: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>,
+ *     QueryPackage: (packageId: string, version: string, targetFramework: string) => Promise<string>,
+ *     QueryPackageDependencies: (packageId: string, version: string, targetFramework: string, assemblyId: string) => Promise<string>,
+ *     QueryPackageHeapEntries: (packageId: string, version: string, targetFramework: string, assemblyFileName: string, heap: string) => Promise<string>,
+ *     QueryPackageIntegrations: (packageId: string, version: string, targetFramework: string) => Promise<string>,
+ *     QueryPackageMetadata: (packageId: string, version: string, targetFramework: string) => Promise<string>,
+ *     QueryPackageMetadataTable: (packageId: string, version: string, targetFramework: string, assemblyFileName: string, tableIndex: number, startRowId: number, maxRows: number) => Promise<string>,
+ *     QueryPackageOpportunities: (packageId: string, version: string, targetFramework: string) => Promise<string>,
+ *     QueryPackagePerformance: (packageId: string, version: string, targetFramework: string) => Promise<string>,
+ *     QueryPackageVersions: (packageId: string) => Promise<string>,
+ *     QueryPlatformHeapEntries: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string, heap: string) => Promise<string>,
+ *     QueryPlatformIntegrations: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>,
+ *     QueryPlatformMetadata: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>,
+ *     QueryPlatformMetadataTable: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string, tableIndex: number, startRowId: number, maxRows: number) => Promise<string>,
+ *     QueryPlatformOpportunities: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>,
+ *     QueryPlatformPerformance: (targetFramework: string, platformVersion: string, assemblyFileName: string, pack: string) => Promise<string>,
+ *     QueryTypeMemberSource: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>,
+ *     QueryTypeProjection: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeId: string) => Promise<string>,
+ *     QueryTypeSource: (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string) => Promise<string>,
+ *     ResolveHomeDemo: (scenarioId: string) => string,
+ *     ResolvePackageDependencyVersion: (packageId: string, declaredRange: string | null) => Promise<string>,
+ *     RunHomeDemo: (scenarioId: string) => Promise<string>,
+ *     SearchTypes: (query: string, candidatesJson: string) => string,
+ *   },
+ * }} $ManagedExports
+ */
+/** @type {$ManagedExports | undefined} */
+let $managedExports;
+
+/** @returns {$ManagedExports} */
+function $requireManagedExports() {
+  if (!$managedExports) throw new Error("The browser inspection engine is not initialized.");
+  return $managedExports;
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function $parseJson(value) {
+  return JSON.parse(value);
+}
+
+/**
+ * @param {(status: string) => void} [onStatus]
+ * @returns {Promise<unknown>}
+ */
 export async function initializeEngine(onStatus = () => {}) {
   onStatus("Loading .NET WebAssembly…");
   const runtime = await dotnet.create();
-  const exports = await runtime.getAssemblyExports("InspectWeb.Engine");
-  buildIdentityExport = exports.InspectionEngine.BuildIdentity;
-  cancelSourceQueryExport = exports.InspectionEngine.CancelSourceQuery;
-  configureHostExport = exports.InspectionEngine.ConfigureHost;
-  decodeWorkspaceShareStateExport = exports.InspectionEngine.DecodeWorkspaceShareState;
-  encodeWorkspaceShareStateExport = exports.InspectionEngine.EncodeWorkspaceShareState;
-  expandPlatformCallGraphExport = exports.InspectionEngine.ExpandPlatformCallGraph;
-  getPackageDocumentExport = exports.InspectionEngine.GetPackageDocument;
-  listHomeDemosExport = exports.InspectionEngine.ListHomeDemos;
-  listVocabularyExport = exports.InspectionEngine.ListVocabulary;
-  loadRuntimePackExport = exports.InspectionEngine.LoadRuntimePack;
-  loadRuntimePackAssemblyExport = exports.InspectionEngine.LoadRuntimePackAssembly;
-  matchPackageDependencyCoordinateExport = exports.InspectionEngine.MatchPackageDependencyCoordinate;
-  packageCacheStatsExport = exports.InspectionEngine.PackageCacheStats;
-  queryGraphMemberSurfaceExport = exports.InspectionEngine.QueryGraphMemberSurface;
-  queryMemberAnnotatedSourceExport = exports.InspectionEngine.QueryMemberAnnotatedSource;
-  queryMemberCallGraphExport = exports.InspectionEngine.QueryMemberCallGraph;
-  queryMemberDocumentationExport = exports.InspectionEngine.QueryMemberDocumentation;
-  queryMemberFactsExport = exports.InspectionEngine.QueryMemberFacts;
-  queryMemberSourceExport = exports.InspectionEngine.QueryMemberSource;
-  queryPackageExport = exports.InspectionEngine.QueryPackage;
-  queryPackageDependenciesExport = exports.InspectionEngine.QueryPackageDependencies;
-  queryPackageHeapEntriesExport = exports.InspectionEngine.QueryPackageHeapEntries;
-  queryPackageIntegrationsExport = exports.InspectionEngine.QueryPackageIntegrations;
-  queryPackageMetadataExport = exports.InspectionEngine.QueryPackageMetadata;
-  queryPackageMetadataTableExport = exports.InspectionEngine.QueryPackageMetadataTable;
-  queryPackageOpportunitiesExport = exports.InspectionEngine.QueryPackageOpportunities;
-  queryPackagePerformanceExport = exports.InspectionEngine.QueryPackagePerformance;
-  queryPackageVersionsExport = exports.InspectionEngine.QueryPackageVersions;
-  queryPlatformHeapEntriesExport = exports.InspectionEngine.QueryPlatformHeapEntries;
-  queryPlatformIntegrationsExport = exports.InspectionEngine.QueryPlatformIntegrations;
-  queryPlatformMetadataExport = exports.InspectionEngine.QueryPlatformMetadata;
-  queryPlatformMetadataTableExport = exports.InspectionEngine.QueryPlatformMetadataTable;
-  queryPlatformOpportunitiesExport = exports.InspectionEngine.QueryPlatformOpportunities;
-  queryPlatformPerformanceExport = exports.InspectionEngine.QueryPlatformPerformance;
-  queryTypeMemberSourceExport = exports.InspectionEngine.QueryTypeMemberSource;
-  queryTypeProjectionExport = exports.InspectionEngine.QueryTypeProjection;
-  queryTypeSourceExport = exports.InspectionEngine.QueryTypeSource;
-  resolveHomeDemoExport = exports.InspectionEngine.ResolveHomeDemo;
-  resolvePackageDependencyVersionExport = exports.InspectionEngine.ResolvePackageDependencyVersion;
-  runHomeDemoExport = exports.InspectionEngine.RunHomeDemo;
-  searchTypesExport = exports.InspectionEngine.SearchTypes;
-  configureHostExport(window.location.origin);
+  // This assertion is the one untyped .NET runtime boundary. $ManagedExports is
+  // generated from the same authenticated surface as the wrappers below.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  const exports = /** @type {$ManagedExports} */ (await runtime.getAssemblyExports("InspectWeb.Engine"));
+  exports.InspectionEngine.ConfigureHost(window.location.origin);
   await runtime.runMain();
+  $managedExports = exports;
   return exports;
 }
 
+/**
+ * @returns {BrowserBuildIdentity}
+ */
 export function buildIdentity() {
-  if (!buildIdentityExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = buildIdentityExport();
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.BuildIdentity();
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserBuildIdentity} */ (parsed);
 }
 
+/**
+ * @returns {void}
+ */
 export function cancelSourceQuery() {
-  if (!cancelSourceQueryExport) throw new Error("The browser inspection engine is not initialized.");
-  return cancelSourceQueryExport();
+  const exports = $requireManagedExports();
+  return exports.InspectionEngine.CancelSourceQuery();
 }
 
+/**
+ * @param {string} origin
+ * @returns {void}
+ */
 export function configureHost(origin) {
-  if (!configureHostExport) throw new Error("The browser inspection engine is not initialized.");
-  return configureHostExport(origin);
+  const exports = $requireManagedExports();
+  return exports.InspectionEngine.ConfigureHost(origin);
 }
 
+/**
+ * @param {string} encoded
+ * @returns {BrowserWorkspaceShareDecodeResult}
+ */
 export function decodeWorkspaceShareState(encoded) {
-  if (!decodeWorkspaceShareStateExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = decodeWorkspaceShareStateExport(encoded);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.DecodeWorkspaceShareState(encoded);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserWorkspaceShareDecodeResult} */ (parsed);
 }
 
+/**
+ * @param {string} stateJson
+ * @returns {BrowserWorkspaceShareEncodeResult}
+ */
 export function encodeWorkspaceShareState(stateJson) {
-  if (!encodeWorkspaceShareStateExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = encodeWorkspaceShareStateExport(stateJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.EncodeWorkspaceShareState(stateJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserWorkspaceShareEncodeResult} */ (parsed);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assembly
+ * @param {string} pack
+ * @param {string} assemblyVersion
+ * @param {string | null} assemblyCulture
+ * @param {string | null} assemblyPublicKeyToken
+ * @param {string} typeFullName
+ * @param {string} memberName
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @returns {Promise<BrowserCallGraph>}
+ */
 export async function expandPlatformCallGraph(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken) {
-  if (!expandPlatformCallGraphExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await expandPlatformCallGraphExport(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.ExpandPlatformCallGraph(targetFramework, platformVersion, assembly, pack, assemblyVersion, assemblyCulture, assemblyPublicKeyToken, typeFullName, memberName, selectorKey, metadataToken);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserCallGraph} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} path
+ * @returns {Promise<BrowserPackageDocumentContent>}
+ */
 export async function getPackageDocument(packageId, version, path) {
-  if (!getPackageDocumentExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await getPackageDocumentExport(packageId, version, path);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.GetPackageDocument(packageId, version, path);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageDocumentContent} */ (parsed);
 }
 
+/**
+ * @returns {BrowserHomeDemoCatalog}
+ */
 export function listHomeDemos() {
-  if (!listHomeDemosExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = listHomeDemosExport();
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.ListHomeDemos();
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserHomeDemoCatalog} */ (parsed);
 }
 
+/**
+ * @returns {BrowserVocabularyDocument}
+ */
 export function listVocabulary() {
-  if (!listVocabularyExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = listVocabularyExport();
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.ListVocabulary();
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserVocabularyDocument} */ (parsed);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @returns {Promise<string>}
+ */
 export async function loadRuntimePack(targetFramework, platformVersion) {
-  if (!loadRuntimePackExport) throw new Error("The browser inspection engine is not initialized.");
-  return await loadRuntimePackExport(targetFramework, platformVersion);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.LoadRuntimePack(targetFramework, platformVersion);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @returns {Promise<string>}
+ */
 export async function loadRuntimePackAssembly(targetFramework, platformVersion, assemblyFileName, pack) {
-  if (!loadRuntimePackAssemblyExport) throw new Error("The browser inspection engine is not initialized.");
-  return await loadRuntimePackAssemblyExport(targetFramework, platformVersion, assemblyFileName, pack);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.LoadRuntimePackAssembly(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string | null} declaredRange
+ * @param {string} candidatesJson
+ * @returns {BrowserDependencyCoordinateMatch}
+ */
 export function matchPackageDependencyCoordinate(packageId, declaredRange, candidatesJson) {
-  if (!matchPackageDependencyCoordinateExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = matchPackageDependencyCoordinateExport(packageId, declaredRange, candidatesJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.MatchPackageDependencyCoordinate(packageId, declaredRange, candidatesJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserDependencyCoordinateMatch} */ (parsed);
 }
 
+/**
+ * @returns {BrowserPackageCacheStats}
+ */
 export function packageCacheStats() {
-  if (!packageCacheStatsExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = packageCacheStatsExport();
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.PackageCacheStats();
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageCacheStats} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} memberName
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @returns {Promise<BrowserMemberSurface>}
+ */
 export async function queryGraphMemberSurface(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken) {
-  if (!queryGraphMemberSurfaceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryGraphMemberSurfaceExport(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryGraphMemberSurface(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserMemberSurface} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} typeQueryId
+ * @param {string} memberName
+ * @param {string} memberSignature
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @param {string} styleOptionsJson
+ * @returns {Promise<BrowserAnnotatedSource>}
+ */
 export async function queryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson) {
-  if (!queryMemberAnnotatedSourceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryMemberAnnotatedSourceExport(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserAnnotatedSource} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} typeQueryId
+ * @param {string} memberName
+ * @param {string} memberSignature
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @param {string} workspaceJson
+ * @returns {Promise<BrowserCallGraph>}
+ */
 export async function queryMemberCallGraph(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson) {
-  if (!queryMemberCallGraphExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryMemberCallGraphExport(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryMemberCallGraph(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, workspaceJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserCallGraph} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} framework
+ * @param {string} assemblyName
+ * @param {string} documentationId
+ * @returns {Promise<BrowserMemberDocumentation>}
+ */
 export async function queryMemberDocumentation(packageId, version, framework, assemblyName, documentationId) {
-  if (!queryMemberDocumentationExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryMemberDocumentationExport(packageId, version, framework, assemblyName, documentationId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryMemberDocumentation(packageId, version, framework, assemblyName, documentationId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserMemberDocumentation} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeId
+ * @param {string} memberName
+ * @param {string} memberSignature
+ * @returns {Promise<string>}
+ */
 export async function queryMemberFacts(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature) {
-  if (!queryMemberFactsExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryMemberFactsExport(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryMemberFacts(packageId, version, targetFramework, assemblyName, typeId, memberName, memberSignature);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} memberName
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @param {string} styleOptionsJson
+ * @returns {Promise<BrowserSource>}
+ */
 export async function queryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson) {
-  if (!queryMemberSourceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryMemberSourceExport(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserSource} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @returns {Promise<BrowserPackageSurface>}
+ */
 export async function queryPackage(packageId, version, targetFramework) {
-  if (!queryPackageExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackageExport(packageId, version, targetFramework);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackage(packageId, version, targetFramework);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageSurface} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyId
+ * @returns {Promise<BrowserPackageDependencies>}
+ */
 export async function queryPackageDependencies(packageId, version, targetFramework, assemblyId) {
-  if (!queryPackageDependenciesExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackageDependenciesExport(packageId, version, targetFramework, assemblyId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackageDependencies(packageId, version, targetFramework, assemblyId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageDependencies} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyFileName
+ * @param {string} heap
+ * @returns {Promise<string>}
+ */
 export async function queryPackageHeapEntries(packageId, version, targetFramework, assemblyFileName, heap) {
-  if (!queryPackageHeapEntriesExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPackageHeapEntriesExport(packageId, version, targetFramework, assemblyFileName, heap);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPackageHeapEntries(packageId, version, targetFramework, assemblyFileName, heap);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @returns {Promise<BrowserPackageIntegrations>}
+ */
 export async function queryPackageIntegrations(packageId, version, targetFramework) {
-  if (!queryPackageIntegrationsExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackageIntegrationsExport(packageId, version, targetFramework);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackageIntegrations(packageId, version, targetFramework);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageIntegrations} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @returns {Promise<string>}
+ */
 export async function queryPackageMetadata(packageId, version, targetFramework) {
-  if (!queryPackageMetadataExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPackageMetadataExport(packageId, version, targetFramework);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPackageMetadata(packageId, version, targetFramework);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyFileName
+ * @param {number} tableIndex
+ * @param {number} startRowId
+ * @param {number} maxRows
+ * @returns {Promise<string>}
+ */
 export async function queryPackageMetadataTable(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows) {
-  if (!queryPackageMetadataTableExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPackageMetadataTableExport(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPackageMetadataTable(packageId, version, targetFramework, assemblyFileName, tableIndex, startRowId, maxRows);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @returns {Promise<BrowserPackageOpportunities>}
+ */
 export async function queryPackageOpportunities(packageId, version, targetFramework) {
-  if (!queryPackageOpportunitiesExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackageOpportunitiesExport(packageId, version, targetFramework);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackageOpportunities(packageId, version, targetFramework);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageOpportunities} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @returns {Promise<BrowserPackagePerformance>}
+ */
 export async function queryPackagePerformance(packageId, version, targetFramework) {
-  if (!queryPackagePerformanceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackagePerformanceExport(packageId, version, targetFramework);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackagePerformance(packageId, version, targetFramework);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackagePerformance} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @returns {Promise<ReadonlyArray<string>>}
+ */
 export async function queryPackageVersions(packageId) {
-  if (!queryPackageVersionsExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPackageVersionsExport(packageId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPackageVersions(packageId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {ReadonlyArray<string>} */ (parsed);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @param {string} heap
+ * @returns {Promise<string>}
+ */
 export async function queryPlatformHeapEntries(targetFramework, platformVersion, assemblyFileName, pack, heap) {
-  if (!queryPlatformHeapEntriesExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPlatformHeapEntriesExport(targetFramework, platformVersion, assemblyFileName, pack, heap);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPlatformHeapEntries(targetFramework, platformVersion, assemblyFileName, pack, heap);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @returns {Promise<BrowserPackageIntegrations>}
+ */
 export async function queryPlatformIntegrations(targetFramework, platformVersion, assemblyFileName, pack) {
-  if (!queryPlatformIntegrationsExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPlatformIntegrationsExport(targetFramework, platformVersion, assemblyFileName, pack);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPlatformIntegrations(targetFramework, platformVersion, assemblyFileName, pack);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageIntegrations} */ (parsed);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @returns {Promise<string>}
+ */
 export async function queryPlatformMetadata(targetFramework, platformVersion, assemblyFileName, pack) {
-  if (!queryPlatformMetadataExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPlatformMetadataExport(targetFramework, platformVersion, assemblyFileName, pack);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPlatformMetadata(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @param {number} tableIndex
+ * @param {number} startRowId
+ * @param {number} maxRows
+ * @returns {Promise<string>}
+ */
 export async function queryPlatformMetadataTable(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows) {
-  if (!queryPlatformMetadataTableExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPlatformMetadataTableExport(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPlatformMetadataTable(targetFramework, platformVersion, assemblyFileName, pack, tableIndex, startRowId, maxRows);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @returns {Promise<BrowserPackageOpportunities>}
+ */
 export async function queryPlatformOpportunities(targetFramework, platformVersion, assemblyFileName, pack) {
-  if (!queryPlatformOpportunitiesExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryPlatformOpportunitiesExport(targetFramework, platformVersion, assemblyFileName, pack);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryPlatformOpportunities(targetFramework, platformVersion, assemblyFileName, pack);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserPackageOpportunities} */ (parsed);
 }
 
+/**
+ * @param {string} targetFramework
+ * @param {string} platformVersion
+ * @param {string} assemblyFileName
+ * @param {string} pack
+ * @returns {Promise<string>}
+ */
 export async function queryPlatformPerformance(targetFramework, platformVersion, assemblyFileName, pack) {
-  if (!queryPlatformPerformanceExport) throw new Error("The browser inspection engine is not initialized.");
-  return await queryPlatformPerformanceExport(targetFramework, platformVersion, assemblyFileName, pack);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.QueryPlatformPerformance(targetFramework, platformVersion, assemblyFileName, pack);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} memberName
+ * @param {string} selectorKey
+ * @param {number} metadataToken
+ * @param {string} styleOptionsJson
+ * @returns {Promise<BrowserSource>}
+ */
 export async function queryTypeMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson) {
-  if (!queryTypeMemberSourceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryTypeMemberSourceExport(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryTypeMemberSource(packageId, version, targetFramework, assemblyName, typeIdentity, memberName, selectorKey, metadataToken, styleOptionsJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserSource} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeId
+ * @returns {Promise<BrowserTypeMetadata>}
+ */
 export async function queryTypeProjection(packageId, version, targetFramework, assemblyName, typeId) {
-  if (!queryTypeProjectionExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryTypeProjectionExport(packageId, version, targetFramework, assemblyName, typeId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryTypeProjection(packageId, version, targetFramework, assemblyName, typeId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserTypeMetadata} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string} version
+ * @param {string} targetFramework
+ * @param {string} assemblyName
+ * @param {string} typeIdentity
+ * @param {string} styleOptionsJson
+ * @returns {Promise<BrowserSource>}
+ */
 export async function queryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
-  if (!queryTypeSourceExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await queryTypeSourceExport(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.QueryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserSource} */ (parsed);
 }
 
+/**
+ * @param {string} scenarioId
+ * @returns {BrowserHomeDemoResolveResult}
+ */
 export function resolveHomeDemo(scenarioId) {
-  if (!resolveHomeDemoExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = resolveHomeDemoExport(scenarioId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.ResolveHomeDemo(scenarioId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserHomeDemoResolveResult} */ (parsed);
 }
 
+/**
+ * @param {string} packageId
+ * @param {string | null} declaredRange
+ * @returns {Promise<string>}
+ */
 export async function resolvePackageDependencyVersion(packageId, declaredRange) {
-  if (!resolvePackageDependencyVersionExport) throw new Error("The browser inspection engine is not initialized.");
-  return await resolvePackageDependencyVersionExport(packageId, declaredRange);
+  const exports = $requireManagedExports();
+  return await exports.InspectionEngine.ResolvePackageDependencyVersion(packageId, declaredRange);
 }
 
+/**
+ * @param {string} scenarioId
+ * @returns {Promise<BrowserHomeDemoRunResult>}
+ */
 export async function runHomeDemo(scenarioId) {
-  if (!runHomeDemoExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = await runHomeDemoExport(scenarioId);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = await exports.InspectionEngine.RunHomeDemo(scenarioId);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {BrowserHomeDemoRunResult} */ (parsed);
 }
 
+/**
+ * @param {string} query
+ * @param {string} candidatesJson
+ * @returns {ReadonlyArray<BrowserTypeSearchHit>}
+ */
 export function searchTypes(query, candidatesJson) {
-  if (!searchTypesExport) throw new Error("The browser inspection engine is not initialized.");
-  const result = searchTypesExport(query, candidatesJson);
-  return JSON.parse(result);
+  const exports = $requireManagedExports();
+  const result = exports.InspectionEngine.SearchTypes(query, candidatesJson);
+  const parsed = $parseJson(result);
+  // The authenticated serializer contract fixes this function's exact wire type.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return /** @type {ReadonlyArray<BrowserTypeSearchHit>} */ (parsed);
 }

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -11,7 +11,7 @@
     "build": "npm run typecheck && vite build && node scripts/verify-site-artifact.js dist",
     "preview": "vite preview",
     "test": "npm run typecheck && node --test",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json && tsc --noEmit -p tsconfig.runtime-wrapper.json",
     "lint": "node scripts/verify-analysis-host.js && oxlint src test scripts engine/wwwroot/inspect-web-engine.js vite.config.js",
     "analyze": "npm run lint && knip"
   },

--- a/prototypes/inspect-web/runtime-types/_framework/dotnet.d.ts
+++ b/prototypes/inspect-web/runtime-types/_framework/dotnet.d.ts
@@ -1,0 +1,8 @@
+interface DotnetRuntime {
+  getAssemblyExports(assemblyName: string): Promise<unknown>;
+  runMain(): Promise<number>;
+}
+
+export declare const dotnet: {
+  create(): Promise<DotnetRuntime>;
+};

--- a/prototypes/inspect-web/test/runtime-wrapper-toolchain.test.ts
+++ b/prototypes/inspect-web/test/runtime-wrapper-toolchain.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+interface TsconfigFile {
+  readonly extends?: string;
+  readonly compilerOptions: Readonly<Record<string, unknown>>;
+  readonly include?: readonly string[];
+}
+
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters
+function readJson<T>(specifier: string): T {
+  const parsed: unknown = JSON.parse(
+    readFileSync(new URL(specifier, import.meta.url), "utf8"),
+  );
+  // Repo-owned configuration is asserted field-by-field below.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return parsed as T;
+}
+
+test("the generated runtime wrapper has a dedicated checked-JavaScript project", () => {
+  const config = readJson<TsconfigFile>("../tsconfig.runtime-wrapper.json");
+
+  assert.equal(config.extends, "./tsconfig.json");
+  assert.equal(config.compilerOptions.checkJs, true);
+  assert.deepEqual(
+    config.compilerOptions.rootDirs,
+    ["./engine/wwwroot", "./runtime-types"],
+  );
+  assert.deepEqual(
+    config.include,
+    [
+      "./engine/wwwroot/inspect-web-engine.js",
+      "./runtime-types/**/*.d.ts",
+      "./src/inspect-web-engine.d.ts",
+    ],
+  );
+});
+
+test("the generated runtime wrapper keeps the real relative host import", () => {
+  const wrapper = readFileSync(
+    new URL("../engine/wwwroot/inspect-web-engine.js", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    wrapper,
+    /^\/\/ GENERATED FILE[\s\S]*import \{ dotnet \} from "\.\/_framework\/dotnet\.js";/u,
+  );
+  assert.doesNotMatch(wrapper, /@ts-(?:check|ignore|nocheck|expect-error)/u);
+});
+
+test("the wrapper project rejects drift from a qualified managed export path", () => {
+  const root = new URL("../", import.meta.url);
+  const original = readFileSync(
+    new URL("engine/wwwroot/inspect-web-engine.js", root),
+    "utf8",
+  );
+  const mutated = original.replace(
+    "exports.InspectionEngine.QueryPackageMetadata(",
+    "exports.InspectionEngine.QueryPackageMetadataMissing(",
+  );
+  assert.notEqual(mutated, original, "the managed export mutation must apply");
+
+  const probe = mkdtempSync(join(tmpdir(), "inspect-web-runtime-wrapper-"));
+  try {
+    mkdirSync(join(probe, "engine/wwwroot"), { recursive: true });
+    mkdirSync(join(probe, "runtime-types/_framework"), { recursive: true });
+    mkdirSync(join(probe, "src"), { recursive: true });
+    writeFileSync(
+      join(probe, "engine/wwwroot/inspect-web-engine.js"),
+      mutated,
+    );
+    writeFileSync(
+      join(probe, "runtime-types/_framework/dotnet.d.ts"),
+      readFileSync(new URL("runtime-types/_framework/dotnet.d.ts", root)),
+    );
+    writeFileSync(
+      join(probe, "src/inspect-web-engine.d.ts"),
+      readFileSync(new URL("src/inspect-web-engine.d.ts", root)),
+    );
+    writeFileSync(
+      join(probe, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          allowJs: true,
+          checkJs: true,
+          lib: ["DOM", "ES2022"],
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          noEmit: true,
+          paths: {
+            "/inspect-web-engine.js": ["./src/inspect-web-engine.d.ts"],
+          },
+          rootDirs: ["./engine/wwwroot", "./runtime-types"],
+          strict: true,
+          target: "ES2022",
+          types: [],
+        },
+        include: [
+          "./engine/wwwroot/inspect-web-engine.js",
+          "./runtime-types/**/*.d.ts",
+          "./src/inspect-web-engine.d.ts",
+        ],
+      }),
+    );
+
+    const compile = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("node_modules/typescript/bin/tsc", root)),
+        "-p",
+        probe,
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.notEqual(
+      compile.status,
+      0,
+      "the wrapper project accepted a managed export path absent from its generated shape",
+    );
+    assert.match(
+      compile.stdout,
+      /Property 'QueryPackageMetadataMissing' does not exist/u,
+      `the mutation failed for an unrelated reason:\n${compile.stdout}`,
+    );
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+});
+
+test("the wrapper fails before initialization and reuses its initialized runtime", () => {
+  const root = new URL("../", import.meta.url);
+  const probe = mkdtempSync(join(tmpdir(), "inspect-web-runtime-behavior-"));
+  try {
+    mkdirSync(join(probe, "_framework"), { recursive: true });
+    writeFileSync(
+      join(probe, "package.json"),
+      JSON.stringify({ type: "module" }),
+    );
+    writeFileSync(
+      join(probe, "inspect-web-engine.js"),
+      readFileSync(
+        new URL("engine/wwwroot/inspect-web-engine.js", root),
+      ),
+    );
+    writeFileSync(
+      join(probe, "_framework/dotnet.js"),
+      `
+      export let createCount = 0;
+      const inspectionEngine = new Proxy(
+        { ConfigureHost() {} },
+        { get(target, property) { return target[property] ?? (() => "{}"); } },
+      );
+      export const dotnet = {
+        async create() {
+          createCount++;
+          return {
+            async getAssemblyExports() {
+              return { InspectionEngine: inspectionEngine };
+            },
+            async runMain() {},
+          };
+        },
+      };
+      `,
+    );
+    writeFileSync(
+      join(probe, "run.mjs"),
+      `
+      import {
+        buildIdentity,
+        initializeEngine,
+      } from "./inspect-web-engine.js";
+      import { createCount } from "./_framework/dotnet.js";
+
+      let preInitializationError;
+      try {
+        buildIdentity();
+      } catch (error) {
+        preInitializationError = error;
+      }
+      if (!(preInitializationError instanceof Error)
+          || preInitializationError.message
+            !== "The browser inspection engine is not initialized.") {
+        throw new Error("the pre-initialization call did not expose the expected failure");
+      }
+
+      globalThis.window = { location: { origin: "https://example.invalid" } };
+      await initializeEngine();
+      buildIdentity();
+      if (createCount !== 1) {
+        throw new Error(\`expected one runtime, observed \${createCount}\`);
+      }
+      `,
+    );
+
+    const run = spawnSync(process.execPath, [join(probe, "run.mjs")], {
+      encoding: "utf8",
+    });
+
+    assert.equal(
+      run.status,
+      0,
+      `the generated wrapper behavior probe failed:\n${run.stderr}`,
+    );
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+});

--- a/prototypes/inspect-web/test/runtime-wrapper-toolchain.test.ts
+++ b/prototypes/inspect-web/test/runtime-wrapper-toolchain.test.ts
@@ -57,6 +57,10 @@ test("the generated runtime wrapper keeps the real relative host import", () => 
     wrapper,
     /^\/\/ GENERATED FILE[\s\S]*import \{ dotnet \} from "\.\/_framework\/dotnet\.js";/u,
   );
+  assert.match(
+    wrapper,
+    /@typedef \{import\("\/inspect-web-engine\.js"\)\./u,
+  );
   assert.doesNotMatch(wrapper, /@ts-(?:check|ignore|nocheck|expect-error)/u);
 });
 

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3318,9 +3318,9 @@ test("generated source wrappers parse their JSON envelopes", () => {
   ]) {
     assert.match(
       wrapper(name),
-      /const parsed = \$parseJson\(result\);[\s\S]*?return \/\*\* @type \{[^}]+} \*\/ \(parsed\);/);
+      /const \$parsed = \$parseJson\(\$result\);[\s\S]*?return \/\*\* @type \{[^}]+} \*\/ \(\$parsed\);/);
   }
-  assert.doesNotMatch(wrapper("queryMemberFacts"), /JSON\.parse\(result\)/);
+  assert.doesNotMatch(wrapper("queryMemberFacts"), /\$parseJson\(/);
 });
 
 test("MethodDef-only member sections are hidden for bodiless APIs", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2882,7 +2882,7 @@ test("all dependency navigation paths use one product-owned coordinate matcher",
     6);
   assert.match(
     generatedEngineSource,
-    /exports\.InspectionEngine\.MatchPackageDependencyCoordinate\(packageId, declaredRange, candidatesJson\)/);
+    /\$exports\.InspectionEngine\.MatchPackageDependencyCoordinate\(packageId, declaredRange, candidatesJson\)/);
   assert.match(
     appSource,
     /matchPackageDependencyCoordinate\([\s\S]*?JSON\.stringify\(dependencyCoordinateCandidates\(packages\)\)/);
@@ -3121,7 +3121,7 @@ test("type source identity includes decompiler taste", () => {
 test("source operations cancel when superseded or hidden", () => {
   assert.match(
     generatedEngineSource,
-    /export function cancelSourceQuery\(\)[\s\S]*?return exports\.InspectionEngine\.CancelSourceQuery\(\)/);
+    /export function cancelSourceQuery\(\)[\s\S]*?return \$exports\.InspectionEngine\.CancelSourceQuery\(\)/);
   assert.match(
     appSource,
     /cancelSourceQuery: cancelSourceInspection/);
@@ -3736,7 +3736,7 @@ test("graph-only members open through the typed member surface", () => {
     /const graphOnlyTarget =[\s\S]*clearMemberContentCache\(\);[\s\S]*state\.selectedBodyTarget = graphOnlyTarget;[\s\S]*retainMemberSectionIfSupported\(group\)/);
   assert.match(
     generatedEngineSource,
-    /exports\.InspectionEngine\.QueryGraphMemberSurface\(packageId, version, targetFramework/);
+    /\$exports\.InspectionEngine\.QueryGraphMemberSurface\(packageId, version, targetFramework/);
   assert.match(
     generatedEngineSource,
     /export async function queryGraphMemberSurface\(packageId, version, targetFramework/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2882,7 +2882,7 @@ test("all dependency navigation paths use one product-owned coordinate matcher",
     6);
   assert.match(
     generatedEngineSource,
-    /matchPackageDependencyCoordinateExport = exports\.InspectionEngine\.MatchPackageDependencyCoordinate/);
+    /exports\.InspectionEngine\.MatchPackageDependencyCoordinate\(packageId, declaredRange, candidatesJson\)/);
   assert.match(
     appSource,
     /matchPackageDependencyCoordinate\([\s\S]*?JSON\.stringify\(dependencyCoordinateCandidates\(packages\)\)/);
@@ -3121,10 +3121,7 @@ test("type source identity includes decompiler taste", () => {
 test("source operations cancel when superseded or hidden", () => {
   assert.match(
     generatedEngineSource,
-    /cancelSourceQueryExport = exports\.InspectionEngine\.CancelSourceQuery/);
-  assert.match(
-    generatedEngineSource,
-    /export function cancelSourceQuery\(\)[\s\S]*?return cancelSourceQueryExport\(\)/);
+    /export function cancelSourceQuery\(\)[\s\S]*?return exports\.InspectionEngine\.CancelSourceQuery\(\)/);
   assert.match(
     appSource,
     /cancelSourceQuery: cancelSourceInspection/);
@@ -3291,7 +3288,7 @@ test("source operations cancel when superseded or hidden", () => {
 test("browser engine configures the same-origin managed MSDL API", () => {
   assert.match(
     generatedEngineSource,
-    /configureHostExport = exports\.InspectionEngine\.ConfigureHost[\s\S]*?configureHostExport\(window\.location\.origin\)/);
+    /exports\.InspectionEngine\.ConfigureHost\(window\.location\.origin\);[\s\S]*?await runtime\.runMain\(\)/);
 });
 
 test("generated browser engine module is syntactically valid", () => {
@@ -3319,7 +3316,9 @@ test("generated source wrappers parse their JSON envelopes", () => {
     "queryMemberSource",
     "queryTypeMemberSource",
   ]) {
-    assert.match(wrapper(name), /return JSON\.parse\(result\);/);
+    assert.match(
+      wrapper(name),
+      /const parsed = \$parseJson\(result\);[\s\S]*?return \/\*\* @type \{[^}]+} \*\/ \(parsed\);/);
   }
   assert.doesNotMatch(wrapper("queryMemberFacts"), /JSON\.parse\(result\)/);
 });
@@ -3737,7 +3736,7 @@ test("graph-only members open through the typed member surface", () => {
     /const graphOnlyTarget =[\s\S]*clearMemberContentCache\(\);[\s\S]*state\.selectedBodyTarget = graphOnlyTarget;[\s\S]*retainMemberSectionIfSupported\(group\)/);
   assert.match(
     generatedEngineSource,
-    /queryGraphMemberSurfaceExport = exports\.InspectionEngine\.QueryGraphMemberSurface/);
+    /exports\.InspectionEngine\.QueryGraphMemberSurface\(packageId, version, targetFramework/);
   assert.match(
     generatedEngineSource,
     /export async function queryGraphMemberSurface\(packageId, version, targetFramework/);

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -111,7 +111,8 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   assert.deepEqual(testTsconfig.include, ["./**/*.ts"]);
   assert.equal(
     packageJson.scripts.typecheck,
-    "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
+    "tsc --noEmit && tsc --noEmit -p test/tsconfig.json "
+      + "&& tsc --noEmit -p tsconfig.runtime-wrapper.json",
   );
 });
 

--- a/prototypes/inspect-web/tsconfig.runtime-wrapper.json
+++ b/prototypes/inspect-web/tsconfig.runtime-wrapper.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "rootDirs": [
+      "./engine/wwwroot",
+      "./runtime-types"
+    ]
+  },
+  "include": [
+    "./engine/wwwroot/inspect-web-engine.js",
+    "./runtime-types/**/*.d.ts",
+    "./src/inspect-web-engine.d.ts"
+  ]
+}

--- a/src/tsbindgen/DtsEmitter.cs
+++ b/src/tsbindgen/DtsEmitter.cs
@@ -41,12 +41,7 @@ static class DtsEmitter
         ILInspector.JsExportSurface.JsExportSurface surface,
         TsBindGenDiagnostics? diagnostics = null)
     {
-        ApiType[] declarationTypes =
-        [
-            .. surface.Records
-                .Concat(surface.Enums)
-                .Where(type => ShouldEmit(surface, type)),
-        ];
+        ApiType[] declarationTypes = DeclarationTypes(surface);
         ValidateTypeNames(declarationTypes);
         ValidateWireNames(declarationTypes);
         ValidateFunctionNames(surface.Functions);
@@ -91,16 +86,25 @@ static class DtsEmitter
         sb.Append(
             "export declare function initializeEngine(onStatus?: (status: string) => void): Promise<unknown>;\n");
 
-        foreach (JsExportFunction function in surface.Functions.OrderBy(f => f.Name, StringComparer.Ordinal))
-            EmitFunction(
-                sb,
-                function,
-                knownTypeNames,
-                knownTypeIdentities,
-                diagnostics);
+        foreach (TypeScriptFunctionSignature function in MapFunctionSignatures(
+            surface,
+            knownTypeNames,
+            knownTypeIdentities,
+            diagnostics))
+        {
+            EmitFunction(sb, function);
+        }
 
         return sb.ToString();
     }
+
+    internal static ApiType[] DeclarationTypes(
+        ILInspector.JsExportSurface.JsExportSurface surface) =>
+        [
+            .. surface.Records
+                .Concat(surface.Enums)
+                .Where(type => ShouldEmit(surface, type)),
+        ];
 
     static bool ShouldEmit(
         ILInspector.JsExportSurface.JsExportSurface surface,
@@ -647,54 +651,119 @@ static class DtsEmitter
     static void EmitBlockedType(StringBuilder sb, ApiType type) =>
         sb.Append("export type ").Append(type.Name).Append(" = unknown;\n\n");
 
-    static void EmitFunction(
-        StringBuilder sb,
-        JsExportFunction function,
+    internal static TypeScriptFunctionSignature[] MapFunctionSignatures(
+        ILInspector.JsExportSurface.JsExportSurface surface,
         IReadOnlySet<string> knownTypeNames,
         IReadOnlySet<ApiTypeReferenceIdentity> knownTypeIdentities,
         TsBindGenDiagnostics? diagnostics)
     {
-        string returnType = function.ReturnWireType is { } returnWireType
-            ? TsTypeMapper.MapReturnEnvelope(
-                function.ReturnType,
-                returnWireType,
-                knownTypeNames,
-                diagnostics,
-                $"{function.Name} return",
-                BlockedAliases(
-                    function.ReturnWireTypeReferences
-                        .Concat(function.ReturnTypeReferences)
-                        .ToArray(),
-                    knownTypeNames,
-                    knownTypeIdentities))
-            : TsTypeMapper.MapReturnType(
-                function.ReturnType,
-                knownTypeNames,
-                diagnostics,
-                $"{function.Name} return",
-                BlockedAliases(
-                    function.ReturnTypeReferences,
-                    knownTypeNames,
-                    knownTypeIdentities));
+        return
+        [
+            .. surface.Functions
+                .OrderBy(function => function.Name, StringComparer.Ordinal)
+                .Select(function =>
+                {
+                    IReadOnlySet<string>? interopReturnBlockedAliases =
+                        BlockedAliases(
+                            function.ReturnTypeReferences,
+                            knownTypeNames,
+                            knownTypeIdentities);
+                    string interopReturnType = TsTypeMapper.MapReturnType(
+                        function.ReturnType,
+                        knownTypeNames,
+                        function.ReturnWireType is null ? diagnostics : null,
+                        $"{function.Name} return",
+                        interopReturnBlockedAliases);
+                    IReadOnlySet<string>? wireReturnBlockedAliases =
+                        function.ReturnWireType is null
+                            ? null
+                            : BlockedAliases(
+                                function.ReturnWireTypeReferences
+                                    .Concat(function.ReturnTypeReferences)
+                                    .ToArray(),
+                                knownTypeNames,
+                                knownTypeIdentities);
+                    string returnType = function.ReturnWireType is { } returnWireType
+                        ? TsTypeMapper.MapReturnEnvelope(
+                            function.ReturnType,
+                            returnWireType,
+                            knownTypeNames,
+                            diagnostics,
+                            $"{function.Name} return",
+                            wireReturnBlockedAliases)
+                        : interopReturnType;
+                    string? wireType = function.ReturnWireType is { } wireTypeName
+                        ? TsTypeMapper.MapJsonWireType(
+                            wireTypeName,
+                            knownTypeNames,
+                            blockedAliases: wireReturnBlockedAliases)
+                        : null;
+                    TypeScriptParameterSignature[] parameters =
+                    [
+                        .. function.Parameters.Select(parameter =>
+                            new TypeScriptParameterSignature(
+                                CamelCase.FromPascalCase(parameter.Name),
+                                TsTypeMapper.MapParameterType(
+                                    parameter.Type,
+                                    knownTypeNames,
+                                    diagnostics,
+                                    $"{function.Name}.{parameter.Name}",
+                                    BlockedAliases(
+                                        parameter.TypeReferences,
+                                        knownTypeNames,
+                                        knownTypeIdentities)))),
+                    ];
+                    return new TypeScriptFunctionSignature(
+                        function,
+                        CamelCase.FromPascalCase(function.Name),
+                        interopReturnType,
+                        returnType,
+                        wireType,
+                        parameters);
+                }),
+        ];
+    }
 
-        var parameters = function.Parameters.Select(p =>
-            $"{CamelCase.FromPascalCase(p.Name)}: {TsTypeMapper.MapParameterType(
-                p.Type,
-                knownTypeNames,
-                diagnostics,
-                $"{function.Name}.{p.Name}",
-                BlockedAliases(
-                    p.TypeReferences,
-                    knownTypeNames,
-                    knownTypeIdentities))}");
+    static void EmitFunction(
+        StringBuilder sb,
+        TypeScriptFunctionSignature function)
+    {
+        var parameters = function.Parameters.Select(parameter =>
+            $"{parameter.Name}: {parameter.Type}");
 
         sb.Append("export declare function ")
-          .Append(CamelCase.FromPascalCase(function.Name))
+          .Append(function.Name)
           .Append('(')
           .Append(string.Join(", ", parameters))
           .Append("): ")
-          .Append(returnType)
+          .Append(function.ReturnType)
           .Append(";\n");
+    }
+
+    internal static TypeScriptFunctionSignature[] MapFunctionSignatures(
+        ILInspector.JsExportSurface.JsExportSurface surface,
+        TsBindGenDiagnostics? diagnostics = null)
+    {
+        ApiType[] declarationTypes = DeclarationTypes(surface);
+        var knownTypeNames = new HashSet<string>(
+            declarationTypes.SelectMany(
+                type => new[] { type.Name, type.FullName, type.MetadataName }
+                    .Where(identity => !string.IsNullOrEmpty(identity))
+                    .Select(identity => identity!)),
+            StringComparer.Ordinal);
+        var knownTypeIdentities = surface.AssemblyIdentity is { } assembly
+            ? new HashSet<ApiTypeReferenceIdentity>(
+                declarationTypes.Select(type =>
+                    new ApiTypeReferenceIdentity(
+                        assembly,
+                        type.FullName,
+                        type.DefinitionName)))
+            : [];
+        return MapFunctionSignatures(
+            surface,
+            knownTypeNames,
+            knownTypeIdentities,
+            diagnostics);
     }
 
     static IReadOnlySet<string>? BlockedAliases(

--- a/src/tsbindgen/DtsEmitter.cs
+++ b/src/tsbindgen/DtsEmitter.cs
@@ -454,6 +454,9 @@ static class DtsEmitter
 
     static void ValidateFunctionNames(IEnumerable<JsExportFunction> functions)
     {
+        JsExportFunction[] functionArray = functions.ToArray();
+        bool bootstrapsHost =
+            functionArray.Any(IsConfigureHostBootstrap);
         var moduleBindings = new HashSet<string>(
             [
                 "dotnet",
@@ -463,7 +466,8 @@ static class DtsEmitter
                 "$requireManagedExports",
             ],
             StringComparer.Ordinal);
-        foreach (JsExportFunction function in functions)
+
+        foreach (JsExportFunction function in functionArray)
         {
             string functionName = CamelCase.FromPascalCase(function.Name);
             if (!TypeScriptIdentifier.IsStrictModeBindingIdentifier(functionName)
@@ -473,6 +477,17 @@ static class DtsEmitter
                 throw new UnsupportedWireContractException(
                     "JS-export function",
                     "export names must be TypeScript identifiers");
+            }
+
+            if (bootstrapsHost
+                && string.Equals(
+                    functionName,
+                    "window",
+                    StringComparison.Ordinal))
+            {
+                throw new UnsupportedWireContractException(
+                    "JS-export function",
+                    "export name collides with the browser window binding required by the ConfigureHost bootstrap");
             }
 
             if (!moduleBindings.Add(functionName))
@@ -518,6 +533,20 @@ static class DtsEmitter
             }
         }
     }
+
+    internal static bool IsConfigureHostBootstrap(
+        JsExportFunction function) =>
+        string.Equals(
+            function.Name,
+            "ConfigureHost",
+            StringComparison.Ordinal)
+        && function.ReturnType == "void"
+        && function.Parameters is
+        [
+            {
+                Type: "string",
+            },
+        ];
 
     static bool IsComposedIdentifierName(string name) =>
         name.Split('.').All(TypeScriptIdentifier.IsIdentifierName);

--- a/src/tsbindgen/DtsEmitter.cs
+++ b/src/tsbindgen/DtsEmitter.cs
@@ -486,10 +486,16 @@ static class DtsEmitter
             bool parsesJson =
                 function.ReturnWireType is not null
                 && TsTypeMapper.IsJsonEnvelopeReturnType(function.ReturnType);
-            var generatedLocals = new HashSet<string>(
+            var generatedBindings = new HashSet<string>(
                 parsesJson
-                    ? ["$exports", "$parsed", "$result"]
-                    : ["$exports"],
+                    ? [
+                        "$exports",
+                        "$parsed",
+                        "$parseJson",
+                        "$requireManagedExports",
+                        "$result",
+                    ]
+                    : ["$exports", "$requireManagedExports"],
                 StringComparer.Ordinal);
             foreach (ApiParameter parameter in function.Parameters)
             {
@@ -503,7 +509,7 @@ static class DtsEmitter
                 }
 
                 if (!parameterNames.Add(parameterName)
-                    || generatedLocals.Contains(parameterName))
+                    || generatedBindings.Contains(parameterName))
                 {
                     throw new UnsupportedWireContractException(
                         "JS-export parameter",

--- a/src/tsbindgen/DtsEmitter.cs
+++ b/src/tsbindgen/DtsEmitter.cs
@@ -455,14 +455,18 @@ static class DtsEmitter
     static void ValidateFunctionNames(IEnumerable<JsExportFunction> functions)
     {
         var moduleBindings = new HashSet<string>(
-            ["dotnet", "initializeEngine"],
+            [
+                "dotnet",
+                "initializeEngine",
+                "$managedExports",
+                "$parseJson",
+                "$requireManagedExports",
+            ],
             StringComparer.Ordinal);
         foreach (JsExportFunction function in functions)
         {
             string functionName = CamelCase.FromPascalCase(function.Name);
-            string exportSlotName = functionName + "Export";
             if (!TypeScriptIdentifier.IsStrictModeBindingIdentifier(functionName)
-                || !TypeScriptIdentifier.IsStrictModeBindingIdentifier(exportSlotName)
                 || !IsComposedIdentifierName(function.DeclaringType)
                 || !TypeScriptIdentifier.IsIdentifierName(function.Name))
             {
@@ -471,8 +475,7 @@ static class DtsEmitter
                     "export names must be TypeScript identifiers");
             }
 
-            if (!moduleBindings.Add(functionName)
-                || !moduleBindings.Add(exportSlotName))
+            if (!moduleBindings.Add(functionName))
             {
                 throw new UnsupportedWireContractException(
                     "JS-export function",
@@ -480,9 +483,14 @@ static class DtsEmitter
             }
 
             var parameterNames = new HashSet<string>(StringComparer.Ordinal);
-            bool reservesResult =
+            bool parsesJson =
                 function.ReturnWireType is not null
                 && TsTypeMapper.IsJsonEnvelopeReturnType(function.ReturnType);
+            var generatedLocals = new HashSet<string>(
+                parsesJson
+                    ? ["$exports", "$parsed", "$result"]
+                    : ["$exports"],
+                StringComparer.Ordinal);
             foreach (ApiParameter parameter in function.Parameters)
             {
                 string parameterName =
@@ -495,8 +503,7 @@ static class DtsEmitter
                 }
 
                 if (!parameterNames.Add(parameterName)
-                    || parameterName == exportSlotName
-                    || reservesResult && parameterName == "result")
+                    || generatedLocals.Contains(parameterName))
                 {
                     throw new UnsupportedWireContractException(
                         "JS-export parameter",

--- a/src/tsbindgen/JsEmitter.cs
+++ b/src/tsbindgen/JsEmitter.cs
@@ -23,8 +23,12 @@ namespace tsbindgen;
 /// </remarks>
 static class JsEmitter
 {
-    public static string Emit(ILInspector.JsExportSurface.JsExportSurface surface)
+    public static string Emit(
+        ILInspector.JsExportSurface.JsExportSurface surface,
+        string declarationModuleSpecifier)
     {
+        ArgumentException.ThrowIfNullOrEmpty(declarationModuleSpecifier);
+
         string assemblyName = surface.AssemblyIdentity?.Name
             ?? throw new InvalidOperationException(
                 "Runtime wrapper emission requires an assembly identity.");
@@ -36,11 +40,16 @@ static class JsEmitter
             DtsEmitter.MapFunctionSignatures(surface);
         string managedExportsTypeName =
             AllocateManagedExportsTypeName(declarationTypes);
+        // JavaScriptEncoder leaves '*'; encode it so a module specifier cannot close the JSDoc.
+        string encodedDeclarationModuleSpecifier =
+            JavaScriptEncoder.Default.Encode(declarationModuleSpecifier)
+                .Replace("*", "\\u002A", StringComparison.Ordinal);
 
         foreach (ApiType declarationType in declarationTypes
             .OrderBy(type => type.Name, StringComparer.Ordinal))
         {
-            sb.Append("/** @typedef {import(\"/inspect-web-engine.js\").")
+            sb.Append("/** @typedef {import(\"")
+              .Append(encodedDeclarationModuleSpecifier).Append("\").")
               .Append(declarationType.Name).Append("} ")
               .Append(declarationType.Name).Append(" */\n");
         }
@@ -86,7 +95,8 @@ static class JsEmitter
         // its own origin (for MSDL-proxied source requests) before any other export is used, so
         // this generator calls it here rather than leaving every caller to remember to.
         TypeScriptFunctionSignature? configureHost = functions.FirstOrDefault(
-            function => IsConfigureHostBootstrap(function.Function));
+            function => DtsEmitter.IsConfigureHostBootstrap(
+                function.Function));
         if (configureHost is not null)
         {
             sb.Append("  exports.").Append(configureHost.Function.DeclaringType)
@@ -171,20 +181,6 @@ static class JsEmitter
               .Append(") => ").Append(function.InteropReturnType).Append(",\n");
         }
     }
-
-    static bool IsConfigureHostBootstrap(
-        JsExportFunction function) =>
-        string.Equals(
-            function.Name,
-            "ConfigureHost",
-            StringComparison.Ordinal)
-        && function.ReturnType == "void"
-        && function.Parameters is
-        [
-            {
-                Type: "string",
-            },
-        ];
 
     static void EmitFunction(
         StringBuilder sb,

--- a/src/tsbindgen/JsEmitter.cs
+++ b/src/tsbindgen/JsEmitter.cs
@@ -34,6 +34,8 @@ static class JsEmitter
         ApiType[] declarationTypes = DtsEmitter.DeclarationTypes(surface);
         TypeScriptFunctionSignature[] functions =
             DtsEmitter.MapFunctionSignatures(surface);
+        string managedExportsTypeName =
+            AllocateManagedExportsTypeName(declarationTypes);
 
         foreach (ApiType declarationType in declarationTypes
             .OrderBy(type => type.Name, StringComparer.Ordinal))
@@ -45,10 +47,12 @@ static class JsEmitter
         if (declarationTypes.Length > 0)
             sb.Append('\n');
 
-        EmitManagedExportsType(sb, functions);
-        sb.Append("/** @type {$ManagedExports | undefined} */\n");
+        EmitManagedExportsType(sb, functions, managedExportsTypeName);
+        sb.Append("/** @type {").Append(managedExportsTypeName)
+          .Append(" | undefined} */\n");
         sb.Append("let $managedExports;\n\n");
-        sb.Append("/** @returns {$ManagedExports} */\n");
+        sb.Append("/** @returns {").Append(managedExportsTypeName)
+          .Append("} */\n");
         sb.Append("function $requireManagedExports() {\n");
         sb.Append("  if (!$managedExports) throw new Error(\"The browser inspection engine is not initialized.\");\n");
         sb.Append("  return $managedExports;\n");
@@ -69,10 +73,12 @@ static class JsEmitter
         sb.Append("export async function initializeEngine(onStatus = () => {}) {\n");
         sb.Append("  onStatus(\"Loading .NET WebAssembly…\");\n");
         sb.Append("  const runtime = await dotnet.create();\n");
-        sb.Append("  // This assertion is the one untyped .NET runtime boundary. $ManagedExports is\n");
+        sb.Append("  // This assertion is the one untyped .NET runtime boundary. ")
+          .Append(managedExportsTypeName).Append(" is\n");
         sb.Append("  // generated from the same authenticated surface as the wrappers below.\n");
         sb.Append("  // oxlint-disable-next-line typescript/no-unsafe-type-assertion\n");
-        sb.Append("  const exports = /** @type {$ManagedExports} */ (await runtime.getAssemblyExports(\"")
+        sb.Append("  const exports = /** @type {").Append(managedExportsTypeName)
+          .Append("} */ (await runtime.getAssemblyExports(\"")
           .Append(JavaScriptEncoder.Default.Encode(assemblyName))
           .Append("\"));\n");
 
@@ -103,7 +109,8 @@ static class JsEmitter
 
     static void EmitManagedExportsType(
         StringBuilder sb,
-        IReadOnlyList<TypeScriptFunctionSignature> functions)
+        IReadOnlyList<TypeScriptFunctionSignature> functions,
+        string managedExportsTypeName)
     {
         var root = new ExportTypeNode();
         foreach (TypeScriptFunctionSignature function in functions)
@@ -124,8 +131,20 @@ static class JsEmitter
         sb.Append("/**\n");
         sb.Append(" * @typedef {{\n");
         EmitManagedExportsProperties(sb, root, indent: 2);
-        sb.Append(" * }} $ManagedExports\n");
+        sb.Append(" * }} ").Append(managedExportsTypeName).Append('\n');
         sb.Append(" */\n");
+    }
+
+    static string AllocateManagedExportsTypeName(
+        IReadOnlyList<ApiType> declarationTypes)
+    {
+        var declarationNames = new HashSet<string>(
+            declarationTypes.Select(type => type.Name),
+            StringComparer.Ordinal);
+        string name = "$ManagedExports";
+        while (declarationNames.Contains(name))
+            name += '$';
+        return name;
     }
 
     static void EmitManagedExportsProperties(

--- a/src/tsbindgen/JsEmitter.cs
+++ b/src/tsbindgen/JsEmitter.cs
@@ -189,9 +189,10 @@ static class JsEmitter
         sb.Append(" */\n");
         sb.Append("export ").Append(isAsync ? "async " : "").Append("function ")
           .Append(function.Name).Append('(').Append(parameterList).Append(") {\n");
-        sb.Append("  const exports = $requireManagedExports();\n");
+        sb.Append("  const $exports = $requireManagedExports();\n");
 
-        string call = $"exports.{function.Function.DeclaringType}.{function.Function.Name}({parameterList})";
+        string call =
+            $"$exports.{function.Function.DeclaringType}.{function.Function.Name}({parameterList})";
         if (isAsync)
         {
             call = $"await {call}";
@@ -199,12 +200,12 @@ static class JsEmitter
 
         if (parsesJson)
         {
-            sb.Append("  const result = ").Append(call).Append(";\n");
-            sb.Append("  const parsed = $parseJson(result);\n");
+            sb.Append("  const $result = ").Append(call).Append(";\n");
+            sb.Append("  const $parsed = $parseJson($result);\n");
             sb.Append("  // The authenticated serializer contract fixes this function's exact wire type.\n");
             sb.Append("  // oxlint-disable-next-line typescript/no-unsafe-type-assertion\n");
             sb.Append("  return /** @type {").Append(function.WireReturnType)
-              .Append("} */ (parsed);\n");
+              .Append("} */ ($parsed);\n");
         }
         else
         {

--- a/src/tsbindgen/JsEmitter.cs
+++ b/src/tsbindgen/JsEmitter.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Encodings.Web;
 using ILInspector.JsExportSurface;
+using ILInspector.Metadata;
 
 namespace tsbindgen;
 
@@ -12,7 +13,7 @@ namespace tsbindgen;
 /// from the assembly's real exports. Every JSON-string envelope this module parses corresponds
 /// exactly to the DTO type <see cref="DtsEmitter"/> already put in the sibling <c>.d.ts</c> via
 /// <see cref="JsExportFunction.ReturnWireType"/> — the same wire-contract resolution drives both,
-/// so the two files can't independently drift from each other.
+/// and both emitters consume the same mapped function-signature model.
 /// </summary>
 /// <remarks>
 /// <c>initializeEngine</c> returns the raw <c>getAssemblyExports()</c> object so a caller that
@@ -30,48 +31,126 @@ static class JsEmitter
         var sb = new StringBuilder();
         sb.Append("import { dotnet } from \"./_framework/dotnet.js\";\n\n");
 
-        JsExportFunction[] functions = [.. surface.Functions.OrderBy(f => f.Name, StringComparer.Ordinal)];
+        ApiType[] declarationTypes = DtsEmitter.DeclarationTypes(surface);
+        TypeScriptFunctionSignature[] functions =
+            DtsEmitter.MapFunctionSignatures(surface);
 
-        foreach (JsExportFunction function in functions)
+        foreach (ApiType declarationType in declarationTypes
+            .OrderBy(type => type.Name, StringComparer.Ordinal))
         {
-            sb.Append("let ").Append(CamelCase.FromPascalCase(function.Name)).Append("Export;\n");
+            sb.Append("/** @typedef {import(\"/inspect-web-engine.js\").")
+              .Append(declarationType.Name).Append("} ")
+              .Append(declarationType.Name).Append(" */\n");
         }
+        if (declarationTypes.Length > 0)
+            sb.Append('\n');
 
-        sb.Append("\nexport async function initializeEngine(onStatus = () => {}) {\n");
+        EmitManagedExportsType(sb, functions);
+        sb.Append("/** @type {$ManagedExports | undefined} */\n");
+        sb.Append("let $managedExports;\n\n");
+        sb.Append("/** @returns {$ManagedExports} */\n");
+        sb.Append("function $requireManagedExports() {\n");
+        sb.Append("  if (!$managedExports) throw new Error(\"The browser inspection engine is not initialized.\");\n");
+        sb.Append("  return $managedExports;\n");
+        sb.Append("}\n\n");
+
+        sb.Append("/**\n");
+        sb.Append(" * @param {string} value\n");
+        sb.Append(" * @returns {unknown}\n");
+        sb.Append(" */\n");
+        sb.Append("function $parseJson(value) {\n");
+        sb.Append("  return JSON.parse(value);\n");
+        sb.Append("}\n\n");
+
+        sb.Append("/**\n");
+        sb.Append(" * @param {(status: string) => void} [onStatus]\n");
+        sb.Append(" * @returns {Promise<unknown>}\n");
+        sb.Append(" */\n");
+        sb.Append("export async function initializeEngine(onStatus = () => {}) {\n");
         sb.Append("  onStatus(\"Loading .NET WebAssembly…\");\n");
         sb.Append("  const runtime = await dotnet.create();\n");
-        sb.Append("  const exports = await runtime.getAssemblyExports(\"")
+        sb.Append("  // This assertion is the one untyped .NET runtime boundary. $ManagedExports is\n");
+        sb.Append("  // generated from the same authenticated surface as the wrappers below.\n");
+        sb.Append("  // oxlint-disable-next-line typescript/no-unsafe-type-assertion\n");
+        sb.Append("  const exports = /** @type {$ManagedExports} */ (await runtime.getAssemblyExports(\"")
           .Append(JavaScriptEncoder.Default.Encode(assemblyName))
-          .Append("\");\n");
-
-        foreach (JsExportFunction function in functions)
-        {
-            string tsName = CamelCase.FromPascalCase(function.Name);
-            sb.Append("  ").Append(tsName).Append("Export = exports.")
-              .Append(function.DeclaringType).Append('.').Append(function.Name).Append(";\n");
-        }
+          .Append("\"));\n");
 
         // ConfigureHost is a bootstrap step, not an on-demand export: the browser host must know
         // its own origin (for MSDL-proxied source requests) before any other export is used, so
         // this generator calls it here rather than leaving every caller to remember to.
-        JsExportFunction? configureHost = functions.FirstOrDefault(
-            IsConfigureHostBootstrap);
+        TypeScriptFunctionSignature? configureHost = functions.FirstOrDefault(
+            function => IsConfigureHostBootstrap(function.Function));
         if (configureHost is not null)
         {
-            sb.Append("  ").Append(CamelCase.FromPascalCase(configureHost.Name))
-              .Append("Export(window.location.origin);\n");
+            sb.Append("  exports.").Append(configureHost.Function.DeclaringType)
+              .Append('.').Append(configureHost.Function.Name)
+              .Append("(window.location.origin);\n");
         }
 
         sb.Append("  await runtime.runMain();\n");
+        sb.Append("  $managedExports = exports;\n");
         sb.Append("  return exports;\n");
         sb.Append("}\n");
 
-        foreach (JsExportFunction function in functions)
+        foreach (TypeScriptFunctionSignature function in functions)
         {
             EmitFunction(sb, function);
         }
 
         return sb.ToString();
+    }
+
+    static void EmitManagedExportsType(
+        StringBuilder sb,
+        IReadOnlyList<TypeScriptFunctionSignature> functions)
+    {
+        var root = new ExportTypeNode();
+        foreach (TypeScriptFunctionSignature function in functions)
+        {
+            ExportTypeNode node = root;
+            foreach (string segment in function.Function.DeclaringType.Split('.'))
+            {
+                if (!node.Children.TryGetValue(segment, out ExportTypeNode? child))
+                {
+                    child = new ExportTypeNode();
+                    node.Children.Add(segment, child);
+                }
+                node = child;
+            }
+            node.Functions.Add(function);
+        }
+
+        sb.Append("/**\n");
+        sb.Append(" * @typedef {{\n");
+        EmitManagedExportsProperties(sb, root, indent: 2);
+        sb.Append(" * }} $ManagedExports\n");
+        sb.Append(" */\n");
+    }
+
+    static void EmitManagedExportsProperties(
+        StringBuilder sb,
+        ExportTypeNode node,
+        int indent)
+    {
+        foreach ((string name, ExportTypeNode child) in node.Children)
+        {
+            sb.Append(" * ").Append(' ', indent).Append(name).Append(": {\n");
+            EmitManagedExportsProperties(sb, child, indent + 2);
+            sb.Append(" * ").Append(' ', indent).Append("},\n");
+        }
+
+        foreach (TypeScriptFunctionSignature function in node.Functions
+            .OrderBy(function => function.Function.Name, StringComparer.Ordinal))
+        {
+            sb.Append(" * ").Append(' ', indent)
+              .Append(function.Function.Name).Append(": (")
+              .Append(string.Join(
+                  ", ",
+                  function.Parameters.Select(parameter =>
+                      $"{parameter.Name}: {parameter.Type}")))
+              .Append(") => ").Append(function.InteropReturnType).Append(",\n");
+        }
     }
 
     static bool IsConfigureHostBootstrap(
@@ -88,21 +167,31 @@ static class JsEmitter
             },
         ];
 
-    static void EmitFunction(StringBuilder sb, JsExportFunction function)
+    static void EmitFunction(
+        StringBuilder sb,
+        TypeScriptFunctionSignature function)
     {
-        string tsName = CamelCase.FromPascalCase(function.Name);
-        bool isAsync = TsTypeMapper.IsAsyncReturnType(function.ReturnType);
-        bool parsesJson = function.ReturnWireType is not null
-            && TsTypeMapper.IsJsonEnvelopeReturnType(function.ReturnType);
-        var parameters = function.Parameters.Select(p => CamelCase.FromPascalCase(p.Name)).ToArray();
-        string parameterList = string.Join(", ", parameters);
+        bool isAsync = TsTypeMapper.IsAsyncReturnType(function.Function.ReturnType);
+        bool parsesJson = function.Function.ReturnWireType is not null
+            && TsTypeMapper.IsJsonEnvelopeReturnType(function.Function.ReturnType);
+        string parameterList = string.Join(
+            ", ",
+            function.Parameters.Select(parameter => parameter.Name));
 
         sb.Append('\n');
+        sb.Append("/**\n");
+        foreach (TypeScriptParameterSignature parameter in function.Parameters)
+        {
+            sb.Append(" * @param {").Append(parameter.Type).Append("} ")
+              .Append(parameter.Name).Append('\n');
+        }
+        sb.Append(" * @returns {").Append(function.ReturnType).Append("}\n");
+        sb.Append(" */\n");
         sb.Append("export ").Append(isAsync ? "async " : "").Append("function ")
-          .Append(tsName).Append('(').Append(parameterList).Append(") {\n");
-        sb.Append("  if (!").Append(tsName).Append("Export) throw new Error(\"The browser inspection engine is not initialized.\");\n");
+          .Append(function.Name).Append('(').Append(parameterList).Append(") {\n");
+        sb.Append("  const exports = $requireManagedExports();\n");
 
-        string call = $"{tsName}Export({parameterList})";
+        string call = $"exports.{function.Function.DeclaringType}.{function.Function.Name}({parameterList})";
         if (isAsync)
         {
             call = $"await {call}";
@@ -111,7 +200,11 @@ static class JsEmitter
         if (parsesJson)
         {
             sb.Append("  const result = ").Append(call).Append(";\n");
-            sb.Append("  return JSON.parse(result);\n");
+            sb.Append("  const parsed = $parseJson(result);\n");
+            sb.Append("  // The authenticated serializer contract fixes this function's exact wire type.\n");
+            sb.Append("  // oxlint-disable-next-line typescript/no-unsafe-type-assertion\n");
+            sb.Append("  return /** @type {").Append(function.WireReturnType)
+              .Append("} */ (parsed);\n");
         }
         else
         {
@@ -119,5 +212,13 @@ static class JsEmitter
         }
 
         sb.Append("}\n");
+    }
+
+    sealed class ExportTypeNode
+    {
+        public SortedDictionary<string, ExportTypeNode> Children { get; } =
+            new(StringComparer.Ordinal);
+
+        public List<TypeScriptFunctionSignature> Functions { get; } = [];
     }
 }

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -17,7 +17,11 @@ tsbindgen <path-to-assembly.dll>
 tsbindgen <path-to-assembly.dll> --diff-against <path-to-hand-written.d.ts>
 
 # Publish a JavaScript wrapper only after the checked-in declarations cover generated output.
-tsbindgen <path-to-assembly.dll> --diff-against <path-to-hand-written.d.ts> --emit-js <path-to-wrapper.js>
+tsbindgen <path-to-assembly.dll> --diff-against <path-to-hand-written.d.ts> \
+  --emit-js <path-to-wrapper.js> --declaration-module <module-specifier>
+
+# Name the declaration module when writing declarations from stdout.
+tsbindgen <path-to-assembly.dll> --emit-js <path-to-wrapper.js> --declaration-module <module-specifier>
 ```
 
 ## Design
@@ -86,6 +90,9 @@ nested `$ManagedExports` structural type describes the raw
 parameter and return annotations. Record and enum names are type-only imports
 from the generated sibling declaration module, so direct arrays retain their
 interop shape and JSON envelopes use their authenticated wire shape.
+`--declaration-module` makes that consumer-owned module identity explicit
+because `tsbindgen` cannot infer where stdout declarations will be stored.
+There is no inspect-web-specific default.
 If a producer declaration already owns `$ManagedExports`, the internal name
 deterministically gains trailing `$` characters until it is unique; producer
 names remain unchanged.
@@ -105,8 +112,14 @@ gates sync, `Task`, `Task<T>`, nullable, array, record, enum, and JSON-envelope
 projection; `JsEmitter_ModelsInitializationAsOptionalUntilRuntimeStartupCompletes`
 gates the honest initialization state and single host conversion.
 `Emit_RefusesGeneratedWrapperLocalParameterCollisions` and
-`JsEmitter_AllocatesManagedExportsTypeNameAroundProducerDeclarations` gate
-generated value- and type-binding collisions. Inspect-web's
+`Emit_RefusesWindowExportWhenBootstrapUsesBrowserGlobal` gate generated
+value-binding collisions, including the conditional browser-global binding.
+`JsEmitter_AllocatesManagedExportsTypeNameAroundProducerDeclarations` gates
+generated type-binding collisions.
+`JsEmitter_UsesRequestedDeclarationModuleSpecifier` and
+`TsBindGenCommandTests.Invoke_EmitJsRequiresDeclarationModule` gate standalone
+declaration-module selection, while the inspect-web generation script
+explicitly selects its public `/inspect-web-engine.js` module. Inspect-web's
 `npm run typecheck` compiles the committed generated wrapper through
 `tsconfig.runtime-wrapper.json` with `checkJs`; the dedicated
 `runtime-wrapper-toolchain.test.ts` mutation canary proves that a qualified
@@ -381,10 +394,11 @@ ordered sequence of trimmed, non-blank lines. Reordered declarations, moved
 members, missing lines, and extra structure all count as drift; blank-line and
 indentation-only differences do not.
 
-When `--emit-js` and `--diff-against` are both present, tsbindgen validates the
-declaration input and drift before creating or overwriting the JavaScript
-destination. A missing or stale declaration file therefore leaves a prior
-wrapper untouched rather than publishing a success-shaped partial result.
+`--emit-js` requires `--declaration-module`; the inverse pairing is also
+required. When `--emit-js` and `--diff-against` are both present, tsbindgen
+validates the declaration input and drift before creating or overwriting the
+JavaScript destination. A missing or stale declaration file therefore leaves a
+prior wrapper untouched rather than publishing a success-shaped partial result.
 `TsBindGenCommandTests.Invoke_WithMissingDiffAgainst_DoesNotOverwriteExistingJavaScript`,
 `Invoke_WithStaleDiffAgainst_DoesNotOverwriteExistingJavaScript`, and
 `Invoke_WithCoveredDiffAgainst_PublishesJavaScript` gate that publication order.

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -77,6 +77,38 @@ and `Build_ProjectsNestedRuntimeDeclaringTypePath` gate the compiled namespaced
 top-level and nested paths, while the inspect-web generated-artifact check
 remains the global-namespace consumer canary.
 
+The declaration and JavaScript emitters share one mapped function-signature
+model. It keeps three views distinct: the raw JS-interop delegate signature,
+the public wire-aware wrapper signature, and the exact type of a parsed JSON
+result. The generated JavaScript expresses those views as checked JSDoc. A
+nested `$ManagedExports` structural type describes the raw
+`getAssemblyExports` object, while each exported wrapper carries its exact
+parameter and return annotations. Record and enum names are type-only imports
+from the generated sibling declaration module, so direct arrays retain their
+interop shape and JSON envelopes use their authenticated wire shape.
+
+`getAssemblyExports` returns `unknown`; the generated conversion to
+`$ManagedExports` is the single explicit runtime-host trust assertion.
+Initialization state remains `$ManagedExports | undefined` until
+`runMain()` succeeds, and every wrapper narrows it through one throwing helper.
+JSON parsing is annotated with the exact producer-selected wire type rather
+than exposing a caller-selected generic. These annotations do not claim to
+runtime-validate the host object or JSON payload. They make generator mistakes
+in export paths, arguments, async returns, initialization state, and parsed
+result use visible to the TypeScript compiler.
+
+`DtsEmitterTests.JsEmitter_EmitsCheckedInteropAndWireSignaturesFromOneSurface`
+gates sync, `Task`, `Task<T>`, nullable, array, record, enum, and JSON-envelope
+projection; `JsEmitter_ModelsInitializationAsOptionalUntilRuntimeStartupCompletes`
+gates the honest initialization state and single host conversion. Inspect-web's
+`npm run typecheck` compiles the committed generated wrapper through
+`tsconfig.runtime-wrapper.json` with `checkJs`; the dedicated
+`runtime-wrapper-toolchain.test.ts` mutation canary proves that a qualified
+managed-export path drift fails that project. Its runtime behavior probe proves
+the committed module throws before initialization and serves wrappers from the
+single runtime created during initialization. The generation script's `--check`
+mode remains the producer/consumer drift gate.
+
 The inspect-web bootstrap convention automatically invokes only an exact
 `static void ConfigureHost(string)` export with `window.location.origin`.
 Same-name overloads with a different parameter or return type remain ordinary

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -86,10 +86,13 @@ nested `$ManagedExports` structural type describes the raw
 parameter and return annotations. Record and enum names are type-only imports
 from the generated sibling declaration module, so direct arrays retain their
 interop shape and JSON envelopes use their authenticated wire shape.
+If a producer declaration already owns `$ManagedExports`, the internal name
+deterministically gains trailing `$` characters until it is unique; producer
+names remain unchanged.
 
-`getAssemblyExports` returns `unknown`; the generated conversion to
-`$ManagedExports` is the single explicit runtime-host trust assertion.
-Initialization state remains `$ManagedExports | undefined` until
+`getAssemblyExports` returns `unknown`; the conversion to the allocated
+managed-export structural type is the single explicit runtime-host trust
+assertion. Initialization state remains that type or `undefined` until
 `runMain()` succeeds, and every wrapper narrows it through one throwing helper.
 JSON parsing is annotated with the exact producer-selected wire type rather
 than exposing a caller-selected generic. These annotations do not claim to
@@ -100,7 +103,10 @@ result use visible to the TypeScript compiler.
 `DtsEmitterTests.JsEmitter_EmitsCheckedInteropAndWireSignaturesFromOneSurface`
 gates sync, `Task`, `Task<T>`, nullable, array, record, enum, and JSON-envelope
 projection; `JsEmitter_ModelsInitializationAsOptionalUntilRuntimeStartupCompletes`
-gates the honest initialization state and single host conversion. Inspect-web's
+gates the honest initialization state and single host conversion.
+`Emit_RefusesGeneratedWrapperLocalParameterCollisions` and
+`JsEmitter_AllocatesManagedExportsTypeNameAroundProducerDeclarations` gate
+generated value- and type-binding collisions. Inspect-web's
 `npm run typecheck` compiles the committed generated wrapper through
 `tsconfig.runtime-wrapper.json` with `checkJs`; the dedicated
 `runtime-wrapper-toolchain.test.ts` mutation canary proves that a qualified

--- a/src/tsbindgen/TsBindGenCommand.cs
+++ b/src/tsbindgen/TsBindGenCommand.cs
@@ -36,7 +36,15 @@ public static class TsBindGenCommand
         {
             Description = "Path to write a generated runtime .js wrapper module (the wasm bootstrap "
                 + "plus one typed function per [JSExport] export, replacing a hand-maintained shim "
-                + "with a generated bridge module) alongside the printed/diffed .d.ts output.",
+                + "with a generated bridge module) alongside the printed/diffed .d.ts output. "
+                + "Requires --declaration-module.",
+        };
+
+        var declarationModuleOption = new Option<string?>(
+            "--declaration-module")
+        {
+            Description = "TypeScript module specifier that exposes the generated declarations "
+                + "to the checked JavaScript wrapper. Requires --emit-js.",
         };
 
         var rootCommand = new RootCommand(
@@ -45,6 +53,7 @@ public static class TsBindGenCommand
             assemblyArgument,
             diffOption,
             emitJsOption,
+            declarationModuleOption,
         };
 
         rootCommand.SetAction(parseResult =>
@@ -52,10 +61,36 @@ public static class TsBindGenCommand
             string assemblyPath = parseResult.GetValue(assemblyArgument)!;
             string? diffAgainst = parseResult.GetValue(diffOption);
             string? emitJsPath = parseResult.GetValue(emitJsOption);
+            string? declarationModuleSpecifier =
+                parseResult.GetValue(declarationModuleOption);
 
             if (!File.Exists(assemblyPath))
             {
                 stderr.WriteLine($"tsbindgen: assembly not found: {assemblyPath}");
+                return 1;
+            }
+
+            if (emitJsPath is not null
+                && declarationModuleSpecifier is null)
+            {
+                stderr.WriteLine(
+                    "tsbindgen: --emit-js requires --declaration-module.");
+                return 1;
+            }
+
+            if (declarationModuleSpecifier is not null
+                && emitJsPath is null)
+            {
+                stderr.WriteLine(
+                    "tsbindgen: --declaration-module requires --emit-js.");
+                return 1;
+            }
+
+            if (declarationModuleSpecifier is not null
+                && string.IsNullOrWhiteSpace(declarationModuleSpecifier))
+            {
+                stderr.WriteLine(
+                    "tsbindgen: --declaration-module must not be empty or whitespace.");
                 return 1;
             }
 
@@ -196,7 +231,9 @@ public static class TsBindGenCommand
             if (emitJsPath is not null
                 && !diagnostics.HasUnmappedTypes)
             {
-                string generatedJs = JsEmitter.Emit(jsExportSurface);
+                string generatedJs = JsEmitter.Emit(
+                    jsExportSurface,
+                    declarationModuleSpecifier!);
                 try
                 {
                     File.WriteAllText(emitJsPath, generatedJs);

--- a/src/tsbindgen/TypeScriptFunctionSignature.cs
+++ b/src/tsbindgen/TypeScriptFunctionSignature.cs
@@ -1,0 +1,15 @@
+using ILInspector.JsExportSurface;
+
+namespace tsbindgen;
+
+sealed record TypeScriptParameterSignature(
+    string Name,
+    string Type);
+
+sealed record TypeScriptFunctionSignature(
+    JsExportFunction Function,
+    string Name,
+    string InteropReturnType,
+    string ReturnType,
+    string? WireReturnType,
+    IReadOnlyList<TypeScriptParameterSignature> Parameters);

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -200,7 +200,9 @@ public sealed class DtsEmitterTests
         string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
 
         Assert.Contains(
-            "const $parsed = $parseJson($result);\n"
+            "const $result = $exports.ILInspector.JsExportSurface.Fixtures."
+                + "PrimitiveRootFixtureExports.GetRegisteredDecimal();\n"
+                + "  const $parsed = $parseJson($result);\n"
                 + "  // The authenticated serializer contract fixes this "
                 + "function's exact wire type.\n"
                 + "  // oxlint-disable-next-line "
@@ -209,7 +211,14 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "return /** @type {ReadonlyArray<number>} */ ($parsed);",
+            "const $result = $exports.ILInspector.JsExportSurface.Fixtures."
+                + "PrimitiveRootFixtureExports.GetRegisteredDecimalArray();\n"
+                + "  const $parsed = $parseJson($result);\n"
+                + "  // The authenticated serializer contract fixes this "
+                + "function's exact wire type.\n"
+                + "  // oxlint-disable-next-line "
+                + "typescript/no-unsafe-type-assertion\n"
+                + "  return /** @type {ReadonlyArray<number>} */ ($parsed);",
             js,
             StringComparison.Ordinal);
     }
@@ -561,6 +570,57 @@ public sealed class DtsEmitterTests
             StringComparison.Ordinal);
         Assert.DoesNotContain(
             "let getWidgetExport",
+            js,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_AllocatesManagedExportsTypeNameAroundProducerDeclarations()
+    {
+        var surface = new ILInspector.JsExportSurface.JsExportSurface
+        {
+            AssemblyIdentity = new ApiAssemblyIdentity(
+                "Fixture",
+                new Version(1, 0, 0, 0),
+                culture: null,
+                publicKeyToken: null),
+            Records =
+            [
+                new ApiType
+                {
+                    Name = "$ManagedExports",
+                },
+                new ApiType
+                {
+                    Name = "$ManagedExports$",
+                },
+            ],
+        };
+
+        string js = JsEmitter.Emit(surface);
+
+        Assert.Contains(
+            "import(\"/inspect-web-engine.js\").$ManagedExports} "
+                + "$ManagedExports */",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "import(\"/inspect-web-engine.js\").$ManagedExports$} "
+                + "$ManagedExports$ */",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " * }} $ManagedExports$$\n */\n"
+                + "/** @type {$ManagedExports$$ | undefined} */",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "/** @returns {$ManagedExports$$} */",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "const exports = /** @type {$ManagedExports$$} */ "
+                + "(await runtime.getAssemblyExports(\"Fixture\"));",
             js,
             StringComparison.Ordinal);
     }
@@ -2123,6 +2183,9 @@ public sealed class DtsEmitterTests
     [InlineData("$exports", false)]
     [InlineData("$exports", true)]
     [InlineData("$parsed", true)]
+    [InlineData("$parseJson", true)]
+    [InlineData("$requireManagedExports", false)]
+    [InlineData("$requireManagedExports", true)]
     [InlineData("$result", true)]
     public void Emit_RefusesGeneratedWrapperLocalParameterCollisions(
         string parameterName,
@@ -2189,6 +2252,11 @@ public sealed class DtsEmitterTests
                             Name = "Parsed",
                             Type = "string",
                         },
+                        new ApiParameter
+                        {
+                            Name = "$managedExports",
+                            Type = "string",
+                        },
                     ],
                 },
             ],
@@ -2198,8 +2266,50 @@ public sealed class DtsEmitterTests
 
         Assert.Contains(
             "foo(fooExport: string, exports: string, result: string, "
-                + "parsed: string): unknown;",
+                + "parsed: string, $managedExports: string): unknown;",
             dts,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_AcceptsJsonHelperNameForNonParsingWrapperParameter()
+    {
+        var surface = new ILInspector.JsExportSurface.JsExportSurface
+        {
+            AssemblyIdentity = new ApiAssemblyIdentity(
+                "Fixture",
+                new Version(1, 0, 0, 0),
+                culture: null,
+                publicKeyToken: null),
+            Functions =
+            [
+                new JsExportFunction
+                {
+                    DeclaringType = "Ns.Exports",
+                    Name = "Get",
+                    ReturnType = "string",
+                    Parameters =
+                    [
+                        new ApiParameter
+                        {
+                            Name = "$parseJson",
+                            Type = "string",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        string js = JsEmitter.Emit(surface);
+
+        Assert.Contains(
+            """
+            export function get($parseJson) {
+              const $exports = $requireManagedExports();
+              return $exports.Ns.Exports.Get($parseJson);
+            }
+            """,
+            js,
             StringComparison.Ordinal);
     }
 

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -200,16 +200,16 @@ public sealed class DtsEmitterTests
         string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
 
         Assert.Contains(
-            "const parsed = $parseJson(result);\n"
+            "const $parsed = $parseJson($result);\n"
                 + "  // The authenticated serializer contract fixes this "
                 + "function's exact wire type.\n"
                 + "  // oxlint-disable-next-line "
                 + "typescript/no-unsafe-type-assertion\n"
-                + "  return /** @type {number} */ (parsed);",
+                + "  return /** @type {number} */ ($parsed);",
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "return /** @type {ReadonlyArray<number>} */ (parsed);",
+            "return /** @type {ReadonlyArray<number>} */ ($parsed);",
             js,
             StringComparison.Ordinal);
     }
@@ -432,7 +432,7 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "return exports.FixtureExports.Ping();",
+            "return $exports.FixtureExports.Ping();",
             js,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -440,13 +440,13 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "const result = await exports.FixtureExports.QueryWidget();\n"
-                + "  const parsed = $parseJson(result);\n"
+            "const $result = await $exports.FixtureExports.QueryWidget();\n"
+                + "  const $parsed = $parseJson($result);\n"
                 + "  // The authenticated serializer contract fixes this "
                 + "function's exact wire type.\n"
                 + "  // oxlint-disable-next-line "
                 + "typescript/no-unsafe-type-assertion\n"
-                + "  return /** @type {unknown} */ (parsed);",
+                + "  return /** @type {unknown} */ ($parsed);",
             js,
             StringComparison.Ordinal);
     }
@@ -512,7 +512,7 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "return /** @type {WidgetDto} */ (parsed);",
+            "return /** @type {WidgetDto} */ ($parsed);",
             js,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -552,7 +552,7 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "const exports = $requireManagedExports();",
+            "const $exports = $requireManagedExports();",
             js,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -2089,7 +2089,9 @@ public sealed class DtsEmitterTests
 
     [Theory]
     [InlineData("Dotnet", "Other")]
-    [InlineData("Foo", "FooExport")]
+    [InlineData("$managedExports", "Other")]
+    [InlineData("$parseJson", "Other")]
+    [InlineData("$requireManagedExports", "Other")]
     public void Emit_RefusesGeneratedModuleBindingCollisions(
         string firstName,
         string secondName)
@@ -2117,8 +2119,14 @@ public sealed class DtsEmitterTests
             () => DtsEmitter.Emit(surface));
     }
 
-    [Fact]
-    public void Emit_RefusesJsonResultLocalParameterCollision()
+    [Theory]
+    [InlineData("$exports", false)]
+    [InlineData("$exports", true)]
+    [InlineData("$parsed", true)]
+    [InlineData("$result", true)]
+    public void Emit_RefusesGeneratedWrapperLocalParameterCollisions(
+        string parameterName,
+        bool parsesJson)
     {
         var surface = new ILInspector.JsExportSurface.JsExportSurface
         {
@@ -2129,12 +2137,12 @@ public sealed class DtsEmitterTests
                     DeclaringType = "Ns.Exports",
                     Name = "Get",
                     ReturnType = "string",
-                    ReturnWireType = "Widget",
+                    ReturnWireType = parsesJson ? "Widget" : null,
                     Parameters =
                     [
                         new ApiParameter
                         {
-                            Name = "Result",
+                            Name = parameterName,
                             Type = "string",
                         },
                     ],
@@ -2147,7 +2155,7 @@ public sealed class DtsEmitterTests
     }
 
     [Fact]
-    public void Emit_RefusesParameterThatShadowsItsExportSlot()
+    public void Emit_AcceptsNamesFreedByGeneratedBindingChanges()
     {
         var surface = new ILInspector.JsExportSurface.JsExportSurface
         {
@@ -2166,13 +2174,33 @@ public sealed class DtsEmitterTests
                             Name = "FooExport",
                             Type = "string",
                         },
+                        new ApiParameter
+                        {
+                            Name = "Exports",
+                            Type = "string",
+                        },
+                        new ApiParameter
+                        {
+                            Name = "Result",
+                            Type = "string",
+                        },
+                        new ApiParameter
+                        {
+                            Name = "Parsed",
+                            Type = "string",
+                        },
                     ],
                 },
             ],
         };
 
-        Assert.Throws<UnsupportedWireContractException>(
-            () => DtsEmitter.Emit(surface));
+        string dts = DtsEmitter.Emit(surface);
+
+        Assert.Contains(
+            "foo(fooExport: string, exports: string, result: string, "
+                + "parsed: string): unknown;",
+            dts,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -200,13 +200,16 @@ public sealed class DtsEmitterTests
         string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
 
         Assert.Contains(
-            "const result = getRegisteredDecimalExport();\n"
-                + "  return JSON.parse(result);",
+            "const parsed = $parseJson(result);\n"
+                + "  // The authenticated serializer contract fixes this "
+                + "function's exact wire type.\n"
+                + "  // oxlint-disable-next-line "
+                + "typescript/no-unsafe-type-assertion\n"
+                + "  return /** @type {number} */ (parsed);",
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "const result = getRegisteredDecimalArrayExport();\n"
-                + "  return JSON.parse(result);",
+            "return /** @type {ReadonlyArray<number>} */ (parsed);",
             js,
             StringComparison.Ordinal);
     }
@@ -429,7 +432,7 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "return pingExport();",
+            "return exports.FixtureExports.Ping();",
             js,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -437,7 +440,127 @@ public sealed class DtsEmitterTests
             js,
             StringComparison.Ordinal);
         Assert.Contains(
-            "const result = await queryWidgetExport();\n  return JSON.parse(result);",
+            "const result = await exports.FixtureExports.QueryWidget();\n"
+                + "  const parsed = $parseJson(result);\n"
+                + "  // The authenticated serializer contract fixes this "
+                + "function's exact wire type.\n"
+                + "  // oxlint-disable-next-line "
+                + "typescript/no-unsafe-type-assertion\n"
+                + "  return /** @type {unknown} */ (parsed);",
+            js,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_EmitsCheckedInteropAndWireSignaturesFromOneSurface()
+    {
+        string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+
+        Assert.Contains(
+            """
+            /**
+             * @typedef {{
+             *   ILInspector: {
+             *     JsExportSurface: {
+             *       Fixtures: {
+            """,
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *         FixtureExports: {",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *           EchoBytes: (value: number[]) => number[],",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *           GetWidget: (name: string, count: number) => string,",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *           GetWidgetAsync: (name: string) => Promise<string>,",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *           Ping: () => Promise<void>,",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " *           GetWidgetOrCached: (cached: string | null) => string,",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            /**
+             * @param {string} name
+             * @param {number} count
+             * @returns {WidgetDto}
+             */
+            export function getWidget(name, count) {
+            """,
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            """
+            /**
+             * @param {string} name
+             * @returns {Promise<WidgetDto>}
+             */
+            export async function getWidgetAsync(name) {
+            """,
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return /** @type {WidgetDto} */ (parsed);",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            " * @returns {ReadonlyArray<WidgetDto>}\n"
+                + " */\n"
+                + "export function getWidgetArray()",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "/** @typedef {import(\"/inspect-web-engine.js\").WidgetDto} WidgetDto */",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "/** @typedef {import(\"/inspect-web-engine.js\").WidgetStatus} WidgetStatus */",
+            js,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_ModelsInitializationAsOptionalUntilRuntimeStartupCompletes()
+    {
+        string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+
+        Assert.Contains(
+            "/** @type {$ManagedExports | undefined} */\nlet $managedExports;",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "const exports = /** @type {$ManagedExports} */ "
+                + "(await runtime.getAssemblyExports(",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "await runtime.runMain();\n"
+                + "  $managedExports = exports;\n"
+                + "  return exports;",
+            js,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "const exports = $requireManagedExports();",
+            js,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "@ts-",
+            js,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "let getWidgetExport",
             js,
             StringComparison.Ordinal);
     }
@@ -515,7 +638,7 @@ public sealed class DtsEmitterTests
         Assert.Equal(
             expectedBootstrap,
             js.Contains(
-                "configureHostExport(window.location.origin);",
+                "exports.Exports.ConfigureHost(window.location.origin);",
                 StringComparison.Ordinal));
         Assert.Contains(
             "function configureHost(value)",

--- a/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/DtsEmitterTests.cs
@@ -15,6 +15,9 @@ namespace ILInspector.JsExportSurface.Tests;
 
 public sealed class DtsEmitterTests
 {
+    private const string DeclarationModuleSpecifier =
+        "/inspect-web-engine.js";
+
     private static string EmitFixtureDts(
         bool includeAll = false,
         TsBindGenDiagnostics? diagnostics = null)
@@ -197,7 +200,9 @@ public sealed class DtsEmitterTests
     [Fact]
     public void Emit_ParsesDecimalWireRootResults()
     {
-        string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+        string js = JsEmitter.Emit(
+            BuildFixtureSurfaceWithWireContracts(),
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             "const $result = $exports.ILInspector.JsExportSurface.Fixtures."
@@ -430,7 +435,9 @@ public sealed class DtsEmitterTests
             ],
         };
 
-        string js = JsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             "export function getTaskInfo()",
@@ -463,7 +470,9 @@ public sealed class DtsEmitterTests
     [Fact]
     public void JsEmitter_EmitsCheckedInteropAndWireSignaturesFromOneSurface()
     {
-        string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+        string js = JsEmitter.Emit(
+            BuildFixtureSurfaceWithWireContracts(),
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             """
@@ -541,9 +550,45 @@ public sealed class DtsEmitterTests
     }
 
     [Fact]
+    public void JsEmitter_UsesRequestedDeclarationModuleSpecifier()
+    {
+        string js = JsEmitter.Emit(
+            BuildFixtureSurfaceWithWireContracts(),
+            "./custom-wrapper.js");
+
+        Assert.Contains(
+            "/** @typedef {import(\"./custom-wrapper.js\").WidgetDto} WidgetDto */",
+            js,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "/inspect-web-engine.js",
+            js,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_EncodesDeclarationModuleSpecifierWithoutClosingJSDoc()
+    {
+        string js = JsEmitter.Emit(
+            BuildFixtureSurfaceWithWireContracts(),
+            "./types*/contract\".js");
+
+        Assert.Contains(
+            "import(\"./types\\u002A/contract\\u0022.js\").WidgetDto",
+            js,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "types*/contract",
+            js,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void JsEmitter_ModelsInitializationAsOptionalUntilRuntimeStartupCompletes()
     {
-        string js = JsEmitter.Emit(BuildFixtureSurfaceWithWireContracts());
+        string js = JsEmitter.Emit(
+            BuildFixtureSurfaceWithWireContracts(),
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             "/** @type {$ManagedExports | undefined} */\nlet $managedExports;",
@@ -597,7 +642,9 @@ public sealed class DtsEmitterTests
             ],
         };
 
-        string js = JsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             "import(\"/inspect-web-engine.js\").$ManagedExports} "
@@ -639,7 +686,9 @@ public sealed class DtsEmitterTests
                 publicKeyToken: null),
         };
 
-        string js = JsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             "runtime.getAssemblyExports(\""
@@ -693,7 +742,9 @@ public sealed class DtsEmitterTests
             ],
         };
 
-        string js = JsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
 
         Assert.Equal(
             expectedBootstrap,
@@ -2179,6 +2230,82 @@ public sealed class DtsEmitterTests
             () => DtsEmitter.Emit(surface));
     }
 
+    [Fact]
+    public void Emit_RefusesWindowExportWhenBootstrapUsesBrowserGlobal()
+    {
+        var surface = new ILInspector.JsExportSurface.JsExportSurface
+        {
+            Functions =
+            [
+                new JsExportFunction
+                {
+                    DeclaringType = "Ns.Exports",
+                    Name = "ConfigureHost",
+                    ReturnType = "void",
+                    Parameters =
+                    [
+                        new ApiParameter
+                        {
+                            Name = "value",
+                            Type = "string",
+                        },
+                    ],
+                },
+                new JsExportFunction
+                {
+                    DeclaringType = "Ns.Exports",
+                    Name = "Window",
+                    ReturnType = "void",
+                },
+            ],
+        };
+
+        UnsupportedWireContractException exception =
+            Assert.Throws<UnsupportedWireContractException>(
+                () => DtsEmitter.Emit(surface));
+
+        Assert.Contains(
+            "browser window binding required by the ConfigureHost bootstrap",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JsEmitter_AcceptsWindowExportWithoutBootstrapUse()
+    {
+        var surface = new ILInspector.JsExportSurface.JsExportSurface
+        {
+            AssemblyIdentity = new ApiAssemblyIdentity(
+                "Fixture",
+                new Version(1, 0, 0, 0),
+                culture: null,
+                publicKeyToken: null),
+            Functions =
+            [
+                new JsExportFunction
+                {
+                    DeclaringType = "Ns.Exports",
+                    Name = "Window",
+                    ReturnType = "void",
+                },
+            ],
+        };
+
+        DtsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
+
+        Assert.Contains(
+            "export function window()",
+            js,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "window.location.origin",
+            js,
+            StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("$exports", false)]
     [InlineData("$exports", true)]
@@ -2300,7 +2427,9 @@ public sealed class DtsEmitterTests
             ],
         };
 
-        string js = JsEmitter.Emit(surface);
+        string js = JsEmitter.Emit(
+            surface,
+            DeclarationModuleSpecifier);
 
         Assert.Contains(
             """

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -1105,7 +1105,8 @@ public sealed class JsExportSurfaceBuilderTests
                 {
                     AssemblyIdentity = extracted.AssemblyIdentity,
                     Functions = [function],
-                }),
+                },
+                "./fixture.js"),
             StringComparison.Ordinal);
     }
 
@@ -1141,7 +1142,8 @@ public sealed class JsExportSurfaceBuilderTests
                 {
                     AssemblyIdentity = extracted.AssemblyIdentity,
                     Functions = [function],
-                }),
+                },
+                "./fixture.js"),
             StringComparison.Ordinal);
     }
 

--- a/tests/ILInspector.JsExportSurface.Tests/TsBindGenCommandTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/TsBindGenCommandTests.cs
@@ -12,6 +12,9 @@ namespace ILInspector.JsExportSurface.Tests;
 
 public sealed class TsBindGenCommandTests
 {
+    private const string DeclarationModuleSpecifier =
+        "./fixture-contract.js";
+
     private static string FixtureAssemblyPath => typeof(FixtureExports).Assembly.Location;
 
     private static string CleanAssemblyPath => typeof(TsBindGenCommand).Assembly.Location;
@@ -146,7 +149,15 @@ public sealed class TsBindGenCommandTests
             var error = new StringWriter();
 
             int exitCode = TsBindGenCommand.Invoke(
-                [CleanAssemblyPath, "--diff-against", diffPath, "--emit-js", emitJsPath],
+                [
+                    CleanAssemblyPath,
+                    "--diff-against",
+                    diffPath,
+                    "--emit-js",
+                    emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
+                ],
                 output,
                 error);
 
@@ -176,7 +187,15 @@ public sealed class TsBindGenCommandTests
             var error = new StringWriter();
 
             int exitCode = TsBindGenCommand.Invoke(
-                [CleanAssemblyPath, "--diff-against", diffPath, "--emit-js", emitJsPath],
+                [
+                    CleanAssemblyPath,
+                    "--diff-against",
+                    diffPath,
+                    "--emit-js",
+                    emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
+                ],
                 output,
                 error);
 
@@ -215,7 +234,15 @@ public sealed class TsBindGenCommandTests
             var error = new StringWriter();
 
             int exitCode = TsBindGenCommand.Invoke(
-                [CleanAssemblyPath, "--diff-against", diffPath, "--emit-js", emitJsPath],
+                [
+                    CleanAssemblyPath,
+                    "--diff-against",
+                    diffPath,
+                    "--emit-js",
+                    emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
+                ],
                 output,
                 error);
 
@@ -232,6 +259,86 @@ public sealed class TsBindGenCommandTests
             File.Delete(diffPath);
             File.Delete(emitJsPath);
         }
+    }
+
+    [Fact]
+    public void Invoke_EmitJsRequiresDeclarationModule()
+    {
+        string emitJsPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "tsbindgen-missing-declaration-module.js");
+        try
+        {
+            File.Delete(emitJsPath);
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            int exitCode = TsBindGenCommand.Invoke(
+                [CleanAssemblyPath, "--emit-js", emitJsPath],
+                output,
+                error);
+
+            Assert.Equal(
+                1,
+                exitCode);
+            Assert.Empty(output.ToString());
+            Assert.Equal(
+                "tsbindgen: --emit-js requires --declaration-module."
+                    + Environment.NewLine,
+                error.ToString());
+            Assert.False(File.Exists(emitJsPath));
+        }
+        finally
+        {
+            File.Delete(emitJsPath);
+        }
+    }
+
+    [Fact]
+    public void Invoke_DeclarationModuleRequiresJavaScriptOutput()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int exitCode = TsBindGenCommand.Invoke(
+            [CleanAssemblyPath, "--declaration-module", "./custom.js"],
+            output,
+            error);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(output.ToString());
+        Assert.Equal(
+            "tsbindgen: --declaration-module requires --emit-js."
+                + Environment.NewLine,
+            error.ToString());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Invoke_RefusesEmptyDeclarationModule(
+        string declarationModuleSpecifier)
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+
+        int exitCode = TsBindGenCommand.Invoke(
+            [
+                CleanAssemblyPath,
+                "--emit-js",
+                "unused.js",
+                "--declaration-module",
+                declarationModuleSpecifier,
+            ],
+            output,
+            error);
+
+        Assert.Equal(1, exitCode);
+        Assert.Empty(output.ToString());
+        Assert.Equal(
+            "tsbindgen: --declaration-module must not be empty or whitespace."
+                + Environment.NewLine,
+            error.ToString());
     }
 
     [Fact]
@@ -269,7 +376,13 @@ public sealed class TsBindGenCommandTests
         var error = new StringWriter();
 
         int exitCode = TsBindGenCommand.Invoke(
-            [FixtureAssemblyPath, "--emit-js", missingDirectory],
+            [
+                FixtureAssemblyPath,
+                "--emit-js",
+                missingDirectory,
+                "--declaration-module",
+                DeclarationModuleSpecifier,
+            ],
             output,
             error);
 
@@ -323,7 +436,13 @@ public sealed class TsBindGenCommandTests
             var error = new StringWriter();
 
             int exitCode = TsBindGenCommand.Invoke(
-                [assemblyPath, "--emit-js", emitJsPath],
+                [
+                    assemblyPath,
+                    "--emit-js",
+                    emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
+                ],
                 output,
                 error);
 
@@ -376,7 +495,13 @@ public sealed class TsBindGenCommandTests
             var output = new StringWriter();
             var error = new StringWriter();
             int exitCode = TsBindGenCommand.Invoke(
-                [modulePath, "--emit-js", emitJsPath],
+                [
+                    modulePath,
+                    "--emit-js",
+                    emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
+                ],
                 output,
                 error);
 
@@ -412,6 +537,8 @@ public sealed class TsBindGenCommandTests
                 typeof(NeedsUnmappedTypeFixtureExports).Assembly.Location,
                 "--emit-js",
                 emitJsPath,
+                "--declaration-module",
+                DeclarationModuleSpecifier,
             ],
             output,
             error);
@@ -439,6 +566,8 @@ public sealed class TsBindGenCommandTests
                     typeof(ControlPropertyNameFixture).Assembly.Location,
                     "--emit-js",
                     emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
                 ],
                 output,
                 error);
@@ -481,6 +610,8 @@ public sealed class TsBindGenCommandTests
                     typeof(ScalarContextOptionsFixtureExports).Assembly.Location,
                     "--emit-js",
                     emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
                 ],
                 output,
                 error);
@@ -517,6 +648,8 @@ public sealed class TsBindGenCommandTests
                     typeof(JsExportOperatorFixture).Assembly.Location,
                     "--emit-js",
                     emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
                 ],
                 output,
                 error);
@@ -553,6 +686,8 @@ public sealed class TsBindGenCommandTests
                     typeof(LambdaExportFixture).Assembly.Location,
                     "--emit-js",
                     emitJsPath,
+                    "--declaration-module",
+                    DeclarationModuleSpecifier,
                 ],
                 output,
                 error);


### PR DESCRIPTION
Closes #4572.

`tsbindgen --emit-js` now emits checked JSDoc from the same mapped function signatures as its sibling declarations. The generated module has one nested raw managed-export shape, an honest optional initialization state, exact public wrapper signatures, and producer-selected JSON result types; `getAssemblyExports(): unknown` is converted at one explicit runtime-host boundary.

Inspect-web compiles the shipped `.js` artifact through a dedicated strict `checkJs` project. The project supplies only the narrow `_framework/dotnet.js` host API declaration; it does not duplicate the managed export surface. A compiler mutation canary proves a wrong qualified export path is rejected, and a runtime probe proves pre-initialization calls fail visibly while initialized wrappers reuse the one Wasm runtime.

This does not split the generated engine surface or change application ownership; #4497 retains that work. PR #4768's authored toolchain conversion remains independent. Its eventual `package.json` and toolchain-test composition is a small textual integration, not a shared architecture.

## Validation

- Focused `ILInspector.JsExportSurface.Tests` wrapper coverage: 8 passed.
- Full binding-generator suite: 379 passed; one unrelated `SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers` failure reproduces unchanged on `origin/main` with the installed preview SDK.
- `npm run typecheck`, `npm test`, `npm run analyze`, and `npm run build`.
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`: 153 passed.
- `eng/generate-inspect-web-engine-dts.sh --check`.
- `npx markdownlint-cli src/tsbindgen/README.md`.
- Generated wrapper passes all `no-unsafe-*` oxlint rules when explicitly enabled, independent of the existing JavaScript override.
