### PR TITLE
Move platform compatibility tests to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,11 +300,10 @@ jobs:
             exit 1
           fi
 
-  # Build and run the full test matrix on Ubuntu. A reduced Windows leg runs as
-  # the separate `test-windows` job below; macOS is still uncovered by tests and
-  # appears only as a `release.yml` packaging target. Note that release.yml's
-  # `build-native` job does run on `windows-latest`, but it only packs and runs
-  # no tests, so it is not Windows test coverage.
+  # Build and run the PR test matrix on Ubuntu. Windows and macOS compatibility
+  # suites run daily in Deep Inspect, where platform-specific failures do not
+  # hold the predominantly Linux and macOS development fleet on the much slower
+  # Windows runner.
   #
   # Runs on PRs only. A pull_request build validates the PR merged into the
   # current base, so re-running the full test suite on the push to main is
@@ -391,10 +390,10 @@ jobs:
         if: steps.decompiler_pr_corpus.outcome == 'failure'
         run: exit 1
 
-      # --mdv matters here and nowhere else: this is the only workflow that runs
+      # --mdv matters here because this lane runs
       # tests/ILInspector.Metadata.Tests, whose cross-implementation oracle
       # skips without it -- and a skipped oracle is a green leg that compared
-      # nothing.
+      # nothing. Deep Inspect restores the same oracle for its platform lane.
       #
       # continue-on-error lets the rest of the lane still report, so a feed
       # outage does not cost every other result in the job. It does not make
@@ -511,147 +510,6 @@ jobs:
         run: |
           echo "::error::The authenticated GitHub Packages fixture test failed." >&2
           echo "This lane cannot certify hosted fixture consumption. See the fixture test step." >&2
-          exit 1
-
-  # Reduced Windows leg (#3542).
-  #
-  # Until now no test had ever run on Windows in any workflow, so a green PR
-  # said nothing about it. The cost was measured, not hypothetical: #3445,
-  # #3496, #3509, #3519, #3526 and six PluginDiscoveryTests cases found during
-  # #3428 review were all Windows-only failures found by hand on a tree CI
-  # called green. Almost all were fixture-level -- CRLF vs LF, path separators,
-  # executable bits -- which is the class a matrix leg catches cheaply and a
-  # human catches expensively.
-  #
-  # This is a separate job rather than another `include:` on `test` because
-  # most of that job's steps are genuinely bash-only: `mapfile`, a heredoc, a
-  # `chmod`, and `bash eng/*.sh`. Adding `windows-latest` there would need an
-  # `if:` guard on the majority of the steps and would leave the two jobs
-  # sharing a shape neither wants.
-  #
-  # Scope is deliberately reduced: the suites with an observed Windows-only
-  # failure, plus the two cheap path-sensitive ones. Excluded on cost, not
-  # principle: the slow decompiler gates and corpus sensor (the #3326 class),
-  # the separate IL round-trip project, and packaging.
-  #
-  # Like every other job here, this one must never be named as a required
-  # status check directly: it is path-gated and PR/merge-queue-only, and a
-  # required check that does not run is reported as "Expected" forever,
-  # blocking the merge permanently. Its result reaches `ci-required`, the
-  # aggregate gate at the end of this file, which is where it becomes
-  # merge-blocking.
-  test-windows:
-    needs: changes
-    if: needs.changes.outputs.code == 'true' && github.event_name != 'push'
-    runs-on: windows-latest
-    # Raised again after #4350 recurred at 55 minutes: two runs spent 40-41
-    # minutes in the CLI suite and reached Metadata near minute 54, while an
-    # adjacent healthy lane needed 53 minutes. The failed runs project to
-    # 56-57 minutes, so 70 restores about 13 minutes of runner-variance margin.
-    timeout-minutes: 70
-    env:
-      DOTNET_INSPECT_TIPS: q
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
-
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
-          restore-keys: |
-            nuget-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Build
-        id: build
-        run: dotnet build dotnet-inspect.slnx -c Release
-
-      # GitHub's Windows image supplies Git Bash to `shell: bash`, but does not
-      # put that executable on the PATH inherited by .NET test processes.
-      # Publish its exact native path for IlToolsActivationTests rather than
-      # relying on the unrelated Windows Subsystem for Linux bash launcher.
-      #
-      # continue-on-error preserves the other Windows results during a feed
-      # outage. The terminal check below still makes loss of oracle coverage
-      # red after every suite has had a chance to report.
-      - name: Install ilasm/ildasm
-        id: iltools
-        continue-on-error: true
-        timeout-minutes: 5
-        shell: bash
-        run: |
-          printf 'ILTOOLS_BASH=%s\n' "$(cygpath -w "$(command -v bash)")" >> "$GITHUB_ENV"
-          eng/restore-iltools.sh --rid win-x64 --native-paths >> "$GITHUB_PATH"
-
-      # Each suite below runs even when an earlier suite failed. The default
-      # fail-fast behaviour reports the first broken suite and marks the rest
-      # `skipped`, which reads as "fine" when it actually means "unknown" --
-      # the success-shaped-empty-output failure AGENTS.md rules out. A Windows
-      # break is typically one fixture-level bug hitting several suites at
-      # once, so the first red step is the least useful place to stop. Gated on
-      # the build so a compile error still fails fast rather than producing
-      # five copies of the same error.
-
-      # Unfiltered, unlike the Ubuntu lane, and that is the point of this job.
-      # CommandExecutionTests carries a class-level [Trait("Speed", "Slow")], so
-      # `-trait- "Speed=Slow"` drops the entire class -- and both Windows-only
-      # CLI regressions (#3519, #3445) lived in exactly that class. Filtering
-      # here would faithfully reproduce the blind spot this leg exists to close.
-      - name: Run CLI tests (all)
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/dotnet-inspect.Tests -c Release
-
-      - name: Run CSharpText tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project tests/CSharpText.Tests -c Release
-
-      - name: Run artifact contract tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release
-
-      # Covers #3496 and #3509. Both classes involved (StringSwitchRaisingTests,
-      # CorpusSensorComparisonTests) are in the fast subset, so the slow gates
-      # stay excluded without losing the regressions this leg is here for.
-      - name: Run decompiler unit tests (fast)
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
-
-      # Covers the PluginDiscoveryTests failures found during #3428 review:
-      # plugin discovery is exactly the executable-bit and path-separator logic
-      # that differs by OS. Live-network tests are excluded here for the same
-      # reasons as on the Ubuntu lane.
-      - name: Run NuGetFetch tests (offline)
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
-
-      - name: Run metadata tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -longRunning 60
-
-      - name: Run services tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
-
-      - name: Run query tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/DotnetInspector.Queries.Tests -c Release
-
-      - name: Run Research tests
-        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/ILInspector.Research.Tests -c Release -- -failSkips
-
-      - name: Check ilasm/ildasm result
-        if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.iltools.outcome != 'success' }}
-        shell: bash
-        run: |
-          echo "::error::Restoring ilasm/ildasm failed or timed out, so every Windows oracle test skipped." >&2
-          echo "This lane cannot certify oracle-backed results. See the 'Install ilasm/ildasm' step." >&2
           exit 1
 
   # net10.0 fallback build coverage. The official non-AOT "any" package targets
@@ -1235,7 +1093,6 @@ jobs:
       # expensive jobs except inspect-web also skip on pushes to main. That
       # passes the gate by design; the allow list below distinguishes
       # "correctly not run" from "ran and failed".
-      - test-windows
       - build-net10
       - decompiler-gates
       - csharp-diff-smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,10 @@ jobs:
             exit 1
           fi
 
-  # Build and run the PR test matrix on Ubuntu. Windows and macOS compatibility
-  # suites run daily in Deep Inspect, where platform-specific failures do not
-  # hold the predominantly Linux and macOS development fleet on the much slower
-  # Windows runner.
+  # Build and run the PR test matrix on Ubuntu 24.04. Windows, macOS, and Ubuntu
+  # 26.04 compatibility suites run daily in Deep Inspect, where
+  # platform-specific failures do not hold the predominantly Linux and macOS
+  # development fleet on the much slower Windows runner.
   #
   # Runs on PRs only. A pull_request build validates the PR merged into the
   # current base, so re-running the full test suite on the push to main is

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -18,7 +18,7 @@ on:
           - all
   schedule:
     # Daily release certification: full slow tests, the decompiler corpus, and
-    # Windows/macOS compatibility.
+    # Windows/macOS/latest-Ubuntu compatibility.
     - cron: '0 6 * * *'
     # Weekly discovery: current packages and the authored-corpus ratchet.
     - cron: '0 9 * * 1'
@@ -159,7 +159,8 @@ jobs:
     # The reduced platform suite runs daily rather than on every PR. Windows is
     # materially slower than Linux, and platform-specific failures should be
     # discovered by scheduled platform agents instead of holding the primary
-    # development fleet. macOS runs the same suite for symmetric coverage.
+    # development fleet. macOS and Ubuntu 26.04 run the same suite for
+    # symmetric coverage across all three operating systems.
     #
     # The selected suites preserve the Windows-only failures recorded in
     # #3445, #3496, #3509, #3519, #3526, and #3542 plus path-sensitive
@@ -177,6 +178,8 @@ jobs:
             rid: win-x64
           - os: macos-latest
             rid: osx-arm64
+          - os: ubuntu-26.04
+            rid: linux-x64
     runs-on: ${{ matrix.os }}
     # Windows has measured as high as 57 minutes (#4350). The initial macOS
     # lane gets the same larger budget until its runtime variance is known.

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -168,6 +168,7 @@ jobs:
     # round-trip, and packaging remain with their owning daily or release jobs.
     if: >-
       (github.event_name == 'schedule' && github.event.schedule == '0 6 * * *') ||
+      inputs.lane == 'test' ||
       inputs.lane == 'platform-test' ||
       inputs.lane == 'all'
     strategy:

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -13,10 +13,12 @@ on:
           - census
           - package-sweep
           - authored-corpus
+          - platform-test
           - nightly
           - all
   schedule:
-    # Daily release certification: full slow tests plus the decompiler corpus.
+    # Daily release certification: full slow tests, the decompiler corpus, and
+    # Windows/macOS compatibility.
     - cron: '0 6 * * *'
     # Weekly discovery: current packages and the authored-corpus ratchet.
     - cron: '0 9 * * 1'
@@ -152,6 +154,118 @@ jobs:
           echo "This lane cannot certify oracle-backed results. See the 'Install ilasm/ildasm' step." >&2
           exit 1
 
+  platform-test:
+    name: Platform test (${{ matrix.rid }})
+    # The reduced platform suite runs daily rather than on every PR. Windows is
+    # materially slower than Linux, and platform-specific failures should be
+    # discovered by scheduled platform agents instead of holding the primary
+    # development fleet. macOS runs the same suite for symmetric coverage.
+    #
+    # The selected suites preserve the Windows-only failures recorded in
+    # #3445, #3496, #3509, #3519, #3526, and #3542 plus path-sensitive
+    # PluginDiscoveryTests. Slow decompiler gates, the corpus sensor, IL
+    # round-trip, and packaging remain with their owning daily or release jobs.
+    if: >-
+      (github.event_name == 'schedule' && github.event.schedule == '0 6 * * *') ||
+      inputs.lane == 'platform-test' ||
+      inputs.lane == 'all'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: macos-latest
+            rid: osx-arm64
+    runs-on: ${{ matrix.os }}
+    # Windows has measured as high as 57 minutes (#4350). The initial macOS
+    # lane gets the same larger budget until its runtime variance is known.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build
+        id: build
+        run: dotnet build dotnet-inspect.slnx -c Release
+
+      # GitHub's Windows image supplies Git Bash to workflow steps without
+      # exposing it to child .NET processes. Publish its native path so the
+      # activation tests invoke Git Bash rather than the WSL launcher.
+      #
+      # continue-on-error preserves the other platform results during a feed
+      # outage. The terminal check below still makes lost oracle coverage red.
+      - name: Install ilasm/ildasm/mdv
+        id: iltools
+        continue-on-error: true
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = Windows ]; then
+            printf 'ILTOOLS_BASH=%s\n' "$(cygpath -w "$(command -v bash)")" >> "$GITHUB_ENV"
+          fi
+          eng/restore-iltools.sh --rid ${{ matrix.rid }} --mdv --native-paths >> "$GITHUB_PATH"
+
+      # Run every suite after a successful build even if an earlier suite
+      # fails. Platform breaks commonly share one fixture-level cause, and
+      # reporting every affected suite makes the scheduled failure actionable.
+      - name: Run CLI tests (all)
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release
+
+      - name: Run CSharpText tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project tests/CSharpText.Tests -c Release
+
+      - name: Run artifact contract tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release
+
+      - name: Run decompiler unit tests (fast)
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
+
+      - name: Run NuGetFetch tests (offline)
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
+
+      - name: Run metadata tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -longRunning 60
+
+      - name: Run services tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
+
+      - name: Run query tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/DotnetInspector.Queries.Tests -c Release
+
+      - name: Run Research tests
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        run: dotnet run --project src/ILInspector.Research.Tests -c Release -- -failSkips
+
+      - name: Check ilasm/ildasm/mdv result
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.iltools.outcome != 'success' }}
+        shell: bash
+        run: |
+          echo "::error::Restoring ilasm/ildasm/mdv for ${{ matrix.rid }} failed or timed out, so oracle tests skipped." >&2
+          echo "This lane cannot certify oracle-backed results. See the 'Install ilasm/ildasm/mdv' step." >&2
+          exit 1
+
   decompiler-corpus:
     name: Decompiler corpus lane
     # Split out of the test lane so the multi-hour corpus sweep gets its own
@@ -188,7 +302,7 @@ jobs:
 
   release-certification:
     name: Release certification
-    needs: [test, decompiler-corpus]
+    needs: [test, platform-test, decompiler-corpus]
     if: >-
       always() &&
       (
@@ -201,13 +315,16 @@ jobs:
       - name: Certify slow validation
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          PLATFORM_RESULT: ${{ needs.platform-test.result }}
           CORPUS_RESULT: ${{ needs.decompiler-corpus.result }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ "$TEST_RESULT" != success ] || [ "$CORPUS_RESULT" != success ]; then
-            echo "::error::Release certification requires successful test and decompiler-corpus jobs."
-            echo "test=$TEST_RESULT decompiler-corpus=$CORPUS_RESULT"
+          if [ "$TEST_RESULT" != success ] ||
+             [ "$PLATFORM_RESULT" != success ] ||
+             [ "$CORPUS_RESULT" != success ]; then
+            echo "::error::Release certification requires successful test, platform-test, and decompiler-corpus jobs."
+            echo "test=$TEST_RESULT platform-test=$PLATFORM_RESULT decompiler-corpus=$CORPUS_RESULT"
             exit 1
           fi
           echo "Release certification passed for $GITHUB_SHA"
@@ -614,6 +731,7 @@ jobs:
     needs:
       - package-sweep
       - test
+      - platform-test
       - decompiler-corpus
       - release-certification
       - authored-corpus-ratchet

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -17,9 +17,6 @@ internal static partial class WorkflowContract
             ["test"] =
                 "needs.changes.outputs.code == 'true' && " +
                 "github.event_name != 'push'",
-            ["test-windows"] =
-                "needs.changes.outputs.code == 'true' && " +
-                "github.event_name != 'push'",
             ["build-net10"] =
                 "needs.changes.outputs.shipped == 'true' && " +
                 "github.event_name != 'push'",
@@ -155,27 +152,6 @@ internal static partial class WorkflowContract
                 "steps.iltools.outcome == 'failure'",
             ["test/Check GitHub Packages fixture result"] =
                 "steps.package_fixture.outcome == 'failure'",
-            ["test-windows/Run CLI tests (all)"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run CSharpText tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run artifact contract tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run decompiler unit tests (fast)"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run NuGetFetch tests (offline)"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run metadata tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run services tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run query tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Run Research tests"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' }}",
-            ["test-windows/Check ilasm/ildasm result"] =
-                "${{ !cancelled() && steps.build.outcome == 'success' && " +
-                "steps.iltools.outcome != 'success' }}",
             ["decompiler-gates/Upload gate report"] = "always()",
             ["csharp-diff-smoke/Upload C# Diff smoke artifact"] = "always()",
             ["il-diff-smoke/Upload IL Diff smoke artifact"] = "always()",
@@ -186,7 +162,6 @@ internal static partial class WorkflowContract
             "test/Run GitHub Packages fixture test",
             "test/Run PR decompiler corpus sensor",
             "test/Install ilasm/ildasm/mdv",
-            "test-windows/Install ilasm/ildasm",
             "decompiler-gates/Run decompiler gates",
         };
         var allowedShell = new Dictionary<string, string>(
@@ -195,8 +170,6 @@ internal static partial class WorkflowContract
             ["test/Run GitHub Packages fixture test"] = "bash",
             ["test/Run PR decompiler corpus sensor"] = "bash",
             ["test/Install ilasm/ildasm/mdv"] = "bash",
-            ["test-windows/Install ilasm/ildasm"] = "bash",
-            ["test-windows/Check ilasm/ildasm result"] = "bash",
             ["csharp-diff-smoke/Run C# Diff baseline smoke"] = "bash",
             ["il-diff-smoke/Run IL Diff baseline smoke"] = "bash",
             ["skill-gate/Run embedded skill tests"] = "bash",
@@ -209,14 +182,11 @@ internal static partial class WorkflowContract
             ["test/Run PR decompiler corpus sensor"] =
                 "decompiler_pr_corpus",
             ["test/Install ilasm/ildasm/mdv"] = "iltools",
-            ["test-windows/Build"] = "build",
-            ["test-windows/Install ilasm/ildasm"] = "iltools",
             ["decompiler-gates/Run decompiler gates"] = "gates",
         };
         var allowedTimeoutMinutes = new Dictionary<string, string>(
             StringComparer.Ordinal)
         {
-            ["test-windows/Install ilasm/ildasm"] = "5",
             ["decompiler-gates/Run decompiler gates"] = "45",
         };
         var seenIf = new HashSet<string>(StringComparer.Ordinal);
@@ -234,7 +204,6 @@ internal static partial class WorkflowContract
                 "steps",
                 $"jobs.{jobName}");
             var identities = new HashSet<string>(StringComparer.Ordinal);
-            bool windowsBuildSeen = false;
             foreach (YamlNode stepNode in steps.Children)
             {
                 YamlMappingNode step = RequireMapping(
@@ -249,24 +218,6 @@ internal static partial class WorkflowContract
                 }
 
                 string key = $"{jobName}/{identity}";
-                if (key == "test-windows/Build")
-                {
-                    windowsBuildSeen = true;
-                }
-                if (key == "test-windows/Run Research tests")
-                {
-                    if (!windowsBuildSeen)
-                    {
-                        throw new InvalidOperationException(
-                            $"{key} must run after test-windows/Build.");
-                    }
-                    RequireScalarValue(
-                        step,
-                        "run",
-                        "dotnet run --project " +
-                        "src/ILInspector.Research.Tests -c Release -- -failSkips",
-                        key);
-                }
                 ValidateOptionalStepValue(
                     step,
                     "if",

--- a/eng/ci-detect-changes.sh
+++ b/eng/ci-detect-changes.sh
@@ -313,7 +313,7 @@ while IFS= read -r -d '' file; do
     # sweep's own rules. Under docs/, which no arm here would catch.
     docs/data/nuget-top-packages.lock.json) CODE=true ;;
     docs/data/nuget-top-packages.json) CODE=true ;;
-    # The test lane is what actually runs these scripts (the
+    # The PR test lane is what actually runs these scripts before merge (the
     # `Install ilasm/ildasm/mdv` step and IlToolsActivationTests), so
     # it is the only thing that can catch a break in them. Without
     # this, a PR touching only a script skips that lane and

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -20388,7 +20388,7 @@ public partial class CommandExecutionTests
     /// so the assembling <c>TrimEnd</c> cannot be dropped. All of these have teeth on every
     /// platform. <see cref="PackageCommand_AllLibraries_MarkdownUsesLfThroughout"/> covers the
     /// complementary property, the line ending itself, over the per-library path; that assertion
-    /// has teeth only on the <c>test-windows</c> leg.
+    /// has teeth only on the nightly <c>platform-test (win-x64)</c> leg.
     /// </para>
     /// <para>
     /// Both producers are covered, because they fail differently. The aggregated path (#3951, which

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -644,7 +644,7 @@ public class IlToolsActivationTests
             StringComparison.Ordinal);
         Assert.True(jobStart >= 0);
         int nextJob = workflow.IndexOf(
-            "\n  decompiler-corpus:",
+            "\n  platform-test:",
             jobStart,
             StringComparison.Ordinal);
         Assert.True(jobStart < nextJob);

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -725,15 +725,15 @@ public class IlToolsActivationTests
     }
 
     [Fact]
-    public void WindowsWorkflow_RestoresOraclesAndExposesGitBashBeforeCliTests()
+    public void PlatformWorkflow_RestoresOraclesAndExposesGitBashBeforeCliTests()
     {
         string workflow = File.ReadAllText(
-            Path.Combine(RepoRoot, ".github", "workflows", "ci.yml"));
+            Path.Combine(RepoRoot, ".github", "workflows", "deep-inspect.yml"));
         int jobStart = workflow.IndexOf(
-            "\n  test-windows:\n",
+            "\n  platform-test:\n",
             StringComparison.Ordinal);
         int nextJob = workflow.IndexOf(
-            "\n  build-net10:",
+            "\n  decompiler-corpus:",
             jobStart,
             StringComparison.Ordinal);
         Assert.True(jobStart >= 0);
@@ -743,16 +743,23 @@ public class IlToolsActivationTests
             "\n    steps:\n",
             StringComparison.Ordinal);
         Assert.True(stepsStart >= 0);
-        Assert.Contains("timeout-minutes: 70", job[..stepsStart]);
+        string jobHeader = job[..stepsStart];
+        Assert.Contains("inputs.lane == 'test'", jobHeader);
+        Assert.Contains("inputs.lane == 'platform-test'", jobHeader);
+        Assert.Contains("inputs.lane == 'all'", jobHeader);
+        Assert.Contains("- os: windows-latest\n            rid: win-x64", jobHeader);
+        Assert.Contains("- os: macos-latest\n            rid: osx-arm64", jobHeader);
+        Assert.Contains("- os: ubuntu-26.04\n            rid: linux-x64", jobHeader);
+        Assert.Contains("timeout-minutes: 90", jobHeader);
 
         int install = job.IndexOf(
-            "- name: Install ilasm/ildasm",
+            "- name: Install ilasm/ildasm/mdv",
             StringComparison.Ordinal);
         int cliTests = job.IndexOf(
             "- name: Run CLI tests (all)",
             StringComparison.Ordinal);
         int terminalCheck = job.IndexOf(
-            "- name: Check ilasm/ildasm result",
+            "- name: Check ilasm/ildasm/mdv result",
             StringComparison.Ordinal);
         Assert.True(install >= 0);
         Assert.True(install < cliTests);
@@ -768,8 +775,9 @@ public class IlToolsActivationTests
         Assert.Contains("timeout-minutes: 5", installStep);
         Assert.Contains("shell: bash", installStep);
         Assert.Contains("ILTOOLS_BASH=", installStep);
+        Assert.Contains("if [ \"$RUNNER_OS\" = Windows ]; then", installStep);
         Assert.Contains(
-            "eng/restore-iltools.sh --rid win-x64 --native-paths >> \"$GITHUB_PATH\"",
+            "eng/restore-iltools.sh --rid ${{ matrix.rid }} --mdv --native-paths >> \"$GITHUB_PATH\"",
             installStep);
 
         string checkStep = job[terminalCheck..];
@@ -802,14 +810,17 @@ public class IlToolsActivationTests
         Assert.True(certification >= 0);
         Assert.True(certification < nextJob);
         string job = workflow[certification..nextJob];
-        Assert.Contains("needs: [test, decompiler-corpus]", job);
+        Assert.Contains("needs: [test, platform-test, decompiler-corpus]", job);
         Assert.Contains("inputs.lane == 'test'", job);
         Assert.Contains("inputs.lane == 'all'", job);
         Assert.Contains("TEST_RESULT: ${{ needs.test.result }}", job);
-        Assert.Contains("CORPUS_RESULT: ${{ needs.decompiler-corpus.result }}", job);
         Assert.Contains(
-            "if [ \"$TEST_RESULT\" != success ] || [ \"$CORPUS_RESULT\" != success ]",
+            "PLATFORM_RESULT: ${{ needs.platform-test.result }}",
             job);
+        Assert.Contains("CORPUS_RESULT: ${{ needs.decompiler-corpus.result }}", job);
+        Assert.Contains("[ \"$TEST_RESULT\" != success ] ||", job);
+        Assert.Contains("[ \"$PLATFORM_RESULT\" != success ] ||", job);
+        Assert.Contains("[ \"$CORPUS_RESULT\" != success ]; then", job);
     }
 
     [Fact]


### PR DESCRIPTION
Moves Windows compatibility testing out of the PR merge gate and adds daily
Windows/macOS/Ubuntu 26.04 certification. Code PRs now complete on the Ubuntu
24.04 path, while platform-specific failures are assigned to scheduled
platform agents.

Owner: CI orchestration. Owning workflows:
`.github/workflows/ci.yml` and `.github/workflows/deep-inspect.yml`.

## Demo

Before, every code PR's `ci-required` job waited for `test-windows`, recently
measured at 45-50 minutes.

After, PR CI contains no Windows job. Deep Inspect's `platform-test` lane
creates these parallel jobs on the exact `main` commit being certified:

```text
Platform test (win-x64)
Platform test (osx-arm64)
Platform test (linux-x64)
```

The same lane is available through manual dispatch for fixed-head validation.
Both matrix results feed daily `Release certification`, and any scheduled
failure reaches the existing issue-reporting job.

## Validation

- `actionlint` on `ci.yml` and `deep-inspect.yml`
- `git diff --check`
- CI change-detection workflow contract parsed with the removed PR consumer
- Fixed-head `platform-test` dispatch pending on this PR head
