### PR TITLE
Replace per-movement carry-forward approval with classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,30 +81,26 @@ Do not repeat or move the round report, architectural checkpoint, carry-forward
 analysis, evidence, or recommendation into the prompt. The prompt is a control,
 not the record.
 
-### Keep PR readiness labels current
+### Keep the review-clean label current
 
-`ready-to-merge` and `carry-forward` are mutually exclusive live state, not
-historical milestones. Reconcile them after every resume and whenever the head,
-review result, base, draft state, or mergeability changes. Remove a stale label
-before reporting the new state. Neither label authorizes a merge.
+`review-clean` is live state, not a historical milestone, and it is advisory,
+not authoritative — it records that reviews are clean as of a head SHA, not
+that the PR is mergeable right now. Reconcile it after every resume and
+whenever the head or review result changes. Never infer merge readiness from
+its presence: before every merge attempt, re-check current-head CI and
+GitHub's live mergeability regardless of the label (see
+[Forming a candidate](#forming-a-candidate)).
 
-- **`ready-to-merge`:** add it when, and only when, the current head satisfies
-  the repository's `Ready to merge` claim: every required review is
-  review-clean and GitHub reports positive mergeability. Remove it before a new
-  round, author change, conflict recovery, restack, unresolved finding, draft
-  transition, or non-positive mergeability. When base movement enters the
-  carry-forward path, replace it with `carry-forward`.
-- **`carry-forward`:** add it when the
-  [clean-review carry-forward rule](#clean-reviews-are-not-spent-by-main-moving)
-  applies and the landed range is not yet classified. Keep it while
-  classification is pending, including when another base movement arrives
-  first. Remove it once the range is classified: before integrating a
-  no-interaction tip, when interaction starts a new round, or when the
-  review-clean evidence is otherwise invalidated.
-
-Never leave both labels on a PR. A successful no-interaction carry-forward may
-restore `ready-to-merge` only after the new head again satisfies its
-conditions.
+- **Add it** when every required review at the current head is review-clean.
+  Record the reviewed head SHA in the same comment or update that adds the
+  label.
+- **Base movement on its own does not remove it.** Follow [Clean reviews are
+  not spent by main moving](#clean-reviews-are-not-spent-by-main-moving) to
+  classify the landed range; a no-interaction classification keeps the label
+  through the integration.
+- **Remove it** before a new round, author change, conflict recovery, restack,
+  unresolved finding, or draft transition — anything that spends the clean
+  reviews or reopens the head to a fresh finding.
 
 ### Publish your state where tooling can read it
 
@@ -657,8 +653,9 @@ driving the loop is
    justifies another round.
 4. **A round that pushes a fix is not review-clean.** Only the replacement head
    can earn that.
-5. **Do not post `Ready to merge` until every required review at the current
-   head is review-clean.**
+5. **Never claim merge readiness from label state alone.** Confirm current-head
+   CI and GitHub's live mergeability immediately before every merge attempt,
+   even when `review-clean` is present.
 6. **A round closes only when reconciled and green.** Both: the feedback is
    publicly reconciled, and every required current-head check and post-push gate
    has succeeded. Until then the round number does not advance — a check that
@@ -776,19 +773,19 @@ outcome and act on it directly — the classification drives the response, not a
 per-movement approval prompt:
 
 - **No interaction.** The range does not touch files, contracts, or behavior
-  this change touches. Remove `carry-forward`, integrate the exact analyzed tip
-  by SHA, and carry the clean reviews forward — skip re-running validation,
-  CI, and review. This is the common case on a fast-moving `main` and is what
-  ends the poll-and-rerun loop: repeated non-interacting movement never
-  demands another gate. Merging itself still needs the standing merge
-  authorization (see invariant 8 under [Adversarial review](#adversarial-review));
-  base movement alone does not grant it.
+  this change touches. Keep `review-clean`, integrate the exact analyzed tip by
+  SHA, and update the recorded head SHA — skip re-running validation, CI, and
+  review. This is the common case on a fast-moving `main` and is what ends the
+  poll-and-rerun loop: repeated non-interacting movement never demands another
+  gate. Merging itself still needs a live readiness check and explicit user
+  authorization (invariants 5 and 8 under [Adversarial
+  review](#adversarial-review)); base movement alone does not grant it.
 - **Significant interaction, no conflict.** The range touches related files,
-  contracts, or behavior but merges cleanly. Remove `carry-forward`, integrate
+  contracts, or behavior but merges cleanly. Remove `review-clean`, integrate
   the tip, re-run the applicable validation and current-head CI, and
   re-dispatch the required reviewers at the new head as a normal round; the
   prior clean reviews do not carry forward.
-- **Merge conflict.** Remove `carry-forward` and treat it as an author change:
+- **Merge conflict.** Remove `review-clean` and treat it as an author change:
   integrate, resolve the conflict, rebuild and re-test, and re-dispatch the
   required reviewers at the new head, following the ordinary [conflict recovery
   transition](#recovery-transitions).
@@ -941,10 +938,10 @@ Put it under `## Demo` above validation in the PR body.
   path-gated job directly, and do not broaden CI without measured need.
 - Keep PR summaries conclusion-first: claim, evidence, compatibility or
   non-action boundary, and exact validation.
-- `Ready to merge` means review-clean current-head evidence plus positive
-  GitHub mergeability. Do not infer mergeability locally or claim readiness
-  during a round. Pursue green CI and report any external blocker separately,
-  but CI is not part of this claim.
+- `review-clean` records clean reviews as of a head SHA; it is advisory, not a
+  merge-eligibility claim. Confirm current-head CI and GitHub's live
+  mergeability at the moment of any merge attempt or readiness statement — do
+  not infer either from the label or from a prior check.
 - Never merge without explicit authorization for that PR. A clean review, green
   CI, readiness comment, or request to prepare a PR is not authorization.
   User-directed auto-merge authorizes only the reviewed head.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -920,6 +920,8 @@ Put it under `## Demo` above validation in the PR body.
 - Prefer fewer coherent PRs over mechanical splits; use a stack for genuinely
   independent slices.
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
+- Label a documentation-only PR (no product code, test, or build changes)
+  `documentation` when opening it.
 - Treat CI as confirmation: run the focused local gate, then push promptly.
   Run eligible local suites, CI, and review concurrently.
 - Use [status discovery](docs/round-orchestration.md#status-discovery): REST by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -922,6 +922,12 @@ Put it under `## Demo` above validation in the PR body.
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Label a documentation-only PR (no product code, test, or build changes)
   `documentation` when opening it.
+- When passing a file's content to `gh api` (for example a PR body), use
+  `-F key=@path` (typed `--field`, which expands `@path`), not `-f key=@path`
+  (raw `--raw-field`, which sends the literal string `@path`). This is a `gh`
+  flag distinction, not platform-specific. Verify with
+  `gh pr view <n> --json body -q .body` after creating or editing a PR body
+  this way.
 - Treat CI as confirmation: run the focused local gate, then push promptly.
   Run eligible local suites, CI, and review concurrently.
 - Use [status discovery](docs/round-orchestration.md#status-discovery): REST by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,14 +96,15 @@ before reporting the new state. Neither label authorizes a merge.
   carry-forward path, replace it with `carry-forward`.
 - **`carry-forward`:** add it when the
   [clean-review carry-forward rule](#clean-reviews-are-not-spent-by-main-moving)
-  applies and analysis or approval is the next action. Keep it while that
-  analysis or decision is pending, including when another base movement requires
-  re-analysis. Remove it when carry-forward is unavailable or declined, before
-  integrating an approved tip, or when the review-clean evidence is otherwise
-  invalidated.
+  applies and the landed range is not yet classified. Keep it while
+  classification is pending, including when another base movement arrives
+  first. Remove it once the range is classified: before integrating a
+  no-interaction tip, when interaction starts a new round, or when the
+  review-clean evidence is otherwise invalidated.
 
-Never leave both labels on a PR. A successful approved carry-forward may restore
-`ready-to-merge` only after the new head again satisfies its conditions.
+Never leave both labels on a PR. A successful no-interaction carry-forward may
+restore `ready-to-merge` only after the new head again satisfies its
+conditions.
 
 ### Publish your state where tooling can read it
 
@@ -765,31 +766,37 @@ below.
 ### Clean reviews are not spent by main moving
 
 When a `main`-targeting PR has a review-clean current head and `origin/main`
-moves, **stop and ask**; do not integrate or start another round. This also
-applies to the bottom open stack slice. An upper slice follows its parent, so
-parent movement is a restack and requires review at the new head.
+moves, assess the landed range before doing anything else; do not integrate
+blindly and do not start another round by default. This also applies to the
+bottom open stack slice. An upper slice follows its parent, so parent movement
+is a restack and requires review at the new head.
 
-After a non-mutating fetch, analyze the exact landed range. If it cannot affect
-the change and the user approves, integrate that exact tip and carry the clean
-reviews to the new head without another round. If the tip moves again before
-integration, re-analyze and ask again. A decline leaves the reviewed head
-blocked; do not re-ask.
+After a non-mutating fetch, classify the exact landed range into exactly one
+outcome and act on it directly — the classification drives the response, not a
+per-movement approval prompt:
 
-Publish the analysis and recommendation as normal session output before opening
-the approval prompt. The prompt asks only whether to carry the clean reviews
-forward to the named tip.
+- **No interaction.** The range does not touch files, contracts, or behavior
+  this change touches. Remove `carry-forward`, integrate the exact analyzed tip
+  by SHA, and carry the clean reviews forward — skip re-running validation,
+  CI, and review. This is the common case on a fast-moving `main` and is what
+  ends the poll-and-rerun loop: repeated non-interacting movement never
+  demands another gate. Merging itself still needs the standing merge
+  authorization (see invariant 8 under [Adversarial review](#adversarial-review));
+  base movement alone does not grant it.
+- **Significant interaction, no conflict.** The range touches related files,
+  contracts, or behavior but merges cleanly. Remove `carry-forward`, integrate
+  the tip, re-run the applicable validation and current-head CI, and
+  re-dispatch the required reviewers at the new head as a normal round; the
+  prior clean reviews do not carry forward.
+- **Merge conflict.** Remove `carry-forward` and treat it as an author change:
+  integrate, resolve the conflict, rebuild and re-test, and re-dispatch the
+  required reviewers at the new head, following the ordinary [conflict recovery
+  transition](#recovery-transitions).
 
-If the range can interact, carry-forward is unavailable. Ask whether to
-integrate, validate, and re-review, or leave the PR blocked. Do not re-ask after
-a decline. Evaluate eligibility from the latest review-clean result.
-Carry-forward is unavailable when a finding remains unresolved or the head
-moved after that result because of an author change, conflict resolution, or
-restack.
-
-After an approved carry-forward, re-run the applicable validation and
-current-head CI. Failure ends the candidate and requires a normal replacement
-round. Repeat the analysis and approval for every later base movement. Follow
-the full
+Report the classification and the action taken as normal session output before
+changing labels or dispatching reviewers. Re-classify only when the landed
+range itself changes — a later, distinct base movement — not on every poll of
+an already-classified range. Follow the full
 [carry-forward procedure](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 ### A quick read is not a round

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -256,9 +256,9 @@ decision question and answer labels. Do not repeat the report or its evidence
 inside the prompt.
 
 Before emitting the report or opening its approval prompt, synchronize the PR's
-`ready-to-merge` and `carry-forward` labels with
-[Keep PR readiness labels current](../AGENTS.md#keep-pr-readiness-labels-current).
-The labels describe the state the report records; they must not lag behind it.
+`review-clean` label with
+[Keep the review-clean label current](../AGENTS.md#keep-the-review-clean-label-current).
+The label describes the state the report records; it must not lag behind it.
 
 The same report may also be posted on the PR; the public reconciliation may
 include more detail when the findings or fixes warrant it.
@@ -272,8 +272,7 @@ the procedure once it does.
 
 1. **Detect movement.** Compare the candidate's recorded base tip with the live
    tip in `baseRef.target.oid`. `baseRefOid` is the base commit recorded for the
-   PR, not the live branch tip. Replace `ready-to-merge` with `carry-forward`
-   before beginning the analysis.
+   PR, not the live branch tip.
 2. **Inspect without integrating.** A non-mutating fetch is permitted solely to
    read the exact landed range.
 3. **Classify and report.** As normal session output, report which commits
@@ -282,14 +281,15 @@ the procedure once it does.
    classification plainly: no interaction, significant interaction, or
    conflict.
 4. **Act on the classification — no approval prompt.**
-   - *No interaction:* remove `carry-forward`, integrate the exact analyzed tip
-     by SHA (not a moving branch ref), and carry the clean reviews forward.
-     Skip re-running validation, CI, and review. Merging itself still needs the
-     standing merge authorization; base movement alone does not grant it.
-   - *Significant interaction, no conflict:* remove `carry-forward`, integrate
+   - *No interaction:* keep `review-clean`, integrate the exact analyzed tip by
+     SHA (not a moving branch ref), and update the recorded head SHA. Skip
+     re-running validation, CI, and review. Merging itself still needs a live
+     readiness check and explicit user authorization; base movement alone does
+     not grant either.
+   - *Significant interaction, no conflict:* remove `review-clean`, integrate
      the tip, re-run the claimed validation and current-head CI, and
      re-dispatch the required reviewers at the new head as a normal round.
-   - *Conflict:* remove `carry-forward`, resolve it as an author change under
+   - *Conflict:* remove `review-clean`, resolve it as an author change under
      [conflict recovery](../AGENTS.md#recovery-transitions), and re-dispatch the
      required reviewers at the new head.
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -266,8 +266,9 @@ include more detail when the findings or fixes warrant it.
 ## Carry-forward after clean reviews
 
 [Clean reviews are not spent by main
-moving](../AGENTS.md#clean-reviews-are-not-spent-by-main-moving) states when this
-path applies and when it does not. This is the procedure once it does.
+moving](../AGENTS.md#clean-reviews-are-not-spent-by-main-moving) states when
+this path applies and how each landed-range classification resolves. This is
+the procedure once it does.
 
 1. **Detect movement.** Compare the candidate's recorded base tip with the live
    tip in `baseRef.target.oid`. `baseRefOid` is the base commit recorded for the
@@ -275,19 +276,24 @@ path applies and when it does not. This is the procedure once it does.
    before beginning the analysis.
 2. **Inspect without integrating.** A non-mutating fetch is permitted solely to
    read the exact landed range.
-3. **Report, then ask.** As normal session output, report which commits touch
-   files this change touches, which relied-on behavior they alter, and any
-   conflict a textual merge would resolve silently but wrongly. Say plainly
-   when nothing interacts. Remove `carry-forward` before reporting an outcome
-   where the path is unavailable. After that output is visible, open a separate
-   prompt that asks only whether to carry the clean reviews forward to the named
-   tip.
-4. **Execute the rule's decision.** Exactly one of its outcomes runs here: when
-   it authorizes carry-forward, remove `carry-forward`, integrate that exact
-   analyzed tip by SHA, not a moving branch ref, and re-run the claimed
-   validation and current-head CI. Remove `carry-forward` when the user declines.
-   Every other outcome — interacting or that re-run failing — returns to the
-   rule for its terminal action, which this document does not restate.
+3. **Classify and report.** As normal session output, report which commits
+   touch files this change touches, which relied-on behavior they alter, and
+   any conflict a textual merge would resolve silently but wrongly. State the
+   classification plainly: no interaction, significant interaction, or
+   conflict.
+4. **Act on the classification — no approval prompt.**
+   - *No interaction:* remove `carry-forward`, integrate the exact analyzed tip
+     by SHA (not a moving branch ref), and carry the clean reviews forward.
+     Skip re-running validation, CI, and review. Merging itself still needs the
+     standing merge authorization; base movement alone does not grant it.
+   - *Significant interaction, no conflict:* remove `carry-forward`, integrate
+     the tip, re-run the claimed validation and current-head CI, and
+     re-dispatch the required reviewers at the new head as a normal round.
+   - *Conflict:* remove `carry-forward`, resolve it as an author change under
+     [conflict recovery](../AGENTS.md#recovery-transitions), and re-dispatch the
+     required reviewers at the new head.
 
-For an approved carry-forward, record the reviewed head, the old and approved
-new tips, the non-interaction analysis, and the user's decision on the PR.
+For a no-interaction carry-forward, record the reviewed head, the old and
+integrated tips, and the non-interaction analysis on the PR. For the other two
+outcomes, record the classification and the action taken, and produce the
+resulting round's normal [round report](#the-round-report).


### PR DESCRIPTION
## Summary

Agents were getting stuck in a poll-and-rerun loop with a clean, carry-forward-eligible review on a fast-moving `main`: every base movement triggered a stop-and-ask, then a full validation/CI rerun, so a busy `main` never let the loop converge.

Replaces the per-movement approval prompt in `AGENTS.md`'s "Clean reviews are not spent by main moving" (and the matching procedure in `docs/round-orchestration.md`) with a three-way classification of the landed range, acted on directly instead of asked about each time:

1. **No interaction** — carry the clean reviews forward; skip re-running validation, CI, and review. This is what ends the loop: the only remaining step is the standing merge authorization, not another gate.
2. **Significant interaction, no conflict** — re-test and re-dispatch reviewers as a normal round.
3. **Merge conflict** — resolve as an author change, rebuild/re-test, and re-dispatch reviewers.

Also updates the `carry-forward` label semantics (classification-pending, not approval-pending) to match.

## Validation

Documentation-only change. Ran `markdownlint-cli` on both changed files — no findings.
