### PR TITLE
Curate navigation and overlay TLA+ models

### DIFF
--- a/docs/tla-plus-methodology.md
+++ b/docs/tla-plus-methodology.md
@@ -48,6 +48,22 @@ The model demonstrates single-flight admission, incompatible-generation
 exclusion, voluntary and disposal-forced draining, late-result suppression,
 guard witnesses, and weak-fairness progress.
 
+## Inspection subject navigation
+
+[`NavigationSession.tla`](design/models/inspection-subject-navigation/NavigationSession.tla),
+[`AtomicRestoration.tla`](design/models/inspection-subject-navigation/AtomicRestoration.tla),
+and
+[`SnapshotAuthority.tla`](design/models/inspection-subject-navigation/SnapshotAuthority.tla)
+are accompanied by matching configurations and a shared model
+[`README.md`](design/models/inspection-subject-navigation/README.md).
+
+The three independent models divide one design into retained-session ordering
+and effect authority, atomic subject-and-lens restoration, and retained versus
+stateless snapshot custody. They demonstrate choosing separate finite models
+for orthogonal mechanisms, naming the token or operation whose progress a
+liveness property claims, independently retaining requested payloads, and
+pairing action coverage with targeted mutation probes.
+
 ## AssemblyContextGroupLifecycle
 
 [`AssemblyContextGroupLifecycle.tla`](models/assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla)
@@ -59,6 +75,20 @@ result-publication, finalization, disposal, and quiescent-release lifecycle for
 [Inspection space](inspection-space.md). It demonstrates same-participant
 contention, ordinary versus one-shot release, exceptional retry, resource
 ordering, and independent counterexample mutations.
+
+## PlatformOverlayResolution
+
+[`PlatformOverlayResolution.tla`](design/models/platform-overlay-resolution/PlatformOverlayResolution.tla)
+is accompanied by safety, liveness, and broken-policy configurations and a
+model
+[`README.md`](design/models/platform-overlay-resolution/README.md).
+
+It models arbitration among already-classified designated, platform, and
+unentitled candidates across every registration order. It demonstrates proving
+policy precedence independent of incidental order and version equality,
+retaining shadowed candidates as evidence, making unruled ties visible, and
+using committed negative controls to prevent a known coherence failure from
+becoming a success-shaped missing result.
 
 ## ZfsHoldTight
 


### PR DESCRIPTION
## Summary

- add the inspection-subject-navigation model set as the exemplar for dividing
  one design into independent finite models
- add `PlatformOverlayResolution` as the exemplar for order- and
  version-independent policy arbitration with visible failure attribution
- retain all four existing examples; neither addition teaches an incumbent's
  lesson better enough to justify replacement

This brings the curated set to its maximum of six because both additions
provide distinct methodology value, not to consume available capacity.

## Demo

`docs/tla-plus-methodology.md` now presents two additional H2 examples:

- **Inspection subject navigation** links its three independent specifications
  and explains their model-boundary, correlation, and liveness techniques.
- **PlatformOverlayResolution** links its executable policy model and explains
  its permutation checks, shadow evidence, visible ambiguity, and committed
  broken-policy controls.

`CompileBackAdmission`, `DeadlineStreamLifecycle`, `PackageCachePublication`,
`PackageRealizationAdmission`, and `SemanticRowSelection` were considered but
not added because their strongest current lessons overlap existing examples,
are not clearly better than those examples, or lack equivalent supporting
methodology artifacts.

## Candidate

- Head: `a87522235c755532c17810d4d096d7935e93ccd3`
- Effective base:
  `58774db3a010b34024d6b954834e2d995e599354`

## Validation

```text
npx markdownlint-cli docs/tla-plus-methodology.md
```
