### PR TITLE
Authenticate runtime-async JSON results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,6 @@ jobs:
       # whether the fixture builds. Run the focused owner gates so CI proves
       # both lowerings issue equal authenticated JSExport wire facts.
       - name: Run JSExport runtime-async wire gates
-        shell: bash
         run: |
           set -euo pipefail
           results="$RUNNER_TEMP/jsexport-runtime-async-wire-tests.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,16 @@ jobs:
       - name: Run analysis tests (fast)
         run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -trait- "Speed=Slow"
 
+      # The runtime-async compiler switch changes IL lowering without changing
+      # whether the fixture builds. Run the focused owner gates so CI proves
+      # both lowerings issue equal authenticated JSExport wire facts.
+      - name: Run JSExport runtime-async wire gates
+        run: >-
+          dotnet run --project tests/ILInspector.JsExportSurface.Tests
+          -c Release --no-build --
+          -method '*Build_ProducesEqualWireFactsAcrossAsyncLowerings*'
+          -method '*RuntimeAsync*'
+
       - name: Run runfaster tests
         run: dotnet run --project src/runfaster.Tests -c Release
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,11 +484,19 @@ jobs:
       # whether the fixture builds. Run the focused owner gates so CI proves
       # both lowerings issue equal authenticated JSExport wire facts.
       - name: Run JSExport runtime-async wire gates
-        run: >-
-          dotnet run --project tests/ILInspector.JsExportSurface.Tests
-          -c Release --no-build --
-          -method '*Build_ProducesEqualWireFactsAcrossAsyncLowerings*'
-          -method '*RuntimeAsync*'
+        shell: bash
+        run: |
+          set -euo pipefail
+          results="$RUNNER_TEMP/jsexport-runtime-async-wire-tests.xml"
+          dotnet run --project tests/ILInspector.JsExportSurface.Tests \
+            -c Release --no-build -- \
+            -method '*Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult*' \
+            -method '*RuntimeAsync*' \
+            -xml "$results"
+          if ! grep -Eq 'total="[1-9][0-9]*"' "$results"; then
+            echo "::error::JSExport runtime-async wire test filters selected no tests." >&2
+            exit 1
+          fi
 
       - name: Run runfaster tests
         run: dotnet run --project src/runfaster.Tests -c Release

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -344,11 +344,12 @@ structurally equal owner-issued `JsExportFunction` facts, it produces
 byte-identical TypeScript.
 
 Lowering-independent body and JSON-wire authentication is a precondition on
-the input surface, owned by `ILInspector.JsExportSurface`. That owner does not
-currently issue equivalent authenticated return facts for runtime async;
-[#4790](https://github.com/richlander/dotnet-inspect/issues/4790) records the
-focused prerequisite. The target supports both lowerings by consuming that
-owner-issued invariant after #4790 lands, not by reconstructing its evidence.
+the input surface, owned by `ILInspector.JsExportSurface`. The paired compiled
+fixture gate
+`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
+proves that owner issues equivalent authenticated return facts for compiler
+async and runtime async. The target supports both lowerings by consuming that
+owner-issued invariant, not by reconstructing its evidence.
 
 Inspect-web's paired deployment canary is a separate consumer responsibility.
 [#4792](https://github.com/richlander/dotnet-inspect/issues/4792) owns its
@@ -620,8 +621,6 @@ The current implementation predates this decision:
   that remain reachable for hand-composed surfaces, although the SDK's
   JavaScript interop source generator rejects a compiled `[JSExport]`
   `ValueTask` signature with `SYSLIB1072`;
-- authenticated async return-wire discovery recognizes compiler-generated
-  `MoveNext` result sinks but not a runtime-async export's own physical body;
 - `JsExportSurfaceBuilder` authenticates each generated registration's
   signature hash and preserves the exact dispatch identity as
   `JsExportFunction.RuntimeDispatchKey`, but the current emitter does not
@@ -655,8 +654,8 @@ The implementation effort should:
 7. expose `runEntryPoint()` as separately identified module infrastructure over
    the same private runtime, without invoking it from initialization or leaking
    `RuntimeAPI` into the public declaration;
-8. consume lowering-independent wire facts after the
-   `ILInspector.JsExportSurface` prerequisite in #4790 lands;
+8. consume lowering-independent wire facts issued by
+   `ILInspector.JsExportSurface`;
 9. consume each exact owner-issued runtime dispatch identity after the
    `ILInspector.JsExportSurface` prerequisite in
    [#4791](https://github.com/richlander/dotnet-inspect/issues/4791) lands;
@@ -721,10 +720,12 @@ The target remains unverified until all of these gates exist:
   JSON wire values;
 - structurally equal hand-composed owner-issued surfaces produce byte-identical
   TypeScript without any lowering-specific generator branch;
-- after #4790, an integration gate gives the command its paired
-  compiler-async and runtime-async assemblies and proves structurally equal
-  owner-issued surface facts generate byte-identical TypeScript; the physical
-  lowering and authentication gates remain with that prerequisite owner;
+- an integration gate gives the command paired compiler-async and
+  runtime-async assemblies and proves structurally equal owner-issued surface
+  facts generate byte-identical TypeScript; physical lowering and
+  authentication remain gated by
+  `JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
+  in the prerequisite owner;
 - an SDK compile-negative fixture requires method-scoped `SYSLIB1072` to be
   present for `[JSExport]` `ValueTask` and `ValueTask<T>` signatures without
   assuming it is the build's only cascading diagnostic, while a hand-composed

--- a/docs/design/ts-jsexport.md
+++ b/docs/design/ts-jsexport.md
@@ -346,10 +346,14 @@ byte-identical TypeScript.
 Lowering-independent body and JSON-wire authentication is a precondition on
 the input surface, owned by `ILInspector.JsExportSurface`. The paired compiled
 fixture gate
-`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
-proves that owner issues equivalent authenticated return facts for compiler
-async and runtime async. The target supports both lowerings by consuming that
-owner-issued invariant, not by reconstructing its evidence.
+`Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult`
+proves that owner issues equivalent authenticated return facts when the
+serializer result reaches completion with direct call provenance. Analysis
+does not yet carry that provenance through a compiler state-machine field when
+the value is serialized before a suspension and returned afterward; issue
+[#5025](https://github.com/richlander/dotnet-inspect/issues/5025) owns that
+prerequisite. The target supports both lowerings by consuming
+owner-issued facts, not by reconstructing missing evidence.
 
 Inspect-web's paired deployment canary is a separate consumer responsibility.
 [#4792](https://github.com/richlander/dotnet-inspect/issues/4792) owns its
@@ -621,6 +625,9 @@ The current implementation predates this decision:
   that remain reachable for hand-composed surfaces, although the SDK's
   JavaScript interop source generator rejects a compiled `[JSExport]`
   `ValueTask` signature with `SYSLIB1072`;
+- owner-issued return-wire facts can differ when compiler lowering hoists a
+  serialized result through a state-machine field, pending Analysis issue
+  #5025;
 - `JsExportSurfaceBuilder` authenticates each generated registration's
   signature hash and preserves the exact dispatch identity as
   `JsExportFunction.RuntimeDispatchKey`, but the current emitter does not
@@ -654,8 +661,8 @@ The implementation effort should:
 7. expose `runEntryPoint()` as separately identified module infrastructure over
    the same private runtime, without invoking it from initialization or leaking
    `RuntimeAPI` into the public declaration;
-8. consume lowering-independent wire facts issued by
-   `ILInspector.JsExportSurface`;
+8. consume wire facts issued by `ILInspector.JsExportSurface` without
+   inspecting lowering or reconstructing the missing #5025 field provenance;
 9. consume each exact owner-issued runtime dispatch identity after the
    `ILInspector.JsExportSurface` prerequisite in
    [#4791](https://github.com/richlander/dotnet-inspect/issues/4791) lands;
@@ -722,10 +729,11 @@ The target remains unverified until all of these gates exist:
   TypeScript without any lowering-specific generator branch;
 - an integration gate gives the command paired compiler-async and
   runtime-async assemblies and proves structurally equal owner-issued surface
-  facts generate byte-identical TypeScript; physical lowering and
-  authentication remain gated by
-  `JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
-  in the prerequisite owner;
+  facts generate byte-identical TypeScript; direct serializer-to-completion
+  lowering and authentication remain gated by
+  `Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult`
+  in the prerequisite owner, while #5025 must close the cross-suspension field
+  provenance residual;
 - an SDK compile-negative fixture requires method-scoped `SYSLIB1072` to be
   present for `[JSExport]` `ValueTask` and `ValueTask<T>` signatures without
   assuming it is the build's only cascading diagnostic, while a hand-composed

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -78,6 +78,7 @@
     <Project Path="src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj" />
     <Project Path="src/ILInspector.Instructions/ILInspector.Instructions.csproj" />
     <Project Path="src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <Project Path="src/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj" />
     <Project Path="src/ILInspector.JsExportSurface/ILInspector.JsExportSurface.csproj" />
     <Project Path="src/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
     <Project Path="src/ILInspector.SourceLink/ILInspector.SourceLink.csproj" />

--- a/src/ILInspector.JsExportSurface.Fixtures/FixtureExports.cs
+++ b/src/ILInspector.JsExportSurface.Fixtures/FixtureExports.cs
@@ -41,6 +41,53 @@ public static partial class FixtureExports
             FixtureJsonContext.Default.StringArray);
 
     [JSExport]
+    public static async Task<string> GetWidgetOrRawAfterAwait(
+        bool raw)
+    {
+        await Task.Yield();
+        return raw
+            ? "{}"
+            : JsonSerializer.Serialize(
+                new WidgetDto("widget", 0, [], null),
+                FixtureJsonContext.Default.WidgetDto);
+    }
+
+    [JSExport]
+    public static async Task<string> GetWidgetFromIncompleteFlowAfterAwait(
+        string? cached)
+    {
+        await Task.Yield();
+        string result;
+        if (cached is null)
+        {
+            result = JsonSerializer.Serialize(
+                new WidgetDto("widget", 0, [], null),
+                FixtureJsonContext.Default.WidgetDto);
+        }
+        else
+        {
+            result = cached;
+        }
+
+        return result;
+    }
+
+    [JSExport]
+    public static async Task<string> GetWidgetThroughLocalAsync()
+    {
+        await Task.Yield();
+        return await SerializeLocalAsync();
+
+        static async Task<string> SerializeLocalAsync()
+        {
+            await Task.Yield();
+            return JsonSerializer.Serialize(
+                new WidgetDto("widget", 0, [], null),
+                FixtureJsonContext.Default.WidgetDto);
+        }
+    }
+
+    [JSExport]
     public static byte[] EchoBytes(byte[] value) => value;
 
     [JSExport]

--- a/src/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj
+++ b/src/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>ILInspector.JsExportSurface.Fixtures</AssemblyName>
+    <RootNamespace>ILInspector.JsExportSurface.Fixtures</RootNamespace>
+    <Features>$(Features);runtime-async=on</Features>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile
+      Include="../ILInspector.JsExportSurface.Fixtures/*.cs"
+      Link="%(Filename)%(Extension)" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -97,6 +97,9 @@ public sealed class JsExportFunction
     /// cref="ReturnType"/> is already a marshalable type, or the export has no return payload), or
     /// when more than one distinct DTO was found for the return position (an ambiguity this is
     /// left unresolved rather than guessed — see <see cref="JsonWireContractResolver"/> remarks).
+    /// Compiler-state-machine and runtime-async implementations issue the same fact when their
+    /// authenticated wire contracts are equivalent; gated by
+    /// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings</c>.
     /// </summary>
     public string? ReturnWireType { get; init; }
 

--- a/src/ILInspector.JsExportSurface/JsExportSurface.cs
+++ b/src/ILInspector.JsExportSurface/JsExportSurface.cs
@@ -97,9 +97,11 @@ public sealed class JsExportFunction
     /// cref="ReturnType"/> is already a marshalable type, or the export has no return payload), or
     /// when more than one distinct DTO was found for the return position (an ambiguity this is
     /// left unresolved rather than guessed — see <see cref="JsonWireContractResolver"/> remarks).
-    /// Compiler-state-machine and runtime-async implementations issue the same fact when their
-    /// authenticated wire contracts are equivalent; gated by
-    /// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings</c>.
+    /// Compiler-state-machine and runtime-async implementations issue the same fact when Analysis
+    /// proves the same direct serializer-to-completion contract; gated by
+    /// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult</c>.
+    /// Serializer values hoisted through a compiler state-machine field remain unresolved pending
+    /// issue #5025.
     /// </summary>
     public string? ReturnWireType { get; init; }
 

--- a/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
@@ -45,6 +45,10 @@ namespace ILInspector.JsExportSurface;
 /// <see cref="JsExportFunction.ReturnWireType"/> unset rather than guessing. "Distinct" is judged
 /// by assembly-scoped structural identity, preventing an external type from aliasing an unrelated
 /// discovered local DTO that shares its qualified name.
+/// When compiler lowering hoists a serialized local across a suspension, Analysis does not yet
+/// carry that call provenance through the state-machine field; issue #5025 owns that prerequisite.
+/// This resolver leaves the compiler form unresolved rather than reconstructing field flow or
+/// weakening the runtime form.
 /// </para>
 /// <para>
 /// A compiler-async sink is authentic only when Analysis's declared-body mapping proves that its
@@ -52,7 +56,7 @@ namespace ILInspector.JsExportSurface;
 /// not qualify. Runtime-async evidence must remain on the export itself, so a serializer return
 /// from a lifted local function or another method cannot be borrowed. Serializer evidence likewise
 /// requires complete argument provenance to a registered context property's getter.
-/// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings</c>,
+/// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult</c>,
 /// <c>JsonWireContractResolverTests.RuntimeAsyncAuthenticationRejectsForgedAttributionAndMetadata</c>,
 /// <c>JsonWireContractResolverTests.Build_RuntimeAsyncRejectsMixedSerializerAndRawReturns</c>,
 /// <c>JsonWireContractResolverTests.Build_RuntimeAsyncRejectsIncompleteReturnCoverage</c>, and

--- a/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
+++ b/src/ILInspector.JsExportSurface/JsonWireContractResolver.cs
@@ -33,21 +33,31 @@ namespace ILInspector.JsExportSurface;
 /// </para>
 /// <para>
 /// A return DTO is resolved only when Analysis proves complete envelope coverage: every
-/// synchronous physical <c>ret</c>, or every authentic async
-/// <c>AsyncTaskMethodBuilder&lt;T&gt;.SetResult</c> sink, is fed exclusively by an exact,
-/// authenticated <c>Serialize&lt;T&gt;</c> call for one structural DTO identity. Discarded,
-/// raw, non-serializer, and unresolved sources therefore leave the wire type unset. A body with
-/// more than one distinct proven return DTO (e.g. different DTOs serialized on different branches)
+/// synchronous physical <c>ret</c>, runtime-async export <c>ret</c>, or compiler-async
+/// <c>AsyncTaskMethodBuilder&lt;T&gt;.SetResult</c> sink is fed exclusively by an exact,
+/// authenticated <c>Serialize&lt;T&gt;</c> call for one structural DTO identity. Runtime-async
+/// returns require Analysis's explicit <see cref="AsyncLoweringKind.Runtime"/> attribution on the
+/// exact exported physical method plus its trusted <c>Task&lt;string&gt;</c> declaration; this
+/// layer never infers lowering from matching method names or tokens. Discarded, raw,
+/// non-serializer, and unresolved sources therefore leave the wire type unset. A body with more
+/// than one distinct proven return DTO (e.g. different DTOs serialized on different branches)
 /// remains ambiguous: <see cref="Attach"/> leaves
 /// <see cref="JsExportFunction.ReturnWireType"/> unset rather than guessing. "Distinct" is judged
 /// by assembly-scoped structural identity, preventing an external type from aliasing an unrelated
 /// discovered local DTO that shares its qualified name.
 /// </para>
 /// <para>
-/// An async sink is authentic only when Analysis's declared-body mapping proves that its physical
-/// <c>MoveNext</c> body belongs to this export; a builder used by an ordinary method does not
-/// qualify. Serializer evidence likewise requires complete argument provenance to a registered
-/// context property's getter.
+/// A compiler-async sink is authentic only when Analysis's declared-body mapping proves that its
+/// physical <c>MoveNext</c> body belongs to this export; a builder used by an ordinary method does
+/// not qualify. Runtime-async evidence must remain on the export itself, so a serializer return
+/// from a lifted local function or another method cannot be borrowed. Serializer evidence likewise
+/// requires complete argument provenance to a registered context property's getter.
+/// <c>JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings</c>,
+/// <c>JsonWireContractResolverTests.RuntimeAsyncAuthenticationRejectsForgedAttributionAndMetadata</c>,
+/// <c>JsonWireContractResolverTests.Build_RuntimeAsyncRejectsMixedSerializerAndRawReturns</c>,
+/// <c>JsonWireContractResolverTests.Build_RuntimeAsyncRejectsIncompleteReturnCoverage</c>, and
+/// <c>JsonWireContractResolverTests.Build_RuntimeAsyncRejectsAnotherMethodsSerializerEvidence</c>
+/// gate the runtime-async equivalence and close negatives.
 /// <c>JsonWireContractResolverTests.Build_RejectsUnrelatedAsyncBuilderResultSink</c> and
 /// <c>JsonWireContractResolverTests.Build_RequiresRegisteredContextPropertyArgumentProvenance</c>,
 /// plus
@@ -160,9 +170,14 @@ public static class JsonWireContractResolver
 
             if (sink.Kind == MethodResultSinkKind.MethodReturn)
             {
-                if (sink.EvidenceMethod.MetadataToken == metadataToken
-                    && IsTrustedSystemString(
-                        sink.EvidenceMethod.ReturnType))
+                if (IsAuthenticSynchronousResultSink(
+                        bodyIndex,
+                        sink,
+                        metadataToken)
+                    || IsAuthenticRuntimeAsyncResultSink(
+                        bodyIndex,
+                        sink,
+                        metadataToken))
                 {
                     sinks.Add(sink);
                 }
@@ -178,7 +193,7 @@ public static class JsonWireContractResolver
                 sink.ILOffset);
             if (consumer is not null
                 && IsTrustedAsyncResultSink(consumer.Callee)
-                && IsAuthenticAsyncResultSink(
+                && IsAuthenticStateMachineResultSink(
                     bodyIndex,
                     sink,
                     metadataToken))
@@ -233,7 +248,35 @@ public static class JsonWireContractResolver
         return dto;
     }
 
-    static bool IsAuthenticAsyncResultSink(
+    static bool IsAuthenticSynchronousResultSink(
+        LibraryBodyIndex bodyIndex,
+        MethodResultSink sink,
+        int exportMetadataToken)
+        => sink.Caller.MetadataToken == exportMetadataToken
+            && sink.Caller == sink.EvidenceMethod
+            && sink.AsyncBody is null
+            && bodyIndex.DeclaredMethods.Contains(
+                sink.EvidenceMethod)
+            && IsTrustedSystemString(
+                sink.EvidenceMethod.ReturnType);
+
+    internal static bool IsAuthenticRuntimeAsyncResultSink(
+        LibraryBodyIndex bodyIndex,
+        MethodResultSink sink,
+        int exportMetadataToken)
+        => sink.Caller.MetadataToken == exportMetadataToken
+            && sink.Caller == sink.EvidenceMethod
+            && sink.AsyncBody is
+            {
+                Lowering: AsyncLoweringKind.Runtime,
+            } asyncBody
+            && asyncBody.SourceMethod == sink.Caller
+            && bodyIndex.DeclaredMethods.Contains(
+                sink.EvidenceMethod)
+            && IsTrustedTaskOfString(
+                sink.EvidenceMethod.ReturnType);
+
+    static bool IsAuthenticStateMachineResultSink(
         LibraryBodyIndex bodyIndex,
         MethodResultSink sink,
         int exportMetadataToken)
@@ -389,6 +432,18 @@ public static class JsonWireContractResolver
                 identity.Name,
                 "System.Runtime");
     }
+
+    static bool IsTrustedTaskOfString(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance
+            && type.ElementType is { } identity
+            && IsTrustedFrameworkType(
+                identity,
+                "System.Threading.Tasks",
+                "Task`1",
+                "System.Runtime")
+            && type.TypeArguments.Length == 1
+            && IsTrustedSystemString(
+                type.TypeArguments[0]);
 
     static DirectCall? CallAt(
         LibraryBodyIndex bodyIndex,

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -127,20 +127,26 @@ Two matching generated-root PropertyDefs with the same metadata identity also
 fail rather than letting declaration metadata select one while runtime code
 calls the other.
 
-Return JSON-wire facts are lowering-independent. A synchronous `string` export
-must return only authenticated source-generated `Serialize<T>` results.
-A compiler-async `Task<string>` export must feed those results into the
-authenticated `MoveNext` builder completion sink. A runtime-async
-`Task<string>` export must instead carry Analysis's explicit `Runtime`
-attribution on the exact exported physical method and return those same
-serializer results from that method's own `ret`. The resolver does not infer
-lowering from identity coincidences or recognize runtime-async IL shapes.
+For a direct serializer-to-completion contract, return JSON-wire facts are
+lowering-independent. A synchronous `string` export must return only
+authenticated source-generated `Serialize<T>` results. A compiler-async
+`Task<string>` export must feed those results into the authenticated `MoveNext`
+builder completion sink. A runtime-async `Task<string>` export must instead
+carry Analysis's explicit `Runtime` attribution on the exact exported physical
+method and return those same serializer results from that method's own `ret`.
+The resolver does not infer lowering from identity coincidences or recognize
+runtime-async IL shapes.
 Incomplete coverage, a raw/serialized mixture, an untrusted `Task<string>`
 declaration, or serializer evidence from a lifted local function or another
 method leaves `ReturnWireType` unset.
-`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
+When compiler lowering hoists a serialized value across a suspension,
+Analysis does not yet carry its call provenance through the state-machine
+field. Issue #5025 owns that prerequisite; this layer leaves the compiler form
+unresolved rather than reconstructing field flow or weakening the runtime
+form.
+`Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult`
 gates equal owner-issued facts from paired compilations of the same genuinely
-awaited export.
+awaited direct-result export.
 `RuntimeAsyncAuthenticationRejectsForgedAttributionAndMetadata`,
 `Build_RuntimeAsyncRejectsMixedSerializerAndRawReturns`,
 `Build_RuntimeAsyncRejectsIncompleteReturnCoverage`, and

--- a/src/ILInspector.JsExportSurface/README.md
+++ b/src/ILInspector.JsExportSurface/README.md
@@ -127,6 +127,26 @@ Two matching generated-root PropertyDefs with the same metadata identity also
 fail rather than letting declaration metadata select one while runtime code
 calls the other.
 
+Return JSON-wire facts are lowering-independent. A synchronous `string` export
+must return only authenticated source-generated `Serialize<T>` results.
+A compiler-async `Task<string>` export must feed those results into the
+authenticated `MoveNext` builder completion sink. A runtime-async
+`Task<string>` export must instead carry Analysis's explicit `Runtime`
+attribution on the exact exported physical method and return those same
+serializer results from that method's own `ret`. The resolver does not infer
+lowering from identity coincidences or recognize runtime-async IL shapes.
+Incomplete coverage, a raw/serialized mixture, an untrusted `Task<string>`
+declaration, or serializer evidence from a lifted local function or another
+method leaves `ReturnWireType` unset.
+`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
+gates equal owner-issued facts from paired compilations of the same genuinely
+awaited export.
+`RuntimeAsyncAuthenticationRejectsForgedAttributionAndMetadata`,
+`Build_RuntimeAsyncRejectsMixedSerializerAndRawReturns`,
+`Build_RuntimeAsyncRejectsIncompleteReturnCoverage`, and
+`Build_RuntimeAsyncRejectsAnotherMethodsSerializerEvidence` gate the close
+negative boundaries.
+
 `JsExportSurfaceBuilderTests.Build_RejectsBodylessJsExportsWithoutRuntimeWrappers`,
 `Extract_RetainsFilteredJsExportRowsFromCompilerGeneratedTypes`,
 `Build_RejectsJsExportWithoutGeneratedRuntimeWrapper`,

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -50,13 +50,14 @@ reach. The SDK's JavaScript interop source generator instead rejects a compiled
 `[JSExport] ValueTask` signature with `SYSLIB1072`, before a runtime-publishable
 surface exists. The target architecture removes those mapper branches, retains
 that SDK compile-time negative, and rejects an unsupported hand-composed input
-visibly. Async JSON return authentication currently recognizes the
-compiler-async form whose physical result sink is in `MoveNext`; it does not
-yet recognize the equivalent runtime-async form whose physical body and return
-sink remain on the exported method. Issue
-[#4790](https://github.com/richlander/dotnet-inspect/issues/4790) owns that
-`ILInspector.JsExportSurface` prerequisite; the target generator only consumes
-the lowering-independent facts.
+visibly. For supported `Task<string>` exports,
+`ILInspector.JsExportSurface` authenticates async JSON returns in both the
+compiler-async form whose physical result sink is in `MoveNext` and the
+runtime-async form whose physical body and return sink remain on the exported
+method. `tsbindgen` consumes the resulting lowering-independent
+`JsExportFunction` facts and does not recognize either lowering itself.
+`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
+gates structurally equal owner-issued facts for paired compiled artifacts.
 
 Generated JSON-wire interfaces are producer-owned snapshots: their properties
 are `readonly`, arrays use `ReadonlyArray<T>`, and string-keyed dictionaries use

--- a/src/tsbindgen/README.md
+++ b/src/tsbindgen/README.md
@@ -50,14 +50,17 @@ reach. The SDK's JavaScript interop source generator instead rejects a compiled
 `[JSExport] ValueTask` signature with `SYSLIB1072`, before a runtime-publishable
 surface exists. The target architecture removes those mapper branches, retains
 that SDK compile-time negative, and rejects an unsupported hand-composed input
-visibly. For supported `Task<string>` exports,
-`ILInspector.JsExportSurface` authenticates async JSON returns in both the
-compiler-async form whose physical result sink is in `MoveNext` and the
-runtime-async form whose physical body and return sink remain on the exported
-method. `tsbindgen` consumes the resulting lowering-independent
-`JsExportFunction` facts and does not recognize either lowering itself.
-`JsonWireContractResolverTests.Build_ProducesEqualWireFactsAcrossAsyncLowerings`
-gates structurally equal owner-issued facts for paired compiled artifacts.
+visibly. For supported `Task<string>` exports whose serializer result reaches
+the completion sink with direct call provenance, `ILInspector.JsExportSurface`
+authenticates async JSON returns in both the compiler-async form whose physical
+result sink is in `MoveNext` and the runtime-async form whose physical body and
+return sink remain on the exported method. `tsbindgen` consumes the resulting
+owner-issued `JsExportFunction` facts and does not recognize either lowering
+itself.
+`Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult`
+gates structurally equal owner-issued facts for the paired direct-result
+artifacts. Analysis issue #5025 tracks the missing compiler provenance when a
+serialized value is hoisted through a state-machine field across a suspension.
 
 Generated JSON-wire interfaces are producer-owned snapshots: their properties
 are `readonly`, arrays use `ReadonlyArray<T>`, and string-keyed dictionaries use

--- a/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
+++ b/tests/ILInspector.JsExportSurface.Tests/ILInspector.JsExportSurface.Tests.csproj
@@ -25,10 +25,27 @@
     <ProjectReference Include="../../src/ILInspector.JsExportSurface/ILInspector.JsExportSurface.csproj" />
     <ProjectReference Include="../../src/tsbindgen/tsbindgen.csproj" />
     <ProjectReference Include="../../src/ILInspector.JsExportSurface.Fixtures/ILInspector.JsExportSurface.Fixtures.csproj" />
+    <ProjectReference
+      Include="../../src/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj"
+      ReferenceOutputAssembly="false" />
     <ProjectReference Include="../ILInspector.JsExportSurface.NamingFixtures/ILInspector.JsExportSurface.NamingFixtures.csproj" />
     <ProjectReference Include="../ILInspector.JsExportSurface.OperatorFixtures/ILInspector.JsExportSurface.OperatorFixtures.csproj" />
     <ProjectReference Include="../ILInspector.JsExportSurface.PublishabilityFixtures/ILInspector.JsExportSurface.PublishabilityFixtures.csproj" />
     <ProjectReference Include="../ILInspector.JsExportSurface.ScalarFixtures/ILInspector.JsExportSurface.ScalarFixtures.csproj" />
   </ItemGroup>
+
+  <Target Name="CopyRuntimeAsyncFixture" AfterTargets="Build">
+    <MSBuild
+      Projects="../../src/ILInspector.JsExportSurface.RuntimeAsyncFixtures/ILInspector.JsExportSurface.RuntimeAsyncFixtures.csproj"
+      Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_RuntimeAsyncFixtureTargetPath" />
+    </MSBuild>
+    <Error
+      Condition="'@(_RuntimeAsyncFixtureTargetPath)' == ''"
+      Text="The runtime-async JSExport fixture target path was not resolved." />
+    <Copy
+      SourceFiles="@(_RuntimeAsyncFixtureTargetPath)"
+      DestinationFiles="$(TargetDir)ILInspector.JsExportSurface.RuntimeAsyncFixtures.dll" />
+  </Target>
 
 </Project>

--- a/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsExportSurfaceBuilderTests.cs
@@ -53,10 +53,15 @@ public sealed class JsExportSurfaceBuilderTests
         ILInspector.JsExportSurface.JsExportSurface surface = BuildFixtureSurface();
 
         var names = surface.Functions.Select(f => f.Name).ToHashSet(StringComparer.Ordinal);
-        Assert.Equal(43, surface.Functions.Count);
+        Assert.Equal(46, surface.Functions.Count);
         Assert.Contains("GetWidget", names);
         Assert.Contains("GetWidgetAsync", names);
         Assert.Contains("GetStringArrayAsyncAfterAwait", names);
+        Assert.Contains("GetWidgetOrRawAfterAwait", names);
+        Assert.Contains(
+            "GetWidgetFromIncompleteFlowAfterAwait",
+            names);
+        Assert.Contains("GetWidgetThroughLocalAsync", names);
         Assert.Contains("EchoBytes", names);
         Assert.Contains("GetRegisteredString", names);
         Assert.Contains("Ping", names);

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireContractResolverTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireContractResolverTests.cs
@@ -23,6 +23,10 @@ public sealed class JsonWireContractResolverTests
 {
     private const string FixtureNamespace =
         "ILInspector.JsExportSurface.Fixtures.";
+    private static readonly string s_runtimeAsyncFixturePath =
+        Path.Combine(
+            AppContext.BaseDirectory,
+            "ILInspector.JsExportSurface.RuntimeAsyncFixtures.dll");
 
     [Fact]
     public void WireTypesEqual_DistinguishesCompleteAssemblyIdentity()
@@ -281,6 +285,16 @@ public sealed class JsonWireContractResolverTests
                 "cc7b13ffcd2ddd51"),
             [dto]);
 
+    static TypeRef TaskOfString(
+        string assemblyName = "System.Runtime")
+        => TypeRef.GenericInstance(
+            ExternalType(
+                assemblyName,
+                "System.Threading.Tasks",
+                "Task`1",
+                "b03f5f7f11d50a3a"),
+            [SystemString()]);
+
     static MemberRef SourceGeneratedSerialize(TypeRef dto)
     {
         TypeRef typeParameter = TypeRef.MethodGenericParameter(0, "TValue");
@@ -326,8 +340,15 @@ public sealed class JsonWireContractResolverTests
     }
 
     private static ILInspector.JsExportSurface.JsExportSurface BuildFixtureSurfaceWithWireContracts()
+        => BuildFixtureSurfaceWithWireContracts(
+            typeof(FixtureExports).Assembly.Location)
+            .Surface;
+
+    private static (
+        ILInspector.JsExportSurface.JsExportSurface Surface,
+        LibraryBodyIndex BodyIndex)
+        BuildFixtureSurfaceWithWireContracts(string path)
     {
-        string path = typeof(FixtureExports).Assembly.Location;
         using FileStream stream = File.OpenRead(path);
         using var peReader = new PEReader(stream);
         ApiSurface apiSurface = ApiSurfaceExtractor.Extract(peReader, includeAll: false);
@@ -335,7 +356,9 @@ public sealed class JsonWireContractResolverTests
             path,
             LibraryBodyAnalysisFeatures.MethodEvidence
                 | LibraryBodyAnalysisFeatures.JsonWireContractFlow);
-        return JsExportSurfaceBuilder.Build(apiSurface, bodyIndex);
+        return (
+            JsExportSurfaceBuilder.Build(apiSurface, bodyIndex),
+            bodyIndex);
     }
 
     [Fact]
@@ -440,6 +463,340 @@ public sealed class JsonWireContractResolverTests
 
         Assert.Equal("string[]", function.ReturnWireType);
     }
+
+    [Fact]
+    public void Build_ProducesEqualWireFactsAcrossAsyncLowerings()
+    {
+        var (compilerSurface, compilerBodyIndex) =
+            BuildFixtureSurfaceWithWireContracts(
+                typeof(FixtureExports).Assembly.Location);
+        var (runtimeSurface, runtimeBodyIndex) =
+            BuildFixtureSurfaceWithWireContracts(
+                s_runtimeAsyncFixturePath);
+
+        const string exportName =
+            "GetStringArrayAsyncAfterAwait";
+        MethodIdentity compilerExport = Assert.Single(
+            compilerBodyIndex.DeclaredMethods,
+            method => method.Name == exportName);
+        MethodIdentity runtimeExport = Assert.Single(
+            runtimeBodyIndex.DeclaredMethods,
+            method => method.Name == exportName);
+        DirectCall compilerSerializer = Assert.Single(
+            compilerBodyIndex.DirectCalls,
+            call => call.Caller == compilerExport
+                && call.Callee.Name == "Serialize");
+        DirectCall runtimeSerializer = Assert.Single(
+            runtimeBodyIndex.DirectCalls,
+            call => call.Caller == runtimeExport
+                && call.Callee.Name == "Serialize");
+        MethodResultSink compilerResult = Assert.Single(
+            compilerBodyIndex.ResultSinks,
+            sink => sink.Caller == compilerExport
+                && sink.SourceCallOffsets.Contains(
+                    compilerSerializer.ILOffset));
+        MethodResultSink runtimeResult = Assert.Single(
+            runtimeBodyIndex.ResultSinks,
+            sink => sink.Caller == runtimeExport
+                && sink.SourceCallOffsets.Contains(
+                    runtimeSerializer.ILOffset));
+
+        Assert.Equal(
+            MethodResultSinkKind.SingleArgumentCall,
+            compilerResult.Kind);
+        Assert.Equal("MoveNext", compilerResult.EvidenceMethod.Name);
+        Assert.Equal(
+            AsyncLoweringKind.StateMachine,
+            Assert.IsType<AsyncBodyAttribution>(
+                compilerResult.AsyncBody)
+                .Lowering);
+        Assert.Equal(
+            MethodResultSinkKind.MethodReturn,
+            runtimeResult.Kind);
+        Assert.Equal(runtimeExport, runtimeResult.EvidenceMethod);
+        AsyncBodyAttribution runtimeAttribution =
+            Assert.IsType<AsyncBodyAttribution>(
+                runtimeResult.AsyncBody);
+        Assert.Equal(
+            AsyncLoweringKind.Runtime,
+            runtimeAttribution.Lowering);
+        Assert.Equal(runtimeExport, runtimeAttribution.SourceMethod);
+        Assert.DoesNotContain(
+            runtimeBodyIndex.Methods,
+            method => method.Name == "MoveNext"
+                && method.DeclaringType
+                    .ToQualifiedDisplayString()
+                    .Contains(
+                        $"<{exportName}>",
+                        StringComparison.Ordinal));
+
+        JsExportFunction compilerFunction = Assert.Single(
+            compilerSurface.Functions,
+            function => function.Name == exportName);
+        JsExportFunction runtimeFunction = Assert.Single(
+            runtimeSurface.Functions,
+            function => function.Name == exportName);
+        Assert.Equal(
+            System.Text.Json.JsonSerializer.Serialize(
+                compilerFunction),
+            System.Text.Json.JsonSerializer.Serialize(
+                runtimeFunction));
+        Assert.Equal(
+            compilerFunction.ReturnTypeReferences,
+            runtimeFunction.ReturnTypeReferences);
+        Assert.Equal(
+            compilerFunction.ReturnWireTypeReferences,
+            runtimeFunction.ReturnWireTypeReferences);
+        Assert.Equal(
+            compilerFunction.ParameterWireTypeReferences,
+            runtimeFunction.ParameterWireTypeReferences);
+        Assert.Equal("string[]", runtimeFunction.ReturnWireType);
+
+        string[] compilerFacts =
+        [
+            .. compilerSurface.Functions
+                .Select(function =>
+                    System.Text.Json.JsonSerializer.Serialize(
+                        function))
+                .Order(StringComparer.Ordinal),
+        ];
+        string[] runtimeFacts =
+        [
+            .. runtimeSurface.Functions
+                .Select(function =>
+                    System.Text.Json.JsonSerializer.Serialize(
+                        function))
+                .Order(StringComparer.Ordinal),
+        ];
+        Assert.Equal(compilerFacts, runtimeFacts);
+    }
+
+    [Fact]
+    public void RuntimeAsyncAuthenticationRejectsForgedAttributionAndMetadata()
+    {
+        MethodIdentity export = RuntimeAsyncMethod(
+            0x06000001,
+            TaskOfString());
+        MethodIdentity other = RuntimeAsyncMethod(
+            0x06000002,
+            TaskOfString(),
+            "Other");
+        LibraryBodyIndex bodyIndex =
+            LibraryBodyIndex.FromEvidence(
+                [export, other],
+                []);
+        MethodResultSink authentic = RuntimeAsyncSink(
+            export,
+            export,
+            export,
+            AsyncLoweringKind.Runtime);
+
+        Assert.True(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    bodyIndex,
+                    authentic,
+                    export.MetadataToken));
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    bodyIndex,
+                    RuntimeAsyncSink(
+                        export,
+                        export,
+                        export,
+                        AsyncLoweringKind.StateMachine),
+                    export.MetadataToken));
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    bodyIndex,
+                    RuntimeAsyncSink(
+                        export,
+                        export,
+                        other,
+                        AsyncLoweringKind.Runtime),
+                    export.MetadataToken));
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    bodyIndex,
+                    RuntimeAsyncSink(
+                        export,
+                        other,
+                        export,
+                        AsyncLoweringKind.Runtime),
+                    export.MetadataToken));
+
+        MethodIdentity synchronous = export with
+        {
+            ReturnType = SystemString(),
+        };
+        MethodIdentity spoofedTask = export with
+        {
+            ReturnType = TaskOfString("Lookalikes"),
+        };
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    LibraryBodyIndex.FromEvidence(
+                        [synchronous],
+                        []),
+                    RuntimeAsyncSink(
+                        synchronous,
+                        synchronous,
+                        synchronous,
+                        AsyncLoweringKind.Runtime),
+                    synchronous.MetadataToken));
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    LibraryBodyIndex.FromEvidence(
+                        [spoofedTask],
+                        []),
+                    RuntimeAsyncSink(
+                        spoofedTask,
+                        spoofedTask,
+                        spoofedTask,
+                        AsyncLoweringKind.Runtime),
+                    spoofedTask.MetadataToken));
+    }
+
+    [Fact]
+    public void Build_RuntimeAsyncRejectsMixedSerializerAndRawReturns()
+    {
+        var (surface, bodyIndex) =
+            BuildFixtureSurfaceWithWireContracts(
+                s_runtimeAsyncFixturePath);
+        MethodIdentity export = Assert.Single(
+            bodyIndex.DeclaredMethods,
+            method =>
+                method.Name == "GetWidgetOrRawAfterAwait");
+        MethodResultSink[] returns =
+        [
+            .. bodyIndex.ResultSinks.Where(sink =>
+                sink.Caller == export
+                && sink.Kind
+                    == MethodResultSinkKind.MethodReturn),
+        ];
+
+        Assert.Contains(
+            returns,
+            sink => sink.IsComplete
+                && !sink.SourceCallOffsets.IsDefaultOrEmpty);
+        Assert.Contains(
+            returns,
+            sink => !sink.IsComplete);
+        Assert.Null(
+            Assert.Single(
+                surface.Functions,
+                function =>
+                    function.Name
+                        == "GetWidgetOrRawAfterAwait")
+                .ReturnWireType);
+    }
+
+    [Fact]
+    public void Build_RuntimeAsyncRejectsIncompleteReturnCoverage()
+    {
+        var (surface, bodyIndex) =
+            BuildFixtureSurfaceWithWireContracts(
+                s_runtimeAsyncFixturePath);
+        MethodIdentity export = Assert.Single(
+            bodyIndex.DeclaredMethods,
+            method =>
+                method.Name
+                    == "GetWidgetFromIncompleteFlowAfterAwait");
+        MethodResultSink result = Assert.Single(
+            bodyIndex.ResultSinks,
+            sink => sink.Caller == export
+                && sink.Kind
+                    == MethodResultSinkKind.MethodReturn);
+
+        Assert.Equal(
+            AsyncLoweringKind.Runtime,
+            Assert.IsType<AsyncBodyAttribution>(
+                result.AsyncBody)
+                .Lowering);
+        Assert.False(result.IsComplete);
+        Assert.Null(
+            Assert.Single(
+                surface.Functions,
+                function =>
+                    function.Name
+                        == "GetWidgetFromIncompleteFlowAfterAwait")
+                .ReturnWireType);
+    }
+
+    [Fact]
+    public void Build_RuntimeAsyncRejectsAnotherMethodsSerializerEvidence()
+    {
+        var (surface, bodyIndex) =
+            BuildFixtureSurfaceWithWireContracts(
+                s_runtimeAsyncFixturePath);
+        MethodIdentity export = Assert.Single(
+            bodyIndex.DeclaredMethods,
+            method =>
+                method.Name == "GetWidgetThroughLocalAsync");
+        MethodResultSink foreignSink = Assert.Single(
+            bodyIndex.ResultSinks,
+            sink => sink.Caller == export
+                && sink.EvidenceMethod != export
+                && sink.SourceCallOffsets.Any(
+                    offset => bodyIndex.DirectCalls.Any(call =>
+                        call.EvidenceMethod
+                            == sink.EvidenceMethod
+                        && call.ILOffset == offset
+                        && call.Callee.Name
+                            == "Serialize")));
+        Assert.False(
+            JsonWireContractResolver
+                .IsAuthenticRuntimeAsyncResultSink(
+                    bodyIndex,
+                    foreignSink,
+                    export.MetadataToken));
+        Assert.Null(
+            Assert.Single(
+                surface.Functions,
+                function =>
+                    function.Name
+                        == "GetWidgetThroughLocalAsync")
+                .ReturnWireType);
+    }
+
+    static MethodIdentity RuntimeAsyncMethod(
+        int metadataToken,
+        TypeRef returnType,
+        string name = "Export")
+        => new(
+            "Fixture",
+            new Guid("00112233-4455-6677-8899-aabbccddeeff"),
+            ExternalType(
+                "Fixture",
+                "Fixtures",
+                "Exports",
+                publicKeyToken: null),
+            name,
+            [],
+            returnType,
+            metadataToken,
+            IsStatic: true);
+
+    static MethodResultSink RuntimeAsyncSink(
+        MethodIdentity caller,
+        MethodIdentity evidence,
+        MethodIdentity source,
+        AsyncLoweringKind lowering)
+        => new(
+            caller,
+            evidence,
+            ILOffset: 0,
+            MethodResultSinkKind.MethodReturn,
+            SourceCallOffsets: [1],
+            IsComplete: true)
+        {
+            AsyncBody = new(source, lowering),
+        };
 
     [Fact]
     public void Build_ResolvesRegisteredString()

--- a/tests/ILInspector.JsExportSurface.Tests/JsonWireContractResolverTests.cs
+++ b/tests/ILInspector.JsExportSurface.Tests/JsonWireContractResolverTests.cs
@@ -465,7 +465,7 @@ public sealed class JsonWireContractResolverTests
     }
 
     [Fact]
-    public void Build_ProducesEqualWireFactsAcrossAsyncLowerings()
+    public void Build_ProducesEqualWireFactsAcrossAsyncLoweringsForDirectSerializerResult()
     {
         var (compilerSurface, compilerBodyIndex) =
             BuildFixtureSurfaceWithWireContracts(


### PR DESCRIPTION
## Summary

- authenticate .NET 11 runtime-async `Task<string>` JSON returns from Analysis-issued `Runtime` attribution, exact export/source/evidence identity, and trusted declared return metadata
- compile the same JSExport fixture source with compiler async and runtime async, then prove the genuinely awaited direct-result operation publishes structurally equal `JsExportFunction` wire facts
- fail closed for forged attribution or metadata, incomplete return coverage, serializer/raw mixtures, and serializer evidence belonging to another physical method
- run the focused paired-lowering owner gates in PR CI, since a successful build alone cannot prove which lowering the compiler emitted

## Compatibility boundary

The existing synchronous `string` and compiler-state-machine `Task<string>` authentication paths remain intact. This change adds no TypeScript lowering logic, Mono runtime-async support, ABI changes, or new marshalled signatures; consumers continue to consume owner-issued surface facts without recognizing lowering.

Analysis does not yet preserve direct-call provenance when compiler lowering hoists a serialized value through a state-machine field across a suspension. #5025 owns that prerequisite; this PR leaves that compiler form unresolved rather than reconstructing field flow or weakening the runtime fact.

## Evidence

- focused integrated wire/authentication gate: 9 passed
- guarded PR-CI lowering gate: 5 selected, 5 passed
- full JSExport suite: 386 passed; the sole `SourceGeneratedJson_OmitsInaccessibleJsonIncludedMembers` preview-SDK failure reproduces at the base commit
- full Release solution build: 0 warnings, 0 errors
- changed Markdown passes `markdownlint`

Fixes #4790
Parent: #4611
