### PR TITLE
Extract object-initializer slot-reuse fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5398,12 +5398,6 @@ public sealed class JoinImpl : IJoinShape
     public string Shape() => "impl";
 }
 
-public sealed class SlotReuseSection
-{
-    public string Status { get; set; } = "";
-    public int Missing { get; set; }
-}
-
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
 
 public interface CfgDimFace

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerSlotReuseSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerSlotReuseSamples.cs
@@ -1,0 +1,7 @@
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class SlotReuseSection
+{
+    public string Status { get; set; } = "";
+    public int Missing { get; set; }
+}


### PR DESCRIPTION
Moves `SlotReuseSection` unchanged from `CfgSampleClass.cs` into the feature-focused `ObjectInitializerSlotReuseSamples.cs` fixture file. `CfgSampleClass.ReusedSlotStringListCount` retains the same compiled target identity and object-initializer slot-reuse behavior.

Part of #3913.

## Demo

`ReusedTempSpillFold_StringListCount_RaisesObjectInitializer` still raises `new SlotReuseSection { Status = ..., Missing = ... }` without leaking a mistyped carrier after the source split.

## Validation

Exact head: `2c76f4f7f39304065d6ea2ed460c871283898a9c`
Exact integrated base: `711fc3dd3c33eb6ed660f5c462fe72bea592cde9`

- `ReusedTempSpillFold_StringListCount_RaisesObjectInitializer`: 1 passed
- Release solution build: passed with 0 errors
- Decompiler fast gate: 5,644 passed with 8 expected Windows skips
- Stable-path render A/B: 22,132 methods; 0 changed, added, or removed
- CI: pending live current-head check

## Review

Round 1 used GPT-5.6 Sol and Claude Opus 5 on the exact head. Both returned clean; no findings or changes resulted.

## Non-action boundary

No symbols, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.