### PR TITLE
Add product-owned nuspec package query facets

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -11,8 +11,8 @@ See [overview.md](../overview.md) for subsystem ownership,
 [Artifact acquisition and workspace composition](artifact-acquisition-and-workspaces.md)
 owns the source-neutral boundary below workspace-backed assembly queries.
 [The package query CLI](package-query-cli.md) applies this split to a
-concrete, not-yet-implemented feature: nuspec/promoted facet predicates over
-`find --package-prefix`.
+concrete feature: its host-neutral nuspec facet engine is implemented at L1,
+while CLI exposure and promoted-tier predicates remain future work.
 
 ## Purpose
 
@@ -75,12 +75,18 @@ Implementation
 comparison, assembly-context Integrations, implementation relationships,
 type/member search, extension reachability, progressive member call-graph
 slices, group-scoped PDB-mapped-or-decompiled type/member source, immutable
-package-manifest facts, and bounded package-prefix profiles. Package dependency
-selection and package-prefix profiles consume the same validated manifest-facts
-query. The profile's L2 `Packages` section owns package/dependency row grain,
-schema, projection, and visible failure or truncation evidence; `find` retains
-only request binding, acquisition authorization, diagnostics, and format
-selection. The
+package-manifest facts, bounded package-prefix profiles, and product-owned
+nuspec package-query facets. Package dependency selection, package-prefix
+profiles, and package-query facets consume the same validated manifest-facts
+query. The package-query contract owns ordered opaque facet descriptors, typed
+selection validation, ANDed evaluation, inert evidence, distinct candidate and
+match bounds, and typed completion without choosing a renderer. This contract
+is gated by `PackageQueryTests` and the
+`PackageQueryPlanner_IsReachableFromBrowserConsumer` consumer canary. The
+profile's L2 `Packages` section owns package/dependency row grain, schema,
+projection, and visible failure or truncation evidence; `find` retains only
+request binding, acquisition authorization, diagnostics, and format selection.
+The
 API-comparison seam
 retains Metadata-owned Finding correspondence and compatibility classification
 over two host-resolved surfaces. The body-signal seam consumes already-acquired

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -9,22 +9,32 @@ document's vocabulary as canonical rather than inventing its own.
 ## Status
 
 Design proposal, partially landed. `find --package-prefix`'s corpus-streaming
-mechanism and typed L1 query (`PackageProfileQuery`) — plus, further than
-this document originally recommended as a follow-up slice, its rendering
-path — already merged in #4551 onto the shared `Sections`/shape-ladder
-registry (`PackageProfileSections`, `SectionPipeline<PackageProfileView>`),
-the same registry `library`, `member`, and `package` use. `PackageDependencyGroupsQuery`
-also landed in #4551, in the same L1 layer, but backs the browser's
-single-package dependency view (`InspectionEngine.QueryPackageDependencies`),
-not `find --package-prefix`'s corpus-streaming query. See
+mechanism and typed L1 query (`PackageProfileQuery`) — plus, further than this
+document originally recommended as a follow-up slice, its rendering path —
+already merged in #4551 onto the shared `Sections`/shape-ladder registry
+(`PackageProfileSections`, `SectionPipeline<PackageProfileView>`), the same
+registry `library`, `member`, and `package` use.
+`PackageDependencyGroupsQuery` also landed in #4551, in the same L1 layer, but
+backs the browser's single-package dependency view
+(`InspectionEngine.QueryPackageDependencies`), not
+`find --package-prefix`'s corpus-streaming query. See
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
 for what shipped and what did not.
 
-Still proposal-only, not present on `main`: the facet/predicate layer, the
-tier capability gate, and — despite the Sections migration landing —
-`find --package-prefix`'s corpus limit is still spelled `-t`, not the settled
-`-n` target from [Item and line limits](item-and-line-limits.md), which
-resolves the repository-wide flag-numbering problem this document surfaced.
+The current sources also implement the host-neutral L1 nuspec facet contract
+as `PackageQuery`: product-owned ordered descriptors, typed request planning,
+ANDed predicate evaluation over `PackageProfileQuery`, non-empty inert
+evidence, separate candidate and match bounds, visible failures, and typed
+completion. `PackageQueryTests` is its Release gate;
+`PackageQueryPlanner_IsReachableFromBrowserConsumer` is the Browser consumer
+canary.
+
+Still proposal-only: CLI `--where` wiring, the tier capability gate, and the
+promoted IL tier. Despite the Sections migration landing,
+`find --package-prefix`'s corpus limit is also still spelled `-t`, not the
+settled `-n` target from [Item and line limits](item-and-line-limits.md),
+which resolves the repository-wide flag-numbering problem this document
+surfaced.
 
 Related docs:
 
@@ -61,13 +71,13 @@ and partial-source failure, rendered through the shared Sections registry
 just as `library`/`member`/`package` are. Its corpus-limit spelling is still
 `-t`, not yet the target `-n` vocabulary — see
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
-What it does not have yet is a way to
-ask "and does each package satisfy *this*" — a facet predicate — cheaply for
-nuspec-derived facts and, on explicit request, expensively for facts that
-require opening IL. This document proposes that predicate layer, and where each piece of it
-belongs across the existing L1/L2/L3 split, rather than treating the CLI
-project as a place to accumulate new bespoke logic the way it did before that
-split existed.
+The L1 nuspec facet engine now provides a host-neutral way to ask "and does
+each package satisfy *this*" over facts already available from the source and
+exact manifest. The CLI does not expose it yet, and the explicit promoted tier
+for facts that require opening IL remains unimplemented. This document defines
+where those pieces belong across the existing L1/L2/L3 split, rather than
+treating the CLI project as a place to accumulate new bespoke logic the way it
+did before that split existed.
 
 ## Is this CLI-side or core?
 
@@ -178,29 +188,33 @@ now declared sections, yet the corpus limit is still `-t`, not `-n`. See
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
 for the resulting follow-up.
 
-## Two-tier facets, reusing `--where`
+## Two-tier facets, one product vocabulary
 
-The web design's nuspec/promoted split maps directly onto capability, not
-vocabulary:
+The web design's nuspec/promoted split maps directly onto capability. L1 owns
+the vocabulary and predicate semantics; front ends submit product-issued
+opaque facet IDs and do not reconstruct those predicates:
 
-- **`nuspec` tier.** Free, always evaluated, over every streamed package —
-  backed entirely by fields `PackageProfileQuery` already surfaces (#4551,
-  merged; target frameworks, declared dependencies, owners, metadata
-  fields). No new grammar:
-  `RowPredicateSyntaxParser`'s existing `Field=value` / `!=` / `>=` / `<=`
-  grammar, ANDed via repeated `--where` flags exactly as it works today for
-  Performance Triage, is the vocabulary. A package row's section schema
-  simply grows nuspec-derived fields, the same way any other section
-  declares its filterable columns per
-  [row-query-order.md](row-query-order.md).
+- **`nuspec` tier.** Available over the bounded package profile produced from
+  source metadata and exact manifests. `PackageQuery.Facets` is the finite,
+  ordered vocabulary. `PackageQuery.Plan` validates selected IDs and
+  compatibility, and `PackageQuery.ExecuteAsync` ANDs the selected definitions
+  before applying the semantic match limit. A facet's tier names the
+  production envelope in which it is available, not the narrowest individual
+  field its predicate reads; the common nuspec result row still carries exact
+  manifest facts.
 - **`promoted` tier.** Requires opening IL for a bounded set of candidates —
   never for the whole corpus. This must be capability-gated the same way the
   repository already gates other exhaustive/expensive work (`--all`,
-  README.md:474, 535): a promoted-tier `--where` field used without the gate
-  present is a parse-time error naming the missing flag, the same shape as
-  `output-shapes.md`'s existing coordinate-carrier errors (for example, "IL
-  coordinate sections require `--il-offset`"). The equivalent here reads
-  something like "field `UsesUnion` requires `--deepen`."
+  README.md:474, 535). The exact CLI spelling remains for its implementation
+  slice, but the adapter must resolve that spelling through product-owned
+  descriptors or bindings and submit opaque IDs. It must not hard-code a
+  second predicate vocabulary in L2 or L3.
+
+The future CLI may reuse `RowPredicateSyntaxParser` and repeated `--where`
+syntax as an input grammar, but this document no longer defines package facets
+as arbitrary section-field predicates. If `--where` is retained, the
+implementation slice must add product-owned CLI bindings for the finite facet
+set so the CLI and browser continue to invoke the same L1 definitions.
 
 ### Tier gating: nuspec vs. promoted
 
@@ -290,6 +304,13 @@ before promoted IL evaluation. Help text and rendered completion state must
 name the candidate bound, and the asserted ordering must name its enforcing
 gate.
 
+`PackageQuery.ExecuteAsync` now implements the nuspec half with separate
+`MaximumCandidates` and `MaximumMatches` bounds.
+`ExecuteAsync_FiltersBeforeMatchLimitAndStopsManifestAcquisition` gates the
+filter-before-match-limit ordering, while
+`ExecuteAsync_PreservesCandidateLimitAfterFiltering` gates honest
+candidate-bound completion. Promoted-tier ordering remains proposal-only.
+
 ## Shared request/outcome shape with the browser
 
 [package-query-experience.md](package-query-experience.md)'s non-goals already
@@ -335,15 +356,24 @@ the CLI's named facets as canonical for the browser's facet rail.
    `-t`-as-package-limit for the settled `-n` contract, and `-S`/`--where`
    remain unwired. See
    [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
-3. **Retire `-t` for `-n` on `find --package-prefix`**, closing the gap step
-   2 left open, and **wire nuspec-tier `--where`** onto package-profile rows,
-   deciding and documenting the filter-before-bound ordering from
+3. **Product-owned nuspec facet contract — implemented in the current
+   sources.** `PackageQuery` composes `PackageProfileQuery` without package
+   payload acquisition, publishes stable ordered facet descriptors, validates
+   opaque selections, and streams matched package rows with product-authored
+   evidence and honest completion. `PackageQueryTests` and
+   `PackageQueryPlanner_IsReachableFromBrowserConsumer` are the named Release
+   gates.
+4. **Retire `-t` for `-n` on `find --package-prefix`**, closing the gap step
+   2 left open, and **wire the product-owned nuspec facets into the CLI**,
+   preserving the filter-before-bound ordering from
    [Completion and bound honesty parity](#completion-and-bound-honesty-parity-with-the-browser).
+   The slice must settle a CLI spelling and any product-owned bindings needed
+   to lower that spelling to opaque facet IDs without duplicating predicates.
    Neither sub-goal has landed yet.
-4. **Add the promoted-tier capability gate and `--deepen`-bounded IL
+5. **Add the promoted-tier capability gate and `--deepen`-bounded IL
    evaluation**, including the L2 tier-gating error for an ungated
    promoted-tier field.
-5. **Define the shared save/resume file shape**, coordinated with whatever
+6. **Define the shared save/resume file shape**, coordinated with whatever
    the browser experience's local-storage record settles on when it is
    implemented.
 

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -146,13 +146,13 @@ between 1 and..."). `-S` and `--where` are also not yet wired (there is
 currently exactly one section, `Packages`, so `-S` selection is moot until the
 facet layer adds more to select between).
 
-**Interaction concern for the next slice:** the Sections migration and the
+**Interaction concern for the next CLI slice:** the Sections migration and the
 `-t`→`-n` flag rename were assumed to be one atomic step; in practice they
-decoupled, and the migration landed first. The next slice (wiring nuspec-tier
-`--where`, [Landing sequence](#landing-sequence) step 3) should not silently
-inherit `-t` as precedent — it should either retire `-t` for `-n` itself, or
-explicitly hand that retirement to whatever implements #4677 across the CLI,
-naming which PR owns it so it does not fall through the gap a second time.
+decoupled, and the migration landed first. The CLI facet wiring in
+[Landing sequence](#landing-sequence) step 4 should not silently inherit `-t`
+as precedent — it should either retire `-t` for `-n` itself, or explicitly
+hand that retirement to whatever implements #4677 across the CLI, naming
+which PR owns it so it does not fall through the gap a second time.
 
 ### `-t` is the wrong flag to build on; `-n` owns the corpus limit
 
@@ -331,9 +331,9 @@ the CLI's named facets as canonical for the browser's facet rail.
 
 ## Non-goals (v1)
 
-- No new expression grammar. `--where`'s existing `Field op Value` syntax is
-  the vocabulary for both tiers; this document does not propose a richer
-  predicate language.
+- No new general expression grammar in the L1 contract. The finite
+  product-issued facet IDs are canonical; any future CLI grammar must lower
+  through product-owned bindings rather than defining another predicate set.
 - No relational query surface here. Package-to-capability or
   package-to-integration questions route through the existing inspection
   graph, not through a new edge concept invented for this document.

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -309,7 +309,12 @@ gate.
 `ExecuteAsync_FiltersBeforeMatchLimitAndStopsManifestAcquisition` gates the
 filter-before-match-limit ordering, while
 `ExecuteAsync_PreservesCandidateLimitAfterFiltering` gates honest
-candidate-bound completion. Promoted-tier ordering remains proposal-only.
+candidate-bound completion. Reaching the semantic match limit is deliberately
+conservative: execution stops without acquiring another manifest, so
+`MatchLimitReached` means more matches may exist even when the last emitted row
+also happened to exhaust the source. This behavior is gated by
+`ExecuteAsync_ExactExhaustionAtMatchLimitIsConservative`. Promoted-tier
+ordering remains proposal-only.
 
 ## Shared request/outcome shape with the browser
 

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -60,6 +60,27 @@ public sealed class BrowserEngineBoundaryTests
                 Assert.Single(facts.DependencyGroups).Dependencies).Id);
     }
 
+    [Fact]
+    public void PackageQueryPlanner_IsReachableFromBrowserConsumer()
+    {
+        PackageQueryPlan plan = Assert.IsType<PackageQueryPlanResult.Accepted>(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Example.",
+                    [
+                        PackageQuery.ToolFacetId,
+                        PackageQuery.NoDependenciesFacetId,
+                    ]))).Plan;
+
+        Assert.Equal(PackageQueryFacetTier.Nuspec, plan.Facets[0].Tier);
+        Assert.Equal(
+            [
+                PackageQuery.ToolFacetId,
+                PackageQuery.NoDependenciesFacetId,
+            ],
+            plan.Facets.Select(facet => facet.Id));
+    }
+
     public static object PerformanceBoxingProbe(int value) => value;
 
     public static int PerformanceNoAllocationProbe(int value) => value;

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -11,12 +11,12 @@ public sealed class PackageQueryTests
     {
         Assert.Equal(
             [
-                (PackageQuery.VerifiedFacetId, 100),
-                (PackageQuery.ToolFacetId, 200),
-                (PackageQuery.HasDependenciesFacetId, 300),
-                (PackageQuery.NoDependenciesFacetId, 400),
-                (PackageQuery.MillionDownloadsFacetId, 500),
-                (PackageQuery.EmbeddedReadmeFacetId, 600),
+                ("package.query.source-verified", 100),
+                ("package.query.dotnet-tool", 200),
+                ("package.query.has-dependencies", 300),
+                ("package.query.no-dependencies", 400),
+                ("package.query.downloads-1m", 500),
+                ("package.query.embedded-readme", 600),
             ],
             PackageQuery.Facets.Select(facet =>
                 (facet.Id, facet.Weight)));
@@ -42,7 +42,9 @@ public sealed class PackageQueryTests
     [InlineData(" Contoso.", PackageQueryRequestFailureReason.InvalidPrefix)]
     [InlineData("\u202EContoso.", PackageQueryRequestFailureReason.InvalidPrefix)]
     [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidCandidateLimit, 0, 1)]
+    [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidCandidateLimit, PackageProfileQuery.MaximumPackageLimit + 1, 1)]
     [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidMatchLimit, 1, 0)]
+    [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidMatchLimit, 1, PackageProfileQuery.MaximumPackageLimit + 1)]
     public void Plan_RejectsInvalidScopeAndBoundsWithoutThrowing(
         string prefix,
         PackageQueryRequestFailureReason expected,
@@ -87,6 +89,24 @@ public sealed class PackageQueryTests
     }
 
     [Fact]
+    public void Plan_AcceptsMaximumBounds()
+    {
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: PackageProfileQuery.MaximumPackageLimit,
+                    MaximumMatches: PackageProfileQuery.MaximumPackageLimit)));
+
+        Assert.Equal(
+            PackageProfileQuery.MaximumPackageLimit,
+            plan.MaximumCandidates);
+        Assert.Equal(
+            PackageProfileQuery.MaximumPackageLimit,
+            plan.MaximumMatches);
+    }
+
+    [Fact]
     public void Plan_RejectsInvalidUnknownDuplicateAndIncompatibleFacets()
     {
         PackageQueryRequestFailure invalid = Rejected(
@@ -104,7 +124,7 @@ public sealed class PackageQueryTests
         Assert.Equal(
             PackageQueryRequestFailureReason.UnknownFacet,
             unknown.Reason);
-        Assert.Equal(["package.query.unknown"], unknown.FacetIds);
+        Assert.Empty(unknown.FacetIds);
 
         PackageQueryRequestFailure duplicate = Rejected(
             PackageQuery.Plan(
@@ -136,6 +156,42 @@ public sealed class PackageQueryTests
                 PackageQuery.NoDependenciesFacetId,
             ],
             incompatible.FacetIds);
+    }
+
+    [Fact]
+    public void Plan_RejectsUnsafeOrExcessiveFacetSelectionsWithoutEchoingThem()
+    {
+        PackageQueryRequestFailure unsafeId = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    ["package.query.\u202Eunsafe"])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.InvalidFacetId,
+            unsafeId.Reason);
+        Assert.Empty(unsafeId.FacetIds);
+
+        PackageQueryRequestFailure longId = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [new string('a', PackageQuery.MaximumFacetIdLength + 1)])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.InvalidFacetId,
+            longId.Reason);
+        Assert.Empty(longId.FacetIds);
+
+        PackageQueryRequestFailure tooMany = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    Enumerable.Repeat(
+                        PackageQuery.ToolFacetId,
+                        PackageQuery.Facets.Length + 1).ToArray())));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.TooManyFacets,
+            tooMany.Reason);
+        Assert.Empty(tooMany.FacetIds);
     }
 
     [Fact]
@@ -325,6 +381,83 @@ public sealed class PackageQueryTests
                 PackageQuery.ToolFacetId,
             ],
             match.Evidence.Select(evidence => evidence.Id));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RejectsCloseFacetNegatives()
+    {
+        await AssertNoMatchesAsync(
+            new FakePackageSource(
+                [Match("Contoso.Downloads", totalDownloads: 999_999)],
+                new Dictionary<string, byte[]>
+                {
+                    ["contoso.downloads@1.0.0"] =
+                        Manifest("Contoso.Downloads"),
+                }),
+            PackageQuery.MillionDownloadsFacetId);
+
+        await AssertNoMatchesAsync(
+            SourceFor(Manifest("Contoso.NoReadme"), "Contoso.NoReadme"),
+            PackageQuery.EmbeddedReadmeFacetId);
+
+        await AssertNoMatchesAsync(
+            SourceFor(
+                Manifest(
+                    "Contoso.BlankReadme",
+                    readme: "<readme> </readme>"),
+                "Contoso.BlankReadme"),
+            PackageQuery.EmbeddedReadmeFacetId);
+
+        await AssertNoMatchesAsync(
+            SourceFor(
+                Manifest(
+                    "Contoso.Dependent",
+                    dependencies:
+                    """
+                    <dependency id="Example.Dependency" version="[1.0.0]" />
+                    """),
+                "Contoso.Dependent"),
+            PackageQuery.NoDependenciesFacetId);
+
+        await AssertNoMatchesAsync(
+            SourceFor(
+                Manifest(
+                    "Contoso.NotTool",
+                    packageTypes:
+                    """
+                    <packageTypes>
+                      <packageType name="DotnetTooling" />
+                    </packageTypes>
+                    """),
+                "Contoso.NotTool"),
+            PackageQuery.ToolFacetId);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MillionDownloadsIncludesExactThreshold()
+    {
+        var source = new FakePackageSource(
+            [Match("Contoso.Downloads", totalDownloads: 1_000_000)],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.downloads@1.0.0"] =
+                    Manifest("Contoso.Downloads"),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.MillionDownloadsFacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Single(events.OfType<PackageQueryEvent.Match>());
     }
 
     [Fact]
@@ -530,6 +663,71 @@ public sealed class PackageQueryTests
         Assert.Equal(0, summary.Matches);
     }
 
+    [Fact]
+    public async Task ExecuteAsync_CountsMalformedCandidateBeforeMatchLimit()
+    {
+        PackageSearchMatch malformed = new(
+            new SearchResult(null!, "1.0.0"),
+            new PackageCandidateObservation(
+                PackageSourceCoordinate.Create(
+                    "Contoso.Malformed",
+                    "1.0.0"),
+                PackageSourceIdentity.NuGetOrg,
+                PackageDiscoveryContract.KeywordSearch,
+                PackageListingState.Listed));
+        var source = new FakePackageSource(
+            [
+                malformed,
+                Match("Contoso.Valid"),
+            ],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.valid@1.0.0"] = Manifest("Contoso.Valid"),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(PackageQueryCompletionKind.MatchLimitReached, summary.Completion);
+        Assert.Equal(2, summary.Candidates);
+        Assert.Equal(1, summary.Failures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExactExhaustionAtMatchLimitIsConservative()
+    {
+        var source = SourceFor(Manifest("Contoso.Package"));
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            PackageQueryCompletionKind.MatchLimitReached,
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1])
+                .Value.Completion);
+        Assert.Single(source.ManifestRequests);
+    }
+
     [Theory]
     [InlineData(
         PackageSearchTruncationReason.SourcePageLimit,
@@ -600,6 +798,35 @@ public sealed class PackageQueryTests
 
         Assert.Single(source.ManifestRequests);
         Assert.Equal(0, source.PackageRequests);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    public async Task ExecuteAsync_CancellationAfterMatchSuppressesCompletion(
+        int maximumMatches)
+    {
+        var source = SourceFor(Manifest("Contoso.Package"));
+        using var cancellation = new CancellationTokenSource();
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: maximumMatches)));
+        await using IAsyncEnumerator<PackageQueryEvent> events =
+            PackageQuery.ExecuteAsync(
+                    source,
+                    plan,
+                    cancellation.Token)
+                .GetAsyncEnumerator(cancellation.Token);
+
+        Assert.True(await events.MoveNextAsync());
+        Assert.IsType<PackageQueryEvent.Match>(events.Current);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await events.MoveNextAsync());
     }
 
     private static PackageQueryPlan Accepted(PackageQueryPlanResult result) =>
@@ -674,6 +901,31 @@ public sealed class PackageQueryTests
         await foreach (PackageQueryEvent item in source)
             events.Add(item);
         return events;
+    }
+
+    private static async Task AssertNoMatchesAsync(
+        FakePackageSource source,
+        string facetId)
+    {
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [facetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Empty(events.OfType<PackageQueryEvent.Match>());
+        Assert.Equal(
+            PackageQueryCompletionKind.Exhausted,
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1])
+                .Value.Completion);
     }
 
     private sealed class FakePackageSource(

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -1,0 +1,789 @@
+using System.Text;
+using InertText;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class PackageQueryTests
+{
+    [Fact]
+    public void FacetDescriptors_HaveStableOrderedIds()
+    {
+        Assert.Equal(
+            [
+                (PackageQuery.VerifiedFacetId, 100),
+                (PackageQuery.ToolFacetId, 200),
+                (PackageQuery.HasDependenciesFacetId, 300),
+                (PackageQuery.NoDependenciesFacetId, 400),
+                (PackageQuery.MillionDownloadsFacetId, 500),
+                (PackageQuery.EmbeddedReadmeFacetId, 600),
+            ],
+            PackageQuery.Facets.Select(facet =>
+                (facet.Id, facet.Weight)));
+        Assert.All(
+            PackageQuery.Facets,
+            facet => Assert.Equal(
+                PackageQueryFacetTier.Nuspec,
+                facet.Tier));
+        Assert.Equal(
+            PackageQuery.DependencySelectionGroupId,
+            PackageQuery.Facets.Single(facet =>
+                facet.Id == PackageQuery.HasDependenciesFacetId)
+                .SelectionGroupId);
+        Assert.Equal(
+            PackageQuery.DependencySelectionGroupId,
+            PackageQuery.Facets.Single(facet =>
+                facet.Id == PackageQuery.NoDependenciesFacetId)
+                .SelectionGroupId);
+    }
+
+    [Theory]
+    [InlineData("", PackageQueryRequestFailureReason.InvalidPrefix)]
+    [InlineData(" Contoso.", PackageQueryRequestFailureReason.InvalidPrefix)]
+    [InlineData("\u202EContoso.", PackageQueryRequestFailureReason.InvalidPrefix)]
+    [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidCandidateLimit, 0, 1)]
+    [InlineData("Contoso.", PackageQueryRequestFailureReason.InvalidMatchLimit, 1, 0)]
+    public void Plan_RejectsInvalidScopeAndBoundsWithoutThrowing(
+        string prefix,
+        PackageQueryRequestFailureReason expected,
+        int maximumCandidates = 1,
+        int maximumMatches = 1)
+    {
+        PackageQueryPlanResult result = PackageQuery.Plan(
+            new PackageQueryRequest(
+                prefix,
+                MaximumCandidates: maximumCandidates,
+                MaximumMatches: maximumMatches));
+
+        Assert.Equal(
+            expected,
+            Assert.IsType<PackageQueryPlanResult.Rejected>(result)
+                .Failure.Reason);
+    }
+
+    [Fact]
+    public void Plan_AcceptsScopeOnlyQuery()
+    {
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(new PackageQueryRequest("Contoso.")));
+
+        Assert.Empty(plan.Facets);
+        Assert.Equal("Contoso.", plan.Prefix.ToString());
+        Assert.Equal(PackageQuery.DefaultMaximumCandidates, plan.MaximumCandidates);
+        Assert.Equal(PackageQuery.DefaultMaximumMatches, plan.MaximumMatches);
+    }
+
+    [Fact]
+    public void Plan_AcceptsMatchLimitAboveCandidateLimit()
+    {
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 50)));
+
+        Assert.Equal(50, plan.MaximumCandidates);
+        Assert.Equal(PackageQuery.DefaultMaximumMatches, plan.MaximumMatches);
+    }
+
+    [Fact]
+    public void Plan_RejectsInvalidUnknownDuplicateAndIncompatibleFacets()
+    {
+        PackageQueryRequestFailure invalid = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest("Contoso.", [""])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.InvalidFacetId,
+            invalid.Reason);
+
+        PackageQueryRequestFailure unknown = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    ["package.query.unknown"])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.UnknownFacet,
+            unknown.Reason);
+        Assert.Equal(["package.query.unknown"], unknown.FacetIds);
+
+        PackageQueryRequestFailure duplicate = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [
+                        PackageQuery.ToolFacetId,
+                        PackageQuery.ToolFacetId,
+                    ])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.DuplicateFacet,
+            duplicate.Reason);
+        Assert.Equal([PackageQuery.ToolFacetId], duplicate.FacetIds);
+
+        PackageQueryRequestFailure incompatible = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [
+                        PackageQuery.NoDependenciesFacetId,
+                        PackageQuery.HasDependenciesFacetId,
+                    ])));
+        Assert.Equal(
+            PackageQueryRequestFailureReason.IncompatibleFacets,
+            incompatible.Reason);
+        Assert.Equal(
+            [
+                PackageQuery.HasDependenciesFacetId,
+                PackageQuery.NoDependenciesFacetId,
+            ],
+            incompatible.FacetIds);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FiltersBeforeMatchLimitAndStopsManifestAcquisition()
+    {
+        PackageSearchMatch[] candidates =
+        [
+            Match("Contoso.One", verified: false),
+            Match("Contoso.Two", verified: true),
+            Match("Contoso.Three", verified: false),
+            Match("Contoso.Four", verified: false),
+            Match("Contoso.Five", verified: true),
+            Match("Contoso.Six", verified: true),
+        ];
+        var source = new FakePackageSource(
+            candidates,
+            candidates.ToDictionary(
+                candidate =>
+                    $"{candidate.Metadata.Id.ToLowerInvariant()}@1.0.0",
+                candidate => Manifest(candidate.Metadata.Id)));
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.VerifiedFacetId],
+                    MaximumCandidates: 6,
+                    MaximumMatches: 2)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            ["Contoso.Two", "Contoso.Five"],
+            events.OfType<PackageQueryEvent.Match>()
+                .Select(item => item.Value.Package.PackageId));
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(PackageQueryCompletionKind.MatchLimitReached, summary.Completion);
+        Assert.Equal(5, summary.Candidates);
+        Assert.Equal(2, summary.Matches);
+        Assert.Equal(5, source.ManifestRequests.Count);
+        Assert.Equal(6, source.LastSearchTake);
+        Assert.Equal(0, source.PackageRequests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmitsProductOrderedEvidenceForEverySelectedFacet()
+    {
+        var source = new FakePackageSource(
+            [
+                Match(
+                    "Contoso.Tool",
+                    verified: true,
+                    totalDownloads: 1_500_000),
+            ],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.tool@1.0.0"] = Manifest(
+                    "Contoso.Tool",
+                    dependencies:
+                    """
+                    <group targetFramework="net8.0">
+                      <dependency id="Example.Dependency" version="[1.0.0]" />
+                    </group>
+                    """,
+                    packageTypes:
+                    """
+                    <packageTypes>
+                      <packageType name="DotnetTool" />
+                    </packageTypes>
+                    """,
+                    readme: "<readme>README.md</readme>"),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [
+                        PackageQuery.EmbeddedReadmeFacetId,
+                        PackageQuery.MillionDownloadsFacetId,
+                        PackageQuery.HasDependenciesFacetId,
+                        PackageQuery.ToolFacetId,
+                        PackageQuery.VerifiedFacetId,
+                    ],
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        PackageQueryMatch match =
+            Assert.IsType<PackageQueryEvent.Match>(events[0]).Value;
+        Assert.Equal(PackageQueryFacetTier.Nuspec, match.Tier);
+        Assert.Equal(
+            [
+                PackageQuery.PrefixEvidenceId,
+                PackageQuery.VerifiedFacetId,
+                PackageQuery.ToolFacetId,
+                PackageQuery.HasDependenciesFacetId,
+                PackageQuery.MillionDownloadsFacetId,
+                PackageQuery.EmbeddedReadmeFacetId,
+            ],
+            match.Evidence.Select(evidence => evidence.Id));
+        Assert.Equal(
+            "Package ID matches prefix \"Contoso.\".",
+            match.Evidence[0].Value);
+        Assert.Contains(
+            "1 dependency across 1 target-framework group.",
+            match.Evidence[3].Value,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "1,500,000 total downloads",
+            match.Evidence[4].Value,
+            StringComparison.Ordinal);
+        Assert.All(
+            match.Evidence,
+            evidence =>
+            {
+                Assert.NotEmpty(evidence.Value);
+                Assert.True(
+                    InertString.IsPermitted(
+                        TextPolicy.Prose,
+                        evidence.Value));
+            });
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RequiresEverySelectedFacet()
+    {
+        var source = new FakePackageSource(
+            [
+                Match("Contoso.Tool", verified: true),
+                Match("Contoso.Library", verified: true),
+                Match("Contoso.UnverifiedTool"),
+            ],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.tool@1.0.0"] = Manifest(
+                    "Contoso.Tool",
+                    packageTypes:
+                    """
+                    <packageTypes>
+                      <packageType name="DotnetTool" />
+                    </packageTypes>
+                    """),
+                ["contoso.library@1.0.0"] = Manifest(
+                    "Contoso.Library"),
+                ["contoso.unverifiedtool@1.0.0"] = Manifest(
+                    "Contoso.UnverifiedTool",
+                    packageTypes:
+                    """
+                    <packageTypes>
+                      <packageType name="DotnetTool" />
+                    </packageTypes>
+                    """),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [
+                        PackageQuery.VerifiedFacetId,
+                        PackageQuery.ToolFacetId,
+                    ],
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        PackageQueryMatch match = Assert.Single(
+            events.OfType<PackageQueryEvent.Match>()).Value;
+        Assert.Equal("Contoso.Tool", match.Package.PackageId);
+        Assert.Equal(
+            [
+                PackageQuery.PrefixEvidenceId,
+                PackageQuery.VerifiedFacetId,
+                PackageQuery.ToolFacetId,
+            ],
+            match.Evidence.Select(evidence => evidence.Id));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ScopeOnlyQueryCarriesNonEmptyScopeEvidence()
+    {
+        var source = SourceFor(Manifest("Contoso.Package"));
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        PackageQueryMatch match =
+            Assert.IsType<PackageQueryEvent.Match>(events[0]).Value;
+        PackageQueryEvidence evidence = Assert.Single(match.Evidence);
+        Assert.Equal(PackageQuery.PrefixEvidenceId, evidence.Id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AllEmptyDependencyGroupsMatchNoDependencies()
+    {
+        byte[] manifest = Manifest(
+            "Contoso.EmptyGroups",
+            dependencies:
+            """
+            <group targetFramework="net8.0"></group>
+            <group targetFramework="net9.0"></group>
+            """);
+
+        var noDependenciesSource = SourceFor(
+            manifest,
+            "Contoso.EmptyGroups");
+        PackageQueryPlan noDependencies = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.NoDependenciesFacetId],
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+        List<PackageQueryEvent> noDependencyEvents = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                noDependenciesSource,
+                noDependencies,
+                TestContext.Current.CancellationToken));
+        Assert.Single(noDependencyEvents.OfType<PackageQueryEvent.Match>());
+
+        var hasDependenciesSource = SourceFor(
+            manifest,
+            "Contoso.EmptyGroups");
+        PackageQueryPlan hasDependencies = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.HasDependenciesFacetId],
+                    MaximumCandidates: 2,
+                    MaximumMatches: 1)));
+        List<PackageQueryEvent> hasDependencyEvents = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                hasDependenciesSource,
+                hasDependencies,
+                TestContext.Current.CancellationToken));
+        Assert.Empty(hasDependencyEvents.OfType<PackageQueryEvent.Match>());
+        Assert.Equal(
+            PackageQueryCompletionKind.Exhausted,
+            Assert.IsType<PackageQueryEvent.Completed>(
+                hasDependencyEvents[^1]).Value.Completion);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PerCandidateFailureDoesNotBecomeTerminalFailure()
+    {
+        var source = new FakePackageSource(
+            [
+                Match("Other.Package"),
+                Match("Contoso.Valid"),
+            ],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.valid@1.0.0"] = Manifest("Contoso.Valid"),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: 2)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Single(events.OfType<PackageQueryEvent.Failure>());
+        Assert.Single(events.OfType<PackageQueryEvent.Match>());
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(PackageQueryCompletionKind.Exhausted, summary.Completion);
+        Assert.Equal(2, summary.Candidates);
+        Assert.Equal(1, summary.Failures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TerminalSearchFailureProducesFailedCompletion()
+    {
+        var source = new FakePackageSource(
+            [],
+            new Dictionary<string, byte[]>())
+        {
+            SearchFailure = new PackageSourceFailure(
+                PackageSourceIdentity.NuGetOrg,
+                PackageSourceKind.NuGetGallery,
+                PackageSourceCapabilities.Search,
+                Coordinate: null,
+                PackageSourceFailureKind.Timeout,
+                "The package source operation exceeded its configured deadline."),
+        };
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(new PackageQueryRequest("Contoso.")));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Single(events.OfType<PackageQueryEvent.Failure>());
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(PackageQueryCompletionKind.Failed, summary.Completion);
+        Assert.Equal(0, summary.Candidates);
+        Assert.Equal(1, summary.Failures);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TerminalSearchContractFailureProducesFailedCompletion()
+    {
+        var source = new FakePackageSource(
+            [
+                Match("Contoso.One"),
+                Match("Contoso.Two"),
+            ],
+            new Dictionary<string, byte[]>());
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        PackageProfileFailure failure =
+            Assert.IsType<PackageQueryEvent.Failure>(events[0]).Value;
+        Assert.Equal(PackageProfileFailureKind.SearchContract, failure.Kind);
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(PackageQueryCompletionKind.Failed, summary.Completion);
+        Assert.Equal(0, summary.Candidates);
+        Assert.Equal(1, summary.Failures);
+        Assert.Empty(source.ManifestRequests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PreservesCandidateLimitAfterFiltering()
+    {
+        var source = SourceFor(
+            Manifest("Contoso.Library"),
+            "Contoso.Library",
+            PackageSearchTruncationReason.RequestedLimit);
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolFacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Empty(events.OfType<PackageQueryEvent.Match>());
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(
+            PackageQueryCompletionKind.CandidateLimitReached,
+            summary.Completion);
+        Assert.Equal(1, summary.Candidates);
+        Assert.Equal(0, summary.Matches);
+    }
+
+    [Theory]
+    [InlineData(
+        PackageSearchTruncationReason.SourcePageLimit,
+        PackageQueryCompletionKind.SourcePageLimitReached)]
+    [InlineData(
+        PackageSearchTruncationReason.ClientPageLimit,
+        PackageQueryCompletionKind.ClientPageLimitReached)]
+    public async Task ExecuteAsync_PreservesPaginationCompletion(
+        PackageSearchTruncationReason truncationReason,
+        PackageQueryCompletionKind expected)
+    {
+        var source = SourceFor(
+            Manifest("Contoso.Package"),
+            truncationReason: truncationReason);
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 2,
+                    MaximumMatches: 2)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            expected,
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1])
+                .Value.Completion);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancellationStopsFurtherManifestWork()
+    {
+        var source = new FakePackageSource(
+            [
+                Match("Contoso.One"),
+                Match("Contoso.Two"),
+                Match("Contoso.Three"),
+            ],
+            new Dictionary<string, byte[]>
+            {
+                ["contoso.one@1.0.0"] = Manifest("Contoso.One"),
+                ["contoso.two@1.0.0"] = Manifest("Contoso.Two"),
+                ["contoso.three@1.0.0"] = Manifest("Contoso.Three"),
+            });
+        using var cancellation = new CancellationTokenSource();
+        source.OnManifestRequest = count =>
+        {
+            if (count == 1)
+                cancellation.Cancel();
+        };
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => CollectAsync(
+                PackageQuery.ExecuteAsync(
+                    source,
+                    plan,
+                    cancellation.Token)));
+
+        Assert.Single(source.ManifestRequests);
+        Assert.Equal(0, source.PackageRequests);
+    }
+
+    private static PackageQueryPlan Accepted(PackageQueryPlanResult result) =>
+        Assert.IsType<PackageQueryPlanResult.Accepted>(result).Plan;
+
+    private static PackageQueryRequestFailure Rejected(
+        PackageQueryPlanResult result) =>
+        Assert.IsType<PackageQueryPlanResult.Rejected>(result).Failure;
+
+    private static PackageSearchMatch Match(
+        string packageId,
+        string version = "1.0.0",
+        bool verified = false,
+        long totalDownloads = 0)
+    {
+        PackageSourceCoordinate coordinate =
+            PackageSourceCoordinate.Create(packageId, version);
+        return new PackageSearchMatch(
+            new SearchResult(
+                packageId,
+                version,
+                TotalDownloads: totalDownloads,
+                Verified: verified),
+            new PackageCandidateObservation(
+                coordinate,
+                PackageSourceIdentity.NuGetOrg,
+                PackageDiscoveryContract.KeywordSearch,
+                PackageListingState.Listed));
+    }
+
+    private static FakePackageSource SourceFor(
+        byte[] manifest,
+        string packageId = "Contoso.Package",
+        PackageSearchTruncationReason truncationReason =
+            PackageSearchTruncationReason.None) =>
+        new(
+            [Match(packageId)],
+            new Dictionary<string, byte[]>
+            {
+                [$"{packageId.ToLowerInvariant()}@1.0.0"] = manifest,
+            })
+        {
+            SearchTruncationReason = truncationReason,
+        };
+
+    private static byte[] Manifest(
+        string packageId,
+        string version = "1.0.0",
+        string dependencies = "",
+        string packageTypes = "",
+        string readme = "") =>
+        Encoding.UTF8.GetBytes(
+            $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+              <metadata>
+                <id>{{packageId}}</id>
+                <version>{{version}}</version>
+                <authors>Manifest Author</authors>
+                <description>Package query test.</description>
+                {{packageTypes}}
+                {{readme}}
+                <dependencies>{{dependencies}}</dependencies>
+              </metadata>
+            </package>
+            """);
+
+    private static async Task<List<PackageQueryEvent>> CollectAsync(
+        IAsyncEnumerable<PackageQueryEvent> source)
+    {
+        List<PackageQueryEvent> events = [];
+        await foreach (PackageQueryEvent item in source)
+            events.Add(item);
+        return events;
+    }
+
+    private sealed class FakePackageSource(
+        IReadOnlyList<PackageSearchMatch> matches,
+        IReadOnlyDictionary<string, byte[]> manifests)
+        : IPackageSourceClient
+    {
+        public PackageSourceFailure? SearchFailure { get; init; }
+        public PackageSearchTruncationReason SearchTruncationReason
+        {
+            get;
+            init;
+        }
+        public Action<int>? OnManifestRequest { get; set; }
+        public List<string> ManifestRequests { get; } = [];
+        public int LastSearchTake { get; private set; }
+        public int PackageRequests { get; private set; }
+        public PackageSourceIdentity Identity => PackageSourceIdentity.NuGetOrg;
+        public PackageSourceKind Kind => PackageSourceKind.NuGetGallery;
+        public PackageSourceCapabilities Capabilities =>
+            PackageSourceCapabilities.Search
+            | PackageSourceCapabilities.Manifest;
+
+        public Task<PackageSourceOperationResult<PackageSearchResult>>
+            SearchByPrefixAsync(
+                string prefix,
+                int take = 100,
+                bool prerelease = false,
+                CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastSearchTake = take;
+            PackageSourceOperationResult<PackageSearchResult> result =
+                SearchFailure is null
+                    ? new PackageSourceOperationResult<PackageSearchResult>
+                        .Succeeded(
+                            new PackageSearchResult(
+                                matches,
+                                SearchTruncationReason))
+                    : new PackageSourceOperationResult<PackageSearchResult>
+                        .Failed(SearchFailure);
+            return Task.FromResult(result);
+        }
+
+        public Task<PackageSourceOperationResult<PackageSourceManifest>>
+            GetManifestAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            PackageSourceCoordinate coordinate =
+                PackageSourceCoordinate.Create(packageId, version);
+            string key = $"{coordinate.PackageId}@{coordinate.Version}";
+            ManifestRequests.Add(key);
+            OnManifestRequest?.Invoke(ManifestRequests.Count);
+            PackageSourceOperationResult<PackageSourceManifest> result =
+                manifests.TryGetValue(key, out byte[]? content)
+                    ? new PackageSourceOperationResult<PackageSourceManifest>
+                        .Succeeded(
+                            new PackageSourceManifest(
+                                coordinate,
+                                Identity,
+                                Kind,
+                                content))
+                    : new PackageSourceOperationResult<PackageSourceManifest>
+                        .Failed(
+                            new PackageSourceFailure(
+                                Identity,
+                                Kind,
+                                PackageSourceCapabilities.Manifest,
+                                coordinate,
+                                PackageSourceFailureKind.NotFound,
+                                "The requested payload was not found at the package source."));
+            return Task.FromResult(result);
+        }
+
+        public Task<PackageSourceOperationResult<PackageSearchResult>>
+            SearchAsync(
+                string query,
+                int take = 20,
+                bool prerelease = false,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<PackageSourceOperationResult<PackageVersionResult>>
+            GetVersionsAsync(
+                string packageId,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<PackageSourceOperationResult<PackageSourcePayload>>
+            GetPackageAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default)
+        {
+            PackageRequests++;
+            throw new NotSupportedException();
+        }
+
+        public Task<PackageSourceOperationResult<PackageSourcePayload>>
+            TryGetSymbolsAsync(
+                string packageId,
+                string version,
+                CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -43,16 +43,20 @@ public enum PackageQueryRequestFailureReason
     InvalidPrefix,
     InvalidCandidateLimit,
     InvalidMatchLimit,
+    TooManyFacets,
     InvalidFacetId,
     UnknownFacet,
     DuplicateFacet,
     IncompatibleFacets,
 }
 
-/// <summary>A typed, content-free package-query planning failure.</summary>
+/// <summary>
+/// A typed, content-safe package-query planning failure. Returned facet IDs
+/// are always product-issued.
+/// </summary>
 public sealed record PackageQueryRequestFailure
 {
-    public PackageQueryRequestFailure(
+    internal PackageQueryRequestFailure(
         PackageQueryRequestFailureReason reason,
         IEnumerable<string>? facetIds = null,
         int? value = null)
@@ -74,6 +78,8 @@ public sealed record PackageQueryRequestFailure
             $"The package-query candidate limit must be between 1 and {PackageProfileQuery.MaximumPackageLimit}.",
         PackageQueryRequestFailureReason.InvalidMatchLimit =>
             $"The package-query match limit must be between 1 and {PackageProfileQuery.MaximumPackageLimit}.",
+        PackageQueryRequestFailureReason.TooManyFacets =>
+            "The package-query request selected more facets than the product offers.",
         PackageQueryRequestFailureReason.InvalidFacetId =>
             "A package-query facet ID is empty or invalid.",
         PackageQueryRequestFailureReason.UnknownFacet =>
@@ -191,6 +197,7 @@ public static class PackageQuery
 {
     public const int DefaultMaximumCandidates = 200;
     public const int DefaultMaximumMatches = 100;
+    public const int MaximumFacetIdLength = 100;
 
     public const string PrefixEvidenceId = "package.query.scope.prefix";
     public const string VerifiedFacetId = "package.query.source-verified";
@@ -321,11 +328,26 @@ public static class PackageQuery
                 value: request.MaximumMatches);
         }
 
-        ImmutableArray<string> requestedIds =
-            request.FacetIds is null ? [] : [.. request.FacetIds];
-        if (requestedIds.Any(string.IsNullOrWhiteSpace))
+        IReadOnlyCollection<string> requested =
+            request.FacetIds ?? [];
+        if (requested.Count > Definitions.Length)
+        {
+            return Rejected(PackageQueryRequestFailureReason.TooManyFacets);
+        }
+
+        if (requested.Any(id =>
+            string.IsNullOrWhiteSpace(id)
+            || id.Length > MaximumFacetIdLength
+            || !InertString.IsPermitted(TextPolicy.Field, id)))
         {
             return Rejected(PackageQueryRequestFailureReason.InvalidFacetId);
+        }
+
+        ImmutableArray<string> requestedIds = [.. requested];
+        var selectedIds = requestedIds.ToHashSet(StringComparer.Ordinal);
+        if (selectedIds.Any(id => !DefinitionsById.ContainsKey(id)))
+        {
+            return Rejected(PackageQueryRequestFailureReason.UnknownFacet);
         }
 
         var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -341,20 +363,6 @@ public static class PackageQuery
             return Rejected(
                 PackageQueryRequestFailureReason.DuplicateFacet,
                 duplicates);
-        }
-
-        var selectedIds = requestedIds.ToHashSet(StringComparer.Ordinal);
-        string[] unknown =
-        [
-            .. selectedIds
-                .Where(id => !DefinitionsById.ContainsKey(id))
-                .Order(StringComparer.Ordinal),
-        ];
-        if (unknown.Length > 0)
-        {
-            return Rejected(
-                PackageQueryRequestFailureReason.UnknownFacet,
-                unknown);
         }
 
         ImmutableArray<PackageQueryFacetDefinition> selected =
@@ -418,6 +426,7 @@ public static class PackageQuery
         int candidates = 0;
         int matches = 0;
         int failures = 0;
+        cancellationToken.ThrowIfCancellationRequested();
         await foreach (PackageProfileEvent profileEvent
             in PackageProfileQuery.ExecuteAsync(
                 source,
@@ -427,6 +436,7 @@ public static class PackageQuery
                     plan.IncludePrerelease),
                 cancellationToken).ConfigureAwait(false))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             switch (profileEvent)
             {
                 case PackageProfileEvent.Match match:
@@ -440,6 +450,7 @@ public static class PackageQuery
                             match.Value,
                             PackageQueryFacetTier.Nuspec,
                             evidence));
+                    cancellationToken.ThrowIfCancellationRequested();
                     if (matches >= plan.MaximumMatches)
                     {
                         yield return Completed(
@@ -455,7 +466,8 @@ public static class PackageQuery
 
                 case PackageProfileEvent.Failure failure:
                     failures++;
-                    if (failure.Value.PackageId is not null)
+                    if (failure.Value.Kind
+                        is not PackageProfileFailureKind.Search)
                     {
                         candidates++;
                     }

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -1,0 +1,568 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using InertText;
+using NuGetFetch;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>The production envelope in which a package-query facet is available.</summary>
+public enum PackageQueryFacetTier
+{
+    Nuspec,
+}
+
+/// <summary>One product-owned package-query facet.</summary>
+/// <param name="Id">Stable opaque identity submitted by consumers without interpretation.</param>
+/// <param name="Label">User-facing label.</param>
+/// <param name="Summary">Short explanation of the predicate.</param>
+/// <param name="Weight">Producer-owned display order; this is not result ranking.</param>
+/// <param name="Tier">The production envelope in which the facet is available.</param>
+/// <param name="SelectionGroupId">
+/// Optional opaque identity shared by facets that cannot be selected together.
+/// </param>
+public sealed record PackageQueryFacetDescriptor(
+    string Id,
+    string Label,
+    string Summary,
+    int Weight,
+    PackageQueryFacetTier Tier,
+    string? SelectionGroupId = null);
+
+/// <summary>A bounded package-query request over one package-ID prefix.</summary>
+public sealed record PackageQueryRequest(
+    string Prefix,
+    IReadOnlyCollection<string>? FacetIds = null,
+    int MaximumCandidates = PackageQuery.DefaultMaximumCandidates,
+    int MaximumMatches = PackageQuery.DefaultMaximumMatches,
+    bool IncludePrerelease = false);
+
+/// <summary>Why a package-query request could not become an executable plan.</summary>
+public enum PackageQueryRequestFailureReason
+{
+    InvalidPrefix,
+    InvalidCandidateLimit,
+    InvalidMatchLimit,
+    InvalidFacetId,
+    UnknownFacet,
+    DuplicateFacet,
+    IncompatibleFacets,
+}
+
+/// <summary>A typed, content-free package-query planning failure.</summary>
+public sealed record PackageQueryRequestFailure
+{
+    public PackageQueryRequestFailure(
+        PackageQueryRequestFailureReason reason,
+        IEnumerable<string>? facetIds = null,
+        int? value = null)
+    {
+        Reason = reason;
+        FacetIds = facetIds is null ? [] : [.. facetIds];
+        Value = value;
+    }
+
+    public PackageQueryRequestFailureReason Reason { get; }
+    public ImmutableArray<string> FacetIds { get; }
+    public int? Value { get; }
+
+    public string Message => Reason switch
+    {
+        PackageQueryRequestFailureReason.InvalidPrefix =>
+            "The package-query prefix is invalid.",
+        PackageQueryRequestFailureReason.InvalidCandidateLimit =>
+            $"The package-query candidate limit must be between 1 and {PackageProfileQuery.MaximumPackageLimit}.",
+        PackageQueryRequestFailureReason.InvalidMatchLimit =>
+            $"The package-query match limit must be between 1 and {PackageProfileQuery.MaximumPackageLimit}.",
+        PackageQueryRequestFailureReason.InvalidFacetId =>
+            "A package-query facet ID is empty or invalid.",
+        PackageQueryRequestFailureReason.UnknownFacet =>
+            "One or more package-query facet IDs are unknown.",
+        PackageQueryRequestFailureReason.DuplicateFacet =>
+            "A package-query facet ID was selected more than once.",
+        PackageQueryRequestFailureReason.IncompatibleFacets =>
+            "The selected package-query facets cannot be combined.",
+        _ => "The package-query request is invalid.",
+    };
+}
+
+/// <summary>The result of validating and lowering one package-query request.</summary>
+public abstract record PackageQueryPlanResult
+{
+    private PackageQueryPlanResult()
+    {
+    }
+
+    public sealed record Accepted(PackageQueryPlan Plan) : PackageQueryPlanResult;
+    public sealed record Rejected(PackageQueryRequestFailure Failure) : PackageQueryPlanResult;
+}
+
+/// <summary>
+/// One validated package-query plan. Construction is product-owned so execution
+/// cannot receive unknown or incompatible facet identities.
+/// </summary>
+public sealed class PackageQueryPlan
+{
+    internal PackageQueryPlan(
+        InertString prefix,
+        InertString prefixEvidence,
+        ImmutableArray<PackageQueryFacetDefinition> definitions,
+        int maximumCandidates,
+        int maximumMatches,
+        bool includePrerelease)
+    {
+        Prefix = prefix;
+        PrefixEvidence = prefixEvidence;
+        Definitions = definitions;
+        Facets = [.. definitions.Select(definition => definition.Descriptor)];
+        MaximumCandidates = maximumCandidates;
+        MaximumMatches = maximumMatches;
+        IncludePrerelease = includePrerelease;
+    }
+
+    public InertString Prefix { get; }
+    public ImmutableArray<PackageQueryFacetDescriptor> Facets { get; }
+    public int MaximumCandidates { get; }
+    public int MaximumMatches { get; }
+    public bool IncludePrerelease { get; }
+
+    internal InertString PrefixEvidence { get; }
+    internal ImmutableArray<PackageQueryFacetDefinition> Definitions { get; }
+}
+
+/// <summary>One product-authored explanation for a package-query match.</summary>
+public sealed record PackageQueryEvidence(
+    string Id,
+    InertString Text)
+{
+    public string Value => Text.ToString();
+}
+
+/// <summary>One package that satisfied every selected package-query facet.</summary>
+public sealed record PackageQueryMatch(
+    PackageProfileMatch Package,
+    PackageQueryFacetTier Tier,
+    ImmutableArray<PackageQueryEvidence> Evidence);
+
+/// <summary>Why one package-query stream stopped.</summary>
+public enum PackageQueryCompletionKind
+{
+    Exhausted,
+    MatchLimitReached,
+    CandidateLimitReached,
+    SourcePageLimitReached,
+    ClientPageLimitReached,
+    Failed,
+}
+
+/// <summary>Terminal accounting for one package-query stream.</summary>
+public sealed record PackageQuerySummary(
+    InertString Prefix,
+    PackageSourceIdentity Producer,
+    int CandidateLimit,
+    int MatchLimit,
+    int Candidates,
+    int Matches,
+    int Failures,
+    PackageQueryCompletionKind Completion);
+
+/// <summary>One event from a package-query stream.</summary>
+public abstract record PackageQueryEvent
+{
+    private PackageQueryEvent()
+    {
+    }
+
+    public sealed record Match(PackageQueryMatch Value) : PackageQueryEvent;
+    public sealed record Failure(PackageProfileFailure Value) : PackageQueryEvent;
+    public sealed record Completed(PackageQuerySummary Value) : PackageQueryEvent;
+}
+
+internal sealed record PackageQueryFacetDefinition(
+    PackageQueryFacetDescriptor Descriptor,
+    Func<PackageProfileMatch, bool> Matches,
+    Func<PackageProfileMatch, InertString> Evidence);
+
+/// <summary>
+/// Plans and executes product-owned nuspec-tier facets over a bounded package
+/// profile without acquiring package archives or assemblies.
+/// </summary>
+public static class PackageQuery
+{
+    public const int DefaultMaximumCandidates = 200;
+    public const int DefaultMaximumMatches = 100;
+
+    public const string PrefixEvidenceId = "package.query.scope.prefix";
+    public const string VerifiedFacetId = "package.query.source-verified";
+    public const string ToolFacetId = "package.query.dotnet-tool";
+    public const string HasDependenciesFacetId = "package.query.has-dependencies";
+    public const string NoDependenciesFacetId = "package.query.no-dependencies";
+    public const string MillionDownloadsFacetId = "package.query.downloads-1m";
+    public const string EmbeddedReadmeFacetId = "package.query.embedded-readme";
+    public const string DependencySelectionGroupId = "package.query.dependencies";
+
+    static readonly ImmutableArray<PackageQueryFacetDefinition> Definitions =
+    [
+        new(
+            new PackageQueryFacetDescriptor(
+                VerifiedFacetId,
+                "source verified",
+                "The package source reports a verified package identity.",
+                100,
+                PackageQueryFacetTier.Nuspec),
+            static match => match.Verified,
+            static _ => Evidence(
+                "The package source reports this package as verified.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                ToolFacetId,
+                ".NET tool",
+                "The package manifest declares the .NET tool package type.",
+                200,
+                PackageQueryFacetTier.Nuspec),
+            static match => match.Manifest.IsToolPackage,
+            static _ => Evidence(
+                "The package manifest declares a .NET tool package.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                HasDependenciesFacetId,
+                "has dependencies",
+                "The package manifest declares at least one dependency.",
+                300,
+                PackageQueryFacetTier.Nuspec,
+                DependencySelectionGroupId),
+            static match => DependencyCount(match) > 0,
+            static match =>
+            {
+                int dependencies = DependencyCount(match);
+                int groups = NonEmptyDependencyGroupCount(match);
+                return Evidence(
+                    $"The package manifest declares {dependencies.ToString(CultureInfo.InvariantCulture)} "
+                    + $"{Pluralize(dependencies, "dependency", "dependencies")} across "
+                    + $"{groups.ToString(CultureInfo.InvariantCulture)} target-framework "
+                    + $"{Pluralize(groups, "group", "groups")}.");
+            }),
+        new(
+            new PackageQueryFacetDescriptor(
+                NoDependenciesFacetId,
+                "no dependencies",
+                "The package manifest declares no dependencies.",
+                400,
+                PackageQueryFacetTier.Nuspec,
+                DependencySelectionGroupId),
+            static match => DependencyCount(match) == 0,
+            static _ => Evidence(
+                "The package manifest declares no dependencies.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                MillionDownloadsFacetId,
+                "1M+ downloads",
+                "The package source reports at least one million total downloads.",
+                500,
+                PackageQueryFacetTier.Nuspec),
+            static match => match.TotalDownloads >= 1_000_000,
+            static match => Evidence(
+                $"The package source reports {match.TotalDownloads.ToString("N0", CultureInfo.InvariantCulture)} total downloads.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                EmbeddedReadmeFacetId,
+                "embedded README",
+                "The package manifest declares an embedded README file.",
+                600,
+                PackageQueryFacetTier.Nuspec),
+            static match => !string.IsNullOrWhiteSpace(
+                match.Manifest.ReadmeFile),
+            static _ => Evidence(
+                "The package manifest declares an embedded README file.")),
+    ];
+
+    static readonly IReadOnlyDictionary<string, PackageQueryFacetDefinition>
+        DefinitionsById = Definitions.ToDictionary(
+            definition => definition.Descriptor.Id,
+            StringComparer.Ordinal);
+
+    /// <summary>
+    /// The complete ordered facet vocabulary. The literal ID set is gated by
+    /// <c>FacetDescriptors_HaveStableOrderedIds</c>.
+    /// </summary>
+    public static ImmutableArray<PackageQueryFacetDescriptor> Facets { get; } =
+        [.. Definitions.Select(definition => definition.Descriptor)];
+
+    /// <summary>
+    /// Validates and lowers a request without throwing for user-controlled
+    /// prefix, bound, or facet values.
+    /// </summary>
+    public static PackageQueryPlanResult Plan(PackageQueryRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string prefixEvidence =
+            $"Package ID matches prefix \"{request.Prefix}\".";
+        if (!PackageProfileQuery.IsValidPrefix(request.Prefix)
+            || !InertString.IsPermitted(TextPolicy.Prose, request.Prefix)
+            || !InertString.IsPermitted(TextPolicy.Prose, prefixEvidence))
+        {
+            return Rejected(PackageQueryRequestFailureReason.InvalidPrefix);
+        }
+
+        if (request.MaximumCandidates
+            is <= 0 or > PackageProfileQuery.MaximumPackageLimit)
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason.InvalidCandidateLimit,
+                value: request.MaximumCandidates);
+        }
+
+        if (request.MaximumMatches
+            is <= 0 or > PackageProfileQuery.MaximumPackageLimit)
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason.InvalidMatchLimit,
+                value: request.MaximumMatches);
+        }
+
+        ImmutableArray<string> requestedIds =
+            request.FacetIds is null ? [] : [.. request.FacetIds];
+        if (requestedIds.Any(string.IsNullOrWhiteSpace))
+        {
+            return Rejected(PackageQueryRequestFailureReason.InvalidFacetId);
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        string[] duplicates =
+        [
+            .. requestedIds
+                .Where(id => !seen.Add(id))
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+        if (duplicates.Length > 0)
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason.DuplicateFacet,
+                duplicates);
+        }
+
+        var selectedIds = requestedIds.ToHashSet(StringComparer.Ordinal);
+        string[] unknown =
+        [
+            .. selectedIds
+                .Where(id => !DefinitionsById.ContainsKey(id))
+                .Order(StringComparer.Ordinal),
+        ];
+        if (unknown.Length > 0)
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason.UnknownFacet,
+                unknown);
+        }
+
+        ImmutableArray<PackageQueryFacetDefinition> selected =
+        [
+            .. Definitions.Where(definition =>
+                selectedIds.Contains(definition.Descriptor.Id)),
+        ];
+        IGrouping<string, PackageQueryFacetDefinition>? incompatible =
+            selected
+                .Where(definition =>
+                    definition.Descriptor.SelectionGroupId is not null)
+                .GroupBy(definition =>
+                    definition.Descriptor.SelectionGroupId!,
+                    StringComparer.Ordinal)
+                .FirstOrDefault(group => group.Skip(1).Any());
+        if (incompatible is not null)
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason.IncompatibleFacets,
+                incompatible.Select(definition =>
+                    definition.Descriptor.Id));
+        }
+
+        return new PackageQueryPlanResult.Accepted(
+            new PackageQueryPlan(
+                Evidence(request.Prefix),
+                Evidence(prefixEvidence),
+                selected,
+                request.MaximumCandidates,
+                request.MaximumMatches,
+                request.IncludePrerelease));
+    }
+
+    /// <summary>Executes and materializes one validated package query.</summary>
+    public static async ValueTask<ImmutableArray<PackageQueryEvent>>
+        ExecuteToArrayAsync(
+            IPackageSourceClient source,
+            PackageQueryPlan plan,
+            CancellationToken cancellationToken = default)
+    {
+        var events = ImmutableArray.CreateBuilder<PackageQueryEvent>();
+        await foreach (PackageQueryEvent queryEvent in ExecuteAsync(
+            source,
+            plan,
+            cancellationToken).ConfigureAwait(false))
+        {
+            events.Add(queryEvent);
+        }
+
+        return events.ToImmutable();
+    }
+
+    public static async IAsyncEnumerable<PackageQueryEvent> ExecuteAsync(
+        IPackageSourceClient source,
+        PackageQueryPlan plan,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(plan);
+
+        int candidates = 0;
+        int matches = 0;
+        int failures = 0;
+        await foreach (PackageProfileEvent profileEvent
+            in PackageProfileQuery.ExecuteAsync(
+                source,
+                new PackagePrefixProfileRequest(
+                    plan.Prefix.ToString(),
+                    plan.MaximumCandidates,
+                    plan.IncludePrerelease),
+                cancellationToken).ConfigureAwait(false))
+        {
+            switch (profileEvent)
+            {
+                case PackageProfileEvent.Match match:
+                    candidates++;
+                    if (!TryMatch(plan, match.Value, out var evidence))
+                        continue;
+
+                    matches++;
+                    yield return new PackageQueryEvent.Match(
+                        new PackageQueryMatch(
+                            match.Value,
+                            PackageQueryFacetTier.Nuspec,
+                            evidence));
+                    if (matches >= plan.MaximumMatches)
+                    {
+                        yield return Completed(
+                            plan,
+                            source.Identity,
+                            candidates,
+                            matches,
+                            failures,
+                            PackageQueryCompletionKind.MatchLimitReached);
+                        yield break;
+                    }
+                    break;
+
+                case PackageProfileEvent.Failure failure:
+                    failures++;
+                    if (failure.Value.PackageId is not null)
+                    {
+                        candidates++;
+                    }
+
+                    yield return new PackageQueryEvent.Failure(failure.Value);
+                    break;
+
+                case PackageProfileEvent.Completed completed:
+                    yield return Completed(
+                        plan,
+                        completed.Value.Producer,
+                        completed.Value.Candidates,
+                        matches,
+                        completed.Value.Failures,
+                        completed.Value.Candidates == 0
+                            && completed.Value.Failures > 0
+                            ? PackageQueryCompletionKind.Failed
+                            : MapCompletion(
+                                completed.Value.TruncationReason));
+                    yield break;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "The package profile stream ended without a completion event.");
+    }
+
+    static bool TryMatch(
+        PackageQueryPlan plan,
+        PackageProfileMatch match,
+        out ImmutableArray<PackageQueryEvidence> evidence)
+    {
+        var builder = ImmutableArray.CreateBuilder<PackageQueryEvidence>(
+            plan.Definitions.Length + 1);
+        builder.Add(
+            new PackageQueryEvidence(
+                PrefixEvidenceId,
+                plan.PrefixEvidence));
+        foreach (PackageQueryFacetDefinition definition in plan.Definitions)
+        {
+            if (!definition.Matches(match))
+            {
+                evidence = [];
+                return false;
+            }
+
+            builder.Add(
+                new PackageQueryEvidence(
+                    definition.Descriptor.Id,
+                    definition.Evidence(match)));
+        }
+
+        evidence = builder.MoveToImmutable();
+        return true;
+    }
+
+    static int DependencyCount(PackageProfileMatch match) =>
+        match.Manifest.DependencyGroups.Sum(group =>
+            group.Dependencies.Length);
+
+    static int NonEmptyDependencyGroupCount(PackageProfileMatch match) =>
+        match.Manifest.DependencyGroups.Count(group =>
+            !group.Dependencies.IsEmpty);
+
+    static string Pluralize(int count, string singular, string plural) =>
+        count == 1 ? singular : plural;
+
+    static InertString Evidence(string value) =>
+        new(TextPolicy.Prose, value);
+
+    static PackageQueryEvent.Completed Completed(
+        PackageQueryPlan plan,
+        PackageSourceIdentity producer,
+        int candidates,
+        int matches,
+        int failures,
+        PackageQueryCompletionKind completion) =>
+        new(
+            new PackageQuerySummary(
+                plan.Prefix,
+                producer,
+                plan.MaximumCandidates,
+                plan.MaximumMatches,
+                candidates,
+                matches,
+                failures,
+                completion));
+
+    static PackageQueryCompletionKind MapCompletion(
+        PackageSearchTruncationReason reason) =>
+        reason switch
+        {
+            PackageSearchTruncationReason.None =>
+                PackageQueryCompletionKind.Exhausted,
+            PackageSearchTruncationReason.RequestedLimit =>
+                PackageQueryCompletionKind.CandidateLimitReached,
+            PackageSearchTruncationReason.SourcePageLimit =>
+                PackageQueryCompletionKind.SourcePageLimitReached,
+            PackageSearchTruncationReason.ClientPageLimit =>
+                PackageQueryCompletionKind.ClientPageLimitReached,
+            _ => throw new InvalidOperationException(
+                "Unknown package search truncation reason."),
+        };
+
+    static PackageQueryPlanResult.Rejected Rejected(
+        PackageQueryRequestFailureReason reason,
+        IEnumerable<string>? facetIds = null,
+        int? value = null) =>
+        new(new PackageQueryRequestFailure(reason, facetIds, value));
+}


### PR DESCRIPTION
## Summary

Adds the host-neutral L1 nuspec package-query contract:

- six product-owned, ordered facet descriptors with stable opaque IDs;
- typed planning failures for invalid, unknown, duplicate, or incompatible
  selections;
- ANDed filtering over `PackageProfileQuery` with separate candidate and
  semantic match bounds;
- inert product-authored evidence, visible partial failures, and typed
  exhausted/bounded/failed completion; and
- a Browser consumer canary plus owning-architecture updates.

The query composes the existing package-profile and exact-manifest path. It
does not download package payloads or load assemblies.

Closes #5011. #5012 remains the dependent inspect-web shell and rendering
slice.

## Demo

The deterministic `Contoso.Tool` fixture selects source verification, .NET
tool, dependency, download, and embedded-README facets. The new L1 stream
produces one package row with product-owned evidence:

```text
Contoso.Tool 1.0.0 [Nuspec]
  Package ID matches prefix "Contoso.".
  The package source reports this package as verified.
  The package manifest declares a .NET tool package.
  The package manifest declares 1 dependency across 1 target-framework group.
  The package source reports 1,500,000 total downloads.
  The package manifest declares an embedded README file.
```

The neighboring combined-facet fixture excludes both a verified non-tool
package and an unverified tool package, demonstrating that selections are
ANDed rather than independently projected.

This slice intentionally adds no CLI or inspect-web UI; those consumers now
have one shared typed operation to adapt.

## Architecture

[`docs/design/package-query-cli.md`](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/package-query-cli.md)
remains the owner. The update makes the finite L1 facet vocabulary canonical
and requires future CLI syntax to lower through product-owned bindings rather
than defining another predicate set.

## Validation

```text
dotnet run --project src/DotnetInspector.Queries.Tests -c Release
  737 passed

dotnet run --project prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release
  162 passed

dotnet build dotnet-inspect.slnx -c Release
dotnet publish prototypes/inspect-web/engine/InspectWeb.Engine.csproj -c Release
dotnet publish src/dotnet-inspect/dotnet-inspect.csproj -c Release -r osx-arm64
npx markdownlint-cli docs/design/package-query-cli.md docs/design/inspection-layers.md
```
