### PR TITLE
Encourage TLA+ for interaction modeling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,6 +357,20 @@ approval. Before requesting approval, present the component map, explain why
 focused designs cannot close independently, and name the intended claims and
 non-claims.
 
+### Keep specifications readable; model interactions
+
+Design specifications own detailed requirements, component boundaries, and
+policies. Keep them readable as prose and typed contracts; do not turn them
+into unconventional EBNF-like descriptions of operational behavior. When a
+feature's correctness depends on significant stateful, concurrent, distributed,
+or scheduling interactions, prefer a small TLA+ model that states the relevant
+safety and liveness properties and model-check it before implementation. Use
+the model to evaluate whether the interaction or algorithm is effective, and
+keep the design specification focused on what the system must guarantee. Link
+the model from the owning design and record the checked properties and any
+material counterexamples; the model supplements rather than replaces the
+readable specification.
+
 ### Reviewing focused designs
 
 Review a focused design against its named owner, owning document, immediate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,13 +363,16 @@ Design specifications own detailed requirements, component boundaries, and
 policies. Keep them readable as prose and typed contracts; do not turn them
 into unconventional EBNF-like descriptions of operational behavior. When a
 feature's correctness depends on significant stateful, concurrent, distributed,
-or scheduling interactions, prefer a small TLA+ model that states the relevant
-safety and liveness properties and model-check it before implementation. Use
+or scheduling interactions, use a small TLA+ model that states the relevant
+safety and liveness properties, and model-check it before implementation. Use
 the model to evaluate whether the interaction or algorithm is effective, and
 keep the design specification focused on what the system must guarantee. Link
-the model from the owning design and record the checked properties and any
-material counterexamples; the model supplements rather than replaces the
-readable specification.
+the model from the owning design and record its assumptions, checking bounds,
+checked properties, and any material counterexamples. These results establish
+evidence about the model, not the implementation. Implementation-level safety,
+soundness, or faithfulness claims must still follow
+[Asserted properties name their gate](#asserted-properties-name-their-gate).
+The model supplements rather than replaces the readable specification.
 
 ### Reviewing focused designs
 


### PR DESCRIPTION
## Summary

- Keep design specifications readable and focused on detailed requirements,
  component boundaries, policies, and typed contracts.
- Prefer a small TLA+ model before implementation when correctness depends on
  significant stateful, concurrent, distributed, or scheduling interactions.
- Record the checked safety and liveness properties, material counterexamples,
  and a link to the model from the owning design.

## Compatibility

This is repository guidance only and does not change product behavior.

## Validation

- `npx markdownlint-cli AGENTS.md`
