### PR TITLE
Isolate Windows allocation canary from parallel tests

### DIFF
--- a/tests/ILInspector.Metadata.Tests/ArrayShapeTextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ArrayShapeTextTests.cs
@@ -158,9 +158,9 @@ public class ArrayShapeTextTests
         var (reader, handle) = BuildTypeSpec(
             [0x14, 0x08, 0xdf, 0xff, 0xff, 0xff, 0x00, 0x00]);
 
-        long before = GC.GetTotalAllocatedBytes(precise: true);
+        long before = GC.GetAllocatedBytesForCurrentThread();
         var result = GuardedSignatureDecoder.DecodeTypeSpecification(reader, handle);
-        long allocated = GC.GetTotalAllocatedBytes(precise: true) - before;
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
 
         string rendered = Assert.IsType<SignatureDecodeResult<string>.Decoded>(result).Value;
         Assert.Contains("invalid rank", rendered, StringComparison.Ordinal);


### PR DESCRIPTION
Fixes #4758.

The hostile-rank allocation canary now measures only allocations made by its synchronous decoder thread. Parallel metadata tests can no longer contaminate the Windows sample, while the historical ~2 GB separator-string regression still crosses the unchanged 1 MiB threshold on that same thread.

## Demo

Before, Windows run [33023298342](https://github.com/richlander/dotnet-inspect/actions/runs/33023298342/job/98359078927) measured exactly 1 MiB from the process-wide counter and failed while unrelated tests ran in parallel.

After:

```text
> dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.ArrayShapeTextTests
Total: 24, Errors: 0, Failed: 0, Skipped: 0

> dotnet run --project tests/ILInspector.Metadata.Tests -c Release
Total: 2212, Errors: 0, Failed: 0, Skipped: 0
```

What to notice: the focused hostile-rank gate remains enabled with its original rendering and `< 1 MiB` assertions, and the complete suite passes under its normal parallel execution. Neighboring array-shape cases remain unchanged.

## Change

- Replace `GC.GetTotalAllocatedBytes(precise: true)` with `GC.GetAllocatedBytesForCurrentThread()` around `GuardedSignatureDecoder.DecodeTypeSpecification`.
- Keep the input, decoded-result assertions, rendering bound, and allocation threshold unchanged.

## Boundary

This is metadata test-infrastructure only. It does not change decoder behavior, production allocation policy, test parallelism, or the threshold.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.ArrayShapeTextTests` — 24 passed
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` — 2,212 passed
- LF and `git diff --check` clean