### PR TITLE
Extract unbox receiver fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5435,17 +5435,6 @@ public enum CfgTiny : byte { A = 1, B = 2 }
 [System.Flags]
 public enum CfgStyles { None = 0, Alpha = 1, Beta = 2, Gamma = 16 }
 
-// A value-type Equals(object) that reads a field off the unboxed argument:
-// `((CfgBoxed)other).Value` compiles to `unbox` (a managed pointer into the
-// box) + `ldfld`, so the field receiver is an Unbox node. The printer must
-// spell the access `((CfgBoxed)other).Value`, NOT `(ref (CfgBoxed)other).Value`
-// — the `ref` form is CS1525 "Invalid expression term 'ref'".
-public struct CfgBoxed
-{
-    public int Value;
-    public bool FieldEquals(object other) => Value == ((CfgBoxed)other).Value;
-}
-
 public sealed class CfgNullableTarget
 {
     public int Value;

--- a/src/ILInspector.Decompiler.Tests/UnboxReceiverSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/UnboxReceiverSamples.cs
@@ -1,0 +1,12 @@
+namespace ILInspector.Decompiler.Tests;
+
+// The source-level cast reads a field from the boxed argument and compiles to
+// `unbox` (a managed pointer into the box) plus `ldfld`. The decompiler must
+// preserve that receiver as `Unsafe.Unbox<CfgBoxed>(other).Value`, not as a
+// value-copy cast or invalid bare `ref` expression.
+// UnboxReceiverRenderingTests.UnboxFieldReceiver_SpellsUnsafeUnbox gates this shape.
+public struct CfgBoxed
+{
+    public int Value;
+    public bool FieldEquals(object other) => Value == ((CfgBoxed)other).Value;
+}


### PR DESCRIPTION
Moves `CfgBoxed` beside `UnboxReceiverRenderingTests` in the feature-focused `UnboxReceiverSamples.cs` file while preserving the compiler input and metadata identity. The stale fixture comment now describes the established `Unsafe.Unbox<T>` output and names its enforcing test.

Part of #3913.

## Demo

`UnboxFieldReceiver_SpellsUnsafeUnbox` continues to render the compiler-produced `unbox` + `ldfld` receiver as `Unsafe.Unbox<CfgBoxed>(other).Value`, preserving access to the in-box value rather than a copy.

## Validation

Exact head: `27523fd23a53b4b12af0ed3a6aa046715a439b55`
Exact integrated base: `8d64d84c2d78409c10b3b093eb4062ae93fd18bb`

- Release solution build: passed with 0 warnings and 0 errors
- `UnboxReceiverRenderingTests`: 1 passed in Release
- Decompiler fast gate: 5,643 passed, 8 expected Windows skips, and the known `ToLowerOrdinal` failure reproduced identically on the exact base
- Stable-path render A/B: 22,132 methods; 0 changed, 0 added, 0 removed
- Adversarial review: GPT-5.6 Sol and Claude Opus 5 clean on the replacement head
- CI: `ci-required` succeeded on the replacement head

## Workflow adjustment

The user authorized fixed-head adversarial review to run in parallel with CI and broader local validation. The first attempt was superseded after an unrelated exact-base build break; the replacement candidate merges the fix from current main and was fully revalidated and re-reviewed.

## Non-action boundary

No symbols, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.