### PR TITLE
Model platform overlay arbitration and coherence

### DIFF
--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolution.tla
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolution.tla
@@ -1,0 +1,322 @@
+----------------------- MODULE PlatformOverlayResolution -----------------------
+EXTENDS FiniteSets, Integers, Sequences, TLC
+
+\* Owned by docs/design/platform-composition-and-overlays.md.
+\* Candidate acquisition, identity decoding, and compatibility computation are
+\* inputs. The model owns only arbitration among already-classified candidates
+\* and attribution when traversal crosses an incoherent overlay/platform pair.
+
+CONSTANTS
+    DesignatedOne,
+    DesignatedTwo,
+    Platform,
+    Unentitled,
+    ExactReference,
+    SkewedReference,
+    NoCandidate,
+    SelectionMode,
+    SuppressCoherenceFailure
+
+Candidates == {DesignatedOne, DesignatedTwo, Platform, Unentitled}
+DesignatedCandidates == {DesignatedOne, DesignatedTwo}
+PlatformCandidates == {Platform}
+EntitledCandidates == DesignatedCandidates \union PlatformCandidates
+References == {ExactReference, SkewedReference}
+
+ASSUME
+    /\ Cardinality(Candidates) = 4
+    /\ Cardinality(References) = 2
+    /\ NoCandidate \notin Candidates
+    /\ SelectionMode \in
+        {"Policy", "RegistrationOrder", "VersionSensitive"}
+    /\ SuppressCoherenceFailure \in BOOLEAN
+
+Phases == {"Registering", "Loaded", "Resolved", "Traversed"}
+ResolutionFailures == {"Pending", "None", "NoMatch", "Ambiguous"}
+TraversalOutcomes ==
+    {"NotStarted", "Found", "ResolutionFailed", "CoherenceFailure", "Missing"}
+
+NoDuplicates(sequence) ==
+    \A left, right \in 1..Len(sequence):
+        left # right => sequence[left] # sequence[right]
+
+RegisteredSet(sequence) ==
+    {sequence[index] : index \in 1..Len(sequence)}
+
+RegistrationSequences ==
+    {sequence \in UNION {[1..length -> Candidates] : length \in 0..4}:
+        NoDuplicates(sequence)}
+
+RegistrationPermutations(sequence) ==
+    {candidate \in [1..Len(sequence) -> Candidates]:
+        /\ NoDuplicates(candidate)
+        /\ RegisteredSet(candidate) = RegisteredSet(sequence)}
+
+\* Every modeled candidate has the requested name and can bind under the
+\* adjacent identity policy. Entitlement remains a separate acquisition fact.
+EligibleFor(sequence, reference) ==
+    {candidate \in RegisteredSet(sequence):
+        /\ candidate \in EntitledCandidates
+        /\ reference \in References}
+
+TopCandidates(sequence, reference) ==
+    LET eligible == EligibleFor(sequence, reference)
+        designated == eligible \cap DesignatedCandidates
+        platform == eligible \cap PlatformCandidates
+    IN
+        IF designated # {} THEN designated ELSE platform
+
+PolicyCandidate(sequence, reference) ==
+    LET top == TopCandidates(sequence, reference)
+    IN
+        IF Cardinality(top) = 1
+        THEN CHOOSE candidate \in top : TRUE
+        ELSE NoCandidate
+
+FirstEligibleIndex(sequence, reference) ==
+    CHOOSE index \in 1..Len(sequence):
+        /\ sequence[index] \in EligibleFor(sequence, reference)
+        /\ \A earlier \in 1..(index - 1):
+            sequence[earlier] \notin EligibleFor(sequence, reference)
+
+RegistrationOrderCandidate(sequence, reference) ==
+    IF EligibleFor(sequence, reference) = {}
+    THEN NoCandidate
+    ELSE sequence[FirstEligibleIndex(sequence, reference)]
+
+\* ExactReference happens to version-match the platform candidate, while
+\* SkewedReference happens to version-match the designated candidates.
+\* Both references are otherwise bindable under the owner contract.
+VersionEqual(reference, candidate) ==
+    IF reference = ExactReference
+    THEN candidate = Platform
+    ELSE candidate \in DesignatedCandidates
+
+VersionSensitiveCandidate(sequence, reference) ==
+    LET policy == PolicyCandidate(sequence, reference)
+        eligible == EligibleFor(sequence, reference)
+        matchingPlatforms ==
+            {candidate \in eligible \cap PlatformCandidates:
+                VersionEqual(reference, candidate)}
+    IN
+        IF policy = NoCandidate
+        THEN NoCandidate
+        ELSE
+            IF /\ eligible \cap DesignatedCandidates # {}
+               /\ matchingPlatforms # {}
+            THEN CHOOSE candidate \in matchingPlatforms : TRUE
+            ELSE policy
+
+CandidateFor(sequence, reference) ==
+    CASE SelectionMode = "Policy" ->
+            PolicyCandidate(sequence, reference)
+      [] SelectionMode = "RegistrationOrder" ->
+            RegistrationOrderCandidate(sequence, reference)
+      [] OTHER ->
+            VersionSensitiveCandidate(sequence, reference)
+
+FailureFor(sequence, reference) ==
+    IF CandidateFor(sequence, reference) # NoCandidate
+    THEN "None"
+    ELSE
+        IF EligibleFor(sequence, reference) = {}
+        THEN "NoMatch"
+        ELSE "Ambiguous"
+
+ShadowedFor(sequence, reference) ==
+    LET selected == CandidateFor(sequence, reference)
+    IN
+        IF selected = NoCandidate
+        THEN {}
+        ELSE EligibleFor(sequence, reference) \ {selected}
+
+KnownSkewFor(sequence, reference) ==
+    /\ reference = SkewedReference
+    /\ EligibleFor(sequence, reference) \cap DesignatedCandidates # {}
+    /\ EligibleFor(sequence, reference) \cap PlatformCandidates # {}
+
+VARIABLES
+    phase,
+    registration,
+    loadWarning,
+    selection,
+    shadowed,
+    resolutionFailure,
+    traversal
+
+vars ==
+    <<phase, registration, loadWarning, selection, shadowed,
+      resolutionFailure, traversal>>
+
+Init ==
+    /\ phase = "Registering"
+    /\ registration = <<>>
+    /\ loadWarning = [reference \in References |-> FALSE]
+    /\ selection = [reference \in References |-> NoCandidate]
+    /\ shadowed = [reference \in References |-> {}]
+    /\ resolutionFailure =
+        [reference \in References |-> "Pending"]
+    /\ traversal = [reference \in References |-> "NotStarted"]
+
+Register(candidate) ==
+    /\ phase = "Registering"
+    /\ candidate \in Candidates \ RegisteredSet(registration)
+    /\ registration' = Append(registration, candidate)
+    /\ UNCHANGED
+        <<phase, loadWarning, selection, shadowed, resolutionFailure,
+          traversal>>
+
+FinishLoad ==
+    /\ phase = "Registering"
+    /\ phase' = "Loaded"
+    /\ loadWarning' =
+        [reference \in References |->
+            KnownSkewFor(registration, reference)]
+    /\ UNCHANGED
+        <<registration, selection, shadowed, resolutionFailure, traversal>>
+
+Resolve ==
+    /\ phase = "Loaded"
+    /\ phase' = "Resolved"
+    /\ selection' =
+        [reference \in References |->
+            CandidateFor(registration, reference)]
+    /\ shadowed' =
+        [reference \in References |->
+            ShadowedFor(registration, reference)]
+    /\ resolutionFailure' =
+        [reference \in References |->
+            FailureFor(registration, reference)]
+    /\ UNCHANGED <<registration, loadWarning, traversal>>
+
+TraversalFor(reference) ==
+    IF resolutionFailure[reference] # "None"
+    THEN "ResolutionFailed"
+    ELSE
+        IF /\ selection[reference] \in DesignatedCandidates
+           /\ KnownSkewFor(registration, reference)
+        THEN
+            IF SuppressCoherenceFailure
+            THEN "Missing"
+            ELSE "CoherenceFailure"
+        ELSE "Found"
+
+Traverse ==
+    /\ phase = "Resolved"
+    /\ phase' = "Traversed"
+    /\ traversal' =
+        [reference \in References |-> TraversalFor(reference)]
+    /\ UNCHANGED
+        <<registration, loadWarning, selection, shadowed, resolutionFailure>>
+
+Next ==
+    (\/ \E candidate \in Candidates : Register(candidate))
+    \/ FinishLoad
+    \/ Resolve
+    \/ Traverse
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(FinishLoad)
+    /\ WF_vars(Resolve)
+    /\ WF_vars(Traverse)
+
+TypeOK ==
+    /\ phase \in Phases
+    /\ registration \in RegistrationSequences
+    /\ loadWarning \in [References -> BOOLEAN]
+    /\ selection \in [References -> Candidates \union {NoCandidate}]
+    /\ shadowed \in [References -> SUBSET Candidates]
+    /\ resolutionFailure \in [References -> ResolutionFailures]
+    /\ traversal \in [References -> TraversalOutcomes]
+
+SelectedCandidatesAreEntitled ==
+    \A reference \in References:
+        selection[reference] # NoCandidate =>
+            /\ selection[reference] \in EntitledCandidates
+            /\ selection[reference] \in RegisteredSet(registration)
+
+SelectionMatchesFailure ==
+    phase \in {"Resolved", "Traversed"} =>
+        \A reference \in References:
+            (selection[reference] = NoCandidate)
+                <=> (resolutionFailure[reference] # "None")
+
+DesignatedPrecedence ==
+    phase \in {"Resolved", "Traversed"} =>
+        \A reference \in References:
+            LET designated ==
+                    EligibleFor(registration, reference)
+                        \cap DesignatedCandidates
+            IN
+                Cardinality(designated) = 1 =>
+                    selection[reference] \in designated
+
+UnruledTieIsVisible ==
+    phase \in {"Resolved", "Traversed"} =>
+        \A reference \in References:
+            Cardinality(TopCandidates(registration, reference)) > 1 =>
+                /\ selection[reference] = NoCandidate
+                /\ resolutionFailure[reference] = "Ambiguous"
+
+ShadowingIsRecorded ==
+    phase \in {"Resolved", "Traversed"} =>
+        \A reference \in References:
+            selection[reference] # NoCandidate =>
+                shadowed[reference] =
+                    EligibleFor(registration, reference)
+                        \ {selection[reference]}
+
+SelectionIsOrderIndependent ==
+    phase \in {"Resolved", "Traversed"} =>
+        \A reference \in References:
+            \A alternate \in RegistrationPermutations(registration):
+                CandidateFor(registration, reference) =
+                    CandidateFor(alternate, reference)
+
+ReferenceVersionDoesNotChangeWinner ==
+    phase \in {"Resolved", "Traversed"} =>
+        LET exactDesignated ==
+                EligibleFor(registration, ExactReference)
+                    \cap DesignatedCandidates
+            skewedDesignated ==
+                EligibleFor(registration, SkewedReference)
+                    \cap DesignatedCandidates
+            exactPlatform ==
+                EligibleFor(registration, ExactReference)
+                    \cap PlatformCandidates
+            skewedPlatform ==
+                EligibleFor(registration, SkewedReference)
+                    \cap PlatformCandidates
+        IN
+            /\ Cardinality(exactDesignated) = 1
+            /\ exactDesignated = skewedDesignated
+            /\ exactPlatform # {}
+            /\ skewedPlatform # {}
+            => selection[ExactReference] = selection[SkewedReference]
+
+KnownSkewIsWarnedAtLoad ==
+    phase \in {"Loaded", "Resolved", "Traversed"} =>
+        \A reference \in References:
+            KnownSkewFor(registration, reference) =>
+                loadWarning[reference]
+
+IncoherenceIsAttributed ==
+    phase = "Traversed" =>
+        \A reference \in References:
+            /\ selection[reference] \in DesignatedCandidates
+            /\ KnownSkewFor(registration, reference)
+            => traversal[reference] = "CoherenceFailure"
+
+CoherentTraversalSucceeds ==
+    phase = "Traversed" =>
+        \A reference \in References:
+            /\ selection[reference] # NoCandidate
+            /\ ~(/\ selection[reference] \in DesignatedCandidates
+                 /\ KnownSkewFor(registration, reference))
+            => traversal[reference] = "Found"
+
+ResolutionConverges == <> (phase = "Traversed")
+
+=============================================================================

--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenOrder.cfg
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenOrder.cfg
@@ -1,0 +1,17 @@
+\* Mutation: registration order chooses the winner.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    DesignatedOne = designatedOne
+    DesignatedTwo = designatedTwo
+    Platform = platform
+    Unentitled = unentitled
+    ExactReference = exactReference
+    SkewedReference = skewedReference
+    NoCandidate = noCandidate
+    SelectionMode = "RegistrationOrder"
+    SuppressCoherenceFailure = FALSE
+
+SPECIFICATION Spec
+
+INVARIANT SelectionIsOrderIndependent

--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenSilent.cfg
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenSilent.cfg
@@ -1,0 +1,17 @@
+\* Mutation: incoherent traversal returns a success-shaped missing result.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    DesignatedOne = designatedOne
+    DesignatedTwo = designatedTwo
+    Platform = platform
+    Unentitled = unentitled
+    ExactReference = exactReference
+    SkewedReference = skewedReference
+    NoCandidate = noCandidate
+    SelectionMode = "Policy"
+    SuppressCoherenceFailure = TRUE
+
+SPECIFICATION Spec
+
+INVARIANT IncoherenceIsAttributed

--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenVersion.cfg
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionBrokenVersion.cfg
@@ -1,0 +1,17 @@
+\* Mutation: incidental version equality changes the selected provenance.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    DesignatedOne = designatedOne
+    DesignatedTwo = designatedTwo
+    Platform = platform
+    Unentitled = unentitled
+    ExactReference = exactReference
+    SkewedReference = skewedReference
+    NoCandidate = noCandidate
+    SelectionMode = "VersionSensitive"
+    SuppressCoherenceFailure = FALSE
+
+SPECIFICATION Spec
+
+INVARIANT ReferenceVersionDoesNotChangeWinner

--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionLiveness.cfg
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionLiveness.cfg
@@ -1,0 +1,23 @@
+\* Bounded liveness exploration under weak fairness.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    DesignatedOne = designatedOne
+    DesignatedTwo = designatedTwo
+    Platform = platform
+    Unentitled = unentitled
+    ExactReference = exactReference
+    SkewedReference = skewedReference
+    NoCandidate = noCandidate
+    SelectionMode = "Policy"
+    SuppressCoherenceFailure = FALSE
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    SelectedCandidatesAreEntitled
+    DesignatedPrecedence
+    IncoherenceIsAttributed
+
+PROPERTY ResolutionConverges

--- a/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionSafety.cfg
+++ b/docs/design/models/platform-overlay-resolution/PlatformOverlayResolutionSafety.cfg
@@ -1,0 +1,28 @@
+\* Full bounded safety exploration.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    DesignatedOne = designatedOne
+    DesignatedTwo = designatedTwo
+    Platform = platform
+    Unentitled = unentitled
+    ExactReference = exactReference
+    SkewedReference = skewedReference
+    NoCandidate = noCandidate
+    SelectionMode = "Policy"
+    SuppressCoherenceFailure = FALSE
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    SelectedCandidatesAreEntitled
+    SelectionMatchesFailure
+    DesignatedPrecedence
+    UnruledTieIsVisible
+    ShadowingIsRecorded
+    SelectionIsOrderIndependent
+    ReferenceVersionDoesNotChangeWinner
+    KnownSkewIsWarnedAtLoad
+    IncoherenceIsAttributed
+    CoherentTraversalSucceeds

--- a/docs/design/models/platform-overlay-resolution/README.md
+++ b/docs/design/models/platform-overlay-resolution/README.md
@@ -1,0 +1,156 @@
+# Platform overlay resolution model
+
+This TLA+ model is the executable interaction companion to
+[Platform composition and overlays](../../platform-composition-and-overlays.md).
+It explores how one already-collected candidate set is resolved when designated
+and platform assemblies can both satisfy a reference, and how a known
+overlay/platform coherence mismatch is reported when traversal crosses the
+pair.
+
+The model exists to answer interaction questions that are difficult to settle
+from prose:
+
+- Does designation outrank platform independently of candidate registration
+  order?
+- Can incidental version equality change which provenance wins?
+- Does an unruled tie become a visible ambiguity rather than a silent pick?
+- Is every entitled candidate passed over by a successful selection recorded
+  as shadowed evidence?
+- Can a known newer-overlay/older-platform mismatch become a success-shaped
+  missing result at traversal?
+- Does every closed candidate set reach a selected result or typed failure?
+
+## Relationship to the product
+
+The model is owned by the precedence and coherence rules in
+`platform-composition-and-overlays.md`. It abstracts the candidate enumeration
+and first-match behavior currently found in
+`AssemblyDependencyResolver.ResolveCore`, the provenance mapping that
+classifies caller-enumerated corpus paths as designated, and the typed binding
+selection returned to traversal.
+
+The four bounded candidates are:
+
+- two designated candidates, allowing an unruled same-precedence tie;
+- one platform candidate; and
+- one identity-matching but unentitled candidate.
+
+Candidates register in every possible order and loading may close after any
+subset. Resolution runs only after the set closes. Two references share the
+same bindable candidates but carry different incidental version-equality facts:
+one happens to match the platform candidate and one the designated candidates.
+The policy selection deliberately ignores that equality; the version mutation
+does not.
+
+The skewed reference represents an overlay known to target a newer closure than
+the available platform. Loading records a warning without rejecting the
+workspace. Traversal then reports `CoherenceFailure` when it requires that
+platform closure. The silent mutation returns `Missing` instead.
+
+## Assumptions and non-claims
+
+The checked model assumes:
+
+- candidate acquisition has completed before resolution;
+- adjacent owners have already supplied immutable candidate identity,
+  provenance, entitlement, and pair-coherence facts;
+- every modeled candidate has the requested simple name and is bindable under
+  the adjacent identity policy;
+- `DesignatedAsset` and `PlatformAsset` are the only entitled provenance kinds;
+- one traversal requires a member from the platform closure; and
+- a newer-overlay/older-platform relationship is the modeled incoherence case.
+
+Artifact acquisition, filesystem discovery, PE and metadata decoding, identity
+matching, framework parsing, warning presentation, type lookup, and every
+compatibility dimension other than the abstract skew relation are outside the
+model. The model does not change or validate the entitlement rule. TLC results
+establish properties of this state machine under the stated assumptions and
+bounds, not properties of the shipped implementation. Formal
+model-to-implementation correspondence is unverified.
+
+## Checked configurations
+
+| Configuration | Purpose |
+| --- | --- |
+| `PlatformOverlayResolutionSafety.cfg` | Explores every candidate subset and registration order. Checks type safety, entitlement, selection/failure consistency, designated precedence, visible ambiguity, shadow evidence, order independence, version independence, load warning, coherence attribution, and coherent traversal. |
+| `PlatformOverlayResolutionLiveness.cfg` | Checks that every candidate-registration prefix eventually closes, resolves, and traverses under weak fairness. |
+| `PlatformOverlayResolutionBrokenOrder.cfg` | Replaces policy selection with first-registered selection. It must violate `SelectionIsOrderIndependent`. |
+| `PlatformOverlayResolutionBrokenVersion.cfg` | Lets a version-equal platform candidate outrank a designated candidate. It must violate `ReferenceVersionDoesNotChangeWinner`. |
+| `PlatformOverlayResolutionBrokenSilent.cfg` | Converts an attributed coherence failure into `Missing`. It must violate `IncoherenceIsAttributed`. |
+
+All configurations disable TLC's deadlock check because `Traversed` is an
+intentional terminal phase. The temporal specification permits stuttering in
+that state.
+
+## Running TLC
+
+Follow the repository
+[TLA+ setup runbook](../../../runbooks/tla-plus-setup.md) for the pinned
+toolchain. Run configurations sequentially because concurrent TLC processes
+using `-cleanup` can remove one another's metadata.
+
+```bash
+TLA_TOOLS_JAR=/path/to/tla2tools.jar
+cd docs/design/models/platform-overlay-resolution
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers auto -cleanup -coverage 1 \
+  -config PlatformOverlayResolutionSafety.cfg \
+  PlatformOverlayResolution.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers auto -cleanup -coverage 1 \
+  -config PlatformOverlayResolutionLiveness.cfg \
+  PlatformOverlayResolution.tla
+```
+
+The mutation configurations are expected to exit unsuccessfully:
+
+```bash
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config PlatformOverlayResolutionBrokenOrder.cfg \
+  PlatformOverlayResolution.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config PlatformOverlayResolutionBrokenVersion.cfg \
+  PlatformOverlayResolution.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config PlatformOverlayResolutionBrokenSilent.cfg \
+  PlatformOverlayResolution.tla
+```
+
+## Recorded result
+
+The positive configurations completed with no errors:
+
+| Configuration | Generated states | Distinct states | Maximum depth | Result |
+| --- | ---: | ---: | ---: | --- |
+| Safety | 260 | 260 | 8 | All 11 invariants passed. |
+| Liveness | 260 | 260 | 8 | `ResolutionConverges` passed. |
+
+The state graph contains all 65 registration prefixes in each of the
+`Registering`, `Loaded`, `Resolved`, and `Traversed` phases. Safety-run action
+coverage was 64 `Register` transitions and 65 transitions each for
+`FinishLoad`, `Resolve`, and `Traverse`. In particular, warning and traversal
+expressions for the modeled incoherent pair had nonzero coverage.
+
+Each mutation exited with TLC status 12 on its intended invariant:
+
+| Configuration | Generated / distinct | Maximum depth | Counterexample |
+| --- | ---: | ---: | --- |
+| Broken order | 69 / 69 | 5 | Registration `<<DesignatedOne, DesignatedTwo>>` silently selected `DesignatedOne`, violating `SelectionIsOrderIndependent` instead of reporting the unruled tie. |
+| Broken version | 74 / 74 | 5 | With `DesignatedOne` and `Platform`, the exact reference selected `Platform` while the skewed reference selected `DesignatedOne`, violating `ReferenceVersionDoesNotChangeWinner`. |
+| Broken silent failure | 138 / 138 | 6 | With `DesignatedOne` and `Platform`, skewed traversal returned `Missing` with no resolution failure, violating `IncoherenceIsAttributed`. |
+
+The runs used the repository-pinned TLA+ v1.8.0 tools, TLC build
+`2026.08.21.155922` revision `9787e65`. The checked
+`tla2tools.jar` SHA-256 was
+`eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a`.
+The available runtime was OpenJDK `21.0.12`; the repository runbook's preferred
+Java 25 runtime was not installed on this shared host. Java 21 satisfies the
+tool's Java 11-or-later requirement, so the machine configuration was left
+unchanged and the runtime deviation is recorded here.

--- a/docs/design/platform-composition-and-overlays.md
+++ b/docs/design/platform-composition-and-overlays.md
@@ -201,11 +201,27 @@ both can satisfy the same reference.
 The precedence rule for this case is simple: **when resolving a reference that
 can bind to both, the binding policy selects the participant backed by the
 designated artifact over the participant backed by the platform artifact**.
+The selection answer retains every other eligible entitled candidate as typed
+shadow evidence, so consumers can explain the composition without reconstructing
+policy from enumeration order. A shadowed candidate is evidence, not an active
+participant.
 That gives every acquisition system the same well-defined graph to compose
 with; it does not require specifying the current resolver's case-by-case
 accidents. Any other tie between entitled candidates needs its own stated rule
 or a diagnostic rather than a silent pick. The current resolver does not yet
 enforce this contract; tracked as **#4593**.
+
+### Executable interaction model
+
+The
+[platform overlay resolution model](models/platform-overlay-resolution/README.md)
+explores candidate registration order, designated/platform arbitration,
+unruled ties, shadow evidence, incidental version equality, and attributed
+coherence failure at traversal. Its assumptions, bounds, checked properties,
+and mutation controls are recorded beside the executable specification.
+
+TLC results are evidence about the model, not the implementation. Formal
+model-to-implementation correspondence remains unverified.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- model designated/platform arbitration independently of candidate registration
  order and incidental assembly-version equality
- require unruled same-precedence ties to remain visible and successful
  selections to retain typed shadow evidence
- model newer-overlay/older-platform skew as a load warning followed by an
  attributed traversal failure
- record bounded positive results and three targeted mutation counterexamples

This is a model-only adversarial design exercise. It does not implement #4593
or #4592, and formal model-to-implementation correspondence remains unverified.

## Demo

```bash
cd docs/design/models/platform-overlay-resolution
java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
  -workers auto -cleanup -coverage 1 \
  -config PlatformOverlayResolutionSafety.cfg \
  PlatformOverlayResolution.tla
```

The policy model explores all 260 reachable states: every one of the 65
candidate-registration prefixes in each of four phases. All 11 safety
properties pass. The neighboring mutation configurations demonstrate that the
checks reject registration-order selection, version-sensitive winner changes,
and success-shaped missing results under known incoherence.

## Validation

- safety: 260 generated / 260 distinct states, maximum depth 8
- liveness: 260 generated / 260 distinct states, maximum depth 8
- broken-order mutation: `SelectionIsOrderIndependent` violated
- broken-version mutation: `ReferenceVersionDoesNotChangeWinner` violated
- broken-silent mutation: `IncoherenceIsAttributed` violated
- Markdown lint on both changed Markdown files

The runs used the pinned TLA+ v1.8.0 tools with OpenJDK 21.0.12. Java 25 was
not installed on the shared host; the actual runtime and jar checksum are
recorded beside the model.

Closes #4991
