### PR TITLE
Extract reference join fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5404,11 +5404,6 @@ public sealed class SlotReuseSection
     public int Missing { get; set; }
 }
 
-public sealed class JoinTypeProvider
-{
-    public System.Type ResolvedType => typeof(string);
-}
-
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
 
 public interface CfgDimFace

--- a/src/ILInspector.Decompiler.Tests/ReferenceJoinSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceJoinSamples.cs
@@ -1,0 +1,6 @@
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class JoinTypeProvider
+{
+    public System.Type ResolvedType => typeof(string);
+}


### PR DESCRIPTION
Moves `JoinTypeProvider` unchanged from `CfgSampleClass.cs` into the feature-focused `ReferenceJoinSamples.cs` fixture file. `CfgSampleClass.NullConditionalCrossAssemblyReference` retains the same compiled provider identity and cross-assembly reference join behavior.

Part of #3913.

## Demo

`ReferenceJoin_NullLiteralAdoptsCrossAssemblyReferenceType` still imports the null-conditional `System.Type` join at Full fidelity with no join-type diagnostic after the source split.

## Validation

Exact head: `5b994272aa76752614a2e36217c83f3a16aa4e56`
Exact integrated base: `a92d037c7a0b9b1e38722240f058a29dc6da0157`

- `ReferenceJoin_NullLiteralAdoptsCrossAssemblyReferenceType`: 1 passed
- Release solution build: passed with 0 errors
- Decompiler fast gate: 5,644 passed with 8 expected Windows skips
- Stable-path render A/B: 22,132 methods; 0 changed, added, or removed
- CI: pending live current-head check

## Review

Round 1 used GPT-5.6 Sol and Claude Opus 5 on the exact head. Both returned clean; no findings or changes resulted.

## Non-action boundary

No symbols, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.