### PR TITLE
Extract value-type this fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5435,15 +5435,6 @@ public enum CfgTiny : byte { A = 1, B = 2 }
 [System.Flags]
 public enum CfgStyles { None = 0, Alpha = 1, Beta = 2, Gamma = 16 }
 
-// A value-type instance method whose `this` value is read directly: returning
-// `this` by value compiles to `ldarg.0; ldobj` (a load-indirect of the `this`
-// managed pointer), which must render as `this`, not the CS0193 `*this`.
-public struct CfgSelf
-{
-    public int Value;
-    public CfgSelf Identity() => this;
-}
-
 // A value-type Equals(object) that reads a field off the unboxed argument:
 // `((CfgBoxed)other).Value` compiles to `unbox` (a managed pointer into the
 // box) + `ldfld`, so the field receiver is an Unbox node. The printer must

--- a/src/ILInspector.Decompiler.Tests/ValueTypeThisSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/ValueTypeThisSamples.cs
@@ -1,0 +1,10 @@
+namespace ILInspector.Decompiler.Tests;
+
+// A value-type instance method whose `this` value is read directly: returning
+// `this` by value compiles to `ldarg.0; ldobj` (a load-indirect of the `this`
+// managed pointer), which must render as `this`, not the CS0193 `*this`.
+public struct CfgSelf
+{
+    public int Value;
+    public CfgSelf Identity() => this;
+}


### PR DESCRIPTION
Moves `CfgSelf` and its existing explanatory comment unchanged from `CfgSampleClass.cs` into the feature-focused `ValueTypeThisSamples.cs` fixture file. `ValueTypeThisRead_RendersAsThis` retains the same compiled type identity and managed-`this` load behavior.

Part of #3913.

## Demo

`ValueTypeThisRead_RendersAsThis` still renders the value-type instance read as `return this;`, never the invalid `*this`, after the source split.

## Validation

Exact head: `30c92542ddbd497d283581d1baa2f6fc6c7586eb`
Exact integrated base: `3555fbebaf65c35d6113d79d57f3a75f758f6f7b`

- `ValueTypeThisRead_RendersAsThis`: 1 passed in Release
- Release solution build: passed with 0 errors
- Decompiler fast gate: 5,643 passed, 8 expected Windows skips, and the known `ToLowerOrdinal` failure reproduced identically on the exact base
- Stable-path render A/B: 22,132 methods; 0 changed, 0 added, 0 removed
- Adversarial review: GPT-5.6 Sol and Claude Opus 5 clean on the exact head
- CI: `ci-required` succeeded on the exact head

## Non-action boundary

No symbols, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.