### PR TITLE
Clarify review splitting and gh fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,8 +131,8 @@ to whichever window is *current*, which is somebody else's.
 Always target `"${TMUX_PANE:?}"`. The state must include
 `head` and either `pr` or, before a PR exists, `issue`; add `round`, `reviews`,
 `blocked`, `waiting`, and `rec` when applicable. Values contain no spaces. `rec`
-is `continue`, `wait`, `merge`, `approve`, or `stop`. Clear both options when the
-window no longer owns the work.
+is `continue`, `wait`, `merge`, `split`, `approve`, or `stop`. Clear both
+options when the window no longer owns the work.
 
 `blocked` and `waiting` are both things you are waiting on, split by **who can
 act on them**:
@@ -901,11 +901,14 @@ comments are themselves a sign that the remaining work should be split into
 focused successors. The same presumption and burden apply at every 6-round
 boundary after round 12.
 
-The split recommendation keeps the locked candidate unchanged while the user
-decides. If approved, publicly map every current claim and unresolved finding
-to a focused successor, close the current PR as superseded without merging it,
-and open the successors from their effective base. Each successor starts at
-round 1; reviews, round counts, and authorization blocks do not carry forward.
+After round 12 closes, the split recommendation puts the completed head in an
+immutable decision hold while the user decides. This is not a round lock; do
+not mutate the head or dispatch another round during the hold. If approved,
+publicly map every current claim and every finding — including resolved or
+dismissed findings and their resulting changes or rationale — to a focused
+successor, close the current PR as superseded without merging it, and open the
+successors from their effective base. Each successor starts at round 1;
+reviews, round counts, and authorization blocks do not carry forward.
 
 At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -937,9 +937,13 @@ Put it under `## Demo` above validation in the PR body.
 - Avoid high-level `gh` commands when they fail by querying deprecated GraphQL
   fields. In particular, `gh pr edit` may hit the removed Projects (classic)
   fields even when changing unrelated metadata. Do not retry it; use the
-  operation-specific REST endpoint through `gh api` instead, such as
-  `PATCH repos/{owner}/{repo}/pulls/{n}` for PR title, body, or base changes,
-  and the corresponding issue endpoint for labels, assignees, or milestones.
+  operation-specific REST endpoint through `gh api` instead. Use
+  `PATCH repos/{owner}/{repo}/pulls/<number>` for PR title, body, or base
+  changes; the issue labels POST and per-label DELETE endpoints for label
+  additions and removals; the issue assignees POST and DELETE endpoints for
+  assignee additions and removals; and
+  `PATCH repos/{owner}/{repo}/issues/<number>` for milestone changes. Do not
+  replace complete label or assignee arrays to perform an add or remove.
   Verify the resulting metadata after the REST update.
 - Treat CI as confirmation: run the focused local gate, then push promptly.
   Run eligible local suites, CI, and review concurrently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -878,7 +878,7 @@ candidate cycle; do not ask for approval, set `HELP`, or wait for user input.
 Approval is required only before rounds 7, 13, 19, and so on. Each approval
 allows at most six more rounds; stop sooner when review converges. At a block
 boundary, conflict recovery may resolve and push immediately, but reviewers
-still wait for approval.
+still wait for approval, unless an immutable split decision hold is active.
 
 Before requesting another block, answer:
 
@@ -910,12 +910,13 @@ boundary after round 12.
 After round 12 or a later six-round boundary closes, the split recommendation
 puts the completed head in an immutable decision hold while the user decides.
 This is not a round lock; do not mutate the head or dispatch another round
-during the hold. If approved, publicly assign every current change, claim, and
-finding — including resolved or dismissed findings and their resulting changes
-or rationale — to a focused successor, or explicitly record why an item is
-being dropped. Close the current PR as superseded without merging it, and open
-the successors from their effective base. Each successor starts at round 1;
-reviews, round counts, and authorization blocks do not carry forward.
+during the hold, including for conflict recovery. If approved, publicly assign
+every current change, claim, and finding — including resolved or dismissed
+findings and their resulting changes or rationale — to a focused successor, or
+explicitly record why an item is being dropped. Close the current PR as
+superseded without merging it, and open the successors from their effective
+base. Each successor starts at round 1; reviews, round counts, and authorization
+blocks do not carry forward.
 
 At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -742,11 +742,12 @@ least one reviewer returned a finding.
   unchanged head. Repeat only with concrete transient evidence; otherwise treat
   it as requiring an author change.
 
-If final-gate CI fails after a documentation-only round closes, it does not
-reopen or renumber that completed round. Retry an evidenced transient failure
-at the unchanged head. If the failure requires an author change, remove
-`review-clean`, make the fix, and form a candidate at the next round number,
-respecting the next six-round authorization boundary.
+If final-gate CI reports a non-successful conclusion after a documentation-only
+round closes, it does not reopen or renumber that completed round. Retry a
+failed or cancelled run at the unchanged head only with concrete transient
+evidence. If the result requires an author change, remove `review-clean`, make
+the fix, and form a candidate at the next round number, respecting the next
+six-round authorization boundary.
 
 Never close with a required check red. A superseded attempt spends no round and
 gets no completion report. Let its reviewers finish or have cancellation
@@ -899,6 +900,12 @@ restacking are not strong reasons. Sprawling changes accumulated across review
 comments are themselves a sign that the remaining work should be split into
 focused successors. The same presumption and burden apply at every 6-round
 boundary after round 12.
+
+The split recommendation keeps the locked candidate unchanged while the user
+decides. If approved, publicly map every current claim and unresolved finding
+to a focused successor, close the current PR as superseded without merging it,
+and open the successors from their effective base. Each successor starts at
+round 1; reviews, round counts, and authorization blocks do not carry forward.
 
 At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,8 +343,8 @@ reference owner contracts rather than restating participating components'
 internal inventories or policies. When another component needs prerequisite
 work, file or record that residual and handle it as an independently reviewable
 effort or stack slice. Do not expand the current design merely to make the whole
-end-to-end system appear closed. The preference for fewer coherent PRs does not
-justify combining independently owned component designs.
+end-to-end system appear closed. PR coherence does not justify combining
+independently owned component designs.
 
 A **broad design** sweeps an end-to-end lifecycle such as acquisition,
 analysis, publication, and presentation or, outside the bounded one-donor
@@ -875,6 +875,17 @@ Before requesting another block, answer:
    decision is not standing authorization; identify the new evidence that makes
    implementation rounds the better investment.
 
+When a PR reaches round 12, split the remaining work into focused successors
+unless the checkpoint establishes a strong reason to keep the PR intact and
+the user explicitly approves that exception. The strong reason must explain
+why the remaining claims cannot become independently reviewable successors,
+why the reviews are still converging, and why continuing the same PR is safer
+than splitting it. Reviewer familiarity, sunk cost, or the inconvenience of
+restacking are not strong reasons. Sprawling changes accumulated across review
+comments are themselves a sign that the remaining work should be split into
+focused successors. The same presumption and burden apply at every 6-round
+boundary after round 12.
+
 At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
 
 1. **Would a design doc better define the design space?** Foundational APIs
@@ -883,11 +894,11 @@ At round 12 and every 6-round boundary after (18, 24, and so on), also answer:
    hardening to followup work would unlock this PR's value for other agent
    work sooner.
 
-State the proposed remedy and end with one recommendation: approve the next
-implementation block, switch to a docs-only design PR, or stop. If consecutive
-rounds only strengthen the harness while the product goes unchallenged, report
-that count and recommend a final round or a stop waiver rather than continuing
-by reflex.
+State the proposed remedy and end with one recommendation: split into focused
+successors, approve the next implementation block under the strong-reason
+exception, switch to a docs-only design PR, or stop. If consecutive rounds only
+strengthen the harness while the product goes unchallenged, report that count
+and recommend splitting or stopping rather than continuing by reflex.
 
 Publish the complete checkpoint as normal session output before opening the
 approval prompt. The prompt asks only which recommended action to authorize; it
@@ -914,8 +925,6 @@ Put it under `## Demo` above validation in the PR body.
 
 ## PR and CI discipline
 
-- Prefer fewer coherent PRs over mechanical splits; use a stack for genuinely
-  independent slices.
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
 - Label a documentation-only PR (no product code, test, or build changes)
   `documentation` when opening it.
@@ -925,6 +934,13 @@ Put it under `## Demo` above validation in the PR body.
   flag distinction, not platform-specific. Verify with
   `gh pr view <n> --json body -q .body` after creating or editing a PR body
   this way.
+- Avoid high-level `gh` commands when they fail by querying deprecated GraphQL
+  fields. In particular, `gh pr edit` may hit the removed Projects (classic)
+  fields even when changing unrelated metadata. Do not retry it; use the
+  operation-specific REST endpoint through `gh api` instead, such as
+  `PATCH repos/{owner}/{repo}/pulls/{n}` for PR title, body, or base changes,
+  and the corresponding issue endpoint for labels, assignees, or milestones.
+  Verify the resulting metadata after the REST update.
 - Treat CI as confirmation: run the focused local gate, then push promptly.
   Run eligible local suites, CI, and review concurrently.
 - Use [status discovery](docs/round-orchestration.md#status-discovery): REST by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -698,16 +698,19 @@ reopen the locked candidate.
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
 | First attempt at round 1 | Pushed settled head, recorded effective base, focused gate | CI and mergeability |
-| Documentation-only attempt at any round | Pushed settled head, recorded effective base, zero conflicts, pre-commit `markdownlint` | CI and mergeability |
 | Ordinary subsequent round | First-attempt requirements, zero conflicts, green current-head `ci-required` | Nothing required |
 | Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, zero conflicts, green current-head `ci-required` | Nothing required |
 
-The documentation-only row overrides the other attempt rows. Run `markdownlint`
-before committing every documentation change. Once that commit is pushed,
-review may dispatch and the round may close without waiting for CI.
-`ci-required` remains mandatory for final merge readiness. The user may
-authorize review in parallel with CI for other changes.
+Documentation-only candidates do not wait for CI before review. Read the
+applicable attempt row with only two substitutions: `markdownlint` must pass
+before commit and replaces any requirement for green current-head
+`ci-required`, and `ci-required` may remain pending. Every other requirement
+still applies, including the settled push, recorded effective base, zero
+conflicts where required, and round authorization. A documentation-only round
+may close after reconciliation and the local lint gate; `ci-required` remains
+mandatory for final merge readiness. The user may authorize review in parallel
+with CI for other changes.
 
 #### Review-clean, and what it gates
 
@@ -738,6 +741,12 @@ least one reviewer returned a finding.
 - **Cancelled or evidenced transient failure:** keep the lock and retry the
   unchanged head. Repeat only with concrete transient evidence; otherwise treat
   it as requiring an author change.
+
+If final-gate CI fails after a documentation-only round closes, it does not
+reopen or renumber that completed round. Retry an evidenced transient failure
+at the unchanged head. If the failure requires an author change, remove
+`review-clean`, make the fix, and form a candidate at the next round number,
+respecting the next six-round authorization boundary.
 
 Never close with a required check red. A superseded attempt spends no round and
 gets no completion report. Let its reviewers finish or have cancellation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,9 @@ act on them**:
   prioritise, and that the next agent hitting the same wall can find instead of
   re-investigating it. If a flake blocks you and no issue exists, file one and
   cite it.
-- **`waiting`** takes a predicate a tool can evaluate against your `head`:
-  `check:<name>`, `checks`, `merge`, or `review`. Use it when nothing is wrong
+- **`waiting`** takes one or more comma-separated predicates a tool can evaluate
+  against your `head`: `check:<name>`, `checks`, `merge`, or `review`. The wait
+  ends only when every listed predicate clears. Use it when nothing is wrong
   and nothing is openable — a check that has not reported yet is not a defect
   and does not deserve an issue.
 
@@ -742,12 +743,12 @@ least one reviewer returned a finding.
   unchanged head. Repeat only with concrete transient evidence; otherwise treat
   it as requiring an author change.
 
-If final-gate CI reports a non-successful conclusion after a documentation-only
-round closes, it does not reopen or renumber that completed round. Retry a
-failed or cancelled run at the unchanged head only with concrete transient
-evidence. If the result requires an author change, remove `review-clean`, make
-the fix, and form a candidate at the next round number, respecting the next
-six-round authorization boundary.
+If final-gate `ci-required` reports any conclusion other than success after a
+documentation-only round closes, it does not reopen or renumber that completed
+round. Retry at the unchanged head only with concrete evidence that the result
+is transient and requires no author change. Otherwise remove `review-clean`,
+make the required fix, and form a candidate at the next round number,
+respecting the next six-round authorization boundary.
 
 Never close with a required check red. A superseded attempt spends no round and
 gets no completion report. Let its reviewers finish or have cancellation
@@ -901,13 +902,14 @@ comments are themselves a sign that the remaining work should be split into
 focused successors. The same presumption and burden apply at every 6-round
 boundary after round 12.
 
-After round 12 closes, the split recommendation puts the completed head in an
-immutable decision hold while the user decides. This is not a round lock; do
-not mutate the head or dispatch another round during the hold. If approved,
-publicly map every current claim and every finding — including resolved or
-dismissed findings and their resulting changes or rationale — to a focused
-successor, close the current PR as superseded without merging it, and open the
-successors from their effective base. Each successor starts at round 1;
+After round 12 or a later six-round boundary closes, the split recommendation
+puts the completed head in an immutable decision hold while the user decides.
+This is not a round lock; do not mutate the head or dispatch another round
+during the hold. If approved, publicly assign every current change, claim, and
+finding — including resolved or dismissed findings and their resulting changes
+or rationale — to a focused successor, or explicitly record why an item is
+being dropped. Close the current PR as superseded without merging it, and open
+the successors from their effective base. Each successor starts at round 1;
 reviews, round counts, and authorization blocks do not carry forward.
 
 At round 12 and every 6-round boundary after (18, 24, and so on), also answer:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -626,7 +626,8 @@ rather than duplicating their evolving commands and gates here.
 
 ### Markdown
 
-All changed Markdown must pass `markdownlint`. Run the fixer first when needed:
+All changed Markdown must pass `markdownlint` before commit. Run the fixer first
+when needed:
 
 ```bash
 npx markdownlint-cli --fix <file>
@@ -658,9 +659,11 @@ driving the loop is
    even when `review-clean` is present.
 6. **A round closes only when reconciled and green.** Both: the feedback is
    publicly reconciled, and every required current-head check and post-push gate
-   has succeeded. Until then the round number does not advance — a check that
-   goes red first makes the next push a failed-gate restart at the *same*
-   number, not the next round.
+   has succeeded. For a documentation-only PR, the pre-commit `markdownlint`
+   result is the per-round green gate; `ci-required` may remain pending until
+   final merge readiness. Until the applicable gate is green the round number
+   does not advance — a check that goes red first makes the next push a
+   failed-gate restart at the *same* number, not the next round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
@@ -695,14 +698,16 @@ reopen the locked candidate.
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
 | First attempt at round 1 | Pushed settled head, recorded effective base, focused gate | CI and mergeability |
+| Documentation-only attempt at any round | Pushed settled head, recorded effective base, zero conflicts, pre-commit `markdownlint` | CI and mergeability |
 | Ordinary subsequent round | First-attempt requirements, zero conflicts, green current-head `ci-required` | Nothing required |
 | Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, zero conflicts, green current-head `ci-required` | Nothing required |
 
-Markdown lint is the focused gate for documentation-only changes. A
-documentation conflict-recovery attempt may review before lint finishes, but
-cannot reconcile or close without it. The user may authorize review in parallel
-with CI.
+The documentation-only row overrides the other attempt rows. Run `markdownlint`
+before committing every documentation change. Once that commit is pushed,
+review may dispatch and the round may close without waiting for CI.
+`ci-required` remains mandatory for final merge readiness. The user may
+authorize review in parallel with CI for other changes.
 
 #### Review-clean, and what it gates
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -247,6 +247,10 @@ shared failure. `Waiting` records a predicate tooling can evaluate, such as
   not ask, set `HELP`, or wait for user input.
 - `wait` requires a non-empty `Blocked` or `Waiting` field and means the agent
   will resume when it clears.
+- When a completed documentation-only round is otherwise ready but
+  `ci-required` remains pending or missing, use
+  `Waiting: check:ci-required` and `Recommendation: wait`. Add `merge` to
+  `Waiting` when live mergeability is also unresolved.
 - `split into focused successors` is valid at round 12 and later six-round
   boundaries after the required checkpoint. It requests the user's split
   decision and follows the transition in

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -153,9 +153,9 @@ detects conflicts early.
 | `MERGEABLE`, documentation-only | Treat it as the expected CI completion check. If CI is unexpectedly pending, wait 10 minutes plus jitter. |
 | `MERGEABLE`, not documentation-only | Expect CI at about 35 minutes from the push; schedule the next check about 30 minutes out. |
 
-Read the table top-down: the first matching row wins. A failed or cancelled
-check outranks every mergeability value, because `MERGEABLE` describes the merge
-path and never means green. The green row is the exit: every other row schedules
+Read the table top-down: the first matching row wins. A non-successful check
+outranks every mergeability value, because `MERGEABLE` describes the merge path
+and never means green. The green row is the exit: every other row schedules
 another check, so polling stops only by reaching it or by leaving for a recovery
 transition.
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -145,7 +145,7 @@ detects conflicts early.
 
 | First check says | Do this |
 | --- | --- |
-| `ci-required` failed or was cancelled | Stop polling. Classify it and apply the applicable [recovery transition](../AGENTS.md#recovery-transitions). A settled red result is an answer, not something to wait out. |
+| `ci-required` completed without success | Stop polling. Classify it and apply the applicable [recovery transition](../AGENTS.md#recovery-transitions). A settled non-success result is an answer, not something to wait out. |
 | `CONFLICTING` | Apply the conflict transition in [Canonical round flow](../AGENTS.md#canonical-round-flow), then schedule a new five-minute check. |
 | `MERGEABLE`, `ci-required` green at this head | **Done. Stop polling** and proceed to whatever waited on the answer. |
 | `UNKNOWN`, CI green | Ask REST, which triggers the computation; see [resolving `UNKNOWN`](#resolving-unknown). |
@@ -221,7 +221,7 @@ Round <n> is complete for PR <number>.
 
 Reviews: <clean>/<required> clean — <status by reviewer>
 Blocked: <PR or issue numbers not yours to fix; omit when empty>
-Waiting: <tool-evaluable predicate; omit when empty>
+Waiting: <comma-separated tool-evaluable predicates; omit when empty>
 Recommendation: [continue, wait, merge, split into focused successors,
 approve next rounds, stop (reason)]
 
@@ -239,18 +239,21 @@ Classification must match the reviewer outcomes:
 
 `Reviews` records the dual-clean count that GitHub cannot observe. Every
 `Blocked` entry must be an existing PR or issue; file one before citing a new
-shared failure. `Waiting` records a predicate tooling can evaluate, such as
-`check:<name>`, `checks`, `merge`, or `review`; it is not a blocker.
+shared failure. `Waiting` records one or more comma-separated predicates tooling
+can evaluate, such as `check:<name>`, `checks`, `merge`, or `review`; it is not
+a blocker, and it clears only when every listed predicate clears.
 
 - `continue` means the next round is inside the current authorized six-round
   block. Emit the report, then immediately begin the next candidate cycle. Do
   not ask, set `HELP`, or wait for user input.
 - `wait` requires a non-empty `Blocked` or `Waiting` field and means the agent
   will resume when it clears.
-- When a completed documentation-only round is otherwise ready but
-  `ci-required` remains pending or missing, use
-  `Waiting: check:ci-required` and `Recommendation: wait`. Add `merge` to
-  `Waiting` when live mergeability is also unresolved.
+- When a completed documentation-only round is review-clean and no further
+  author or review round is needed, but `ci-required` remains pending or
+  missing, use `Waiting: check:ci-required` and `Recommendation: wait`. Use
+  `Waiting: check:ci-required,merge` when live mergeability is also unresolved.
+  An intermediate or fix-producing round still reports `continue` and does not
+  wait for CI.
 - `split into focused successors` is valid at round 12 and later six-round
   boundaries after the required checkpoint. It requests the user's split
   decision and follows the transition in

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -221,7 +221,9 @@ Round <n> is complete for PR <number>.
 
 Reviews: <clean>/<required> clean — <status by reviewer>
 Blocked: <PR or issue numbers not yours to fix; omit when empty>
-Recommendation: [continue, wait, merge, approve next rounds, stop (reason)]
+Waiting: <tool-evaluable predicate; omit when empty>
+Recommendation: [continue, wait, merge, split into focused successors,
+approve next rounds, stop (reason)]
 
 Fix description: <prose description of changes made in response to the round>.
 ```
@@ -237,18 +239,23 @@ Classification must match the reviewer outcomes:
 
 `Reviews` records the dual-clean count that GitHub cannot observe. Every
 `Blocked` entry must be an existing PR or issue; file one before citing a new
-shared failure.
+shared failure. `Waiting` records a predicate tooling can evaluate, such as
+`check:<name>`, `checks`, `merge`, or `review`; it is not a blocker.
 
 - `continue` means the next round is inside the current authorized six-round
   block. Emit the report, then immediately begin the next candidate cycle. Do
   not ask, set `HELP`, or wait for user input.
-- `wait` requires a non-empty blocker list and means the agent will resume when
-  it clears.
+- `wait` requires a non-empty `Blocked` or `Waiting` field and means the agent
+  will resume when it clears.
+- `split into focused successors` is valid at round 12 and later six-round
+  boundaries after the required checkpoint. It requests the user's split
+  decision and follows the transition in
+  [Stop after six rounds](../AGENTS.md#stop-after-six-rounds).
 - `approve next rounds` is valid only after rounds 6, 12, 18, and so on, after
   the required architectural checkpoint. Never use it for an earlier round in
   the current block.
-- `merge`, `approve next rounds`, and `stop` request a user decision; `stop`
-  does not close anything until approved.
+- `merge`, `split into focused successors`, `approve next rounds`, and `stop`
+  request a user decision; `stop` does not close anything until approved.
 
 When the recommendation needs approval, render the complete report first as
 normal session output. Then open a separate prompt containing only the concise

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -304,8 +304,10 @@ a blocker, and it clears only when every listed predicate clears.
   author or review round is needed, but `ci-required` remains pending or
   missing, use `Waiting: check:ci-required` and `Recommendation: wait`. Use
   `Waiting: check:ci-required,merge` when live mergeability is also unresolved.
-  An intermediate or fix-producing round still reports `continue` and does not
-  wait for CI.
+  An intermediate or fix-producing round reports `continue` without waiting for
+  CI only when the next round remains inside the current authorized block. At a
+  six-round boundary, use the applicable approval, split, or stop recommendation
+  without waiting for CI.
 - `split into focused successors` is valid at round 12 and later six-round
   boundaries after the required checkpoint. It requests the user's split
   decision and follows the transition in


### PR DESCRIPTION
## Summary

- require focused successors after round 12 unless the user explicitly approves
  a documented strong-reason exception
- identify sprawling review-driven changes as a signal to split
- remove the preference for fewer, larger PRs
- document REST fallbacks when high-level `gh` commands query deprecated
  GraphQL fields
- let documentation-only review rounds use pre-commit `markdownlint` as their
  green gate while reserving CI for final merge readiness
- define report and transition mechanics for final-gate waiting and required
  round-12 splits

## Demo

Before, the review guidance allowed another implementation block after round 12
without a presumption that the work should split. It also preferred fewer
coherent PRs and did not explain how to recover when `gh pr edit` encountered
removed Projects (classic) fields.

After, round 12 defaults to focused successors, PR sizing is neutral, and
agents are directed to operation-specific REST endpoints for affected metadata
updates. Documentation-only reviews can also proceed without waiting for CI
after `markdownlint` passes before commit.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md`
