### PR TITLE
Extract ref-kind call-site fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5374,19 +5374,6 @@ public class CfgSampleClass
     }
 }
 
-public sealed class RefKindBox<T>
-{
-    T _value = default!;
-
-    public bool TryGet(out T value)
-    {
-        value = _value;
-        return true;
-    }
-
-    public void Put(in T value) => _value = value;
-}
-
 public interface IJoinShape
 {
     string Shape();

--- a/src/ILInspector.Decompiler.Tests/RefKindCallSiteSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/RefKindCallSiteSamples.cs
@@ -1,0 +1,14 @@
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class RefKindBox<T>
+{
+    T _value = default!;
+
+    public bool TryGet(out T value)
+    {
+        value = _value;
+        return true;
+    }
+
+    public void Put(in T value) => _value = value;
+}


### PR DESCRIPTION
Moves `RefKindBox<T>` unchanged from `CfgSampleClass.cs` into the feature-focused `RefKindCallSiteSamples.cs` fixture file. `CfgSampleClass.GenericRefKindCallSites` retains the same compiled helper identity and ref-kind call-site behavior.

Part of #3913.

## Demo

`CallSite_RefKinds_RecoveredForGenericInstanceCalls` still renders `TryGet(out ...)` while leaving the `in` argument to `Put(...)` bare after the source split.

## Validation

Exact head: `941bd0bb8d638fe0014704e1001d6559aaf1b55a`
Exact integrated base: `1a694b7dc62784d841e4da45f32e22234cc9f514`

- `CallSite_RefKinds_RecoveredForGenericInstanceCalls`: 1 passed
- Release solution build: passed with 0 errors
- Decompiler fast gate: 5,644 passed with 8 expected Windows skips
- Stable-path render A/B: 22,132 methods; 0 changed, added, or removed
- CI: pending live current-head check

## Review

Round 1 used GPT-5.6 Sol and Claude Opus 5 on the exact head. Both returned clean; no findings or changes resulted.

## Non-action boundary

No symbols, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.