### PR TITLE
Preserve exact JSExport runtime dispatch keys

### DIFF
--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -375,9 +375,9 @@ facade transformations; they do not create another managed operation.
 The runtime dispatch identity is opaque input, distinct from both the managed
 method name and the public TypeScript binding. The generated implementation
 indexes the narrowed export aggregate with that exact key. It never relies on a
-bare method name or registration order to select an overload. The current
-surface authenticates but does not project that key; #4791 owns the focused
-input-contract prerequisite.
+bare method name or registration order to select an overload.
+`JsExportFunction.RuntimeDispatchKey` projects the authenticated key as the
+focused input-contract prerequisite owned by #4791.
 
 Each supported overload remains a distinct managed operation and receives its
 own facade function. This is correspondence over runtime exports, not
@@ -623,8 +623,9 @@ The current implementation predates this decision:
 - authenticated async return-wire discovery recognizes compiler-generated
   `MoveNext` result sinks but not a runtime-async export's own physical body;
 - `JsExportSurfaceBuilder` authenticates each generated registration's
-  signature hash but omits that exact dispatch identity from
-  `JsExportFunction`; and
+  signature hash and preserves the exact dispatch identity as
+  `JsExportFunction.RuntimeDispatchKey`, but the current emitter does not
+  consume it; and
 - the current emitter traverses declaring-type paths with ordinary property
   lookup, invokes a bare runtime method name, rejects same-spelling managed
   operations, and rejects distinct enum or DTO identities with the same simple

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -127,10 +127,11 @@ be combined with Analysis evidence from another module. The candidate is
 deliberately not publication provenance:
 `ILInspector.JsExportSurface` authenticates the Analysis-owned
 registration body and wrapper-to-stub-to-export MethodDef call chain, including
-an exact count of trusted `BindManagedFunction` calls, exactly one call whose
-proven first string-literal argument is the export's structured runtime binding
-name, equal module identities throughout, and complete body analysis for the
-registration, wrapper, and stub, before publishing a runtime binding.
+an exact count of trusted `BindManagedFunction` calls, one same-name call per
+managed export sharing the structured runtime binding name, exactly one of
+those calls matching each wrapper's authenticated signature hash, equal module
+identities throughout, and complete body analysis for the registration,
+wrapper, and stub, before publishing a runtime binding.
 This separates Metadata's declaration fact from body evidence and rejects
 diagnosed chains, prefix siblings, or handwritten wrapper names. Null remains
 the compatibility shape for older or hand-composed surfaces only through the

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -137,7 +137,7 @@ the compatibility shape for older or hand-composed surfaces only through the
 declaration-only `Build(surface)` seam; a body-backed build requires exact
 non-null provenance.
 `Build_RejectsRegistrationBodyCountMismatch` and
-`Build_RejectsDuplicatedRuntimeBindingTarget`,
+`Build_RejectsSecondRuntimeBindingTargetWithDifferentHash`,
 `Build_RejectsRuntimeWrapperFromDifferentModule`,
 `Build_WithBodiesRejectsLegacyNullWrapperProvenance`, and
 `ApiTypeJson_RoundTripsRuntimeJsExportFailureEvidence` gate the exact evidence

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -71,10 +71,13 @@ public sealed class JsExportFunction
     /// </summary>
     /// <remarks>
     /// The body-backed builder derives this key only from the authenticated
-    /// <c>BindManagedFunction</c> registration and wrapper signature hash.
+    /// <c>BindManagedFunction</c> registration and wrapper signature hash,
+    /// retaining the registration's signed <c>int32</c> literal spelling.
     /// Declaration-only and hand-composed surfaces may leave it unset.
     /// <c>JsExportSurfaceBuilderTests.Build_ProjectsDistinctRuntimeDispatchKeysForCompiledOverloads</c>
-    /// gates the projection.
+    /// and
+    /// <c>JsExportSurfaceBuilderTests.Build_PreservesNegativeRuntimeDispatchKeyLiteral</c>
+    /// gate the projection.
     /// </remarks>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? RuntimeDispatchKey { get; init; }

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -65,6 +65,20 @@ public sealed class JsExportFunction
 
     public required string Name { get; init; }
 
+    /// <summary>
+    /// Exact own-property key published for this method beneath
+    /// <see cref="DeclaringType"/> by <c>getAssemblyExports</c>.
+    /// </summary>
+    /// <remarks>
+    /// The body-backed builder derives this key only from the authenticated
+    /// <c>BindManagedFunction</c> registration and wrapper signature hash.
+    /// Declaration-only and hand-composed surfaces may leave it unset.
+    /// <c>JsExportSurfaceBuilderTests.Build_ProjectsDistinctRuntimeDispatchKeysForCompiledOverloads</c>
+    /// gates the projection.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RuntimeDispatchKey { get; init; }
+
     public required string ReturnType { get; init; }
 
     [JsonIgnore]

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -115,10 +115,10 @@ public static class JsExportSurfaceBuilder
                         FormatMemberLocation(type, member),
                         "bodyless JS exports have no runtime wrapper");
                 }
-                bool hasManagedNameOverloads =
+                int managedNameExportCount =
                     type.Members.Count(candidate =>
                         HasJsExportEvidence(candidate)
-                        && candidate.Name == member.Name) > 1;
+                        && candidate.Name == member.Name);
                 string? runtimeDispatchKey = null;
                 if (bodyIndex is null
                         ? member.HasRuntimeJsExportWrapperCandidate
@@ -131,7 +131,7 @@ public static class JsExportSurfaceBuilder
                                 type,
                                 member,
                                 incompleteBodyTokens,
-                                hasManagedNameOverloads,
+                                managedNameExportCount,
                                 out runtimeDispatchKey))
                 {
                     throw new UnsupportedJsExportSurfaceException(
@@ -872,7 +872,7 @@ public static class JsExportSurfaceBuilder
         ApiType declaringType,
         ApiMember export,
         IReadOnlySet<int> incompleteBodyTokens,
-        bool hasManagedNameOverloads,
+        int managedNameExportCount,
         out string? runtimeDispatchKey)
     {
         runtimeDispatchKey = null;
@@ -911,7 +911,7 @@ public static class JsExportSurfaceBuilder
                     wrapper,
                     export.Name,
                     incompleteBodyTokens,
-                    hasManagedNameOverloads,
+                    managedNameExportCount,
                     out DirectCall? registration,
                     out int signatureHash))
                 continue;
@@ -980,7 +980,7 @@ public static class JsExportSurfaceBuilder
         MethodIdentity wrapper,
         string exportName,
         IReadOnlySet<int> incompleteBodyTokens,
-        bool hasManagedNameOverloads,
+        int managedNameExportCount,
         out DirectCall? registration,
         out int signatureHash)
     {
@@ -1027,8 +1027,7 @@ public static class JsExportSurfaceBuilder
                 runtimeBindingName,
                 StringComparison.Ordinal)),
         ];
-        if (!hasManagedNameOverloads
-            && named.Length != 1)
+        if (named.Length != managedNameExportCount)
         {
             return false;
         }

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -115,6 +115,10 @@ public static class JsExportSurfaceBuilder
                         FormatMemberLocation(type, member),
                         "bodyless JS exports have no runtime wrapper");
                 }
+                bool hasManagedNameOverloads =
+                    type.Members.Count(candidate =>
+                        HasJsExportEvidence(candidate)
+                        && candidate.Name == member.Name) > 1;
                 string? runtimeDispatchKey = null;
                 if (bodyIndex is null
                         ? member.HasRuntimeJsExportWrapperCandidate
@@ -127,6 +131,7 @@ public static class JsExportSurfaceBuilder
                                 type,
                                 member,
                                 incompleteBodyTokens,
+                                hasManagedNameOverloads,
                                 out runtimeDispatchKey))
                 {
                     throw new UnsupportedJsExportSurfaceException(
@@ -867,6 +872,7 @@ public static class JsExportSurfaceBuilder
         ApiType declaringType,
         ApiMember export,
         IReadOnlySet<int> incompleteBodyTokens,
+        bool hasManagedNameOverloads,
         out string? runtimeDispatchKey)
     {
         runtimeDispatchKey = null;
@@ -905,6 +911,7 @@ public static class JsExportSurfaceBuilder
                     wrapper,
                     export.Name,
                     incompleteBodyTokens,
+                    hasManagedNameOverloads,
                     out DirectCall? registration,
                     out int signatureHash))
                 continue;
@@ -973,6 +980,7 @@ public static class JsExportSurfaceBuilder
         MethodIdentity wrapper,
         string exportName,
         IReadOnlySet<int> incompleteBodyTokens,
+        bool hasManagedNameOverloads,
         out DirectCall? registration,
         out int signatureHash)
     {
@@ -1012,15 +1020,24 @@ public static class JsExportSurfaceBuilder
             return false;
         }
 
-        DirectCall[] matching =
+        DirectCall[] named =
         [
             .. bindings.Where(call => string.Equals(
                 call.FirstArgumentStringLiteral,
                 runtimeBindingName,
-                StringComparison.Ordinal)
-                && HasSignatureHash(
-                    call,
-                    expectedSignatureHash)),
+                StringComparison.Ordinal)),
+        ];
+        if (!hasManagedNameOverloads
+            && named.Length != 1)
+        {
+            return false;
+        }
+
+        DirectCall[] matching =
+        [
+            .. named.Where(call => HasSignatureHash(
+                call,
+                expectedSignatureHash)),
         ];
         if (matching is not [var match]
             || match.IsReachable != true

--- a/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurfaceBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using ILInspector.Analysis;
 using ILInspector.Metadata;
 
@@ -114,17 +115,19 @@ public static class JsExportSurfaceBuilder
                         FormatMemberLocation(type, member),
                         "bodyless JS exports have no runtime wrapper");
                 }
+                string? runtimeDispatchKey = null;
                 if (bodyIndex is null
                         ? member.HasRuntimeJsExportWrapperCandidate
                             == false
                         : member.HasRuntimeJsExportWrapperCandidate
                                 != true
-                            || !HasAuthenticatedRuntimeJsExportWrapper(
+                            || !TryGetAuthenticatedRuntimeJsExportWrapper(
                                 bodyIndex,
                                 surface.AssemblyIdentity,
                                 type,
                                 member,
-                                incompleteBodyTokens))
+                                incompleteBodyTokens,
+                                out runtimeDispatchKey))
                 {
                     throw new UnsupportedJsExportSurfaceException(
                         FormatMemberLocation(type, member),
@@ -153,6 +156,7 @@ public static class JsExportSurfaceBuilder
                 {
                     DeclaringType = type.FullName,
                     Name = member.Name,
+                    RuntimeDispatchKey = runtimeDispatchKey,
                     ReturnType = signature.ReturnType ?? member.ReturnType ?? "void",
                     ReturnTypeReferences =
                         signature.ReturnTypeReferences,
@@ -857,13 +861,15 @@ public static class JsExportSurfaceBuilder
     /// <c>GeneratedJsExportAuthenticationTests.Build_RejectsUnreachableGeneratedWrapperEntry</c>
     /// gates that.
     /// </remarks>
-    static bool HasAuthenticatedRuntimeJsExportWrapper(
+    static bool TryGetAuthenticatedRuntimeJsExportWrapper(
         LibraryBodyIndex bodyIndex,
         ApiAssemblyIdentity? assemblyIdentity,
         ApiType declaringType,
         ApiMember export,
-        IReadOnlySet<int> incompleteBodyTokens)
+        IReadOnlySet<int> incompleteBodyTokens,
+        out string? runtimeDispatchKey)
     {
+        runtimeDispatchKey = null;
         if (export.MetadataToken is not { } exportToken
             || export.RuntimeJsExportWrapperCandidates is not
                 { Count: > 0 } candidates)
@@ -899,7 +905,8 @@ public static class JsExportSurfaceBuilder
                     wrapper,
                     export.Name,
                     incompleteBodyTokens,
-                    out DirectCall? registration))
+                    out DirectCall? registration,
+                    out int signatureHash))
                 continue;
             if (incompleteBodyTokens.Contains(wrapper.MetadataToken))
                 continue;
@@ -946,6 +953,11 @@ public static class JsExportSurfaceBuilder
                     continue;
                 }
 
+                runtimeDispatchKey =
+                    export.Name
+                    + "."
+                    + signatureHash.ToString(
+                        CultureInfo.InvariantCulture);
                 return true;
             }
         }
@@ -961,9 +973,11 @@ public static class JsExportSurfaceBuilder
         MethodIdentity wrapper,
         string exportName,
         IReadOnlySet<int> incompleteBodyTokens,
-        out DirectCall? registration)
+        out DirectCall? registration,
+        out int signatureHash)
     {
         registration = null;
+        signatureHash = 0;
         if (candidate.RegistrationCount <= 0
             || candidate.ModuleVersionId is not { } moduleVersionId
             || incompleteBodyTokens.Contains(
@@ -990,33 +1004,50 @@ public static class JsExportSurfaceBuilder
         if (bindings.Length != candidate.RegistrationCount)
             return false;
 
-        DirectCall[] named =
+        if (!RuntimeJsExportWrapperName.TryGetSignatureHash(
+                wrapper.Name,
+                exportName,
+                out uint expectedSignatureHash))
+        {
+            return false;
+        }
+
+        DirectCall[] matching =
         [
             .. bindings.Where(call => string.Equals(
                 call.FirstArgumentStringLiteral,
                 runtimeBindingName,
-                StringComparison.Ordinal)),
+                StringComparison.Ordinal)
+                && HasSignatureHash(
+                    call,
+                    expectedSignatureHash)),
         ];
-        if (named is not [var match]
+        if (matching is not [var match]
             || match.IsReachable != true
-            || match.ResolvedArgumentValues.Count != 3
-            || !RuntimeJsExportWrapperName.TryGetSignatureHash(
-                wrapper.Name,
-                exportName,
-                out uint expectedSignatureHash)
             || match.ResolvedArgumentValues[1].Single is not
                 {
                     Kind: ResolvedValueSourceKind.Int32Literal,
-                    Int32Value: { } signatureHash,
-                }
-            || unchecked((uint)signatureHash) != expectedSignatureHash)
+                    Int32Value: { } matchedSignatureHash,
+                })
         {
             return false;
         }
 
         registration = match;
+        signatureHash = matchedSignatureHash;
         return true;
     }
+
+    static bool HasSignatureHash(
+        DirectCall registration,
+        uint expectedSignatureHash) =>
+        registration.ResolvedArgumentValues.Count == 3
+        && registration.ResolvedArgumentValues[1].Single is
+            {
+                Kind: ResolvedValueSourceKind.Int32Literal,
+                Int32Value: { } signatureHash,
+            }
+        && unchecked((uint)signatureHash) == expectedSignatureHash;
 
     /// <summary>
     /// Requires the registration's marshaler descriptor to be the span Analysis

--- a/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
@@ -121,6 +121,7 @@ public static class JsonWireContractResolver
         {
             DeclaringType = function.DeclaringType,
             Name = function.Name,
+            RuntimeDispatchKey = function.RuntimeDispatchKey,
             ReturnType = function.ReturnType,
             ReturnTypeReferences =
                 function.ReturnTypeReferences,

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -36,7 +36,9 @@ applications do not need it in their runtime bundle.
   `RuntimeDispatchKey` published by `getAssemblyExports()`. Overloads sharing a
   managed name are matched by both binding name and authenticated signature
   hash, so each receives its own runtime key without relying on registration
-  order. The
+  order. A non-overloaded export retains the stricter one-binding-name
+  requirement, preventing a second same-name registration from taking over the
+  runtime's bare-name compatibility alias. The
   `ReadOnlySpan<JSMarshalerType>` descriptor argument must resolve to one
   element per export return and parameter, each built by a
   `JSMarshalerType` factory compatible with that managed type. A diagnosed
@@ -132,6 +134,7 @@ calls the other.
 `Build_RejectsRuntimeWrapperFromDifferentModule`,
 `Build_RejectsRuntimeWrapperWithoutModuleIdentity`,
 `Build_RejectsRuntimeWrapperWithNullModuleIdentity`,
+`Build_RejectsSecondRuntimeBindingTargetWithDifferentHash`,
 `Build_RejectsRuntimeWrapperWithUnauthenticatedMarshalerArgument`,
 `Build_RejectsRuntimeRegistrationWithUntrustedCoreAlias`,
 `Build_RejectsRuntimeWrapperWithUntrustedCoreVoid`,

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -36,9 +36,11 @@ applications do not need it in their runtime bundle.
   `RuntimeDispatchKey` published by `getAssemblyExports()`. Overloads sharing a
   managed name are matched by both binding name and authenticated signature
   hash, so each receives its own runtime key without relying on registration
-  order. A non-overloaded export retains the stricter one-binding-name
-  requirement, preventing a second same-name registration from taking over the
-  runtime's bare-name compatibility alias. The
+  order. The number of same-name runtime bindings must equal the number of
+  managed exports in the overload group. This retains the stricter
+  one-binding-name requirement for a non-overloaded export and prevents an
+  unmatched registration from taking over the runtime's bare-name
+  compatibility alias. The
   `ReadOnlySpan<JSMarshalerType>` descriptor argument must resolve to one
   element per export return and parameter, each built by a
   `JSMarshalerType` factory compatible with that managed type. A diagnosed
@@ -130,11 +132,11 @@ calls the other.
 `Build_RejectsHandwrittenRuntimeWrapperCandidate`,
 `Build_DoesNotBorrowWrapperRegistrationFromAnotherType`,
 `Build_RejectsRegistrationBodyCountMismatch`,
-`Build_RejectsDuplicatedRuntimeBindingTarget`,
 `Build_RejectsRuntimeWrapperFromDifferentModule`,
 `Build_RejectsRuntimeWrapperWithoutModuleIdentity`,
 `Build_RejectsRuntimeWrapperWithNullModuleIdentity`,
 `Build_RejectsSecondRuntimeBindingTargetWithDifferentHash`,
+`Build_RejectsUnmatchedRuntimeBindingForOverloadGroup`,
 `Build_RejectsRuntimeWrapperWithUnauthenticatedMarshalerArgument`,
 `Build_RejectsRuntimeRegistrationWithUntrustedCoreAlias`,
 `Build_RejectsRuntimeWrapperWithUntrustedCoreVoid`,

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -144,6 +144,7 @@ calls the other.
 `Build_WithBodiesRejectsLegacyNullWrapperProvenance`,
 `Build_DoesNotCreditPrefixSiblingWrapper`,
 `Build_ProjectsDistinctRuntimeDispatchKeysForCompiledOverloads`,
+`Build_PreservesNegativeRuntimeDispatchKeyLiteral`,
 `Build_DoesNotBorrowAnotherOverloadWrapperRegistration`,
 `Build_RejectsDiagnosedRuntimeWrapperChain`,
 `Build_ProjectsRuntimeQualifiedDeclaringTypePath`,

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -25,9 +25,10 @@ applications do not need it in their runtime bundle.
   MethodDef. A registration for another declaring type, or a handwritten
   registration elsewhere, cannot be borrowed. Analysis then authenticates the
   exact registration token as a body containing the retained number of trusted
-  `BindManagedFunction` calls, exactly one trusted call whose proven first
-  string-literal argument equals the export's structured runtime binding name,
-  non-empty equal metadata/body module MVIDs, an exact
+  `BindManagedFunction` calls, exactly as many trusted calls whose proven first
+  string-literal argument equals the export's structured runtime binding name
+  as managed exports sharing that name, non-empty equal metadata/body module
+  MVIDs, an exact
   `System.Runtime.InteropServices.JavaScript` `JSMarshalerArgument`, plus a
   **reachable** wrapper-to-stub-to-export MethodDef call chain. The
   registration's second argument must be an `int32` literal equal to the

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -32,6 +32,11 @@ applications do not need it in their runtime bundle.
   **reachable** wrapper-to-stub-to-export MethodDef call chain. The
   registration's second argument must be an `int32` literal equal to the
   decimal suffix of the wrapper's own `__Wrapper_<Name>_<digits>` name, and its
+  signed decimal value is retained with the method name as the exact
+  `RuntimeDispatchKey` published by `getAssemblyExports()`. Overloads sharing a
+  managed name are matched by both binding name and authenticated signature
+  hash, so each receives its own runtime key without relying on registration
+  order. The
   `ReadOnlySpan<JSMarshalerType>` descriptor argument must resolve to one
   element per export return and parameter, each built by a
   `JSMarshalerType` factory compatible with that managed type. A diagnosed
@@ -132,6 +137,8 @@ calls the other.
 `Build_RejectsRuntimeWrapperWithUntrustedCoreVoid`,
 `Build_WithBodiesRejectsLegacyNullWrapperProvenance`,
 `Build_DoesNotCreditPrefixSiblingWrapper`,
+`Build_ProjectsDistinctRuntimeDispatchKeysForCompiledOverloads`,
+`Build_DoesNotBorrowAnotherOverloadWrapperRegistration`,
 `Build_RejectsDiagnosedRuntimeWrapperChain`,
 `Build_ProjectsRuntimeQualifiedDeclaringTypePath`,
 `Build_ProjectsNestedRuntimeDeclaringTypePath`,

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -103,13 +103,13 @@ The current wrapper indexes that path by the bare managed method name. It also
 traverses each declaring-type segment through ordinary JavaScript property
 lookup, so an inherited segment can escape the assembly export root.
 `JsExportSurfaceBuilder` authenticates each generated registration's signature
-hash but does not retain the exact runtime member key on `JsExportFunction`, so
-the emitter cannot select overloads exactly. Issue
-[#4791](https://github.com/richlander/dotnet-inspect/issues/4791) owns the
-target-language-neutral input fact; `ts-jsexport` will consume that opaque key
-instead of inferring dispatch from a TypeScript or managed display name, and
-will validate the complete path through own data-property descriptors before
-publishing initialized state.
+hash and retains the exact runtime member key as
+`JsExportFunction.RuntimeDispatchKey`, but the current emitter does not consume
+it and therefore cannot select overloads exactly. The replacement
+`ts-jsexport` emitter will consume that target-language-neutral input instead of
+inferring dispatch from a TypeScript or managed display name, and will validate
+the complete path through own data-property descriptors before publishing
+initialized state.
 
 The inspect-web bootstrap convention automatically invokes only an exact
 `static void ConfigureHost(string)` export with `window.location.origin`.

--- a/tests/ILInspector.JsExportSurface.PublishabilityFixtures/PublishabilityFixtures.cs
+++ b/tests/ILInspector.JsExportSurface.PublishabilityFixtures/PublishabilityFixtures.cs
@@ -63,6 +63,16 @@ public static partial class WrapperPrefixCollisionFixture
     public static int Foo_Bar(int value) => value + 2;
 }
 
+[SupportedOSPlatform("browser")]
+public static partial class OverloadedExportFixture
+{
+    [JSExport]
+    public static string Identify(int value) => $"int:{value}";
+
+    [JSExport]
+    public static string Identify(string value) => $"string:{value}";
+}
+
 public static partial class NestedExportContainer
 {
     [SupportedOSPlatform("browser")]

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -1106,6 +1107,221 @@ public sealed class JsExportSurfaceBuilderTests
                     AssemblyIdentity = extracted.AssemblyIdentity,
                     Functions = [function],
                 }),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_ProjectsDistinctRuntimeDispatchKeysForCompiledOverloads()
+    {
+        string path = typeof(OverloadedExportFixture).Assembly.Location;
+        ApiSurface extracted = ExtractApiSurface(path);
+        ApiType fixture = Assert.Single(
+            extracted.Types,
+            type => type.Name == nameof(OverloadedExportFixture));
+        fixture.Members =
+        [
+            .. fixture.Members.Where(
+                member => member.Name
+                    == nameof(OverloadedExportFixture.Identify)),
+        ];
+        extracted.FilteredRuntimeJsExportFacts = [];
+        extracted.Types = [fixture];
+        LibraryBodyIndex bodyIndex = OpenWireContractBodyIndex(path);
+
+        JsExportFunction[] functions =
+        [
+            .. JsExportSurfaceBuilder.Build(
+                extracted,
+                bodyIndex)
+                .Functions,
+        ];
+
+        Assert.Equal(2, functions.Length);
+        Assert.All(
+            functions,
+            function => Assert.Matches(
+                "^Identify\\.[0-9]+$",
+                function.RuntimeDispatchKey));
+        Assert.Equal(
+            2,
+            functions
+                .Select(function => function.RuntimeDispatchKey)
+                .Distinct(StringComparer.Ordinal)
+                .Count());
+
+        DirectCall[] registrations =
+        [
+            .. bodyIndex.DirectCalls
+                .Where(call =>
+                    call.Callee.Name == "BindManagedFunction"
+                    && call.FirstArgumentStringLiteral?.EndsWith(
+                        ":Identify",
+                        StringComparison.Ordinal) == true),
+        ];
+        string[] registrationKeys =
+        [
+            .. registrations
+                .Select(call =>
+                    "Identify."
+                    + Assert.IsType<int>(
+                        call.ResolvedArgumentValues[1]
+                            .Single!
+                            .Int32Value)
+                        .ToString(CultureInfo.InvariantCulture))
+                .Order(StringComparer.Ordinal),
+        ];
+        Assert.Equal(
+            registrationKeys,
+            functions
+                .Select(function => function.RuntimeDispatchKey!)
+                .Order(StringComparer.Ordinal));
+
+        var runtimeExports =
+            registrations.ToDictionary(
+                call =>
+                    "Identify."
+                    + Assert.IsType<int>(
+                        call.ResolvedArgumentValues[1]
+                            .Single!
+                            .Int32Value)
+                        .ToString(CultureInfo.InvariantCulture),
+                call => call.SpanArgumentSources
+                    .ForArgument(2)!
+                    .Elements[1]
+                    .Single!
+                    .Name switch
+                {
+                    "get_Int32" =>
+                        (Func<object, string>)(value =>
+                            $"int:{Assert.IsType<int>(value)}"),
+                    "get_String" =>
+                        value =>
+                            $"string:{Assert.IsType<string>(value)}",
+                    var name => throw new InvalidOperationException(
+                        $"Unexpected parameter marshaler '{name}'."),
+                },
+                StringComparer.Ordinal);
+        JsExportFunction intFunction = Assert.Single(
+            functions,
+            function => function.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        JsExportFunction stringFunction = Assert.Single(
+            functions,
+            function => function.Parameters is
+            [
+                {
+                    Type: "string",
+                },
+            ]);
+        runtimeExports.Add(
+            "Identify",
+            runtimeExports[intFunction.RuntimeDispatchKey!]);
+
+        Assert.Equal(
+            "int:7",
+            runtimeExports[intFunction.RuntimeDispatchKey!](7));
+        Assert.Equal(
+            "string:seven",
+            runtimeExports[stringFunction.RuntimeDispatchKey!](
+                "seven"));
+        Assert.Same(
+            runtimeExports[intFunction.RuntimeDispatchKey!],
+            runtimeExports["Identify"]);
+        Assert.NotSame(
+            runtimeExports[stringFunction.RuntimeDispatchKey!],
+            runtimeExports["Identify"]);
+
+        string json = JsonSerializer.Serialize(
+            new ILInspector.JsExportSurface.JsExportSurface
+            {
+                AssemblyIdentity = extracted.AssemblyIdentity,
+                Functions = functions,
+            });
+        Assert.All(
+            functions,
+            function => Assert.Contains(
+                $"\"RuntimeDispatchKey\":\"{function.RuntimeDispatchKey}\"",
+                json,
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Build_DoesNotBorrowAnotherOverloadWrapperRegistration()
+    {
+        string path = typeof(OverloadedExportFixture).Assembly.Location;
+        ApiSurface extracted = ExtractApiSurface(path);
+        ApiType fixture = Assert.Single(
+            extracted.Types,
+            type => type.Name == nameof(OverloadedExportFixture));
+        ApiMember[] overloads =
+        [
+            .. fixture.Members.Where(
+                member => member.Name
+                    == nameof(OverloadedExportFixture.Identify)),
+        ];
+        Assert.Equal(2, overloads.Length);
+        extracted.FilteredRuntimeJsExportFacts = [];
+        extracted.Types = [fixture];
+        LibraryBodyIndex bodyIndex = OpenWireContractBodyIndex(path);
+
+        JsExportFunction[] accepted =
+        [
+            .. JsExportSurfaceBuilder.Build(
+                extracted,
+                bodyIndex)
+                .Functions,
+        ];
+        Assert.Equal(2, accepted.Length);
+        JsExportFunction intFunction = Assert.Single(
+            accepted,
+            function => function.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        uint intHash = uint.Parse(
+            intFunction.RuntimeDispatchKey!.AsSpan(
+                "Identify.".Length),
+            CultureInfo.InvariantCulture);
+        RuntimeJsExportWrapperCandidate wrongCandidate = Assert.Single(
+            overloads[0].RuntimeJsExportWrapperCandidates!,
+            candidate =>
+            {
+                MethodIdentity wrapper = Assert.Single(
+                    bodyIndex.Methods,
+                    method => method.MetadataToken
+                        == candidate.WrapperMethodToken);
+                Assert.True(
+                    RuntimeJsExportWrapperName.TryGetSignatureHash(
+                        wrapper.Name,
+                        nameof(OverloadedExportFixture.Identify),
+                        out uint candidateHash));
+                return candidateHash != intHash;
+            });
+        ApiMember intExport = Assert.Single(
+            overloads,
+            member => member.SignatureModel?.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        intExport.RuntimeJsExportWrapperCandidates = [wrongCandidate];
+        fixture.Members = [intExport];
+
+        UnsupportedJsExportSurfaceException exception =
+            Assert.Throws<UnsupportedJsExportSurfaceException>(
+                () => JsExportSurfaceBuilder.Build(
+                    extracted,
+                    bodyIndex));
+        Assert.Contains(
+            "no compiler-generated runtime wrapper",
+            exception.Message,
             StringComparison.Ordinal);
     }
 

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -1155,11 +1155,6 @@ public sealed class JsExportSurfaceBuilderTests
         ];
 
         Assert.Equal(2, functions.Length);
-        Assert.All(
-            functions,
-            function => Assert.Matches(
-                "^Identify\\.[0-9]+$",
-                function.RuntimeDispatchKey));
         Assert.Equal(
             2,
             functions
@@ -1293,6 +1288,196 @@ public sealed class JsExportSurfaceBuilderTests
     }
 
     [Fact]
+    public void Build_PreservesNegativeRuntimeDispatchKeyLiteral()
+    {
+        string path = typeof(OverloadedExportFixture).Assembly.Location;
+        ApiSurface extracted = ExtractApiSurface(path);
+        ApiType fixture = Assert.Single(
+            extracted.Types,
+            type => type.Name == nameof(OverloadedExportFixture));
+        fixture.Members =
+        [
+            .. fixture.Members.Where(
+                member => member.Name
+                    == nameof(OverloadedExportFixture.Identify)),
+        ];
+        extracted.FilteredRuntimeJsExportFacts = [];
+        extracted.Types = [fixture];
+        LibraryBodyIndex bodyIndex = OpenWireContractBodyIndex(path);
+        JsExportFunction intFunction = Assert.Single(
+            JsExportSurfaceBuilder.Build(
+                extracted,
+                bodyIndex).Functions,
+            function => function.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        int originalSignatureHash = int.Parse(
+            intFunction.RuntimeDispatchKey!.AsSpan(
+                "Identify.".Length),
+            CultureInfo.InvariantCulture);
+        ApiMember intExport = Assert.Single(
+            fixture.Members,
+            member => member.SignatureModel?.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        RuntimeJsExportWrapperCandidate candidate = Assert.Single(
+            intExport.RuntimeJsExportWrapperCandidates!,
+            candidate =>
+            {
+                MethodIdentity method = Assert.Single(
+                    bodyIndex.Methods,
+                    method => method.MetadataToken
+                        == candidate.WrapperMethodToken);
+                Assert.True(
+                    RuntimeJsExportWrapperName.TryGetSignatureHash(
+                        method.Name,
+                        nameof(OverloadedExportFixture.Identify),
+                        out uint wrapperHash));
+                return wrapperHash
+                    == unchecked((uint)originalSignatureHash);
+            });
+        MethodIdentity wrapper = Assert.Single(
+            bodyIndex.Methods,
+            method => method.MetadataToken
+                == candidate.WrapperMethodToken);
+        DirectCall wrapperCall = Assert.Single(
+            bodyIndex.DirectCalls,
+            call => call.EvidenceMethod.MetadataToken
+                    == wrapper.MetadataToken
+                && call.Callee.Name.StartsWith(
+                    $"<{wrapper.Name}>g____Stub|",
+                    StringComparison.Ordinal));
+        MethodIdentity stub = Assert.Single(
+            bodyIndex.Methods,
+            method => method.MetadataToken
+                == wrapperCall.CalleeDefinitionToken);
+        DirectCall registration = Assert.Single(
+            bodyIndex.DirectCalls,
+            call => call.EvidenceMethod.MetadataToken
+                    == candidate.RegistrationMethodToken
+                && call.Callee.Name == "BindManagedFunction"
+                && call.FirstArgumentStringLiteral?.EndsWith(
+                    ":Identify",
+                    StringComparison.Ordinal) == true
+                && call.ResolvedArgumentValues[1].Single
+                    is
+                    {
+                        Kind:
+                            ResolvedValueSourceKind.Int32Literal,
+                        Int32Value: { } signatureHash,
+                    }
+                && signatureHash == originalSignatureHash);
+
+        const uint unsignedSignatureHash = uint.MaxValue;
+        const int signedSignatureHash = -1;
+        Assert.Equal(
+            unsignedSignatureHash,
+            unchecked((uint)signedSignatureHash));
+        string wrapperName =
+            $"__Wrapper_Identify_{unsignedSignatureHash}";
+        MethodIdentity rewrittenWrapper = wrapper with
+        {
+            Name = wrapperName,
+        };
+        MethodIdentity rewrittenStub = stub with
+        {
+            Name = stub.Name.Replace(
+                $"<{wrapper.Name}>",
+                $"<{wrapperName}>",
+                StringComparison.Ordinal),
+        };
+        ResolvedValueSource hashSource = Assert.IsType<
+            ResolvedValueSource>(
+                registration.ResolvedArgumentValues[1].Single);
+        var rewrittenArguments = new ResolvedValueSets(
+        [
+            registration.ResolvedArgumentValues[0],
+            new ResolvedValueSet(
+                [
+                    hashSource with
+                    {
+                        Int32Value = signedSignatureHash,
+                    },
+                ],
+                isResolved: true),
+            registration.ResolvedArgumentValues[2],
+        ]);
+        ImmutableArray<MethodIdentity> methods =
+        [
+            .. bodyIndex.Methods.Select(method =>
+                method.MetadataToken == wrapper.MetadataToken
+                    ? rewrittenWrapper
+                    : method.MetadataToken == stub.MetadataToken
+                        ? rewrittenStub
+                        : method),
+        ];
+        ImmutableArray<DirectCall> calls =
+        [
+            .. bodyIndex.DirectCalls.Select(call =>
+                call.EvidenceMethod.MetadataToken
+                        == registration.EvidenceMethod.MetadataToken
+                    && call.ILOffset == registration.ILOffset
+                    ? call with
+                    {
+                        ResolvedArgumentValues =
+                            rewrittenArguments,
+                    }
+                    : call.EvidenceMethod.MetadataToken
+                            == wrapper.MetadataToken
+                        ? call with
+                        {
+                            Caller = rewrittenWrapper,
+                            EvidenceMethod = rewrittenWrapper,
+                        }
+                        : call.EvidenceMethod.MetadataToken
+                                == stub.MetadataToken
+                            ? call with
+                            {
+                                Caller = rewrittenStub,
+                                EvidenceMethod = rewrittenStub,
+                            }
+                            : call),
+        ];
+        LibraryBodyIndex rewrittenIndex =
+            LibraryBodyIndex.FromEvidence(
+                methods,
+                [],
+                diagnostics: bodyIndex.Diagnostics,
+                directCalls: calls,
+                resultSinks: bodyIndex.ResultSinks);
+
+        JsExportFunction rewrittenFunction = Assert.Single(
+            JsExportSurfaceBuilder.Build(
+                extracted,
+                rewrittenIndex).Functions,
+            function => function.Parameters is
+            [
+                {
+                    Type: "int",
+                },
+            ]);
+        Assert.Equal(
+            $"Identify.{signedSignatureHash}",
+            rewrittenFunction.RuntimeDispatchKey);
+        string json = JsonSerializer.Serialize(
+            new ILInspector.JsExportSurface.JsExportSurface
+            {
+                AssemblyIdentity = extracted.AssemblyIdentity,
+                Functions = [rewrittenFunction],
+            });
+        Assert.Contains(
+            $"\"RuntimeDispatchKey\":\"Identify.{signedSignatureHash}\"",
+            json,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Build_DoesNotBorrowAnotherOverloadWrapperRegistration()
     {
         string path = typeof(OverloadedExportFixture).Assembly.Location;
@@ -1327,10 +1512,10 @@ public sealed class JsExportSurfaceBuilderTests
                     Type: "int",
                 },
             ]);
-        uint intHash = uint.Parse(
+        uint intHash = unchecked((uint)int.Parse(
             intFunction.RuntimeDispatchKey!.AsSpan(
                 "Identify.".Length),
-            CultureInfo.InvariantCulture);
+            CultureInfo.InvariantCulture));
         RuntimeJsExportWrapperCandidate wrongCandidate = Assert.Single(
             overloads[0].RuntimeJsExportWrapperCandidates!,
             candidate =>

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -947,7 +947,7 @@ public sealed class JsExportSurfaceBuilderTests
     }
 
     [Fact]
-    public void Build_RejectsDuplicatedRuntimeBindingTarget()
+    public void Build_RejectsSecondRuntimeBindingTargetWithDifferentHash()
     {
         string path =
             typeof(PopulateExports).Assembly.Location;
@@ -968,7 +968,7 @@ public sealed class JsExportSurfaceBuilderTests
             Assert.Single(
                 export.RuntimeJsExportWrapperCandidates!);
         Assert.True(candidate.RegistrationCount > 1);
-        string target = Assert.Single(
+        DirectCall targetCall = Assert.Single(
             bodyIndex.DirectCalls
                 .Where(call =>
                     call.EvidenceMethod.MetadataToken
@@ -976,16 +976,34 @@ public sealed class JsExportSurfaceBuilderTests
                     && call.FirstArgumentStringLiteral?.EndsWith(
                         $":{export.Name}",
                         StringComparison.Ordinal)
-                        == true)
-                .Select(call =>
-                    call.FirstArgumentStringLiteral!)
-                .Distinct());
+                        == true));
+        string target = targetCall.FirstArgumentStringLiteral!;
+        int targetHash = Assert.IsType<int>(
+            targetCall.ResolvedArgumentValues[1]
+                .Single!
+                .Int32Value);
+        DirectCall decoy = Assert.Single(
+            bodyIndex.DirectCalls
+                .Where(call =>
+                    call.EvidenceMethod.MetadataToken
+                        == candidate.RegistrationMethodToken
+                    && call.Callee.Name == "BindManagedFunction"
+                    && call.FirstArgumentStringLiteral is not null
+                    && call.ResolvedArgumentValues[1].Single
+                        is
+                        {
+                            Kind:
+                                ResolvedValueSourceKind.Int32Literal,
+                            Int32Value: { } hash,
+                        }
+                    && hash != targetHash)
+                .Take(1));
         ImmutableArray<DirectCall> duplicatedCalls =
         [
             .. bodyIndex.DirectCalls.Select(call =>
                 call.EvidenceMethod.MetadataToken
-                    == candidate.RegistrationMethodToken
-                    && call.FirstArgumentStringLiteral is not null
+                        == decoy.EvidenceMethod.MetadataToken
+                    && call.ILOffset == decoy.ILOffset
                     ? call with
                     {
                         FirstArgumentStringLiteral = target,
@@ -1217,10 +1235,6 @@ public sealed class JsExportSurfaceBuilderTests
                     Type: "string",
                 },
             ]);
-        runtimeExports.Add(
-            "Identify",
-            runtimeExports[intFunction.RuntimeDispatchKey!]);
-
         Assert.Equal(
             "int:7",
             runtimeExports[intFunction.RuntimeDispatchKey!](7));
@@ -1228,12 +1242,6 @@ public sealed class JsExportSurfaceBuilderTests
             "string:seven",
             runtimeExports[stringFunction.RuntimeDispatchKey!](
                 "seven"));
-        Assert.Same(
-            runtimeExports[intFunction.RuntimeDispatchKey!],
-            runtimeExports["Identify"]);
-        Assert.NotSame(
-            runtimeExports[stringFunction.RuntimeDispatchKey!],
-            runtimeExports["Identify"]);
 
         string json = JsonSerializer.Serialize(
             new ILInspector.JsExportSurface.JsExportSurface

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -1195,30 +1195,62 @@ public sealed class JsExportSurfaceBuilderTests
                 .Order(StringComparer.Ordinal));
 
         var runtimeExports =
-            registrations.ToDictionary(
-                call =>
-                    "Identify."
-                    + Assert.IsType<int>(
-                        call.ResolvedArgumentValues[1]
-                            .Single!
-                            .Int32Value)
-                        .ToString(CultureInfo.InvariantCulture),
-                call => call.SpanArgumentSources
-                    .ForArgument(2)!
-                    .Elements[1]
-                    .Single!
-                    .Name switch
-                {
-                    "get_Int32" =>
-                        (Func<object, string>)(value =>
-                            $"int:{Assert.IsType<int>(value)}"),
-                    "get_String" =>
-                        value =>
-                            $"string:{Assert.IsType<string>(value)}",
-                    var name => throw new InvalidOperationException(
-                        $"Unexpected parameter marshaler '{name}'."),
-                },
+            new Dictionary<string, MethodInfo>(
                 StringComparer.Ordinal);
+        foreach (RuntimeJsExportWrapperCandidate candidate
+            in fixture.Members
+                .SelectMany(member =>
+                    member.RuntimeJsExportWrapperCandidates!)
+                .DistinctBy(candidate =>
+                    candidate.WrapperMethodToken))
+        {
+            MethodIdentity wrapper = Assert.Single(
+                bodyIndex.Methods,
+                method => method.MetadataToken
+                    == candidate.WrapperMethodToken);
+            Assert.True(
+                RuntimeJsExportWrapperName.TryGetSignatureHash(
+                    wrapper.Name,
+                    nameof(OverloadedExportFixture.Identify),
+                    out uint wrapperHash));
+            DirectCall registration = Assert.Single(
+                registrations,
+                call => call.ResolvedArgumentValues[1].Single
+                    is
+                    {
+                        Kind:
+                            ResolvedValueSourceKind.Int32Literal,
+                        Int32Value: { } hash,
+                    }
+                    && unchecked((uint)hash) == wrapperHash);
+            DirectCall wrapperCall = Assert.Single(
+                bodyIndex.DirectCalls,
+                call => call.EvidenceMethod.MetadataToken
+                        == wrapper.MetadataToken
+                    && call.Callee.Name.StartsWith(
+                        $"<{wrapper.Name}>g____Stub|",
+                        StringComparison.Ordinal));
+            DirectCall exportCall = Assert.Single(
+                bodyIndex.DirectCalls,
+                call => call.EvidenceMethod.MetadataToken
+                        == wrapperCall.CalleeDefinitionToken
+                    && call.Callee.DeclaringType.Name
+                        == nameof(OverloadedExportFixture)
+                    && call.Callee.Name
+                        == nameof(OverloadedExportFixture.Identify));
+            MethodInfo implementation = Assert.IsAssignableFrom<MethodInfo>(
+                typeof(OverloadedExportFixture).Module.ResolveMethod(
+                    exportCall.CalleeDefinitionToken));
+            int signatureHash = Assert.IsType<int>(
+                registration.ResolvedArgumentValues[1]
+                    .Single!
+                    .Int32Value);
+            runtimeExports.Add(
+                "Identify."
+                    + signatureHash.ToString(
+                        CultureInfo.InvariantCulture),
+                implementation);
+        }
         JsExportFunction intFunction = Assert.Single(
             functions,
             function => function.Parameters is
@@ -1237,11 +1269,14 @@ public sealed class JsExportSurfaceBuilderTests
             ]);
         Assert.Equal(
             "int:7",
-            runtimeExports[intFunction.RuntimeDispatchKey!](7));
+            Assert.IsType<string>(
+                runtimeExports[intFunction.RuntimeDispatchKey!]
+                    .Invoke(null, [7])));
         Assert.Equal(
             "string:seven",
-            runtimeExports[stringFunction.RuntimeDispatchKey!](
-                "seven"));
+            Assert.IsType<string>(
+                runtimeExports[stringFunction.RuntimeDispatchKey!]
+                    .Invoke(null, ["seven"])));
 
         string json = JsonSerializer.Serialize(
             new ILInspector.JsExportSurface.JsExportSurface
@@ -1320,13 +1355,106 @@ public sealed class JsExportSurfaceBuilderTests
                 },
             ]);
         intExport.RuntimeJsExportWrapperCandidates = [wrongCandidate];
-        fixture.Members = [intExport];
+        fixture.Members = [.. overloads];
 
         UnsupportedJsExportSurfaceException exception =
             Assert.Throws<UnsupportedJsExportSurfaceException>(
                 () => JsExportSurfaceBuilder.Build(
                     extracted,
                     bodyIndex));
+        Assert.Contains(
+            "no compiler-generated runtime wrapper",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_RejectsUnmatchedRuntimeBindingForOverloadGroup()
+    {
+        string path = typeof(OverloadedExportFixture).Assembly.Location;
+        ApiSurface extracted = ExtractApiSurface(path);
+        ApiType fixture = Assert.Single(
+            extracted.Types,
+            type => type.Name == nameof(OverloadedExportFixture));
+        fixture.Members =
+        [
+            .. fixture.Members.Where(
+                member => member.Name
+                    == nameof(OverloadedExportFixture.Identify)),
+        ];
+        Assert.Equal(2, fixture.Members.Count);
+        extracted.FilteredRuntimeJsExportFacts = [];
+        extracted.Types = [fixture];
+        LibraryBodyIndex bodyIndex = OpenWireContractBodyIndex(path);
+        RuntimeJsExportWrapperCandidate[] candidates =
+        [
+            .. fixture.Members[0].RuntimeJsExportWrapperCandidates!,
+        ];
+        Assert.NotEmpty(candidates);
+        int registrationToken = candidates[0].RegistrationMethodToken;
+        Assert.All(
+            candidates,
+            candidate => Assert.Equal(
+                registrationToken,
+                candidate.RegistrationMethodToken));
+        DirectCall[] targetCalls =
+        [
+            .. bodyIndex.DirectCalls.Where(call =>
+                call.EvidenceMethod.MetadataToken == registrationToken
+                && call.Callee.Name == "BindManagedFunction"
+                && call.FirstArgumentStringLiteral?.EndsWith(
+                    ":Identify",
+                    StringComparison.Ordinal) == true),
+        ];
+        Assert.Equal(2, targetCalls.Length);
+        string target = Assert.Single(
+            targetCalls
+                .Select(call => call.FirstArgumentStringLiteral!)
+                .Distinct(StringComparer.Ordinal));
+        HashSet<int> targetHashes =
+        [
+            .. targetCalls.Select(call =>
+                Assert.IsType<int>(
+                    call.ResolvedArgumentValues[1]
+                        .Single!
+                        .Int32Value)),
+        ];
+        DirectCall decoy = bodyIndex.DirectCalls.First(call =>
+            call.EvidenceMethod.MetadataToken == registrationToken
+            && call.Callee.Name == "BindManagedFunction"
+            && call.FirstArgumentStringLiteral is not null
+            && call.ResolvedArgumentValues[1].Single
+                is
+                {
+                    Kind: ResolvedValueSourceKind.Int32Literal,
+                    Int32Value: { } hash,
+                }
+            && !targetHashes.Contains(hash));
+        ImmutableArray<DirectCall> calls =
+        [
+            .. bodyIndex.DirectCalls.Select(call =>
+                call.EvidenceMethod.MetadataToken
+                        == decoy.EvidenceMethod.MetadataToken
+                    && call.ILOffset == decoy.ILOffset
+                    ? call with
+                    {
+                        FirstArgumentStringLiteral = target,
+                    }
+                    : call),
+        ];
+        LibraryBodyIndex tamperedIndex =
+            LibraryBodyIndex.FromEvidence(
+                bodyIndex.Methods,
+                [],
+                diagnostics: bodyIndex.Diagnostics,
+                directCalls: calls,
+                resultSinks: bodyIndex.ResultSinks);
+
+        UnsupportedJsExportSurfaceException exception =
+            Assert.Throws<UnsupportedJsExportSurfaceException>(
+                () => JsExportSurfaceBuilder.Build(
+                    extracted,
+                    tamperedIndex));
         Assert.Contains(
             "no compiler-generated runtime wrapper",
             exception.Message,


### PR DESCRIPTION
## Summary

Preserve each SDK-generated `[JSExport]` registration's exact authenticated
runtime dispatch key on `JsExportFunction`, including real compiler-produced
overloads. This closes #4791 and gives the future TypeScript facade an opaque
owner-issued identity instead of forcing it to recover one from method names or
registration order.

## Demo

The compiled fixture now publishes two `Identify` overloads whose runtime keys
select distinct behavior:

| Managed overload | Authenticated runtime key in this SDK | Result |
| --- | --- | --- |
| `Identify(int)` | `Identify.1859881935` | `int:7` |
| `Identify(string)` | `Identify.304094707` | `string:seven` |

The test derives these keys from Analysis-owned registration evidence rather
than hard-coding the SDK's current signature hashes.

## Changes

- Add nullable `JsExportFunction.RuntimeDispatchKey` and preserve it through
  wire-contract attachment and JSON serialization.
- Authenticate genuine managed overload groups by fully-qualified runtime
  binding name plus the wrapper's signature hash.
- Retain the stricter one-binding-name rule for non-overloaded exports so a
  second registration cannot take over the runtime's bare-name compatibility
  alias.
- Add compiled positive and close-negative fixtures proving overloads cannot
  borrow another registration, wrapper, or signature hash.

Declaration-only and hand-composed compatibility surfaces may leave the key
unset; non-null product keys are serialized unchanged.

## Validation

- 7 focused runtime-dispatch and declaring-type-path tests passed.
- Full `ILInspector.JsExportSurface.Tests`: 381/382 passed. The remaining
  `SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers` failure reproduces
  unchanged on `origin/main` under the current preview SDK.
- `markdownlint` passed for the owner README.
- `git diff --check` passed.

## Non-goals

This does not choose TypeScript names, implement facade lifecycle policy, alter
the runtime export-object layout, or change inspect-web.
