### PR TITLE
Bind assembly descriptors to artifact registrations

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -376,6 +376,13 @@ and registration observations and retained-content opens revalidate the query
 lease supplied when the reference was issued. The type makes no claim that the
 content is a managed assembly; Metadata owns that decode and identity.
 
+Assembly projection passes the exact acquisition registration and the
+reference's guarded content callback to
+`ResolvedAssemblyReference.CreateFromArtifactIfManaged`. Metadata retains the
+registration, decodes assembly identity, and binds a non-empty MVID. It does
+not receive the workspace role set or interpret a lease-scoped path as content
+authority, designation, or trust.
+
 It does not:
 
 - resolve package versions;

--- a/docs/design/assembly-image-lifetime.md
+++ b/docs/design/assembly-image-lifetime.md
@@ -307,7 +307,9 @@ Existing gates prove narrower pieces:
 - `Session_ParsesTheBytesCopiedBeforeSourceMutation`;
 - `RootAndStrictRegistration_ShareOneImmutableImage`;
 - `LocalArtifactSnapshot_MutationCannotChangeInspectionBytes`;
-- `LocalOnlyHost_InspectsCallerSuppliedLocalAssembly`.
+- `ArtifactDescriptor_PreservesRegistrationAndBindsNonEmptyMvid`;
+- `ArtifactDescriptor_RejectsSameIdentityFromDifferentModuleGeneration`;
+- `LocalOnlyHost_PreservesArtifactRegistrationThroughAssemblyInspection`.
 
 The complete contract remains unverified until equivalent gates exist for:
 

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -204,6 +204,23 @@ original value-equal record to a registration-backed, non-equatable descriptor:
 > authorization lease; a descriptor path is not read authority. Do not add
 > another source variant to Metadata as the target integration seam.
 
+The current artifact bridge is
+`ResolvedAssemblyReference.CreateFromArtifactIfManaged`. It consumes the exact
+artifact acquisition registration and a guarded stream callback supplied by
+the artifact owner, decodes the assembly identity, and binds the registration
+to the image's non-empty MVID. Artifact-backed opens revalidate both assembly
+identity and MVID. `AssemblyImage`, retained snapshots, metadata-only
+`PdbContext` assembly-image opens, and the remaining descriptor-based Metadata
+readers all use that same check. Compatibility path and stream factories remain
+available while their callers migrate; they do not manufacture an artifact
+registration.
+
+This bridge does not consume workspace roles or source-specific provenance.
+Those remain owner-issued evidence for workspace admission and trust policy.
+PDB artifact acquisition, symbol stores, and SourceLink policy are separate
+contracts; only validation of the assembly PE opened by an existing
+descriptor-based PDB entry point belongs here.
+
 ```csharp
 public abstract record AssemblyResolutionProvenance
 {

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -163,6 +163,11 @@ plans once and may reuse them across assembly contexts.
 layers: generation-scoped identity and registration, adapter-owned typed
 provenance and diagnostics, acquisition outcomes, and owner-issued guarded
 admission/query access. It references no project.
+Despite its historical `DotnetInspector.*` project-name prefix, this contract
+floor is not tool-tier composition: `ILInspector.Metadata` may reference this
+project, and no other `DotnetInspector.*` project. The
+`EngineProjectsReferenceOnlyTheSourceNeutralArtifactFloor` architecture gate
+enforces that exception and rejects every wider engine-to-tool edge.
 `DotnetInspector.Artifacts.Workspaces` composes bounded immutable contributions
 into a sealed `ArtifactSetSession`, and `DotnetInspector.Artifacts.Local`
 snapshots explicit files before registration. The package-free host fixture

--- a/src/ILInspector.Metadata/AssemblyAcquisition.cs
+++ b/src/ILInspector.Metadata/AssemblyAcquisition.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Artifacts;
 
 namespace ILInspector.Metadata;
 
@@ -176,8 +178,53 @@ public abstract record AssemblyResolutionProvenance
 /// </summary>
 public sealed class AssemblyAcquisitionRegistration
 {
-    internal AssemblyAcquisitionRegistration()
+    readonly object _gate = new();
+    Guid? _moduleVersionId;
+
+    internal AssemblyAcquisitionRegistration(
+        ArtifactAcquisitionRegistration? artifactRegistration = null)
     {
+        ArtifactRegistration = artifactRegistration;
+    }
+
+    /// <summary>
+    /// Exact artifact acquisition registration that authorized this assembly
+    /// descriptor, when the descriptor was projected from an artifact.
+    /// </summary>
+    public ArtifactAcquisitionRegistration? ArtifactRegistration { get; }
+
+    /// <summary>
+    /// Module generation bound to the artifact-backed descriptor.
+    /// </summary>
+    public Guid? ModuleVersionId
+    {
+        get
+        {
+            lock (_gate)
+                return _moduleVersionId;
+        }
+    }
+
+    internal void BindModuleVersionId(Guid moduleVersionId)
+    {
+        if (moduleVersionId == Guid.Empty)
+        {
+            throw new BadImageFormatException(
+                "The selected assembly has an empty module version identifier.");
+        }
+
+        lock (_gate)
+        {
+            if (_moduleVersionId is Guid existing
+                && existing != moduleVersionId)
+            {
+                throw new BadImageFormatException(
+                    "The opened assembly module version identifier does not "
+                    + "match the artifact-bound acquisition descriptor.");
+            }
+
+            _moduleVersionId = moduleVersionId;
+        }
     }
 }
 
@@ -296,6 +343,41 @@ public sealed class ResolvedAssemblyReference
         Func<Stream> openRead,
         AssemblyResolutionProvenance provenance,
         DateTime? lastWriteTimeUtc = null)
+        => CreateFromStreamIfManagedCore(
+            artifactRegistration: null,
+            openRead,
+            provenance,
+            lastWriteTimeUtc);
+
+    /// <summary>
+    /// Projects one authorized artifact registration into a managed assembly
+    /// descriptor while preserving artifact correspondence.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="openRead"/> remains the caller-supplied guarded content
+    /// capability. Artifact access and lease validation stay with the artifact
+    /// owner; this boundary decodes assembly identity and binds the non-empty
+    /// module version identifier.
+    /// </remarks>
+    public static ResolvedAssemblyReference? CreateFromArtifactIfManaged(
+        ArtifactAcquisitionRegistration artifactRegistration,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance,
+        DateTime? lastWriteTimeUtc = null)
+    {
+        ArgumentNullException.ThrowIfNull(artifactRegistration);
+        return CreateFromStreamIfManagedCore(
+            artifactRegistration,
+            openRead,
+            provenance,
+            lastWriteTimeUtc);
+    }
+
+    static ResolvedAssemblyReference? CreateFromStreamIfManagedCore(
+        ArtifactAcquisitionRegistration? artifactRegistration,
+        Func<Stream> openRead,
+        AssemblyResolutionProvenance provenance,
+        DateTime? lastWriteTimeUtc)
     {
         ArgumentNullException.ThrowIfNull(openRead);
         ArgumentNullException.ThrowIfNull(provenance);
@@ -328,13 +410,30 @@ public sealed class ResolvedAssemblyReference
 
         using (peReader)
         {
+            MetadataReader metadata = peReader.GetMetadataReader();
+            if (artifactRegistration is not null
+                && !metadata.IsAssembly)
+            {
+                return null;
+            }
+
             AssemblyReferenceIdentity identity =
                 AssemblyReferenceIdentity.FromAssemblyDefinition(
-                    peReader.GetMetadataReader());
+                    metadata);
             if (string.IsNullOrWhiteSpace(identity.Name))
                 return null;
 
-            return Create(
+            var registration =
+                new AssemblyAcquisitionRegistration(artifactRegistration);
+            if (artifactRegistration is not null)
+            {
+                ModuleDefinition module = metadata.GetModuleDefinition();
+                registration.BindModuleVersionId(
+                    metadata.GetGuid(module.Mvid));
+            }
+
+            return new ResolvedAssemblyReference(
+                registration,
                 identity,
                 path: null,
                 openRead,
@@ -467,6 +566,37 @@ public sealed class ResolvedAssemblyReference
     /// returned by <see cref="OpenRead"/>, when available.
     /// </summary>
     public DateTime? LastWriteTimeUtc { get; }
+
+    internal void ValidateArtifactContent(PEReader peReader)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+        if (Registration.ArtifactRegistration is null)
+            return;
+        if (!peReader.HasMetadata)
+        {
+            throw new BadImageFormatException(
+                "The artifact-bound assembly image has no managed metadata.");
+        }
+
+        MetadataReader metadata = peReader.GetMetadataReader();
+        if (!metadata.IsAssembly)
+        {
+            throw new BadImageFormatException(
+                "The artifact-bound image is a module, not an assembly.");
+        }
+
+        AssemblyReferenceIdentity actual =
+            AssemblyReferenceIdentity.FromAssemblyDefinition(metadata);
+        if (actual != Identity)
+        {
+            throw new BadImageFormatException(
+                "The opened assembly identity does not match the "
+                + "artifact-bound acquisition descriptor.");
+        }
+
+        ModuleDefinition module = metadata.GetModuleDefinition();
+        Registration.BindModuleVersionId(metadata.GetGuid(module.Mvid));
+    }
 
     /// <summary>
     /// Returns this descriptor with the same acquisition registration and an

--- a/src/ILInspector.Metadata/AssemblyImage.cs
+++ b/src/ILInspector.Metadata/AssemblyImage.cs
@@ -66,7 +66,21 @@ public sealed class AssemblyImage : IDisposable
     /// Opens an image from a resolved assembly reference, using its stream opener. This is the
     /// descriptor-based entry point that keeps callers off bare paths.
     /// </summary>
-    public static AssemblyImage Open(ResolvedAssemblyReference reference) => FromStream(reference.OpenRead());
+    public static AssemblyImage Open(ResolvedAssemblyReference reference)
+    {
+        ArgumentNullException.ThrowIfNull(reference);
+        AssemblyImage image = FromStream(reference.OpenRead());
+        try
+        {
+            reference.ValidateArtifactContent(image.PEReader);
+            return image;
+        }
+        catch (Exception ex)
+        {
+            OwnedResourceCleanup.DisposeAfterFailure(image, ex);
+            throw;
+        }
+    }
 
     internal static AssemblyImage Open(AssemblyImageSnapshot snapshot)
     {

--- a/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
+++ b/src/ILInspector.Metadata/AssemblyImageSnapshot.cs
@@ -146,6 +146,7 @@ public sealed class AssemblyImageSnapshot
                 }
 
                 MetadataReader reader = peReader.GetMetadataReader();
+                assembly.ValidateArtifactContent(peReader);
                 AssemblyReferenceIdentity identity =
                     AssemblyReferenceIdentity.FromAssemblyDefinition(
                         reader);
@@ -240,6 +241,7 @@ public sealed class AssemblyImageSnapshot
             }
 
             MetadataReader reader = peReader.GetMetadataReader();
+            assembly.ValidateArtifactContent(peReader);
             AssemblyReferenceIdentity identity =
                 AssemblyReferenceIdentity.FromAssemblyDefinition(reader);
             if (!IdentityMatches(assembly.Identity, identity))

--- a/src/ILInspector.Metadata/AssemblyInspector.cs
+++ b/src/ILInspector.Metadata/AssemblyInspector.cs
@@ -294,6 +294,7 @@ public static class AssemblyInspector
         ArgumentNullException.ThrowIfNull(assembly);
         using var stream = assembly.OpenRead();
         using var peReader = new PEReader(stream);
+        assembly.ValidateArtifactContent(peReader);
         return ExtractReferenceIdentitiesAndCompany(peReader);
     }
 

--- a/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
+++ b/src/ILInspector.Metadata/AssemblyTypeDeclarationInventory.cs
@@ -74,6 +74,7 @@ public static class AssemblyTypeDeclarationInventoryReader
             }
 
             MetadataReader reader = peReader.GetMetadataReader();
+            assembly.ValidateArtifactContent(peReader);
             AssemblyReferenceIdentity actual =
                 AssemblyReferenceIdentity.FromAssemblyDefinition(reader);
             if (actual != assembly.Identity)

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CSharpText\CSharpText.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Artifacts\DotnetInspector.Artifacts.csproj" />
     <ProjectReference Include="..\ILInspector.Findings\ILInspector.Findings.csproj" />
     <ProjectReference Include="..\InertText\InertText.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -419,7 +419,8 @@ public class PdbContext : IDisposable
             loadLocalPdb: false,
             loadEmbeddedPdb: true,
             maxEmbeddedPdbBytes: maxEmbeddedPdbBytes,
-            expansionBudget: expansionBudget);
+            expansionBudget: expansionBudget,
+            assemblyRegistration: assembly);
     }
 
     /// <summary>
@@ -465,7 +466,8 @@ public class PdbContext : IDisposable
             PEStreamOptions.Default,
             assembly.LastWriteTimeUtc,
             loadLocalPdb: false,
-            loadEmbeddedPdb: false);
+            loadEmbeddedPdb: false,
+            assemblyRegistration: assembly);
     }
 
     /// <summary>
@@ -495,7 +497,8 @@ public class PdbContext : IDisposable
             loadLocalPdb: false,
             loadEmbeddedPdb: true,
             maxEmbeddedPdbBytes: maxEmbeddedPdbBytes,
-            expansionBudget: expansionBudget);
+            expansionBudget: expansionBudget,
+            assemblyRegistration: assembly);
     }
 
     /// <summary>
@@ -513,7 +516,8 @@ public class PdbContext : IDisposable
             assembly.Identity.Name,
             log,
             PEStreamOptions.Default,
-            assembly.LastWriteTimeUtc);
+            assembly.LastWriteTimeUtc,
+            assemblyRegistration: assembly);
     }
 
     /// <summary>
@@ -583,7 +587,8 @@ public class PdbContext : IDisposable
             log,
             PEStreamOptions.PrefetchEntireImage | PEStreamOptions.LeaveOpen,
             assembly.LastWriteTimeUtc,
-            loadLocalPdb: true);
+            loadLocalPdb: true,
+            assemblyRegistration: assembly);
     }
 
     static PdbContext Open(
@@ -616,7 +621,8 @@ public class PdbContext : IDisposable
         bool loadLocalPdb = true,
         bool loadEmbeddedPdb = true,
         int maxEmbeddedPdbBytes = int.MaxValue,
-        PdbExpansionBudget? expansionBudget = null)
+        PdbExpansionBudget? expansionBudget = null,
+        ResolvedAssemblyReference? assemblyRegistration = null)
     {
         PEReader? peReader = null;
         PdbContext? context = null;
@@ -630,6 +636,7 @@ public class PdbContext : IDisposable
             peReader = new PEReader(
                 stream,
                 streamOptions | PEStreamOptions.LeaveOpen);
+            assemblyRegistration?.ValidateArtifactContent(peReader);
             context = new PdbContext(
                 stream,
                 peReader,

--- a/src/ILInspector.Metadata/SignatureSpellability.cs
+++ b/src/ILInspector.Metadata/SignatureSpellability.cs
@@ -137,6 +137,7 @@ public sealed class SignatureSpellability
         {
             stream = resolved.OpenRead();
             pe = new PEReader(stream);
+            resolved.ValidateArtifactContent(pe);
             if (pe.HasMetadata)
             {
                 var reader = pe.GetMetadataReader();

--- a/src/dotnet-inspect.Tests/LayeringTests.cs
+++ b/src/dotnet-inspect.Tests/LayeringTests.cs
@@ -17,7 +17,7 @@ namespace DotnetInspector.Tests;
 public sealed class LayeringTests
 {
     [Fact]
-    public async Task LocalOnlyHost_InspectsCallerSuppliedLocalAssembly()
+    public async Task LocalOnlyHost_PreservesArtifactRegistrationThroughAssemblyInspection()
     {
         string assemblyPath = typeof(AssemblyOnlyInspector).Assembly.Location;
         string temporaryDirectory =
@@ -29,12 +29,17 @@ public sealed class LayeringTests
         File.Copy(assemblyPath, temporaryAssembly);
         try
         {
+            AssemblyOnlyInspectionResult result =
+                await AssemblyOnlyInspector
+                    .InspectAfterDeletingSourceAsync(
+                        temporaryAssembly,
+                        TestContext.Current.CancellationToken);
             Assert.Equal(
                 "DotnetInspector.AssemblyOnlyHost.Fixture",
-                await AssemblyOnlyInspector
-                    .ReadAssemblyNameAfterDeletingSourceAsync(
-                        temporaryAssembly,
-                        TestContext.Current.CancellationToken));
+                result.AssemblyName);
+            Assert.Same(
+                result.ArtifactRegistration,
+                result.AssemblyRegistration.ArtifactRegistration);
             Assert.False(File.Exists(temporaryAssembly));
         }
         finally
@@ -96,6 +101,9 @@ public sealed class LayeringTests
         Assert.Contains(
             closure,
             path => Path.GetFileNameWithoutExtension(path) == "ILInspector.MetadataPrimitives");
+        Assert.Contains(
+            closure,
+            path => Path.GetFileNameWithoutExtension(path) == "DotnetInspector.Artifacts");
         AssertNoForbiddenImplementations(root, closure, PackageOrStorageImplementationProjects);
     }
 

--- a/tests/DotnetInspector.AssemblyOnlyHost.Fixture/AssemblyOnlyInspector.cs
+++ b/tests/DotnetInspector.AssemblyOnlyHost.Fixture/AssemblyOnlyInspector.cs
@@ -5,10 +5,15 @@ using ILInspector.Metadata;
 
 namespace DotnetInspector.AssemblyOnlyHost.Fixture;
 
+public sealed record AssemblyOnlyInspectionResult(
+    string AssemblyName,
+    ArtifactAcquisitionRegistration ArtifactRegistration,
+    AssemblyAcquisitionRegistration AssemblyRegistration);
+
 public static class AssemblyOnlyInspector
 {
-    public static async ValueTask<string>
-        ReadAssemblyNameAfterDeletingSourceAsync(
+    public static async ValueTask<AssemblyOnlyInspectionResult>
+        InspectAfterDeletingSourceAsync(
         string assemblyPath,
         CancellationToken cancellationToken = default)
     {
@@ -52,8 +57,11 @@ public static class AssemblyOnlyInspector
                 "The local artifact lacks caller-designation authority.");
         }
 
+        ArtifactAcquisitionRegistration artifactRegistration =
+            content.Registration;
         ResolvedAssemblyReference assembly =
-            ResolvedAssemblyReference.CreateFromStreamIfManaged(
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                artifactRegistration,
                 content.OpenRead,
                 AssemblyResolutionProvenance.Local(
                     "artifact-session"))
@@ -61,9 +69,12 @@ public static class AssemblyOnlyInspector
                 "The local artifact has no managed metadata.");
         using AssemblyInspectionSession session =
             AssemblyInspectionSession.Open(assembly);
-        return session.AssemblyInfo().AssemblyName
-            ?? throw new InvalidDataException(
-                $"{assemblyPath} has no assembly name.");
+        return new AssemblyOnlyInspectionResult(
+            session.AssemblyInfo().AssemblyName
+                ?? throw new InvalidDataException(
+                    $"{assemblyPath} has no assembly name."),
+            artifactRegistration,
+            assembly.Registration);
     }
 
     private static T AssertSingle<T>(IReadOnlyList<T> values) =>

--- a/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/EngineToolBoundaryTests.cs
@@ -5,7 +5,8 @@ namespace ILInspector.Metadata.Tests;
 /// <summary>
 /// Architecture guardrail for the engine/tool boundary (#2568, #2579): a production
 /// <c>ILInspector.*</c> (engine) project must never reference a <c>DotnetInspector.*</c>
-/// (tool) project. The dependency arrow points tool → engine only. Test projects are
+/// tool project. The source-neutral <c>DotnetInspector.Artifacts</c> contract floor is
+/// the sole exception despite its historical project-name prefix. Test projects are
 /// intentionally excluded — pulling shared fixtures/services into a test is normal and
 /// is a separate policy call from the production boundary.
 /// </summary>
@@ -45,7 +46,7 @@ public class EngineToolBoundaryTests
     }
 
     [Fact]
-    public void NoProductionEngineProjectReferencesTheToolTier()
+    public void EngineProjectsReferenceOnlyTheSourceNeutralArtifactFloor()
     {
         var srcDir = Path.Combine(FindRepoRoot(), "src");
         var violations = new List<string>();
@@ -61,15 +62,22 @@ public class EngineToolBoundaryTests
                 // csproj Include paths use either separator (the repo mixes `..\` and
                 // `../`); normalize so the leaf name is extracted on any OS.
                 var referenceName = Path.GetFileNameWithoutExtension(reference.Replace('\\', '/'));
-                if (referenceName.StartsWith("DotnetInspector.", StringComparison.Ordinal))
+                bool isArtifactContractFloor =
+                    projectName == "ILInspector.Metadata"
+                    && referenceName == "DotnetInspector.Artifacts";
+                if (referenceName.StartsWith("DotnetInspector.", StringComparison.Ordinal)
+                    && !isArtifactContractFloor)
+                {
                     violations.Add($"{projectName} -> {referenceName}");
+                }
             }
         }
 
         Assert.True(
             violations.Count == 0,
-            "Production ILInspector.* (engine) projects must not reference DotnetInspector.* (tool); "
-            + "the arrow points tool -> engine only. Violations:\n  "
+            "Production ILInspector.* (engine) projects may reference only "
+            + "DotnetInspector.Artifacts from the DotnetInspector.* project family. "
+            + "Violations:\n  "
             + string.Join("\n  ", violations));
     }
 

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using DotnetInspector.Artifacts;
 using ILInspector.Metadata;
 
 namespace ILInspector.Metadata.Tests;
@@ -168,6 +169,114 @@ public class InspectionAcquisitionPlanTests
         {
             File.Delete(invalid);
         }
+    }
+
+    [Fact]
+    public void ArtifactDescriptor_PreservesRegistrationAndBindsNonEmptyMvid()
+    {
+        Guid mvid = Guid.NewGuid();
+        byte[] image =
+            BuildSimpleAssembly("ArtifactBound", "Type", mvid);
+        ArtifactAcquisitionRegistration artifactRegistration =
+            RegisterArtifact(
+                () => new MemoryStream(image, writable: false));
+
+        ResolvedAssemblyReference descriptor =
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                artifactRegistration,
+                () => new MemoryStream(image, writable: false),
+                AssemblyResolutionProvenance.Local("test"))
+            ?? throw new InvalidOperationException(
+                "The managed assembly was not recognized.");
+
+        Assert.Same(
+            artifactRegistration,
+            descriptor.Registration.ArtifactRegistration);
+        Assert.Equal(
+            mvid,
+            descriptor.Registration.ModuleVersionId);
+
+        using AssemblyInspectionSession first =
+            AssemblyInspectionSession.Open(descriptor);
+        using AssemblyInspectionSession second =
+            AssemblyInspectionSession.Open(descriptor);
+        Assert.Equal("ArtifactBound", first.AssemblyInfo().AssemblyName);
+        Assert.Equal("ArtifactBound", second.AssemblyInfo().AssemblyName);
+    }
+
+    [Fact]
+    public void ArtifactDescriptor_RejectsSameIdentityFromDifferentModuleGeneration()
+    {
+        byte[] selected =
+            BuildSimpleAssembly(
+                "ArtifactBound",
+                "Type",
+                Guid.NewGuid());
+        ArtifactAcquisitionRegistration artifactRegistration =
+            RegisterArtifact(
+                () => new MemoryStream(selected, writable: false));
+        ResolvedAssemblyReference descriptor =
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                artifactRegistration,
+                () => new MemoryStream(selected, writable: false),
+                AssemblyResolutionProvenance.Local("test"))
+            ?? throw new InvalidOperationException(
+                "The managed assembly was not recognized.");
+
+        selected =
+            BuildSimpleAssembly(
+                "ArtifactBound",
+                "Type",
+                Guid.NewGuid());
+
+        Assert.Throws<BadImageFormatException>(
+            () => AssemblyImage.Open(descriptor));
+        Assert.Throws<BadImageFormatException>(
+            () => PdbContext.OpenMetadataOnly(descriptor));
+        var snapshot =
+            Assert.IsType<AssemblyImageSnapshotResult.Rejected>(
+                AssemblyImageSnapshot.Open(
+                    descriptor,
+                    static _ => true,
+                    static _ => { }));
+        Assert.Equal(
+            CandidateOpenFailureKind.InvalidImage,
+            snapshot.Failure.Kind);
+    }
+
+    [Fact]
+    public void ArtifactDescriptor_RejectsEmptyMvidModuleAndMalformedImage()
+    {
+        byte[] emptyMvid =
+            BuildSimpleAssembly(
+                "ArtifactBound",
+                "Type",
+                Guid.Empty);
+        ArtifactAcquisitionRegistration emptyMvidRegistration =
+            RegisterArtifact(
+                () => new MemoryStream(emptyMvid, writable: false));
+
+        Assert.Throws<BadImageFormatException>(
+            () => ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                emptyMvidRegistration,
+                () => new MemoryStream(emptyMvid, writable: false),
+                AssemblyResolutionProvenance.Local("test")));
+
+        byte[] module = BuildModuleImage();
+        Assert.Null(
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                RegisterArtifact(
+                    () => new MemoryStream(module, writable: false)),
+                () => new MemoryStream(module, writable: false),
+                AssemblyResolutionProvenance.Local("test")));
+
+        byte[] malformed = [0x01, 0x02, 0x03];
+        Assert.Null(
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                RegisterArtifact(
+                    () => new MemoryStream(malformed, writable: false)),
+                () => new MemoryStream(malformed, writable: false),
+                AssemblyResolutionProvenance.Local("test")));
     }
 
     [Fact]
@@ -1268,6 +1377,33 @@ public class InspectionAcquisitionPlanTests
             path: null,
             openRead: () => new MemoryStream(image(), writable: false),
             provenance: AssemblyResolutionProvenance.Local("test"));
+
+    static ArtifactAcquisitionRegistration RegisterArtifact(
+        Func<Stream> openRead)
+    {
+        var authority = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            authority.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+               authority.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                TestArtifactProvenance.Instance,
+                openRead);
+        }
+
+        authority.CreateRetainedContent(
+            contribution.Registration,
+            openRead);
+        authority.CompleteAdmission(admission);
+        return contribution.Registration;
+    }
+
+    sealed class TestArtifactProvenance : IArtifactProvenance
+    {
+        public static TestArtifactProvenance Instance { get; } = new();
+    }
 
     // These callers intentionally block on test gates, so dedicated threads keep the
     // test independent of ThreadPool injection timing on low-core CI runners.


### PR DESCRIPTION
## Summary

- preserve the exact artifact acquisition registration when guarded artifact
  content becomes a `ResolvedAssemblyReference`
- bind artifact-backed assembly registrations to a non-empty MVID and reject
  later identity or module-generation drift across every descriptor-backed
  Metadata assembly opener
- keep workspace roles, source-specific provenance, PDB acquisition, package
  implementations, and storage implementations outside Metadata
- reconcile the engine boundary gate with the already-designed
  source-neutral `DotnetInspector.Artifacts` contract floor

Compatibility path and stream factories remain available and do not
manufacture artifact registrations.

## Demo

The package-free local host now carries its query-authorized artifact
registration across the assembly boundary instead of dropping it:

```csharp
ResolvedAssemblyReference.CreateFromArtifactIfManaged(
    content.Registration,
    content.OpenRead,
    AssemblyResolutionProvenance.Local("artifact-session"));
```

After the source file is deleted, the host still inspects the retained content
and proves by reference identity that the resulting assembly registration owns
the exact upstream artifact registration:

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- \
  -method '*LocalOnlyHost*' -method '*MetadataClosure*'
Total: 3, Errors: 0, Failed: 0, Skipped: 0
```

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
  (`2237` passed)
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -method '*LocalOnlyHost*' -method '*MetadataClosure*'`
  (`3` passed)
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/assembly-inspection-query.md docs/design/artifact-acquisition-and-workspaces.md docs/design/assembly-image-lifetime.md docs/design/inspection-layers.md`

Closes #4954
