### PR TITLE
Add manifest Browser and resource canaries

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -214,6 +214,38 @@ the oracle dependency enters a product, NativeAOT, or Browser path. The pinned
 coordinates, hashes, baseline, and maintenance procedure are recorded in
 [`eng/package-manifest-corpus.md`](../../eng/package-manifest-corpus.md).
 
+The manifest-facts path has two consumer and resource canaries.
+`BrowserEngineBoundaryTests.PackageManifestFacts_FromInMemoryBytesRemainBrowserCompatible`
+executes the query from exact in-memory bytes in the inspect-web consumer test
+surface. The CI inspect-web lane publishes the Browser/Wasm engine, where the
+exported `QueryPackageDependencies` operation roots the same query through
+`PackageDependencyGroupsQuery`; the
+`PackageManifestFactsQuery.cs` change-detection canary ensures changes to that
+path cannot skip the lane.
+`PackageManifestFactsQueryTests.Execute_AcceptsManifestAtExactByteLimit`,
+`Execute_AcceptsManifestAtExactDecodedCharacterLimit`,
+`Execute_EnforcesManifestByteLimit`, and
+`Execute_RejectsManifestBeyondDecodedCharacterLimit` gate the byte and
+decoded-character boundaries. The existing
+`Execute_AcceptsScalarAndCollectionLimits`,
+`Execute_RejectsOversizedScalarFact`,
+`Execute_RejectsExcessivePackageTypeCardinality`,
+`Execute_RejectsExcessiveDependencyGroupCardinality`, and
+`Execute_RejectsExcessiveDependencyCardinality` tests gate the remaining exact
+boundaries.
+
+`FindCommandTests.PackageProfileDefaultScale_AcquiresEachManifestOnceAndBoundsProjectedRows`
+is the deterministic operation-count canary. Its pinned input is the default
+100-coordinate profile, with 64 dependencies per manifest and a 25-row output
+window. The recorded baseline is one search, exactly one manifest request per
+coordinate, no package archive requests, one registry materialization reused by
+subsequent reads, and exactly 25 projected rows. Run it with:
+
+```bash
+dotnet run --project src/dotnet-inspect.Tests -c Release -- \
+  -method '*PackageProfileDefaultScale*'
+```
+
 L1 does not reference Markout.
 
 ### L2 — `DotnetInspector.Sections`

--- a/eng/CiChangeDetection/DetectionTestSuite.cs
+++ b/eng/CiChangeDetection/DetectionTestSuite.cs
@@ -314,6 +314,20 @@ internal static class DetectionTestSuite
                 FormatValues(webDependency));
         }
 
+        Dictionary<string, string> manifestQueryDependency = RunDetection(
+            repository,
+            body,
+            "pull_request",
+            "src/DotnetInspector.Queries/PackageManifestFactsQuery.cs",
+            outputs);
+        if (manifestQueryDependency["code"] != "true"
+            || manifestQueryDependency["web"] != "true")
+        {
+            throw new InvalidOperationException(
+                "Package-manifest query canary did not select code and web: "
+                + FormatValues(manifestQueryDependency));
+        }
+
         Dictionary<string, string> sharedWebCompileInput = RunDetection(
             repository,
             body,

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -6,6 +6,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Versioning;
+using System.Text;
 using System.Xml;
 using System.Text.Json;
 using DotnetInspector.Packages;
@@ -25,6 +26,39 @@ namespace InspectWeb.Engine.Tests;
 public sealed class BrowserEngineBoundaryTests
 {
     const int MiB = 1024 * 1024;
+
+    [Fact]
+    public void PackageManifestFacts_FromInMemoryBytesRemainBrowserCompatible()
+    {
+        PackageSourceCoordinate coordinate =
+            PackageSourceCoordinate.Create(
+                "Example.Package",
+                "1.0.0");
+        byte[] manifestBytes = Encoding.UTF8.GetBytes(
+            """
+            <package>
+              <metadata>
+                <id>Example.Package</id>
+                <version>1.0.0</version>
+                <dependencies>
+                  <dependency id="Example.Dependency" version="[2.0.0]" />
+                </dependencies>
+              </metadata>
+            </package>
+            """);
+
+        PackageManifestFacts facts = Assert.IsType<
+            PackageManifestFactsResult.Available>(
+                PackageManifestFactsQuery.Execute(
+                    manifestBytes,
+                    coordinate)).Value;
+
+        Assert.Equal(coordinate, facts.Coordinate);
+        Assert.Equal(
+            "Example.Dependency",
+            Assert.Single(
+                Assert.Single(facts.DependencyGroups).Dependencies).Id);
+    }
 
     public static object PerformanceBoxingProbe(int value) => value;
 

--- a/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageManifestFactsQueryTests.cs
@@ -301,6 +301,74 @@ public sealed class PackageManifestFactsQueryTests
     }
 
     [Fact]
+    public void Execute_AcceptsManifestAtExactByteLimit()
+    {
+        byte[] manifestBytes = Encoding.UTF8.GetBytes(
+            PadToManifestByteCount(
+                MinimalManifest(),
+                PackageManifestFactsQuery.MaxManifestBytes));
+
+        PackageManifestFacts facts = Available(
+            PackageManifestFactsQuery.Execute(
+                manifestBytes,
+                PackageSourceCoordinate.Create(
+                    "Example.Package",
+                    "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFactsQuery.MaxManifestBytes,
+            manifestBytes.Length);
+        Assert.Equal(
+            PackageSourceCoordinate.Create(
+                "Example.Package",
+                "1.0.0"),
+            facts.Coordinate);
+    }
+
+    [Fact]
+    public void Execute_AcceptsManifestAtExactDecodedCharacterLimit()
+    {
+        string manifest = PadToCharacterCount(
+            MinimalManifest(),
+            PackageManifestFactsQuery.MaxManifestCharacters);
+
+        PackageManifestFacts facts = Available(
+            PackageManifestFactsQuery.Execute(
+                Encoding.UTF8.GetBytes(manifest),
+                PackageSourceCoordinate.Create(
+                    "Example.Package",
+                    "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFactsQuery.MaxManifestCharacters,
+            manifest.Length);
+        Assert.Equal(
+            PackageSourceCoordinate.Create(
+                "Example.Package",
+                "1.0.0"),
+            facts.Coordinate);
+    }
+
+    [Fact]
+    public void Execute_RejectsManifestBeyondDecodedCharacterLimit()
+    {
+        string manifest = PadToCharacterCount(
+            MinimalManifest(),
+            PackageManifestFactsQuery.MaxManifestCharacters + 1);
+        PackageManifestFactsResult.Failed failure = Assert.IsType<
+            PackageManifestFactsResult.Failed>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(manifest),
+                    PackageSourceCoordinate.Create(
+                        "Example.Package",
+                        "1.0.0")));
+
+        Assert.Equal(
+            PackageManifestFailureReason.MalformedXml,
+            failure.Failure.Reason);
+    }
+
+    [Fact]
     public void Execute_RejectsOversizedScalarFact()
     {
         string authors = new(
@@ -538,4 +606,46 @@ public sealed class PackageManifestFactsQueryTests
     private static PackageManifestFacts Available(
         PackageManifestFactsResult result) =>
         Assert.IsType<PackageManifestFactsResult.Available>(result).Value;
+
+    private static string MinimalManifest() =>
+        """
+        <package>
+          <metadata>
+            <id>Example.Package</id>
+            <version>1.0.0</version>
+          </metadata>
+        </package>
+        """;
+
+    private static string PadToManifestByteCount(
+        string manifest,
+        int byteCount)
+    {
+        int remaining = byteCount - Encoding.UTF8.GetByteCount(manifest);
+        Assert.True(remaining >= 7);
+        int multibyteCharacters = (remaining - 7) / 3;
+        int singleBytePadding =
+            remaining - 7 - (multibyteCharacters * 3);
+        string padded = manifest
+            + "<!--"
+            + new string('漢', multibyteCharacters)
+            + new string(' ', singleBytePadding)
+            + "-->";
+        Assert.Equal(
+            byteCount,
+            Encoding.UTF8.GetByteCount(padded));
+        return padded;
+    }
+
+    private static string PadToCharacterCount(
+        string manifest,
+        int characterCount)
+    {
+        int remaining = characterCount - manifest.Length;
+        Assert.True(remaining >= 7);
+        string padded =
+            manifest + "<!--" + new string('a', remaining - 7) + "-->";
+        Assert.Equal(characterCount, padded.Length);
+        return padded;
+    }
 }

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text;
 using System.Text.Json;
 using DotnetInspector.Queries;
 using DotnetInspector.Commands;
@@ -440,6 +441,60 @@ public class FindCommandTests
     }
 
     [Fact]
+    public async Task
+        PackageProfileDefaultScale_AcquiresEachManifestOnceAndBoundsProjectedRows()
+    {
+        const int candidateCount = 100;
+        const int dependenciesPerManifest = 64;
+        const int projectedRowLimit = 25;
+        var source = new DefaultScalePackageSource(
+            candidateCount,
+            dependenciesPerManifest);
+        PackageProfileSectionCatalog catalog =
+            PackageProfileSections.CreateCatalog();
+        HashSet<InspectionQueryDefinition> requested =
+            catalog.Pipeline.GetRequiredQueries(
+                Verbosity.Normal,
+                [PackageProfileSections.Packages]);
+
+        InspectionQueryResults results =
+            await catalog.QueryRegistry.RunAsync(
+                requested,
+                new PackageProfileQueryContext(
+                    source,
+                    new PackagePrefixProfileRequest("Contoso.")),
+                cancellationToken:
+                    TestContext.Current.CancellationToken);
+        ImmutableArray<PackageProfileEvent> events =
+            results.Get(PackageProfileQuery.Definition);
+        PackageProfileView view =
+            PackageProfileSections.CreateDocument(
+                "Contoso.",
+                events,
+                RowWindow.Head(projectedRowLimit));
+        ImmutableArray<PackageProfileEvent> secondRead =
+            results.Get(PackageProfileQuery.Definition);
+
+        Assert.Equal(1, source.SearchRequests);
+        Assert.Equal(candidateCount, source.ManifestRequests.Count);
+        Assert.Equal(
+            candidateCount,
+            source.ManifestRequests
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count());
+        Assert.Equal(0, source.PackageRequests);
+        Assert.Equal(events, secondRead);
+        Assert.Equal(
+            candidateCount,
+            events.Count(profileEvent =>
+                profileEvent is PackageProfileEvent.Match));
+        Assert.Equal(
+            projectedRowLimit,
+            PackageProfileSections.CountRows(view));
+        Assert.Equal(projectedRowLimit, view.Results!.Count);
+    }
+
+    [Fact]
     public void PackageProfileSection_ReusesContainedPackageCells()
     {
         const int dependencyCount = 1000;
@@ -866,6 +921,134 @@ public class FindCommandTests
                 string version,
                 CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
+
+        public Task<PackageSourceOperationResult<PackageSourcePayload>>
+            TryGetSymbolsAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class DefaultScalePackageSource(
+        int candidateCount,
+        int dependenciesPerManifest)
+        : IPackageSourceClient
+    {
+        public int SearchRequests { get; private set; }
+        public List<string> ManifestRequests { get; } = [];
+        public int PackageRequests { get; private set; }
+        public PackageSourceIdentity Identity =>
+            PackageSourceIdentity.NuGetOrg;
+        public PackageSourceKind Kind =>
+            PackageSourceKind.NuGetGallery;
+        public PackageSourceCapabilities Capabilities =>
+            PackageSourceCapabilities.Search
+            | PackageSourceCapabilities.Manifest;
+
+        public Task<PackageSourceOperationResult<PackageSearchResult>>
+            SearchByPrefixAsync(
+                string prefix,
+                int take = 100,
+                bool prerelease = false,
+                CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SearchRequests++;
+            PackageSearchMatch[] matches =
+            [
+                .. Enumerable.Range(0, candidateCount)
+                    .Select(index =>
+                    {
+                        string packageId =
+                            $"Contoso.Package{index:D3}";
+                        PackageSourceCoordinate coordinate =
+                            PackageSourceCoordinate.Create(
+                                packageId,
+                                "1.0.0");
+                        return new PackageSearchMatch(
+                            new SearchResult(
+                                packageId,
+                                "1.0.0"),
+                            new PackageCandidateObservation(
+                                coordinate,
+                                Identity,
+                                PackageDiscoveryContract.KeywordSearch,
+                                PackageListingState.Listed));
+                    }),
+            ];
+            return Task.FromResult<
+                PackageSourceOperationResult<PackageSearchResult>>(
+                    new PackageSourceOperationResult<PackageSearchResult>
+                        .Succeeded(
+                            new PackageSearchResult(
+                                matches,
+                                PackageSearchTruncationReason.None)));
+        }
+
+        public Task<PackageSourceOperationResult<PackageSourceManifest>>
+            GetManifestAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PackageSourceCoordinate coordinate =
+                PackageSourceCoordinate.Create(packageId, version);
+            ManifestRequests.Add(
+                $"{coordinate.PackageId}@{coordinate.Version}");
+            string dependencies = string.Concat(
+                Enumerable.Range(0, dependenciesPerManifest)
+                    .Select(index =>
+                        $"""<dependency id="Dependency.{index:D3}" version="1.0.0" />"""));
+            byte[] content = Encoding.UTF8.GetBytes(
+                $$"""
+                <package>
+                  <metadata>
+                    <id>{{coordinate.PackageId}}</id>
+                    <version>{{coordinate.Version}}</version>
+                    <dependencies>{{dependencies}}</dependencies>
+                  </metadata>
+                </package>
+                """);
+            return Task.FromResult<
+                PackageSourceOperationResult<PackageSourceManifest>>(
+                    new PackageSourceOperationResult<PackageSourceManifest>
+                        .Succeeded(
+                            new PackageSourceManifest(
+                                coordinate,
+                                Identity,
+                                Kind,
+                                content)));
+        }
+
+        public Task<PackageSourceOperationResult<PackageSearchResult>>
+            SearchAsync(
+                string query,
+                int take = 20,
+                bool prerelease = false,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<PackageSourceOperationResult<PackageVersionResult>>
+            GetVersionsAsync(
+                string packageId,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<PackageSourceOperationResult<PackageSourcePayload>>
+            GetPackageAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default)
+        {
+            PackageRequests++;
+            throw new NotSupportedException();
+        }
 
         public Task<PackageSourceOperationResult<PackageSourcePayload>>
             TryGetSymbolsAsync(

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -475,13 +475,17 @@ public class FindCommandTests
         ImmutableArray<PackageProfileEvent> secondRead =
             results.Get(PackageProfileQuery.Definition);
 
-        Assert.Equal(1, source.SearchRequests);
-        Assert.Equal(candidateCount, source.ManifestRequests.Count);
         Assert.Equal(
-            candidateCount,
-            source.ManifestRequests
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Count());
+            [
+                (
+                    Prefix: "Contoso.",
+                    Take: candidateCount,
+                    Prerelease: false),
+            ],
+            source.SearchRequests);
+        Assert.Equal(
+            source.CandidateCoordinates,
+            source.ManifestRequests);
         Assert.Equal(0, source.PackageRequests);
         Assert.Equal(events, secondRead);
         Assert.Equal(
@@ -939,8 +943,18 @@ public class FindCommandTests
         int dependenciesPerManifest)
         : IPackageSourceClient
     {
-        public int SearchRequests { get; private set; }
-        public List<string> ManifestRequests { get; } = [];
+        public PackageSourceCoordinate[] CandidateCoordinates { get; } =
+        [
+            .. Enumerable.Range(0, candidateCount)
+                .Select(index =>
+                    PackageSourceCoordinate.Create(
+                        $"Contoso.Package{index:D3}",
+                        "1.0.0")),
+        ];
+        public List<(string Prefix, int Take, bool Prerelease)>
+            SearchRequests
+        { get; } = [];
+        public List<PackageSourceCoordinate> ManifestRequests { get; } = [];
         public int PackageRequests { get; private set; }
         public PackageSourceIdentity Identity =>
             PackageSourceIdentity.NuGetOrg;
@@ -958,28 +972,19 @@ public class FindCommandTests
                 CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            SearchRequests++;
+            SearchRequests.Add((prefix, take, prerelease));
             PackageSearchMatch[] matches =
             [
-                .. Enumerable.Range(0, candidateCount)
-                    .Select(index =>
-                    {
-                        string packageId =
-                            $"Contoso.Package{index:D3}";
-                        PackageSourceCoordinate coordinate =
-                            PackageSourceCoordinate.Create(
-                                packageId,
-                                "1.0.0");
-                        return new PackageSearchMatch(
+                .. CandidateCoordinates.Select(coordinate =>
+                        new PackageSearchMatch(
                             new SearchResult(
-                                packageId,
-                                "1.0.0"),
+                                coordinate.PackageId,
+                                coordinate.Version),
                             new PackageCandidateObservation(
                                 coordinate,
                                 Identity,
                                 PackageDiscoveryContract.KeywordSearch,
-                                PackageListingState.Listed));
-                    }),
+                                PackageListingState.Listed))),
             ];
             return Task.FromResult<
                 PackageSourceOperationResult<PackageSearchResult>>(
@@ -999,8 +1004,18 @@ public class FindCommandTests
             cancellationToken.ThrowIfCancellationRequested();
             PackageSourceCoordinate coordinate =
                 PackageSourceCoordinate.Create(packageId, version);
-            ManifestRequests.Add(
-                $"{coordinate.PackageId}@{coordinate.Version}");
+            if (!CandidateCoordinates.Contains(coordinate))
+            {
+                throw new InvalidOperationException(
+                    "The query requested a coordinate outside the search result.");
+            }
+            if (ManifestRequests.Contains(coordinate))
+            {
+                throw new InvalidOperationException(
+                    "The query requested one manifest more than once.");
+            }
+
+            ManifestRequests.Add(coordinate);
             string dependencies = string.Concat(
                 Enumerable.Range(0, dependenciesPerManifest)
                     .Select(index =>


### PR DESCRIPTION
## Summary

- prove package-manifest facts remain compatible with the inspect-web
  Browser/Wasm consumer from exact in-memory bytes
- pair the manifest byte and decoded-character ceilings with exact-boundary
  positives and close negatives
- measure the default 100-coordinate package profile at one search, one
  manifest request per coordinate, no archive requests, one reused
  materialization, and a 25-row projection
- ensure changes to `PackageManifestFactsQuery` cannot skip the inspect-web CI
  lane

## Demo

```text
$ dotnet run --project src/dotnet-inspect.Tests -c Release -- \
    -method '*PackageProfileDefaultScale*'
dotnet-inspect.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0
```

The passing canary fixes its input at 100 package coordinates with 64
dependencies each. Its assertions measure one search, 100 distinct manifest
requests, zero package-archive requests, reuse of the materialized query
result, and exactly 25 projected rows.

## Validation

- `DotnetInspector.Queries.Tests`: 24/24 focused manifest-facts tests pass
- `dotnet-inspect.Tests`: default-scale operation canary passes
- `InspectWeb.Engine.Tests`: 161/161 tests pass
- Browser/Wasm `dotnet publish` succeeds with the manifest query rooted through
  `QueryPackageDependencies`
- CI change-detection fail-safe and path canaries pass
- `dotnet build dotnet-inspect.slnx -c Release`: 0 warnings, 0 errors
- changed Markdown passes `markdownlint`

## Compatibility

This PR changes no product behavior, structural acceptance, failure taxonomy,
acquisition implementation, or presentation contract. It adds executable
consumer, limit, request-count, and row-window evidence around the existing
Queries-owned behavior.

Closes #4723
Closes #4714
