### PR TITLE
Update adversarial review seat-selection guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,26 +803,19 @@ feedback; the settled PR still requires its full round.
 | Tier | Requirement |
 | --- | --- |
 | Trivial | No review. State why the change is trivial. |
-| Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer. |
+| Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |
 
-When uncertain, use the standard round. The roster is:
+When uncertain, use the standard round. Pick the second seat from the prior
+round's clean count: no prior round or 0/2 clean → prefer GPT-5.6 Sol again;
+1/2 clean → keep GPT-5.6 Sol fixed, rule out last round's second seat, then
+prefer a different family than the author (the author's family only as a
+fallback) at that model's highest available quality. Record the choice and its
+reasoning on the PR.
 
-- **GPT-5.6 Sol** — the fixed seat, in every round
-- Claude Opus
-- Gemini Pro
-
-Prefer a second seat from a different family than the author, using that
-model's highest available quality. Reuse the author's family only as a fallback
-and record it on the PR. If a roster model is unavailable to fill a seat,
-select another model for that seat, report the substitution on the PR, and
-proceed without waiting for approval; a substituted seat still counts as
-filled. One round evaluates one settled head with all required reviewers.
-
-When the prior round's result was 0/2 clean, prefer filling both seats with
-**GPT-5.6 Sol** for the next round. When the prior round's result was 1/2
-clean, do not repeat the same seat pairing for the next round — keep the fixed
-seat as GPT-5.6 Sol, but pick a second seat different from the second seat used
-last round.
+If a roster model is unavailable, substitute another model for that seat,
+report the substitution on the PR, and proceed without approval — a
+substituted seat still counts as filled. One round evaluates one settled head
+with all required reviewers.
 
 ### Running the round
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -806,11 +806,15 @@ feedback; the settled PR still requires its full round.
 | Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |
 
 When uncertain, use the standard round. Pick the second seat from the prior
-round's clean count: no prior round or 0/2 clean → prefer GPT-5.6 Sol again;
-1/2 clean → keep GPT-5.6 Sol fixed, rule out last round's second seat, then
-prefer a different family than the author (the author's family only as a
-fallback) at that model's highest available quality. Record the choice and its
-reasoning on the PR.
+round's clean count:
+
+- **No prior round, or 0/2 clean:** prefer GPT-5.6 Sol again for the second
+  seat.
+- **1/2 clean:** keep GPT-5.6 Sol fixed, rule out last round's second seat,
+  then prefer a different family than the author (the author's family only as
+  a fallback) at that model's highest available quality.
+
+Record the choice and its reasoning on the PR.
 
 If a roster model is unavailable, substitute another model for that seat,
 report the substitution on the PR, and proceed without approval — a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -813,9 +813,16 @@ When uncertain, use the standard round. The roster is:
 
 Prefer a second seat from a different family than the author, using that
 model's highest available quality. Reuse the author's family only as a fallback
-and record it on the PR. If the harness lacks a required roster model, run the
-available seat and ask the user for the missing one; an out-of-roster model does
-not count. One round evaluates one settled head with all required reviewers.
+and record it on the PR. If a roster model is unavailable to fill a seat,
+select another model for that seat, report the substitution on the PR, and
+proceed without waiting for approval; a substituted seat still counts as
+filled. One round evaluates one settled head with all required reviewers.
+
+When the prior round's result was 0/2 clean, prefer filling both seats with
+**GPT-5.6 Sol** for the next round. When the prior round's result was 1/2
+clean, do not repeat the same seat pairing for the next round — keep the fixed
+seat as GPT-5.6 Sol, but pick a second seat different from the second seat used
+last round.
 
 ### Running the round
 


### PR DESCRIPTION
## Summary

Updates `AGENTS.md`'s "How many reviewers, and from which models" section with two seat-selection changes:

1. **Unavailable roster model:** when a seat can't be filled because a model is unavailable, select another model for that seat, report the substitution on the PR, and proceed — no user approval required (previously required asking the user for the missing seat).
2. **Seat pairing based on prior clean count:** prefer filling both seats with GPT-5.6 Sol when the prior round's result was 0/2 clean. When the prior round was 1/2 clean, don't repeat the same seat pairing — keep GPT-5.6 Sol as the fixed seat but pick a different second seat than the one used last round.

## Validation

Documentation-only change. Ran `markdownlint-cli` on `AGENTS.md` — no findings.