### PR TITLE
Define nuspec structural compatibility

### DIFF
--- a/docs/design/nuspec-structural-compatibility.md
+++ b/docs/design/nuspec-structural-compatibility.md
@@ -1,0 +1,95 @@
+# Nuspec structural compatibility
+
+`DotnetInspector.Services` owns recognition and extraction of nuspec XML
+structure. This document defines which `package` and `metadata` namespace forms
+that parser accepts and which nearby XML shapes do not become package metadata.
+
+The policy is intentionally narrower than XSD validation. Deployed manifests
+use more than one historical schema placement, while this parser needs only a
+stable structural boundary for the facts it extracts.
+
+## Supported document forms
+
+The document root must have the case-sensitive local name `package`. Its
+namespace is either empty or belongs to the Microsoft nuspec namespace family:
+
+```text
+http://schemas.microsoft.com/packaging/{version}/nuspec.xsd
+```
+
+The existing parser treats the namespace-family prefix and suffix
+case-insensitively and requires a non-empty `{version}`. Prefix choice is
+irrelevant because XML expanded names use the namespace URI.
+
+Package metadata, when present, is exactly one direct `metadata` child in one of
+these forms:
+
+| `package` namespace | `metadata` namespace | Meaning |
+| --- | --- | --- |
+| empty | empty | namespace-free manifest |
+| Microsoft nuspec `N` | the same `N` | root-schema manifest |
+| empty | Microsoft nuspec `N` | legacy metadata-schema manifest |
+
+The selected metadata namespace determines the reported manifest version.
+Namespace-free metadata reports `nuspec`; a Microsoft namespace reports its
+`{version}` token.
+
+The real-manifest corpus records deployed examples of root-schema and legacy
+metadata-schema placement. Its live verifier is the compatibility check before
+this matrix is tightened; see
+[`eng/package-manifest-corpus.md`](../../eng/package-manifest-corpus.md).
+
+## Close structural cases
+
+- A root with another local name or a foreign namespace is rejected.
+- Microsoft-nuspec metadata under a namespaced root must use exactly the root
+  namespace. Namespace-free or differently versioned metadata there is
+  rejected rather than reinterpreted.
+- More than one compatible direct `metadata` child is rejected, including a
+  namespace-free and legacy-schema pair under a namespace-free root.
+- A foreign-namespace direct `metadata` child is an extension-shaped sibling,
+  not package metadata. It is ignored and does not shadow one compatible
+  `metadata` child.
+- A nested `metadata` element is not a direct package child and is ignored.
+- Metadata fields are read only as direct children in the selected metadata
+  namespace. Foreign or nested lookalikes are not package fields.
+- No direct compatible `metadata` child produces an empty `NuspecData`; the
+  Services parser does not require package identity.
+
+These distinctions avoid both permissive local-name matching and rejecting
+unrelated extension content.
+
+## Ownership boundaries
+
+Services owns XML shape recognition, namespace relationships, field extraction,
+and safe malformed/unsupported-structure failures. `HardenedXml` remains the
+shared XML decoding boundary.
+
+`PackageManifestFactsQuery` owns expected identity matching, dependency
+contract validation, scalar/count/byte limits, and projection into typed
+manifest failures. Acquisition belongs to the host, and CLI or Browser
+presentation is outside this policy. This document neither changes those
+contracts nor makes Services an acquisition or presentation owner.
+
+Missing `metadata`, `id`, or `version` is therefore not a structural parser
+error. A consuming query may reject the resulting incomplete facts according
+to its own contract.
+
+## Gates
+
+`NuspecParserTests.ParseContent_SupportedPackageAndMetadataNamespaceFormsAreAccepted`
+gates the three supported namespace placements.
+`ParseContent_IncompatibleNuspecMetadataNamespaceIsRejected`,
+`ParseContent_DuplicateCompatibleMetadataIsRejected`,
+`ParseContent_ForeignDirectMetadataIsNotPackageMetadata`,
+`ParseContent_NestedMetadataIsNotPackageMetadata`, and
+`ParseContent_ForeignMetadataSiblingDoesNotShadowPackageMetadata` gate the
+direct-child and namespace boundary.
+`ParseContent_InvalidDocumentRootIsRejected` gates the root contract.
+`PackageManifestFactsQueryTests.Execute_ReportsIncompatibleMetadataNamespaceAsUnsupportedDocumentShape`
+gates projection of the tightened Services boundary into the existing
+content-free typed query failure.
+
+The pinned live command in `eng/package-manifest-corpus.md` is required evidence
+for an acceptance-policy change; synthetic unit tests alone do not establish
+real-package compatibility.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -71,7 +71,9 @@ substrates, and inspection producers that will extend that space.
 - `src/DotnetInspector.Services/` contains shared services such as assembly-set
   and PDB acquisition, platform/package resolution, dependency resolution,
   signatures, SourceLink availability/integrity operations, source fetching,
-  and nuspec parsing.
+  and nuspec parsing. It owns the accepted package/metadata XML structure
+  defined by [nuspec structural compatibility](design/nuspec-structural-compatibility.md);
+  Queries owns manifest identity, dependency validation, and resource policy.
 - `src/DotnetInspector.Core/` is the reference-free tool runtime kernel beneath
   Packages, Services, and the CLI: cache roots and eviction (`CoreCache`,
   `AsyncCache`), the single `HttpClientFactory` seam with offline and

--- a/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
@@ -170,6 +170,30 @@ public sealed class PackageManifestFactsQueryTests
     }
 
     [Fact]
+    public void Execute_ReportsIncompatibleMetadataNamespaceAsUnsupportedDocumentShape()
+    {
+        PackageManifestFactsResult.Failed failure = Assert.IsType<
+            PackageManifestFactsResult.Failed>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(
+                        """
+                        <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                          <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+                            <id>Example.Package</id>
+                            <version>1.0.0</version>
+                          </metadata>
+                        </package>
+                        """),
+                    PackageSourceCoordinate.Create(
+                        "Example.Package",
+                        "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFailureReason.UnsupportedDocumentShape,
+            failure.Failure.Reason);
+    }
+
+    [Fact]
     public void Execute_RejectsInvalidDependencyContract()
     {
         PackageManifestFactsResult.Failed failure = Assert.IsType<

--- a/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
@@ -494,13 +494,16 @@ public class NuspecParserTests : IDisposable
             StringComparison.Ordinal);
     }
 
-    [Fact]
-    public void ParseContent_ForeignDirectMetadataIsNotPackageMetadata()
+    [Theory]
+    [InlineData("https://example.test/extension")]
+    [InlineData(" ")]
+    public void ParseContent_ForeignDirectMetadataIsNotPackageMetadata(
+        string metadataNamespace)
     {
         NuspecData result = NuspecParser.ParseContent(
-            """
+            $$"""
             <package>
-              <metadata xmlns="https://example.test/extension">
+              <metadata xmlns="{{metadataNamespace}}">
                 <id>Foreign.Package</id>
                 <version>1.0.0</version>
               </metadata>
@@ -556,6 +559,8 @@ public class NuspecParserTests : IDisposable
         "<notpackage><metadata><id>Example.Package</id><version>1.0.0</version></metadata></notpackage>")]
     [InlineData(
         "<package xmlns=\"https://example.test/not-nuspec\"><metadata><id>Example.Package</id><version>1.0.0</version></metadata></package>")]
+    [InlineData(
+        "<package xmlns=\" \"><metadata><id>Example.Package</id><version>1.0.0</version></metadata></package>")]
     public void ParseContent_InvalidDocumentRootIsRejected(string xml)
     {
         InvalidDataException exception =

--- a/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
@@ -419,6 +419,140 @@ public class NuspecParserTests : IDisposable
 
     [Theory]
     [InlineData(
+        "<package><metadata><id>Example.Package</id><version>1.0.0</version></metadata></package>",
+        "nuspec")]
+    [InlineData(
+        "<package xmlns=\"http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd\"><metadata><id>Example.Package</id><version>1.0.0</version></metadata></package>",
+        "2013/05")]
+    [InlineData(
+        "<package><metadata xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\"><id>Example.Package</id><version>1.0.0</version></metadata></package>",
+        "2010/07")]
+    public void ParseContent_SupportedPackageAndMetadataNamespaceFormsAreAccepted(
+        string xml,
+        string manifestVersion)
+    {
+        NuspecData result = NuspecParser.ParseContent(xml);
+
+        Assert.Equal("Example.Package", result.PackageName);
+        Assert.Equal("1.0.0", result.Version);
+        Assert.Equal(manifestVersion, result.ManifestVersion);
+    }
+
+    [Theory]
+    [InlineData(
+        "<package xmlns=\"http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd\"><metadata xmlns=\"\"><id>Example.Package</id><version>1.0.0</version></metadata></package>")]
+    [InlineData(
+        "<package xmlns=\"http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd\"><metadata xmlns=\"http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd\"><id>Example.Package</id><version>1.0.0</version></metadata></package>")]
+    public void ParseContent_IncompatibleNuspecMetadataNamespaceIsRejected(
+        string xml)
+    {
+        InvalidDataException exception =
+            Assert.Throws<InvalidDataException>(
+                () => NuspecParser.ParseContent(xml));
+
+        Assert.Contains(
+            "metadata namespace",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Example.Package",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseContent_DuplicateCompatibleMetadataIsRejected()
+    {
+        const string xml = """
+            <package>
+              <metadata>
+                <id>First.Package</id>
+                <version>1.0.0</version>
+              </metadata>
+              <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+                <id>Second.Package</id>
+                <version>2.0.0</version>
+              </metadata>
+            </package>
+            """;
+
+        InvalidDataException exception =
+            Assert.Throws<InvalidDataException>(
+                () => NuspecParser.ParseContent(xml));
+
+        Assert.Contains(
+            "multiple metadata elements",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "First.Package",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Second.Package",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseContent_ForeignDirectMetadataIsNotPackageMetadata()
+    {
+        NuspecData result = NuspecParser.ParseContent(
+            """
+            <package>
+              <metadata xmlns="https://example.test/extension">
+                <id>Foreign.Package</id>
+                <version>1.0.0</version>
+              </metadata>
+            </package>
+            """);
+
+        Assert.Null(result.PackageName);
+        Assert.Null(result.Version);
+    }
+
+    [Fact]
+    public void ParseContent_NestedMetadataIsNotPackageMetadata()
+    {
+        NuspecData result = NuspecParser.ParseContent(
+            """
+            <package>
+              <extension>
+                <metadata>
+                  <id>Nested.Package</id>
+                  <version>1.0.0</version>
+                </metadata>
+              </extension>
+            </package>
+            """);
+
+        Assert.Null(result.PackageName);
+        Assert.Null(result.Version);
+    }
+
+    [Fact]
+    public void ParseContent_ForeignMetadataSiblingDoesNotShadowPackageMetadata()
+    {
+        NuspecData result = NuspecParser.ParseContent(
+            """
+            <package>
+              <metadata xmlns="https://example.test/extension">
+                <id>Foreign.Package</id>
+                <version>1.0.0</version>
+              </metadata>
+              <metadata>
+                <id>Example.Package</id>
+                <version>2.0.0</version>
+              </metadata>
+            </package>
+            """);
+
+        Assert.Equal("Example.Package", result.PackageName);
+        Assert.Equal("2.0.0", result.Version);
+    }
+
+    [Theory]
+    [InlineData(
         "<notpackage><metadata><id>Example.Package</id><version>1.0.0</version></metadata></notpackage>")]
     [InlineData(
         "<package xmlns=\"https://example.test/not-nuspec\"><metadata><id>Example.Package</id><version>1.0.0</version></metadata></package>")]

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -268,7 +268,7 @@ public static class NuspecParser
     private static bool IsNuspecNamespace(XNamespace ns)
     {
         var uri = ns.NamespaceName;
-        if (string.IsNullOrWhiteSpace(uri))
+        if (uri.Length == 0)
             return true;
 
         const string prefix = "http://schemas.microsoft.com/packaging/";

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -100,14 +100,31 @@ public static class NuspecParser
                 "The package manifest has an invalid document root.");
         }
 
-        XElement[] metadataElements =
+        XElement[] metadataCandidates =
         [
             .. root.Elements().Where(element =>
                 element.Name.LocalName.Equals(
                     "metadata",
-                    StringComparison.Ordinal)
-                && IsNuspecNamespace(element.Name.Namespace)),
+                    StringComparison.Ordinal)),
         ];
+        XElement[] nuspecMetadataCandidates =
+        [
+            .. metadataCandidates.Where(element =>
+                IsNuspecNamespace(element.Name.Namespace)),
+        ];
+        XElement[] metadataElements =
+        [
+            .. nuspecMetadataCandidates.Where(element =>
+                IsCompatibleMetadataNamespace(
+                    root.Name.Namespace,
+                    element.Name.Namespace)),
+        ];
+        if (nuspecMetadataCandidates.Length != metadataElements.Length)
+        {
+            throw new InvalidDataException(
+                "The package manifest metadata namespace does not match its document root.");
+        }
+
         if (metadataElements.Length > 1)
         {
             throw new InvalidDataException(
@@ -260,4 +277,10 @@ public static class NuspecParser
             && uri.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
             && uri.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool IsCompatibleMetadataNamespace(
+        XNamespace rootNamespace,
+        XNamespace metadataNamespace) =>
+        string.IsNullOrEmpty(rootNamespace.NamespaceName)
+            || rootNamespace == metadataNamespace;
 }


### PR DESCRIPTION
## Summary

- define the Services-owned nuspec structural compatibility policy
- accept namespace-free, root-schema, and legacy metadata-schema manifests
- reject incompatible Microsoft nuspec namespace combinations and duplicate
  compatible metadata while preserving foreign-extension tolerance
- keep identity, dependency, resource, acquisition, and presentation policy
  with their existing owners

## Evidence

- 35 focused `NuspecParserTests` pass in Release
- 21 focused `PackageManifestFactsQueryTests` pass in Release
- all four pinned real manifests pass the live corpus verifier with exact hashes
- `dotnet build dotnet-inspect.slnx -c Release --no-restore` passes with
  0 warnings and 0 errors
- changed design documents pass `markdownlint`

## Compatibility

The accepted matrix covers namespace-free manifests, Microsoft nuspec
namespaces on both `package` and `metadata`, and the deployed legacy form with
a namespace-free root and namespaced metadata. The pinned corpus proves both
root-schema and legacy metadata-schema packages.

This intentionally tightens namespaced roots whose direct `metadata` resets to
no namespace or uses a different Microsoft nuspec namespace. Those shapes now
produce the existing content-free `UnsupportedDocumentShape` query failure.
Foreign direct metadata remains extension-shaped content and does not shadow
one valid package metadata element.

## Non-claims

- this does not add XSD validation or require identity in Services
- this does not change manifest acquisition or presentation
- Browser/Wasm and measured resource/request canaries remain #4723

Closes #4722
Part of #4714
