### PR TITLE
Add project document query contracts

### DIFF
--- a/src/DotnetInspector.Queries.Tests/ProjectDocumentQueriesTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ProjectDocumentQueriesTests.cs
@@ -1,0 +1,570 @@
+using System.Reflection;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class ProjectDocumentQueriesTests
+{
+    /// <summary>
+    /// The host-neutral project document contract. The surface test below asserts set equality
+    /// against the assembly, so a new contract type that skips these gates fails.
+    /// </summary>
+    private static readonly Type[] ContractTypes =
+    [
+        typeof(ProjectDependencyCoordinate),
+        typeof(ProjectSkillEntry),
+        typeof(ProjectAgentGuidanceEntry),
+        typeof(ProjectPackageDocumentEntry),
+        typeof(ProjectDocumentFailureReason),
+        typeof(ProjectDocumentSubjectDisposition),
+        typeof(ProjectDocumentFailure),
+        typeof(ProjectSkillsRequest),
+        typeof(ProjectAgentGuidanceRequest),
+        typeof(ProjectPackageDocumentsRequest),
+        typeof(ProjectSkillsResult),
+        typeof(ProjectAgentGuidanceResult),
+        typeof(ProjectPackageDocumentsResult),
+        typeof(ProjectSkillsQuery),
+        typeof(ProjectAgentGuidanceQuery),
+        typeof(ProjectPackageDocumentsQuery),
+    ];
+
+    [Fact]
+    public void SkillsQuery_OrdersEntriesByPackageThenDocumentPath()
+    {
+        ProjectSkillsResult result = ProjectSkillsQuery.Execute(
+            new ProjectSkillsRequest(
+                [
+                    Skill("Zulu", "2.0.0", "skills/z/SKILL.md"),
+                    Skill("alpha", "1.0.0", "skills/c/SKILL.md"),
+                    Skill("Alpha", "1.0.0", "skills/b/SKILL.md"),
+                    Skill("Alpha", "1.0.0", "skills/a/SKILL.md"),
+                ]));
+
+        Assert.Equal(
+            [
+                ("Alpha", "skills/a/SKILL.md"),
+                ("Alpha", "skills/b/SKILL.md"),
+                ("alpha", "skills/c/SKILL.md"),
+                ("Zulu", "skills/z/SKILL.md"),
+            ],
+            result.Skills.Select(entry => (entry.Package.PackageId, entry.DocumentPath)));
+    }
+
+    [Fact]
+    public void SkillsQuery_KeepsMissingAndUnreadableRowsWithNullContent()
+    {
+        ProjectSkillsResult result = ProjectSkillsQuery.Execute(
+            new ProjectSkillsRequest(
+                [
+                    Skill("Alpha", "1.0.0", "skills/present/SKILL.md") with
+                    {
+                        Name = "present",
+                        Size = 12,
+                        Content = "body",
+                    },
+                    Skill("Alpha", "1.0.0", "skills/missing/SKILL.md"),
+                    Skill("Alpha", "1.0.0", "skills/empty/SKILL.md") with { Content = "" },
+                ],
+                [
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Alpha", "1.0.0"),
+                        "skills/missing/SKILL.md",
+                        ProjectDocumentFailureReason.Missing),
+                ]));
+
+        Assert.Equal(
+            ["skills/empty/SKILL.md", "skills/missing/SKILL.md", "skills/present/SKILL.md"],
+            result.Skills.Select(entry => entry.DocumentPath));
+        Assert.Equal("", result.Skills[0].Content);
+        Assert.Null(result.Skills[1].Content);
+        Assert.Null(result.Skills[1].Size);
+        Assert.Null(result.Skills[1].Name);
+        Assert.Equal("body", result.Skills[2].Content);
+
+        ProjectDocumentFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(ProjectDocumentSubjectDisposition.Named, failure.Disposition);
+        Assert.Equal("skills/missing/SKILL.md", failure.DocumentPath);
+        Assert.Equal(ProjectDocumentFailureReason.Missing, failure.Reason);
+    }
+
+    [Fact]
+    public void SkillsQuery_RejectsDuplicateRowIdentity()
+    {
+        var request = new ProjectSkillsRequest(
+            [
+                Skill("Alpha", "1.0.0", "skills/a/SKILL.md"),
+                Skill("alpha", "1.0.0", "skills/a/SKILL.md"),
+            ]);
+
+        InspectionQueryException exception =
+            Assert.Throws<InspectionQueryException>(() => ProjectSkillsQuery.Execute(request));
+        Assert.Contains("distinct package and document identity", exception.Message);
+    }
+
+    [Fact]
+    public void SkillsQuery_KeepsDistinctPathsAndVersionsApart()
+    {
+        ProjectSkillsResult result = ProjectSkillsQuery.Execute(
+            new ProjectSkillsRequest(
+                [
+                    Skill("Alpha", "2.0.0", "skills/a/SKILL.md"),
+                    Skill("Alpha", "1.0.0", "skills/a/SKILL.md"),
+                    Skill("Alpha", "1.0.0", "skills/b/SKILL.md"),
+                ]));
+
+        Assert.Equal(
+            [
+                ("1.0.0", "skills/a/SKILL.md"),
+                ("1.0.0", "skills/b/SKILL.md"),
+                ("2.0.0", "skills/a/SKILL.md"),
+            ],
+            result.Skills.Select(entry => (entry.Package.Version, entry.DocumentPath)));
+    }
+
+    [Fact]
+    public void AgentGuidanceQuery_KeepsARowForADependencyWithoutGuidance()
+    {
+        ProjectAgentGuidanceResult result = ProjectAgentGuidanceQuery.Execute(
+            new ProjectAgentGuidanceRequest(
+                [
+                    new ProjectAgentGuidanceEntry(Coordinate("Zulu", "2.0.0")),
+                    new ProjectAgentGuidanceEntry(
+                        Coordinate("Alpha", "1.0.0"),
+                        "AGENTS.md",
+                        "alpha",
+                        Description: null,
+                        Size: 4,
+                        Content: "body"),
+                    new ProjectAgentGuidanceEntry(
+                        Coordinate("Mike", "1.5.0"),
+                        "AGENTS.md",
+                        Size: 9),
+                ],
+                [
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Mike", "1.5.0"),
+                        "AGENTS.md",
+                        ProjectDocumentFailureReason.Unreadable),
+                ]));
+
+        Assert.Equal(
+            ["Alpha", "Mike", "Zulu"],
+            result.Guidance.Select(entry => entry.Package.PackageId));
+        Assert.Equal("body", result.Guidance[0].Content);
+        Assert.Null(result.Guidance[1].Content);
+        Assert.Equal("AGENTS.md", result.Guidance[1].DocumentPath);
+        Assert.Null(result.Guidance[2].Content);
+        Assert.Null(result.Guidance[2].DocumentPath);
+        Assert.Equal(
+            ProjectDocumentFailureReason.Unreadable,
+            Assert.Single(result.Failures).Reason);
+    }
+
+    [Fact]
+    public void AgentGuidanceQuery_RejectsDuplicateRowIdentity()
+    {
+        var request = new ProjectAgentGuidanceRequest(
+            [
+                new ProjectAgentGuidanceEntry(Coordinate("Alpha", "1.0.0"), "AGENTS.md"),
+                new ProjectAgentGuidanceEntry(Coordinate("alpha", "1.0.0"), "docs/AGENTS.md"),
+            ]);
+
+        Assert.Throws<InspectionQueryException>(
+            () => ProjectAgentGuidanceQuery.Execute(request));
+    }
+
+    [Fact]
+    public void PackageDocumentsQuery_OrdersDocumentsAndKeepsNullContent()
+    {
+        ProjectPackageDocumentsResult result = ProjectPackageDocumentsQuery.Execute(
+            new ProjectPackageDocumentsRequest(
+                [
+                    new ProjectPackageDocumentEntry(
+                        Coordinate("Zulu", "2.0.0"),
+                        "README.md",
+                        Size: 1,
+                        Content: "z"),
+                    new ProjectPackageDocumentEntry(Coordinate("Mike", "1.5.0")),
+                    new ProjectPackageDocumentEntry(
+                        Coordinate("Alpha", "1.0.0"),
+                        "PROJECT.md",
+                        Size: 1,
+                        Content: "a"),
+                ],
+                [
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Mike", "1.5.0"),
+                        documentPath: null,
+                        ProjectDocumentFailureReason.Unacquired),
+                ]));
+
+        Assert.Equal(
+            ["Alpha", "Mike", "Zulu"],
+            result.Documents.Select(document => document.Package.PackageId));
+        Assert.Null(result.Documents[1].Content);
+        Assert.Null(result.Documents[1].DocumentPath);
+        Assert.Null(result.Documents[1].Size);
+
+        ProjectDocumentFailure failure = Assert.Single(result.Failures);
+        Assert.Equal(ProjectDocumentFailureReason.Unacquired, failure.Reason);
+        Assert.Null(failure.DocumentPath);
+        Assert.Equal("Mike", failure.Package?.PackageId);
+    }
+
+    [Fact]
+    public void PackageDocumentsQuery_RejectsDuplicateRowIdentity()
+    {
+        var request = new ProjectPackageDocumentsRequest(
+            [
+                new ProjectPackageDocumentEntry(Coordinate("Alpha", "1.0.0"), "README.md"),
+                new ProjectPackageDocumentEntry(Coordinate("ALPHA", "1.0.0"), "PROJECT.md"),
+            ]);
+
+        Assert.Throws<InspectionQueryException>(
+            () => ProjectPackageDocumentsQuery.Execute(request));
+    }
+
+    [Fact]
+    public void Failures_OrderNamedSubjectsBeforeRedactedFailures()
+    {
+        ProjectSkillsResult result = ProjectSkillsQuery.Execute(
+            new ProjectSkillsRequest(
+                [],
+                [
+                    ProjectDocumentFailure.Redacted(
+                        ProjectDocumentFailureReason.InvalidMetadata),
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Zulu", "2.0.0"),
+                        "skills/z/SKILL.md",
+                        ProjectDocumentFailureReason.Missing),
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Alpha", "1.0.0"),
+                        "skills/b/SKILL.md",
+                        ProjectDocumentFailureReason.Unreadable),
+                    ProjectDocumentFailure.Named(
+                        Coordinate("Alpha", "1.0.0"),
+                        "skills/a/SKILL.md",
+                        ProjectDocumentFailureReason.Missing),
+                ]));
+
+        Assert.Equal(
+            [
+                ("Alpha", "skills/a/SKILL.md"),
+                ("Alpha", "skills/b/SKILL.md"),
+                ("Zulu", "skills/z/SKILL.md"),
+                (null, null),
+            ],
+            result.Failures.Select(failure => (failure.Package?.PackageId, failure.DocumentPath)));
+        Assert.Equal(
+            ProjectDocumentSubjectDisposition.Redacted,
+            result.Failures[^1].Disposition);
+    }
+
+    [Fact]
+    public void RedactedFailure_CarriesNoPackageAuthoredIdentity()
+    {
+        ProjectDocumentFailure failure =
+            ProjectDocumentFailure.Redacted(ProjectDocumentFailureReason.InvalidMetadata);
+
+        Assert.Equal(ProjectDocumentSubjectDisposition.Redacted, failure.Disposition);
+        Assert.Null(failure.Package);
+        Assert.Null(failure.DocumentPath);
+        Assert.Equal(
+            "A project document declares metadata that does not satisfy its contract.",
+            failure.Message);
+    }
+
+    /// <summary>
+    /// The non-vacuity gate for the redaction invariant: a redacted failure carries no subject
+    /// only because the two factories are the only way to build one.
+    /// </summary>
+    [Fact]
+    public void Failure_HasNoConstructionPathBesideItsFactories()
+    {
+        Assert.Empty(
+            typeof(ProjectDocumentFailure).GetConstructors(
+                BindingFlags.Public | BindingFlags.Instance));
+        Assert.Equal(
+            ["Named", "Redacted"],
+            typeof(ProjectDocumentFailure)
+                .GetMethods(
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+                .Order());
+        Assert.DoesNotContain(
+            typeof(ProjectDocumentFailure).GetProperties(
+                BindingFlags.Public | BindingFlags.Instance),
+            property => property.CanWrite);
+    }
+
+    [Fact]
+    public void FailureMessage_IsStableForEveryReason()
+    {
+        Dictionary<ProjectDocumentFailureReason, string> expected = new()
+        {
+            [ProjectDocumentFailureReason.Missing] =
+                "A document the restored project lists is missing from the package.",
+            [ProjectDocumentFailureReason.Unreadable] =
+                "A project document could not be read.",
+            [ProjectDocumentFailureReason.Unacquired] =
+                "A project document could not be acquired from the package that declares it.",
+            [ProjectDocumentFailureReason.InvalidMetadata] =
+                "A project document declares metadata that does not satisfy its contract.",
+        };
+
+        Assert.Equal(
+            Enum.GetValues<ProjectDocumentFailureReason>().Order(),
+            expected.Keys.Order());
+        foreach ((ProjectDocumentFailureReason reason, string message) in expected)
+        {
+            Assert.Equal(message, ProjectDocumentFailure.Redacted(reason).Message);
+            Assert.NotEqual(UnknownReasonMessage, message);
+        }
+    }
+
+    [Fact]
+    public void FailureMessage_IsSafeForUnknownFutureReason()
+    {
+        ProjectDocumentFailure failure =
+            ProjectDocumentFailure.Redacted((ProjectDocumentFailureReason)int.MaxValue);
+
+        Assert.Equal(UnknownReasonMessage, failure.Message);
+    }
+
+    [Fact]
+    public void Results_DoNotDependOnHostEnumerationOrder()
+    {
+        ProjectSkillEntry[] entries =
+        [
+            Skill("Zulu", "2.0.0", "skills/z/SKILL.md"),
+            Skill("Alpha", "1.0.0", "skills/b/SKILL.md"),
+            Skill("Alpha", "1.0.0", "skills/a/SKILL.md"),
+            Skill("Mike", "1.5.0", "skills/m/SKILL.md"),
+        ];
+        (string PackageId, string DocumentPath)[] expected =
+        [
+            .. ProjectSkillsQuery.Execute(new ProjectSkillsRequest(entries))
+                .Skills
+                .Select(entry => (entry.Package.PackageId, entry.DocumentPath)),
+        ];
+
+        foreach (ProjectSkillEntry[] permutation in Permutations(entries))
+        {
+            Assert.Equal(
+                expected,
+                ProjectSkillsQuery.Execute(new ProjectSkillsRequest(permutation))
+                    .Skills
+                    .Select(entry => (entry.Package.PackageId, entry.DocumentPath)));
+        }
+    }
+
+    [Fact]
+    public void Requests_MaterializeInputSoLaterMutationCannotChangeResults()
+    {
+        List<ProjectSkillEntry> skills = [Skill("Alpha", "1.0.0", "skills/a/SKILL.md")];
+        List<ProjectDocumentFailure> failures =
+            [ProjectDocumentFailure.Redacted(ProjectDocumentFailureReason.InvalidMetadata)];
+        var request = new ProjectSkillsRequest(skills, failures);
+
+        skills.Add(Skill("Zulu", "2.0.0", "skills/z/SKILL.md"));
+        failures.Add(
+            ProjectDocumentFailure.Redacted(ProjectDocumentFailureReason.Unreadable));
+        ProjectSkillsResult result = ProjectSkillsQuery.Execute(request);
+
+        Assert.Equal("skills/a/SKILL.md", Assert.Single(result.Skills).DocumentPath);
+        Assert.Equal(
+            ProjectDocumentFailureReason.InvalidMetadata,
+            Assert.Single(result.Failures).Reason);
+    }
+
+    [Fact]
+    public void Requests_RejectMissingRowCollections()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new ProjectSkillsRequest(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new ProjectAgentGuidanceRequest(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new ProjectPackageDocumentsRequest(null!));
+        Assert.Throws<ArgumentException>(
+            () => new ProjectSkillsRequest([null!]));
+    }
+
+    [Fact]
+    public void Definitions_DeclareTruthfulCostsUnderDemand()
+    {
+        InspectionQueryRegistry<ProjectDocumentQueryContext> registry = CreateRegistry();
+
+        Assert.Equal(
+            InspectionCost.NetworkFree,
+            registry.CostOf(ProjectSkillsQuery.Definition));
+        Assert.Equal(
+            InspectionCost.NetworkFree,
+            registry.CostOf(ProjectAgentGuidanceQuery.Definition));
+        Assert.Equal(
+            InspectionCost.Unbounded,
+            registry.CostOf(ProjectPackageDocumentsQuery.Definition));
+    }
+
+    [Fact]
+    public void RegistryRun_ExecutesOnlyDemandedProjectDocumentQueries()
+    {
+        InspectionQueryRegistry<ProjectDocumentQueryContext> registry = CreateRegistry();
+        var context = new ProjectDocumentQueryContext();
+
+        InspectionQueryResults results = registry.Run(
+            [ProjectSkillsQuery.Definition, ProjectAgentGuidanceQuery.Definition],
+            context);
+
+        Assert.True(results.TryGet(ProjectSkillsQuery.Definition, out ProjectSkillsResult? skills));
+        Assert.Equal("skills/a/SKILL.md", Assert.Single(skills!.Skills).DocumentPath);
+        Assert.True(results.TryGet(ProjectAgentGuidanceQuery.Definition, out _));
+        Assert.False(results.TryGet(ProjectPackageDocumentsQuery.Definition, out _));
+        Assert.Equal(1, context.SkillReads);
+        Assert.Equal(1, context.AgentGuidanceReads);
+        Assert.Equal(0, context.PackageDocumentReads);
+    }
+
+    [Fact]
+    public void ProjectDocumentContracts_AreTheDeclaredHostNeutralSurface()
+    {
+        Assert.Equal(
+            ContractTypes.Select(type => type.FullName).Order(),
+            typeof(ProjectSkillsQuery).Assembly
+                .GetExportedTypes()
+                .Where(type =>
+                    !type.IsNested
+                    && type.Namespace == "DotnetInspector.Queries"
+                    && type.Name.StartsWith("Project", StringComparison.Ordinal))
+                .Select(type => type.FullName)
+                .Order());
+    }
+
+    /// <summary>
+    /// The boundary gate: these contracts carry already-acquired typed input, so no host
+    /// filesystem, package-client, Markout, or presentation type may appear on their surface.
+    /// </summary>
+    [Fact]
+    public void ProjectDocumentContracts_ExposeNoHostOrAcquisitionTypes()
+    {
+        string[] allowedNamespaces =
+        [
+            "System",
+            "System.Collections.Generic",
+            "System.Collections.Immutable",
+            "DotnetInspector.Queries",
+        ];
+
+        foreach (Type contract in ContractTypes)
+        {
+            foreach (Type used in SurfaceTypes(contract))
+            {
+                Assert.Contains(used.Namespace ?? "", allowedNamespaces);
+            }
+        }
+    }
+
+    private const string UnknownReasonMessage = "A project document could not be inspected.";
+
+    private static IEnumerable<Type> SurfaceTypes(Type contract)
+    {
+        const BindingFlags Surface =
+            BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static
+            | BindingFlags.DeclaredOnly;
+
+        IEnumerable<Type> declared =
+        [
+            .. contract.GetProperties(Surface).Select(property => property.PropertyType),
+            .. contract.GetConstructors(Surface)
+                .SelectMany(constructor => constructor.GetParameters())
+                .Select(parameter => parameter.ParameterType),
+            .. contract.GetMethods(Surface)
+                .Where(method => !method.IsSpecialName)
+                .SelectMany(method =>
+                    method.GetParameters()
+                        .Select(parameter => parameter.ParameterType)
+                        .Append(method.ReturnType)),
+        ];
+        return declared.SelectMany(Flatten).Distinct();
+    }
+
+    private static IEnumerable<Type> Flatten(Type type)
+    {
+        Type element = type.IsByRef || type.IsArray ? type.GetElementType()! : type;
+        yield return element;
+        foreach (Type argument in element.GetGenericArguments())
+        {
+            foreach (Type flattened in Flatten(argument))
+                yield return flattened;
+        }
+    }
+
+    private static InspectionQueryRegistry<ProjectDocumentQueryContext> CreateRegistry()
+        => new InspectionQueryRegistry<ProjectDocumentQueryContext>()
+            .Add(ProjectSkillsQuery.Definition, static context => context.ReadSkills())
+            .Add(
+                ProjectAgentGuidanceQuery.Definition,
+                static context => context.ReadAgentGuidance())
+            .Add(
+                ProjectPackageDocumentsQuery.Definition,
+                static context => context.ReadPackageDocuments());
+
+    private static ProjectDependencyCoordinate Coordinate(string packageId, string version)
+        => new(packageId, version);
+
+    private static ProjectSkillEntry Skill(string packageId, string version, string documentPath)
+        => new(Coordinate(packageId, version), documentPath);
+
+    private static IEnumerable<TItem[]> Permutations<TItem>(IReadOnlyList<TItem> items)
+    {
+        if (items.Count <= 1)
+        {
+            yield return [.. items];
+            yield break;
+        }
+
+        for (int index = 0; index < items.Count; index++)
+        {
+            TItem head = items[index];
+            TItem[] rest = [.. items.Where((_, position) => position != index)];
+            foreach (TItem[] permutation in Permutations(rest))
+                yield return [head, .. permutation];
+        }
+    }
+
+    /// <summary>
+    /// A host context that records which project document reads a demanded query performed.
+    /// </summary>
+    private sealed class ProjectDocumentQueryContext
+    {
+        public int SkillReads { get; private set; }
+
+        public int AgentGuidanceReads { get; private set; }
+
+        public int PackageDocumentReads { get; private set; }
+
+        public ProjectSkillsResult ReadSkills()
+        {
+            SkillReads++;
+            return ProjectSkillsQuery.Execute(
+                new ProjectSkillsRequest([Skill("Alpha", "1.0.0", "skills/a/SKILL.md")]));
+        }
+
+        public ProjectAgentGuidanceResult ReadAgentGuidance()
+        {
+            AgentGuidanceReads++;
+            return ProjectAgentGuidanceQuery.Execute(
+                new ProjectAgentGuidanceRequest(
+                    [new ProjectAgentGuidanceEntry(Coordinate("Alpha", "1.0.0"))]));
+        }
+
+        public ProjectPackageDocumentsResult ReadPackageDocuments()
+        {
+            PackageDocumentReads++;
+            return ProjectPackageDocumentsQuery.Execute(
+                new ProjectPackageDocumentsRequest(
+                    [new ProjectPackageDocumentEntry(Coordinate("Alpha", "1.0.0"))]));
+        }
+    }
+}

--- a/src/DotnetInspector.Queries/ProjectDocumentQueries.cs
+++ b/src/DotnetInspector.Queries/ProjectDocumentQueries.cs
@@ -1,0 +1,517 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// The restored coordinate of one direct project dependency that authored a project document.
+/// </summary>
+/// <remarks>
+/// The coordinate is host-supplied identity for a dependency the host already restored. These
+/// queries compare and order it; they never resolve, acquire, or parse it. Record equality is
+/// exact, while row identity uses NuGet's case-insensitive package-id rule through
+/// <see cref="ProjectDocumentIdentity"/>.
+/// </remarks>
+public sealed record ProjectDependencyCoordinate
+{
+    public ProjectDependencyCoordinate(string packageId, string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+        PackageId = packageId;
+        Version = version;
+    }
+
+    /// <summary>The package id exactly as the restored project spells it.</summary>
+    public string PackageId { get; }
+
+    /// <summary>The restored package version exactly as the project spells it.</summary>
+    public string Version { get; }
+}
+
+/// <summary>
+/// One skill document a direct project dependency ships.
+/// </summary>
+/// <param name="Package">The dependency that authored the document.</param>
+/// <param name="DocumentPath">
+/// The package-relative path the dependency spells for the document. It is opaque row identity
+/// here: no query parses it, resolves it, or treats it as a host filesystem path.
+/// </param>
+/// <param name="Name">The declared skill name, or <see langword="null"/> when it is unavailable.</param>
+/// <param name="Description">
+/// The declared skill description, or <see langword="null"/> when it is unavailable.
+/// </param>
+/// <param name="Size">The document's byte size, or <see langword="null"/> when it is unknown.</param>
+/// <param name="Content">
+/// The already-acquired document content, or <see langword="null"/> when the document is missing
+/// or could not be read. A missing or unreadable document keeps its row and stays
+/// <see langword="null"/>; it never becomes an empty document.
+/// </param>
+public sealed record ProjectSkillEntry(
+    ProjectDependencyCoordinate Package,
+    string DocumentPath,
+    string? Name = null,
+    string? Description = null,
+    long? Size = null,
+    string? Content = null);
+
+/// <summary>
+/// One direct project dependency's optional agent-guidance document.
+/// </summary>
+/// <param name="Package">The dependency the row reports.</param>
+/// <param name="DocumentPath">
+/// The package-relative path of the guidance document, or <see langword="null"/> when the
+/// dependency ships none. The path is opaque row data, not a host filesystem path.
+/// </param>
+/// <param name="Name">The declared guidance name, or <see langword="null"/> when it is unavailable.</param>
+/// <param name="Description">
+/// The declared guidance description, or <see langword="null"/> when it is unavailable.
+/// </param>
+/// <param name="Size">The document's byte size, or <see langword="null"/> when it is unknown.</param>
+/// <param name="Content">
+/// The already-acquired document content, or <see langword="null"/> when the dependency ships no
+/// guidance or the document could not be read. Every direct dependency keeps a row either way.
+/// </param>
+public sealed record ProjectAgentGuidanceEntry(
+    ProjectDependencyCoordinate Package,
+    string? DocumentPath = null,
+    string? Name = null,
+    string? Description = null,
+    long? Size = null,
+    string? Content = null);
+
+/// <summary>
+/// The package document one direct project dependency ships, such as its readme.
+/// </summary>
+/// <param name="Package">The dependency that authored the document.</param>
+/// <param name="DocumentPath">
+/// The package-relative path of the selected document, or <see langword="null"/> when the
+/// dependency ships none. The path is opaque row data, not a host filesystem path.
+/// </param>
+/// <param name="Size">The document's byte size, or <see langword="null"/> when it is unknown.</param>
+/// <param name="Content">
+/// The already-acquired document content, or <see langword="null"/> when the dependency ships no
+/// document or the document could not be acquired or read.
+/// </param>
+public sealed record ProjectPackageDocumentEntry(
+    ProjectDependencyCoordinate Package,
+    string? DocumentPath = null,
+    long? Size = null,
+    string? Content = null);
+
+/// <summary>
+/// The stable reason one project document could not be inspected.
+/// </summary>
+public enum ProjectDocumentFailureReason
+{
+    /// <summary>The restored project listed the document, but it was not present.</summary>
+    Missing,
+
+    /// <summary>The document was present, but its content could not be read.</summary>
+    Unreadable,
+
+    /// <summary>The document could not be acquired from the package that declares it.</summary>
+    Unacquired,
+
+    /// <summary>The document declares metadata that does not satisfy its contract.</summary>
+    InvalidMetadata,
+}
+
+/// <summary>
+/// Whether a project-document failure may name the package-authored subject that produced it.
+/// </summary>
+public enum ProjectDocumentSubjectDisposition
+{
+    /// <summary>The failure names the dependency coordinate and document path it came from.</summary>
+    Named,
+
+    /// <summary>
+    /// The failure withholds package-authored identity because that identity cannot safely be
+    /// echoed, such as when a document's own declared metadata is what failed validation.
+    /// </summary>
+    Redacted,
+}
+
+/// <summary>
+/// One visible project-document acquisition or read failure.
+/// </summary>
+/// <remarks>
+/// <see cref="Message"/> is product-authored and content-free: it is derived from
+/// <see cref="Reason"/> and never quotes artifact text. A
+/// <see cref="ProjectDocumentSubjectDisposition.Redacted"/> failure carries no package-authored
+/// identity at all, because <see cref="Named"/> and <see cref="Redacted"/> are the only ways to
+/// construct one. <c>RedactedFailure_CarriesNoPackageAuthoredIdentity</c>,
+/// <c>Failure_HasNoConstructionPathBesideItsFactories</c>,
+/// <c>FailureMessage_IsStableForEveryReason</c>, and
+/// <c>FailureMessage_IsSafeForUnknownFutureReason</c> gate this contract.
+/// </remarks>
+public sealed record ProjectDocumentFailure
+{
+    private ProjectDocumentFailure(
+        ProjectDocumentSubjectDisposition disposition,
+        ProjectDependencyCoordinate? package,
+        string? documentPath,
+        ProjectDocumentFailureReason reason)
+    {
+        Disposition = disposition;
+        Package = package;
+        DocumentPath = documentPath;
+        Reason = reason;
+    }
+
+    /// <summary>Reports a failure whose package-authored subject is safe to name.</summary>
+    /// <param name="package">The dependency whose document failed.</param>
+    /// <param name="documentPath">
+    /// The package-relative path of the document, or <see langword="null"/> when the failure has
+    /// no single document path, such as a package whose documents were never acquired.
+    /// </param>
+    /// <param name="reason">The stable reason the document could not be inspected.</param>
+    public static ProjectDocumentFailure Named(
+        ProjectDependencyCoordinate package,
+        string? documentPath,
+        ProjectDocumentFailureReason reason)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        return new(ProjectDocumentSubjectDisposition.Named, package, documentPath, reason);
+    }
+
+    /// <summary>
+    /// Reports a failure whose package-authored subject is withheld. The result carries the
+    /// reason alone, so no artifact-authored identity reaches a consumer.
+    /// </summary>
+    /// <param name="reason">The stable reason the document could not be inspected.</param>
+    public static ProjectDocumentFailure Redacted(ProjectDocumentFailureReason reason)
+        => new(
+            ProjectDocumentSubjectDisposition.Redacted,
+            package: null,
+            documentPath: null,
+            reason);
+
+    /// <summary>Whether this failure names or withholds its package-authored subject.</summary>
+    public ProjectDocumentSubjectDisposition Disposition { get; }
+
+    /// <summary>
+    /// The dependency whose document failed, or <see langword="null"/> when the subject is
+    /// redacted.
+    /// </summary>
+    public ProjectDependencyCoordinate? Package { get; }
+
+    /// <summary>
+    /// The package-relative path of the failed document, or <see langword="null"/> when the
+    /// subject is redacted or the failure names no single document.
+    /// </summary>
+    public string? DocumentPath { get; }
+
+    /// <summary>The stable reason the document could not be inspected.</summary>
+    public ProjectDocumentFailureReason Reason { get; }
+
+    /// <summary>A stable, product-authored description of <see cref="Reason"/>.</summary>
+    public string Message => Reason switch
+    {
+        ProjectDocumentFailureReason.Missing =>
+            "A document the restored project lists is missing from the package.",
+        ProjectDocumentFailureReason.Unreadable =>
+            "A project document could not be read.",
+        ProjectDocumentFailureReason.Unacquired =>
+            "A project document could not be acquired from the package that declares it.",
+        ProjectDocumentFailureReason.InvalidMetadata =>
+            "A project document declares metadata that does not satisfy its contract.",
+        _ => "A project document could not be inspected.",
+    };
+}
+
+/// <summary>The already-acquired dependency skill documents one query projects.</summary>
+public sealed record ProjectSkillsRequest
+{
+    public ProjectSkillsRequest(
+        IEnumerable<ProjectSkillEntry> skills,
+        IEnumerable<ProjectDocumentFailure>? failures = null)
+    {
+        ArgumentNullException.ThrowIfNull(skills);
+        Skills = ProjectDocumentIdentity.Materialize(skills, nameof(skills));
+        Failures = ProjectDocumentIdentity.Materialize(failures, nameof(failures));
+    }
+
+    /// <summary>One entry per skill document the host acquired, in any order.</summary>
+    public ImmutableArray<ProjectSkillEntry> Skills { get; }
+
+    /// <summary>Every skill document the host could not acquire or read.</summary>
+    public ImmutableArray<ProjectDocumentFailure> Failures { get; }
+}
+
+/// <summary>The already-acquired agent-guidance documents one query projects.</summary>
+public sealed record ProjectAgentGuidanceRequest
+{
+    public ProjectAgentGuidanceRequest(
+        IEnumerable<ProjectAgentGuidanceEntry> guidance,
+        IEnumerable<ProjectDocumentFailure>? failures = null)
+    {
+        ArgumentNullException.ThrowIfNull(guidance);
+        Guidance = ProjectDocumentIdentity.Materialize(guidance, nameof(guidance));
+        Failures = ProjectDocumentIdentity.Materialize(failures, nameof(failures));
+    }
+
+    /// <summary>One entry per direct dependency, whether or not it ships guidance.</summary>
+    public ImmutableArray<ProjectAgentGuidanceEntry> Guidance { get; }
+
+    /// <summary>Every guidance document the host could not read.</summary>
+    public ImmutableArray<ProjectDocumentFailure> Failures { get; }
+}
+
+/// <summary>The already-acquired dependency package documents one query projects.</summary>
+public sealed record ProjectPackageDocumentsRequest
+{
+    public ProjectPackageDocumentsRequest(
+        IEnumerable<ProjectPackageDocumentEntry> documents,
+        IEnumerable<ProjectDocumentFailure>? failures = null)
+    {
+        ArgumentNullException.ThrowIfNull(documents);
+        Documents = ProjectDocumentIdentity.Materialize(documents, nameof(documents));
+        Failures = ProjectDocumentIdentity.Materialize(failures, nameof(failures));
+    }
+
+    /// <summary>At most one entry per direct dependency, in any order.</summary>
+    public ImmutableArray<ProjectPackageDocumentEntry> Documents { get; }
+
+    /// <summary>Every package document the host could not acquire or read.</summary>
+    public ImmutableArray<ProjectDocumentFailure> Failures { get; }
+}
+
+/// <summary>The deterministic result of inspecting dependency skill documents.</summary>
+public sealed record ProjectSkillsResult(
+    ImmutableArray<ProjectSkillEntry> Skills,
+    ImmutableArray<ProjectDocumentFailure> Failures);
+
+/// <summary>The deterministic result of inspecting dependency agent guidance.</summary>
+public sealed record ProjectAgentGuidanceResult(
+    ImmutableArray<ProjectAgentGuidanceEntry> Guidance,
+    ImmutableArray<ProjectDocumentFailure> Failures);
+
+/// <summary>The deterministic result of inspecting dependency package documents.</summary>
+public sealed record ProjectPackageDocumentsResult(
+    ImmutableArray<ProjectPackageDocumentEntry> Documents,
+    ImmutableArray<ProjectDocumentFailure> Failures);
+
+/// <summary>
+/// Projects already-acquired dependency skill documents into a deterministic result.
+/// </summary>
+/// <remarks>
+/// Every skill document the host acquired keeps a row, including a missing or unreadable one,
+/// so a consumer can address rows by ordinal. The declared cost is
+/// <see cref="InspectionCost.NetworkFree"/> because the host acquired and authorized the
+/// documents before the request was built; this query performs no acquisition.
+/// <c>SkillsQuery_OrdersEntriesByPackageThenDocumentPath</c>,
+/// <c>SkillsQuery_KeepsMissingAndUnreadableRowsWithNullContent</c>, and
+/// <c>SkillsQuery_RejectsDuplicateRowIdentity</c> gate that contract.
+/// </remarks>
+public static class ProjectSkillsQuery
+{
+    public static InspectionQuery<ProjectSkillsResult> Definition { get; } =
+        new("Project skills", InspectionCost.NetworkFree);
+
+    public static ProjectSkillsResult Execute(ProjectSkillsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ImmutableArray<ProjectSkillEntry> skills = ProjectDocumentIdentity.Order(
+            request.Skills,
+            static entry => entry.Package,
+            static entry => entry.DocumentPath);
+        ProjectDocumentIdentity.RequireDistinctRows(
+            skills,
+            static entry => entry.Package,
+            static entry => entry.DocumentPath,
+            "skill");
+        return new ProjectSkillsResult(
+            skills,
+            ProjectDocumentIdentity.OrderFailures(request.Failures));
+    }
+}
+
+/// <summary>
+/// Projects already-acquired agent-guidance documents into a deterministic result.
+/// </summary>
+/// <remarks>
+/// The result keeps one row per direct dependency, so a dependency that ships no guidance stays
+/// visible with a <see langword="null"/> document path and content. The declared cost is
+/// <see cref="InspectionCost.NetworkFree"/> because the host acquired and authorized the
+/// documents before the request was built; this query performs no acquisition.
+/// <c>AgentGuidanceQuery_KeepsARowForADependencyWithoutGuidance</c> and
+/// <c>AgentGuidanceQuery_RejectsDuplicateRowIdentity</c> gate that contract.
+/// </remarks>
+public static class ProjectAgentGuidanceQuery
+{
+    public static InspectionQuery<ProjectAgentGuidanceResult> Definition { get; } =
+        new("Project agent guidance", InspectionCost.NetworkFree);
+
+    public static ProjectAgentGuidanceResult Execute(ProjectAgentGuidanceRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ImmutableArray<ProjectAgentGuidanceEntry> guidance = ProjectDocumentIdentity.Order(
+            request.Guidance,
+            static entry => entry.Package,
+            static entry => entry.DocumentPath);
+        ProjectDocumentIdentity.RequireDistinctCoordinates(
+            guidance,
+            static entry => entry.Package,
+            "agent guidance");
+        return new ProjectAgentGuidanceResult(
+            guidance,
+            ProjectDocumentIdentity.OrderFailures(request.Failures));
+    }
+}
+
+/// <summary>
+/// Projects already-acquired dependency package documents into a deterministic result.
+/// </summary>
+/// <remarks>
+/// The result keeps at most one row per direct dependency. The declared cost is
+/// <see cref="InspectionCost.Unbounded"/>: unlike skills and guidance, a host builds this request
+/// by reaching past restored content to every dependency's package, so the demand that produces
+/// the input is network-bound and fans out with the dependency count. The query itself performs
+/// no acquisition. <c>PackageDocumentsQuery_OrdersDocumentsAndKeepsNullContent</c>,
+/// <c>PackageDocumentsQuery_RejectsDuplicateRowIdentity</c>, and
+/// <c>Definitions_DeclareTruthfulCostsUnderDemand</c> gate that contract.
+/// </remarks>
+public static class ProjectPackageDocumentsQuery
+{
+    public static InspectionQuery<ProjectPackageDocumentsResult> Definition { get; } =
+        new("Project package documents", InspectionCost.Unbounded);
+
+    public static ProjectPackageDocumentsResult Execute(ProjectPackageDocumentsRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ImmutableArray<ProjectPackageDocumentEntry> documents = ProjectDocumentIdentity.Order(
+            request.Documents,
+            static entry => entry.Package,
+            static entry => entry.DocumentPath);
+        ProjectDocumentIdentity.RequireDistinctCoordinates(
+            documents,
+            static entry => entry.Package,
+            "package document");
+        return new ProjectPackageDocumentsResult(
+            documents,
+            ProjectDocumentIdentity.OrderFailures(request.Failures));
+    }
+}
+
+/// <summary>
+/// The shared ordering and row-identity rules of the project document queries.
+/// </summary>
+/// <remarks>
+/// Ordering is total over row identity, so a result does not depend on the order in which a host
+/// enumerated its documents. Rows that tie on every ordering key are duplicate identities and are
+/// rejected rather than ordered arbitrarily.
+/// </remarks>
+internal static class ProjectDocumentIdentity
+{
+    /// <summary>Orders optional document paths exactly, with an absent path first.</summary>
+    private static readonly IComparer<string?> OptionalOrdinal =
+        Comparer<string?>.Create(static (left, right) => string.CompareOrdinal(left, right));
+
+    /// <summary>Orders optional package ids the way NuGet package identity compares them.</summary>
+    private static readonly IComparer<string?> OptionalOrdinalIgnoreCase =
+        Comparer<string?>.Create(
+            static (left, right) => StringComparer.OrdinalIgnoreCase.Compare(left, right));
+
+    internal static ImmutableArray<TItem> Materialize<TItem>(
+        IEnumerable<TItem>? items,
+        string parameterName)
+        where TItem : class
+    {
+        if (items is null)
+            return [];
+
+        ImmutableArray<TItem> materialized = [.. items];
+        if (materialized.Any(static item => item is null))
+            throw new ArgumentException("A project document row cannot be null.", parameterName);
+
+        return materialized;
+    }
+
+    internal static ImmutableArray<TEntry> Order<TEntry>(
+        ImmutableArray<TEntry> entries,
+        Func<TEntry, ProjectDependencyCoordinate> coordinate,
+        Func<TEntry, string?> documentPath)
+        =>
+        [
+            .. entries
+                .OrderBy(entry => coordinate(entry).PackageId, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(entry => coordinate(entry).PackageId, StringComparer.Ordinal)
+                .ThenBy(entry => coordinate(entry).Version, StringComparer.Ordinal)
+                .ThenBy(documentPath, OptionalOrdinal),
+        ];
+
+    /// <summary>
+    /// Rejects rows that share one dependency coordinate and document path, so every row keeps a
+    /// distinct identity a consumer can address.
+    /// </summary>
+    internal static void RequireDistinctRows<TEntry>(
+        ImmutableArray<TEntry> entries,
+        Func<TEntry, ProjectDependencyCoordinate> coordinate,
+        Func<TEntry, string?> rowIdentityPath,
+        string subject)
+    {
+        var seen = new HashSet<RowIdentity>();
+        foreach (TEntry entry in entries)
+        {
+            ProjectDependencyCoordinate package = coordinate(entry);
+            if (!seen.Add(new RowIdentity(
+                    package.PackageId,
+                    package.Version,
+                    rowIdentityPath(entry))))
+            {
+                throw new InspectionQueryException(
+                    $"Project {subject} rows must have distinct package and document identity.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rejects rows that share one dependency coordinate, for a result that reports at most one
+    /// document per direct dependency.
+    /// </summary>
+    internal static void RequireDistinctCoordinates<TEntry>(
+        ImmutableArray<TEntry> entries,
+        Func<TEntry, ProjectDependencyCoordinate> coordinate,
+        string subject)
+        => RequireDistinctRows(entries, coordinate, static _ => null, subject);
+
+    internal static ImmutableArray<ProjectDocumentFailure> OrderFailures(
+        ImmutableArray<ProjectDocumentFailure> failures)
+        =>
+        [
+            .. failures
+                .OrderBy(static failure =>
+                    failure.Disposition == ProjectDocumentSubjectDisposition.Redacted ? 1 : 0)
+                .ThenBy(
+                    static failure => failure.Package?.PackageId,
+                    OptionalOrdinalIgnoreCase)
+                .ThenBy(static failure => failure.Package?.PackageId, OptionalOrdinal)
+                .ThenBy(static failure => failure.Package?.Version, OptionalOrdinal)
+                .ThenBy(static failure => failure.DocumentPath, OptionalOrdinal)
+                .ThenBy(static failure => failure.Reason),
+        ];
+
+    /// <summary>
+    /// One row's identity. Package ids compare case-insensitively because NuGet package identity
+    /// does; versions and document paths compare exactly.
+    /// </summary>
+    private readonly record struct RowIdentity(
+        string PackageId,
+        string Version,
+        string? DocumentPath)
+    {
+        public bool Equals(RowIdentity other)
+            => StringComparer.OrdinalIgnoreCase.Equals(PackageId, other.PackageId)
+                && StringComparer.Ordinal.Equals(Version, other.Version)
+                && StringComparer.Ordinal.Equals(DocumentPath, other.DocumentPath);
+
+        public override int GetHashCode()
+            => HashCode.Combine(
+                StringComparer.OrdinalIgnoreCase.GetHashCode(PackageId),
+                StringComparer.Ordinal.GetHashCode(Version),
+                DocumentPath is null ? 0 : StringComparer.Ordinal.GetHashCode(DocumentPath));
+    }
+}


### PR DESCRIPTION
`DotnetInspector.Queries` now exposes deterministic, host-neutral project document contracts for dependency Skills, Agent Guidance, and Package Docs.

## Demo

Before this change, the CLI had no query-layer seam for already-acquired project documents. A host can now construct typed inputs and receive stable rows without passing paths, package clients, CLI options, or presentation callbacks:

```csharp
var result = ProjectSkillsQuery.Execute(
    new ProjectSkillsRequest(
    [
        new(new("Zulu", "2.0.0"), "skills/z/SKILL.md"),
        new(new("Alpha", "1.0.0"), "skills/a/SKILL.md"),
    ]));

// Alpha/skills/a/SKILL.md, then Zulu/skills/z/SKILL.md
```

Missing and unreadable documents retain their row with null content. Failures are typed and visible, including a structurally enforced redacted disposition for unsafe package-authored identity.

## Validation

- Current head `afd02b51a19a69f82d1562db87acfc19e620611e`
- Base `5bb2e04e61df58709d6e89ded9ca4d46157ad4c8`
- `dotnet run --project src\DotnetInspector.Queries.Tests -c Release --no-restore`: 717 passed
- Pre-rebase Release solution build passed; current-head CI will confirm the merge path

## Boundaries

No providers, acquisition, filesystem access, sections, CLI flags, discovery, presentation, or user-visible project-command behavior.

Closes #4891
