### PR TITLE
Separate TLA+ methodology from setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,8 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 | Running a review round | `docs/round-orchestration.md` |
 | Querying GitHub PR and CI status | `docs/github-status-queries.md` |
 | Hosting a network-accessible inspect-web demo | `docs/runbooks/inspect-web-demo-hosting.md` |
-| Installing and pinning TLA+ and Java, or curated TLA+ examples | `docs/runbooks/tla-plus-setup.md` |
+| Installing and pinning TLA+ and Java | `docs/runbooks/tla-plus-setup.md` |
+| TLA+ methodology and curated examples | `docs/tla-plus-methodology.md` |
 | Release and publishing | `docs/release-workflow.md` |
 | Changes spanning Markout and this repo | `docs/markout-co-development.md` |
 
@@ -379,7 +380,9 @@ feature's correctness depends on significant stateful, concurrent, distributed,
 or scheduling interactions, use a small TLA+ model that states the relevant
 safety and liveness properties, and model-check it before implementation.
 (See [`docs/runbooks/tla-plus-setup.md`](docs/runbooks/tla-plus-setup.md) for
-installing and pinning the TLA+ tools and Java, and curated model examples.)
+installing and pinning the TLA+ tools and Java, and
+[`docs/tla-plus-methodology.md`](docs/tla-plus-methodology.md) for modeling
+methodology and curated examples.)
 Use the model to evaluate whether the interaction or algorithm is effective,
 and keep the design specification focused on what the system must guarantee.
 Link the model from the owning design and record its assumptions, checking

--- a/docs/runbooks/tla-plus-setup.md
+++ b/docs/runbooks/tla-plus-setup.md
@@ -133,41 +133,5 @@ java -jar /path/to/tla2tools.jar -help   # aliases to tlc2.TLC
 See `USE.md` in the TLA+ repository for the full command list (`tla2sany.SANY`,
 `tlc2.TLC`, `tlc2.REPL`, `pcal.trans`, `tla2tex.TLA`).
 
-## Curated TLA+ examples
-
-TLA+ is used per
-[`AGENTS.md`](../../AGENTS.md#keep-specifications-readable-model-interactions)
-to check stateful or concurrent interactions that are hard to reason about in
-prose alone.
-
-Keep each model in its own directory, normally under `docs/models/` or the
-owning design's `models/` directory. Keep its `.tla` module and any companion
-`.cfg` configurations, model `README.md`, or local exclusions for generated
-TLC artifacts together; do not place standalone model files in the parent
-models directory or combine unrelated models in one directory.
-
-The following table is a user-curated set of at most six merged examples, not
-an inventory of repository models. It is intentionally incomplete.
-Contributors and agents must not add a new model to this list as part of normal
-model work; only the user may add, remove, or replace a curated example.
-
-| Example | What it demonstrates |
-| --- | --- |
-| [`TsJsExportLifecycle.tla`](../design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla) (plus scenario and mutation configurations and a model [`README.md`](../design/models/ts-jsexport-lifecycle/README.md)) | Models two generated `ts-jsexport` facades, multiple callers, one shared SDK runtime, shared-in-flight and serialized coordination, local failure isolation, terminal state, and bounded realm restart. Demonstrates separate success/failure scenarios and targeted counterexample mutations without claiming implementation or browser conformance. |
-| [`ArtifactSessionAdmission.tla`](../models/artifact-session-admission/ArtifactSessionAdmission.tla) ([`.cfg`](../models/artifact-session-admission/ArtifactSessionAdmission.cfg)) | Models `ArtifactSetSession` admission for [Artifact acquisition and workspace composition](../design/artifact-acquisition-and-workspaces.md#artifactsetsession). Demonstrates single-flight admission, incompatible-generation exclusion, voluntary and disposal-forced draining, late-result suppression, guard witnesses, and weak-fairness progress. |
-| [`AssemblyContextGroupLifecycle.tla`](../models/assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla) (plus safety, liveness, and mutation configurations and a model [`README.md`](../models/assembly-context-group-lifecycle/README.md)) | Models the existing `AssemblyContextGroup` callback, image-budget, result-publication, finalization, disposal, and quiescent-release lifecycle for [Inspection space](../inspection-space.md). Demonstrates same-participant contention, ordinary versus one-shot release, exceptional retry, resource ordering, and independent counterexample mutations. |
-
-## Check in models as you go
-
-A TLA+ model that exists only as uncommitted files in a local worktree is not
-a checked-in asset — it is not backed up, not reviewable, and invisible to
-every other contributor and agent until it is committed and pushed. This
-guidance exists because real, apparently-finished model sets have previously
-sat only on one machine.
-
-Commit a model to its branch and push that branch as soon as it reaches a
-checkable state (parses, and TLC runs against its `.cfg` without unexpected
-errors), the same way any other source file is checked in during ordinary
-work — do not wait for the owning design PR to be otherwise complete. Treat an
-uncommitted `.tla`/`.cfg`/model-`README.md` set sitting in a worktree as a bug
-to fix, not a stable resting state.
+See [TLA+ methodology](../tla-plus-methodology.md) for model-layout and
+check-in conventions and representative models.

--- a/docs/tla-plus-methodology.md
+++ b/docs/tla-plus-methodology.md
@@ -1,0 +1,77 @@
+# TLA+ methodology
+
+TLA+ is used per
+[`AGENTS.md`](../AGENTS.md#keep-specifications-readable-model-interactions) to
+check stateful or concurrent interactions that are hard to reason about in
+prose alone.
+
+Keep each model in its own directory, normally under `docs/models/` or the
+owning design's `models/` directory. Keep its `.tla` module and any companion
+`.cfg` configurations, model `README.md`, or local exclusions for generated
+TLC artifacts together; do not place standalone model files in the parent
+models directory or combine unrelated models in one directory.
+
+A TLA+ model that exists only as uncommitted files in a local worktree is not
+a checked-in asset: it is not backed up, reviewable, or visible to other
+contributors and agents. Commit a model to its branch and push that branch as
+soon as it reaches a checkable state: its module parses and TLC runs against
+its `.cfg` without unexpected errors. Do not wait for the owning design PR to
+be otherwise complete. Treat an uncommitted
+`.tla`/`.cfg`/model-`README.md` set as a bug to fix, not a stable resting
+state.
+
+The examples below are a user-curated set of at most six merged models, not an
+inventory of repository models. The set is intentionally incomplete.
+Contributors and agents must not add a model as part of normal model work; only
+the user may add, remove, or replace a curated example.
+
+## TsJsExportLifecycle
+
+[`TsJsExportLifecycle.tla`](design/models/ts-jsexport-lifecycle/TsJsExportLifecycle.tla)
+is accompanied by scenario and mutation configurations and a model
+[`README.md`](design/models/ts-jsexport-lifecycle/README.md).
+
+It models two generated `ts-jsexport` facades, multiple callers, one shared SDK
+runtime, shared-in-flight and serialized coordination, local failure isolation,
+terminal state, and bounded realm restart. It demonstrates separate
+success/failure scenarios and targeted counterexample mutations without
+claiming implementation or browser conformance.
+
+## ArtifactSessionAdmission
+
+[`ArtifactSessionAdmission.tla`](models/artifact-session-admission/ArtifactSessionAdmission.tla)
+and its [configuration](models/artifact-session-admission/ArtifactSessionAdmission.cfg)
+model `ArtifactSetSession` admission for
+[Artifact acquisition and workspace composition](design/artifact-acquisition-and-workspaces.md#artifactsetsession).
+
+The model demonstrates single-flight admission, incompatible-generation
+exclusion, voluntary and disposal-forced draining, late-result suppression,
+guard witnesses, and weak-fairness progress.
+
+## AssemblyContextGroupLifecycle
+
+[`AssemblyContextGroupLifecycle.tla`](models/assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla)
+is accompanied by safety, liveness, and mutation configurations and a model
+[`README.md`](models/assembly-context-group-lifecycle/README.md).
+
+It models the existing `AssemblyContextGroup` callback, image-budget,
+result-publication, finalization, disposal, and quiescent-release lifecycle for
+[Inspection space](inspection-space.md). It demonstrates same-participant
+contention, ordinary versus one-shot release, exceptional retry, resource
+ordering, and independent counterexample mutations.
+
+## ZfsHoldTight
+
+[`ZfsHoldTight.tla`](https://github.com/richlander/zfs-hold-tight/blob/425e111a4a3b11f9eeeb9410af1edd1acb196093/docs/model/ZfsHoldTight.tla)
+is accompanied by a
+[configuration](https://github.com/richlander/zfs-hold-tight/blob/425e111a4a3b11f9eeeb9410af1edd1acb196093/docs/model/ZfsHoldTight.cfg)
+and recorded
+[design and results](https://github.com/richlander/zfs-hold-tight/blob/425e111a4a3b11f9eeeb9410af1edd1acb196093/docs/DESIGN.md#status).
+
+It models retention-policy changes against a persisted pruning watermark,
+genuine feed gaps, and a pool-wide health latch. It demonstrates separating
+current policy from historical authority, modeling exogenous events without
+accidentally freezing them, refining over-broad properties from TLC
+counterexamples, and pairing model claims with implementation regression
+tests. Calendar details and keeper expiry are deliberately outside its model
+scope.


### PR DESCRIPTION
## Summary

- move TLA+ model layout, check-in discipline, and curated examples into
  `docs/tla-plus-methodology.md`
- give each curated model its own H2 section instead of a table row
- add the pinned `ZfsHoldTight` model as an incident-driven example
- keep the setup runbook focused on installing and invoking the toolchain

## Demo

Before this change, installation instructions, repository modeling conventions,
and curated examples shared one setup runbook.

After this change:

- `docs/runbooks/tla-plus-setup.md` ends with a link to the methodology document
- `docs/tla-plus-methodology.md` presents each example as a readable section
- `AGENTS.md` routes setup and methodology questions independently

The product and its build behavior are unchanged.

## Candidate

- Head: `6e790f4fd0b59978a3dcaed87b17707f57f07269`
- Effective base at push:
  `4a774088713077fbdc1ba9c8c3eeab20b21cff26`

## Validation

```text
npx markdownlint-cli AGENTS.md docs/runbooks/tla-plus-setup.md docs/tla-plus-methodology.md
```
