### PR TITLE
Define safe NuGet source-result identity

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -8,6 +8,8 @@ configuration, authentication, timeout ownership, and presentation.
 
 The implementation plan is tracked by
 [#4239](https://github.com/richlander/dotnet-inspect/issues/4239).
+The focused typed source-result identity contract is tracked by
+[#4795](https://github.com/richlander/dotnet-inspect/issues/4795).
 
 ## Scope
 
@@ -302,6 +304,178 @@ listed fail-open data. Replacing that desktop behavior and its
 Markdown/TSV/JSONL projection remains implementation work for
 [#4239](https://github.com/richlander/dotnet-inspect/issues/4239).
 
+## Typed source-result identity and safe retention
+
+This section owns one NuGetFetch contract: the identity carried by typed source
+clients and operation results, and the subset of source information safe to
+retain after an operation. It does not define a consumer's package-source
+authorization identity. The target properties are unverified until the
+[identity gates](#identity-gates) run in the NuGetFetch Release suite.
+
+### Identity responsibility
+
+`PackageSourceIdentity` answers one question:
+
+> Which immutable package producer did this NuGetFetch client query?
+
+It is the producer identity returned by `IPackageSourceClient.Identity` and
+carried by candidate observations, manifests, payloads, and source failures.
+Every result from one client carries an identity equal to that client. A
+transport family, runtime endpoint, credential scope, registry ID, display
+name, or consumer cache authority is not a producer identity.
+
+The canonical producer locator consists of the lowercase scheme, normalized
+IDN host, explicit port, and endpoint path. IPv6 hosts retain URI brackets,
+valid percent-escape hex digits use uppercase, and one optional trailing slash
+is folded. Path case and repeated trailing slashes remain distinct. Query and
+fragment are runtime transport data and do not enter producer identity. This
+preserves one producer across rotation of a signed query. A feed that serves
+distinct immutable content domains based on query credentials is incompatible
+with this contract and requires distinct endpoint paths.
+
+NuGet Gallery and the canonical NuGet.org v3 client intentionally share one
+producer identity while retaining different transport kinds. Other paths
+remain distinct even when they share an origin. These properties are gated by
+`PackageSourceIdentity_SignedQueryRotationKeepsProducer`,
+`PackageSourceIdentity_DistinctPathsRemainDistinct`, and
+`PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`.
+
+### Opaque key and safe display
+
+The identity retains no raw or credential-bearing producer locator.
+Construction derives two values and then discards the raw canonical locator:
+
+- `Key` is a versioned, fixed-width opaque digest of the canonical producer
+  locator. Equality, hashing, NuGetFetch-owned cache keys, and serialization
+  use this value.
+- `Display` is the `InertString` result of `UrlRedaction.ForDiagnostics` over
+  the canonical locator. Consumers may convert it to text for diagnostics; it
+  does not participate in equality or authorization.
+
+The HTTP key format is `p1-http-` followed by the lowercase hexadecimal
+SHA-256 digest. The version and source-kind namespace permit a future
+canonicalization change or a non-HTTP source to use a distinct key space
+instead of aliasing existing identities. The digest is computed over UTF-8
+bytes and is identical on desktop and Browser/Wasm. A consumer never parses
+the key to recover an endpoint.
+
+A credential-bearing path such as `/auth/SECRET/` therefore contributes to the
+opaque key without retaining `SECRET` in the identity object, while `Display`
+uses the shared URL-redaction owner to replace the credential-bearing segment.
+Signed query text is absent from the canonical locator and can appear only as
+the redactor's fixed query marker when a runtime endpoint is displayed
+separately.
+
+`PackageSourceIdentity` defines equality and hashing from `Key` alone rather
+than from all stored record fields. `Display` is necessarily many-to-one:
+distinct credential-bearing paths can have the same redacted display while
+remaining distinct producers. That collision is why display text cannot
+participate in equality, cache keys, or authorization.
+
+`PackageSourceIdentity_KeyIsOpaqueStableAndPortable`,
+`PackageSourceIdentity_CredentialPathIsNotRetained`, and
+`PackageSourceIdentity_DisplayIsInertAndNonAuthoritative` gate these
+properties. The existing
+`HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling` gate remains part of the
+canonicalization contract. Each gate includes a nearby non-secret path so an
+implementation that erases every path cannot pass.
+
+### Typed result and failure contract
+
+Typed operation successes retain the producer identity:
+
+- every `PackageCandidateObservation` in search or version results;
+- `PackageSourceManifest`;
+- `PackageSourcePayload`; and
+- every future source-owned result that claims producer provenance.
+
+`PackageSourceFailure` retains the same safe identity, transport kind,
+capability, exact coordinate when applicable, failure kind, and an
+owner-authored fixed summary. It does not retain a runtime endpoint, raw URI,
+exception message, response text, authorization data, or any other
+feed-controlled scalar. New diagnostic context must use `Display` or another
+owner-issued inert value rather than interpolating identity or exception text.
+
+The identity is immutable before an operation begins. Projection rejects a
+success or failure whose producer identity differs from the client that issued
+it. This prevents a transport profile or response from rewriting provenance
+after the caller selected a producer.
+
+`PackageSourceResults_AllProducerBearingShapesUseClientIdentity` derives its
+expected shape set from the source-result declarations so both a missing and a
+new ungated producer-bearing result fail. Its non-vacuity case attempts to
+project a mismatched identity.
+`PackageSourceFailure_RetainsNoLocatorOrRemoteText` derives its expected field
+set from the failure declaration, then exercises signed-query, credential-path,
+exception-message, response-body, and authorization-header secrets against
+every retained field and its diagnostic projection. Both a new ungated field
+and a retained secret fail the gate.
+
+### Consumer association boundary
+
+A consumer may apply a stricter authorization identity than NuGetFetch's
+immutable producer identity. For example, a desktop package cache may keep two
+query-distinct configured endpoints separate even though NuGetFetch treats
+their rotating signatures as transports for one producer.
+
+The association point is the exact `IPackageSourceClient` handle the consumer
+invokes. A consumer mints its authority while classifying the configured
+source, carries it alongside that handle, and wraps the returned operation
+result without deriving authority from `PackageSourceIdentity.Key`, `Display`,
+or a runtime endpoint. NuGetFetch neither accepts nor interprets that consumer
+authority. This keeps protocol provenance and consumer authorization separate
+while allowing the consumer to retain both typed identities.
+
+This handoff is consumed by the focused package composition effort
+[#4797](https://github.com/richlander/dotnet-inspect/issues/4797). Its
+non-vacuity gate must invoke two client handles with the same NuGetFetch
+producer identity and different consumer authorities, then prove that the
+returned candidate and payload associations remain distinct.
+
+The current internal `Value` property is also consumed as a raw display value
+and as input to query-sensitive package credential and cache canonicalization.
+Replacing it with `Key` and `Display` is therefore a coordinated internal API
+migration, not a compatible representation change. The NuGetFetch
+implementation must not land until #4797 preserves the package owner's
+query-sensitive configured-endpoint authority, stops feeding either new
+identity field to `NuGetCache.GetSourceKey`, selects `Display` explicitly for
+diagnostics, and records any cache migration consequence. Those are consumer
+obligations owned and gated by #4797, not behaviors redefined here.
+
+### Identity gates
+
+The following gates run in `src/NuGetFetch.Tests` in Release:
+
+- `PackageSourceIdentity_SignedQueryRotationKeepsProducer`;
+- `PackageSourceIdentity_DistinctPathsRemainDistinct`;
+- `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`;
+- `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`;
+- `PackageSourceIdentity_CredentialPathIsNotRetained`;
+- `PackageSourceIdentity_DisplayIsInertAndNonAuthoritative`;
+- `HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling`;
+- `PackageSourceResults_AllProducerBearingShapesUseClientIdentity`; and
+- `PackageSourceFailure_RetainsNoLocatorOrRemoteText`.
+
+The gates use the real identity constructor and typed result projection. A
+fixture-only redactor, a test-created replacement identity, or an assertion
+against only the friendly display cannot satisfy the contract.
+
+### Non-claims
+
+This identity owner does not define:
+
+- package-source mapping, configured-alias collapse, consumer cache
+  authorization, or multi-source aggregation;
+- operation deadline fields, which belong to
+  [#4770](https://github.com/richlander/dotnet-inspect/issues/4770);
+- credential-plugin eligibility, which belongs to
+  [#4776](https://github.com/richlander/dotnet-inspect/issues/4776);
+- Core offline diagnostic rendering, which belongs to
+  [#4766](https://github.com/richlander/dotnet-inspect/issues/4766);
+- source-client transport construction, endpoint validation, protocol retry,
+  or payload-stream lifetime; or
+- browser registry, persistence, source-bundle, and presentation policy.
+
 ## Cache and provenance
 
 Candidate and payload caches are source-scoped:
@@ -575,7 +749,7 @@ The first two implementation slices establish the typed source identity,
 credential-free descriptor, capability, runtime-client, and factory contracts
 in NuGetFetch. It adapts the existing desktop `PackageSource` input to a NuGet
 v3 client without migrating current consumers, and centralizes canonical HTTP
-producer identity so credential scope and future transports use the same key.
+producer identity independently from runtime credential scope.
 Portable descriptors reject user information, queries, and fragments. The
 desktop compatibility adapter keeps established query-bearing signed service
 indexes as runtime-only configuration rather than admitting them into a
@@ -663,7 +837,10 @@ transport profile, capability, and exact coordinate when applicable, and
 distinguish unsupported capability, exact payload absence, authentication,
 timeout, malformed metadata, bounded-response rejection, and transport
 failure. Their retained messages are source-safe summaries rather than
-transport URLs or response text. Caller cancellation remains cancellation,
+transport URLs or response text. The identity and retained-failure target is
+defined by
+[Typed source-result identity and safe retention](#typed-source-result-identity-and-safe-retention).
+Caller cancellation remains cancellation,
 deadline aborts are typed timeouts, and transport-originated cancellation with
 neither condition active is a typed transport failure.
 `V3SearchCallerCancellationRemainsCancellation`,

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -329,15 +329,18 @@ IDN host, explicit port, and endpoint path. IPv6 hosts retain URI brackets,
 valid percent-escape hex digits use uppercase, and one optional trailing slash
 is folded. Path case and repeated trailing slashes remain distinct. Query and
 fragment are runtime transport data and do not enter producer identity. This
-preserves one producer across rotation of a signed query. A feed that serves
-distinct immutable content domains based on credentials is incompatible with
-this contract and requires a stable non-credential endpoint-path distinction.
+preserves one producer when a signed query is added or rotated and when a
+fragment is added or changed. A feed that serves distinct immutable content
+domains based on credentials is incompatible with this contract and requires a
+stable non-credential endpoint-path distinction.
 
 NuGet Gallery and the canonical NuGet.org v3 client intentionally share one
 producer identity while retaining different transport kinds. Paths that differ
 outside an owner-recognized credential slot remain distinct even when they
 share an origin. These properties are gated by
 `PackageSourceIdentity_SignedQueryRotationKeepsProducer`,
+`PackageSourceIdentity_QueryPresenceDoesNotChangeProducer`,
+`PackageSourceIdentity_FragmentRotationKeepsProducer`,
 `PackageSourceIdentity_DistinctNonCredentialPathsRemainDistinct`, and
 `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`.
 
@@ -431,7 +434,11 @@ required inventory covers:
 - DNS case, IDN, IPv4, unscoped IPv6, and scoped IPv6 hosts;
 - empty/root, double-root, and optional trailing-slash paths;
 - valid percent escapes with alternate hex case;
-- an owner-recognized credential slot and its rotation; and
+- no query, one signed query, and a rotated signed query;
+- no fragment and multiple fragment spellings;
+- an owner-recognized credential slot and its rotation, including
+  case-insensitive `auth`, consecutive `auth` segments, and empty path segments
+  between `auth` and its credential; and
 - distinct canonical paths that full-URL display reconstruction folds,
   including encoded trailing whitespace after a non-ASCII segment.
 
@@ -525,6 +532,8 @@ behaviors redefined here.
 The following gates run in `src/NuGetFetch.Tests` in Release:
 
 - `PackageSourceIdentity_SignedQueryRotationKeepsProducer`;
+- `PackageSourceIdentity_QueryPresenceDoesNotChangeProducer`;
+- `PackageSourceIdentity_FragmentRotationKeepsProducer`;
 - `PackageSourceIdentity_DistinctNonCredentialPathsRemainDistinct`;
 - `PackageSourceIdentity_RootAndDoubleSlashRemainDistinct`;
 - `PackageSourceIdentity_ScopedIpv6ZonesRemainDistinct`;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -180,10 +180,10 @@ to represent NuGet.org through its canonical v3 service index while sharing the
 same package-source identity and provenance label. Transport strategy is a
 host capability, not a second visible producer.
 
-The canonical producer identity for both transports is
-`https://api.nuget.org/v3/index.json`. The Gallery browser client uses that
-identity without requesting the URL. A registry ID is a user-interface handle,
-not a producer identity or cache key.
+The canonical producer locator for both transports is
+`https://api.nuget.org/v3/index.json`. The Gallery browser client derives the
+same producer identity without requesting the locator. A registry ID is a
+user-interface handle, not a producer identity or cache key.
 
 Candidate caches additionally identify the discovery contract and its version,
 such as complete listing-aware enumeration versus keyword search. A
@@ -330,8 +330,8 @@ valid percent-escape hex digits use uppercase, and one optional trailing slash
 is folded. Path case and repeated trailing slashes remain distinct. Query and
 fragment are runtime transport data and do not enter producer identity. This
 preserves one producer across rotation of a signed query. A feed that serves
-distinct immutable content domains based on query credentials is incompatible
-with this contract and requires distinct endpoint paths.
+distinct immutable content domains based on credentials is incompatible with
+this contract and requires a stable non-credential endpoint-path distinction.
 
 NuGet Gallery and the canonical NuGet.org v3 client intentionally share one
 producer identity while retaining different transport kinds. Other paths
@@ -343,42 +343,50 @@ remain distinct even when they share an origin. These properties are gated by
 ### Opaque key and safe display
 
 The identity retains no raw or credential-bearing producer locator.
-Construction derives two values and then discards the raw canonical locator:
+Construction redacts the canonical locator through
+`UrlRedaction.ForDiagnostics`, derives two values from that owner-issued safe
+result, and then discards the raw canonical locator:
 
-- `Key` is a versioned, fixed-width opaque digest of the canonical producer
-  locator. Equality, hashing, NuGetFetch-owned cache keys, and serialization
-  use this value.
-- `Display` is the `InertString` result of `UrlRedaction.ForDiagnostics` over
-  the canonical locator. Consumers may convert it to text for diagnostics; it
-  does not participate in equality or authorization.
+- `Display` is the resulting `InertString`. Consumers may convert it to text
+  for diagnostics but must not compare it or use it for authorization.
+- `Key` is a versioned, fixed-width opaque digest of the exact
+  `Display.ToString()` value. Equality, hashing, NuGetFetch-owned cache keys,
+  and serialization use this value.
 
 The HTTP key format is `p1-http-` followed by the lowercase hexadecimal
 SHA-256 digest. The version and source-kind namespace permit a future
-canonicalization change or a non-HTTP source to use a distinct key space
-instead of aliasing existing identities. The digest is computed over UTF-8
-bytes and is identical on desktop and Browser/Wasm. A consumer never parses
-the key to recover an endpoint.
+canonicalization or redaction-policy change, or a non-HTTP source, to use a
+distinct key space instead of aliasing existing identities. The digest is
+computed over the safe display's UTF-8 bytes and is identical on desktop and
+Browser/Wasm. A consumer never parses the key to recover an endpoint.
 
-A credential-bearing path such as `/auth/SECRET/` therefore contributes to the
-opaque key without retaining `SECRET` in the identity object, while `Display`
-uses the shared URL-redaction owner to replace the credential-bearing segment.
-Signed query text is absent from the canonical locator and can appear only as
-the redactor's fixed query marker when a runtime endpoint is displayed
-separately.
+A credential-bearing path such as `/auth/SECRET/` becomes
+`/auth/REDACTED/` before key derivation. Rotating that credential therefore
+changes neither display nor producer equality and leaves no secret-derived
+digest to test guesses against. Signed query text is absent from the canonical
+locator and can appear only as the redactor's fixed query marker when a runtime
+endpoint is displayed separately.
 
 `PackageSourceIdentity` defines equality and hashing from `Key` alone rather
 than from all stored record fields. `Display` is necessarily many-to-one:
-distinct credential-bearing paths can have the same redacted display while
-remaining distinct producers. That collision is why display text cannot
-participate in equality, cache keys, or authorization.
+rotated credential-bearing paths have the same redacted display and
+intentionally identify one producer. Non-credential path segments remain part
+of display and key derivation. A server that uses credential values to select
+distinct immutable content domains must expose a stable non-credential path
+distinction. Display text remains non-authoritative because a consumer's
+configured endpoint and credential scope are separate identities.
 
 `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`,
+`PackageSourceIdentity_CredentialPathRotationKeepsProducer`,
 `PackageSourceIdentity_CredentialPathIsNotRetained`, and
 `PackageSourceIdentity_DisplayIsInertAndNonAuthoritative` gate these
 properties. The existing
 `HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling` gate remains part of the
-canonicalization contract. Each gate includes a nearby non-secret path so an
-implementation that erases every path cannot pass.
+canonicalization contract. The opaque-key gate uses fixed expected vectors,
+including a credential-bearing path, so a canonicalization or redaction change
+fails until the key version and vectors change together. Each path gate
+includes a nearby non-secret path so an implementation that erases every path
+cannot pass.
 
 ### Typed result and failure contract
 
@@ -436,9 +444,19 @@ distinct. A new or omitted producer-bearing operation fails the gate.
 
 The current internal `Value` property is also consumed as a raw display value
 and as input to query-sensitive package credential and cache canonicalization.
-Replacing it with `Key` and `Display` is therefore a coordinated internal API
-migration, not a compatible representation change. The NuGetFetch
-implementation must not land until these consumer-owner prerequisites close:
+Replacing it with `Key` and `Display` is therefore a staged internal API
+migration, not one compatible representation change:
+
+1. NuGetFetch adds `Key` and `Display` alongside `Value`. Existing equality,
+   hashing, `Value`, and query-sensitive construction behavior remain
+   unchanged. This additive slice does not claim the safe-retention target.
+2. The consumer-owner prerequisites below migrate every `Value` use.
+3. NuGetFetch removes `Value`, retires query-sensitive identity construction,
+   and activates the target key-only equality, hashing, and safe-retention
+   contract.
+
+The final transition must not land until these consumer-owner prerequisites
+close:
 
 - #4797 preserves the package owner's query-sensitive configured-endpoint
   authority, stops package acquisition from feeding either new identity field
@@ -460,6 +478,7 @@ The following gates run in `src/NuGetFetch.Tests` in Release:
 - `PackageSourceIdentity_DistinctPathsRemainDistinct`;
 - `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`;
 - `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`;
+- `PackageSourceIdentity_CredentialPathRotationKeepsProducer`;
 - `PackageSourceIdentity_CredentialPathIsNotRetained`;
 - `PackageSourceIdentity_DisplayIsInertAndNonAuthoritative`;
 - `HttpProducerIdentityFoldsIdnAndPercentEscapeSpelling`;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -364,8 +364,9 @@ text:
    byte length and encode the port as an unsigned 16-bit big-endian value.
 3. Prefix the exact canonical path with the fixed ASCII relative-path sentinel
    `p`, pass that value to `UrlRedaction.ForDiagnostics`, and frame the
-   resulting `InertString` text as the path component. The sentinel remains in
-   the framed value. It forces the redaction owner down its relative-path
+   UTF-8 bytes of the resulting `InertString` text as the path component. Its
+   unsigned 32-bit frame length is the UTF-8 byte count. The sentinel remains
+   in the framed value. It forces the redaction owner down its relative-path
    contract, so the authoritative credential-slot rule runs without a second
    URI reconstruction.
 4. Concatenate scheme, host, port, and safe-path frames in that order and hash
@@ -420,6 +421,22 @@ canonical paths that full-URL diagnostic rendering normalizes together,
 including encoded trailing whitespace after a non-ASCII segment. An
 implementation that erases every path, retains an unredacted path frame, or
 hashes only display cannot pass.
+
+`PackageSourceIdentity_KeyVersionVectorsAreExactAndComplete` owns the fixed
+digest table for `p1-http-`. The gate asserts both the exact expected digest and
+the complete required case-name set, so a missing or stale vector fails. Its
+required inventory covers:
+
+- HTTP and HTTPS with default and non-default ports;
+- DNS case, IDN, IPv4, unscoped IPv6, and scoped IPv6 hosts;
+- empty/root, double-root, and optional trailing-slash paths;
+- valid percent escapes with alternate hex case;
+- an owner-recognized credential slot and its rotation; and
+- distinct canonical paths that full-URL display reconstruction folds,
+  including encoded trailing whitespace after a non-ASCII segment.
+
+Relational fold and separation gates remain in addition to this table; they do
+not substitute for exact version vectors.
 
 ### Typed result and failure contract
 
@@ -514,6 +531,7 @@ The following gates run in `src/NuGetFetch.Tests` in Release:
 - `PackageSourceIdentity_FullUrlDisplayFoldsDoNotFoldKey`;
 - `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`;
 - `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`;
+- `PackageSourceIdentity_KeyVersionVectorsAreExactAndComplete`;
 - `PackageSourceIdentity_CredentialPathRotationKeepsProducer`;
 - `PackageSourceIdentity_CredentialPathIsNotRetained`;
 - `PackageSourceIdentity_DisplayIsInertAndNonAuthoritative`;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -344,29 +344,45 @@ share an origin. These properties are gated by
 ### Opaque key and safe display
 
 The identity retains no raw or credential-bearing producer locator.
-Construction redacts the canonical locator through
-`UrlRedaction.ForDiagnostics`, derives two values from that owner-issued safe
-result, and then discards the raw canonical locator. During key derivation it
-also derives whether the canonical path is empty after the optional
-trailing-slash fold:
+Construction derives two values and then discards the raw canonical
+components:
 
-- `Display` is the resulting `InertString`. Consumers may convert it to text
-  for diagnostics but must not compare it or use it for authorization.
+- `Display` is the `InertString` returned by
+  `UrlRedaction.ForDiagnostics` for the canonical locator. Consumers may
+  convert it to text for diagnostics but must not compare it or use it for
+  authorization.
 - `Key` is a versioned, fixed-width opaque digest of the exact
-  framed safe material: one byte that is `0x00` for an empty canonical path or
-  `0x01` for a non-empty canonical path, followed by the UTF-8 bytes of
-  `Display.ToString()`. Equality, hashing, NuGetFetch-owned cache keys, and
-  serialization use this value.
+  component-framed safe material described below. Equality, hashing,
+  NuGetFetch-owned cache keys, and serialization use this value.
+
+Key construction frames the canonical components without reparsing display
+text:
+
+1. UTF-8 encode the lowercase scheme and canonical IDN or bracketed IPv6 host,
+   including an IPv6 zone identifier when present.
+2. Prefix each variable-width component with its unsigned 32-bit big-endian
+   byte length and encode the port as an unsigned 16-bit big-endian value.
+3. Prefix the exact canonical path with the fixed ASCII relative-path sentinel
+   `p`, pass that value to `UrlRedaction.ForDiagnostics`, and frame the
+   resulting `InertString` text as the path component. The sentinel remains in
+   the framed value. It forces the redaction owner down its relative-path
+   contract, so the authoritative credential-slot rule runs without a second
+   URI reconstruction.
+4. Concatenate scheme, host, port, and safe-path frames in that order and hash
+   the result.
 
 The HTTP key format is `p1-http-` followed by the lowercase hexadecimal
 SHA-256 digest. The version and source-kind namespace permit a future
 canonicalization or redaction-policy change, or a non-HTTP source, to use a
 distinct key space instead of aliasing existing identities. The digest is
-computed over only the framed safe material and is identical on desktop and
-Browser/Wasm. The path-presence bit prevents diagnostic URI reconstruction
-from folding the canonical root and double-slash-root paths together; it is
-not retained separately. A consumer never parses the key to recover an
+computed over only the component-framed safe material and is identical on
+desktop and Browser/Wasm. A consumer never parses the key to recover an
 endpoint.
+
+The key provides opacity, not confidentiality, for non-secret producer
+components such as host and stable path names. Those values are low entropy.
+Credential values from queries and owner-recognized path slots do not enter
+the key material.
 
 A credential-bearing path such as `/auth/SECRET/` becomes
 `/auth/REDACTED/` before key derivation. Rotating that credential therefore
@@ -380,11 +396,12 @@ than from all stored record fields. `Display` is necessarily many-to-one. The
 URL-redaction owner defines every non-empty segment immediately following an
 `auth` segment as credential data regardless of its spelling, so rotations in
 that position intentionally identify one producer. Stable segments before or
-after that credential slot remain part of display and key derivation. A server
-that uses credential values to select distinct immutable content domains must
-expose such a stable non-credential path distinction. Display text remains
-non-authoritative because a consumer's configured endpoint and credential
-scope are separate identities.
+after that credential slot remain part of safe-path key derivation even when
+full-URL display reconstruction normalizes their spelling. A server that uses
+credential values to select distinct immutable content domains must expose
+such a stable non-credential path distinction. Display text remains
+non-authoritative and may be many-to-one. A consumer's configured endpoint and
+credential scope remain separate identities.
 
 `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`,
 `PackageSourceIdentity_CredentialPathRotationKeepsProducer`,
@@ -398,8 +415,11 @@ fails until the key version and vectors change together. Each path gate
 includes credentials rotated in one `auth` slot as a fold case, stable segments
 outside that slot as a separation case, root and double-slash root as a
 separation case, and absent versus one optional trailing slash as a spelling
-fold. An implementation that erases every path or hashes only display cannot
-pass.
+fold. The separation cases also cover scoped IPv6 zone identifiers and
+canonical paths that full-URL diagnostic rendering normalizes together,
+including encoded trailing whitespace after a non-ASCII segment. An
+implementation that erases every path, retains an unredacted path frame, or
+hashes only display cannot pass.
 
 ### Typed result and failure contract
 
@@ -490,6 +510,8 @@ The following gates run in `src/NuGetFetch.Tests` in Release:
 - `PackageSourceIdentity_SignedQueryRotationKeepsProducer`;
 - `PackageSourceIdentity_DistinctNonCredentialPathsRemainDistinct`;
 - `PackageSourceIdentity_RootAndDoubleSlashRemainDistinct`;
+- `PackageSourceIdentity_ScopedIpv6ZonesRemainDistinct`;
+- `PackageSourceIdentity_FullUrlDisplayFoldsDoNotFoldKey`;
 - `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`;
 - `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`;
 - `PackageSourceIdentity_CredentialPathRotationKeepsProducer`;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -334,10 +334,11 @@ distinct immutable content domains based on credentials is incompatible with
 this contract and requires a stable non-credential endpoint-path distinction.
 
 NuGet Gallery and the canonical NuGet.org v3 client intentionally share one
-producer identity while retaining different transport kinds. Other paths
-remain distinct even when they share an origin. These properties are gated by
+producer identity while retaining different transport kinds. Paths that differ
+outside an owner-recognized credential slot remain distinct even when they
+share an origin. These properties are gated by
 `PackageSourceIdentity_SignedQueryRotationKeepsProducer`,
-`PackageSourceIdentity_DistinctPathsRemainDistinct`, and
+`PackageSourceIdentity_DistinctNonCredentialPathsRemainDistinct`, and
 `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`.
 
 ### Opaque key and safe display
@@ -345,20 +346,27 @@ remain distinct even when they share an origin. These properties are gated by
 The identity retains no raw or credential-bearing producer locator.
 Construction redacts the canonical locator through
 `UrlRedaction.ForDiagnostics`, derives two values from that owner-issued safe
-result, and then discards the raw canonical locator:
+result, and then discards the raw canonical locator. During key derivation it
+also derives whether the canonical path is empty after the optional
+trailing-slash fold:
 
 - `Display` is the resulting `InertString`. Consumers may convert it to text
   for diagnostics but must not compare it or use it for authorization.
 - `Key` is a versioned, fixed-width opaque digest of the exact
-  `Display.ToString()` value. Equality, hashing, NuGetFetch-owned cache keys,
-  and serialization use this value.
+  framed safe material: one byte that is `0x00` for an empty canonical path or
+  `0x01` for a non-empty canonical path, followed by the UTF-8 bytes of
+  `Display.ToString()`. Equality, hashing, NuGetFetch-owned cache keys, and
+  serialization use this value.
 
 The HTTP key format is `p1-http-` followed by the lowercase hexadecimal
 SHA-256 digest. The version and source-kind namespace permit a future
 canonicalization or redaction-policy change, or a non-HTTP source, to use a
 distinct key space instead of aliasing existing identities. The digest is
-computed over the safe display's UTF-8 bytes and is identical on desktop and
-Browser/Wasm. A consumer never parses the key to recover an endpoint.
+computed over only the framed safe material and is identical on desktop and
+Browser/Wasm. The path-presence bit prevents diagnostic URI reconstruction
+from folding the canonical root and double-slash-root paths together; it is
+not retained separately. A consumer never parses the key to recover an
+endpoint.
 
 A credential-bearing path such as `/auth/SECRET/` becomes
 `/auth/REDACTED/` before key derivation. Rotating that credential therefore
@@ -368,13 +376,15 @@ locator and can appear only as the redactor's fixed query marker when a runtime
 endpoint is displayed separately.
 
 `PackageSourceIdentity` defines equality and hashing from `Key` alone rather
-than from all stored record fields. `Display` is necessarily many-to-one:
-rotated credential-bearing paths have the same redacted display and
-intentionally identify one producer. Non-credential path segments remain part
-of display and key derivation. A server that uses credential values to select
-distinct immutable content domains must expose a stable non-credential path
-distinction. Display text remains non-authoritative because a consumer's
-configured endpoint and credential scope are separate identities.
+than from all stored record fields. `Display` is necessarily many-to-one. The
+URL-redaction owner defines every non-empty segment immediately following an
+`auth` segment as credential data regardless of its spelling, so rotations in
+that position intentionally identify one producer. Stable segments before or
+after that credential slot remain part of display and key derivation. A server
+that uses credential values to select distinct immutable content domains must
+expose such a stable non-credential path distinction. Display text remains
+non-authoritative because a consumer's configured endpoint and credential
+scope are separate identities.
 
 `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`,
 `PackageSourceIdentity_CredentialPathRotationKeepsProducer`,
@@ -385,8 +395,11 @@ properties. The existing
 canonicalization contract. The opaque-key gate uses fixed expected vectors,
 including a credential-bearing path, so a canonicalization or redaction change
 fails until the key version and vectors change together. Each path gate
-includes a nearby non-secret path so an implementation that erases every path
-cannot pass.
+includes credentials rotated in one `auth` slot as a fold case, stable segments
+outside that slot as a separation case, root and double-slash root as a
+separation case, and absent versus one optional trailing slash as a spelling
+fold. An implementation that erases every path or hashes only display cannot
+pass.
 
 ### Typed result and failure contract
 
@@ -475,7 +488,8 @@ behaviors redefined here.
 The following gates run in `src/NuGetFetch.Tests` in Release:
 
 - `PackageSourceIdentity_SignedQueryRotationKeepsProducer`;
-- `PackageSourceIdentity_DistinctPathsRemainDistinct`;
+- `PackageSourceIdentity_DistinctNonCredentialPathsRemainDistinct`;
+- `PackageSourceIdentity_RootAndDoubleSlashRemainDistinct`;
 - `PackageSourceIdentity_GalleryAndV3ShareNuGetOrgProducer`;
 - `PackageSourceIdentity_KeyIsOpaqueStableAndPortable`;
 - `PackageSourceIdentity_CredentialPathRotationKeepsProducer`;

--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -428,19 +428,29 @@ while allowing the consumer to retain both typed identities.
 
 This handoff is consumed by the focused package composition effort
 [#4797](https://github.com/richlander/dotnet-inspect/issues/4797). Its
-non-vacuity gate must invoke two client handles with the same NuGetFetch
-producer identity and different consumer authorities, then prove that the
-returned candidate and payload associations remain distinct.
+non-vacuity gate must derive the producer-bearing operation set from the typed
+source-client surface, invoke two client handles with the same NuGetFetch
+producer identity and different consumer authorities for each operation, and
+prove that candidate, manifest, payload, and failure associations remain
+distinct. A new or omitted producer-bearing operation fails the gate.
 
 The current internal `Value` property is also consumed as a raw display value
 and as input to query-sensitive package credential and cache canonicalization.
 Replacing it with `Key` and `Display` is therefore a coordinated internal API
 migration, not a compatible representation change. The NuGetFetch
-implementation must not land until #4797 preserves the package owner's
-query-sensitive configured-endpoint authority, stops feeding either new
-identity field to `NuGetCache.GetSourceKey`, selects `Display` explicitly for
-diagnostics, and records any cache migration consequence. Those are consumer
-obligations owned and gated by #4797, not behaviors redefined here.
+implementation must not land until these consumer-owner prerequisites close:
+
+- #4797 preserves the package owner's query-sensitive configured-endpoint
+  authority, stops package acquisition from feeding either new identity field
+  to `NuGetCache.GetSourceKey`, and records its cache migration consequence;
+- [#4805](https://github.com/richlander/dotnet-inspect/issues/4805) migrates
+  browser workspace acquisition association without parsing either field as a
+  URL or local path; and
+- [#4806](https://github.com/richlander/dotnet-inspect/issues/4806) projects
+  safe display and stable producer ID into the package-profile output shape.
+
+Those are consumer obligations owned and gated by their focused efforts, not
+behaviors redefined here.
 
 ### Identity gates
 


### PR DESCRIPTION
## Summary

Define NuGetFetch's typed source-result identity and safe-retention contract
without taking ownership of package authorization, Core diagnostics, timeout
identity, or authentication eligibility.

The design:

- keeps one immutable producer identity across source clients, candidates,
  manifests, payloads, failures, provenance, and NuGetFetch-owned caches;
- replaces retained raw producer locators with a versioned, source-kind-scoped
  opaque key and an owner-redacted `InertString` display;
- requires typed success and failure projection to preserve the issuing
  client's identity;
- derives result-shape and retained-failure gates from declarations so new
  ungated fields fail; and
- defines the exact client handle as the association point for a consumer-owned
  stricter authority.

Owner: **NuGetFetch typed source-result identity**  
Owning document: `docs/design/browser-package-sources.md`

## Demo

The intended contract turns a producer locator such as:

```text
https://feed.example/auth/SECRET/v3/index.json?sig=ROTATING
```

into two non-authoritative retained fields:

```text
Key:     p1-http-<lowercase SHA-256 of framed safe source components>
Display: https://feed.example/auth/REDACTED/v3/index.json
```

The rotating query remains runtime transport data, the credential in the path
is removed before key derivation, and neither secret is available to a retained
failure or guessable from the stable key. A separate non-credential path
segment still distinguishes different producers. The length-framed scheme,
host, port, and owner-redacted relative path preserve canonical distinctions
even when diagnostic URI rendering folds them.

## Compatibility

This is a target design for a staged internal API migration, not an
implementation change. `Key` and `Display` first land additively while
preserving `Value` and current equality. Removing `Value` and activating
key-only equality then waits until:

- #4797 preserves the package owner's query-sensitive configured-endpoint
  authority and stops treating NuGetFetch identity as package cache input;
- #4805 migrates browser workspace acquisition association without reparsing
  the new identity fields; and
- #4806 projects safe display and stable producer ID into package-profile
  output.

## Validation

```text
npx markdownlint-cli --fix docs/design/browser-package-sources.md
npx markdownlint-cli docs/design/browser-package-sources.md
git diff --check
```

Closes #4795.
