### PR TITLE
Ask before re-reviewing trivial base interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,29 +189,32 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
   findings carry forward.
 - **Auto-merge on the final push:** once every required review is review-clean,
   the user may authorize auto-merge for the intended final head; the agent may
-  ask. If the head moves after arming, disarm, review the new head, and ask
-  again.
+  ask. If the head moves after arming, disarm and ask again before arming the
+  new exact head. Review that head first unless the user approves its
+  exact-head trivial-interaction waiver.
 - **"CI is ready":** the user's statement that CI has no failures and the PR is
   mergeable. Trust it without re-checking and move to the next task, such as
   dispatching the next round's reviewers.
 - **Authorizing the next round before CI completes:** the agent does not need
   to check CI status first; proceed with the authorized round.
 - **Skip re-review after a trivial base interaction:** requires the user's
-  approval for one exact integration head. Offer this adjustment only for a
-  `main`-targeting PR or bottom open stack slice that changes from a
-  review-clean head solely to integrate a moved base. Every overlap must be
-  mechanically resolved by taking the analyzed base side verbatim or dropping
-  the PR's change to that file, the resulting PR diff must be a subset of the
-  reviewed diff, and no surviving reviewed claim, contract, or behavior may
-  change. Dropping an entire conflicting-file change may narrow the PR;
-  explain why that removal does not weaken its remaining claims. Present that
-  evidence before asking. Run the affected focused gates and retain all
-  current-head CI and mergeability requirements. The prior reviews remain
-  evidence only for their reviewed head: remove `review-clean`, do not
-  describe the integration head as reviewed or review-clean, and record the
-  exact-head waiver publicly. Any semantic conflict resolution, new authored
-  change, or interaction with surviving reviewed behavior requires ordinary
-  re-review.
+  approval for one exact integration head against one exact analyzed base tip.
+  Offer this adjustment only for a `main`-targeting PR or bottom open stack
+  slice that changes from a review-clean head solely to integrate a moved
+  base. Every overlap must be mechanically resolved by taking the analyzed
+  base side verbatim or dropping the PR's change to that file, the resulting
+  PR diff must be a subset of the reviewed diff, and no surviving reviewed
+  claim, contract, or behavior may change. Dropping an entire conflicting-file
+  change may narrow the PR; explain why that removal does not weaken its
+  remaining claims. Present that evidence before asking. Run the affected
+  focused gates and retain all current-head CI and mergeability requirements.
+  The prior reviews remain evidence only for their reviewed head: remove
+  `review-clean`, do not describe the integration head as reviewed or
+  review-clean, and record the exact-head and exact-base waiver publicly. Any
+  later movement of either the head or base expires a pending or approved
+  waiver and re-enters carry-forward analysis. Any semantic conflict
+  resolution, new authored change, or interaction with surviving reviewed
+  behavior requires ordinary re-review.
 
 ## Before changing files
 
@@ -896,22 +899,28 @@ below.
 
 ### Clean reviews are not spent by main moving
 
-When a `main`-targeting PR has a review-clean current head and `origin/main`
-moves, assess the landed range before doing anything else; do not integrate
-blindly and do not start another round by default. This also applies to the
-bottom open stack slice. An upper slice follows its parent, so parent movement
-is a restack and requires review at the new head.
+When a `main`-targeting PR has a review-clean current head or a current head
+with a pending or approved trivial-interaction waiver and `origin/main` moves,
+assess the landed range before doing anything else; do not integrate blindly
+and do not start another round by default. Any movement beyond a waiver's
+recorded base expires that waiver before classification. This also applies to
+the bottom open stack slice. An upper slice follows its parent, so parent
+movement is a restack and requires review at the new head.
 
 After a non-mutating fetch, classify the exact landed range into exactly one
 outcome and act on it directly:
 
 - **No interaction.** The range does not touch files, contracts, or behavior
-  this change touches. Keep `review-clean`, integrate the exact analyzed tip by
-  SHA, and update the recorded head SHA — skip re-running validation, CI, and
-  review. This is the common case on a fast-moving `main` and is what ends the
-  poll-and-rerun loop: repeated non-interacting movement never demands another
-  gate. Merging itself still needs a live readiness check and explicit user
-  authorization (invariants 5 and 8 under [Adversarial
+  this change touches. From a review-clean head, keep `review-clean`, integrate
+  the exact analyzed tip by SHA, update the recorded head SHA, and skip
+  re-running validation, CI, and review. This is the common case on a
+  fast-moving `main` and is what ends the poll-and-rerun loop: repeated
+  non-interacting movement from a reviewed head never demands another gate.
+  From a pending or approved waiver head, integrate the exact tip but do not
+  transfer the old exact-head waiver: present the new head and base and ask for
+  a fresh waiver before dispatching review, retaining the waiver path's
+  current-head gate requirements. Merging itself still needs a live readiness
+  check and explicit user authorization (invariants 5 and 8 under [Adversarial
   review](#adversarial-review)); base movement alone does not grant it.
 - **Trivial interaction.** The range overlaps files, but integration can
   resolve every overlap mechanically by taking the analyzed base side verbatim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,10 +188,11 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
   failure requiring an author change still supersedes the attempt, and all
   findings carry forward.
 - **Auto-merge on the final push:** once every required review is review-clean,
-  the user may authorize auto-merge for the intended final head; the agent may
-  ask. If the head moves after arming, disarm and ask again before arming the
-  new exact head. Review that head first unless the user approves its
-  exact-head trivial-interaction waiver.
+  or the intended final head/base carries an approved exact-head
+  trivial-interaction waiver, the user may authorize auto-merge for that exact
+  candidate; the agent may ask. If the head or base moves after arming, disarm
+  and ask again before arming the new exact candidate. Review that head first
+  unless the user approves its exact-head trivial-interaction waiver.
 - **"CI is ready":** the user's statement that CI has no failures and the PR is
   mergeable. Trust it without re-checking and move to the next task, such as
   dispatching the next round's reviewers.
@@ -200,21 +201,26 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 - **Skip re-review after a trivial base interaction:** requires the user's
   approval for one exact integration head against one exact analyzed base tip.
   Offer this adjustment only for a `main`-targeting PR or bottom open stack
-  slice that changes from a review-clean head solely to integrate a moved
-  base. Every overlap must be mechanically resolved by taking the analyzed
-  base side verbatim or dropping the PR's change to that file, the resulting
-  PR diff must be a subset of the reviewed diff, and no surviving reviewed
-  claim, contract, or behavior may change. Dropping an entire conflicting-file
-  change may narrow the PR; explain why that removal does not weaken its
-  remaining claims. Present that evidence before asking. Run the affected
-  focused gates and retain all current-head CI and mergeability requirements.
-  The prior reviews remain evidence only for their reviewed head: remove
-  `review-clean`, do not describe the integration head as reviewed or
-  review-clean, and record the exact-head and exact-base waiver publicly. Any
-  later movement of either the head or base expires a pending or approved
-  waiver and re-enters carry-forward analysis. Any semantic conflict
-  resolution, new authored change, or interaction with surviving reviewed
-  behavior requires ordinary re-review.
+  slice whose waiver lineage starts at one immutable review-clean head and
+  recorded base. The first candidate changes from that reviewed head solely to
+  integrate a moved base; a renewal may change from a recorded pending or
+  approved candidate in the same lineage solely to integrate another moved
+  base. At every step, resolve each overlap mechanically by taking the analyzed
+  base side verbatim or dropping the PR's change to that file. The cumulative
+  PR diff against the newest base must remain a subset of the original reviewed
+  diff, and no surviving reviewed claim, contract, or behavior may change.
+  Dropping an entire conflicting-file change may narrow the PR; explain why
+  that removal does not weaken its remaining claims. Present that evidence
+  before asking. Run the affected focused gates and retain all current-head CI
+  and mergeability requirements. The prior reviews remain evidence only for
+  their original reviewed head: remove `review-clean`, do not describe an
+  integration head as reviewed or review-clean, and record the immutable
+  reviewed head/base plus the approved exact integration head/base publicly.
+  Any later movement of either the head or base expires the current decision
+  and re-enters carry-forward analysis; a fresh waiver requires the same
+  cumulative lineage proof. Any semantic conflict resolution, new authored
+  change, or interaction with surviving reviewed behavior requires ordinary
+  re-review.
 
 ## Before changing files
 
@@ -1145,7 +1151,8 @@ Put it under `## Demo` above validation in the PR body.
   not infer either from the label or from a prior check.
 - Never merge without explicit authorization for that PR. A clean review, green
   CI, readiness comment, or request to prepare a PR is not authorization.
-  User-directed auto-merge authorizes only the reviewed head.
+  User-directed auto-merge authorizes only the exact reviewed head or the exact
+  head/base pair carrying an approved trivial-interaction waiver.
 
 ### Stacked PRs for multi-slice issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,22 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
   dispatching the next round's reviewers.
 - **Authorizing the next round before CI completes:** the agent does not need
   to check CI status first; proceed with the authorized round.
+- **Skip re-review after a trivial base interaction:** requires the user's
+  approval for one exact integration head. Offer this adjustment only for a
+  `main`-targeting PR or bottom open stack slice that changes from a
+  review-clean head solely to integrate a moved base. Every overlap must be
+  mechanically resolved by taking the analyzed base side verbatim or dropping
+  the PR's change to that file, the resulting PR diff must be a subset of the
+  reviewed diff, and no surviving reviewed claim, contract, or behavior may
+  change. Dropping an entire conflicting-file change may narrow the PR;
+  explain why that removal does not weaken its remaining claims. Present that
+  evidence before asking. Run the affected focused gates and retain all
+  current-head CI and mergeability requirements. The prior reviews remain
+  evidence only for their reviewed head: remove `review-clean`, do not
+  describe the integration head as reviewed or review-clean, and record the
+  exact-head waiver publicly. Any semantic conflict resolution, new authored
+  change, or interaction with surviving reviewed behavior requires ordinary
+  re-review.
 
 ## Before changing files
 
@@ -824,7 +840,10 @@ least one reviewer returned a finding.
 
 - **Conflict:** supersede the attempt, integrate and resolve, push immediately,
   and restart the same round without waiting for CI. The six-round boundary
-  still applies.
+  still applies. A conflict after clean review may instead take the exact-head
+  trivial-interaction waiver path below when its resolution satisfies every
+  stated condition; do not dispatch replacement reviewers while that decision
+  is pending.
 - **Scope violation:** keep the locked head unchanged while the user chooses
   split, abandonment, or an explicitly approved broad exception. Split or
   abandonment supersedes the attempt without spending the round; reconcile
@@ -854,8 +873,9 @@ before the restarted round closes.
 ### Forming a candidate
 
 Spend review only on a pushed, settled head formed by the canonical cycle.
-Record the exact head and effective base. If a conflict, author change, finding,
-or restack moves the head, form a replacement through the cycle again.
+Record the exact head and effective base. If a conflict, author change,
+finding, or restack moves the head, form a replacement through the cycle again
+unless the user approves the exact-head trivial-interaction waiver below.
 
 While a candidate is locked, do not push or integrate. Recovery is the only
 mutation exception; a non-mutating fetch is allowed to re-establish state after
@@ -883,8 +903,7 @@ bottom open stack slice. An upper slice follows its parent, so parent movement
 is a restack and requires review at the new head.
 
 After a non-mutating fetch, classify the exact landed range into exactly one
-outcome and act on it directly — the classification drives the response, not a
-per-movement approval prompt:
+outcome and act on it directly:
 
 - **No interaction.** The range does not touch files, contracts, or behavior
   this change touches. Keep `review-clean`, integrate the exact analyzed tip by
@@ -894,20 +913,33 @@ per-movement approval prompt:
   gate. Merging itself still needs a live readiness check and explicit user
   authorization (invariants 5 and 8 under [Adversarial
   review](#adversarial-review)); base movement alone does not grant it.
+- **Trivial interaction.** The range overlaps files, but integration can
+  resolve every overlap mechanically by taking the analyzed base side verbatim
+  or dropping the PR's change to that file, and no surviving reviewed claim,
+  contract, or behavior changes. Remove `review-clean`, integrate the exact
+  analyzed tip, run affected focused gates, and push the resolution head.
+  Confirm that the resulting PR diff is a subset of the reviewed diff, then
+  present the old and new heads, exact resolution, diff comparison, why any
+  dropped change does not weaken the remaining claims, and gate results. Ask
+  whether to skip re-review for that exact head before dispatching reviewers.
+  A proactive approval may be recorded without asking again. Approval waives
+  re-review but does not transfer review evidence or restore `review-clean`;
+  current-head CI, live mergeability, and explicit merge authorization remain
+  mandatory. Without approval, run the ordinary replacement review.
 - **Significant interaction, no conflict.** The range touches related files,
   contracts, or behavior but merges cleanly. Remove `review-clean`, integrate
   the tip, re-run the applicable validation and current-head CI, and
   re-dispatch the required reviewers at the new head as a normal round; the
   prior clean reviews do not carry forward.
-- **Merge conflict.** Remove `review-clean` and treat it as an author change:
-  integrate, resolve the conflict, rebuild and re-test, and re-dispatch the
-  required reviewers at the new head, following the ordinary [conflict recovery
-  transition](#recovery-transitions).
+- **Merge conflict requiring semantic resolution.** Remove `review-clean` and
+  treat it as an author change: integrate, resolve the conflict, rebuild and
+  re-test, and re-dispatch the required reviewers at the new head, following
+  the ordinary [conflict recovery transition](#recovery-transitions).
 
 Report the classification and the action taken as normal session output before
-changing labels or dispatching reviewers. Re-classify only when the landed
-range itself changes — a later, distinct base movement — not on every poll of
-an already-classified range. Follow the full
+changing labels, integrating a trivial interaction, or dispatching reviewers.
+Re-classify only when the landed range itself changes — a later, distinct base
+movement — not on every poll of an already-classified range. Follow the full
 [carry-forward procedure](docs/round-orchestration.md#carry-forward-after-clean-reviews).
 
 ### A quick read is not a round

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1155,6 +1155,8 @@ that race in the same files. `docs/stacked-prs.md` owns the mechanics.
 - Restacking your own slices is the exception to the no-force-push rule. Use
   `--force-with-lease` and post a `range-diff` proving only the base changed.
 - Apply review depth and the canonical eligibility table per slice and
-  stack-wide. Every moved head needs a review-clean round; restacking never
-  retires findings.
+  stack-wide. Every upper-slice restack and every other moved head needs a
+  review-clean round. The sole exception is a bottom open slice with a
+  user-approved exact-head trivial-interaction waiver; restacking never retires
+  findings.
 - Stop when another slice would exist only to continue the stack.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -302,22 +302,55 @@ the procedure once it does.
 3. **Classify and report.** As normal session output, report which commits
    touch files this change touches, which relied-on behavior they alter, and
    any conflict a textual merge would resolve silently but wrongly. State the
-   classification plainly: no interaction, significant interaction, or
-   conflict.
-4. **Act on the classification — no approval prompt.**
+   classification plainly: no interaction, trivial interaction, significant
+   interaction, or conflict requiring semantic resolution.
+4. **Act on the classification.**
    - *No interaction:* keep `review-clean`, integrate the exact analyzed tip by
      SHA (not a moving branch ref), and update the recorded head SHA. Skip
      re-running validation, CI, and review. Merging itself still needs a live
      readiness check and explicit user authorization; base movement alone does
      not grant either.
+   - *Trivial interaction:* remove `review-clean`, integrate the exact analyzed
+     tip, resolve every overlap mechanically as classified, run affected
+     focused gates, and push. Follow the waiver procedure below before
+     dispatching replacement reviewers.
    - *Significant interaction, no conflict:* remove `review-clean`, integrate
      the tip, re-run the claimed validation and current-head CI, and
      re-dispatch the required reviewers at the new head as a normal round.
-   - *Conflict:* remove `review-clean`, resolve it as an author change under
-     [conflict recovery](../AGENTS.md#recovery-transitions), and re-dispatch the
-     required reviewers at the new head.
+   - *Conflict requiring semantic resolution:* remove `review-clean`, resolve
+     it as an author change under
+     [conflict recovery](../AGENTS.md#recovery-transitions), and re-dispatch
+     the required reviewers at the new head.
 
 For a no-interaction carry-forward, record the reviewed head, the old and
-integrated tips, and the non-interaction analysis on the PR. For the other two
-outcomes, record the classification and the action taken, and produce the
-resulting round's normal [round report](#the-round-report).
+integrated tips, and the non-interaction analysis on the PR. For every other
+outcome, record the classification and the action taken. An ordinary
+replacement review produces the resulting round's normal
+[round report](#the-round-report); an approved trivial-interaction waiver does
+not start or spend a replacement round.
+
+### Trivial-interaction re-review waiver
+
+The binding criteria and evidentiary limits live in
+[Standing adjustments](../AGENTS.md#standing-adjustments). After the exact
+integration head is pushed, publish this evidence before asking:
+
+- the reviewed head, its recorded base, the new base, and the integration head;
+- every overlapping file and the mechanical resolution applied;
+- a comparison proving the resulting PR diff is a subset of the reviewed diff;
+- why removed or base-side changes do not alter the surviving reviewed claims,
+  contracts, or behavior; and
+- the affected focused-gate results and current status observation.
+
+Do not dispatch replacement reviewers while the waiver decision is pending. If
+the user has not already approved the adjustment, open a separate prompt only
+after the evidence appears in normal session output. Ask whether to skip
+re-review for the exact integration head; keep the prompt itself concise.
+
+On approval, record the exact-head waiver and its evidentiary consequence on
+the PR. Keep `review-clean` absent because the new head was not reviewed, and
+continue to current-head CI, live mergeability, and merge authorization.
+Without approval, do not waive review; resume the ordinary replacement
+workflow when work continues. A resolution that no longer satisfies the
+criteria requires ordinary re-review. A later head movement invalidates the
+waiver and requires fresh classification.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -287,8 +287,11 @@ include more detail when the findings or fixes warrant it.
 
 [Clean reviews are not spent by main
 moving](../AGENTS.md#clean-reviews-are-not-spent-by-main-moving) states when
-this path applies and how each landed-range classification resolves. This is
-the procedure once it does.
+this path applies and how each landed-range classification resolves. It applies
+both to a review-clean head and to a head with a pending or approved
+trivial-interaction waiver. A base tip beyond the one recorded for a waiver
+expires that waiver before classification. This is the procedure once the path
+applies.
 
 1. **Detect movement without API spend.** Fetch the effective base
    non-mutating, resolve its remote-tracking ref to an exact SHA, and compare
@@ -306,10 +309,14 @@ the procedure once it does.
    interaction, or conflict requiring semantic resolution.
 4. **Act on the classification.**
    - *No interaction:* keep `review-clean`, integrate the exact analyzed tip by
-     SHA (not a moving branch ref), and update the recorded head SHA. Skip
-     re-running validation, CI, and review. Merging itself still needs a live
-     readiness check and explicit user authorization; base movement alone does
-     not grant either.
+     SHA (not a moving branch ref), and update the recorded head SHA when
+     entering from a review-clean head; only that path skips re-running
+     validation, CI, and review. When entering from a pending or approved
+     waiver head, leave `review-clean` absent, integrate the exact tip, and
+     follow the waiver procedure below for the new head and base, including its
+     current-head gates, before dispatching review. Merging itself still needs
+     a live readiness check and explicit user authorization; base movement
+     alone does not grant either.
    - *Trivial interaction:* remove `review-clean`, integrate the exact analyzed
      tip, resolve every overlap mechanically as classified, run affected
      focused gates, and push. Follow the waiver procedure below before
@@ -347,10 +354,12 @@ the user has not already approved the adjustment, open a separate prompt only
 after the evidence appears in normal session output. Ask whether to skip
 re-review for the exact integration head; keep the prompt itself concise.
 
-On approval, record the exact-head waiver and its evidentiary consequence on
-the PR. Keep `review-clean` absent because the new head was not reviewed, and
-continue to current-head CI, live mergeability, and merge authorization.
+On approval, record the exact-head, exact-base waiver and its evidentiary
+consequence on the PR. Keep `review-clean` absent because the new head was not
+reviewed, and continue to current-head CI, live mergeability, and merge
+authorization.
 Without approval, do not waive review; resume the ordinary replacement
 workflow when work continues. A resolution that no longer satisfies the
-criteria requires ordinary re-review. A later head movement invalidates the
-waiver and requires fresh classification.
+criteria requires ordinary re-review. Any later head or base movement
+invalidates a pending or approved waiver and requires fresh carry-forward
+classification.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -342,9 +342,11 @@ The binding criteria and evidentiary limits live in
 [Standing adjustments](../AGENTS.md#standing-adjustments). After the exact
 integration head is pushed, publish this evidence before asking:
 
-- the reviewed head, its recorded base, the new base, and the integration head;
+- the immutable reviewed head and its recorded base, the prior integration
+  head/base when renewing, and the new integration head/base;
 - every overlapping file and the mechanical resolution applied;
-- a comparison proving the resulting PR diff is a subset of the reviewed diff;
+- a comparison proving the cumulative resulting PR diff is a subset of the
+  original reviewed diff;
 - why removed or base-side changes do not alter the surviving reviewed claims,
   contracts, or behavior; and
 - the affected focused-gate results and current status observation.
@@ -354,10 +356,10 @@ the user has not already approved the adjustment, open a separate prompt only
 after the evidence appears in normal session output. Ask whether to skip
 re-review for the exact integration head; keep the prompt itself concise.
 
-On approval, record the exact-head, exact-base waiver and its evidentiary
-consequence on the PR. Keep `review-clean` absent because the new head was not
-reviewed, and continue to current-head CI, live mergeability, and merge
-authorization.
+On approval, record the immutable reviewed head/base, the approved exact
+integration head/base, and the waiver's evidentiary consequence on the PR.
+Keep `review-clean` absent because the new head was not reviewed, and continue
+to current-head CI, live mergeability, and merge authorization.
 Without approval, do not waive review; resume the ordinary replacement
 workflow when work continues. A resolution that no longer satisfies the
 criteria requires ordinary re-review. Any later head or base movement

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -101,13 +101,22 @@ size. A long stack does not make a trivial slice non-trivial, and every
 non-trivial slice gets the standard review round.
 
 **A slice's head moves for reasons other than findings** — a restack, or a
-retarget after the parent lands. The fixed-head rule applies to those the same
-way: a reviewed slice whose head has moved is not ready until a review is clean
-at the *new* head. Because one restack can move every head above it, a single
-press can invalidate several reviews at once; that is the cost of the button,
-and it is paid per slice. A posted `range-diff` is what keeps each of those
-re-reviews a confirmation rather than a second full pass — without one, a
-reviewer cannot tell a restack from a rewrite.
+retarget after the parent lands. Except for the narrow bottom-slice waiver
+below, the fixed-head rule applies to those the same way: a reviewed slice
+whose head has moved is not ready until a review is clean at the *new* head.
+Because one restack can move every head above it, a single press can invalidate
+several reviews at once; that is the cost of the button, and it is paid per
+slice. A posted `range-diff` is what keeps each of those re-reviews a
+confirmation rather than a second full pass — without one, a reviewer cannot
+tell a restack from a rewrite.
+
+The only moved-stack-head exception is the bottom open slice after it targets
+`main`. If its base integration satisfies the
+[trivial-interaction waiver](../AGENTS.md#standing-adjustments) and the user
+approves that exact head, it may proceed without another review-clean round.
+That integration is not an upper-slice restack: it neither rewrites a child
+onto a newly landed parent nor changes a surviving reviewed claim. The waiver
+keeps `review-clean` absent and does not apply to any slice above the bottom.
 
 **A restack does not retire a finding.** It can destroy the exact head a
 reviewer was given, which makes "reproduce it on a clean exact-head review


### PR DESCRIPTION
## Claim

Offer an explicit exact-head re-review waiver when a review-clean PR changes
only through a mechanically narrowed base integration, instead of
automatically dispatching a redundant replacement round.

## Demo

PR #4830 had a clean-reviewed head, then conflicted only in the shared TLA+
runbook. Conflict recovery took current `main` verbatim and removed the PR's
runbook change, leaving a nine-file PR diff that was a subset of the reviewed
ten-file diff. Under this guidance, the agent:

1. classifies that outcome as a trivial interaction;
2. integrates, validates, and pushes the exact resolution head;
3. publishes the old and new heads, mechanical resolution, subset comparison,
   remaining-claim analysis, focused gates, and status;
4. asks whether to skip re-review before dispatching reviewers; and
5. records an approval as an exact-head waiver without claiming the new head
   was reviewed.

## Boundaries

The waiver is not automatic. It applies only to a `main`-targeting PR or bottom
open stack slice. Its lineage retains one immutable reviewed head/base, every
movement only integrates a moved base mechanically, and the cumulative PR diff
must remain a subset of the original reviewed diff with no surviving reviewed
claim, contract, or behavior changed. Semantic conflict resolution, new
authored changes, and upper-slice restacks still require ordinary review.

The prior fixed-head reviews do not transfer. The integration head remains
without `review-clean`; affected focused gates, current-head CI, live
mergeability, and explicit merge authorization remain mandatory.
Any armed auto-merge is disarmed and must be re-authorized for the waived exact
head/base. Later movement of either expires the current waiver and re-enters
carry-forward; renewal requires the same cumulative lineage proof.

## Validation

```text
npx markdownlint-cli AGENTS.md docs/round-orchestration.md docs/stacked-prs.md
git diff --check
```
