### PR TITLE
Fix package profile query test

### DIFF
--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -459,7 +459,7 @@ public class FindCommandTests
                 [PackageProfileSections.Packages]);
 
         InspectionQueryResults results =
-            await catalog.QueryRegistry.RunAsync(
+            await catalog.QueryCatalog.ToBuilder().RunAsync(
                 requested,
                 new PackageProfileQueryContext(
                     source,


### PR DESCRIPTION
Closes #4964.\n\n## Demo\n\nBefore this change, the Release solution build fails in `FindCommandTests.cs` because `PackageProfileSectionCatalog.QueryRegistry` was removed. The test now materializes a registry through `QueryCatalog.ToBuilder()`, matching the current catalog contract.\n\n## Validation\n\n- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-restore -- -method *PackageProfileDefaultScale_AcquiresEachManifestOnceAndBoundsProjectedRows*`\n- `dotnet build dotnet-inspect.slnx -c Release --no-restore --nologo`\n\nThe focused test passes and the solution builds with zero warnings and errors.\n\nThis is a test-only compatibility correction; product behavior is unchanged.