### PR TITLE
Compile reusable package section catalog

### DIFF
--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -186,6 +186,18 @@ allocate no memory after static initialization;
 gates that narrower claim. `LibrarySections.CreatePipeline()` remains a fresh
 mutable compatibility builder for focused tests and extensions.
 
+`PackageSectionDescriptors` applies the same fixed-domain model to package
+inspection: one process-wide SourceLink query catalog and one compiled section
+catalog replace per-command registry and pipeline construction.
+`PackageSectionCatalog_QueryPlansMatchMutablePipeline` gates section-demand
+equivalence, and
+`PackageCatalog_RepeatedAcquisitionAndCommonPlanningAllocateNothing` gates
+allocation-free repeated catalog acquisition and common plan lookup. Package
+execution composes the selected section plan with the immutable query catalog
+once per request and reuses that execution plan across every selected package
+and every library inspected inside it. `CreatePipeline()` and
+`CreateQueryRegistry()` remain fresh mutable compatibility builders.
+
 Commands compile arbitrary multi-query demand once and reuse the resulting
 immutable query plan for every assembly in that request, so package inspection
 does not rebuild dependency state per assembly. The mutable

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1805,10 +1805,10 @@ public class SectionPipelineTests
         Assert.Equal([SourceAvailabilityQuery.Definition], availability);
         Assert.Equal([SourceIntegrityQuery.Definition], integrity);
         Assert.Equal(
-            catalog.QueryRegistry
+            catalog.QueryCatalog
                 .ExpandRequired(availability.Concat(integrity))
                 .OrderBy(q => q.Name, StringComparer.Ordinal),
-            catalog.QueryRegistry.RegisteredQueries.OrderBy(q => q.Name, StringComparer.Ordinal));
+            catalog.QueryCatalog.RegisteredQueries.OrderBy(q => q.Name, StringComparer.Ordinal));
 
         var categories = catalog.Pipeline.GetCategoryMap();
         Assert.Equal(
@@ -3850,10 +3850,18 @@ public class SectionPipelineTests
 
     [Fact]
     public void LibrarySectionCatalog_QueryPlansMatchMutablePipeline()
+        => AssertSectionCatalogQueryPlansMatch(
+            LibrarySections.CreateCatalog().Sections);
+
+    [Fact]
+    public void PackageSectionCatalog_QueryPlansMatchMutablePipeline()
+        => AssertSectionCatalogQueryPlansMatch(
+            PackageSectionDescriptors.CreateCatalog().Sections);
+
+    private static void AssertSectionCatalogQueryPlansMatch<TModel>(
+        SectionCatalog<TModel> catalog)
     {
-        LibrarySectionCatalog libraryCatalog = LibrarySections.CreateCatalog();
-        SectionCatalog<LibraryInspection> catalog = libraryCatalog.Sections;
-        SectionPipeline<LibraryInspection> pipeline = catalog.Pipeline;
+        SectionPipeline<TModel> pipeline = catalog.Pipeline;
 
         foreach (Verbosity verbosity in Enum.GetValues<Verbosity>())
         {
@@ -3928,6 +3936,76 @@ public class SectionPipelineTests
 
             Assert.True(expected.SetEquals(actual.Queries));
         }
+    }
+
+    [Fact]
+    public void PackageCatalog_RepeatedAcquisitionAndCommonPlanningAllocateNothing()
+    {
+        PackageSectionCatalog packageCatalog =
+            PackageSectionDescriptors.CreateCatalog();
+        SectionCatalog<InspectionResult> sectionCatalog =
+            packageCatalog.Sections;
+        InspectionQueryCatalog<SourceLinkQueryContext> queryCatalog =
+            packageCatalog.QueryCatalog;
+        SectionQueryPlan automaticPlan =
+            sectionCatalog.PlanQueries(Verbosity.Normal);
+        HashSet<string> exactSelection = new(StringComparer.OrdinalIgnoreCase)
+        {
+            PackageSections.SourceLinkAvailability,
+        };
+        SectionQueryPlan exactPlan =
+            sectionCatalog.PlanQueries(Verbosity.Normal, exactSelection);
+        InspectionQueryPlan<SourceLinkQueryContext> exactQueryPlan =
+            queryCatalog.Plan(exactPlan.Queries[0]);
+        InspectionQueryPlan<SourceLinkQueryContext> emptyQueryPlan =
+            queryCatalog.Plan(Array.Empty<InspectionQueryDefinition>());
+        ImmutableArray<string> categoryMembers =
+            sectionCatalog.CategoryMap[SectionCategoryNames.SourceLink];
+        HashSet<string> categorySelection =
+            new(categoryMembers, StringComparer.OrdinalIgnoreCase);
+        SectionQueryPlan categoryPlan =
+            sectionCatalog.PlanQueries(Verbosity.Normal, categorySelection);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int iteration = 0; iteration < 1_000; iteration++)
+        {
+            if (!ReferenceEquals(
+                    packageCatalog,
+                    PackageSectionDescriptors.CreateCatalog())
+                || !ReferenceEquals(
+                    sectionCatalog,
+                    PackageSectionDescriptors.SectionCatalog)
+                || !ReferenceEquals(
+                    queryCatalog,
+                    PackageSectionDescriptors.QueryCatalog)
+                || !ReferenceEquals(
+                    automaticPlan,
+                    sectionCatalog.PlanQueries(Verbosity.Normal))
+                || !ReferenceEquals(
+                    exactPlan,
+                    sectionCatalog.PlanQueries(
+                        Verbosity.Normal,
+                        exactSelection))
+                || !ReferenceEquals(
+                    exactQueryPlan,
+                    queryCatalog.Plan(exactPlan.Queries[0]))
+                || !ReferenceEquals(
+                    emptyQueryPlan,
+                    queryCatalog.Plan(
+                        Array.Empty<InspectionQueryDefinition>()))
+                || !ReferenceEquals(
+                    categoryPlan,
+                    sectionCatalog.PlanQueries(
+                        Verbosity.Normal,
+                        categorySelection)))
+            {
+                throw new InvalidOperationException(
+                    "The package catalog or a precomputed plan changed identity.");
+            }
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -45,9 +45,10 @@ public class PackageCommand
         var packageArgs = options.PackageArgs;
         var explicitVersion = options.ExplicitVersion;
         var catalog = PackageSectionDescriptors.CreateCatalog();
+        var sectionCatalog = catalog.Sections;
         var pipeline = catalog.Pipeline;
-        var queryRegistry = catalog.QueryRegistry;
-        var sectionNames = pipeline.SelectableSectionNames;
+        var queryCatalog = catalog.QueryCatalog;
+        var sectionNames = sectionCatalog.SelectableSectionNames;
         bool packageLibraryMode = options.PackageLibrary != null || options.AllLibraries;
         if (!packageLibraryMode)
             options = NormalizeDependencyProjection(options);
@@ -80,8 +81,8 @@ public class PackageCommand
                     var selectResult = SelectResolver.ResolveSelectAsSections(
                         options.Select,
                         sectionNames,
-                        pipeline.BareSelectSectionNames,
-                        pipeline.GetCategoryMap(),
+                        sectionCatalog.BareSelectSectionNames,
+                        sectionCatalog.SelectionCategoryMap,
                         selectDefault: options.SelectDefault
                             && !hasExplicitSelection);
                     if (SelectOutput.WriteUnresolved(selectResult))
@@ -98,7 +99,7 @@ public class PackageCommand
                 tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.Tabular && !options.JsonOutput,
                 verbosity: (int)options.Verbosity,
                 sectionCostAnnotations: pipeline.GetCostAnnotations(),
-                sectionCategories: pipeline.GetCategoryMap(),
+                sectionCategories: sectionCatalog.SelectionCategoryMap,
                 // --schema reveals the full catalog including the @Hidden pole; a static -D
                 // without --schema keeps the curated top-level view.
                 catalogHiddenSections: options.Schema ? null : pipeline.GetCatalogHiddenSections(),
@@ -132,7 +133,10 @@ public class PackageCommand
         {
             // -S/--select with values: resolve as section filter for backpressure
             var selectResult = SelectResolver.ResolveSelectAsSections(
-                options.Select, sectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap(),
+                options.Select,
+                sectionNames,
+                sectionCatalog.InfoSectionNames,
+                sectionCatalog.SelectionCategoryMap,
                 selectDefault: options.SelectDefault);
             if (SelectOutput.WriteUnresolved(selectResult)) return 1;
             if (selectResult.Sections != null)
@@ -243,7 +247,7 @@ public class PackageCommand
 
             IReadOnlyCollection<string>? tabularSections =
                 options.FixedOverview
-                    ? pipeline.BareSelectSectionNames
+                    ? sectionCatalog.BareSelectSectionNames
                     : options.IncludeSections;
             if (!options.Count
                 && !OutputFormatResolver.ValidateSingleSectionForTabular(
@@ -290,13 +294,21 @@ public class PackageCommand
         var logger = context.Logger;
 
         if (packageArgs.Length > 1)
+        {
+            PackageSourceQueryPlan sourceQueryPlan = CreatePackageSourceQueryPlan(
+                sectionCatalog,
+                queryCatalog,
+                producerOptions,
+                excludeUnbounded:
+                    options.Discover is not null && !options.Schema);
             return await ExecuteMultiPackageAsync(
                 packageArgs,
                 options,
                 producerOptions,
                 context,
-                pipeline,
-                queryRegistry);
+                sectionCatalog,
+                sourceQueryPlan);
+        }
 
         // Handle --versions mode: list versions and exit early
         if (options.ListVersions)
@@ -872,14 +884,13 @@ public class PackageCommand
                     producerOptions,
                     pipeline))
                 PopulatePackageContentAudit(result, extractPath);
-            HashSet<InspectionQueryDefinition> sourceQueries =
-                pipeline.GetRequiredQueries(
-                    producerOptions.Verbosity,
-                    producerOptions.IncludeSections,
-                    producerOptions.FixedOverview,
-                    excludeUnbounded: effectiveDiscovery);
+            PackageSourceQueryPlan sourceQueryPlan = CreatePackageSourceQueryPlan(
+                sectionCatalog,
+                queryCatalog,
+                producerOptions,
+                excludeUnbounded: effectiveDiscovery);
             if (ShouldPopulatePackageSourceFiles(producerOptions)
-                || sourceQueries.Count > 0)
+                || !sourceQueryPlan.SectionPlan.Queries.IsEmpty)
             {
                 await PopulatePackageSourceLinkAsync(
                     result,
@@ -889,8 +900,7 @@ public class PackageCommand
                     producerOptions,
                     context,
                     logger,
-                    queryRegistry,
-                    sourceQueries);
+                    sourceQueryPlan);
             }
 
             // Filter output based on options
@@ -1002,7 +1012,7 @@ public class PackageCommand
                         sectionCostAnnotations:
                             pipeline.GetCostAnnotations(),
                         sectionCategories:
-                            pipeline.GetCategoryMap(),
+                            sectionCatalog.SelectionCategoryMap,
                         catalogHiddenSections:
                             options.Schema
                                 ? null
@@ -1137,9 +1147,10 @@ public class PackageCommand
         InspectionOptions options,
         InspectionOptions producerOptions,
         CommandContext context,
-        SectionPipeline<InspectionResult> pipeline,
-        InspectionQueryRegistry<SourceLinkQueryContext> queryRegistry)
+        SectionCatalog<InspectionResult> sectionCatalog,
+        PackageSourceQueryPlan sourceQueryPlan)
     {
+        SectionPipeline<InspectionResult> pipeline = sectionCatalog.Pipeline;
         if (options.ShowContent)
             return await ExecuteMultiPackageContentAsync(packageArgs, options, context);
 
@@ -1154,7 +1165,7 @@ public class PackageCommand
             || IsPackageFileSection(rowSection)
             || options.IncludeSections?.Any(IsPackageFileSection) == true
             || (options.FixedOverview
-                && pipeline.BareSelectSectionNames.Any(IsPackageFileSection))
+                && sectionCatalog.BareSelectSectionNames.Any(IsPackageFileSection))
             || options.IncludeSections?.Contains(PackageSections.Signals) == true
             || options.IncludeSections?.Contains(PackageSections.AuditArtifactText) == true
             || options.IncludeSections?.Contains(PackageSections.AuditFindings) == true
@@ -1197,8 +1208,8 @@ public class PackageCommand
                 producerOptions,
                 context,
                 wantsFilesSection,
-                pipeline,
-                queryRegistry);
+                sectionCatalog,
+                sourceQueryPlan);
             if (result == null)
                 return 1;
             results.Add(result);
@@ -2641,9 +2652,10 @@ public class PackageCommand
         InspectionOptions producerOptions,
         CommandContext context,
         bool wantsFilesSection,
-        SectionPipeline<InspectionResult> pipeline,
-        InspectionQueryRegistry<SourceLinkQueryContext> queryRegistry)
+        SectionCatalog<InspectionResult> sectionCatalog,
+        PackageSourceQueryPlan sourceQueryPlan)
     {
+        SectionPipeline<InspectionResult> pipeline = sectionCatalog.Pipeline;
         var logger = context.Logger;
         string? extractPath = null;
         PackageExtractionResult? resolution = null;
@@ -2734,14 +2746,8 @@ public class PackageCommand
                 PopulatePackageContentAudit(result, extractPath);
             }
 
-            HashSet<InspectionQueryDefinition> sourceQueries =
-                pipeline.GetRequiredQueries(
-                    producerOptions.Verbosity,
-                    producerOptions.IncludeSections,
-                    producerOptions.FixedOverview,
-                    excludeUnbounded: options.Discover != null && !options.Schema);
             if (ShouldPopulatePackageSourceFiles(producerOptions)
-                || sourceQueries.Count > 0)
+                || !sourceQueryPlan.SectionPlan.Queries.IsEmpty)
             {
                 await PopulatePackageSourceLinkAsync(
                     result,
@@ -2751,8 +2757,7 @@ public class PackageCommand
                     producerOptions,
                     context,
                     logger,
-                    queryRegistry,
-                    sourceQueries);
+                    sourceQueryPlan);
             }
 
             FilterResultForOutput(result, options);
@@ -2918,6 +2923,36 @@ public class PackageCommand
     private static bool ShouldPopulatePackageSourceFiles(InspectionOptions options)
         => options.IncludeSections?.Contains(PackageSections.SourceLinkFiles) == true;
 
+    private static PackageSourceQueryPlan CreatePackageSourceQueryPlan(
+        SectionCatalog<InspectionResult> sectionCatalog,
+        InspectionQueryCatalog<SourceLinkQueryContext> queryCatalog,
+        InspectionOptions options,
+        bool excludeUnbounded)
+    {
+        SectionQueryPlan sectionPlan = sectionCatalog.PlanQueries(
+            options.Verbosity,
+            options.IncludeSections,
+            options.FixedOverview,
+            excludeUnbounded);
+        // The IEnumerable overload boxes ImmutableArray; use the direct common-plan overloads
+        // and reserve general compilation for uncommon multi-query demand.
+        InspectionQueryPlan<SourceLinkQueryContext> queryPlan =
+            sectionPlan.Queries.Length switch
+            {
+                0 => queryCatalog.Plan(
+                    Array.Empty<InspectionQueryDefinition>()),
+                1 => queryCatalog.Plan(sectionPlan.Queries[0]),
+                _ => queryCatalog.Plan(sectionPlan.Queries),
+            };
+        return new PackageSourceQueryPlan(
+            sectionPlan,
+            queryPlan);
+    }
+
+    private readonly record struct PackageSourceQueryPlan(
+        SectionQueryPlan SectionPlan,
+        InspectionQueryPlan<SourceLinkQueryContext> QueryPlan);
+
     private static async Task PopulatePackageSourceLinkAsync(
         InspectionResult result,
         string extractPath,
@@ -2926,9 +2961,9 @@ public class PackageCommand
         InspectionOptions options,
         CommandContext context,
         VerboseLogger logger,
-        InspectionQueryRegistry<SourceLinkQueryContext> queryRegistry,
-        HashSet<InspectionQueryDefinition> requestedQueries)
+        PackageSourceQueryPlan sourceQueryPlan)
     {
+        var requestedQueries = sourceQueryPlan.SectionPlan.Queries;
         bool collectSourceFiles = ShouldPopulatePackageSourceFiles(options);
         bool auditAvailability =
             requestedQueries.Contains(SourceAvailabilityQuery.Definition);
@@ -2976,11 +3011,11 @@ public class PackageCommand
                     options.SourceOptions);
 
                 InspectionQueryResults? queryResults = null;
-                if (requestedQueries.Count > 0)
+                if (!requestedQueries.IsEmpty)
                 {
-                    queryResults = await queryRegistry.RunAsync(
-                        requestedQueries,
-                        queryContext).ConfigureAwait(false);
+                    queryResults = await sourceQueryPlan.QueryPlan
+                        .RunAsync(queryContext)
+                        .ConfigureAwait(false);
                 }
                 else if (collectSourceFiles)
                 {

--- a/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/PackageSectionDescriptors.cs
@@ -5,8 +5,11 @@ using DotnetInspector.Views;
 namespace DotnetInspector.Sections;
 
 public sealed record PackageSectionCatalog(
-    SectionPipeline<InspectionResult> Pipeline,
-    InspectionQueryRegistry<SourceLinkQueryContext> QueryRegistry);
+    SectionCatalog<InspectionResult> Sections,
+    InspectionQueryCatalog<SourceLinkQueryContext> QueryCatalog)
+{
+    public SectionPipeline<InspectionResult> Pipeline => Sections.Pipeline;
+}
 
 /// <summary>
 /// Section descriptors for the package command.
@@ -19,24 +22,31 @@ public sealed record PackageSectionCatalog(
 /// </summary>
 public static class PackageSectionDescriptors
 {
-    /// <summary>Builds the section pipeline with all package sections registered.</summary>
-    public static SectionPipeline<InspectionResult> CreatePipeline()
-    {
-        var queryRegistry = CreateQueryRegistry();
-        return CreatePipeline(queryRegistry.CostOf);
-    }
+    /// <summary>The reusable fixed-domain catalog for package SourceLink queries.</summary>
+    public static InspectionQueryCatalog<SourceLinkQueryContext> QueryCatalog { get; } =
+        BuildQueryCatalog();
 
-    public static PackageSectionCatalog CreateCatalog()
-    {
-        var queryRegistry = CreateQueryRegistry();
-        return new PackageSectionCatalog(
-            CreatePipeline(queryRegistry.CostOf),
-            queryRegistry);
-    }
+    /// <summary>The reusable fixed-domain catalog for package sections and query-demand plans.</summary>
+    public static SectionCatalog<InspectionResult> SectionCatalog { get; } =
+        CreatePipeline().Compile();
+
+    /// <summary>The complete reusable package section and query catalog.</summary>
+    public static PackageSectionCatalog Catalog { get; } =
+        new(SectionCatalog, QueryCatalog);
+
+    /// <summary>Builds the section pipeline with all package sections registered.</summary>
+    public static SectionPipeline<InspectionResult> CreatePipeline() =>
+        CreatePipeline(QueryCatalog.CostOf);
+
+    public static PackageSectionCatalog CreateCatalog() => Catalog;
 
     public static InspectionQueryRegistry<SourceLinkQueryContext> CreateQueryRegistry()
+        => QueryCatalog.ToBuilder();
+
+    private static InspectionQueryCatalog<SourceLinkQueryContext> BuildQueryCatalog()
         => new InspectionQueryRegistry<SourceLinkQueryContext>()
-            .AddSourceLinkQueries(static context => context);
+            .AddSourceLinkQueries(static context => context)
+            .Compile();
 
     private static SectionPipeline<InspectionResult> CreatePipeline(
         Func<InspectionQueryDefinition, InspectionCost> queryCost)


### PR DESCRIPTION
## Summary

- compile the fixed package SourceLink query and section domains once per process
- compose one immutable request plan and reuse it across selected packages and their libraries
- retain fresh mutable compatibility builders for focused tests and extensions

Architecture owner: `docs/design/section-pipeline.md`

## Evidence

- `PackageSectionCatalog_QueryPlansMatchMutablePipeline` proves compiled and mutable section-demand equivalence
- `PackageCatalog_RepeatedAcquisitionAndCommonPlanningAllocateNothing` proves allocation-free repeated catalog acquisition and common planning
- Release solution build: 0 warnings, 0 errors
- focused package, SourceLink, and command execution tests passed
- `package Markout -v:q` and `package Markout -S "SourceLink Availability"` passed; the latter audited 1/1 library
- Markdown lint and `git diff --check` passed

## Non-goals

- Diff, package profile, and API catalog migration
- SourceLink acquisition or authorization policy changes

Closes #4799
