### PR TITLE
Add host-neutral analysis request planner

### DIFF
--- a/docs/design/analysis-surfaces-and-universes.md
+++ b/docs/design/analysis-surfaces-and-universes.md
@@ -11,11 +11,13 @@ request plan. Producer execution, result semantics, and presentation remain
 with their existing owners.
 
 Tracking: [#4967](https://github.com/richlander/dotnet-inspect/issues/4967).
+Implementation: [#5014](https://github.com/richlander/dotnet-inspect/issues/5014).
 
 ## Status
 
-This is a target design. Runtime implementation and every property in
-[Verification](#verification) remain unverified until their named gates land.
+The host-neutral runtime contract is implemented by
+`AnalysisRequestPlanning.cs`. Its asserted properties are enforced by the
+named gates in [Verification](#verification).
 
 The word *analysis* is generic here: it means a producer-backed inspection
 question such as Integrations, calls, metadata, API shape, or body analysis.
@@ -117,7 +119,7 @@ The report surface identifies the domain the answer is about.
 | Type | One or more owner-issued Type targets |
 | Library | One or more acquired Library targets |
 | Root | One or more realized Root targets, such as Package |
-| Workspace | One owner-issued workspace or operation target |
+| Workspace | Exactly one owner-issued workspace or operation target |
 
 These kinds do not mint identities or define structural composition. They bind
 owner-issued identities to the analysis descriptor's accepted target roles and
@@ -224,12 +226,19 @@ does not derive them from Section names.
 
 The configured descriptor catalog is finite for one build. Observation
 instances remain open-ended within the bounded universe supplied to a request.
+Structural discovery projects each configured owner descriptor by the same
+definition identity; it does not replace the descriptor or erase its typed
+owner declarations. An owner retains that descriptor identity when it binds a
+request, so the validated plan retains the same typed catalog and requirement
+currency without deriving either from the generic catalog view.
 
 ### Request capability
 
 Request capability validates one complete request against its analysis
 descriptor before producer execution. It checks:
 
+- that the analysis descriptor is configured in the current catalog;
+- report-surface cardinality;
 - report-surface kind and typed target roles;
 - Targeted or Census mode invariants;
 - analysis-descriptor support for the requested mode;
@@ -241,10 +250,12 @@ Rejection is a typed planning outcome with guidance. It is not a producer
 inspection, a successful empty result, or a Finding state. Validation must not
 execute the producer merely to decide whether the producer is supported.
 
-The request owner declares a closed set of rejection reasons covering invalid
-mode, descriptor-unsupported mode, unsupported surface, unsupported target
-role, unsatisfied or unbounded universe, missing structural prerequisite, and
-unsupported projection. Every rejection is decided before producer execution.
+The request owner declares a closed set of rejection reasons covering an
+unconfigured analysis, invalid report-surface cardinality, invalid mode,
+descriptor-unsupported mode, unsupported surface, unsupported target role,
+missing, unsatisfied, or unbounded universe, missing structural prerequisite,
+and unsupported projection. Every rejection is decided before producer
+execution.
 User-gesture provenance, capability authorization, and cost enforcement remain
 host-preflight responsibilities under
 [Progressive disclosure](progressive-disclosure.md).
@@ -318,6 +329,8 @@ The request owner must distinguish:
 | Case | Request interpretation |
 | --- | --- |
 | Configured descriptor with no request | Structurally discoverable capability only |
+| Request names a descriptor outside the configured catalog | Typed capability rejection before execution |
+| Report surface has no target, or Workspace has other than one target | Typed capability rejection before execution |
 | Targeted mode with no target in a descriptor-declared privileged-anchor role | Invalid request |
 | Census mode with a target in a descriptor-declared privileged-anchor role | Invalid request |
 | Structurally valid mode unsupported by the descriptor | Typed capability rejection before execution |
@@ -371,8 +384,10 @@ The target implementation is unverified until these named gates land:
 - `AnalysisRequest_CensusRejectsPrivilegedContainedAnchor`
 - `AnalysisRequest_ModeValidationDerivesFromDeclaredTargetFunctions`
 - `AnalysisRequest_RejectsMissingOrUnboundedUniverseBeforeProducerExecution`
+- `AnalysisRequest_RejectsInvalidReportSurfaceCardinalityBeforeProducerExecution`
 - `AnalysisCapability_StructuralDiscoveryDoesNotResolveContentExecuteProducersOrProbeEffectiveness`
 - `AnalysisCapability_ListsConfiguredUnobservedIntegrationDescriptors`
+- `AnalysisCapability_RejectsUnconfiguredAnalysisBeforeProducerExecution`
 - `AnalysisCapability_RejectsUnsupportedModeBeforeProducerExecution`
 - `AnalysisCapability_RejectsUnsupportedSurfaceBeforeProducerExecution`
 - `AnalysisCapability_RejectsUnsupportedTargetRoleBeforeProducerExecution`
@@ -383,6 +398,7 @@ The target implementation is unverified until these named gates land:
 - `AnalysisCapability_RejectionDoesNotUseFindingInspectionState`
 - `AnalysisPlan_RetainsExactRequestFieldsAndDescriptorRequirements`
 - `AnalysisPlan_RetainsUniverseCompletenessAndFailureInputs`
+- `AnalysisPlanningResults_HavePlannerOwnedConstruction`
 - `AnalysisProjection_RowsAndGraphRetainOneAnalysisIdentity`
 - `AnalysisUniverseProviderKindDoesNotChangeRequestFieldSemantics`
 

--- a/docs/design/analysis-surfaces-and-universes.md
+++ b/docs/design/analysis-surfaces-and-universes.md
@@ -399,6 +399,7 @@ The target implementation is unverified until these named gates land:
 - `AnalysisPlan_RetainsExactRequestFieldsAndDescriptorRequirements`
 - `AnalysisPlan_RetainsUniverseCompletenessAndFailureInputs`
 - `AnalysisPlanningResults_HavePlannerOwnedConstruction`
+- `AnalysisUniverseCapabilities_RejectNullDeclaration`
 - `AnalysisProjection_RowsAndGraphRetainOneAnalysisIdentity`
 - `AnalysisUniverseProviderKindDoesNotChangeRequestFieldSemantics`
 

--- a/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
@@ -1,0 +1,1019 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using DotnetInspector.Queries;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class AnalysisRequestPlanningTests
+{
+    [Fact]
+    public void AnalysisCapability_ListsConfiguredUnobservedIntegrationDescriptors()
+    {
+        Scenario scenario = new();
+        var second = new AnalysisDescriptor(
+            "Dependency census",
+            "v1",
+            [AnalysisQuestionMode.Census],
+            [
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    scenario.DomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ],
+            [scenario.RowsProjection]);
+
+        var planner = new AnalysisRequestPlanner([scenario.Analysis, second], [scenario.Prerequisite]);
+
+        Assert.Equal([scenario.Analysis, second], planner.Descriptors);
+        var integration =
+            Assert.IsType<IntegrationAnalysisDescriptor>(planner.Descriptors[0]);
+        Assert.Equal(scenario.Concepts, integration.Concepts);
+    }
+
+    [Fact]
+    public void AnalysisPlan_RetainsExactRequestFieldsAndDescriptorRequirements()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<TargetIdentity> surface = scenario.ValidTargetedSurface();
+        AnalysisUniverseDescription<UniverseBoundary, UniverseState> universe =
+            scenario.ValidUniverse();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            surface,
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var validated = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(request));
+
+        Assert.Same(scenario.Analysis, validated.Plan.Analysis);
+        Assert.Same(surface, validated.Plan.ReportSurface);
+        Assert.Same(universe, validated.Plan.Universe);
+        Assert.Equal(AnalysisQuestionMode.Targeted, validated.Plan.Mode);
+        Assert.Same(scenario.RowsProjection, validated.Plan.Projection);
+        Assert.Equal(scenario.Analysis.UniverseRequirements, validated.Plan.UniverseRequirements);
+        Assert.Equal(
+            scenario.Analysis.StructuralPrerequisites,
+            validated.Plan.StructuralPrerequisites);
+        Assert.Equal(scenario.Analysis.PreflightRequirements, validated.Plan.PreflightRequirements);
+        Assert.Same(universe.RequestedBoundary, validated.Plan.Universe.RequestedBoundary);
+        Assert.Same(universe.RealizedBoundary, validated.Plan.Universe.RealizedBoundary);
+    }
+
+    [Fact]
+    public void AnalysisPlan_RetainsUniverseCompletenessAndFailureInputs()
+    {
+        Scenario scenario = new();
+        UniverseState state = new("Partial", ["package-a failed"]);
+        var universe = new AnalysisUniverseDescription<UniverseBoundary, UniverseState>(
+            AnalysisUniverseBoundKind.Finite,
+            new("requested"),
+            new("realized"),
+            [scenario.SubjectCapability, scenario.EvidenceCapability],
+            state);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var validated = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(request));
+
+        Assert.Same(universe.ProviderState, validated.Plan.Universe.ProviderState);
+        Assert.Equal("Partial", validated.Plan.Universe.ProviderState.Completeness);
+        Assert.Equal(["package-a failed"], validated.Plan.Universe.ProviderState.Failures);
+    }
+
+    [Fact]
+    public void Plan_ValidatesIntegrationShapedWorkspaceCensus()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidCensusSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Census,
+            scenario.MatrixProjection);
+
+        var validated = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(request));
+
+        Assert.Equal(AnalysisReportSurfaceKind.Workspace, validated.Plan.ReportSurface.Kind);
+        Assert.Equal(AnalysisQuestionMode.Census, validated.Plan.Mode);
+        Assert.Same(scenario.MatrixProjection, validated.Plan.Projection);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedModeBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        AnalysisDescriptor censusOnly = scenario.CreateAnalysis(
+            supportedModes: [AnalysisQuestionMode.Census],
+            targetRoles:
+            [
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    scenario.DomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ]);
+        var planner = new AnalysisRequestPlanner([censusOnly], [scenario.Prerequisite]);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            censusOnly,
+            scenario.Surface(
+                AnalysisReportSurfaceKind.Workspace,
+                scenario.DomainRole,
+                "workspace"),
+            universe: null,
+            AnalysisQuestionMode.Targeted,
+            scenario.UnsupportedProjection);
+
+        AnalysisRequestRejection rejection = Reject(planner.Plan(request));
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedMode>(rejection);
+        Assert.Equal(AnalysisQuestionMode.Targeted, unsupported.Mode);
+        Assert.NotEmpty(unsupported.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedSurfaceBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.Surface(AnalysisReportSurfaceKind.Type, scenario.AnchorRole, "type"),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedSurface>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisReportSurfaceKind.Type, unsupported.SurfaceKind);
+        Assert.NotEmpty(unsupported.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedTargetRoleBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedRole = new AnalysisTargetRoleDescriptor(scenario.AnchorRole.Name);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.Surface(AnalysisReportSurfaceKind.Library, sameNamedRole, "library"),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedTargetRole>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Same(sameNamedRole, unsupported.Role);
+        Assert.NotEmpty(unsupported.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_TargetedRequiresAcceptedAnchor()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.Surface(
+                AnalysisReportSurfaceKind.Library,
+                scenario.TargetedDomainRole,
+                "library"),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisModeViolation.TargetedMissingPrivilegedAnchor, invalid.Violation);
+        Assert.NotEmpty(invalid.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_CensusRejectsPrivilegedContainedAnchor()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.Surface(
+                AnalysisReportSurfaceKind.Workspace,
+                scenario.CensusAnchorRole,
+                "workspace"),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Census,
+            scenario.RowsProjection);
+
+        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisModeViolation.CensusContainsPrivilegedAnchor, invalid.Violation);
+        Assert.NotEmpty(invalid.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_RejectsMissingOrUnboundedUniverseBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            universe: null,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        AnalysisRequestRejection rejection = Reject(scenario.Planner.Plan(request));
+
+        Assert.IsType<AnalysisRequestRejection.MissingUniverse>(rejection);
+        Assert.NotEmpty(rejection.Guidance);
+
+        var unboundedRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.Universe(
+                AnalysisUniverseBoundKind.Unbounded,
+                [scenario.SubjectCapability, scenario.EvidenceCapability]),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        AnalysisRequestRejection unboundedRejection =
+            Reject(scenario.Planner.Plan(unboundedRequest));
+
+        Assert.IsType<AnalysisRequestRejection.UnboundedUniverse>(unboundedRejection);
+        Assert.NotEmpty(unboundedRejection.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsatisfiedUniverseBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedSubjectCapability =
+            new AnalysisUniverseCapabilityDescriptor(scenario.SubjectCapability.Name);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.Universe(AnalysisUniverseBoundKind.Finite, [sameNamedSubjectCapability]),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(
+            [scenario.SubjectRequirement, scenario.EvidenceRequirement],
+            unsatisfied.Requirements);
+        Assert.NotEmpty(unsatisfied.Guidance);
+    }
+
+    [Fact]
+    public void Plan_RetainsDistinctOwnerScopedRequirementsSharingOneCapability()
+    {
+        Scenario scenario = new();
+        var registrations = new IntegrationConceptDescriptor("Registrations");
+        var clientConstruction = new IntegrationConceptDescriptor("Client construction");
+        var attributes = new IntegrationProducerPolicyDescriptor("Attribute policy");
+        var calls = new IntegrationProducerPolicyDescriptor("Call policy");
+        var attributeRequirement = new IntegrationUniverseRequirementDescriptor(
+            "Attribute evidence",
+            scenario.EvidenceCapability,
+            attributes,
+            [registrations, clientConstruction]);
+        var callRequirement = new IntegrationUniverseRequirementDescriptor(
+            "Call evidence",
+            scenario.EvidenceCapability,
+            calls,
+            [clientConstruction]);
+        AnalysisDescriptor analysis = scenario.CreateAnalysis(
+            universeRequirements:
+            [
+                scenario.SubjectRequirement,
+                attributeRequirement,
+                callRequirement,
+            ]);
+        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var plan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                planner.Plan(request)).Plan;
+
+        Assert.Equal(
+            [scenario.SubjectRequirement, attributeRequirement, callRequirement],
+            plan.UniverseRequirements);
+        AnalysisDescriptor discovered = Assert.Single(planner.Descriptors);
+        var discoveredAttributeRequirement =
+            Assert.IsType<IntegrationUniverseRequirementDescriptor>(
+                discovered.UniverseRequirements[1]);
+        Assert.Equal(
+            [registrations, clientConstruction],
+            discoveredAttributeRequirement.Concepts);
+        Assert.Same(attributes, attributeRequirement.Policy);
+        Assert.Equal([registrations, clientConstruction], attributeRequirement.Concepts);
+        Assert.Same(calls, callRequirement.Policy);
+        Assert.Equal([clientConstruction], callRequirement.Concepts);
+
+        var missingEvidenceRequest =
+            new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+                analysis,
+                scenario.ValidTargetedSurface(),
+                scenario.Universe(
+                    AnalysisUniverseBoundKind.Finite,
+                    [scenario.SubjectCapability]),
+                AnalysisQuestionMode.Targeted,
+                scenario.RowsProjection);
+        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
+            Reject(planner.Plan(missingEvidenceRequest)));
+        Assert.Equal([attributeRequirement, callRequirement], unsatisfied.Requirements);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsMissingStructuralPrerequisiteBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var planner = new AnalysisRequestPlanner([scenario.Analysis], []);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var missing = Assert.IsType<AnalysisRequestRejection.MissingStructuralPrerequisites>(
+            Reject(planner.Plan(request)));
+
+        Assert.Equal([scenario.Prerequisite], missing.Prerequisites);
+        Assert.NotEmpty(missing.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedProjectionBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedProjection =
+            new AnalysisProjectionDescriptor(scenario.RowsProjection.Name);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            sameNamedProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedProjection>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Same(sameNamedProjection, unsupported.Projection);
+        Assert.NotEmpty(unsupported.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_AllDeclaredRejectionsPrecedeProducerExecution()
+    {
+        Scenario scenario = new();
+        var providerState = new PoisonProviderState();
+        var universe = new AnalysisUniverseDescription<UniverseBoundary, PoisonProviderState>(
+            AnalysisUniverseBoundKind.Finite,
+            new("requested"),
+            new("realized"),
+            [scenario.SubjectCapability, scenario.EvidenceCapability],
+            providerState);
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, PoisonProviderState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var validated = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, PoisonProviderState>
+                .Validated>(scenario.Planner.Plan(request));
+
+        Assert.Same(providerState, validated.Plan.Universe.ProviderState);
+        Assert.Equal(0, providerState.ExecutionCount);
+        Assert.DoesNotContain(
+            typeof(Delegate),
+            typeof(AnalysisRequestPlanner)
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
+                .SelectMany(GetMemberTypes));
+    }
+
+    [Fact]
+    public void AnalysisRequest_ReportSurfaceAndUniverseAreIndependent()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<TargetIdentity> targetedSurface = scenario.ValidTargetedSurface();
+        AnalysisReportSurface<TargetIdentity> censusSurface = scenario.ValidCensusSurface();
+        AnalysisUniverseDescription<UniverseBoundary, UniverseState> universe =
+            scenario.ValidUniverse();
+
+        var targeted = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            targetedSurface,
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+        var census = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            censusSurface,
+            universe,
+            AnalysisQuestionMode.Census,
+            scenario.MatrixProjection);
+
+        var targetedPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(targeted)).Plan;
+        var censusPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(census)).Plan;
+
+        Assert.Same(targetedSurface, targetedPlan.ReportSurface);
+        Assert.Same(censusSurface, censusPlan.ReportSurface);
+        Assert.Same(scenario.RowsProjection, targetedPlan.Projection);
+        Assert.Same(scenario.MatrixProjection, censusPlan.Projection);
+        Assert.NotEqual(targetedPlan.Mode, censusPlan.Mode);
+    }
+
+    [Fact]
+    public void DescriptorAndCatalog_FreezeDeclarationCollections()
+    {
+        Scenario scenario = new();
+        AnalysisQuestionMode[] modes = [AnalysisQuestionMode.Targeted];
+        AnalysisTargetRoleDeclaration[] roles =
+        [
+            new(
+                AnalysisReportSurfaceKind.Library,
+                AnalysisQuestionMode.Targeted,
+                scenario.AnchorRole,
+                AnalysisTargetFunction.PrivilegedAnchor),
+        ];
+        AnalysisProjectionDescriptor[] projections = [scenario.RowsProjection];
+        var descriptor = new AnalysisDescriptor(
+            "Frozen",
+            "v1",
+            modes,
+            roles,
+            projections);
+        AnalysisDescriptor[] descriptors = [descriptor];
+        var planner = new AnalysisRequestPlanner(descriptors, []);
+
+        modes[0] = AnalysisQuestionMode.Census;
+        roles[0] = new(
+            AnalysisReportSurfaceKind.Workspace,
+            AnalysisQuestionMode.Census,
+            scenario.DomainRole,
+            AnalysisTargetFunction.ReportDomain);
+        projections[0] = scenario.MatrixProjection;
+        descriptors[0] = scenario.Analysis;
+
+        Assert.Equal([AnalysisQuestionMode.Targeted], descriptor.SupportedModes);
+        Assert.Same(scenario.AnchorRole, Assert.Single(descriptor.TargetRoles).Role);
+        Assert.Same(scenario.RowsProjection, Assert.Single(descriptor.SupportedProjections));
+        Assert.Same(descriptor, Assert.Single(planner.Descriptors));
+    }
+
+    [Fact]
+    public void AnalysisRequest_DeclaresCompleteClosedFieldSet()
+    {
+        Assert.Equal(
+            ["Analysis", "Mode", "Projection", "ReportSurface", "Universe"],
+            typeof(AnalysisRequest<,,>)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(property => property.Name)
+                .Order(StringComparer.Ordinal));
+        Assert.Equal(
+            [
+                AnalysisReportSurfaceKind.Member,
+                AnalysisReportSurfaceKind.Type,
+                AnalysisReportSurfaceKind.Library,
+                AnalysisReportSurfaceKind.Root,
+                AnalysisReportSurfaceKind.Workspace,
+            ],
+            Enum.GetValues<AnalysisReportSurfaceKind>());
+        Assert.Equal(
+            [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
+            Enum.GetValues<AnalysisQuestionMode>());
+
+        Type[] rejectionFamilies = typeof(AnalysisRequestRejection)
+            .GetNestedTypes(BindingFlags.Public)
+            .OrderBy(type => type.Name, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            [
+                typeof(AnalysisRequestRejection.InvalidMode),
+                typeof(AnalysisRequestRejection.MissingStructuralPrerequisites),
+                typeof(AnalysisRequestRejection.MissingUniverse),
+                typeof(AnalysisRequestRejection.UnboundedUniverse),
+                typeof(AnalysisRequestRejection.UnsatisfiedUniverse),
+                typeof(AnalysisRequestRejection.UnsupportedMode),
+                typeof(AnalysisRequestRejection.UnsupportedProjection),
+                typeof(AnalysisRequestRejection.UnsupportedSurface),
+                typeof(AnalysisRequestRejection.UnsupportedTargetRole),
+            ],
+            rejectionFamilies);
+    }
+
+    [Fact]
+    public void AnalysisRequest_MemberReportMayConsumeWorkspaceUniverse()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<TargetIdentity> memberSurface = scenario.Surface(
+            AnalysisReportSurfaceKind.Member,
+            scenario.AnchorRole,
+            "method");
+        AnalysisUniverseDescription<UniverseBoundary, UniverseState> workspaceUniverse =
+            scenario.Universe(
+                AnalysisUniverseBoundKind.Finite,
+                [scenario.SubjectCapability, scenario.EvidenceCapability],
+                providerKind: "Workspace");
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            memberSurface,
+            workspaceUniverse,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var plan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(request)).Plan;
+
+        Assert.Equal(AnalysisReportSurfaceKind.Member, plan.ReportSurface.Kind);
+        Assert.Equal("Workspace", plan.Universe.ProviderState.ProviderKind);
+    }
+
+    [Fact]
+    public void AnalysisRequest_UniverseBreadthCannotWidenReportSurface()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<TargetIdentity> memberSurface = scenario.Surface(
+            AnalysisReportSurfaceKind.Member,
+            scenario.AnchorRole,
+            "method");
+        AnalysisUniverseDescription<UniverseBoundary, UniverseState> broadUniverse =
+            scenario.Universe(
+                AnalysisUniverseBoundKind.Finite,
+                [scenario.SubjectCapability, scenario.EvidenceCapability],
+                requested: "entire-workspace",
+                realized: "entire-workspace");
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            memberSurface,
+            broadUniverse,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var plan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(request)).Plan;
+
+        Assert.Same(memberSurface, plan.ReportSurface);
+        Assert.Equal(AnalysisReportSurfaceKind.Member, plan.ReportSurface.Kind);
+        Assert.Same(broadUniverse, plan.Universe);
+    }
+
+    [Fact]
+    public void AnalysisRequest_ModeValidationDerivesFromDeclaredTargetFunctions()
+    {
+        Scenario scenario = new();
+        var sharedRole = new AnalysisTargetRoleDescriptor("Shared role");
+        AnalysisDescriptor analysis = scenario.CreateAnalysis(
+            targetRoles:
+            [
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Targeted,
+                    sharedRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    sharedRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ]);
+        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
+        AnalysisReportSurface<TargetIdentity> surface = scenario.Surface(
+            AnalysisReportSurfaceKind.Workspace,
+            sharedRole,
+            "workspace");
+
+        var targeted = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            analysis,
+            surface,
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+        var census = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            analysis,
+            surface,
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Census,
+            scenario.RowsProjection);
+
+        Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                planner.Plan(targeted));
+        Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                planner.Plan(census));
+    }
+
+    [Fact]
+    public void AnalysisCapability_StructuralDiscoveryDoesNotResolveContentExecuteProducersOrProbeEffectiveness()
+    {
+        Scenario scenario = new();
+
+        var planner = new AnalysisRequestPlanner([scenario.Analysis], [scenario.Prerequisite]);
+
+        Assert.Same(scenario.Analysis, Assert.Single(planner.Descriptors));
+        Assert.DoesNotContain(
+            typeof(Delegate),
+            typeof(AnalysisRequestPlanner)
+                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
+                .SelectMany(GetMemberTypes));
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectionDoesNotUseFindingInspectionState()
+    {
+        Type[] contractTypes =
+        [
+            typeof(AnalysisRequestRejection),
+            .. typeof(AnalysisRequestRejection).GetNestedTypes(BindingFlags.Public),
+        ];
+
+        string[] referencedTypeNames = contractTypes
+            .SelectMany(type => type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            .Select(property => property.PropertyType.FullName ?? property.PropertyType.Name)
+            .ToArray();
+
+        Assert.DoesNotContain(
+            referencedTypeNames,
+            name => name.Contains("Finding", StringComparison.Ordinal)
+                || name.Contains("InspectionState", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void AnalysisProjection_RowsAndGraphRetainOneAnalysisIdentity()
+    {
+        Scenario scenario = new();
+        var rowsRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+        var graphRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.GraphProjection);
+
+        var rowsPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(rowsRequest)).Plan;
+        var graphPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(graphRequest)).Plan;
+
+        Assert.Same(scenario.Analysis, rowsPlan.Analysis);
+        Assert.Same(rowsPlan.Analysis, graphPlan.Analysis);
+        Assert.Same(scenario.RowsProjection, rowsPlan.Projection);
+        Assert.Same(scenario.GraphProjection, graphPlan.Projection);
+    }
+
+    [Fact]
+    public void AnalysisUniverseProviderKindDoesNotChangeRequestFieldSemantics()
+    {
+        Scenario scenario = new();
+        var prefixRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            scenario.Analysis,
+            scenario.ValidCensusSurface(),
+            scenario.Universe(
+                AnalysisUniverseBoundKind.Finite,
+                [scenario.SubjectCapability, scenario.EvidenceCapability],
+                providerKind: "Package prefix"),
+            AnalysisQuestionMode.Census,
+            scenario.RowsProjection);
+        var projectGraphRequest =
+            new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+                scenario.Analysis,
+                scenario.ValidCensusSurface(),
+                scenario.Universe(
+                    AnalysisUniverseBoundKind.Finite,
+                    [scenario.SubjectCapability, scenario.EvidenceCapability],
+                    providerKind: "Project graph"),
+                AnalysisQuestionMode.Census,
+                scenario.RowsProjection);
+
+        var prefixPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(prefixRequest)).Plan;
+        var graphPlan = Assert.IsType<
+            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
+                scenario.Planner.Plan(projectGraphRequest)).Plan;
+
+        Assert.Same(prefixPlan.Analysis, graphPlan.Analysis);
+        Assert.Equal(prefixPlan.ReportSurface.Kind, graphPlan.ReportSurface.Kind);
+        Assert.Equal(prefixPlan.Mode, graphPlan.Mode);
+        Assert.Same(prefixPlan.Projection, graphPlan.Projection);
+        Assert.NotEqual(
+            prefixPlan.Universe.ProviderState.ProviderKind,
+            graphPlan.Universe.ProviderState.ProviderKind);
+    }
+
+    [Fact]
+    public void Descriptor_RejectsMalformedDeclarations()
+    {
+        Scenario scenario = new();
+
+        Assert.Throws<ArgumentException>(() => new AnalysisDescriptor(
+            "Malformed",
+            "v1",
+            [AnalysisQuestionMode.Targeted],
+            [
+                new(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Census,
+                    scenario.DomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ],
+            [scenario.RowsProjection]));
+        Assert.Throws<ArgumentException>(() => new AnalysisDescriptor(
+            "Malformed",
+            "v1",
+            [AnalysisQuestionMode.Targeted],
+            [
+                new(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    scenario.AnchorRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+                new(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    scenario.AnchorRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ],
+            [scenario.RowsProjection]));
+    }
+
+    [Fact]
+    public void Planner_RejectsDescriptorOutsideCatalog()
+    {
+        Scenario scenario = new();
+        AnalysisDescriptor outside = scenario.CreateAnalysis();
+        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+            outside,
+            scenario.ValidTargetedSurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(
+            () => scenario.Planner.Plan(request));
+
+        Assert.Equal("request", exception.ParamName);
+    }
+
+    private static AnalysisRequestRejection Reject<TTargetIdentity, TUniverseBoundary, TUniverseState>(
+        AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> result)
+        => Assert.IsType<
+            AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>
+                .Rejected>(result).Rejection;
+
+    private static IEnumerable<Type> GetMemberTypes(MemberInfo member)
+        => member switch
+        {
+            MethodInfo method => method
+                .GetParameters()
+                .Select(parameter => parameter.ParameterType)
+                .Append(method.ReturnType),
+            PropertyInfo property => [property.PropertyType],
+            _ => [],
+        };
+
+    private sealed class Scenario
+    {
+        public Scenario()
+        {
+            SubjectRequirement = new("Selected Types", SubjectCapability);
+            EvidenceRequirement = new("Structured evidence", EvidenceCapability);
+            Analysis = new IntegrationAnalysisDescriptor(
+                "Integration census",
+                "v1",
+                [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
+                DefaultTargetRoles(),
+                [RowsProjection, MatrixProjection, GraphProjection],
+                [SubjectRequirement, EvidenceRequirement],
+                [Prerequisite],
+                [Preflight],
+                Concepts);
+            Planner = new([Analysis], [Prerequisite]);
+        }
+
+        public AnalysisTargetRoleDescriptor AnchorRole { get; } = new("Hub");
+
+        public AnalysisTargetRoleDescriptor TargetedDomainRole { get; } = new("Library domain");
+
+        public AnalysisTargetRoleDescriptor DomainRole { get; } = new("Workspace");
+
+        public AnalysisTargetRoleDescriptor CensusAnchorRole { get; } = new("Census hub");
+
+        public AnalysisUniverseCapabilityDescriptor SubjectCapability { get; } =
+            new("Selected-Type membership");
+
+        public AnalysisUniverseCapabilityDescriptor EvidenceCapability { get; } =
+            new("Integration structured evidence");
+
+        public AnalysisUniverseRequirementDescriptor SubjectRequirement { get; }
+
+        public AnalysisUniverseRequirementDescriptor EvidenceRequirement { get; }
+
+        public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; } =
+        [
+            new("Registrations"),
+            new("Client construction"),
+            new("Pipeline hooks"),
+        ];
+
+        public AnalysisStructuralPrerequisiteDescriptor Prerequisite { get; } =
+            new("Integration producer catalog");
+
+        public AnalysisPreflightRequirementDescriptor Preflight { get; } =
+            new("Expensive analysis authorization");
+
+        public AnalysisProjectionDescriptor RowsProjection { get; } = new("Rows");
+
+        public AnalysisProjectionDescriptor MatrixProjection { get; } = new("Matrix");
+
+        public AnalysisProjectionDescriptor GraphProjection { get; } = new("Graph");
+
+        public AnalysisProjectionDescriptor UnsupportedProjection { get; } = new("Tree");
+
+        public AnalysisDescriptor Analysis { get; }
+
+        public AnalysisRequestPlanner Planner { get; }
+
+        public AnalysisDescriptor CreateAnalysis(
+            IReadOnlyList<AnalysisQuestionMode>? supportedModes = null,
+            IReadOnlyList<AnalysisTargetRoleDeclaration>? targetRoles = null,
+            IReadOnlyList<AnalysisUniverseRequirementDescriptor>? universeRequirements = null)
+            => new(
+                "Integration census",
+                "v1",
+                supportedModes
+                    ?? [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
+                targetRoles ?? DefaultTargetRoles(),
+                [RowsProjection, MatrixProjection, GraphProjection],
+                universeRequirements ?? [SubjectRequirement, EvidenceRequirement],
+                [Prerequisite],
+                [Preflight]);
+
+        private ImmutableArray<AnalysisTargetRoleDeclaration> DefaultTargetRoles()
+            =>
+            [
+                new(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    AnchorRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+                new(
+                    AnalysisReportSurfaceKind.Member,
+                    AnalysisQuestionMode.Targeted,
+                    AnchorRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+                new(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    TargetedDomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    DomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+                new(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    CensusAnchorRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+            ];
+
+        public AnalysisReportSurface<TargetIdentity> ValidTargetedSurface()
+            => Surface(AnalysisReportSurfaceKind.Library, AnchorRole, "library");
+
+        public AnalysisReportSurface<TargetIdentity> ValidCensusSurface()
+            => Surface(AnalysisReportSurfaceKind.Workspace, DomainRole, "workspace");
+
+        public AnalysisReportSurface<TargetIdentity> Surface(
+            AnalysisReportSurfaceKind kind,
+            AnalysisTargetRoleDescriptor role,
+            string value)
+            => new(kind, [new(role, new(value))]);
+
+        public AnalysisUniverseDescription<UniverseBoundary, UniverseState> ValidUniverse()
+            => Universe(
+                AnalysisUniverseBoundKind.Finite,
+                [SubjectCapability, EvidenceCapability]);
+
+        public AnalysisUniverseDescription<UniverseBoundary, UniverseState> Universe(
+            AnalysisUniverseBoundKind boundKind,
+            IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities,
+            string providerKind = "Workspace",
+            string requested = "requested",
+            string realized = "realized")
+            => new(
+                boundKind,
+                new(requested),
+                new(realized),
+                capabilities,
+                new("Complete", [], providerKind));
+    }
+
+    private sealed record TargetIdentity(string Value);
+
+    private sealed record UniverseBoundary(string Value);
+
+    private sealed record UniverseState(
+        string Completeness,
+        ImmutableArray<string> Failures,
+        string ProviderKind = "Workspace");
+
+    private sealed class IntegrationConceptDescriptor(string name)
+        : AnalysisRequestDefinition(name);
+
+    private sealed class IntegrationAnalysisDescriptor : AnalysisDescriptor
+    {
+        public IntegrationAnalysisDescriptor(
+            string name,
+            string revision,
+            IReadOnlyList<AnalysisQuestionMode> supportedModes,
+            IReadOnlyList<AnalysisTargetRoleDeclaration> targetRoles,
+            IReadOnlyList<AnalysisProjectionDescriptor> supportedProjections,
+            IReadOnlyList<AnalysisUniverseRequirementDescriptor> universeRequirements,
+            IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor> structuralPrerequisites,
+            IReadOnlyList<AnalysisPreflightRequirementDescriptor> preflightRequirements,
+            IReadOnlyList<IntegrationConceptDescriptor> concepts)
+            : base(
+                name,
+                revision,
+                supportedModes,
+                targetRoles,
+                supportedProjections,
+                universeRequirements,
+                structuralPrerequisites,
+                preflightRequirements)
+        {
+            Concepts = [.. concepts];
+        }
+
+        public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; }
+    }
+
+    private sealed class IntegrationProducerPolicyDescriptor(string name)
+        : AnalysisRequestDefinition(name);
+
+    private sealed class IntegrationUniverseRequirementDescriptor
+        : AnalysisUniverseRequirementDescriptor
+    {
+        public IntegrationUniverseRequirementDescriptor(
+            string name,
+            AnalysisUniverseCapabilityDescriptor capability,
+            IntegrationProducerPolicyDescriptor policy,
+            IReadOnlyList<IntegrationConceptDescriptor> concepts)
+            : base(name, capability)
+        {
+            Policy = policy;
+            Concepts = [.. concepts];
+        }
+
+        public IntegrationProducerPolicyDescriptor Policy { get; }
+
+        public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; }
+    }
+
+    private sealed class PoisonProviderState
+    {
+        public int ExecutionCount { get; private set; }
+
+        public void Execute()
+        {
+            ExecutionCount++;
+            throw new InvalidOperationException("Planning executed a provider.");
+        }
+    }
+}

--- a/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
@@ -7,485 +7,6 @@ namespace DotnetInspector.Queries.Tests;
 public sealed class AnalysisRequestPlanningTests
 {
     [Fact]
-    public void AnalysisCapability_ListsConfiguredUnobservedIntegrationDescriptors()
-    {
-        Scenario scenario = new();
-        var second = new AnalysisDescriptor(
-            "Dependency census",
-            "v1",
-            [AnalysisQuestionMode.Census],
-            [
-                new(
-                    AnalysisReportSurfaceKind.Workspace,
-                    AnalysisQuestionMode.Census,
-                    scenario.DomainRole,
-                    AnalysisTargetFunction.ReportDomain),
-            ],
-            [scenario.RowsProjection]);
-
-        var planner = new AnalysisRequestPlanner([scenario.Analysis, second], [scenario.Prerequisite]);
-
-        Assert.Equal([scenario.Analysis, second], planner.Descriptors);
-        var integration =
-            Assert.IsType<IntegrationAnalysisDescriptor>(planner.Descriptors[0]);
-        Assert.Equal(scenario.Concepts, integration.Concepts);
-    }
-
-    [Fact]
-    public void AnalysisPlan_RetainsExactRequestFieldsAndDescriptorRequirements()
-    {
-        Scenario scenario = new();
-        AnalysisReportSurface<TargetIdentity> surface = scenario.ValidTargetedSurface();
-        AnalysisUniverseDescription<UniverseBoundary, UniverseState> universe =
-            scenario.ValidUniverse();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            surface,
-            universe,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var validated = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(request));
-
-        Assert.Same(scenario.Analysis, validated.Plan.Analysis);
-        Assert.Same(surface, validated.Plan.ReportSurface);
-        Assert.Same(universe, validated.Plan.Universe);
-        Assert.Equal(AnalysisQuestionMode.Targeted, validated.Plan.Mode);
-        Assert.Same(scenario.RowsProjection, validated.Plan.Projection);
-        Assert.Equal(scenario.Analysis.UniverseRequirements, validated.Plan.UniverseRequirements);
-        Assert.Equal(
-            scenario.Analysis.StructuralPrerequisites,
-            validated.Plan.StructuralPrerequisites);
-        Assert.Equal(scenario.Analysis.PreflightRequirements, validated.Plan.PreflightRequirements);
-        Assert.Same(universe.RequestedBoundary, validated.Plan.Universe.RequestedBoundary);
-        Assert.Same(universe.RealizedBoundary, validated.Plan.Universe.RealizedBoundary);
-    }
-
-    [Fact]
-    public void AnalysisPlan_RetainsUniverseCompletenessAndFailureInputs()
-    {
-        Scenario scenario = new();
-        UniverseState state = new("Partial", ["package-a failed"]);
-        var universe = new AnalysisUniverseDescription<UniverseBoundary, UniverseState>(
-            AnalysisUniverseBoundKind.Finite,
-            new("requested"),
-            new("realized"),
-            [scenario.SubjectCapability, scenario.EvidenceCapability],
-            state);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            universe,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var validated = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(request));
-
-        Assert.Same(universe.ProviderState, validated.Plan.Universe.ProviderState);
-        Assert.Equal("Partial", validated.Plan.Universe.ProviderState.Completeness);
-        Assert.Equal(["package-a failed"], validated.Plan.Universe.ProviderState.Failures);
-    }
-
-    [Fact]
-    public void Plan_ValidatesIntegrationShapedWorkspaceCensus()
-    {
-        Scenario scenario = new();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidCensusSurface(),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Census,
-            scenario.MatrixProjection);
-
-        var validated = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(request));
-
-        Assert.Equal(AnalysisReportSurfaceKind.Workspace, validated.Plan.ReportSurface.Kind);
-        Assert.Equal(AnalysisQuestionMode.Census, validated.Plan.Mode);
-        Assert.Same(scenario.MatrixProjection, validated.Plan.Projection);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsUnsupportedModeBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        AnalysisDescriptor censusOnly = scenario.CreateAnalysis(
-            supportedModes: [AnalysisQuestionMode.Census],
-            targetRoles:
-            [
-                new(
-                    AnalysisReportSurfaceKind.Workspace,
-                    AnalysisQuestionMode.Census,
-                    scenario.DomainRole,
-                    AnalysisTargetFunction.ReportDomain),
-            ]);
-        var planner = new AnalysisRequestPlanner([censusOnly], [scenario.Prerequisite]);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            censusOnly,
-            scenario.Surface(
-                AnalysisReportSurfaceKind.Workspace,
-                scenario.DomainRole,
-                "workspace"),
-            universe: null,
-            AnalysisQuestionMode.Targeted,
-            scenario.UnsupportedProjection);
-
-        AnalysisRequestRejection rejection = Reject(planner.Plan(request));
-
-        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedMode>(rejection);
-        Assert.Equal(AnalysisQuestionMode.Targeted, unsupported.Mode);
-        Assert.NotEmpty(unsupported.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsUnsupportedSurfaceBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.Surface(AnalysisReportSurfaceKind.Type, scenario.AnchorRole, "type"),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedSurface>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Equal(AnalysisReportSurfaceKind.Type, unsupported.SurfaceKind);
-        Assert.NotEmpty(unsupported.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsUnsupportedTargetRoleBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var sameNamedRole = new AnalysisTargetRoleDescriptor(scenario.AnchorRole.Name);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.Surface(AnalysisReportSurfaceKind.Library, sameNamedRole, "library"),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedTargetRole>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Same(sameNamedRole, unsupported.Role);
-        Assert.NotEmpty(unsupported.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisRequest_TargetedRequiresAcceptedAnchor()
-    {
-        Scenario scenario = new();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.Surface(
-                AnalysisReportSurfaceKind.Library,
-                scenario.TargetedDomainRole,
-                "library"),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Equal(AnalysisModeViolation.TargetedMissingPrivilegedAnchor, invalid.Violation);
-        Assert.NotEmpty(invalid.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisRequest_CensusRejectsPrivilegedContainedAnchor()
-    {
-        Scenario scenario = new();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.Surface(
-                AnalysisReportSurfaceKind.Workspace,
-                scenario.CensusAnchorRole,
-                "workspace"),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Census,
-            scenario.RowsProjection);
-
-        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Equal(AnalysisModeViolation.CensusContainsPrivilegedAnchor, invalid.Violation);
-        Assert.NotEmpty(invalid.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisRequest_RejectsMissingOrUnboundedUniverseBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            universe: null,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        AnalysisRequestRejection rejection = Reject(scenario.Planner.Plan(request));
-
-        Assert.IsType<AnalysisRequestRejection.MissingUniverse>(rejection);
-        Assert.NotEmpty(rejection.Guidance);
-
-        var unboundedRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            scenario.Universe(
-                AnalysisUniverseBoundKind.Unbounded,
-                [scenario.SubjectCapability, scenario.EvidenceCapability]),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        AnalysisRequestRejection unboundedRejection =
-            Reject(scenario.Planner.Plan(unboundedRequest));
-
-        Assert.IsType<AnalysisRequestRejection.UnboundedUniverse>(unboundedRejection);
-        Assert.NotEmpty(unboundedRejection.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsUnsatisfiedUniverseBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var sameNamedSubjectCapability =
-            new AnalysisUniverseCapabilityDescriptor(scenario.SubjectCapability.Name);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            scenario.Universe(AnalysisUniverseBoundKind.Finite, [sameNamedSubjectCapability]),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Equal(
-            [scenario.SubjectRequirement, scenario.EvidenceRequirement],
-            unsatisfied.Requirements);
-        Assert.NotEmpty(unsatisfied.Guidance);
-    }
-
-    [Fact]
-    public void Plan_RetainsDistinctOwnerScopedRequirementsSharingOneCapability()
-    {
-        Scenario scenario = new();
-        var registrations = new IntegrationConceptDescriptor("Registrations");
-        var clientConstruction = new IntegrationConceptDescriptor("Client construction");
-        var attributes = new IntegrationProducerPolicyDescriptor("Attribute policy");
-        var calls = new IntegrationProducerPolicyDescriptor("Call policy");
-        var attributeRequirement = new IntegrationUniverseRequirementDescriptor(
-            "Attribute evidence",
-            scenario.EvidenceCapability,
-            attributes,
-            [registrations, clientConstruction]);
-        var callRequirement = new IntegrationUniverseRequirementDescriptor(
-            "Call evidence",
-            scenario.EvidenceCapability,
-            calls,
-            [clientConstruction]);
-        AnalysisDescriptor analysis = scenario.CreateAnalysis(
-            universeRequirements:
-            [
-                scenario.SubjectRequirement,
-                attributeRequirement,
-                callRequirement,
-            ]);
-        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            analysis,
-            scenario.ValidTargetedSurface(),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var plan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                planner.Plan(request)).Plan;
-
-        Assert.Equal(
-            [scenario.SubjectRequirement, attributeRequirement, callRequirement],
-            plan.UniverseRequirements);
-        AnalysisDescriptor discovered = Assert.Single(planner.Descriptors);
-        var discoveredAttributeRequirement =
-            Assert.IsType<IntegrationUniverseRequirementDescriptor>(
-                discovered.UniverseRequirements[1]);
-        Assert.Equal(
-            [registrations, clientConstruction],
-            discoveredAttributeRequirement.Concepts);
-        Assert.Same(attributes, attributeRequirement.Policy);
-        Assert.Equal([registrations, clientConstruction], attributeRequirement.Concepts);
-        Assert.Same(calls, callRequirement.Policy);
-        Assert.Equal([clientConstruction], callRequirement.Concepts);
-
-        var missingEvidenceRequest =
-            new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-                analysis,
-                scenario.ValidTargetedSurface(),
-                scenario.Universe(
-                    AnalysisUniverseBoundKind.Finite,
-                    [scenario.SubjectCapability]),
-                AnalysisQuestionMode.Targeted,
-                scenario.RowsProjection);
-        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
-            Reject(planner.Plan(missingEvidenceRequest)));
-        Assert.Equal([attributeRequirement, callRequirement], unsatisfied.Requirements);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsMissingStructuralPrerequisiteBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var planner = new AnalysisRequestPlanner([scenario.Analysis], []);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var missing = Assert.IsType<AnalysisRequestRejection.MissingStructuralPrerequisites>(
-            Reject(planner.Plan(request)));
-
-        Assert.Equal([scenario.Prerequisite], missing.Prerequisites);
-        Assert.NotEmpty(missing.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisCapability_RejectsUnsupportedProjectionBeforeProducerExecution()
-    {
-        Scenario scenario = new();
-        var sameNamedProjection =
-            new AnalysisProjectionDescriptor(scenario.RowsProjection.Name);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            sameNamedProjection);
-
-        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedProjection>(
-            Reject(scenario.Planner.Plan(request)));
-
-        Assert.Same(sameNamedProjection, unsupported.Projection);
-        Assert.NotEmpty(unsupported.Guidance);
-    }
-
-    [Fact]
-    public void AnalysisCapability_AllDeclaredRejectionsPrecedeProducerExecution()
-    {
-        Scenario scenario = new();
-        var providerState = new PoisonProviderState();
-        var universe = new AnalysisUniverseDescription<UniverseBoundary, PoisonProviderState>(
-            AnalysisUniverseBoundKind.Finite,
-            new("requested"),
-            new("realized"),
-            [scenario.SubjectCapability, scenario.EvidenceCapability],
-            providerState);
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, PoisonProviderState>(
-            scenario.Analysis,
-            scenario.ValidTargetedSurface(),
-            universe,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-
-        var validated = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, PoisonProviderState>
-                .Validated>(scenario.Planner.Plan(request));
-
-        Assert.Same(providerState, validated.Plan.Universe.ProviderState);
-        Assert.Equal(0, providerState.ExecutionCount);
-        Assert.DoesNotContain(
-            typeof(Delegate),
-            typeof(AnalysisRequestPlanner)
-                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
-                .SelectMany(GetMemberTypes));
-    }
-
-    [Fact]
-    public void AnalysisRequest_ReportSurfaceAndUniverseAreIndependent()
-    {
-        Scenario scenario = new();
-        AnalysisReportSurface<TargetIdentity> targetedSurface = scenario.ValidTargetedSurface();
-        AnalysisReportSurface<TargetIdentity> censusSurface = scenario.ValidCensusSurface();
-        AnalysisUniverseDescription<UniverseBoundary, UniverseState> universe =
-            scenario.ValidUniverse();
-
-        var targeted = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            targetedSurface,
-            universe,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
-        var census = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            censusSurface,
-            universe,
-            AnalysisQuestionMode.Census,
-            scenario.MatrixProjection);
-
-        var targetedPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(targeted)).Plan;
-        var censusPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(census)).Plan;
-
-        Assert.Same(targetedSurface, targetedPlan.ReportSurface);
-        Assert.Same(censusSurface, censusPlan.ReportSurface);
-        Assert.Same(scenario.RowsProjection, targetedPlan.Projection);
-        Assert.Same(scenario.MatrixProjection, censusPlan.Projection);
-        Assert.NotEqual(targetedPlan.Mode, censusPlan.Mode);
-    }
-
-    [Fact]
-    public void DescriptorAndCatalog_FreezeDeclarationCollections()
-    {
-        Scenario scenario = new();
-        AnalysisQuestionMode[] modes = [AnalysisQuestionMode.Targeted];
-        AnalysisTargetRoleDeclaration[] roles =
-        [
-            new(
-                AnalysisReportSurfaceKind.Library,
-                AnalysisQuestionMode.Targeted,
-                scenario.AnchorRole,
-                AnalysisTargetFunction.PrivilegedAnchor),
-        ];
-        AnalysisProjectionDescriptor[] projections = [scenario.RowsProjection];
-        var descriptor = new AnalysisDescriptor(
-            "Frozen",
-            "v1",
-            modes,
-            roles,
-            projections);
-        AnalysisDescriptor[] descriptors = [descriptor];
-        var planner = new AnalysisRequestPlanner(descriptors, []);
-
-        modes[0] = AnalysisQuestionMode.Census;
-        roles[0] = new(
-            AnalysisReportSurfaceKind.Workspace,
-            AnalysisQuestionMode.Census,
-            scenario.DomainRole,
-            AnalysisTargetFunction.ReportDomain);
-        projections[0] = scenario.MatrixProjection;
-        descriptors[0] = scenario.Analysis;
-
-        Assert.Equal([AnalysisQuestionMode.Targeted], descriptor.SupportedModes);
-        Assert.Same(scenario.AnchorRole, Assert.Single(descriptor.TargetRoles).Role);
-        Assert.Same(scenario.RowsProjection, Assert.Single(descriptor.SupportedProjections));
-        Assert.Same(descriptor, Assert.Single(planner.Descriptors));
-    }
-
-    [Fact]
     public void AnalysisRequest_DeclaresCompleteClosedFieldSet()
     {
         Assert.Equal(
@@ -507,16 +28,15 @@ public sealed class AnalysisRequestPlanningTests
             [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
             Enum.GetValues<AnalysisQuestionMode>());
 
-        Type[] rejectionFamilies = typeof(AnalysisRequestRejection)
-            .GetNestedTypes(BindingFlags.Public)
-            .OrderBy(type => type.Name, StringComparer.Ordinal)
-            .ToArray();
+        Type[] rejectionFamilies = RejectionFamilies();
         Assert.Equal(
             [
                 typeof(AnalysisRequestRejection.InvalidMode),
+                typeof(AnalysisRequestRejection.InvalidReportSurface),
                 typeof(AnalysisRequestRejection.MissingStructuralPrerequisites),
                 typeof(AnalysisRequestRejection.MissingUniverse),
                 typeof(AnalysisRequestRejection.UnboundedUniverse),
+                typeof(AnalysisRequestRejection.UnconfiguredAnalysis),
                 typeof(AnalysisRequestRejection.UnsatisfiedUniverse),
                 typeof(AnalysisRequestRejection.UnsupportedMode),
                 typeof(AnalysisRequestRejection.UnsupportedProjection),
@@ -524,60 +44,93 @@ public sealed class AnalysisRequestPlanningTests
                 typeof(AnalysisRequestRejection.UnsupportedTargetRole),
             ],
             rejectionFamilies);
+        Assert.All(rejectionFamilies, family => Assert.True(family.IsSealed));
+        Assert.All(
+            rejectionFamilies,
+            family => Assert.Empty(
+                family.GetConstructors(BindingFlags.Public | BindingFlags.Instance)));
+        Assert.True(typeof(AnalysisTargetRoleDescriptor).IsAbstract);
+        Assert.True(typeof(AnalysisTargetRoleDeclaration).IsAbstract);
+        Assert.True(typeof(AnalysisDescriptor).IsAbstract);
+        Assert.True(typeof(AnalysisUniverseDescription).IsAbstract);
+    }
+
+    [Fact]
+    public void AnalysisRequest_ReportSurfaceAndUniverseAreIndependent()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<LibraryIdentity> surface = scenario.ValidLibrarySurface();
+        WorkspaceTypeUniverse universe = scenario.ValidUniverse(
+            requested: "workspace-request",
+            realized: "workspace-realized");
+
+        var plan = Validate(
+            scenario.Planner.Plan(
+                scenario.Request(
+                    scenario.Analysis,
+                    surface,
+                    universe,
+                    AnalysisQuestionMode.Targeted,
+                    scenario.RowsProjection)));
+
+        Assert.Same(surface, plan.ReportSurface);
+        Assert.Same(universe, plan.Universe);
+        Assert.Equal(AnalysisReportSurfaceKind.Library, plan.ReportSurface.Kind);
+        Assert.Equal("workspace-request", plan.Universe.RequestedBoundary.Value);
     }
 
     [Fact]
     public void AnalysisRequest_MemberReportMayConsumeWorkspaceUniverse()
     {
         Scenario scenario = new();
-        AnalysisReportSurface<TargetIdentity> memberSurface = scenario.Surface(
+        AnalysisReportSurface<MemberIdentity> memberSurface = scenario.Surface(
             AnalysisReportSurfaceKind.Member,
-            scenario.AnchorRole,
-            "method");
-        AnalysisUniverseDescription<UniverseBoundary, UniverseState> workspaceUniverse =
-            scenario.Universe(
-                AnalysisUniverseBoundKind.Finite,
-                [scenario.SubjectCapability, scenario.EvidenceCapability],
-                providerKind: "Workspace");
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            memberSurface,
-            workspaceUniverse,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
+            scenario.MemberAnchorRole,
+            new("method"));
+        WorkspaceTypeUniverse workspaceUniverse =
+            scenario.ValidUniverse(providerKind: "Workspace");
 
-        var plan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(request)).Plan;
+        AnalysisValidatedPlan<IntegrationAnalysisDescriptor, MemberIdentity, WorkspaceTypeUniverse>
+            plan = Validate(
+                scenario.Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        MemberIdentity,
+                        WorkspaceTypeUniverse>(
+                            scenario.Analysis,
+                            memberSurface,
+                            workspaceUniverse,
+                            AnalysisQuestionMode.Targeted,
+                            scenario.RowsProjection)));
 
         Assert.Equal(AnalysisReportSurfaceKind.Member, plan.ReportSurface.Kind);
-        Assert.Equal("Workspace", plan.Universe.ProviderState.ProviderKind);
+        Assert.Equal("Workspace", plan.Universe.ProviderKind);
     }
 
     [Fact]
     public void AnalysisRequest_UniverseBreadthCannotWidenReportSurface()
     {
         Scenario scenario = new();
-        AnalysisReportSurface<TargetIdentity> memberSurface = scenario.Surface(
+        AnalysisReportSurface<MemberIdentity> memberSurface = scenario.Surface(
             AnalysisReportSurfaceKind.Member,
-            scenario.AnchorRole,
-            "method");
-        AnalysisUniverseDescription<UniverseBoundary, UniverseState> broadUniverse =
-            scenario.Universe(
-                AnalysisUniverseBoundKind.Finite,
-                [scenario.SubjectCapability, scenario.EvidenceCapability],
-                requested: "entire-workspace",
-                realized: "entire-workspace");
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            memberSurface,
-            broadUniverse,
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
+            scenario.MemberAnchorRole,
+            new("method"));
+        WorkspaceTypeUniverse broadUniverse = scenario.ValidUniverse(
+            requested: "entire-workspace",
+            realized: "entire-workspace");
 
-        var plan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(request)).Plan;
+        AnalysisValidatedPlan<IntegrationAnalysisDescriptor, MemberIdentity, WorkspaceTypeUniverse>
+            plan = Validate(
+                scenario.Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        MemberIdentity,
+                        WorkspaceTypeUniverse>(
+                            scenario.Analysis,
+                            memberSurface,
+                            broadUniverse,
+                            AnalysisQuestionMode.Targeted,
+                            scenario.RowsProjection)));
 
         Assert.Same(memberSurface, plan.ReportSurface);
         Assert.Equal(AnalysisReportSurfaceKind.Member, plan.ReportSurface.Kind);
@@ -585,76 +138,377 @@ public sealed class AnalysisRequestPlanningTests
     }
 
     [Fact]
-    public void AnalysisRequest_ModeValidationDerivesFromDeclaredTargetFunctions()
+    public void AnalysisRequest_TargetedRequiresAcceptedAnchor()
     {
         Scenario scenario = new();
-        var sharedRole = new AnalysisTargetRoleDescriptor("Shared role");
-        AnalysisDescriptor analysis = scenario.CreateAnalysis(
-            targetRoles:
-            [
-                new(
-                    AnalysisReportSurfaceKind.Workspace,
-                    AnalysisQuestionMode.Targeted,
-                    sharedRole,
-                    AnalysisTargetFunction.PrivilegedAnchor),
-                new(
-                    AnalysisReportSurfaceKind.Workspace,
-                    AnalysisQuestionMode.Census,
-                    sharedRole,
-                    AnalysisTargetFunction.ReportDomain),
-            ]);
-        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
-        AnalysisReportSurface<TargetIdentity> surface = scenario.Surface(
-            AnalysisReportSurfaceKind.Workspace,
-            sharedRole,
-            "workspace");
-
-        var targeted = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            analysis,
-            surface,
+        var request = scenario.Request(
+            scenario.Analysis,
+            scenario.Surface(
+                AnalysisReportSurfaceKind.Library,
+                scenario.LibraryDomainRole,
+                new("library")),
             scenario.ValidUniverse(),
             AnalysisQuestionMode.Targeted,
             scenario.RowsProjection);
-        var census = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            analysis,
-            surface,
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Census,
-            scenario.RowsProjection);
 
-        Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                planner.Plan(targeted));
-        Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                planner.Plan(census));
+        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisModeViolation.TargetedMissingPrivilegedAnchor, invalid.Violation);
+        Assert.NotEmpty(invalid.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_CensusRejectsPrivilegedContainedAnchor()
+    {
+        Scenario scenario = new();
+        var request = new AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse>(
+                scenario.Analysis,
+                scenario.Surface(
+                    AnalysisReportSurfaceKind.Workspace,
+                    scenario.WorkspaceAnchorRole,
+                    new("workspace")),
+                scenario.ValidUniverse(),
+                AnalysisQuestionMode.Census,
+                scenario.RowsProjection);
+
+        var invalid = Assert.IsType<AnalysisRequestRejection.InvalidMode>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisModeViolation.CensusContainsPrivilegedAnchor, invalid.Violation);
+        Assert.NotEmpty(invalid.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_ModeValidationDerivesFromDeclaredTargetFunctions()
+    {
+        Scenario scenario = new();
+        var role = new AnalysisTargetRoleDescriptor<WorkspaceIdentity>("Shared role");
+        var analysis = new TestAnalysisDescriptor(
+            "Shared-role analysis",
+            "v1",
+            [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
+            [
+                new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Targeted,
+                    role,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+                new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    role,
+                    AnalysisTargetFunction.ReportDomain),
+            ],
+            [scenario.RowsProjection],
+            [scenario.SubjectRequirement],
+            [scenario.Prerequisite]);
+        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
+        AnalysisReportSurface<WorkspaceIdentity> surface = scenario.Surface(
+            AnalysisReportSurfaceKind.Workspace,
+            role,
+            new("workspace"));
+        WorkspaceTypeUniverse universe = scenario.ValidUniverse();
+
+        Validate(
+            planner.Plan(
+                new AnalysisRequest<
+                    TestAnalysisDescriptor,
+                    WorkspaceIdentity,
+                    WorkspaceTypeUniverse>(
+                        analysis,
+                        surface,
+                        universe,
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection)));
+        Validate(
+            planner.Plan(
+                new AnalysisRequest<
+                    TestAnalysisDescriptor,
+                    WorkspaceIdentity,
+                    WorkspaceTypeUniverse>(
+                        analysis,
+                        surface,
+                        universe,
+                        AnalysisQuestionMode.Census,
+                        scenario.RowsProjection)));
+    }
+
+    [Fact]
+    public void AnalysisRequest_RejectsMissingOrUnboundedUniverseBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+
+        Assert.IsType<AnalysisRequestRejection.MissingUniverse>(
+            Reject(
+                scenario.Planner.Plan(
+                    scenario.Request(
+                        scenario.Analysis,
+                        scenario.ValidLibrarySurface(),
+                        universe: null,
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection))));
+        Assert.IsType<AnalysisRequestRejection.UnboundedUniverse>(
+            Reject(
+                scenario.Planner.Plan(
+                    scenario.Request(
+                        scenario.Analysis,
+                        scenario.ValidLibrarySurface(),
+                        scenario.ValidUniverse(boundKind: AnalysisUniverseBoundKind.Unbounded),
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection))));
     }
 
     [Fact]
     public void AnalysisCapability_StructuralDiscoveryDoesNotResolveContentExecuteProducersOrProbeEffectiveness()
     {
         Scenario scenario = new();
-
         var planner = new AnalysisRequestPlanner([scenario.Analysis], [scenario.Prerequisite]);
 
         Assert.Same(scenario.Analysis, Assert.Single(planner.Descriptors));
-        Assert.DoesNotContain(
-            typeof(Delegate),
-            typeof(AnalysisRequestPlanner)
-                .GetMembers(BindingFlags.Public | BindingFlags.Instance)
-                .SelectMany(GetMemberTypes));
+        Assert.Equal(scenario.Concepts, scenario.Analysis.Concepts);
+        Assert.DoesNotContain(AnalysisContractMemberTypes(), ContainsDelegate);
+    }
+
+    [Fact]
+    public void AnalysisCapability_ListsConfiguredUnobservedIntegrationDescriptors()
+    {
+        Scenario scenario = new();
+        var second = new TestAnalysisDescriptor(
+            "Dependency census",
+            "v1",
+            [AnalysisQuestionMode.Census],
+            [
+                new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
+                    AnalysisReportSurfaceKind.Workspace,
+                    AnalysisQuestionMode.Census,
+                    scenario.WorkspaceDomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+            ],
+            [scenario.RowsProjection]);
+        var planner = new AnalysisRequestPlanner(
+            [scenario.Analysis, second],
+            [scenario.Prerequisite]);
+
+        Assert.Equal([scenario.Analysis, second], planner.Descriptors);
+        Assert.Same(scenario.Analysis, planner.Descriptors[0]);
+        Assert.Equal(scenario.Concepts, scenario.Analysis.Concepts);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnconfiguredAnalysisBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        IntegrationAnalysisDescriptor foreign = scenario.CreateAnalysis();
+        var request = scenario.Request(
+            foreign,
+            scenario.ValidLibrarySurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var rejection = Assert.IsType<AnalysisRequestRejection.UnconfiguredAnalysis>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Same(foreign, rejection.Analysis);
+        Assert.NotEmpty(rejection.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisRequest_RejectsInvalidReportSurfaceCardinalityBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var empty = new AnalysisReportSurface<LibraryIdentity>(
+            AnalysisReportSurfaceKind.Library,
+            []);
+        var multipleWorkspaces = new AnalysisReportSurface<WorkspaceIdentity>(
+            AnalysisReportSurfaceKind.Workspace,
+            [
+                new(scenario.WorkspaceDomainRole, new("workspace-a")),
+                new(scenario.WorkspaceDomainRole, new("workspace-b")),
+            ]);
+
+        var missing = Assert.IsType<AnalysisRequestRejection.InvalidReportSurface>(
+            Reject(
+                scenario.Planner.Plan(
+                    scenario.Request(
+                        scenario.Analysis,
+                        empty,
+                        scenario.ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection))));
+        var multiple = Assert.IsType<AnalysisRequestRejection.InvalidReportSurface>(
+            Reject(
+                scenario.Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        WorkspaceIdentity,
+                        WorkspaceTypeUniverse>(
+                            scenario.Analysis,
+                            multipleWorkspaces,
+                            scenario.ValidUniverse(),
+                            AnalysisQuestionMode.Census,
+                            scenario.RowsProjection))));
+
+        Assert.Equal(AnalysisReportSurfaceCardinalityViolation.MissingTarget, missing.Violation);
+        Assert.Equal(
+            AnalysisReportSurfaceCardinalityViolation.WorkspaceRequiresSingleTarget,
+            multiple.Violation);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedModeBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        TestAnalysisDescriptor analysis = scenario.CensusOnlyAnalysis();
+        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
+        var request = new AnalysisRequest<
+            TestAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse>(
+                analysis,
+                scenario.ValidWorkspaceSurface(),
+                universe: null,
+                AnalysisQuestionMode.Targeted,
+                scenario.UnsupportedProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedMode>(
+            Reject(planner.Plan(request)));
+
+        Assert.Equal(AnalysisQuestionMode.Targeted, unsupported.Mode);
+        Assert.NotEmpty(unsupported.Guidance);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedSurfaceBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var typeRole = new AnalysisTargetRoleDescriptor<TypeIdentity>("Type");
+        var request = new AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            TypeIdentity,
+            WorkspaceTypeUniverse>(
+                scenario.Analysis,
+                scenario.Surface(
+                    AnalysisReportSurfaceKind.Type,
+                    typeRole,
+                    new("type")),
+                scenario.ValidUniverse(),
+                AnalysisQuestionMode.Targeted,
+                scenario.RowsProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedSurface>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(AnalysisReportSurfaceKind.Type, unsupported.SurfaceKind);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedTargetRoleBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedRole =
+            new AnalysisTargetRoleDescriptor<LibraryIdentity>(scenario.LibraryAnchorRole.Name);
+        var request = scenario.Request(
+            scenario.Analysis,
+            scenario.Surface(
+                AnalysisReportSurfaceKind.Library,
+                sameNamedRole,
+                new("library")),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedTargetRole>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Same(sameNamedRole, unsupported.Role);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsatisfiedUniverseBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedCapability =
+            new AnalysisUniverseCapabilityDescriptor(scenario.SubjectCapability.Name);
+        WorkspaceTypeUniverse universe = scenario.ValidUniverse(
+            capabilities: [sameNamedCapability]);
+        var request = scenario.Request(
+            scenario.Analysis,
+            scenario.ValidLibrarySurface(),
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Equal(scenario.Analysis.Requirements, unsatisfied.Requirements);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsMissingStructuralPrerequisiteBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var planner = new AnalysisRequestPlanner([scenario.Analysis], []);
+
+        var missing = Assert.IsType<AnalysisRequestRejection.MissingStructuralPrerequisites>(
+            Reject(planner.Plan(scenario.ValidTargetedRequest())));
+
+        Assert.Equal([scenario.Prerequisite], missing.Prerequisites);
+    }
+
+    [Fact]
+    public void AnalysisCapability_RejectsUnsupportedProjectionBeforeProducerExecution()
+    {
+        Scenario scenario = new();
+        var sameNamedProjection =
+            new AnalysisProjectionDescriptor(scenario.RowsProjection.Name);
+        var request = scenario.Request(
+            scenario.Analysis,
+            scenario.ValidLibrarySurface(),
+            scenario.ValidUniverse(),
+            AnalysisQuestionMode.Targeted,
+            sameNamedProjection);
+
+        var unsupported = Assert.IsType<AnalysisRequestRejection.UnsupportedProjection>(
+            Reject(scenario.Planner.Plan(request)));
+
+        Assert.Same(sameNamedProjection, unsupported.Projection);
+    }
+
+    [Fact]
+    public void AnalysisCapability_AllDeclaredRejectionsPrecedeProducerExecution()
+    {
+        Scenario scenario = new();
+
+        ImmutableArray<AnalysisRequestRejection> rejections = scenario.AllRejections();
+
+        Assert.Equal(
+            RejectionFamilies(),
+            rejections
+                .Select(rejection => rejection.GetType())
+                .Distinct()
+                .OrderBy(type => type.Name, StringComparer.Ordinal));
+        Assert.Equal(
+            Enum.GetValues<AnalysisModeViolation>(),
+            rejections
+                .OfType<AnalysisRequestRejection.InvalidMode>()
+                .Select(rejection => rejection.Violation)
+                .Order());
+        Assert.All(rejections, rejection => Assert.NotEmpty(rejection.Guidance));
+        Assert.Equal(0, scenario.ProviderExecutionCount);
+        Assert.DoesNotContain(AnalysisContractMemberTypes(), ContainsDelegate);
     }
 
     [Fact]
     public void AnalysisCapability_RejectionDoesNotUseFindingInspectionState()
     {
-        Type[] contractTypes =
-        [
-            typeof(AnalysisRequestRejection),
-            .. typeof(AnalysisRequestRejection).GetNestedTypes(BindingFlags.Public),
-        ];
-
-        string[] referencedTypeNames = contractTypes
+        string[] referencedTypeNames = RejectionFamilies()
+            .Prepend(typeof(AnalysisRequestRejection))
             .SelectMany(type => type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
             .Select(property => property.PropertyType.FullName ?? property.PropertyType.Name)
             .ToArray();
@@ -666,28 +520,82 @@ public sealed class AnalysisRequestPlanningTests
     }
 
     [Fact]
+    public void AnalysisPlan_RetainsExactRequestFieldsAndDescriptorRequirements()
+    {
+        Scenario scenario = new();
+        AnalysisReportSurface<LibraryIdentity> surface = scenario.ValidLibrarySurface();
+        WorkspaceTypeUniverse universe = scenario.ValidUniverse();
+        var request = scenario.Request(
+            scenario.Analysis,
+            surface,
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var plan = Validate(scenario.Planner.Plan(request));
+
+        Assert.Same(scenario.Analysis, plan.Analysis);
+        Assert.Same(surface, plan.ReportSurface);
+        Assert.Same(universe, plan.Universe);
+        Assert.Equal(AnalysisQuestionMode.Targeted, plan.Mode);
+        Assert.Same(scenario.RowsProjection, plan.Projection);
+        Assert.Equal(scenario.Analysis.UniverseRequirements, plan.UniverseRequirements);
+        Assert.Equal(scenario.Analysis.Requirements, plan.UniverseRequirements);
+        Assert.Equal(
+            scenario.Analysis.StructuralPrerequisites,
+            plan.StructuralPrerequisites);
+        Assert.Equal(scenario.Analysis.PreflightRequirements, plan.PreflightRequirements);
+        Assert.Same(scenario.SubjectRequirement, plan.Analysis.Requirements[0]);
+        Assert.Same(scenario.Concepts[0], plan.Analysis.Requirements[0].Concepts[0]);
+    }
+
+    [Fact]
+    public void AnalysisPlan_RetainsUniverseCompletenessAndFailureInputs()
+    {
+        Scenario scenario = new();
+        var requested = new RequestedTypeBoundary("requested");
+        var realized = new RealizedTypeBoundary("realized");
+        var completeness = new UniverseCompleteness("Partial");
+        var failure = new UniverseFailure("package-a failed");
+        WorkspaceTypeUniverse universe = scenario.ValidUniverse(
+            requestedBoundary: requested,
+            realizedBoundary: realized,
+            completeness: completeness,
+            failures: [failure]);
+        var request = scenario.Request(
+            scenario.Analysis,
+            scenario.ValidLibrarySurface(),
+            universe,
+            AnalysisQuestionMode.Targeted,
+            scenario.RowsProjection);
+
+        var plan = Validate(scenario.Planner.Plan(request));
+
+        Assert.Same(requested, plan.Universe.RequestedBoundary);
+        Assert.Same(realized, plan.Universe.RealizedBoundary);
+        Assert.Same(completeness, plan.Universe.Completeness);
+        Assert.Same(failure, Assert.Single(plan.Universe.Failures));
+    }
+
+    [Fact]
     public void AnalysisProjection_RowsAndGraphRetainOneAnalysisIdentity()
     {
         Scenario scenario = new();
-        var rowsRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+        var rowsRequest = scenario.Request(
             scenario.Analysis,
-            scenario.ValidTargetedSurface(),
+            scenario.ValidLibrarySurface(),
             scenario.ValidUniverse(),
             AnalysisQuestionMode.Targeted,
             scenario.RowsProjection);
-        var graphRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+        var graphRequest = scenario.Request(
             scenario.Analysis,
-            scenario.ValidTargetedSurface(),
+            scenario.ValidLibrarySurface(),
             scenario.ValidUniverse(),
             AnalysisQuestionMode.Targeted,
             scenario.GraphProjection);
 
-        var rowsPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(rowsRequest)).Plan;
-        var graphPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(graphRequest)).Plan;
+        var rowsPlan = Validate(scenario.Planner.Plan(rowsRequest));
+        var graphPlan = Validate(scenario.Planner.Plan(graphRequest));
 
         Assert.Same(scenario.Analysis, rowsPlan.Analysis);
         Assert.Same(rowsPlan.Analysis, graphPlan.Analysis);
@@ -699,139 +607,330 @@ public sealed class AnalysisRequestPlanningTests
     public void AnalysisUniverseProviderKindDoesNotChangeRequestFieldSemantics()
     {
         Scenario scenario = new();
-        var prefixRequest = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            scenario.Analysis,
-            scenario.ValidCensusSurface(),
-            scenario.Universe(
-                AnalysisUniverseBoundKind.Finite,
-                [scenario.SubjectCapability, scenario.EvidenceCapability],
-                providerKind: "Package prefix"),
-            AnalysisQuestionMode.Census,
-            scenario.RowsProjection);
-        var projectGraphRequest =
-            new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
+        var prefixRequest = new AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse>(
                 scenario.Analysis,
-                scenario.ValidCensusSurface(),
-                scenario.Universe(
-                    AnalysisUniverseBoundKind.Finite,
-                    [scenario.SubjectCapability, scenario.EvidenceCapability],
-                    providerKind: "Project graph"),
+                scenario.ValidWorkspaceSurface(),
+                scenario.ValidUniverse(providerKind: "Package prefix"),
+                AnalysisQuestionMode.Census,
+                scenario.RowsProjection);
+        var projectGraphRequest = new AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse>(
+                scenario.Analysis,
+                scenario.ValidWorkspaceSurface(),
+                scenario.ValidUniverse(providerKind: "Project graph"),
                 AnalysisQuestionMode.Census,
                 scenario.RowsProjection);
 
-        var prefixPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(prefixRequest)).Plan;
-        var graphPlan = Assert.IsType<
-            AnalysisRequestPlanningResult<TargetIdentity, UniverseBoundary, UniverseState>.Validated>(
-                scenario.Planner.Plan(projectGraphRequest)).Plan;
+        AnalysisValidatedPlan<
+            IntegrationAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse> prefixPlan = Validate(
+                scenario.Planner.Plan(prefixRequest));
+        AnalysisValidatedPlan<
+            IntegrationAnalysisDescriptor,
+            WorkspaceIdentity,
+            WorkspaceTypeUniverse> graphPlan = Validate(
+                scenario.Planner.Plan(projectGraphRequest));
 
         Assert.Same(prefixPlan.Analysis, graphPlan.Analysis);
         Assert.Equal(prefixPlan.ReportSurface.Kind, graphPlan.ReportSurface.Kind);
         Assert.Equal(prefixPlan.Mode, graphPlan.Mode);
         Assert.Same(prefixPlan.Projection, graphPlan.Projection);
-        Assert.NotEqual(
-            prefixPlan.Universe.ProviderState.ProviderKind,
-            graphPlan.Universe.ProviderState.ProviderKind);
+        Assert.NotEqual(prefixPlan.Universe.ProviderKind, graphPlan.Universe.ProviderKind);
     }
 
     [Fact]
-    public void Descriptor_RejectsMalformedDeclarations()
+    public void AnalysisDeclarations_RejectUndefinedEnums()
     {
         Scenario scenario = new();
 
-        Assert.Throws<ArgumentException>(() => new AnalysisDescriptor(
-            "Malformed",
-            "v1",
-            [AnalysisQuestionMode.Targeted],
-            [
-                new(
-                    AnalysisReportSurfaceKind.Library,
-                    AnalysisQuestionMode.Census,
-                    scenario.DomainRole,
-                    AnalysisTargetFunction.ReportDomain),
-            ],
-            [scenario.RowsProjection]));
-        Assert.Throws<ArgumentException>(() => new AnalysisDescriptor(
-            "Malformed",
-            "v1",
-            [AnalysisQuestionMode.Targeted],
-            [
-                new(
-                    AnalysisReportSurfaceKind.Library,
-                    AnalysisQuestionMode.Targeted,
-                    scenario.AnchorRole,
-                    AnalysisTargetFunction.PrivilegedAnchor),
-                new(
-                    AnalysisReportSurfaceKind.Library,
-                    AnalysisQuestionMode.Targeted,
-                    scenario.AnchorRole,
-                    AnalysisTargetFunction.ReportDomain),
-            ],
-            [scenario.RowsProjection]));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new AnalysisTargetRoleDeclaration<LibraryIdentity>(
+                AnalysisReportSurfaceKind.Library,
+                AnalysisQuestionMode.Targeted,
+                scenario.LibraryAnchorRole,
+                (AnalysisTargetFunction)99));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new AnalysisReportSurface<LibraryIdentity>(
+                (AnalysisReportSurfaceKind)99,
+                [new(scenario.LibraryAnchorRole, new("library"))]));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            scenario.ValidUniverse(boundKind: (AnalysisUniverseBoundKind)99));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            scenario.Request(
+                scenario.Analysis,
+                scenario.ValidLibrarySurface(),
+                scenario.ValidUniverse(),
+                (AnalysisQuestionMode)99,
+                scenario.RowsProjection));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new TestAnalysisDescriptor(
+                "Malformed",
+                "v1",
+                [(AnalysisQuestionMode)99],
+                [
+                    new AnalysisTargetRoleDeclaration<LibraryIdentity>(
+                        AnalysisReportSurfaceKind.Library,
+                        AnalysisQuestionMode.Targeted,
+                        scenario.LibraryAnchorRole,
+                        AnalysisTargetFunction.PrivilegedAnchor),
+                ],
+                [scenario.RowsProjection]));
     }
 
     [Fact]
-    public void Planner_RejectsDescriptorOutsideCatalog()
+    public void AnalysisPlanningResults_HavePlannerOwnedConstruction()
     {
-        Scenario scenario = new();
-        AnalysisDescriptor outside = scenario.CreateAnalysis();
-        var request = new AnalysisRequest<TargetIdentity, UniverseBoundary, UniverseState>(
-            outside,
-            scenario.ValidTargetedSurface(),
-            scenario.ValidUniverse(),
-            AnalysisQuestionMode.Targeted,
-            scenario.RowsProjection);
+        Type openResult = typeof(AnalysisRequestPlanningResult<,,>);
+        Type validated = openResult.GetNestedType(
+            nameof(AnalysisRequestPlanningResult<
+                IntegrationAnalysisDescriptor,
+                LibraryIdentity,
+                WorkspaceTypeUniverse>.Validated))!;
+        Type rejected = openResult.GetNestedType(
+            nameof(AnalysisRequestPlanningResult<
+                IntegrationAnalysisDescriptor,
+                LibraryIdentity,
+                WorkspaceTypeUniverse>.Rejected))!;
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(
-            () => scenario.Planner.Plan(request));
-
-        Assert.Equal("request", exception.ParamName);
+        Assert.Empty(validated.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Empty(rejected.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.False(validated.GetProperty("Plan")!.CanWrite);
+        Assert.False(rejected.GetProperty("Rejection")!.CanWrite);
     }
 
-    private static AnalysisRequestRejection Reject<TTargetIdentity, TUniverseBoundary, TUniverseState>(
-        AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> result)
+    [Fact]
+    public void AnalysisDescriptorsAndCatalogs_FreezeDeclarations()
+    {
+        Scenario scenario = new();
+        AnalysisQuestionMode[] modes = [AnalysisQuestionMode.Targeted];
+        AnalysisTargetRoleDeclaration[] roles =
+        [
+            new AnalysisTargetRoleDeclaration<LibraryIdentity>(
+                AnalysisReportSurfaceKind.Library,
+                AnalysisQuestionMode.Targeted,
+                scenario.LibraryAnchorRole,
+                AnalysisTargetFunction.PrivilegedAnchor),
+        ];
+        AnalysisProjectionDescriptor[] projections = [scenario.RowsProjection];
+        var descriptor = new TestAnalysisDescriptor(
+            "Frozen",
+            "v1",
+            modes,
+            roles,
+            projections);
+        AnalysisDescriptor[] descriptors = [descriptor];
+        var planner = new AnalysisRequestPlanner(descriptors, []);
+
+        modes[0] = AnalysisQuestionMode.Census;
+        roles[0] = new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
+            AnalysisReportSurfaceKind.Workspace,
+            AnalysisQuestionMode.Census,
+            scenario.WorkspaceDomainRole,
+            AnalysisTargetFunction.ReportDomain);
+        projections[0] = scenario.GraphProjection;
+        descriptors[0] = scenario.Analysis;
+
+        Assert.Equal([AnalysisQuestionMode.Targeted], descriptor.SupportedModes);
+        Assert.Same(scenario.LibraryAnchorRole, Assert.Single(descriptor.TargetRoles).Role);
+        Assert.Same(scenario.RowsProjection, Assert.Single(descriptor.SupportedProjections));
+        Assert.Same(descriptor, Assert.Single(planner.Descriptors));
+    }
+
+    [Fact]
+    public void AnalysisRequirements_SharedCapabilitiesRetainTypedOwnerScope()
+    {
+        Scenario scenario = new();
+        IntegrationConceptDescriptor registrations = scenario.Concepts[0];
+        IntegrationConceptDescriptor clients = scenario.Concepts[1];
+        var attributes = new IntegrationProducerPolicyDescriptor("Attribute policy");
+        var calls = new IntegrationProducerPolicyDescriptor("Call policy");
+        var attributeRequirement = new IntegrationUniverseRequirementDescriptor(
+            "Attribute evidence",
+            scenario.EvidenceCapability,
+            attributes,
+            [registrations, clients]);
+        var callRequirement = new IntegrationUniverseRequirementDescriptor(
+            "Call evidence",
+            scenario.EvidenceCapability,
+            calls,
+            [clients]);
+        IntegrationAnalysisDescriptor analysis = scenario.CreateAnalysis(
+            requirements:
+            [
+                scenario.SubjectRequirement,
+                attributeRequirement,
+                callRequirement,
+            ]);
+        var planner = new AnalysisRequestPlanner([analysis], [scenario.Prerequisite]);
+        var plan = Validate(
+            planner.Plan(
+                scenario.Request(
+                    analysis,
+                    scenario.ValidLibrarySurface(),
+                    scenario.ValidUniverse(),
+                    AnalysisQuestionMode.Targeted,
+                    scenario.RowsProjection)));
+
+        Assert.Equal(
+            [scenario.SubjectRequirement, attributeRequirement, callRequirement],
+            plan.Analysis.Requirements);
+        Assert.Equal([registrations, clients], attributeRequirement.Concepts);
+        Assert.Same(calls, callRequirement.Policy);
+
+        WorkspaceTypeUniverse missingEvidence = scenario.ValidUniverse(
+            capabilities: [scenario.SubjectCapability]);
+        var unsatisfied = Assert.IsType<AnalysisRequestRejection.UnsatisfiedUniverse>(
+            Reject(
+                planner.Plan(
+                    scenario.Request(
+                        analysis,
+                        scenario.ValidLibrarySurface(),
+                        missingEvidence,
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection))));
+        IntegrationUniverseRequirementDescriptor[] typedUnmet = analysis.Requirements
+            .Where(
+                requirement => unsatisfied.Requirements.Any(
+                    unmet => ReferenceEquals(unmet, requirement)))
+            .ToArray();
+        Assert.Equal([attributeRequirement, callRequirement], typedUnmet);
+    }
+
+    private static AnalysisValidatedPlan<TAnalysis, TIdentity, TUniverse> Validate<
+        TAnalysis,
+        TIdentity,
+        TUniverse>(
+        AnalysisRequestPlanningResult<TAnalysis, TIdentity, TUniverse> result)
+        where TAnalysis : AnalysisDescriptor
+        where TUniverse : AnalysisUniverseDescription
         => Assert.IsType<
-            AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>
-                .Rejected>(result).Rejection;
+            AnalysisRequestPlanningResult<TAnalysis, TIdentity, TUniverse>.Validated>(
+                result).Plan;
 
-    private static IEnumerable<Type> GetMemberTypes(MemberInfo member)
-        => member switch
+    private static AnalysisRequestRejection Reject<TAnalysis, TIdentity, TUniverse>(
+        AnalysisRequestPlanningResult<TAnalysis, TIdentity, TUniverse> result)
+        where TAnalysis : AnalysisDescriptor
+        where TUniverse : AnalysisUniverseDescription
+        => Assert.IsType<
+            AnalysisRequestPlanningResult<TAnalysis, TIdentity, TUniverse>.Rejected>(
+                result).Rejection;
+
+    private static Type[] RejectionFamilies()
+        => typeof(AnalysisRequestRejection)
+            .GetNestedTypes(BindingFlags.Public)
+            .Where(type => type.IsAssignableTo(typeof(AnalysisRequestRejection)))
+            .OrderBy(type => type.Name, StringComparer.Ordinal)
+            .ToArray();
+
+    private static Type[] AnalysisContractMemberTypes()
+    {
+        Type[] contractTypes = typeof(AnalysisRequestPlanner).Assembly
+            .GetExportedTypes()
+            .Where(
+                type => type.Namespace == typeof(AnalysisRequestPlanner).Namespace
+                    && type.Name.StartsWith("Analysis", StringComparison.Ordinal))
+            .ToArray();
+        return
+        [
+            .. contractTypes.SelectMany(
+                type => type
+                    .GetConstructors(
+                        BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Instance
+                        | BindingFlags.Static)
+                    .SelectMany(constructor => constructor.GetParameters())
+                    .Select(parameter => parameter.ParameterType)),
+            .. contractTypes.SelectMany(
+                type => type
+                    .GetMethods(
+                        BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Instance
+                        | BindingFlags.Static
+                        | BindingFlags.DeclaredOnly)
+                    .SelectMany(
+                        method => method
+                            .GetParameters()
+                            .Select(parameter => parameter.ParameterType)
+                            .Append(method.ReturnType))),
+            .. contractTypes.SelectMany(
+                type => type
+                    .GetProperties(
+                        BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Instance
+                        | BindingFlags.Static)
+                    .Select(property => property.PropertyType)),
+            .. contractTypes.SelectMany(
+                type => type
+                    .GetFields(
+                        BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Instance
+                        | BindingFlags.Static)
+                    .Select(field => field.FieldType)),
+        ];
+    }
+
+    private static bool ContainsDelegate(Type type)
+    {
+        var pending = new Stack<Type>();
+        var visited = new HashSet<Type>();
+        pending.Push(type);
+        while (pending.TryPop(out Type? current))
         {
-            MethodInfo method => method
-                .GetParameters()
-                .Select(parameter => parameter.ParameterType)
-                .Append(method.ReturnType),
-            PropertyInfo property => [property.PropertyType],
-            _ => [],
-        };
+            if (!visited.Add(current))
+                continue;
+            if (typeof(Delegate).IsAssignableFrom(current))
+                return true;
+            if (current.HasElementType && current.GetElementType() is Type element)
+                pending.Push(element);
+            foreach (Type argument in current.GetGenericArguments())
+                pending.Push(argument);
+        }
+
+        return false;
+    }
 
     private sealed class Scenario
     {
         public Scenario()
         {
-            SubjectRequirement = new("Selected Types", SubjectCapability);
-            EvidenceRequirement = new("Structured evidence", EvidenceCapability);
-            Analysis = new IntegrationAnalysisDescriptor(
-                "Integration census",
-                "v1",
-                [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
-                DefaultTargetRoles(),
-                [RowsProjection, MatrixProjection, GraphProjection],
-                [SubjectRequirement, EvidenceRequirement],
-                [Prerequisite],
-                [Preflight],
+            SubjectRequirement = new(
+                "Selected Types",
+                SubjectCapability,
+                SubjectPolicy,
                 Concepts);
+            EvidenceRequirement = new(
+                "Structured evidence",
+                EvidenceCapability,
+                EvidencePolicy,
+                Concepts);
+            Analysis = CreateAnalysis();
             Planner = new([Analysis], [Prerequisite]);
         }
 
-        public AnalysisTargetRoleDescriptor AnchorRole { get; } = new("Hub");
+        public AnalysisTargetRoleDescriptor<LibraryIdentity> LibraryAnchorRole { get; } =
+            new("Hub");
 
-        public AnalysisTargetRoleDescriptor TargetedDomainRole { get; } = new("Library domain");
+        public AnalysisTargetRoleDescriptor<LibraryIdentity> LibraryDomainRole { get; } =
+            new("Library domain");
 
-        public AnalysisTargetRoleDescriptor DomainRole { get; } = new("Workspace");
+        public AnalysisTargetRoleDescriptor<MemberIdentity> MemberAnchorRole { get; } =
+            new("Member");
 
-        public AnalysisTargetRoleDescriptor CensusAnchorRole { get; } = new("Census hub");
+        public AnalysisTargetRoleDescriptor<WorkspaceIdentity> WorkspaceDomainRole { get; } =
+            new("Workspace");
+
+        public AnalysisTargetRoleDescriptor<WorkspaceIdentity> WorkspaceAnchorRole { get; } =
+            new("Workspace hub");
 
         public AnalysisUniverseCapabilityDescriptor SubjectCapability { get; } =
             new("Selected-Type membership");
@@ -839,9 +938,11 @@ public sealed class AnalysisRequestPlanningTests
         public AnalysisUniverseCapabilityDescriptor EvidenceCapability { get; } =
             new("Integration structured evidence");
 
-        public AnalysisUniverseRequirementDescriptor SubjectRequirement { get; }
+        public IntegrationProducerPolicyDescriptor SubjectPolicy { get; } =
+            new("Subject policy");
 
-        public AnalysisUniverseRequirementDescriptor EvidenceRequirement { get; }
+        public IntegrationProducerPolicyDescriptor EvidencePolicy { get; } =
+            new("Evidence policy");
 
         public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; } =
         [
@@ -849,6 +950,10 @@ public sealed class AnalysisRequestPlanningTests
             new("Client construction"),
             new("Pipeline hooks"),
         ];
+
+        public IntegrationUniverseRequirementDescriptor SubjectRequirement { get; }
+
+        public IntegrationUniverseRequirementDescriptor EvidenceRequirement { get; }
 
         public AnalysisStructuralPrerequisiteDescriptor Prerequisite { get; } =
             new("Integration producer catalog");
@@ -864,125 +969,351 @@ public sealed class AnalysisRequestPlanningTests
 
         public AnalysisProjectionDescriptor UnsupportedProjection { get; } = new("Tree");
 
-        public AnalysisDescriptor Analysis { get; }
+        public IntegrationAnalysisDescriptor Analysis { get; }
 
         public AnalysisRequestPlanner Planner { get; }
 
-        public AnalysisDescriptor CreateAnalysis(
-            IReadOnlyList<AnalysisQuestionMode>? supportedModes = null,
-            IReadOnlyList<AnalysisTargetRoleDeclaration>? targetRoles = null,
-            IReadOnlyList<AnalysisUniverseRequirementDescriptor>? universeRequirements = null)
+        public int ProviderExecutionCount { get; private set; }
+
+        public IntegrationAnalysisDescriptor CreateAnalysis(
+            IReadOnlyList<IntegrationUniverseRequirementDescriptor>? requirements = null)
             => new(
                 "Integration census",
                 "v1",
-                supportedModes
-                    ?? [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
-                targetRoles ?? DefaultTargetRoles(),
+                [AnalysisQuestionMode.Targeted, AnalysisQuestionMode.Census],
+                DefaultTargetRoles(),
                 [RowsProjection, MatrixProjection, GraphProjection],
-                universeRequirements ?? [SubjectRequirement, EvidenceRequirement],
+                requirements ?? [SubjectRequirement, EvidenceRequirement],
                 [Prerequisite],
-                [Preflight]);
+                [Preflight],
+                Concepts);
+
+        public TestAnalysisDescriptor CensusOnlyAnalysis()
+            => new(
+                "Census only",
+                "v1",
+                [AnalysisQuestionMode.Census],
+                [
+                    new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
+                        AnalysisReportSurfaceKind.Workspace,
+                        AnalysisQuestionMode.Census,
+                        WorkspaceDomainRole,
+                        AnalysisTargetFunction.ReportDomain),
+                ],
+                [RowsProjection],
+                [SubjectRequirement, EvidenceRequirement],
+                [Prerequisite]);
+
+        public AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            LibraryIdentity,
+            WorkspaceTypeUniverse> ValidTargetedRequest()
+            => Request(
+                Analysis,
+                ValidLibrarySurface(),
+                ValidUniverse(),
+                AnalysisQuestionMode.Targeted,
+                RowsProjection);
+
+        public AnalysisRequest<
+            IntegrationAnalysisDescriptor,
+            LibraryIdentity,
+            WorkspaceTypeUniverse> Request(
+                IntegrationAnalysisDescriptor analysis,
+                AnalysisReportSurface<LibraryIdentity> reportSurface,
+                WorkspaceTypeUniverse? universe,
+                AnalysisQuestionMode mode,
+                AnalysisProjectionDescriptor projection)
+            => new(analysis, reportSurface, universe, mode, projection);
+
+        public AnalysisReportSurface<LibraryIdentity> ValidLibrarySurface()
+            => Surface(
+                AnalysisReportSurfaceKind.Library,
+                LibraryAnchorRole,
+                new("library"));
+
+        public AnalysisReportSurface<WorkspaceIdentity> ValidWorkspaceSurface()
+            => Surface(
+                AnalysisReportSurfaceKind.Workspace,
+                WorkspaceDomainRole,
+                new("workspace"));
+
+        public AnalysisReportSurface<TIdentity> Surface<TIdentity>(
+            AnalysisReportSurfaceKind kind,
+            AnalysisTargetRoleDescriptor<TIdentity> role,
+            TIdentity identity)
+            => new(kind, [new(role, identity)]);
+
+        public WorkspaceTypeUniverse ValidUniverse(
+            AnalysisUniverseBoundKind boundKind = AnalysisUniverseBoundKind.Finite,
+            IReadOnlyList<AnalysisUniverseCapabilityDescriptor>? capabilities = null,
+            string providerKind = "Workspace",
+            string requested = "requested",
+            string realized = "realized",
+            RequestedTypeBoundary? requestedBoundary = null,
+            RealizedTypeBoundary? realizedBoundary = null,
+            UniverseCompleteness? completeness = null,
+            IReadOnlyList<UniverseFailure>? failures = null)
+            => new(
+                boundKind,
+                capabilities ?? [SubjectCapability, EvidenceCapability],
+                requestedBoundary ?? new(requested),
+                realizedBoundary ?? new(realized),
+                completeness ?? new("Complete"),
+                failures ?? [],
+                providerKind,
+                ExecuteProvider);
+
+        public ImmutableArray<AnalysisRequestRejection> AllRejections()
+        {
+            IntegrationAnalysisDescriptor foreign = CreateAnalysis();
+            AnalysisRequestRejection unconfigured = Reject(
+                Planner.Plan(
+                    Request(
+                        foreign,
+                        ValidLibrarySurface(),
+                        ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection missingTarget = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        new(AnalysisReportSurfaceKind.Library, []),
+                        ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection multipleWorkspaces = Reject(
+                Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        WorkspaceIdentity,
+                        WorkspaceTypeUniverse>(
+                            Analysis,
+                            new(
+                                AnalysisReportSurfaceKind.Workspace,
+                                [
+                                    new(WorkspaceDomainRole, new("a")),
+                                    new(WorkspaceDomainRole, new("b")),
+                                ]),
+                            ValidUniverse(),
+                            AnalysisQuestionMode.Census,
+                            RowsProjection)));
+
+            TestAnalysisDescriptor censusOnly = CensusOnlyAnalysis();
+            var censusOnlyPlanner = new AnalysisRequestPlanner(
+                [censusOnly],
+                [Prerequisite]);
+            AnalysisRequestRejection unsupportedMode = Reject(
+                censusOnlyPlanner.Plan(
+                    new AnalysisRequest<
+                        TestAnalysisDescriptor,
+                        WorkspaceIdentity,
+                        WorkspaceTypeUniverse>(
+                            censusOnly,
+                            ValidWorkspaceSurface(),
+                            ValidUniverse(),
+                            AnalysisQuestionMode.Targeted,
+                            RowsProjection)));
+
+            var typeRole = new AnalysisTargetRoleDescriptor<TypeIdentity>("Type");
+            AnalysisRequestRejection unsupportedSurface = Reject(
+                Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        TypeIdentity,
+                        WorkspaceTypeUniverse>(
+                            Analysis,
+                            Surface(
+                                AnalysisReportSurfaceKind.Type,
+                                typeRole,
+                                new("type")),
+                            ValidUniverse(),
+                            AnalysisQuestionMode.Targeted,
+                            RowsProjection)));
+
+            var foreignRole = new AnalysisTargetRoleDescriptor<LibraryIdentity>("Hub");
+            AnalysisRequestRejection unsupportedRole = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        Surface(
+                            AnalysisReportSurfaceKind.Library,
+                            foreignRole,
+                            new("library")),
+                        ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection targetedMode = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        Surface(
+                            AnalysisReportSurfaceKind.Library,
+                            LibraryDomainRole,
+                            new("library")),
+                        ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection censusMode = Reject(
+                Planner.Plan(
+                    new AnalysisRequest<
+                        IntegrationAnalysisDescriptor,
+                        WorkspaceIdentity,
+                        WorkspaceTypeUniverse>(
+                            Analysis,
+                            Surface(
+                                AnalysisReportSurfaceKind.Workspace,
+                                WorkspaceAnchorRole,
+                                new("workspace")),
+                            ValidUniverse(),
+                            AnalysisQuestionMode.Census,
+                            RowsProjection)));
+            AnalysisRequestRejection missingUniverse = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        ValidLibrarySurface(),
+                        universe: null,
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection unboundedUniverse = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        ValidLibrarySurface(),
+                        ValidUniverse(boundKind: AnalysisUniverseBoundKind.Unbounded),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            AnalysisRequestRejection unsatisfiedUniverse = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        ValidLibrarySurface(),
+                        ValidUniverse(capabilities: []),
+                        AnalysisQuestionMode.Targeted,
+                        RowsProjection)));
+            var missingPrerequisitePlanner = new AnalysisRequestPlanner([Analysis], []);
+            AnalysisRequestRejection missingPrerequisite = Reject(
+                missingPrerequisitePlanner.Plan(ValidTargetedRequest()));
+            AnalysisRequestRejection unsupportedProjection = Reject(
+                Planner.Plan(
+                    Request(
+                        Analysis,
+                        ValidLibrarySurface(),
+                        ValidUniverse(),
+                        AnalysisQuestionMode.Targeted,
+                        UnsupportedProjection)));
+
+            return
+            [
+                unconfigured,
+                missingTarget,
+                multipleWorkspaces,
+                unsupportedMode,
+                unsupportedSurface,
+                unsupportedRole,
+                targetedMode,
+                censusMode,
+                missingUniverse,
+                unboundedUniverse,
+                unsatisfiedUniverse,
+                missingPrerequisite,
+                unsupportedProjection,
+            ];
+        }
 
         private ImmutableArray<AnalysisTargetRoleDeclaration> DefaultTargetRoles()
             =>
             [
-                new(
+                new AnalysisTargetRoleDeclaration<LibraryIdentity>(
                     AnalysisReportSurfaceKind.Library,
                     AnalysisQuestionMode.Targeted,
-                    AnchorRole,
+                    LibraryAnchorRole,
                     AnalysisTargetFunction.PrivilegedAnchor),
-                new(
+                new AnalysisTargetRoleDeclaration<LibraryIdentity>(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    LibraryDomainRole,
+                    AnalysisTargetFunction.ReportDomain),
+                new AnalysisTargetRoleDeclaration<MemberIdentity>(
                     AnalysisReportSurfaceKind.Member,
                     AnalysisQuestionMode.Targeted,
-                    AnchorRole,
+                    MemberAnchorRole,
                     AnalysisTargetFunction.PrivilegedAnchor),
-                new(
-                    AnalysisReportSurfaceKind.Library,
-                    AnalysisQuestionMode.Targeted,
-                    TargetedDomainRole,
-                    AnalysisTargetFunction.ReportDomain),
-                new(
+                new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
                     AnalysisReportSurfaceKind.Workspace,
                     AnalysisQuestionMode.Census,
-                    DomainRole,
+                    WorkspaceDomainRole,
                     AnalysisTargetFunction.ReportDomain),
-                new(
+                new AnalysisTargetRoleDeclaration<WorkspaceIdentity>(
                     AnalysisReportSurfaceKind.Workspace,
                     AnalysisQuestionMode.Census,
-                    CensusAnchorRole,
+                    WorkspaceAnchorRole,
                     AnalysisTargetFunction.PrivilegedAnchor),
             ];
 
-        public AnalysisReportSurface<TargetIdentity> ValidTargetedSurface()
-            => Surface(AnalysisReportSurfaceKind.Library, AnchorRole, "library");
-
-        public AnalysisReportSurface<TargetIdentity> ValidCensusSurface()
-            => Surface(AnalysisReportSurfaceKind.Workspace, DomainRole, "workspace");
-
-        public AnalysisReportSurface<TargetIdentity> Surface(
-            AnalysisReportSurfaceKind kind,
-            AnalysisTargetRoleDescriptor role,
-            string value)
-            => new(kind, [new(role, new(value))]);
-
-        public AnalysisUniverseDescription<UniverseBoundary, UniverseState> ValidUniverse()
-            => Universe(
-                AnalysisUniverseBoundKind.Finite,
-                [SubjectCapability, EvidenceCapability]);
-
-        public AnalysisUniverseDescription<UniverseBoundary, UniverseState> Universe(
-            AnalysisUniverseBoundKind boundKind,
-            IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities,
-            string providerKind = "Workspace",
-            string requested = "requested",
-            string realized = "realized")
-            => new(
-                boundKind,
-                new(requested),
-                new(realized),
-                capabilities,
-                new("Complete", [], providerKind));
+        private void ExecuteProvider()
+        {
+            ProviderExecutionCount++;
+            throw new InvalidOperationException("Planning executed a universe provider.");
+        }
     }
 
-    private sealed record TargetIdentity(string Value);
+    private sealed record LibraryIdentity(string Value);
 
-    private sealed record UniverseBoundary(string Value);
+    private sealed record MemberIdentity(string Value);
 
-    private sealed record UniverseState(
-        string Completeness,
-        ImmutableArray<string> Failures,
-        string ProviderKind = "Workspace");
+    private sealed record TypeIdentity(string Value);
+
+    private sealed record WorkspaceIdentity(string Value);
+
+    private sealed record RequestedTypeBoundary(string Value);
+
+    private sealed record RealizedTypeBoundary(string Value);
+
+    private sealed record UniverseCompleteness(string Value);
+
+    private sealed record UniverseFailure(string Value);
+
+    private sealed class WorkspaceTypeUniverse : AnalysisUniverseDescription
+    {
+        private readonly Action _executeProvider;
+
+        public WorkspaceTypeUniverse(
+            AnalysisUniverseBoundKind boundKind,
+            IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities,
+            RequestedTypeBoundary requestedBoundary,
+            RealizedTypeBoundary realizedBoundary,
+            UniverseCompleteness completeness,
+            IReadOnlyList<UniverseFailure> failures,
+            string providerKind,
+            Action executeProvider)
+            : base(boundKind, capabilities)
+        {
+            RequestedBoundary = requestedBoundary;
+            RealizedBoundary = realizedBoundary;
+            Completeness = completeness;
+            Failures = [.. failures];
+            ProviderKind = providerKind;
+            _executeProvider = executeProvider;
+        }
+
+        public RequestedTypeBoundary RequestedBoundary { get; }
+
+        public RealizedTypeBoundary RealizedBoundary { get; }
+
+        public UniverseCompleteness Completeness { get; }
+
+        public ImmutableArray<UniverseFailure> Failures { get; }
+
+        public string ProviderKind { get; }
+
+        public void ExecuteProvider() => _executeProvider();
+    }
 
     private sealed class IntegrationConceptDescriptor(string name)
         : AnalysisRequestDefinition(name);
-
-    private sealed class IntegrationAnalysisDescriptor : AnalysisDescriptor
-    {
-        public IntegrationAnalysisDescriptor(
-            string name,
-            string revision,
-            IReadOnlyList<AnalysisQuestionMode> supportedModes,
-            IReadOnlyList<AnalysisTargetRoleDeclaration> targetRoles,
-            IReadOnlyList<AnalysisProjectionDescriptor> supportedProjections,
-            IReadOnlyList<AnalysisUniverseRequirementDescriptor> universeRequirements,
-            IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor> structuralPrerequisites,
-            IReadOnlyList<AnalysisPreflightRequirementDescriptor> preflightRequirements,
-            IReadOnlyList<IntegrationConceptDescriptor> concepts)
-            : base(
-                name,
-                revision,
-                supportedModes,
-                targetRoles,
-                supportedProjections,
-                universeRequirements,
-                structuralPrerequisites,
-                preflightRequirements)
-        {
-            Concepts = [.. concepts];
-        }
-
-        public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; }
-    }
 
     private sealed class IntegrationProducerPolicyDescriptor(string name)
         : AnalysisRequestDefinition(name);
@@ -1006,14 +1337,57 @@ public sealed class AnalysisRequestPlanningTests
         public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; }
     }
 
-    private sealed class PoisonProviderState
+    private sealed class IntegrationAnalysisDescriptor : AnalysisDescriptor
     {
-        public int ExecutionCount { get; private set; }
-
-        public void Execute()
+        public IntegrationAnalysisDescriptor(
+            string name,
+            string revision,
+            IReadOnlyList<AnalysisQuestionMode> supportedModes,
+            IReadOnlyList<AnalysisTargetRoleDeclaration> targetRoles,
+            IReadOnlyList<AnalysisProjectionDescriptor> supportedProjections,
+            IReadOnlyList<IntegrationUniverseRequirementDescriptor> requirements,
+            IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor> structuralPrerequisites,
+            IReadOnlyList<AnalysisPreflightRequirementDescriptor> preflightRequirements,
+            IReadOnlyList<IntegrationConceptDescriptor> concepts)
+            : base(
+                name,
+                revision,
+                supportedModes,
+                targetRoles,
+                supportedProjections,
+                requirements,
+                structuralPrerequisites,
+                preflightRequirements)
         {
-            ExecutionCount++;
-            throw new InvalidOperationException("Planning executed a provider.");
+            Requirements = [.. requirements];
+            Concepts = [.. concepts];
+        }
+
+        public ImmutableArray<IntegrationUniverseRequirementDescriptor> Requirements { get; }
+
+        public ImmutableArray<IntegrationConceptDescriptor> Concepts { get; }
+    }
+
+    private sealed class TestAnalysisDescriptor : AnalysisDescriptor
+    {
+        public TestAnalysisDescriptor(
+            string name,
+            string revision,
+            IReadOnlyList<AnalysisQuestionMode> supportedModes,
+            IReadOnlyList<AnalysisTargetRoleDeclaration> targetRoles,
+            IReadOnlyList<AnalysisProjectionDescriptor> supportedProjections,
+            IReadOnlyList<AnalysisUniverseRequirementDescriptor>? universeRequirements = null,
+            IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor>? structuralPrerequisites = null)
+            : base(
+                name,
+                revision,
+                supportedModes,
+                targetRoles,
+                supportedProjections,
+                universeRequirements,
+                structuralPrerequisites)
+        {
         }
     }
+
 }

--- a/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AnalysisRequestPlanningTests.cs
@@ -49,6 +49,10 @@ public sealed class AnalysisRequestPlanningTests
             rejectionFamilies,
             family => Assert.Empty(
                 family.GetConstructors(BindingFlags.Public | BindingFlags.Instance)));
+        Assert.All(
+            typeof(AnalysisRequestRejection)
+                .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance),
+            constructor => Assert.True(constructor.IsPrivate));
         Assert.True(typeof(AnalysisTargetRoleDescriptor).IsAbstract);
         Assert.True(typeof(AnalysisTargetRoleDeclaration).IsAbstract);
         Assert.True(typeof(AnalysisDescriptor).IsAbstract);
@@ -501,6 +505,12 @@ public sealed class AnalysisRequestPlanningTests
                 .Order());
         Assert.All(rejections, rejection => Assert.NotEmpty(rejection.Guidance));
         Assert.Equal(0, scenario.ProviderExecutionCount);
+        Type[] contractTypes = AnalysisContractTypes();
+        Type[] planningResultCases = typeof(AnalysisRequestPlanningResult<,,>)
+            .GetNestedTypes(BindingFlags.Public);
+        Assert.All(
+            RejectionFamilies().Concat(planningResultCases),
+            nestedCase => Assert.Contains(nestedCase, contractTypes));
         Assert.DoesNotContain(AnalysisContractMemberTypes(), ContainsDelegate);
     }
 
@@ -702,6 +712,51 @@ public sealed class AnalysisRequestPlanningTests
         Assert.Empty(rejected.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
         Assert.False(validated.GetProperty("Plan")!.CanWrite);
         Assert.False(rejected.GetProperty("Rejection")!.CanWrite);
+        Assert.All(
+            openResult.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance),
+            constructor => Assert.True(constructor.IsPrivate));
+    }
+
+    [Fact]
+    public void AnalysisUniverseCapabilities_RejectNullDeclaration()
+    {
+        Scenario scenario = new();
+        var zeroRequirementAnalysis = new TestAnalysisDescriptor(
+            "Zero requirements",
+            "v1",
+            [AnalysisQuestionMode.Targeted],
+            [
+                new AnalysisTargetRoleDeclaration<LibraryIdentity>(
+                    AnalysisReportSurfaceKind.Library,
+                    AnalysisQuestionMode.Targeted,
+                    scenario.LibraryAnchorRole,
+                    AnalysisTargetFunction.PrivilegedAnchor),
+            ],
+            [scenario.RowsProjection]);
+        var planner = new AnalysisRequestPlanner([zeroRequirementAnalysis], []);
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            var universe = new WorkspaceTypeUniverse(
+                AnalysisUniverseBoundKind.Finite,
+                capabilities: null!,
+                new("requested"),
+                new("realized"),
+                new("Complete"),
+                [],
+                "Workspace",
+                () => throw new InvalidOperationException());
+            planner.Plan(
+                new AnalysisRequest<
+                    TestAnalysisDescriptor,
+                    LibraryIdentity,
+                    WorkspaceTypeUniverse>(
+                        zeroRequirementAnalysis,
+                        scenario.ValidLibrarySurface(),
+                        universe,
+                        AnalysisQuestionMode.Targeted,
+                        scenario.RowsProjection));
+        });
     }
 
     [Fact]
@@ -828,14 +883,22 @@ public sealed class AnalysisRequestPlanningTests
             .OrderBy(type => type.Name, StringComparer.Ordinal)
             .ToArray();
 
-    private static Type[] AnalysisContractMemberTypes()
+    private static Type[] AnalysisContractTypes()
     {
-        Type[] contractTypes = typeof(AnalysisRequestPlanner).Assembly
+        return typeof(AnalysisRequestPlanner).Assembly
             .GetExportedTypes()
             .Where(
                 type => type.Namespace == typeof(AnalysisRequestPlanner).Namespace
-                    && type.Name.StartsWith("Analysis", StringComparison.Ordinal))
+                    && DeclaringTypeChain(type).Any(
+                        candidate => candidate.Name.StartsWith(
+                            "Analysis",
+                            StringComparison.Ordinal)))
             .ToArray();
+    }
+
+    private static Type[] AnalysisContractMemberTypes()
+    {
+        Type[] contractTypes = AnalysisContractTypes();
         return
         [
             .. contractTypes.SelectMany(
@@ -877,6 +940,12 @@ public sealed class AnalysisRequestPlanningTests
                         | BindingFlags.Static)
                     .Select(field => field.FieldType)),
         ];
+    }
+
+    private static IEnumerable<Type> DeclaringTypeChain(Type type)
+    {
+        for (Type? current = type; current is not null; current = current.DeclaringType)
+            yield return current;
     }
 
     private static bool ContainsDelegate(Type type)

--- a/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
+++ b/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
@@ -1,0 +1,643 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>The domain reported by an analysis request.</summary>
+public enum AnalysisReportSurfaceKind
+{
+    Member,
+    Type,
+    Library,
+    Root,
+    Workspace,
+}
+
+/// <summary>Whether an analysis is anchored or enumerates a finite universe.</summary>
+public enum AnalysisQuestionMode
+{
+    Targeted,
+    Census,
+}
+
+/// <summary>The function of one target role in one analysis mode.</summary>
+public enum AnalysisTargetFunction
+{
+    PrivilegedAnchor,
+    ReportDomain,
+}
+
+/// <summary>Whether an owner-issued universe description has a finite boundary.</summary>
+public enum AnalysisUniverseBoundKind
+{
+    Finite,
+    Unbounded,
+}
+
+/// <summary>A violated Targeted or Census invariant.</summary>
+public enum AnalysisModeViolation
+{
+    TargetedMissingPrivilegedAnchor,
+    CensusContainsPrivilegedAnchor,
+}
+
+/// <summary>
+/// Reference-identity base for owner-issued analysis request declarations.
+/// </summary>
+public abstract class AnalysisRequestDefinition
+{
+    protected AnalysisRequestDefinition(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name;
+    }
+
+    /// <summary>A stable diagnostic name that is never used for identity or lookup.</summary>
+    public string Name { get; }
+}
+
+/// <summary>An owner-issued report-target role.</summary>
+public sealed class AnalysisTargetRoleDescriptor(string name) : AnalysisRequestDefinition(name);
+
+/// <summary>An owner-issued evidence capability supplied by a universe provider.</summary>
+public sealed class AnalysisUniverseCapabilityDescriptor(string name)
+    : AnalysisRequestDefinition(name);
+
+/// <summary>
+/// One descriptor-issued requirement for an evidence-universe capability.
+/// </summary>
+public class AnalysisUniverseRequirementDescriptor : AnalysisRequestDefinition
+{
+    public AnalysisUniverseRequirementDescriptor(
+        string name,
+        AnalysisUniverseCapabilityDescriptor capability)
+        : base(name)
+    {
+        ArgumentNullException.ThrowIfNull(capability);
+        Capability = capability;
+    }
+
+    public AnalysisUniverseCapabilityDescriptor Capability { get; }
+}
+
+/// <summary>A producer or query prerequisite checked without executing it.</summary>
+public sealed class AnalysisStructuralPrerequisiteDescriptor(string name)
+    : AnalysisRequestDefinition(name);
+
+/// <summary>A requirement retained for later host authorization or cost enforcement.</summary>
+public sealed class AnalysisPreflightRequirementDescriptor(string name)
+    : AnalysisRequestDefinition(name);
+
+/// <summary>An owner-issued result projection supported by an analysis.</summary>
+public sealed class AnalysisProjectionDescriptor(string name) : AnalysisRequestDefinition(name);
+
+/// <summary>
+/// One role accepted by an analysis for a report surface and question mode.
+/// </summary>
+public sealed class AnalysisTargetRoleDeclaration
+{
+    public AnalysisTargetRoleDeclaration(
+        AnalysisReportSurfaceKind surfaceKind,
+        AnalysisQuestionMode mode,
+        AnalysisTargetRoleDescriptor role,
+        AnalysisTargetFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        SurfaceKind = surfaceKind;
+        Mode = mode;
+        Role = role;
+        Function = function;
+    }
+
+    public AnalysisReportSurfaceKind SurfaceKind { get; }
+
+    public AnalysisQuestionMode Mode { get; }
+
+    public AnalysisTargetRoleDescriptor Role { get; }
+
+    public AnalysisTargetFunction Function { get; }
+}
+
+/// <summary>
+/// One producer-owned analysis declaration. Definition instances are identities.
+/// </summary>
+public class AnalysisDescriptor : AnalysisRequestDefinition
+{
+    public AnalysisDescriptor(
+        string name,
+        string revision,
+        IReadOnlyList<AnalysisQuestionMode> supportedModes,
+        IReadOnlyList<AnalysisTargetRoleDeclaration> targetRoles,
+        IReadOnlyList<AnalysisProjectionDescriptor> supportedProjections,
+        IReadOnlyList<AnalysisUniverseRequirementDescriptor>? universeRequirements = null,
+        IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor>? structuralPrerequisites = null,
+        IReadOnlyList<AnalysisPreflightRequirementDescriptor>? preflightRequirements = null)
+        : base(name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(revision);
+        Revision = revision;
+        SupportedModes = FreezeValues(supportedModes, nameof(supportedModes), requireNonEmpty: true);
+        TargetRoles = FreezeDefinitions(targetRoles, nameof(targetRoles), requireNonEmpty: true);
+        SupportedProjections = FreezeDefinitions(
+            supportedProjections,
+            nameof(supportedProjections),
+            requireNonEmpty: true);
+        UniverseRequirements = FreezeDefinitions(
+            universeRequirements,
+            nameof(universeRequirements));
+        StructuralPrerequisites = FreezeDefinitions(
+            structuralPrerequisites,
+            nameof(structuralPrerequisites));
+        PreflightRequirements = FreezeDefinitions(
+            preflightRequirements,
+            nameof(preflightRequirements));
+
+        var declarations = new HashSet<(
+            AnalysisReportSurfaceKind SurfaceKind,
+            AnalysisQuestionMode Mode,
+            AnalysisTargetRoleDescriptor Role)>();
+        foreach (AnalysisTargetRoleDeclaration declaration in TargetRoles)
+        {
+            if (!SupportedModes.Contains(declaration.Mode))
+            {
+                throw new ArgumentException(
+                    $"Target role '{declaration.Role.Name}' uses unsupported mode '{declaration.Mode}'.",
+                    nameof(targetRoles));
+            }
+
+            if (!declarations.Add((
+                declaration.SurfaceKind,
+                declaration.Mode,
+                declaration.Role)))
+            {
+                throw new ArgumentException(
+                    $"Target role '{declaration.Role.Name}' is declared more than once for "
+                    + $"surface '{declaration.SurfaceKind}' and mode '{declaration.Mode}'.",
+                    nameof(targetRoles));
+            }
+        }
+
+        foreach (AnalysisQuestionMode mode in SupportedModes)
+        {
+            if (!TargetRoles.Any(declaration => declaration.Mode == mode))
+            {
+                throw new ArgumentException(
+                    $"Supported mode '{mode}' has no target-role declarations.",
+                    nameof(targetRoles));
+            }
+        }
+    }
+
+    public string Revision { get; }
+
+    public ImmutableArray<AnalysisQuestionMode> SupportedModes { get; }
+
+    public ImmutableArray<AnalysisTargetRoleDeclaration> TargetRoles { get; }
+
+    public ImmutableArray<AnalysisProjectionDescriptor> SupportedProjections { get; }
+
+    public ImmutableArray<AnalysisUniverseRequirementDescriptor> UniverseRequirements { get; }
+
+    public ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> StructuralPrerequisites { get; }
+
+    public ImmutableArray<AnalysisPreflightRequirementDescriptor> PreflightRequirements { get; }
+
+    private static ImmutableArray<T> FreezeValues<T>(
+        IReadOnlyList<T> values,
+        string parameterName,
+        bool requireNonEmpty)
+        where T : struct, Enum
+    {
+        ArgumentNullException.ThrowIfNull(values, parameterName);
+        ImmutableArray<T> frozen = [.. values];
+        if (requireNonEmpty && frozen.IsEmpty)
+            throw new ArgumentException("At least one value is required.", parameterName);
+        if (frozen.Length != frozen.Distinct().Count())
+            throw new ArgumentException("Duplicate values are not permitted.", parameterName);
+        return frozen;
+    }
+
+    private static ImmutableArray<T> FreezeDefinitions<T>(
+        IReadOnlyList<T>? values,
+        string parameterName,
+        bool requireNonEmpty = false)
+        where T : class
+    {
+        if (values is null)
+        {
+            if (requireNonEmpty)
+                throw new ArgumentNullException(parameterName);
+            return [];
+        }
+
+        ImmutableArray<T> frozen = [.. values];
+        if (requireNonEmpty && frozen.IsEmpty)
+            throw new ArgumentException("At least one declaration is required.", parameterName);
+        if (frozen.Any(static value => value is null))
+            throw new ArgumentException("Null declarations are not permitted.", parameterName);
+        if (frozen.Distinct(ReferenceEqualityComparer.Instance).Count() != frozen.Length)
+            throw new ArgumentException("Duplicate declarations are not permitted.", parameterName);
+        return frozen;
+    }
+}
+
+/// <summary>One typed report identity bound to an owner-issued role.</summary>
+public sealed record AnalysisReportTarget<TIdentity>
+{
+    public AnalysisReportTarget(AnalysisTargetRoleDescriptor role, TIdentity identity)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(identity);
+        Role = role;
+        Identity = identity;
+    }
+
+    public AnalysisTargetRoleDescriptor Role { get; }
+
+    public TIdentity Identity { get; }
+}
+
+/// <summary>A typed report surface whose identities remain owner-issued.</summary>
+public sealed class AnalysisReportSurface<TIdentity>
+{
+    public AnalysisReportSurface(
+        AnalysisReportSurfaceKind kind,
+        IReadOnlyList<AnalysisReportTarget<TIdentity>> targets)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+        Targets = [.. targets];
+        if (Targets.IsEmpty)
+            throw new ArgumentException("A report surface requires at least one target.", nameof(targets));
+        if (Targets.Any(static target => target is null))
+            throw new ArgumentException("Null report targets are not permitted.", nameof(targets));
+        Kind = kind;
+    }
+
+    public AnalysisReportSurfaceKind Kind { get; }
+
+    public ImmutableArray<AnalysisReportTarget<TIdentity>> Targets { get; }
+}
+
+/// <summary>
+/// A finite or unbounded owner-issued universe description with opaque owner state.
+/// </summary>
+public sealed class AnalysisUniverseDescription<TBoundary, TProviderState>
+{
+    public AnalysisUniverseDescription(
+        AnalysisUniverseBoundKind boundKind,
+        TBoundary requestedBoundary,
+        TBoundary realizedBoundary,
+        IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities,
+        TProviderState providerState)
+    {
+        ArgumentNullException.ThrowIfNull(requestedBoundary);
+        ArgumentNullException.ThrowIfNull(realizedBoundary);
+        ArgumentNullException.ThrowIfNull(capabilities);
+        ArgumentNullException.ThrowIfNull(providerState);
+
+        Capabilities = [.. capabilities];
+        if (Capabilities.Any(static capability => capability is null))
+            throw new ArgumentException("Null capabilities are not permitted.", nameof(capabilities));
+        if (Capabilities.Distinct(ReferenceEqualityComparer.Instance).Count() != Capabilities.Length)
+            throw new ArgumentException("Duplicate capabilities are not permitted.", nameof(capabilities));
+
+        BoundKind = boundKind;
+        RequestedBoundary = requestedBoundary;
+        RealizedBoundary = realizedBoundary;
+        ProviderState = providerState;
+    }
+
+    public AnalysisUniverseBoundKind BoundKind { get; }
+
+    public TBoundary RequestedBoundary { get; }
+
+    public TBoundary RealizedBoundary { get; }
+
+    public ImmutableArray<AnalysisUniverseCapabilityDescriptor> Capabilities { get; }
+
+    public TProviderState ProviderState { get; }
+}
+
+/// <summary>One five-field analysis request.</summary>
+public sealed class AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUniverseState>
+{
+    public AnalysisRequest(
+        AnalysisDescriptor analysis,
+        AnalysisReportSurface<TTargetIdentity> reportSurface,
+        AnalysisUniverseDescription<TUniverseBoundary, TUniverseState>? universe,
+        AnalysisQuestionMode mode,
+        AnalysisProjectionDescriptor projection)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(reportSurface);
+        ArgumentNullException.ThrowIfNull(projection);
+        Analysis = analysis;
+        ReportSurface = reportSurface;
+        Universe = universe;
+        Mode = mode;
+        Projection = projection;
+    }
+
+    public AnalysisDescriptor Analysis { get; }
+
+    public AnalysisReportSurface<TTargetIdentity> ReportSurface { get; }
+
+    public AnalysisUniverseDescription<TUniverseBoundary, TUniverseState>? Universe { get; }
+
+    public AnalysisQuestionMode Mode { get; }
+
+    public AnalysisProjectionDescriptor Projection { get; }
+}
+
+/// <summary>A request plan retaining exact owner-issued inputs and declarations.</summary>
+public sealed class AnalysisValidatedPlan<TTargetIdentity, TUniverseBoundary, TUniverseState>
+{
+    internal AnalysisValidatedPlan(
+        AnalysisDescriptor analysis,
+        AnalysisReportSurface<TTargetIdentity> reportSurface,
+        AnalysisUniverseDescription<TUniverseBoundary, TUniverseState> universe,
+        AnalysisQuestionMode mode,
+        AnalysisProjectionDescriptor projection)
+    {
+        Analysis = analysis;
+        ReportSurface = reportSurface;
+        Universe = universe;
+        Mode = mode;
+        Projection = projection;
+        UniverseRequirements = analysis.UniverseRequirements;
+        StructuralPrerequisites = analysis.StructuralPrerequisites;
+        PreflightRequirements = analysis.PreflightRequirements;
+    }
+
+    public AnalysisDescriptor Analysis { get; }
+
+    public AnalysisReportSurface<TTargetIdentity> ReportSurface { get; }
+
+    public AnalysisUniverseDescription<TUniverseBoundary, TUniverseState> Universe { get; }
+
+    public AnalysisQuestionMode Mode { get; }
+
+    public AnalysisProjectionDescriptor Projection { get; }
+
+    public ImmutableArray<AnalysisUniverseRequirementDescriptor> UniverseRequirements { get; }
+
+    public ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> StructuralPrerequisites { get; }
+
+    public ImmutableArray<AnalysisPreflightRequirementDescriptor> PreflightRequirements { get; }
+}
+
+/// <summary>A typed pre-execution request rejection.</summary>
+public abstract record AnalysisRequestRejection
+{
+    private AnalysisRequestRejection()
+    {
+    }
+
+    public abstract string Guidance { get; }
+
+    public sealed record UnsupportedMode(AnalysisQuestionMode Mode) : AnalysisRequestRejection
+    {
+        public override string Guidance => $"Analysis does not support mode '{Mode}'.";
+    }
+
+    public sealed record UnsupportedSurface(AnalysisReportSurfaceKind SurfaceKind)
+        : AnalysisRequestRejection
+    {
+        public override string Guidance =>
+            $"Analysis does not support report surface '{SurfaceKind}'.";
+    }
+
+    public sealed record UnsupportedTargetRole(AnalysisTargetRoleDescriptor Role)
+        : AnalysisRequestRejection
+    {
+        public override string Guidance => $"Analysis does not support target role '{Role.Name}'.";
+    }
+
+    public sealed record InvalidMode(
+        AnalysisQuestionMode Mode,
+        AnalysisModeViolation Violation) : AnalysisRequestRejection
+    {
+        public override string Guidance => Violation switch
+        {
+            AnalysisModeViolation.TargetedMissingPrivilegedAnchor =>
+                "Targeted mode requires at least one privileged anchor.",
+            AnalysisModeViolation.CensusContainsPrivilegedAnchor =>
+                "Census mode cannot contain a privileged anchor.",
+            _ => throw new InvalidOperationException($"Unknown mode violation '{Violation}'."),
+        };
+    }
+
+    public sealed record MissingUniverse : AnalysisRequestRejection
+    {
+        public override string Guidance => "Supply an owner-issued finite universe.";
+    }
+
+    public sealed record UnboundedUniverse : AnalysisRequestRejection
+    {
+        public override string Guidance => "Supply a universe with an explicit finite bound.";
+    }
+
+    public sealed record UnsatisfiedUniverse(
+        ImmutableArray<AnalysisUniverseRequirementDescriptor> Requirements)
+        : AnalysisRequestRejection
+    {
+        public override string Guidance =>
+            $"Universe does not satisfy: {string.Join(", ", Requirements.Select(r => r.Name))}.";
+    }
+
+    public sealed record MissingStructuralPrerequisites(
+        ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> Prerequisites)
+        : AnalysisRequestRejection
+    {
+        public override string Guidance =>
+            $"Missing structural prerequisites: {string.Join(", ", Prerequisites.Select(p => p.Name))}.";
+    }
+
+    public sealed record UnsupportedProjection(AnalysisProjectionDescriptor Projection)
+        : AnalysisRequestRejection
+    {
+        public override string Guidance =>
+            $"Analysis does not support projection '{Projection.Name}'.";
+    }
+}
+
+/// <summary>A validated plan or one typed pre-execution rejection.</summary>
+public abstract record AnalysisRequestPlanningResult<
+    TTargetIdentity,
+    TUniverseBoundary,
+    TUniverseState>
+{
+    private AnalysisRequestPlanningResult()
+    {
+    }
+
+    public sealed record Validated(
+        AnalysisValidatedPlan<TTargetIdentity, TUniverseBoundary, TUniverseState> Plan)
+        : AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>;
+
+    public sealed record Rejected(AnalysisRequestRejection Rejection)
+        : AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>;
+}
+
+/// <summary>
+/// Immutable structural capability catalog and pre-execution request planner.
+/// </summary>
+public sealed class AnalysisRequestPlanner
+{
+    private readonly HashSet<AnalysisDescriptor> _descriptorSet;
+    private readonly HashSet<AnalysisStructuralPrerequisiteDescriptor>
+        _availableStructuralPrerequisites;
+
+    public AnalysisRequestPlanner(
+        IReadOnlyList<AnalysisDescriptor> descriptors,
+        IReadOnlyList<AnalysisStructuralPrerequisiteDescriptor> availableStructuralPrerequisites)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+        ArgumentNullException.ThrowIfNull(availableStructuralPrerequisites);
+        Descriptors = FreezeReferenceSet(descriptors, nameof(descriptors), requireNonEmpty: true);
+        ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> prerequisites =
+            FreezeReferenceSet(
+                availableStructuralPrerequisites,
+                nameof(availableStructuralPrerequisites),
+                requireNonEmpty: false);
+        _descriptorSet = new(Descriptors, ReferenceEqualityComparer.Instance);
+        _availableStructuralPrerequisites =
+            new(prerequisites, ReferenceEqualityComparer.Instance);
+    }
+
+    /// <summary>Configured structural capabilities in declaration order.</summary>
+    public ImmutableArray<AnalysisDescriptor> Descriptors { get; }
+
+    /// <summary>Validates one complete request without executing a producer or query.</summary>
+    public AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> Plan<
+        TTargetIdentity,
+        TUniverseBoundary,
+        TUniverseState>(
+        AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUniverseState> request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (!_descriptorSet.Contains(request.Analysis))
+        {
+            throw new ArgumentException(
+                "The analysis descriptor is not part of this structural capability catalog.",
+                nameof(request));
+        }
+
+        AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> Reject(
+            AnalysisRequestRejection rejection)
+            => new AnalysisRequestPlanningResult<
+                TTargetIdentity,
+                TUniverseBoundary,
+                TUniverseState>.Rejected(rejection);
+
+        AnalysisDescriptor analysis = request.Analysis;
+        if (!analysis.SupportedModes.Contains(request.Mode))
+            return Reject(new AnalysisRequestRejection.UnsupportedMode(request.Mode));
+
+        if (!analysis.TargetRoles.Any(
+            declaration => declaration.SurfaceKind == request.ReportSurface.Kind))
+        {
+            return Reject(
+                new AnalysisRequestRejection.UnsupportedSurface(request.ReportSurface.Kind));
+        }
+
+        var functions = ImmutableArray.CreateBuilder<AnalysisTargetFunction>(
+            request.ReportSurface.Targets.Length);
+        foreach (AnalysisReportTarget<TTargetIdentity> target in request.ReportSurface.Targets)
+        {
+            AnalysisTargetRoleDeclaration? declaration = analysis.TargetRoles.FirstOrDefault(
+                candidate =>
+                    candidate.SurfaceKind == request.ReportSurface.Kind
+                    && candidate.Mode == request.Mode
+                    && ReferenceEquals(candidate.Role, target.Role));
+            if (declaration is null)
+                return Reject(new AnalysisRequestRejection.UnsupportedTargetRole(target.Role));
+            functions.Add(declaration.Function);
+        }
+
+        if (request.Mode == AnalysisQuestionMode.Targeted
+            && !functions.Contains(AnalysisTargetFunction.PrivilegedAnchor))
+        {
+            return Reject(
+                new AnalysisRequestRejection.InvalidMode(
+                    request.Mode,
+                    AnalysisModeViolation.TargetedMissingPrivilegedAnchor));
+        }
+
+        if (request.Mode == AnalysisQuestionMode.Census)
+        {
+            if (functions.Contains(AnalysisTargetFunction.PrivilegedAnchor))
+            {
+                return Reject(
+                    new AnalysisRequestRejection.InvalidMode(
+                        request.Mode,
+                        AnalysisModeViolation.CensusContainsPrivilegedAnchor));
+            }
+        }
+
+        if (request.Universe is null)
+            return Reject(new AnalysisRequestRejection.MissingUniverse());
+        if (request.Universe.BoundKind != AnalysisUniverseBoundKind.Finite)
+            return Reject(new AnalysisRequestRejection.UnboundedUniverse());
+
+        var capabilities = new HashSet<AnalysisUniverseCapabilityDescriptor>(
+            request.Universe.Capabilities,
+            ReferenceEqualityComparer.Instance);
+        ImmutableArray<AnalysisUniverseRequirementDescriptor> unsatisfied =
+        [
+            .. analysis.UniverseRequirements.Where(
+                requirement => !capabilities.Contains(requirement.Capability)),
+        ];
+        if (!unsatisfied.IsEmpty)
+            return Reject(new AnalysisRequestRejection.UnsatisfiedUniverse(unsatisfied));
+
+        ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> missingPrerequisites =
+        [
+            .. analysis.StructuralPrerequisites.Where(
+                prerequisite => !_availableStructuralPrerequisites.Contains(prerequisite)),
+        ];
+        if (!missingPrerequisites.IsEmpty)
+        {
+            return Reject(
+                new AnalysisRequestRejection.MissingStructuralPrerequisites(
+                    missingPrerequisites));
+        }
+
+        if (!analysis.SupportedProjections.Contains(
+            request.Projection,
+            ReferenceEqualityComparer.Instance))
+        {
+            return Reject(
+                new AnalysisRequestRejection.UnsupportedProjection(request.Projection));
+        }
+
+        return new AnalysisRequestPlanningResult<
+            TTargetIdentity,
+            TUniverseBoundary,
+            TUniverseState>.Validated(
+                new AnalysisValidatedPlan<
+                    TTargetIdentity,
+                    TUniverseBoundary,
+                    TUniverseState>(
+                        analysis,
+                        request.ReportSurface,
+                        request.Universe,
+                        request.Mode,
+                        request.Projection));
+    }
+
+    private static ImmutableArray<T> FreezeReferenceSet<T>(
+        IReadOnlyList<T> values,
+        string parameterName,
+        bool requireNonEmpty)
+        where T : class
+    {
+        ImmutableArray<T> frozen = [.. values];
+        if (requireNonEmpty && frozen.IsEmpty)
+            throw new ArgumentException("At least one declaration is required.", parameterName);
+        if (frozen.Any(static value => value is null))
+            throw new ArgumentException("Null declarations are not permitted.", parameterName);
+        if (frozen.Distinct(ReferenceEqualityComparer.Instance).Count() != frozen.Length)
+            throw new ArgumentException("Duplicate declarations are not permitted.", parameterName);
+        return frozen;
+    }
+}

--- a/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
+++ b/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
@@ -296,6 +296,7 @@ public abstract class AnalysisUniverseDescription
         IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities)
     {
         AnalysisRequestGuard.EnumDefined(boundKind, nameof(boundKind));
+        ArgumentNullException.ThrowIfNull(capabilities);
         BoundKind = boundKind;
         Capabilities = AnalysisRequestGuard.FreezeDefinitions(
             capabilities,
@@ -381,7 +382,7 @@ public sealed class AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse>
 }
 
 /// <summary>A typed pre-execution request rejection.</summary>
-public abstract record AnalysisRequestRejection
+public abstract class AnalysisRequestRejection
 {
     private AnalysisRequestRejection()
     {
@@ -389,7 +390,7 @@ public abstract record AnalysisRequestRejection
 
     public abstract string Guidance { get; }
 
-    public sealed record UnconfiguredAnalysis : AnalysisRequestRejection
+    public sealed class UnconfiguredAnalysis : AnalysisRequestRejection
     {
         internal UnconfiguredAnalysis(AnalysisDescriptor analysis)
         {
@@ -403,7 +404,7 @@ public abstract record AnalysisRequestRejection
             $"Analysis '{Analysis.Name}' is not configured in this capability catalog.";
     }
 
-    public sealed record InvalidReportSurface : AnalysisRequestRejection
+    public sealed class InvalidReportSurface : AnalysisRequestRejection
     {
         internal InvalidReportSurface(
             AnalysisReportSurfaceKind surfaceKind,
@@ -429,7 +430,7 @@ public abstract record AnalysisRequestRejection
         };
     }
 
-    public sealed record UnsupportedMode : AnalysisRequestRejection
+    public sealed class UnsupportedMode : AnalysisRequestRejection
     {
         internal UnsupportedMode(AnalysisQuestionMode mode)
         {
@@ -442,7 +443,7 @@ public abstract record AnalysisRequestRejection
         public override string Guidance => $"Analysis does not support mode '{Mode}'.";
     }
 
-    public sealed record UnsupportedSurface : AnalysisRequestRejection
+    public sealed class UnsupportedSurface : AnalysisRequestRejection
     {
         internal UnsupportedSurface(AnalysisReportSurfaceKind surfaceKind)
         {
@@ -456,7 +457,7 @@ public abstract record AnalysisRequestRejection
             $"Analysis does not support report surface '{SurfaceKind}'.";
     }
 
-    public sealed record UnsupportedTargetRole : AnalysisRequestRejection
+    public sealed class UnsupportedTargetRole : AnalysisRequestRejection
     {
         internal UnsupportedTargetRole(AnalysisTargetRoleDescriptor role)
         {
@@ -470,7 +471,7 @@ public abstract record AnalysisRequestRejection
             $"Analysis does not support target role '{Role.Name}'.";
     }
 
-    public sealed record InvalidMode : AnalysisRequestRejection
+    public sealed class InvalidMode : AnalysisRequestRejection
     {
         internal InvalidMode(
             AnalysisQuestionMode mode,
@@ -511,7 +512,7 @@ public abstract record AnalysisRequestRejection
         };
     }
 
-    public sealed record MissingUniverse : AnalysisRequestRejection
+    public sealed class MissingUniverse : AnalysisRequestRejection
     {
         internal MissingUniverse()
         {
@@ -520,7 +521,7 @@ public abstract record AnalysisRequestRejection
         public override string Guidance => "Supply an owner-issued finite universe.";
     }
 
-    public sealed record UnboundedUniverse : AnalysisRequestRejection
+    public sealed class UnboundedUniverse : AnalysisRequestRejection
     {
         internal UnboundedUniverse()
         {
@@ -529,7 +530,7 @@ public abstract record AnalysisRequestRejection
         public override string Guidance => "Supply a universe with an explicit finite bound.";
     }
 
-    public sealed record UnsatisfiedUniverse : AnalysisRequestRejection
+    public sealed class UnsatisfiedUniverse : AnalysisRequestRejection
     {
         internal UnsatisfiedUniverse(
             ImmutableArray<AnalysisUniverseRequirementDescriptor> requirements)
@@ -550,7 +551,7 @@ public abstract record AnalysisRequestRejection
             $"Universe does not satisfy: {string.Join(", ", Requirements.Select(r => r.Name))}.";
     }
 
-    public sealed record MissingStructuralPrerequisites : AnalysisRequestRejection
+    public sealed class MissingStructuralPrerequisites : AnalysisRequestRejection
     {
         internal MissingStructuralPrerequisites(
             ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> prerequisites)
@@ -571,7 +572,7 @@ public abstract record AnalysisRequestRejection
             $"Missing structural prerequisites: {string.Join(", ", Prerequisites.Select(p => p.Name))}.";
     }
 
-    public sealed record UnsupportedProjection : AnalysisRequestRejection
+    public sealed class UnsupportedProjection : AnalysisRequestRejection
     {
         internal UnsupportedProjection(AnalysisProjectionDescriptor projection)
         {
@@ -587,7 +588,7 @@ public abstract record AnalysisRequestRejection
 }
 
 /// <summary>A validated plan or one typed pre-execution rejection.</summary>
-public abstract record AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+public abstract class AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
     where TAnalysis : AnalysisDescriptor
     where TUniverse : AnalysisUniverseDescription
 {
@@ -595,7 +596,7 @@ public abstract record AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity,
     {
     }
 
-    public sealed record Validated
+    public sealed class Validated
         : AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
     {
         internal Validated(AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse> plan)
@@ -607,7 +608,7 @@ public abstract record AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity,
         public AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse> Plan { get; }
     }
 
-    public sealed record Rejected
+    public sealed class Rejected
         : AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
     {
         internal Rejected(AnalysisRequestRejection rejection)

--- a/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
+++ b/src/DotnetInspector.Queries/AnalysisRequestPlanning.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace DotnetInspector.Queries;
 
@@ -40,6 +41,13 @@ public enum AnalysisModeViolation
     CensusContainsPrivilegedAnchor,
 }
 
+/// <summary>A violated report-surface cardinality invariant.</summary>
+public enum AnalysisReportSurfaceCardinalityViolation
+{
+    MissingTarget,
+    WorkspaceRequiresSingleTarget,
+}
+
 /// <summary>
 /// Reference-identity base for owner-issued analysis request declarations.
 /// </summary>
@@ -55,8 +63,18 @@ public abstract class AnalysisRequestDefinition
     public string Name { get; }
 }
 
-/// <summary>An owner-issued report-target role.</summary>
-public sealed class AnalysisTargetRoleDescriptor(string name) : AnalysisRequestDefinition(name);
+/// <summary>Planner-readable base for an owner-issued typed report-target role.</summary>
+public abstract class AnalysisTargetRoleDescriptor : AnalysisRequestDefinition
+{
+    protected AnalysisTargetRoleDescriptor(string name)
+        : base(name)
+    {
+    }
+}
+
+/// <summary>An owner-issued report-target role bound to one identity currency.</summary>
+public sealed class AnalysisTargetRoleDescriptor<TIdentity>(string name)
+    : AnalysisTargetRoleDescriptor(name);
 
 /// <summary>An owner-issued evidence capability supplied by a universe provider.</summary>
 public sealed class AnalysisUniverseCapabilityDescriptor(string name)
@@ -64,6 +82,7 @@ public sealed class AnalysisUniverseCapabilityDescriptor(string name)
 
 /// <summary>
 /// One descriptor-issued requirement for an evidence-universe capability.
+/// Owners may specialize it with typed concept or producer-policy scope.
 /// </summary>
 public class AnalysisUniverseRequirementDescriptor : AnalysisRequestDefinition
 {
@@ -91,20 +110,20 @@ public sealed class AnalysisPreflightRequirementDescriptor(string name)
 public sealed class AnalysisProjectionDescriptor(string name) : AnalysisRequestDefinition(name);
 
 /// <summary>
-/// One role accepted by an analysis for a report surface and question mode.
+/// Planner-readable base for one typed role accepted by an analysis.
 /// </summary>
-public sealed class AnalysisTargetRoleDeclaration
+public abstract class AnalysisTargetRoleDeclaration
 {
-    public AnalysisTargetRoleDeclaration(
+    protected AnalysisTargetRoleDeclaration(
         AnalysisReportSurfaceKind surfaceKind,
         AnalysisQuestionMode mode,
-        AnalysisTargetRoleDescriptor role,
         AnalysisTargetFunction function)
     {
-        ArgumentNullException.ThrowIfNull(role);
+        AnalysisRequestGuard.EnumDefined(surfaceKind, nameof(surfaceKind));
+        AnalysisRequestGuard.EnumDefined(mode, nameof(mode));
+        AnalysisRequestGuard.EnumDefined(function, nameof(function));
         SurfaceKind = surfaceKind;
         Mode = mode;
-        Role = role;
         Function = function;
     }
 
@@ -112,17 +131,38 @@ public sealed class AnalysisTargetRoleDeclaration
 
     public AnalysisQuestionMode Mode { get; }
 
-    public AnalysisTargetRoleDescriptor Role { get; }
+    public abstract AnalysisTargetRoleDescriptor Role { get; }
 
     public AnalysisTargetFunction Function { get; }
 }
 
 /// <summary>
-/// One producer-owned analysis declaration. Definition instances are identities.
+/// One role and identity currency accepted for a report surface and question mode.
 /// </summary>
-public class AnalysisDescriptor : AnalysisRequestDefinition
+public sealed class AnalysisTargetRoleDeclaration<TIdentity>
+    : AnalysisTargetRoleDeclaration
 {
-    public AnalysisDescriptor(
+    public AnalysisTargetRoleDeclaration(
+        AnalysisReportSurfaceKind surfaceKind,
+        AnalysisQuestionMode mode,
+        AnalysisTargetRoleDescriptor<TIdentity> role,
+        AnalysisTargetFunction function)
+        : base(surfaceKind, mode, function)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        Role = role;
+    }
+
+    public override AnalysisTargetRoleDescriptor<TIdentity> Role { get; }
+}
+
+/// <summary>
+/// Planner-readable base for one producer-owned analysis declaration.
+/// Concrete descriptor instances and subtypes remain owner-issued identities.
+/// </summary>
+public abstract class AnalysisDescriptor : AnalysisRequestDefinition
+{
+    protected AnalysisDescriptor(
         string name,
         string revision,
         IReadOnlyList<AnalysisQuestionMode> supportedModes,
@@ -135,19 +175,25 @@ public class AnalysisDescriptor : AnalysisRequestDefinition
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(revision);
         Revision = revision;
-        SupportedModes = FreezeValues(supportedModes, nameof(supportedModes), requireNonEmpty: true);
-        TargetRoles = FreezeDefinitions(targetRoles, nameof(targetRoles), requireNonEmpty: true);
-        SupportedProjections = FreezeDefinitions(
+        SupportedModes = AnalysisRequestGuard.FreezeEnums(
+            supportedModes,
+            nameof(supportedModes),
+            requireNonEmpty: true);
+        TargetRoles = AnalysisRequestGuard.FreezeDefinitions(
+            targetRoles,
+            nameof(targetRoles),
+            requireNonEmpty: true);
+        SupportedProjections = AnalysisRequestGuard.FreezeDefinitions(
             supportedProjections,
             nameof(supportedProjections),
             requireNonEmpty: true);
-        UniverseRequirements = FreezeDefinitions(
+        UniverseRequirements = AnalysisRequestGuard.FreezeDefinitions(
             universeRequirements,
             nameof(universeRequirements));
-        StructuralPrerequisites = FreezeDefinitions(
+        StructuralPrerequisites = AnalysisRequestGuard.FreezeDefinitions(
             structuralPrerequisites,
             nameof(structuralPrerequisites));
-        PreflightRequirements = FreezeDefinitions(
+        PreflightRequirements = AnalysisRequestGuard.FreezeDefinitions(
             preflightRequirements,
             nameof(preflightRequirements));
 
@@ -200,50 +246,14 @@ public class AnalysisDescriptor : AnalysisRequestDefinition
     public ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> StructuralPrerequisites { get; }
 
     public ImmutableArray<AnalysisPreflightRequirementDescriptor> PreflightRequirements { get; }
-
-    private static ImmutableArray<T> FreezeValues<T>(
-        IReadOnlyList<T> values,
-        string parameterName,
-        bool requireNonEmpty)
-        where T : struct, Enum
-    {
-        ArgumentNullException.ThrowIfNull(values, parameterName);
-        ImmutableArray<T> frozen = [.. values];
-        if (requireNonEmpty && frozen.IsEmpty)
-            throw new ArgumentException("At least one value is required.", parameterName);
-        if (frozen.Length != frozen.Distinct().Count())
-            throw new ArgumentException("Duplicate values are not permitted.", parameterName);
-        return frozen;
-    }
-
-    private static ImmutableArray<T> FreezeDefinitions<T>(
-        IReadOnlyList<T>? values,
-        string parameterName,
-        bool requireNonEmpty = false)
-        where T : class
-    {
-        if (values is null)
-        {
-            if (requireNonEmpty)
-                throw new ArgumentNullException(parameterName);
-            return [];
-        }
-
-        ImmutableArray<T> frozen = [.. values];
-        if (requireNonEmpty && frozen.IsEmpty)
-            throw new ArgumentException("At least one declaration is required.", parameterName);
-        if (frozen.Any(static value => value is null))
-            throw new ArgumentException("Null declarations are not permitted.", parameterName);
-        if (frozen.Distinct(ReferenceEqualityComparer.Instance).Count() != frozen.Length)
-            throw new ArgumentException("Duplicate declarations are not permitted.", parameterName);
-        return frozen;
-    }
 }
 
-/// <summary>One typed report identity bound to an owner-issued role.</summary>
+/// <summary>One typed report identity bound to a role accepting that currency.</summary>
 public sealed record AnalysisReportTarget<TIdentity>
 {
-    public AnalysisReportTarget(AnalysisTargetRoleDescriptor role, TIdentity identity)
+    public AnalysisReportTarget(
+        AnalysisTargetRoleDescriptor<TIdentity> role,
+        TIdentity identity)
     {
         ArgumentNullException.ThrowIfNull(role);
         ArgumentNullException.ThrowIfNull(identity);
@@ -251,7 +261,7 @@ public sealed record AnalysisReportTarget<TIdentity>
         Identity = identity;
     }
 
-    public AnalysisTargetRoleDescriptor Role { get; }
+    public AnalysisTargetRoleDescriptor<TIdentity> Role { get; }
 
     public TIdentity Identity { get; }
 }
@@ -263,10 +273,9 @@ public sealed class AnalysisReportSurface<TIdentity>
         AnalysisReportSurfaceKind kind,
         IReadOnlyList<AnalysisReportTarget<TIdentity>> targets)
     {
+        AnalysisRequestGuard.EnumDefined(kind, nameof(kind));
         ArgumentNullException.ThrowIfNull(targets);
         Targets = [.. targets];
-        if (Targets.IsEmpty)
-            throw new ArgumentException("A report surface requires at least one target.", nameof(targets));
         if (Targets.Any(static target => target is null))
             throw new ArgumentException("Null report targets are not permitted.", nameof(targets));
         Kind = kind;
@@ -278,57 +287,41 @@ public sealed class AnalysisReportSurface<TIdentity>
 }
 
 /// <summary>
-/// A finite or unbounded owner-issued universe description with opaque owner state.
+/// Planner-readable universe declarations. Concrete owners retain all other typed state.
 /// </summary>
-public sealed class AnalysisUniverseDescription<TBoundary, TProviderState>
+public abstract class AnalysisUniverseDescription
 {
-    public AnalysisUniverseDescription(
+    protected AnalysisUniverseDescription(
         AnalysisUniverseBoundKind boundKind,
-        TBoundary requestedBoundary,
-        TBoundary realizedBoundary,
-        IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities,
-        TProviderState providerState)
+        IReadOnlyList<AnalysisUniverseCapabilityDescriptor> capabilities)
     {
-        ArgumentNullException.ThrowIfNull(requestedBoundary);
-        ArgumentNullException.ThrowIfNull(realizedBoundary);
-        ArgumentNullException.ThrowIfNull(capabilities);
-        ArgumentNullException.ThrowIfNull(providerState);
-
-        Capabilities = [.. capabilities];
-        if (Capabilities.Any(static capability => capability is null))
-            throw new ArgumentException("Null capabilities are not permitted.", nameof(capabilities));
-        if (Capabilities.Distinct(ReferenceEqualityComparer.Instance).Count() != Capabilities.Length)
-            throw new ArgumentException("Duplicate capabilities are not permitted.", nameof(capabilities));
-
+        AnalysisRequestGuard.EnumDefined(boundKind, nameof(boundKind));
         BoundKind = boundKind;
-        RequestedBoundary = requestedBoundary;
-        RealizedBoundary = realizedBoundary;
-        ProviderState = providerState;
+        Capabilities = AnalysisRequestGuard.FreezeDefinitions(
+            capabilities,
+            nameof(capabilities));
     }
 
     public AnalysisUniverseBoundKind BoundKind { get; }
 
-    public TBoundary RequestedBoundary { get; }
-
-    public TBoundary RealizedBoundary { get; }
-
     public ImmutableArray<AnalysisUniverseCapabilityDescriptor> Capabilities { get; }
-
-    public TProviderState ProviderState { get; }
 }
 
-/// <summary>One five-field analysis request.</summary>
-public sealed class AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUniverseState>
+/// <summary>One five-field analysis request retaining exact owner types.</summary>
+public sealed class AnalysisRequest<TAnalysis, TTargetIdentity, TUniverse>
+    where TAnalysis : AnalysisDescriptor
+    where TUniverse : AnalysisUniverseDescription
 {
     public AnalysisRequest(
-        AnalysisDescriptor analysis,
+        TAnalysis analysis,
         AnalysisReportSurface<TTargetIdentity> reportSurface,
-        AnalysisUniverseDescription<TUniverseBoundary, TUniverseState>? universe,
+        TUniverse? universe,
         AnalysisQuestionMode mode,
         AnalysisProjectionDescriptor projection)
     {
         ArgumentNullException.ThrowIfNull(analysis);
         ArgumentNullException.ThrowIfNull(reportSurface);
+        AnalysisRequestGuard.EnumDefined(mode, nameof(mode));
         ArgumentNullException.ThrowIfNull(projection);
         Analysis = analysis;
         ReportSurface = reportSurface;
@@ -337,11 +330,11 @@ public sealed class AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUnivers
         Projection = projection;
     }
 
-    public AnalysisDescriptor Analysis { get; }
+    public TAnalysis Analysis { get; }
 
     public AnalysisReportSurface<TTargetIdentity> ReportSurface { get; }
 
-    public AnalysisUniverseDescription<TUniverseBoundary, TUniverseState>? Universe { get; }
+    public TUniverse? Universe { get; }
 
     public AnalysisQuestionMode Mode { get; }
 
@@ -349,12 +342,14 @@ public sealed class AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUnivers
 }
 
 /// <summary>A request plan retaining exact owner-issued inputs and declarations.</summary>
-public sealed class AnalysisValidatedPlan<TTargetIdentity, TUniverseBoundary, TUniverseState>
+public sealed class AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse>
+    where TAnalysis : AnalysisDescriptor
+    where TUniverse : AnalysisUniverseDescription
 {
     internal AnalysisValidatedPlan(
-        AnalysisDescriptor analysis,
+        TAnalysis analysis,
         AnalysisReportSurface<TTargetIdentity> reportSurface,
-        AnalysisUniverseDescription<TUniverseBoundary, TUniverseState> universe,
+        TUniverse universe,
         AnalysisQuestionMode mode,
         AnalysisProjectionDescriptor projection)
     {
@@ -368,11 +363,11 @@ public sealed class AnalysisValidatedPlan<TTargetIdentity, TUniverseBoundary, TU
         PreflightRequirements = analysis.PreflightRequirements;
     }
 
-    public AnalysisDescriptor Analysis { get; }
+    public TAnalysis Analysis { get; }
 
     public AnalysisReportSurface<TTargetIdentity> ReportSurface { get; }
 
-    public AnalysisUniverseDescription<TUniverseBoundary, TUniverseState> Universe { get; }
+    public TUniverse Universe { get; }
 
     public AnalysisQuestionMode Mode { get; }
 
@@ -394,88 +389,235 @@ public abstract record AnalysisRequestRejection
 
     public abstract string Guidance { get; }
 
-    public sealed record UnsupportedMode(AnalysisQuestionMode Mode) : AnalysisRequestRejection
+    public sealed record UnconfiguredAnalysis : AnalysisRequestRejection
     {
+        internal UnconfiguredAnalysis(AnalysisDescriptor analysis)
+        {
+            ArgumentNullException.ThrowIfNull(analysis);
+            Analysis = analysis;
+        }
+
+        public AnalysisDescriptor Analysis { get; }
+
+        public override string Guidance =>
+            $"Analysis '{Analysis.Name}' is not configured in this capability catalog.";
+    }
+
+    public sealed record InvalidReportSurface : AnalysisRequestRejection
+    {
+        internal InvalidReportSurface(
+            AnalysisReportSurfaceKind surfaceKind,
+            AnalysisReportSurfaceCardinalityViolation violation)
+        {
+            AnalysisRequestGuard.EnumDefined(surfaceKind, nameof(surfaceKind));
+            AnalysisRequestGuard.EnumDefined(violation, nameof(violation));
+            SurfaceKind = surfaceKind;
+            Violation = violation;
+        }
+
+        public AnalysisReportSurfaceKind SurfaceKind { get; }
+
+        public AnalysisReportSurfaceCardinalityViolation Violation { get; }
+
+        public override string Guidance => Violation switch
+        {
+            AnalysisReportSurfaceCardinalityViolation.MissingTarget =>
+                $"Report surface '{SurfaceKind}' requires at least one target.",
+            AnalysisReportSurfaceCardinalityViolation.WorkspaceRequiresSingleTarget =>
+                "A Workspace report surface requires exactly one workspace or operation target.",
+            _ => throw new UnreachableException(),
+        };
+    }
+
+    public sealed record UnsupportedMode : AnalysisRequestRejection
+    {
+        internal UnsupportedMode(AnalysisQuestionMode mode)
+        {
+            AnalysisRequestGuard.EnumDefined(mode, nameof(mode));
+            Mode = mode;
+        }
+
+        public AnalysisQuestionMode Mode { get; }
+
         public override string Guidance => $"Analysis does not support mode '{Mode}'.";
     }
 
-    public sealed record UnsupportedSurface(AnalysisReportSurfaceKind SurfaceKind)
-        : AnalysisRequestRejection
+    public sealed record UnsupportedSurface : AnalysisRequestRejection
     {
+        internal UnsupportedSurface(AnalysisReportSurfaceKind surfaceKind)
+        {
+            AnalysisRequestGuard.EnumDefined(surfaceKind, nameof(surfaceKind));
+            SurfaceKind = surfaceKind;
+        }
+
+        public AnalysisReportSurfaceKind SurfaceKind { get; }
+
         public override string Guidance =>
             $"Analysis does not support report surface '{SurfaceKind}'.";
     }
 
-    public sealed record UnsupportedTargetRole(AnalysisTargetRoleDescriptor Role)
-        : AnalysisRequestRejection
+    public sealed record UnsupportedTargetRole : AnalysisRequestRejection
     {
-        public override string Guidance => $"Analysis does not support target role '{Role.Name}'.";
+        internal UnsupportedTargetRole(AnalysisTargetRoleDescriptor role)
+        {
+            ArgumentNullException.ThrowIfNull(role);
+            Role = role;
+        }
+
+        public AnalysisTargetRoleDescriptor Role { get; }
+
+        public override string Guidance =>
+            $"Analysis does not support target role '{Role.Name}'.";
     }
 
-    public sealed record InvalidMode(
-        AnalysisQuestionMode Mode,
-        AnalysisModeViolation Violation) : AnalysisRequestRejection
+    public sealed record InvalidMode : AnalysisRequestRejection
     {
+        internal InvalidMode(
+            AnalysisQuestionMode mode,
+            AnalysisModeViolation violation)
+        {
+            AnalysisRequestGuard.EnumDefined(mode, nameof(mode));
+            AnalysisRequestGuard.EnumDefined(violation, nameof(violation));
+            bool compatible = (mode, violation) switch
+            {
+                (AnalysisQuestionMode.Targeted,
+                    AnalysisModeViolation.TargetedMissingPrivilegedAnchor) => true,
+                (AnalysisQuestionMode.Census,
+                    AnalysisModeViolation.CensusContainsPrivilegedAnchor) => true,
+                _ => false,
+            };
+            if (!compatible)
+            {
+                throw new ArgumentException(
+                    $"Mode '{mode}' is incompatible with violation '{violation}'.",
+                    nameof(violation));
+            }
+
+            Mode = mode;
+            Violation = violation;
+        }
+
+        public AnalysisQuestionMode Mode { get; }
+
+        public AnalysisModeViolation Violation { get; }
+
         public override string Guidance => Violation switch
         {
             AnalysisModeViolation.TargetedMissingPrivilegedAnchor =>
                 "Targeted mode requires at least one privileged anchor.",
             AnalysisModeViolation.CensusContainsPrivilegedAnchor =>
                 "Census mode cannot contain a privileged anchor.",
-            _ => throw new InvalidOperationException($"Unknown mode violation '{Violation}'."),
+            _ => throw new UnreachableException(),
         };
     }
 
     public sealed record MissingUniverse : AnalysisRequestRejection
     {
+        internal MissingUniverse()
+        {
+        }
+
         public override string Guidance => "Supply an owner-issued finite universe.";
     }
 
     public sealed record UnboundedUniverse : AnalysisRequestRejection
     {
+        internal UnboundedUniverse()
+        {
+        }
+
         public override string Guidance => "Supply a universe with an explicit finite bound.";
     }
 
-    public sealed record UnsatisfiedUniverse(
-        ImmutableArray<AnalysisUniverseRequirementDescriptor> Requirements)
-        : AnalysisRequestRejection
+    public sealed record UnsatisfiedUniverse : AnalysisRequestRejection
     {
+        internal UnsatisfiedUniverse(
+            ImmutableArray<AnalysisUniverseRequirementDescriptor> requirements)
+        {
+            if (requirements.IsDefaultOrEmpty)
+            {
+                throw new ArgumentException(
+                    "At least one unsatisfied requirement is required.",
+                    nameof(requirements));
+            }
+
+            Requirements = requirements;
+        }
+
+        public ImmutableArray<AnalysisUniverseRequirementDescriptor> Requirements { get; }
+
         public override string Guidance =>
             $"Universe does not satisfy: {string.Join(", ", Requirements.Select(r => r.Name))}.";
     }
 
-    public sealed record MissingStructuralPrerequisites(
-        ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> Prerequisites)
-        : AnalysisRequestRejection
+    public sealed record MissingStructuralPrerequisites : AnalysisRequestRejection
     {
+        internal MissingStructuralPrerequisites(
+            ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> prerequisites)
+        {
+            if (prerequisites.IsDefaultOrEmpty)
+            {
+                throw new ArgumentException(
+                    "At least one missing prerequisite is required.",
+                    nameof(prerequisites));
+            }
+
+            Prerequisites = prerequisites;
+        }
+
+        public ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> Prerequisites { get; }
+
         public override string Guidance =>
             $"Missing structural prerequisites: {string.Join(", ", Prerequisites.Select(p => p.Name))}.";
     }
 
-    public sealed record UnsupportedProjection(AnalysisProjectionDescriptor Projection)
-        : AnalysisRequestRejection
+    public sealed record UnsupportedProjection : AnalysisRequestRejection
     {
+        internal UnsupportedProjection(AnalysisProjectionDescriptor projection)
+        {
+            ArgumentNullException.ThrowIfNull(projection);
+            Projection = projection;
+        }
+
+        public AnalysisProjectionDescriptor Projection { get; }
+
         public override string Guidance =>
             $"Analysis does not support projection '{Projection.Name}'.";
     }
 }
 
 /// <summary>A validated plan or one typed pre-execution rejection.</summary>
-public abstract record AnalysisRequestPlanningResult<
-    TTargetIdentity,
-    TUniverseBoundary,
-    TUniverseState>
+public abstract record AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+    where TAnalysis : AnalysisDescriptor
+    where TUniverse : AnalysisUniverseDescription
 {
     private AnalysisRequestPlanningResult()
     {
     }
 
-    public sealed record Validated(
-        AnalysisValidatedPlan<TTargetIdentity, TUniverseBoundary, TUniverseState> Plan)
-        : AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>;
+    public sealed record Validated
+        : AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+    {
+        internal Validated(AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse> plan)
+        {
+            ArgumentNullException.ThrowIfNull(plan);
+            Plan = plan;
+        }
 
-    public sealed record Rejected(AnalysisRequestRejection Rejection)
-        : AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState>;
+        public AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse> Plan { get; }
+    }
+
+    public sealed record Rejected
+        : AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+    {
+        internal Rejected(AnalysisRequestRejection rejection)
+        {
+            ArgumentNullException.ThrowIfNull(rejection);
+            Rejection = rejection;
+        }
+
+        public AnalysisRequestRejection Rejection { get; }
+    }
 }
 
 /// <summary>
@@ -493,12 +635,14 @@ public sealed class AnalysisRequestPlanner
     {
         ArgumentNullException.ThrowIfNull(descriptors);
         ArgumentNullException.ThrowIfNull(availableStructuralPrerequisites);
-        Descriptors = FreezeReferenceSet(descriptors, nameof(descriptors), requireNonEmpty: true);
+        Descriptors = AnalysisRequestGuard.FreezeDefinitions(
+            descriptors,
+            nameof(descriptors),
+            requireNonEmpty: true);
         ImmutableArray<AnalysisStructuralPrerequisiteDescriptor> prerequisites =
-            FreezeReferenceSet(
+            AnalysisRequestGuard.FreezeDefinitions(
                 availableStructuralPrerequisites,
-                nameof(availableStructuralPrerequisites),
-                requireNonEmpty: false);
+                nameof(availableStructuralPrerequisites));
         _descriptorSet = new(Descriptors, ReferenceEqualityComparer.Instance);
         _availableStructuralPrerequisites =
             new(prerequisites, ReferenceEqualityComparer.Instance);
@@ -508,28 +652,42 @@ public sealed class AnalysisRequestPlanner
     public ImmutableArray<AnalysisDescriptor> Descriptors { get; }
 
     /// <summary>Validates one complete request without executing a producer or query.</summary>
-    public AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> Plan<
+    public AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse> Plan<
+        TAnalysis,
         TTargetIdentity,
-        TUniverseBoundary,
-        TUniverseState>(
-        AnalysisRequest<TTargetIdentity, TUniverseBoundary, TUniverseState> request)
+        TUniverse>(
+        AnalysisRequest<TAnalysis, TTargetIdentity, TUniverse> request)
+        where TAnalysis : AnalysisDescriptor
+        where TUniverse : AnalysisUniverseDescription
     {
         ArgumentNullException.ThrowIfNull(request);
-        if (!_descriptorSet.Contains(request.Analysis))
+
+        AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse> Reject(
+            AnalysisRequestRejection rejection)
+            => new AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+                .Rejected(rejection);
+
+        TAnalysis analysis = request.Analysis;
+        if (!_descriptorSet.Contains(analysis))
+            return Reject(new AnalysisRequestRejection.UnconfiguredAnalysis(analysis));
+
+        if (request.ReportSurface.Targets.IsEmpty)
         {
-            throw new ArgumentException(
-                "The analysis descriptor is not part of this structural capability catalog.",
-                nameof(request));
+            return Reject(
+                new AnalysisRequestRejection.InvalidReportSurface(
+                    request.ReportSurface.Kind,
+                    AnalysisReportSurfaceCardinalityViolation.MissingTarget));
         }
 
-        AnalysisRequestPlanningResult<TTargetIdentity, TUniverseBoundary, TUniverseState> Reject(
-            AnalysisRequestRejection rejection)
-            => new AnalysisRequestPlanningResult<
-                TTargetIdentity,
-                TUniverseBoundary,
-                TUniverseState>.Rejected(rejection);
+        if (request.ReportSurface.Kind == AnalysisReportSurfaceKind.Workspace
+            && request.ReportSurface.Targets.Length != 1)
+        {
+            return Reject(
+                new AnalysisRequestRejection.InvalidReportSurface(
+                    request.ReportSurface.Kind,
+                    AnalysisReportSurfaceCardinalityViolation.WorkspaceRequiresSingleTarget));
+        }
 
-        AnalysisDescriptor analysis = request.Analysis;
         if (!analysis.SupportedModes.Contains(request.Mode))
             return Reject(new AnalysisRequestRejection.UnsupportedMode(request.Mode));
 
@@ -563,15 +721,13 @@ public sealed class AnalysisRequestPlanner
                     AnalysisModeViolation.TargetedMissingPrivilegedAnchor));
         }
 
-        if (request.Mode == AnalysisQuestionMode.Census)
+        if (request.Mode == AnalysisQuestionMode.Census
+            && functions.Contains(AnalysisTargetFunction.PrivilegedAnchor))
         {
-            if (functions.Contains(AnalysisTargetFunction.PrivilegedAnchor))
-            {
-                return Reject(
-                    new AnalysisRequestRejection.InvalidMode(
-                        request.Mode,
-                        AnalysisModeViolation.CensusContainsPrivilegedAnchor));
-            }
+            return Reject(
+                new AnalysisRequestRejection.InvalidMode(
+                    request.Mode,
+                    AnalysisModeViolation.CensusContainsPrivilegedAnchor));
         }
 
         if (request.Universe is null)
@@ -610,27 +766,56 @@ public sealed class AnalysisRequestPlanner
                 new AnalysisRequestRejection.UnsupportedProjection(request.Projection));
         }
 
-        return new AnalysisRequestPlanningResult<
-            TTargetIdentity,
-            TUniverseBoundary,
-            TUniverseState>.Validated(
-                new AnalysisValidatedPlan<
-                    TTargetIdentity,
-                    TUniverseBoundary,
-                    TUniverseState>(
-                        analysis,
-                        request.ReportSurface,
-                        request.Universe,
-                        request.Mode,
-                        request.Projection));
+        return new AnalysisRequestPlanningResult<TAnalysis, TTargetIdentity, TUniverse>
+            .Validated(
+                new AnalysisValidatedPlan<TAnalysis, TTargetIdentity, TUniverse>(
+                    analysis,
+                    request.ReportSurface,
+                    request.Universe,
+                    request.Mode,
+                    request.Projection));
+    }
+}
+
+internal static class AnalysisRequestGuard
+{
+    public static void EnumDefined<TEnum>(TEnum value, string parameterName)
+        where TEnum : struct, Enum
+    {
+        if (!Enum.IsDefined(value))
+            throw new ArgumentOutOfRangeException(parameterName, value, "Undefined enum value.");
     }
 
-    private static ImmutableArray<T> FreezeReferenceSet<T>(
-        IReadOnlyList<T> values,
+    public static ImmutableArray<TEnum> FreezeEnums<TEnum>(
+        IReadOnlyList<TEnum> values,
         string parameterName,
         bool requireNonEmpty)
+        where TEnum : struct, Enum
+    {
+        ArgumentNullException.ThrowIfNull(values, parameterName);
+        ImmutableArray<TEnum> frozen = [.. values];
+        if (requireNonEmpty && frozen.IsEmpty)
+            throw new ArgumentException("At least one value is required.", parameterName);
+        foreach (TEnum value in frozen)
+            EnumDefined(value, parameterName);
+        if (frozen.Length != frozen.Distinct().Count())
+            throw new ArgumentException("Duplicate values are not permitted.", parameterName);
+        return frozen;
+    }
+
+    public static ImmutableArray<T> FreezeDefinitions<T>(
+        IReadOnlyList<T>? values,
+        string parameterName,
+        bool requireNonEmpty = false)
         where T : class
     {
+        if (values is null)
+        {
+            if (requireNonEmpty)
+                throw new ArgumentNullException(parameterName);
+            return [];
+        }
+
         ImmutableArray<T> frozen = [.. values];
         if (requireNonEmpty && frozen.IsEmpty)
             throw new ArgumentException("At least one declaration is required.", parameterName);


### PR DESCRIPTION
Implements the Inspection Analysis Requests owner from #4970 as a host-neutral, pre-execution planner. Requests bind one owner-issued analysis descriptor, typed report surface, finite owner-issued universe, Targeted/Census mode, and projection; planning returns either an immutable exact-input plan or one closed typed rejection.

## Demo

The Integration-shaped consumer canary declares a Workspace/Census request with a finite Type-evidence universe and matrix projection:

```csharp
var request = new AnalysisRequest<
    IntegrationAnalysisDescriptor,
    WorkspaceIdentity,
    WorkspaceTypeUniverse>(
        integrationAnalysis,
        workspaceSurface,
        finiteTypeUniverse,
        AnalysisQuestionMode.Census,
        matrixProjection);

var result = planner.Plan(request);
```

The real canary result is `Validated`: its static type retains the concrete Integration descriptor and Workspace Type universe, including distinct requested/realized boundary currencies, completeness/failures, concept-scoped requirements, structural prerequisites, and later host-preflight requirements. Neighboring Library/Targeted and Member/Targeted gates use the same planner without widening their report surfaces.

## Architecture

- Uses reference identity for analysis, typed role, capability, requirement, prerequisite, and projection declarations; names remain diagnostic only.
- Couples every target role to its owner-issued identity currency and retains the concrete owner analysis and universe types through request, result, and plan.
- Keeps requested/realized boundaries, completeness, failures, configured concept catalogs, and policy scope on typed adjacent-owner aggregates rather than inventing universal identities or outcome states.
- Returns genuinely closed typed class unions for unconfigured analysis, invalid surface cardinality, invalid/unsupported modes, unsupported surfaces/roles/projections, missing or unbounded universes, unsatisfied universe requirements, and missing structural prerequisites.
- Structural discovery and request validation have no producer/query callback and do not enforce host authorization or cost policy.
- Implements all 26 named verification gates in `analysis-surfaces-and-universes.md`, including declaration-derived rejection coverage, nested outcome scan non-vacuity, null capability rejection, and the Integration Workspace/Census canary.

This does not construct or enumerate universes, execute producers, define Integration candidates/results, or implement #3629 or #4979.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release` (735 passed)
- Current-head CI supplies `markdownlint` because this host has no JavaScript runtime

Closes #5014