### PR TITLE
Model shared JSExport facade lifecycle with TLA+

### DIFF
--- a/docs/design/models/ts-jsexport-lifecycle/README.md
+++ b/docs/design/models/ts-jsexport-lifecycle/README.md
@@ -24,6 +24,12 @@ count. The model also includes runtime creation, assembly export acquisition,
 complete validation, state publication, managed-operation and entry-point
 calls, terminal failure, and atomic realm restart.
 
+One-step history variables retain the source phase and call-event state for
+each transition. The checked properties can therefore distinguish a legal
+post-initialization call from managed code invoked by the transition that
+publishes ready state, and can detect any ready or failed facade leaving its
+terminal phase without a realm restart.
+
 The model deliberately keeps these values abstract:
 
 - exact JavaScript property descriptors and dispatch keys;
@@ -66,11 +72,12 @@ Those concerns retain their concrete gates in the owning design and in
 | Failure publishes no partial state | `FailurePublishesNothing` |
 | A facade never disposes the shared runtime | `FacadeNeverDisposesRuntime` |
 | Managed operations and `runEntryPoint()` require readiness | `ManagedCallsRequireReady`, `EntryPointCallsRequireReady` |
-| Initialization invokes neither managed operations nor `runMain()` | `InitializationInvokesNoManagedCode` |
+| Calls begin only from ready, including the transition that publishes ready state | `ManagedCodeStartsReady` |
+| Initialization invokes neither managed operations nor `runMain()` | `InitializationInvokesNoManagedCode`, `ManagedCodeStartsReady` |
 | Requested initialization reaches ready or terminal failure | `RequestedEventuallyTerminates` |
 | A local facade failure does not prevent its peer from reaching ready | `LocalFailureIsolation` |
 | Valid facades both attach to the runtime | `AllFacadesEventuallyReady` |
-| Ready state is stable until realm restart | `ReadyPersistsWithinRealm` |
+| Ready and failed states are stable until realm restart | `TerminalPhasePersistsUntilRestart` |
 
 In the shared-in-flight positive trace, separate caller actions start both
 facades, one facade changes the runtime from absent to creating, the other
@@ -111,10 +118,10 @@ assembly roots, and at most one realm restart:
 
 | Configuration | Runtime/local failures | Generated states | Distinct states | Result |
 | --- | --- | ---: | ---: | --- |
-| `TsJsExportLifecycleShared.cfg` | Enabled | 10,110 | 1,784 | No error |
-| `TsJsExportLifecycleSharedSuccess.cfg` | Disabled | 7,535 | 1,316 | No error |
-| `TsJsExportLifecycleSerialized.cfg` | Enabled | 4,294 | 872 | No error |
-| `TsJsExportLifecycleSerializedSuccess.cfg` | Disabled | 3,135 | 560 | No error |
+| `TsJsExportLifecycleShared.cfg` | Enabled | 28,686 | 4,940 | No error |
+| `TsJsExportLifecycleSharedSuccess.cfg` | Disabled | 22,045 | 3,751 | No error |
+| `TsJsExportLifecycleSerialized.cfg` | Enabled | 11,409 | 2,180 | No error |
+| `TsJsExportLifecycleSerializedSuccess.cfg` | Disabled | 9,371 | 1,631 | No error |
 
 Generic deadlock checking is disabled because reaching terminal facade states
 after the final permitted restart is an expected finite-model endpoint.
@@ -124,7 +131,7 @@ directly.
 
 ## Counterexample mutations
 
-Ten opt-in configurations each enable one incorrect lifecycle transition and
+Twelve opt-in configurations each enable one incorrect lifecycle transition and
 must fail with the named invariant:
 
 | Configuration | Deliberate defect | Expected violation |
@@ -138,7 +145,9 @@ must fail with the named invariant:
 | `TsJsExportLifecycleFailPeer.cfg` | Fails the peer when one facade fails locally | `LocalFailureIsolation` |
 | `TsJsExportLifecycleFailPeerSerialized.cfg` | Fails a serialized peer after local failure | `LocalFailureIsolation` |
 | `TsJsExportLifecycleManagedDuringInit.cfg` | Invokes managed code while initialization is active | `InitializationInvokesNoManagedCode` |
-| `TsJsExportLifecycleLoseReady.cfg` | Leaves ready state without restarting the realm | `ReadyPersistsWithinRealm` |
+| `TsJsExportLifecycleManagedOnReadyTransition.cfg` | Invokes managed code on the transition that publishes ready state | `ManagedCodeStartsReady` |
+| `TsJsExportLifecycleLoseReady.cfg` | Leaves ready state without restarting the realm | `TerminalPhasePersistsUntilRestart` |
+| `TsJsExportLifecycleLoseFailure.cfg` | Leaves failed state without restarting the realm | `TerminalPhasePersistsUntilRestart` |
 
 Run a mutation by substituting its configuration name in the TLC command. A
 successful mutation run is a TLC invariant violation with a concrete state

--- a/docs/design/models/ts-jsexport-lifecycle/README.md
+++ b/docs/design/models/ts-jsexport-lifecycle/README.md
@@ -88,40 +88,39 @@ runtime without starting another one.
 
 ## Running TLC
 
-The recorded run used OpenJDK 21 and TLA+ tools 1.7.4 (`TLC2 2.19`,
-revision `5a47802`). The checked `tla2tools.jar` has SHA-256
-`936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88`.
+Follow the repository
+[TLA+ setup runbook](../../../runbooks/tla-plus-setup.md) for the pinned
+toolchain. The recorded run used OpenJDK 25.0.4 and TLA+ tools 1.8.0
+(`TLC2 2026.08.21.155922`, revision `9787e65`). The checked
+`tla2tools.jar` has SHA-256
+`eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a`.
 
 ```bash
-curl -fsSL \
-  https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar \
-  -o /tmp/tla2tools.jar
-echo "936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88  /tmp/tla2tools.jar" \
-  | sha256sum -c -
+TLA_TOOLS_JAR=/path/to/tla2tools.jar
 cd docs/design/models/ts-jsexport-lifecycle
-java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
-  -workers auto -cleanup \
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup \
   -config TsJsExportLifecycleShared.cfg TsJsExportLifecycle.tla
-java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
-  -workers auto -cleanup \
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup \
   -config TsJsExportLifecycleSharedSuccess.cfg TsJsExportLifecycle.tla
-java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
-  -workers auto -cleanup \
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup \
   -config TsJsExportLifecycleSerialized.cfg TsJsExportLifecycle.tla
-java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
-  -workers auto -cleanup \
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup \
   -config TsJsExportLifecycleSerializedSuccess.cfg TsJsExportLifecycle.tla
 ```
 
 All configurations use two facades, two callers per facade, two distinct
 assembly roots, and at most one realm restart:
 
-| Configuration | Runtime/local failures | Generated states | Distinct states | Result |
-| --- | --- | ---: | ---: | --- |
-| `TsJsExportLifecycleShared.cfg` | Enabled | 28,686 | 4,940 | No error |
-| `TsJsExportLifecycleSharedSuccess.cfg` | Disabled | 22,045 | 3,751 | No error |
-| `TsJsExportLifecycleSerialized.cfg` | Enabled | 11,409 | 2,180 | No error |
-| `TsJsExportLifecycleSerializedSuccess.cfg` | Disabled | 9,371 | 1,631 | No error |
+| Configuration | Runtime/local failures | Generated states | Distinct states | Maximum depth | Result |
+| --- | --- | ---: | ---: | ---: | --- |
+| `TsJsExportLifecycleShared.cfg` | Enabled | 28,686 | 4,940 | 24 | No error |
+| `TsJsExportLifecycleSharedSuccess.cfg` | Disabled | 22,045 | 3,751 | 28 | No error |
+| `TsJsExportLifecycleSerialized.cfg` | Enabled | 11,409 | 2,180 | 24 | No error |
+| `TsJsExportLifecycleSerializedSuccess.cfg` | Disabled | 9,371 | 1,631 | 28 | No error |
 
 Generic deadlock checking is disabled because reaching terminal facade states
 after the final permitted restart is an expected finite-model endpoint.
@@ -151,10 +150,13 @@ must fail with the named invariant:
 
 Run a mutation by substituting its configuration name in the TLC command. A
 successful mutation run is a TLC invariant violation with a concrete state
-trace; a clean exit means the mutation gate is vacuous or broken.
+trace; a clean exit means the mutation gate is vacuous or broken. With TLA+
+tools 1.8.0, pass `-noGenerateSpecTE` when the trace-exploration files are not
+needed.
+
 Mutation state counts are intentionally not recorded because parallel TLC
 workers can encounter the first violating state at different points. Every
-configuration was also run with `-workers 1` and produced its named violation.
+configuration was run with `-workers 1` and produced its named violation.
 These mutations target the lifecycle properties most likely to regress; they
 are non-vacuity evidence, not a requirement to manufacture one mutation per
 checked invariant.

--- a/docs/design/models/ts-jsexport-lifecycle/README.md
+++ b/docs/design/models/ts-jsexport-lifecycle/README.md
@@ -1,0 +1,151 @@
+# ts-jsexport lifecycle model
+
+This directory model-checks the lifecycle interaction defined by
+[`ts-jsexport`](../../ts-jsexport.md). It supplements that readable
+specification; it does not define TypeScript emission or prove an
+implementation.
+
+## Scope
+
+`TsJsExportLifecycle.tla` models two generated facade modules, two callers per
+facade, two assembly-specific export roots, and one SDK-owned runtime in a
+JavaScript realm. It checks both coordination modes permitted by the design:
+
+- `SharedInFlight`: both facade modules begin initialization concurrently and
+  attach through runtime-owner coordination.
+- `Serialized`: the consumer starts the second facade only after the first
+  reaches a terminal result. A local failure therefore does not strand the
+  second facade, which can still reuse the completed runtime.
+
+Each caller issues its own initialization request. The first request for a
+facade starts its state machine; concurrent and later requests join the same
+ready or failed result without incrementing that facade's initialization
+count. The model also includes runtime creation, assembly export acquisition,
+complete validation, state publication, managed-operation and entry-point
+calls, terminal failure, and atomic realm restart.
+
+The model deliberately keeps these values abstract:
+
+- exact JavaScript property descriptors and dispatch keys;
+- generated TypeScript names and wire declarations;
+- managed operation arguments and results;
+- SDK implementation details below runtime creation completion; and
+- browser worker and message transport policy.
+
+Those concerns retain their concrete gates in the owning design and in
+[#4842](https://github.com/richlander/dotnet-inspect/issues/4842).
+
+## Assumptions
+
+- One imported SDK builder owns one runtime state per JavaScript realm.
+- The consumer either serializes facade initialization or supplies shared
+  in-flight runtime coordination.
+- Each bounded caller eventually requests initialization. Runtime creation,
+  assembly acquisition, and validation eventually complete when enabled.
+  `Spec` states those weak-fairness assumptions explicitly.
+- Runtime creation may fail for every attached facade. Local acquisition and
+  validation failures are limited to `FacadeA` so the model can check that
+  `FacadeB` remains able to use the shared runtime.
+- A realm restart atomically discards all facade-local and runtime lifecycle
+  state, after which the same bounded startup scenario begins again.
+- The checked configurations permit one realm restart. The bound covers state
+  reset and a complete second startup without making the epoch unbounded.
+- Two facades and two callers per facade are sufficient to expose duplicate
+  creation, same-facade single-flight, cross-facade root use, and local failure
+  isolation. This bound does not prove arbitrary-cardinality performance.
+
+## Checked properties
+
+| Design property | Model property |
+| --- | --- |
+| One SDK runtime creation per realm | `OneSharedRuntimeCreation` |
+| Concurrent callers join one facade initialization | `OneInitializationPerFacade` |
+| Each facade acquires once | `OneAcquisitionPerFacade` |
+| A facade acquires and publishes only its assembly root | `AcquisitionUsesOwnAssembly`, `PublicationUsesOwnAssembly` |
+| Publication follows complete validation | `PublicationRequiresCompleteValidation`, `ReadyHasCompleteState` |
+| Failure publishes no partial state | `FailurePublishesNothing` |
+| A facade never disposes the shared runtime | `FacadeNeverDisposesRuntime` |
+| Managed operations and `runEntryPoint()` require readiness | `ManagedCallsRequireReady`, `EntryPointCallsRequireReady` |
+| Initialization invokes neither managed operations nor `runMain()` | `InitializationInvokesNoManagedCode` |
+| Requested initialization reaches ready or terminal failure | `RequestedEventuallyTerminates` |
+| A local facade failure does not prevent its peer from reaching ready | `LocalFailureIsolation` |
+| Valid facades both attach to the runtime | `AllFacadesEventuallyReady` |
+| Ready state is stable until realm restart | `ReadyPersistsWithinRealm` |
+
+In the shared-in-flight positive trace, separate caller actions start both
+facades, one facade changes the runtime from absent to creating, the other
+joins that creation, and each then acquires its own root. In the serialized
+positive trace, caller actions start only `FacadeA`; after it reaches a
+terminal result, callers start `FacadeB`, which observes the same completed
+runtime without starting another one.
+
+## Running TLC
+
+The recorded run used OpenJDK 21 and TLA+ tools 1.7.4 (`TLC2 2.19`,
+revision `5a47802`). The checked `tla2tools.jar` has SHA-256
+`936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88`.
+
+```bash
+curl -fsSL \
+  https://github.com/tlaplus/tlaplus/releases/download/v1.7.4/tla2tools.jar \
+  -o /tmp/tla2tools.jar
+echo "936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88  /tmp/tla2tools.jar" \
+  | sha256sum -c -
+cd docs/design/models/ts-jsexport-lifecycle
+java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+  -workers auto -cleanup \
+  -config TsJsExportLifecycleShared.cfg TsJsExportLifecycle.tla
+java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+  -workers auto -cleanup \
+  -config TsJsExportLifecycleSharedSuccess.cfg TsJsExportLifecycle.tla
+java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+  -workers auto -cleanup \
+  -config TsJsExportLifecycleSerialized.cfg TsJsExportLifecycle.tla
+java -XX:+UseParallelGC -cp /tmp/tla2tools.jar tlc2.TLC \
+  -workers auto -cleanup \
+  -config TsJsExportLifecycleSerializedSuccess.cfg TsJsExportLifecycle.tla
+```
+
+All configurations use two facades, two callers per facade, two distinct
+assembly roots, and at most one realm restart:
+
+| Configuration | Runtime/local failures | Generated states | Distinct states | Result |
+| --- | --- | ---: | ---: | --- |
+| `TsJsExportLifecycleShared.cfg` | Enabled | 10,110 | 1,784 | No error |
+| `TsJsExportLifecycleSharedSuccess.cfg` | Disabled | 7,535 | 1,316 | No error |
+| `TsJsExportLifecycleSerialized.cfg` | Enabled | 4,294 | 872 | No error |
+| `TsJsExportLifecycleSerializedSuccess.cfg` | Disabled | 3,135 | 560 | No error |
+
+Generic deadlock checking is disabled because reaching terminal facade states
+after the final permitted restart is an expected finite-model endpoint.
+`RequestedEventuallyTerminates`, `LocalFailureIsolation`, and
+`AllFacadesEventuallyReady` state the applicable progress requirements
+directly.
+
+## Counterexample mutations
+
+Ten opt-in configurations each enable one incorrect lifecycle transition and
+must fail with the named invariant:
+
+| Configuration | Deliberate defect | Expected violation |
+| --- | --- | --- |
+| `TsJsExportLifecycleEarlyPublication.cfg` | Publishes after acquisition but before validation | `PublicationRequiresCompleteValidation` |
+| `TsJsExportLifecycleDuplicateRuntime.cfg` | Starts a second runtime while one is in flight | `OneSharedRuntimeCreation` |
+| `TsJsExportLifecycleDuplicateFacade.cfg` | Starts facade initialization for every concurrent caller | `OneInitializationPerFacade` |
+| `TsJsExportLifecycleDuplicateAcquisition.cfg` | Starts a second acquisition before validation completes | `OneAcquisitionPerFacade` |
+| `TsJsExportLifecycleCrossAssembly.cfg` | Gives a facade the other assembly root | `AcquisitionUsesOwnAssembly` |
+| `TsJsExportLifecycleDisposeRuntime.cfg` | Disposes the shared runtime after local failure | `FacadeNeverDisposesRuntime` |
+| `TsJsExportLifecycleFailPeer.cfg` | Fails the peer when one facade fails locally | `LocalFailureIsolation` |
+| `TsJsExportLifecycleFailPeerSerialized.cfg` | Fails a serialized peer after local failure | `LocalFailureIsolation` |
+| `TsJsExportLifecycleManagedDuringInit.cfg` | Invokes managed code while initialization is active | `InitializationInvokesNoManagedCode` |
+| `TsJsExportLifecycleLoseReady.cfg` | Leaves ready state without restarting the realm | `ReadyPersistsWithinRealm` |
+
+Run a mutation by substituting its configuration name in the TLC command. A
+successful mutation run is a TLC invariant violation with a concrete state
+trace; a clean exit means the mutation gate is vacuous or broken.
+Mutation state counts are intentionally not recorded because parallel TLC
+workers can encounter the first violating state at different points. Every
+configuration was also run with `-workers 1` and produced its named violation.
+These mutations target the lifecycle properties most likely to regress; they
+are non-vacuity evidence, not a requirement to manufacture one mutation per
+checked invariant.

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla
@@ -1,0 +1,674 @@
+--------------------------- MODULE TsJsExportLifecycle ---------------------------
+EXTENDS FiniteSets, Naturals, TLC
+
+CONSTANTS
+    FacadeA,
+    FacadeB,
+    CallerA,
+    CallerB,
+    RootA,
+    RootB,
+    NoRoot,
+    NoEpoch,
+    Coordination,
+    AllowRuntimeFailure,
+    AllowLocalFailure,
+    FailableFacade,
+    MaxRestarts,
+    Mutation
+
+Facades == {FacadeA, FacadeB}
+Callers == {CallerA, CallerB}
+Roots == {RootA, RootB}
+
+Idle == "Idle"
+WaitingRuntime == "WaitingRuntime"
+AwaitingRuntime == "AwaitingRuntime"
+Acquiring == "Acquiring"
+Validating == "Validating"
+Ready == "Ready"
+Failed == "Failed"
+
+FacadePhases ==
+    {Idle, WaitingRuntime, AwaitingRuntime, Acquiring, Validating, Ready, Failed}
+ActivePhases == {WaitingRuntime, AwaitingRuntime, Acquiring, Validating}
+TerminalPhases == {Ready, Failed}
+
+RuntimeAbsent == "RuntimeAbsent"
+RuntimeCreating == "RuntimeCreating"
+RuntimeReady == "RuntimeReady"
+RuntimeFailed == "RuntimeFailed"
+RuntimePhases == {RuntimeAbsent, RuntimeCreating, RuntimeReady, RuntimeFailed}
+
+NoFailure == "NoFailure"
+RuntimeCreationFailure == "RuntimeCreationFailure"
+ExportAcquisitionFailure == "ExportAcquisitionFailure"
+ExportValidationFailure == "ExportValidationFailure"
+PeerInvalidation == "PeerInvalidation"
+LostReadyState == "LostReadyState"
+FailureKinds ==
+    {NoFailure,
+     RuntimeCreationFailure,
+     ExportAcquisitionFailure,
+     ExportValidationFailure,
+     PeerInvalidation,
+     LostReadyState}
+
+SharedInFlight == "SharedInFlight"
+Serialized == "Serialized"
+
+NoMutation == "None"
+EarlyPublication == "EarlyPublication"
+DuplicateRuntimeCreation == "DuplicateRuntimeCreation"
+DuplicateFacadeInitialization == "DuplicateFacadeInitialization"
+DuplicateAcquisition == "DuplicateAcquisition"
+CrossAssemblyRoot == "CrossAssemblyRoot"
+DisposeRuntimeOnFailure == "DisposeRuntimeOnFailure"
+FailPeerOnLocalFailure == "FailPeerOnLocalFailure"
+InvokeManagedDuringInitialization == "InvokeManagedDuringInitialization"
+LoseReadyWithoutRestart == "LoseReadyWithoutRestart"
+Mutations ==
+    {NoMutation,
+     EarlyPublication,
+     DuplicateRuntimeCreation,
+     DuplicateFacadeInitialization,
+     DuplicateAcquisition,
+     CrossAssemblyRoot,
+     DisposeRuntimeOnFailure,
+     FailPeerOnLocalFailure,
+     InvokeManagedDuringInitialization,
+     LoseReadyWithoutRestart}
+
+ASSUME
+    /\ Cardinality(Facades) = 2
+    /\ Cardinality(Callers) = 2
+    /\ Cardinality(Roots) = 2
+    /\ NoRoot \notin Roots
+    /\ NoEpoch \notin Nat
+    /\ Coordination \in {SharedInFlight, Serialized}
+    /\ AllowRuntimeFailure \in BOOLEAN
+    /\ AllowLocalFailure \in BOOLEAN
+    /\ FailableFacade \in Facades
+    /\ MaxRestarts \in Nat
+    /\ Mutation \in Mutations
+
+ExpectedRoot(f) == IF f = FacadeA THEN RootA ELSE RootB
+OtherFacade(f) == IF f = FacadeA THEN FacadeB ELSE FacadeA
+
+VARIABLES
+    phase,
+    waiters,
+    runtimePhase,
+    runtimeStarts,
+    initializationStarts,
+    acquisitionStarts,
+    acquiredRoot,
+    publishedRoot,
+    failureKind,
+    isolationOwed,
+    runtimeDisposed,
+    managedCallEpoch,
+    entryPointCallEpoch,
+    readyEpoch,
+    realmEpoch
+
+vars ==
+    <<phase,
+      waiters,
+      runtimePhase,
+      runtimeStarts,
+      initializationStarts,
+      acquisitionStarts,
+      acquiredRoot,
+      publishedRoot,
+      failureKind,
+      isolationOwed,
+      runtimeDisposed,
+      managedCallEpoch,
+      entryPointCallEpoch,
+      readyEpoch,
+      realmEpoch>>
+
+Init ==
+    /\ phase = [f \in Facades |-> Idle]
+    /\ waiters = [f \in Facades |-> {}]
+    /\ runtimePhase = RuntimeAbsent
+    /\ runtimeStarts = 0
+    /\ initializationStarts = [f \in Facades |-> 0]
+    /\ acquisitionStarts = [f \in Facades |-> 0]
+    /\ acquiredRoot = [f \in Facades |-> NoRoot]
+    /\ publishedRoot = [f \in Facades |-> NoRoot]
+    /\ failureKind = [f \in Facades |-> NoFailure]
+    /\ isolationOwed = [f \in Facades |-> FALSE]
+    /\ runtimeDisposed = FALSE
+    /\ managedCallEpoch = [f \in Facades |-> NoEpoch]
+    /\ entryPointCallEpoch = [f \in Facades |-> NoEpoch]
+    /\ readyEpoch = [f \in Facades |-> NoEpoch]
+    /\ realmEpoch = 0
+
+CanRequest(f) ==
+    \/ Coordination = SharedInFlight
+    \/ f = FacadeA
+    \/ phase[FacadeA] \in TerminalPhases
+
+RequestInitialization(f, c) ==
+    /\ CanRequest(f)
+    /\ c \notin waiters[f]
+    /\ waiters' = [waiters EXCEPT ![f] = @ \cup {c}]
+    /\ phase' =
+        IF phase[f] = Idle
+        THEN [phase EXCEPT ![f] = WaitingRuntime]
+        ELSE phase
+    /\ initializationStarts' =
+        IF phase[f] = Idle \/ Mutation = DuplicateFacadeInitialization
+        THEN [initializationStarts EXCEPT ![f] = @ + 1]
+        ELSE initializationStarts
+    /\ UNCHANGED
+        <<runtimePhase,
+          runtimeStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+StartRuntime(f) ==
+    /\ phase[f] = WaitingRuntime
+    /\ runtimePhase = RuntimeAbsent
+    /\ phase' = [phase EXCEPT ![f] = AwaitingRuntime]
+    /\ runtimePhase' = RuntimeCreating
+    /\ runtimeStarts' = runtimeStarts + 1
+    /\ managedCallEpoch' =
+        IF Mutation = InvokeManagedDuringInitialization
+        THEN [managedCallEpoch EXCEPT ![f] = realmEpoch]
+        ELSE managedCallEpoch
+    /\ entryPointCallEpoch' =
+        IF Mutation = InvokeManagedDuringInitialization
+        THEN [entryPointCallEpoch EXCEPT ![f] = realmEpoch]
+        ELSE entryPointCallEpoch
+    /\ UNCHANGED
+        <<waiters,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          readyEpoch,
+          realmEpoch>>
+
+JoinRuntimeCreation(f) ==
+    /\ Coordination = SharedInFlight
+    /\ phase[f] = WaitingRuntime
+    /\ runtimePhase = RuntimeCreating
+    /\ phase' = [phase EXCEPT ![f] = AwaitingRuntime]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+StartDuplicateRuntime(f) ==
+    /\ Mutation = DuplicateRuntimeCreation
+    /\ phase[f] = WaitingRuntime
+    /\ runtimePhase = RuntimeCreating
+    /\ phase' = [phase EXCEPT ![f] = AwaitingRuntime]
+    /\ runtimeStarts' = runtimeStarts + 1
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CompleteRuntimeSuccess ==
+    /\ runtimePhase = RuntimeCreating
+    /\ runtimePhase' = RuntimeReady
+    /\ UNCHANGED
+        <<phase,
+          waiters,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CompleteRuntimeFailure ==
+    /\ AllowRuntimeFailure
+    /\ runtimePhase = RuntimeCreating
+    /\ runtimePhase' = RuntimeFailed
+    /\ UNCHANGED
+        <<phase,
+          waiters,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+UseReadyRuntime(f) ==
+    /\ phase[f] \in {WaitingRuntime, AwaitingRuntime}
+    /\ runtimePhase = RuntimeReady
+    /\ phase' = [phase EXCEPT ![f] = Acquiring]
+    /\ acquisitionStarts' = [acquisitionStarts EXCEPT ![f] = @ + 1]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+ObserveFailedRuntime(f) ==
+    /\ phase[f] \in {WaitingRuntime, AwaitingRuntime}
+    /\ runtimePhase = RuntimeFailed
+    /\ phase' = [phase EXCEPT ![f] = Failed]
+    /\ failureKind' =
+        [failureKind EXCEPT ![f] = RuntimeCreationFailure]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CompleteAcquisitionSuccess(f) ==
+    /\ phase[f] = Acquiring
+    /\ phase' = [phase EXCEPT ![f] = Validating]
+    /\ acquiredRoot' =
+        [acquiredRoot EXCEPT
+            ![f] =
+                IF Mutation = CrossAssemblyRoot
+                THEN ExpectedRoot(OtherFacade(f))
+                ELSE ExpectedRoot(f)]
+    /\ publishedRoot' =
+        IF Mutation = EarlyPublication
+        THEN [publishedRoot EXCEPT ![f] = ExpectedRoot(f)]
+        ELSE publishedRoot
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CompleteAcquisitionFailure(f) ==
+    /\ AllowLocalFailure
+    /\ f = FailableFacade
+    /\ phase[f] = Acquiring
+    /\ phase' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [phase EXCEPT
+                ![f] = Failed,
+                ![OtherFacade(f)] = Failed]
+        ELSE [phase EXCEPT ![f] = Failed]
+    /\ failureKind' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [failureKind EXCEPT
+                ![f] = ExportAcquisitionFailure,
+                ![OtherFacade(f)] = PeerInvalidation]
+        ELSE [failureKind EXCEPT ![f] = ExportAcquisitionFailure]
+    /\ isolationOwed' =
+        [isolationOwed EXCEPT ![f] = phase[OtherFacade(f)] # Ready]
+    /\ publishedRoot' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [publishedRoot EXCEPT ![OtherFacade(f)] = NoRoot]
+        ELSE publishedRoot
+    /\ readyEpoch' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [readyEpoch EXCEPT ![OtherFacade(f)] = NoEpoch]
+        ELSE readyEpoch
+    /\ runtimePhase' =
+        IF Mutation = DisposeRuntimeOnFailure
+        THEN RuntimeAbsent
+        ELSE runtimePhase
+    /\ runtimeDisposed' =
+        IF Mutation = DisposeRuntimeOnFailure
+        THEN TRUE
+        ELSE runtimeDisposed
+    /\ UNCHANGED
+        <<waiters,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          realmEpoch>>
+
+StartDuplicateAcquisition(f) ==
+    /\ Mutation = DuplicateAcquisition
+    /\ phase[f] = Validating
+    /\ runtimePhase = RuntimeReady
+    /\ phase' = [phase EXCEPT ![f] = Acquiring]
+    /\ acquisitionStarts' = [acquisitionStarts EXCEPT ![f] = @ + 1]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CompleteValidationSuccess(f) ==
+    /\ phase[f] = Validating
+    /\ phase' = [phase EXCEPT ![f] = Ready]
+    /\ publishedRoot' = [publishedRoot EXCEPT ![f] = acquiredRoot[f]]
+    /\ isolationOwed' =
+        [isolationOwed EXCEPT ![OtherFacade(f)] = FALSE]
+    /\ readyEpoch' = [readyEpoch EXCEPT ![f] = realmEpoch]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          failureKind,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          realmEpoch>>
+
+CompleteValidationFailure(f) ==
+    /\ AllowLocalFailure
+    /\ f = FailableFacade
+    /\ phase[f] = Validating
+    /\ phase' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [phase EXCEPT
+                ![f] = Failed,
+                ![OtherFacade(f)] = Failed]
+        ELSE [phase EXCEPT ![f] = Failed]
+    /\ acquiredRoot' = [acquiredRoot EXCEPT ![f] = NoRoot]
+    /\ publishedRoot' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [publishedRoot EXCEPT
+                ![f] = NoRoot,
+                ![OtherFacade(f)] = NoRoot]
+        ELSE [publishedRoot EXCEPT ![f] = NoRoot]
+    /\ failureKind' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [failureKind EXCEPT
+                ![f] = ExportValidationFailure,
+                ![OtherFacade(f)] = PeerInvalidation]
+        ELSE [failureKind EXCEPT ![f] = ExportValidationFailure]
+    /\ isolationOwed' =
+        [isolationOwed EXCEPT ![f] = phase[OtherFacade(f)] # Ready]
+    /\ readyEpoch' =
+        IF Mutation = FailPeerOnLocalFailure
+        THEN [readyEpoch EXCEPT ![OtherFacade(f)] = NoEpoch]
+        ELSE readyEpoch
+    /\ runtimePhase' =
+        IF Mutation = DisposeRuntimeOnFailure
+        THEN RuntimeAbsent
+        ELSE runtimePhase
+    /\ runtimeDisposed' =
+        IF Mutation = DisposeRuntimeOnFailure
+        THEN TRUE
+        ELSE runtimeDisposed
+    /\ UNCHANGED
+        <<waiters,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          realmEpoch>>
+
+CallManagedOperation(f) ==
+    /\ phase[f] = Ready
+    /\ managedCallEpoch' = [managedCallEpoch EXCEPT ![f] = realmEpoch]
+    /\ UNCHANGED
+        <<phase,
+          waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+CallEntryPoint(f) ==
+    /\ phase[f] = Ready
+    /\ entryPointCallEpoch' = [entryPointCallEpoch EXCEPT ![f] = realmEpoch]
+    /\ UNCHANGED
+        <<phase,
+          waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          failureKind,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+LoseReadyState(f) ==
+    /\ Mutation = LoseReadyWithoutRestart
+    /\ phase[f] = Ready
+    /\ phase' = [phase EXCEPT ![f] = Failed]
+    /\ failureKind' = [failureKind EXCEPT ![f] = LostReadyState]
+    /\ publishedRoot' = [publishedRoot EXCEPT ![f] = NoRoot]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
+          readyEpoch,
+          realmEpoch>>
+
+RestartRealm ==
+    /\ \A f \in Facades : phase[f] \in TerminalPhases
+    /\ \A f \in Facades : ~isolationOwed[f]
+    /\ realmEpoch < MaxRestarts
+    /\ phase' = [f \in Facades |-> Idle]
+    /\ waiters' = [f \in Facades |-> {}]
+    /\ runtimePhase' = RuntimeAbsent
+    /\ runtimeStarts' = 0
+    /\ initializationStarts' = [f \in Facades |-> 0]
+    /\ acquisitionStarts' = [f \in Facades |-> 0]
+    /\ acquiredRoot' = [f \in Facades |-> NoRoot]
+    /\ publishedRoot' = [f \in Facades |-> NoRoot]
+    /\ failureKind' = [f \in Facades |-> NoFailure]
+    /\ isolationOwed' = [f \in Facades |-> FALSE]
+    /\ runtimeDisposed' = FALSE
+    /\ managedCallEpoch' = [f \in Facades |-> NoEpoch]
+    /\ entryPointCallEpoch' = [f \in Facades |-> NoEpoch]
+    /\ readyEpoch' = [f \in Facades |-> NoEpoch]
+    /\ realmEpoch' = realmEpoch + 1
+
+FacadeProgress(f) ==
+    \/ StartRuntime(f)
+    \/ JoinRuntimeCreation(f)
+    \/ StartDuplicateRuntime(f)
+    \/ UseReadyRuntime(f)
+    \/ ObserveFailedRuntime(f)
+    \/ CompleteAcquisitionSuccess(f)
+    \/ CompleteAcquisitionFailure(f)
+    \/ StartDuplicateAcquisition(f)
+    \/ CompleteValidationSuccess(f)
+    \/ CompleteValidationFailure(f)
+    \/ LoseReadyState(f)
+
+RuntimeProgress == CompleteRuntimeSuccess \/ CompleteRuntimeFailure
+
+Next ==
+    \/ \E f \in Facades, c \in Callers : RequestInitialization(f, c)
+    \/ RuntimeProgress
+    \/ \E f \in Facades : FacadeProgress(f)
+    \/ \E f \in Facades : CallManagedOperation(f)
+    \/ \E f \in Facades : CallEntryPoint(f)
+    \/ RestartRealm
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ \A f \in Facades, c \in Callers :
+        WF_vars(RequestInitialization(f, c))
+    /\ WF_vars(RuntimeProgress)
+    /\ \A f \in Facades : WF_vars(FacadeProgress(f))
+
+TypeOK ==
+    /\ phase \in [Facades -> FacadePhases]
+    /\ waiters \in [Facades -> SUBSET Callers]
+    /\ runtimePhase \in RuntimePhases
+    /\ runtimeStarts \in Nat
+    /\ initializationStarts \in [Facades -> Nat]
+    /\ acquisitionStarts \in [Facades -> Nat]
+    /\ acquiredRoot \in [Facades -> Roots \cup {NoRoot}]
+    /\ publishedRoot \in [Facades -> Roots \cup {NoRoot}]
+    /\ failureKind \in [Facades -> FailureKinds]
+    /\ isolationOwed \in [Facades -> BOOLEAN]
+    /\ runtimeDisposed \in BOOLEAN
+    /\ managedCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
+    /\ entryPointCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
+    /\ readyEpoch \in [Facades -> Nat \cup {NoEpoch}]
+    /\ realmEpoch \in Nat
+
+OneSharedRuntimeCreation == runtimeStarts <= 1
+
+OneInitializationPerFacade ==
+    \A f \in Facades : initializationStarts[f] <= 1
+
+OneAcquisitionPerFacade ==
+    \A f \in Facades : acquisitionStarts[f] <= 1
+
+AcquisitionUsesOwnAssembly ==
+    \A f \in Facades :
+        acquiredRoot[f] = NoRoot \/ acquiredRoot[f] = ExpectedRoot(f)
+
+PublicationUsesOwnAssembly ==
+    \A f \in Facades :
+        publishedRoot[f] = NoRoot \/ publishedRoot[f] = ExpectedRoot(f)
+
+PublicationRequiresCompleteValidation ==
+    \A f \in Facades : publishedRoot[f] # NoRoot => phase[f] = Ready
+
+FailurePublishesNothing ==
+    \A f \in Facades : phase[f] = Failed => publishedRoot[f] = NoRoot
+
+ReadyHasCompleteState ==
+    \A f \in Facades :
+        phase[f] = Ready =>
+            /\ runtimePhase = RuntimeReady
+            /\ acquiredRoot[f] = ExpectedRoot(f)
+            /\ publishedRoot[f] = ExpectedRoot(f)
+
+ReadyPersistsWithinRealm ==
+    \A f \in Facades :
+        (phase[f] = Ready) <=> (readyEpoch[f] = realmEpoch)
+
+FacadeNeverDisposesRuntime == ~runtimeDisposed
+
+ManagedCallsRequireReady ==
+    \A f \in Facades :
+        managedCallEpoch[f] = NoEpoch \/
+        (managedCallEpoch[f] = realmEpoch /\ phase[f] = Ready)
+
+EntryPointCallsRequireReady ==
+    \A f \in Facades :
+        entryPointCallEpoch[f] = NoEpoch \/
+        (entryPointCallEpoch[f] = realmEpoch /\ phase[f] = Ready)
+
+InitializationInvokesNoManagedCode ==
+    \A f \in Facades :
+        phase[f] \in ActivePhases =>
+            /\ managedCallEpoch[f] # realmEpoch
+            /\ entryPointCallEpoch[f] # realmEpoch
+
+RequestedEventuallyTerminates ==
+    \A f \in Facades :
+        (waiters[f] # {} /\ phase[f] \notin TerminalPhases)
+        ~> phase[f] \in TerminalPhases
+
+AllFacadesEventuallyReady ==
+    []<>(\A f \in Facades : phase[f] = Ready)
+
+LocalFailureIsolation ==
+    \A f \in Facades : isolationOwed[f] ~> ~isolationOwed[f]
+
+=============================================================================

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla
@@ -46,13 +46,15 @@ ExportAcquisitionFailure == "ExportAcquisitionFailure"
 ExportValidationFailure == "ExportValidationFailure"
 PeerInvalidation == "PeerInvalidation"
 LostReadyState == "LostReadyState"
+LostFailedState == "LostFailedState"
 FailureKinds ==
     {NoFailure,
      RuntimeCreationFailure,
      ExportAcquisitionFailure,
      ExportValidationFailure,
      PeerInvalidation,
-     LostReadyState}
+     LostReadyState,
+     LostFailedState}
 
 SharedInFlight == "SharedInFlight"
 Serialized == "Serialized"
@@ -66,7 +68,9 @@ CrossAssemblyRoot == "CrossAssemblyRoot"
 DisposeRuntimeOnFailure == "DisposeRuntimeOnFailure"
 FailPeerOnLocalFailure == "FailPeerOnLocalFailure"
 InvokeManagedDuringInitialization == "InvokeManagedDuringInitialization"
+InvokeManagedOnReadyTransition == "InvokeManagedOnReadyTransition"
 LoseReadyWithoutRestart == "LoseReadyWithoutRestart"
+LoseFailureWithoutRestart == "LoseFailureWithoutRestart"
 Mutations ==
     {NoMutation,
      EarlyPublication,
@@ -77,7 +81,9 @@ Mutations ==
      DisposeRuntimeOnFailure,
      FailPeerOnLocalFailure,
      InvokeManagedDuringInitialization,
-     LoseReadyWithoutRestart}
+     InvokeManagedOnReadyTransition,
+     LoseReadyWithoutRestart,
+     LoseFailureWithoutRestart}
 
 ASSUME
     /\ Cardinality(Facades) = 2
@@ -109,8 +115,11 @@ VARIABLES
     runtimeDisposed,
     managedCallEpoch,
     entryPointCallEpoch,
-    readyEpoch,
-    realmEpoch
+    realmEpoch,
+    previousPhase,
+    previousRealmEpoch,
+    previousManagedCallEpoch,
+    previousEntryPointCallEpoch
 
 vars ==
     <<phase,
@@ -126,8 +135,11 @@ vars ==
       runtimeDisposed,
       managedCallEpoch,
       entryPointCallEpoch,
-      readyEpoch,
-      realmEpoch>>
+      realmEpoch,
+      previousPhase,
+      previousRealmEpoch,
+      previousManagedCallEpoch,
+      previousEntryPointCallEpoch>>
 
 Init ==
     /\ phase = [f \in Facades |-> Idle]
@@ -143,8 +155,11 @@ Init ==
     /\ runtimeDisposed = FALSE
     /\ managedCallEpoch = [f \in Facades |-> NoEpoch]
     /\ entryPointCallEpoch = [f \in Facades |-> NoEpoch]
-    /\ readyEpoch = [f \in Facades |-> NoEpoch]
     /\ realmEpoch = 0
+    /\ previousPhase = [f \in Facades |-> Idle]
+    /\ previousRealmEpoch = 0
+    /\ previousManagedCallEpoch = [f \in Facades |-> NoEpoch]
+    /\ previousEntryPointCallEpoch = [f \in Facades |-> NoEpoch]
 
 CanRequest(f) ==
     \/ Coordination = SharedInFlight
@@ -174,7 +189,6 @@ RequestInitialization(f, c) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 StartRuntime(f) ==
@@ -200,7 +214,6 @@ StartRuntime(f) ==
           failureKind,
           isolationOwed,
           runtimeDisposed,
-          readyEpoch,
           realmEpoch>>
 
 JoinRuntimeCreation(f) ==
@@ -221,7 +234,6 @@ JoinRuntimeCreation(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 StartDuplicateRuntime(f) ==
@@ -242,7 +254,6 @@ StartDuplicateRuntime(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CompleteRuntimeSuccess ==
@@ -261,7 +272,6 @@ CompleteRuntimeSuccess ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CompleteRuntimeFailure ==
@@ -281,7 +291,6 @@ CompleteRuntimeFailure ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 UseReadyRuntime(f) ==
@@ -301,7 +310,6 @@ UseReadyRuntime(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 ObserveFailedRuntime(f) ==
@@ -322,7 +330,6 @@ ObserveFailedRuntime(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CompleteAcquisitionSuccess(f) ==
@@ -349,7 +356,6 @@ CompleteAcquisitionSuccess(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CompleteAcquisitionFailure(f) ==
@@ -374,10 +380,6 @@ CompleteAcquisitionFailure(f) ==
         IF Mutation = FailPeerOnLocalFailure
         THEN [publishedRoot EXCEPT ![OtherFacade(f)] = NoRoot]
         ELSE publishedRoot
-    /\ readyEpoch' =
-        IF Mutation = FailPeerOnLocalFailure
-        THEN [readyEpoch EXCEPT ![OtherFacade(f)] = NoEpoch]
-        ELSE readyEpoch
     /\ runtimePhase' =
         IF Mutation = DisposeRuntimeOnFailure
         THEN RuntimeAbsent
@@ -414,7 +416,6 @@ StartDuplicateAcquisition(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CompleteValidationSuccess(f) ==
@@ -423,7 +424,14 @@ CompleteValidationSuccess(f) ==
     /\ publishedRoot' = [publishedRoot EXCEPT ![f] = acquiredRoot[f]]
     /\ isolationOwed' =
         [isolationOwed EXCEPT ![OtherFacade(f)] = FALSE]
-    /\ readyEpoch' = [readyEpoch EXCEPT ![f] = realmEpoch]
+    /\ managedCallEpoch' =
+        IF Mutation = InvokeManagedOnReadyTransition
+        THEN [managedCallEpoch EXCEPT ![f] = realmEpoch]
+        ELSE managedCallEpoch
+    /\ entryPointCallEpoch' =
+        IF Mutation = InvokeManagedOnReadyTransition
+        THEN [entryPointCallEpoch EXCEPT ![f] = realmEpoch]
+        ELSE entryPointCallEpoch
     /\ UNCHANGED
         <<waiters,
           runtimePhase,
@@ -433,8 +441,6 @@ CompleteValidationSuccess(f) ==
           acquiredRoot,
           failureKind,
           runtimeDisposed,
-          managedCallEpoch,
-          entryPointCallEpoch,
           realmEpoch>>
 
 CompleteValidationFailure(f) ==
@@ -462,10 +468,6 @@ CompleteValidationFailure(f) ==
         ELSE [failureKind EXCEPT ![f] = ExportValidationFailure]
     /\ isolationOwed' =
         [isolationOwed EXCEPT ![f] = phase[OtherFacade(f)] # Ready]
-    /\ readyEpoch' =
-        IF Mutation = FailPeerOnLocalFailure
-        THEN [readyEpoch EXCEPT ![OtherFacade(f)] = NoEpoch]
-        ELSE readyEpoch
     /\ runtimePhase' =
         IF Mutation = DisposeRuntimeOnFailure
         THEN RuntimeAbsent
@@ -499,7 +501,6 @@ CallManagedOperation(f) ==
           isolationOwed,
           runtimeDisposed,
           entryPointCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 CallEntryPoint(f) ==
@@ -518,7 +519,6 @@ CallEntryPoint(f) ==
           isolationOwed,
           runtimeDisposed,
           managedCallEpoch,
-          readyEpoch,
           realmEpoch>>
 
 LoseReadyState(f) ==
@@ -538,7 +538,25 @@ LoseReadyState(f) ==
           runtimeDisposed,
           managedCallEpoch,
           entryPointCallEpoch,
-          readyEpoch,
+          realmEpoch>>
+
+LoseFailedState(f) ==
+    /\ Mutation = LoseFailureWithoutRestart
+    /\ phase[f] = Failed
+    /\ phase' = [phase EXCEPT ![f] = AwaitingRuntime]
+    /\ failureKind' = [failureKind EXCEPT ![f] = LostFailedState]
+    /\ UNCHANGED
+        <<waiters,
+          runtimePhase,
+          runtimeStarts,
+          initializationStarts,
+          acquisitionStarts,
+          acquiredRoot,
+          publishedRoot,
+          isolationOwed,
+          runtimeDisposed,
+          managedCallEpoch,
+          entryPointCallEpoch,
           realmEpoch>>
 
 RestartRealm ==
@@ -558,7 +576,6 @@ RestartRealm ==
     /\ runtimeDisposed' = FALSE
     /\ managedCallEpoch' = [f \in Facades |-> NoEpoch]
     /\ entryPointCallEpoch' = [f \in Facades |-> NoEpoch]
-    /\ readyEpoch' = [f \in Facades |-> NoEpoch]
     /\ realmEpoch' = realmEpoch + 1
 
 FacadeProgress(f) ==
@@ -573,10 +590,11 @@ FacadeProgress(f) ==
     \/ CompleteValidationSuccess(f)
     \/ CompleteValidationFailure(f)
     \/ LoseReadyState(f)
+    \/ LoseFailedState(f)
 
 RuntimeProgress == CompleteRuntimeSuccess \/ CompleteRuntimeFailure
 
-Next ==
+RawNext ==
     \/ \E f \in Facades, c \in Callers : RequestInitialization(f, c)
     \/ RuntimeProgress
     \/ \E f \in Facades : FacadeProgress(f)
@@ -584,13 +602,22 @@ Next ==
     \/ \E f \in Facades : CallEntryPoint(f)
     \/ RestartRealm
 
+WithHistory(action) ==
+    /\ action
+    /\ previousPhase' = phase
+    /\ previousRealmEpoch' = realmEpoch
+    /\ previousManagedCallEpoch' = managedCallEpoch
+    /\ previousEntryPointCallEpoch' = entryPointCallEpoch
+
+Next == WithHistory(RawNext)
+
 Spec ==
     /\ Init
     /\ [][Next]_vars
     /\ \A f \in Facades, c \in Callers :
-        WF_vars(RequestInitialization(f, c))
-    /\ WF_vars(RuntimeProgress)
-    /\ \A f \in Facades : WF_vars(FacadeProgress(f))
+        WF_vars(WithHistory(RequestInitialization(f, c)))
+    /\ WF_vars(WithHistory(RuntimeProgress))
+    /\ \A f \in Facades : WF_vars(WithHistory(FacadeProgress(f)))
 
 TypeOK ==
     /\ phase \in [Facades -> FacadePhases]
@@ -606,8 +633,11 @@ TypeOK ==
     /\ runtimeDisposed \in BOOLEAN
     /\ managedCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
     /\ entryPointCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
-    /\ readyEpoch \in [Facades -> Nat \cup {NoEpoch}]
     /\ realmEpoch \in Nat
+    /\ previousPhase \in [Facades -> FacadePhases]
+    /\ previousRealmEpoch \in Nat
+    /\ previousManagedCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
+    /\ previousEntryPointCallEpoch \in [Facades -> Nat \cup {NoEpoch}]
 
 OneSharedRuntimeCreation == runtimeStarts <= 1
 
@@ -638,9 +668,11 @@ ReadyHasCompleteState ==
             /\ acquiredRoot[f] = ExpectedRoot(f)
             /\ publishedRoot[f] = ExpectedRoot(f)
 
-ReadyPersistsWithinRealm ==
+TerminalPhasePersistsUntilRestart ==
     \A f \in Facades :
-        (phase[f] = Ready) <=> (readyEpoch[f] = realmEpoch)
+        (previousPhase[f] \in TerminalPhases /\
+         previousRealmEpoch = realmEpoch)
+        => phase[f] = previousPhase[f]
 
 FacadeNeverDisposesRuntime == ~runtimeDisposed
 
@@ -659,6 +691,21 @@ InitializationInvokesNoManagedCode ==
         phase[f] \in ActivePhases =>
             /\ managedCallEpoch[f] # realmEpoch
             /\ entryPointCallEpoch[f] # realmEpoch
+
+ManagedCallsStartReady ==
+    \A f \in Facades :
+        ((managedCallEpoch[f] # previousManagedCallEpoch[f]) /\
+         managedCallEpoch[f] = realmEpoch)
+        => previousPhase[f] = Ready
+
+EntryPointCallsStartReady ==
+    \A f \in Facades :
+        ((entryPointCallEpoch[f] # previousEntryPointCallEpoch[f]) /\
+         entryPointCallEpoch[f] = realmEpoch)
+        => previousPhase[f] = Ready
+
+ManagedCodeStartsReady ==
+    ManagedCallsStartReady /\ EntryPointCallsStartReady
 
 RequestedEventuallyTerminates ==
     \A f \in Facades :

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleCrossAssembly.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleCrossAssembly.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "CrossAssemblyRoot"
+
+INVARIANT AcquisitionUsesOwnAssembly

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDisposeRuntime.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDisposeRuntime.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = TRUE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "DisposeRuntimeOnFailure"
+
+INVARIANT FacadeNeverDisposesRuntime

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateAcquisition.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateAcquisition.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "DuplicateAcquisition"
+
+INVARIANT OneAcquisitionPerFacade

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateFacade.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateFacade.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "DuplicateFacadeInitialization"
+
+INVARIANT OneInitializationPerFacade

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateRuntime.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleDuplicateRuntime.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "DuplicateRuntimeCreation"
+
+INVARIANT OneSharedRuntimeCreation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleEarlyPublication.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleEarlyPublication.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "EarlyPublication"
+
+INVARIANT PublicationRequiresCompleteValidation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleFailPeer.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleFailPeer.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = TRUE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "FailPeerOnLocalFailure"
+
+PROPERTY LocalFailureIsolation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleFailPeerSerialized.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleFailPeerSerialized.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "Serialized"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = TRUE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "FailPeerOnLocalFailure"
+
+PROPERTY LocalFailureIsolation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleLoseFailure.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleLoseFailure.cfg
@@ -11,10 +11,10 @@ CONSTANTS
     NoRoot = NoRoot
     NoEpoch = NoEpoch
     Coordination = "SharedInFlight"
-    AllowRuntimeFailure = FALSE
-    AllowLocalFailure = FALSE
+    AllowRuntimeFailure = TRUE
+    AllowLocalFailure = TRUE
     FailableFacade = FacadeA
     MaxRestarts = 1
-    Mutation = "LoseReadyWithoutRestart"
+    Mutation = "LoseFailureWithoutRestart"
 
 INVARIANT TerminalPhasePersistsUntilRestart

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleLoseReady.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleLoseReady.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "LoseReadyWithoutRestart"
+
+INVARIANT ReadyPersistsWithinRealm

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleManagedDuringInit.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleManagedDuringInit.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "InvokeManagedDuringInitialization"
+
+INVARIANT InitializationInvokesNoManagedCode

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleManagedOnReadyTransition.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleManagedOnReadyTransition.cfg
@@ -15,6 +15,6 @@ CONSTANTS
     AllowLocalFailure = FALSE
     FailableFacade = FacadeA
     MaxRestarts = 1
-    Mutation = "LoseReadyWithoutRestart"
+    Mutation = "InvokeManagedOnReadyTransition"
 
-INVARIANT TerminalPhasePersistsUntilRestart
+INVARIANT ManagedCodeStartsReady

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerialized.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerialized.cfg
@@ -27,11 +27,12 @@ INVARIANTS
     PublicationRequiresCompleteValidation
     FailurePublishesNothing
     ReadyHasCompleteState
-    ReadyPersistsWithinRealm
+    TerminalPhasePersistsUntilRestart
     FacadeNeverDisposesRuntime
     ManagedCallsRequireReady
     EntryPointCallsRequireReady
     InitializationInvokesNoManagedCode
+    ManagedCodeStartsReady
 
 PROPERTIES
     RequestedEventuallyTerminates

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerialized.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerialized.cfg
@@ -1,0 +1,38 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "Serialized"
+    AllowRuntimeFailure = TRUE
+    AllowLocalFailure = TRUE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "None"
+
+INVARIANTS
+    TypeOK
+    OneSharedRuntimeCreation
+    OneInitializationPerFacade
+    OneAcquisitionPerFacade
+    AcquisitionUsesOwnAssembly
+    PublicationUsesOwnAssembly
+    PublicationRequiresCompleteValidation
+    FailurePublishesNothing
+    ReadyHasCompleteState
+    ReadyPersistsWithinRealm
+    FacadeNeverDisposesRuntime
+    ManagedCallsRequireReady
+    EntryPointCallsRequireReady
+    InitializationInvokesNoManagedCode
+
+PROPERTIES
+    RequestedEventuallyTerminates
+    LocalFailureIsolation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerializedSuccess.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerializedSuccess.cfg
@@ -1,0 +1,38 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "Serialized"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "None"
+
+INVARIANTS
+    TypeOK
+    OneSharedRuntimeCreation
+    OneInitializationPerFacade
+    OneAcquisitionPerFacade
+    AcquisitionUsesOwnAssembly
+    PublicationUsesOwnAssembly
+    PublicationRequiresCompleteValidation
+    FailurePublishesNothing
+    ReadyHasCompleteState
+    ReadyPersistsWithinRealm
+    FacadeNeverDisposesRuntime
+    ManagedCallsRequireReady
+    EntryPointCallsRequireReady
+    InitializationInvokesNoManagedCode
+
+PROPERTIES
+    RequestedEventuallyTerminates
+    AllFacadesEventuallyReady

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerializedSuccess.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSerializedSuccess.cfg
@@ -27,11 +27,12 @@ INVARIANTS
     PublicationRequiresCompleteValidation
     FailurePublishesNothing
     ReadyHasCompleteState
-    ReadyPersistsWithinRealm
+    TerminalPhasePersistsUntilRestart
     FacadeNeverDisposesRuntime
     ManagedCallsRequireReady
     EntryPointCallsRequireReady
     InitializationInvokesNoManagedCode
+    ManagedCodeStartsReady
 
 PROPERTIES
     RequestedEventuallyTerminates

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleShared.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleShared.cfg
@@ -1,0 +1,38 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = TRUE
+    AllowLocalFailure = TRUE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "None"
+
+INVARIANTS
+    TypeOK
+    OneSharedRuntimeCreation
+    OneInitializationPerFacade
+    OneAcquisitionPerFacade
+    AcquisitionUsesOwnAssembly
+    PublicationUsesOwnAssembly
+    PublicationRequiresCompleteValidation
+    FailurePublishesNothing
+    ReadyHasCompleteState
+    ReadyPersistsWithinRealm
+    FacadeNeverDisposesRuntime
+    ManagedCallsRequireReady
+    EntryPointCallsRequireReady
+    InitializationInvokesNoManagedCode
+
+PROPERTIES
+    RequestedEventuallyTerminates
+    LocalFailureIsolation

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleShared.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleShared.cfg
@@ -27,11 +27,12 @@ INVARIANTS
     PublicationRequiresCompleteValidation
     FailurePublishesNothing
     ReadyHasCompleteState
-    ReadyPersistsWithinRealm
+    TerminalPhasePersistsUntilRestart
     FacadeNeverDisposesRuntime
     ManagedCallsRequireReady
     EntryPointCallsRequireReady
     InitializationInvokesNoManagedCode
+    ManagedCodeStartsReady
 
 PROPERTIES
     RequestedEventuallyTerminates

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSharedSuccess.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSharedSuccess.cfg
@@ -1,0 +1,38 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    FacadeA = FacadeA
+    FacadeB = FacadeB
+    CallerA = CallerA
+    CallerB = CallerB
+    RootA = RootA
+    RootB = RootB
+    NoRoot = NoRoot
+    NoEpoch = NoEpoch
+    Coordination = "SharedInFlight"
+    AllowRuntimeFailure = FALSE
+    AllowLocalFailure = FALSE
+    FailableFacade = FacadeA
+    MaxRestarts = 1
+    Mutation = "None"
+
+INVARIANTS
+    TypeOK
+    OneSharedRuntimeCreation
+    OneInitializationPerFacade
+    OneAcquisitionPerFacade
+    AcquisitionUsesOwnAssembly
+    PublicationUsesOwnAssembly
+    PublicationRequiresCompleteValidation
+    FailurePublishesNothing
+    ReadyHasCompleteState
+    ReadyPersistsWithinRealm
+    FacadeNeverDisposesRuntime
+    ManagedCallsRequireReady
+    EntryPointCallsRequireReady
+    InitializationInvokesNoManagedCode
+
+PROPERTIES
+    RequestedEventuallyTerminates
+    AllFacadesEventuallyReady

--- a/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSharedSuccess.cfg
+++ b/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycleSharedSuccess.cfg
@@ -27,11 +27,12 @@ INVARIANTS
     PublicationRequiresCompleteValidation
     FailurePublishesNothing
     ReadyHasCompleteState
-    ReadyPersistsWithinRealm
+    TerminalPhasePersistsUntilRestart
     FacadeNeverDisposesRuntime
     ManagedCallsRequireReady
     EntryPointCallsRequireReady
     InitializationInvokesNoManagedCode
+    ManagedCodeStartsReady
 
 PROPERTIES
     RequestedEventuallyTerminates

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -319,6 +319,14 @@ instance. A facade whose local acquisition or validation fails never exits or
 disposes the potentially shared runtime. Cross-module coordination,
 configuration, and runtime lifetime remain consumer and runtime policy.
 
+The focused
+[lifecycle model](models/ts-jsexport-lifecycle/README.md) model-checks those
+per-facade and shared-runtime interactions for two facades and two callers per
+facade. It states its abstraction boundary, fairness assumptions, checked
+bounds, safety and progress properties, and counterexample mutations. The model
+establishes evidence about the lifecycle design, not the generated
+implementation; the runtime and browser gates below remain required.
+
 Managed operations and `runEntryPoint()` fail visibly until initialization has
 fulfilled, using one consistent module-owned not-initialized error across all
 entry points. After terminal failure they preserve that initialization failure

--- a/docs/runbooks/tla-plus-setup.md
+++ b/docs/runbooks/tla-plus-setup.md
@@ -146,6 +146,7 @@ on `main`); links point at the PR branch.
 | [`CompileBackAdmission.tla`](https://github.com/richlander/dotnet-inspect/blob/docs/4810-compileback-closure-provenance/docs/models/CompileBackAdmission.tla) ([`.cfg`](https://github.com/richlander/dotnet-inspect/blob/docs/4810-compileback-closure-provenance/docs/models/CompileBackAdmission.cfg)) | [#4838](https://github.com/richlander/dotnet-inspect/pull/4838) | Models the compile-back tool's planning → product-attempt → legacy-attempt → supersession → receipt/verdict transitions for [C# member recompilation](../design/csharp-member-recompilation.md). Checks termination, that `Exact` verdicts always trace to an admitted receipt, that a failed product attempt never crosses into legacy evidence, and that supersession clears the prior receipt. |
 | [`NavigationSession.tla`](https://github.com/richlander/dotnet-inspect/blob/design/inspection-subject-navigation/docs/design/models/inspection-subject-navigation/NavigationSession.tla), [`AtomicRestoration.tla`](https://github.com/richlander/dotnet-inspect/blob/design/inspection-subject-navigation/docs/design/models/inspection-subject-navigation/AtomicRestoration.tla), [`SnapshotAuthority.tla`](https://github.com/richlander/dotnet-inspect/blob/design/inspection-subject-navigation/docs/design/models/inspection-subject-navigation/SnapshotAuthority.tla) (plus matching `.cfg` files and a model [`README.md`](https://github.com/richlander/dotnet-inspect/blob/design/inspection-subject-navigation/docs/design/models/inspection-subject-navigation/README.md)) | [#4830](https://github.com/richlander/dotnet-inspect/pull/4830) | Three independent models backing [Inspection subject navigation](../design/inspection-subject-navigation.md): retained-session intent/supersession/maintenance ordering and effect authority (`NavigationSession`), one-transaction canonical subject+lens restoration (`AtomicRestoration`), and retained-versus-stateless execution and which prior state each may read (`SnapshotAuthority`). Each is scoped to one mechanism; none models identity ranking, availability semantics, UI accessibility, or implementation conformance. |
 | [`SemanticRowSelection.tla`](https://github.com/richlander/dotnet-inspect/blob/docs/4677-selection-planning/docs/models/SemanticRowSelection.tla) ([`.cfg`](https://github.com/richlander/dotnet-inspect/blob/docs/4677-selection-planning/docs/models/SemanticRowSelection.cfg)) | [#4815](https://github.com/richlander/dotnet-inspect/pull/4815) | Models one immutable row-selection plan applied to ordered named sequences for [Semantic row selection](../design/semantic-row-selection.md): sequence-major/stage-major traversal, strict `Range`, positional `Head`/`Tail`, ranked `Top`, resolver caching, callback failure, withheld publication, and atomic success. Checks type safety, atomic publication, at-most-once resolver invocation, sequence/stage failure precedence, and termination under weak fairness. |
+| [`TsJsExportLifecycle.tla`](https://github.com/richlander/dotnet-inspect/blob/design/jsexport-lifecycle-tla/docs/design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla) (plus scenario and mutation configurations and a model [`README.md`](https://github.com/richlander/dotnet-inspect/blob/design/jsexport-lifecycle-tla/docs/design/models/ts-jsexport-lifecycle/README.md)) | [#4918](https://github.com/richlander/dotnet-inspect/pull/4918) | Models two generated `ts-jsexport` facades, two callers per facade, one shared SDK runtime, shared-in-flight and serialized coordination, local failure isolation, terminal state, and bounded realm restart. Checks four success/failure scenarios and twelve targeted counterexample mutations without claiming implementation or browser conformance. |
 
 Each PR records its own TLC run (states generated, distinct states, max
 depth) inline next to its model description. [#4815](https://github.com/richlander/dotnet-inspect/pull/4815)
@@ -156,25 +157,24 @@ writing this runbook.
 
 ### Known in-progress work, not yet checked in
 
-As of this writing, two additional models exist only as uncommitted files in
-a contributor's local worktrees and are not linked above because they have no
-pushed branch or PR to point at:
+As of this writing, one additional model exists only as uncommitted files in a
+contributor's local worktree and is not linked above because it has no pushed
+branch or PR to point at:
 
 - `PackageCachePublication.tla` (plus `Safety`/`Liveness`/`BrokenAtomic`/
   `BrokenEviction` configs and a README), for
   [`cache-concurrency.md`](../design/cache-concurrency.md).
-- `TsJsExportLifecycle.tla` (plus several lifecycle-scenario configs and a
-  README), for [`ts-jsexport.md`](../design/ts-jsexport.md).
 
-Update this table once either is committed and pushed.
+Update this table once it is committed and pushed.
 
 ## Check in models as you go
 
 A TLA+ model that exists only as uncommitted files in a local worktree is not
 a checked-in asset — it is not backed up, not reviewable, and invisible to
 every other contributor and agent until it is committed and pushed. The two
-models above are exactly this risk: real, apparently-finished work (model +
-configs + README) sitting only on one machine's disk.
+models originally listed above were exactly this risk: real,
+apparently-finished work (model + configs + README) sitting only on one
+machine's disk.
 
 Commit a model to its branch and push that branch as soon as it reaches a
 checkable state (parses, and TLC runs against its `.cfg` without unexpected


### PR DESCRIPTION
## Summary

Model-check the `ts-jsexport` lifecycle before implementing its multi-assembly
browser canary:

- model two generated facades, two callers per facade, one shared SDK runtime,
  local terminal failures, and one bounded realm restart;
- check shared-in-flight and consumer-serialized coordination with both
  success-only and failure-enabled configurations;
- make initialization, acquisition, publication, root isolation, peer
  survival, managed-call readiness, and restart stability explicit properties;
  and
- prove twelve central properties are non-vacuous with targeted counterexample
  mutations.

The owning design links the model and keeps its implementation gates intact.
The model establishes evidence about lifecycle interleavings, not generated
TypeScript, SDK internals, or browser behavior.

## Demo

TLC exhaustively checks both supported coordination modes:

```text
TsJsExportLifecycleShared.cfg: 10,110 states generated, 1,784 distinct
TsJsExportLifecycleSharedSuccess.cfg: 7,535 states generated, 1,316 distinct
TsJsExportLifecycleSerialized.cfg: 4,294 states generated, 872 distinct
TsJsExportLifecycleSerializedSuccess.cfg: 3,135 states generated, 560 distinct
Model checking completed. No error has been found.
```

Each opt-in mutation produces a concrete counterexample. For example, making
every concurrent caller start facade initialization fails
`OneInitializationPerFacade`, and failing a peer after another facade's local
failure violates `LocalFailureIsolation` in both coordination modes.

## Validation

- TLA+ tools 1.8.0 / TLC2 `2026.08.21.155922` (`9787e65`), OpenJDK 25
- four complete bounded state-space and temporal-property checks
- twelve targeted mutation configurations, each producing its named violation
- `npx markdownlint-cli docs/design/ts-jsexport.md docs/design/models/ts-jsexport-lifecycle/README.md`
- `git diff --check`

## Non-goals

- Proving JavaScript property-descriptor behavior, TypeScript naming, wire
  contracts, async lowering, or SDK implementation internals.
- Replacing generator, runtime-seam, drift, or browser tests.
- Establishing a repository-wide formal-methods framework.

Closes #4908.
