### PR TITLE
Word reviewer prompts as properties, not attack briefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -829,7 +829,12 @@ with all required reviewers.
 
 Give every reviewer the same self-contained prompt and a separate worktree.
 Review the whole head unless the user narrows scope. Reproduce findings before
-acting on them, wait for all locked-head reviews, and reconcile publicly. Follow
+acting on them, wait for all locked-head reviews, and reconcile publicly.
+
+Word the prompt as a description of the property under test, not as an attack
+brief. A prompt that reads as an exploit tutorial can trip a model's content
+filter, and it fails silently: the reviewer returns nothing and looks broken.
+Suspect the prompt before the model when a reviewer returns empty. Follow
 [running a round](docs/round-orchestration.md#running-a-round) for mechanics and
 reporting.
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -198,35 +198,44 @@ as an attack brief can trip a model's content filter, and **that failure is
 silent**: the reviewer returns an empty or near-empty response with a clean
 worktree, which is indistinguishable from a broken model or a stalled harness.
 
-This is not hypothetical. On #4801 the pinned seat returned empty responses
-seven times across two heads and was very nearly reported to the user as a
-non-functional model in need of repinning. A second reviewer then failed with an
-explicit message — *"the response was blocked by content filtering"* — which
-identified the real cause. The prompt described markup that carries script and
-quoted working payloads (`javascript:alert(1)`, event-handler attributes,
-injected `<script>` elements); it read as an exploit tutorial. Rewording it,
-with the same attack surfaces and the same required evidence, produced full
-reports from both seats on the first attempt.
+This has happened here, and it cost most of a day. A seat returned empty
+several times across two heads and was nearly reported to the user as a
+non-functional model in need of repinning. A reviewer from a different family
+then failed with an explicit message naming content filtering as the cause,
+which is the only reason the real explanation surfaced at all. The prompt had
+been written as a catalog of concrete strings to try against a gate that rejects
+markup able to run unreviewed code. Rewording it -- same surfaces, same required
+evidence, same rigor -- produced full reports from both seats on the first
+attempt.
 
-So the reviewer was refusing the prompt, not the work. Keep prompts in terms of
-the property:
+The reviewer was refusing the prompt, not the work. Keep prompts in terms of the
+property:
 
 - **Say what the property actually is.** If the gate enforces static-analysis
-  coverage, say that, and say the concern is unlinted code rather than
+  coverage, say that, and say the concern is unreviewed code rather than
   attackers. Do not dress a correctness property as a security one for
   emphasis.
-- **Name constructs structurally rather than pasting payloads.** "an `iframe`
-  `srcdoc` attribute, whose entity-encoded content the browser parses as a
-  document" asks for the same probe as a working payload and reads as a
-  specification.
-- **Use inert markers in required evidence.** `globalThis.MY_MARKER = 1` proves
-  a construct reached the output as well as `alert(1)` does.
+- **Name constructs structurally rather than quoting them.** Describing an
+  attribute by what a parser does with its contents asks for the same probe as a
+  literal string and reads as a specification. This is the load-bearing rule:
+  quoted strings are what draws the refusal.
+- **Use an inert marker in the required evidence.** Assigning a uniquely named
+  global proves a construct reached the output exactly as well as anything
+  active does, and it is also easier to grep for.
 - **Describe already-closed cases by name, not by spelling**, when listing the
   floor a reviewer should push past.
 
+Apply the same discipline to notes, issues and documentation, including this
+page. A write-up that reproduces the strings in order to explain them becomes
+the hazard it is describing, for every agent that later reads it. Say what the
+construct was; do not reproduce it. For the same reason, describe an incident by
+what it teaches rather than by pointing at the pull request where it happened,
+so that following the reference is not itself the way to load the problem
+material.
+
 None of this softens the review. "Adversarial" describes the rigor, not a
 simulated attacker, and a reviewer that understands the invariant will find more
-than one handed a list of exploits to retry.
+than one handed a list of strings to retry.
 
 When a reviewer returns empty or near-empty, suspect the prompt before the
 model. Check the worktree for artifacts, then re-dispatch the same work to a

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -191,6 +191,49 @@ worktree. A reviewer's own probe can be vacuous — an added rule clause that
 changes nothing for an already-entitled input looks green for the wrong reason —
 so reproduce the finding and measure it before accepting its severity.
 
+### Wording the prompt
+
+Write the prompt as a description of the property under test. A prompt written
+as an attack brief can trip a model's content filter, and **that failure is
+silent**: the reviewer returns an empty or near-empty response with a clean
+worktree, which is indistinguishable from a broken model or a stalled harness.
+
+This is not hypothetical. On #4801 the pinned seat returned empty responses
+seven times across two heads and was very nearly reported to the user as a
+non-functional model in need of repinning. A second reviewer then failed with an
+explicit message — *"the response was blocked by content filtering"* — which
+identified the real cause. The prompt described markup that carries script and
+quoted working payloads (`javascript:alert(1)`, event-handler attributes,
+injected `<script>` elements); it read as an exploit tutorial. Rewording it,
+with the same attack surfaces and the same required evidence, produced full
+reports from both seats on the first attempt.
+
+So the reviewer was refusing the prompt, not the work. Keep prompts in terms of
+the property:
+
+- **Say what the property actually is.** If the gate enforces static-analysis
+  coverage, say that, and say the concern is unlinted code rather than
+  attackers. Do not dress a correctness property as a security one for
+  emphasis.
+- **Name constructs structurally rather than pasting payloads.** "an `iframe`
+  `srcdoc` attribute, whose entity-encoded content the browser parses as a
+  document" asks for the same probe as a working payload and reads as a
+  specification.
+- **Use inert markers in required evidence.** `globalThis.MY_MARKER = 1` proves
+  a construct reached the output as well as `alert(1)` does.
+- **Describe already-closed cases by name, not by spelling**, when listing the
+  floor a reviewer should push past.
+
+None of this softens the review. "Adversarial" describes the rigor, not a
+simulated attacker, and a reviewer that understands the invariant will find more
+than one handed a list of exploits to retry.
+
+When a reviewer returns empty or near-empty, suspect the prompt before the
+model. Check the worktree for artifacts, then re-dispatch the same work to a
+model from a different family: filters differ, and one may state the reason
+where another fails silently. Do not propose repinning a roster seat on
+empty-response evidence alone.
+
 ### Reconciliation
 
 Reconcile the reviews publicly on the PR: attribute findings, state what was


### PR DESCRIPTION
## Why

A reviewer prompt written as an attack brief can trip a model's content filter, and **that failure is silent**: the reviewer returns an empty response with a clean worktree, which is indistinguishable from a broken model or a stalled harness.

That happened here and cost most of a day. A seat returned empty several times across two heads, and I was about to report it to the operator as a non-functional model in need of repinning. A reviewer from a different family then failed with an explicit message naming content filtering, which is the only reason the real cause surfaced. The prompt had been written as a catalog of concrete strings to try against a gate that rejects markup able to run unreviewed code.

Rewording it -- same surfaces, same required evidence, same worktrees -- produced full reports from both seats on the first attempt, and those reports found a critical bypass the gate had. The reviewers were refusing the prompt, not the work, and the near-miss was a roster change proposed on the strength of a prompt bug.

## What this adds

`docs/round-orchestration.md` gains a **Wording the prompt** subsection under Dispatch with the rules that worked:

- say what the property actually is, and do not dress a correctness property as a security one for emphasis;
- name constructs structurally rather than quoting them, which is the load-bearing rule, since quoted strings are what draws the refusal;
- use an inert uniquely-named global as the marker in required evidence;
- describe already-closed cases by name rather than by spelling.

It also records the diagnostic that would have saved the wasted attempts: **suspect the prompt before the model**, check the worktree for artifacts, and re-dispatch to a different model family, because filters differ and one may state the reason where another fails silently. Do not propose repinning a roster seat on empty-response evidence alone.

The same discipline is extended to notes, issues and documentation, including that page itself. A write-up that reproduces the strings in order to explain them becomes the hazard it is describing for every agent that later reads it, and an incident is better described by what it teaches than by a link to where it happened -- following such a link is both a way to load the problem material and a way to spend a lot of context reaching a lesson the page already states.

`AGENTS.md` gains a short pointer in **Running the round**, keeping the repository-wide rule in the file that owns rules and the detail in the doc that owns round mechanics.

None of this softens review: "adversarial" describes the rigor, not a simulated attacker, and a reviewer that understands the invariant will find more than one handed a list of strings to retry.

## Validation

Documentation-only. `npx markdownlint-cli AGENTS.md docs/round-orchestration.md` is clean. No product behavior claim, so no build or test evidence applies.