### PR TITLE
Realize package roots without compile assemblies

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -965,6 +965,7 @@ The target is complete only when tests equivalent to these exist:
 - `PackageWorkspaceIntegrationsQuery_PreservesExactRootIdentity`
 - `PackageCoordinate_RejectsDifferentContentWithSameIdentity`
 - `PackageScope_DoesNotCollapseDifferentContentAtSameCoordinate`
+- `PackageScope_ValidatesEveryCoordinateAgainstCacheProvenance`
 - `MixedPackageScope_RealizesOnlySelectedCoordinates`
 - `PackageFrameworkUnavailability_DoesNotEmitArtifactFramework`
 - `QueryPackage_ToolsPointerRetainsRootAndManifestDependencies`

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -533,6 +533,14 @@ group as an empty API surface, or route package-root access through an
 acquisition-only assembly set. A selected assembly that fails metadata decoding
 remains a distinct visible participant failure.
 
+Browser workspace registry identity frames every package, version, and
+framework component with its length before composing a multi-package key.
+Caller-controlled framework text therefore remains data inside one coordinate
+and cannot create or remove coordinate boundaries. Manifest dependency groups
+with a missing or blank framework project as NuGet's framework-neutral `any`;
+nonblank framework text that the Browser cannot represent still fails visibly
+rather than being emitted or silently dropped.
+
 This contract does not choose the initial UI subject or define package-view
 presentation. Inspection Subject Navigation owns subject availability and
 initial subject recommendation; host presentation consumes those decisions.
@@ -966,8 +974,10 @@ The target is complete only when tests equivalent to these exist:
 - `PackageCoordinate_RejectsDifferentContentWithSameIdentity`
 - `PackageScope_DoesNotCollapseDifferentContentAtSameCoordinate`
 - `PackageScope_ValidatesEveryCoordinateAgainstCacheProvenance`
+- `PackageScope_RequestedFrameworkCannotForgeCompositeRegistryKey`
 - `MixedPackageScope_RealizesOnlySelectedCoordinates`
 - `PackageFrameworkUnavailability_DoesNotEmitArtifactFramework`
+- `PackageDependencies_BlankDeclaredFrameworkDoesNotAbortProjection`
 - `QueryPackage_ToolsPointerRetainsRootAndManifestDependencies`
 - `QueryPackage_ExplicitEmptyCompileGroupRetainsTypedAbsence`
 - `QueryPackage_NoMatchingFrameworkRetainsRequestedRoot`

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -503,6 +503,40 @@ identity stays in artifact/workspace provenance and optional package query
 results. It does not become a case in a Metadata-owned provenance union that
 assembly inspection must understand.
 
+#### Package Root realization
+
+An exact acquired package is a `PackageRootRealization` before compile-asset
+selection succeeds. That host-neutral product result retains:
+
+- exact package id and version;
+- the requested target framework and the selector's selected framework, when
+  either exists;
+- the package content producer key and cache origin;
+- the complete typed `PackageCompileAssetSelection`, including
+  `NoCompileAssets`, `NoMatchingTargetFramework`, `EmptyCompileGroup`, and
+  `InvalidImplementationAssets`.
+
+Compile-library availability is a capability of that Root, not a precondition
+for the Root to exist. The host workspace retains every requested Root.
+`PackageAssemblyContextRealization` separately creates surface or
+implementation assembly-context groups only for Roots whose selection status is
+`Selected` and whose selected asset set is non-empty. It does not become a
+package-root container. A workspace containing only Root-capable coordinates
+has no assembly groups. A mixed workspace retains all Roots at the host
+boundary while creating groups for selected coordinates only.
+
+A host may project Root-owned facts such as exact identity, package documents,
+or manifest dependencies from a Root-only coordinate. Assembly-backed
+operations must report the retained compile-library outcome as unavailable or
+failed. They must not invent an assembly participant, reinterpret an absent
+group as an empty API surface, or route package-root access through an
+acquisition-only assembly set. A selected assembly that fails metadata decoding
+remains a distinct visible participant failure.
+
+This contract does not choose the initial UI subject or define package-view
+presentation. Inspection Subject Navigation owns subject availability and
+initial subject recommendation; host presentation consumes those decisions.
+
 The adapter also validates package coordinate, version, selected asset path,
 producer, and content identity before minting a package realization and
 acquisition registration. Package-aware graph and dependency queries move to an
@@ -921,6 +955,19 @@ The target is complete only when tests equivalent to these exist:
 - `AssemblyContextGroup_CanBindParticipantsFromDifferentArtifactSources`
 - `RetainedWorkspace_CanAddASecondSealedContextGeneration`
 - `PackageAdapter_ProjectsSelectedEntriesWithoutLeakingPackageTypes`
+- `PackageWithoutCompileAssets_RetainsRootWithoutAssemblyRoles`
+- `ExplicitEmptyCompileGroup_RetainsRootWithoutAssemblyRoles`
+- `NoMatchingFramework_RetainsRequestedRootWithoutAssemblyRoles`
+- `InvalidImplementationLayout_RetainsFailedRootWithoutAssemblyRoles`
+- `MixedPackages_CreateRolesOnlyForSelectedCompileAssets`
+- `PackageRootIdentity_DistinguishesRequestedFrameworksByReference`
+- `PackageWorkspaceIntegrationsQuery_RejectsRootOnlyRealization`
+- `PackageCoordinate_RejectsDifferentContentWithSameIdentity`
+- `MixedPackageScope_RealizesOnlySelectedCoordinates`
+- `PackageFrameworkUnavailability_DoesNotEmitArtifactFramework`
+- `QueryPackage_ToolsPointerRetainsRootAndManifestDependencies`
+- `QueryPackage_ExplicitEmptyCompileGroupRetainsTypedAbsence`
+- `QueryPackage_NoMatchingFrameworkRetainsRequestedRoot`
 - `PackageGraphProjection_UsesAdapterOwnedCorrespondence`
 - `PlatformGraphProjection_UsesAdapterOwnedCorrespondence`
 - `RemotePlatformPack_UsesPackageMappingVersionAndProducerAuthorization`
@@ -969,6 +1016,12 @@ remaining cancellation. `LocalOnlyHost_InspectsCallerSuppliedLocalAssembly`
 deletes its temporary source after publication, then passes an
 `ArtifactContentReference`'s guarded published snapshot opener to Metadata, so
 a source-path fallback cannot satisfy the gate.
+
+`PackageAssemblyContextRealizationTests` enforce package Root retention,
+producer/cache provenance, and assembly-group creation only for selected
+compile assets. `BrowserEngineBoundaryTests` enforce the tools-v2 pointer and
+explicit-empty-group cases, including typed compile-library absence, package
+documents, manifest dependencies, and no fabricated default assembly.
 
 Workspace-wide admission budgets, single-flight/reentrancy, directory
 acquisition, content digests, dependent-group quiescence, and Metadata

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -962,7 +962,9 @@ The target is complete only when tests equivalent to these exist:
 - `MixedPackages_CreateRolesOnlyForSelectedCompileAssets`
 - `PackageRootIdentity_DistinguishesRequestedFrameworksByReference`
 - `PackageWorkspaceIntegrationsQuery_RejectsRootOnlyRealization`
+- `PackageWorkspaceIntegrationsQuery_PreservesExactRootIdentity`
 - `PackageCoordinate_RejectsDifferentContentWithSameIdentity`
+- `PackageScope_DoesNotCollapseDifferentContentAtSameCoordinate`
 - `MixedPackageScope_RealizesOnlySelectedCoordinates`
 - `PackageFrameworkUnavailability_DoesNotEmitArtifactFramework`
 - `QueryPackage_ToolsPointerRetainsRootAndManifestDependencies`

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1543,6 +1543,77 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void PackageScope_ValidatesEveryCoordinateAgainstCacheProvenance()
+    {
+        string provenanceId = $"Exact.Provenance.{Guid.NewGuid():N}";
+        byte[] image =
+            File.ReadAllBytes(typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        byte[] archive =
+            Package(image, $"lib/net11.0/{provenanceId}.dll");
+        var registered = new BrowserPackage(
+            provenanceId,
+            "1.0.0",
+            archive,
+            fromCache: false,
+            producerKey: "producer-a");
+        var unregisteredProducer = new BrowserPackage(
+            provenanceId,
+            "1.0.0",
+            archive,
+            fromCache: false,
+            producerKey: "producer-b");
+        BrowserPackageWorkspace.RegisterAcquiredPackage(registered);
+        var provenanceCoordinate = new BrowserPackageCoordinate(
+            unregisteredProducer,
+            new PackageRootRealization(
+                unregisteredProducer.Content,
+                provenanceId,
+                "1.0.0",
+                "net11.0"));
+
+        Assert.Throws<InvalidOperationException>(
+            () => BrowserPackageWorkspace.OpenScope(
+                [provenanceCoordinate]));
+
+        string frameworksId = $"Exact.Frameworks.{Guid.NewGuid():N}";
+        var cachedPackage = new BrowserPackage(
+            frameworksId,
+            "1.0.0",
+            Package(
+                image,
+                $"lib/net10.0/{frameworksId}.dll"),
+            fromCache: false,
+            producerKey: "producer-a");
+        var unregisteredFramework = new BrowserPackage(
+            frameworksId,
+            "1.0.0",
+            Package(
+                image,
+                $"lib/net11.0/{frameworksId}.dll"),
+            fromCache: false,
+            producerKey: "producer-a");
+        BrowserPackageWorkspace.RegisterAcquiredPackage(cachedPackage);
+        var cachedCoordinate = new BrowserPackageCoordinate(
+            cachedPackage,
+            new PackageRootRealization(
+                cachedPackage.Content,
+                frameworksId,
+                "1.0.0",
+                "net10.0"));
+        var unregisteredCoordinate = new BrowserPackageCoordinate(
+            unregisteredFramework,
+            new PackageRootRealization(
+                unregisteredFramework.Content,
+                frameworksId,
+                "1.0.0",
+                "net11.0"));
+
+        Assert.Throws<InvalidOperationException>(
+            () => BrowserPackageWorkspace.OpenScope(
+                [cachedCoordinate, unregisteredCoordinate]));
+    }
+
+    [Fact]
     public void MixedPackageScope_RealizesOnlySelectedCoordinates()
     {
         byte[] image =

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1364,13 +1364,14 @@ public sealed class BrowserEngineBoundaryTests
         InvalidOperationException error =
             Assert.Throws<InvalidOperationException>(
                 () => coordinate.ImplementationAsset(
-                    coordinate.DefaultAsset.AssemblyName));
+                    Assert.IsType<PackageCompileAsset>(
+                        coordinate.DefaultAsset).AssemblyName));
 
         Assert.Contains("reference assembly only", error.Message);
     }
 
     [Fact]
-    public async Task PackageFrameworkFailure_DoesNotEmitArtifactFramework()
+    public async Task PackageFrameworkUnavailability_DoesNotEmitArtifactFramework()
     {
         const char bidi = '\u202E';
         const string packageId = "Bidi.Framework.Failure";
@@ -1378,21 +1379,53 @@ public sealed class BrowserEngineBoundaryTests
             new BrowserPackage(
                 packageId,
                 "1.0.0",
-                Package(
-                    [0x01],
-                    $"lib/net8.0{bidi}/{packageId}.dll"),
+                PackageEntries(
+                    ($"{packageId}.nuspec", Encoding.UTF8.GetBytes(
+                        $"""
+                         <?xml version="1.0" encoding="utf-8"?>
+                         <package>
+                           <metadata>
+                             <id>{packageId}</id>
+                             <version>1.0.0</version>
+                             <dependencies>
+                               <group targetFramework="net8.0{bidi}" />
+                             </dependencies>
+                           </metadata>
+                         </package>
+                         """)),
+                    ($"lib/net8.0{bidi}/{packageId}.dll", [0x01])),
                 fromCache: false));
 
-        InvalidOperationException failure =
+        BrowserPackageSurface surface = Assert.IsType<BrowserPackageSurface>(
+            JsonSerializer.Deserialize(
+                await InspectionEngine.QueryPackage(
+                    packageId,
+                    "1.0.0",
+                    "net11.0"),
+                BrowserJsonContext.Default.BrowserPackageSurface));
+
+        Assert.DoesNotContain(
+            surface.Frameworks,
+            framework => framework.Contains(bidi, StringComparison.Ordinal));
+        Assert.Equal(
+            BrowserCompileLibraryStatus.NoMatchingTargetFramework,
+            surface.CompileLibrary.Status);
+        Assert.Empty(surface.Frameworks);
+        Assert.DoesNotContain(bidi, surface.ActiveFramework);
+        Assert.DoesNotContain(
+            bidi,
+            surface.CompileLibrary.TargetFramework ?? "");
+        InvalidOperationException dependencyFailure =
             await Assert.ThrowsAsync<InvalidOperationException>(
-                () => BrowserPackageWorkspace.ResolveAsync(
+                () => InspectionEngine.QueryPackageDependencies(
                     packageId,
                     "1.0.0",
                     "net11.0",
-                    TestContext.Current.CancellationToken));
-
-        Assert.DoesNotContain(bidi, failure.Message);
-        Assert.DoesNotContain($"net8.0{bidi}", failure.Message, StringComparison.Ordinal);
+                    assemblyId: ""));
+        Assert.Contains(
+            "cannot be represented safely",
+            dependencyFailure.Message);
+        Assert.DoesNotContain(bidi, dependencyFailure.Message);
 
         var selectedPackage = new BrowserPackage(
             "Bidi.Selected.Framework",
@@ -1401,7 +1434,7 @@ public sealed class BrowserEngineBoundaryTests
                 [0x01],
                 $"lib/net8.0{bidi}/Selected.dll"),
             fromCache: false);
-        var selectedContext = new PackageAssemblyContextSelection(
+        var selectedContext = new PackageRootRealization(
             selectedPackage.Content,
             selectedPackage.PackageId,
             selectedPackage.Version);
@@ -1413,6 +1446,86 @@ public sealed class BrowserEngineBoundaryTests
                 () => coordinate.CompileAsset("Missing.dll"));
 
         Assert.DoesNotContain(bidi, compileFailure.Message);
+    }
+
+    [Fact]
+    public void PackageCoordinate_RejectsDifferentContentWithSameIdentity()
+    {
+        const string packageId = "Exact.Content";
+        byte[] image =
+            File.ReadAllBytes(typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        var package = new BrowserPackage(
+            packageId,
+            "1.0.0",
+            Package(image, $"lib/net11.0/{packageId}.dll"),
+            fromCache: false);
+        var differentContent = new BrowserPackage(
+            packageId,
+            "1.0.0",
+            Package(
+                image,
+                $"lib/net11.0/{packageId}.dll",
+                paddingBytes: 1),
+            fromCache: false);
+        var root = new PackageRootRealization(
+            differentContent.Content,
+            packageId,
+            "1.0.0",
+            "net11.0");
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => new BrowserPackageCoordinate(package, root));
+
+        Assert.Contains("exact content", error.Message);
+    }
+
+    [Fact]
+    public void MixedPackageScope_RealizesOnlySelectedCoordinates()
+    {
+        byte[] image =
+            File.ReadAllBytes(typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        var selectedPackage = new BrowserPackage(
+            "Selected.Library",
+            "1.0.0",
+            Package(image, "lib/net11.0/Selected.Library.dll"),
+            fromCache: false);
+        var rootOnlyPackage = new BrowserPackage(
+            "Tool.Pointer",
+            "1.0.0",
+            PackageEntries(
+                ("tools/net11.0/any/Tool.Pointer.dll", [0x01])),
+            fromCache: false);
+        var selectedCoordinate = new BrowserPackageCoordinate(
+            selectedPackage,
+            new PackageRootRealization(
+                selectedPackage.Content,
+                selectedPackage.PackageId,
+                selectedPackage.Version,
+                "net11.0"));
+        var rootOnlyCoordinate = new BrowserPackageCoordinate(
+            rootOnlyPackage,
+            new PackageRootRealization(
+                rootOnlyPackage.Content,
+                rootOnlyPackage.PackageId,
+                rootOnlyPackage.Version,
+                "net11.0"));
+
+        using var scope = new BrowserInspectionScope(
+            [selectedCoordinate, rootOnlyCoordinate]);
+
+        Assert.Equal(2, scope.Coordinates.Length);
+        BrowserWorkspaceParticipant participant =
+            Assert.Single(scope.SurfaceParticipants);
+        Assert.Same(selectedCoordinate, participant.Coordinate);
+        Assert.Same(
+            selectedCoordinate,
+            Assert.Single(scope.ImplementationParticipants).Coordinate);
+        InvalidOperationException error =
+            Assert.Throws<InvalidOperationException>(
+                () => rootOnlyCoordinate.CompileAsset("Tool.Pointer"));
+        Assert.Contains(
+            nameof(PackageCompileAssetSelectionStatus.NoCompileAssets),
+            error.Message);
     }
 
     [Fact]
@@ -1791,6 +1904,9 @@ public sealed class BrowserEngineBoundaryTests
                         "netcore.app"),
                     BrowserJsonContext.Default.BrowserPackageIntegrations));
         Assert.True(integrations.IsComplete);
+        Assert.Equal(
+            BrowserCompileLibraryStatus.Selected,
+            integrations.CompileLibrary.Status);
         BrowserPackageOpportunities opportunities =
             Assert.IsType<BrowserPackageOpportunities>(
                 JsonSerializer.Deserialize(
@@ -1800,6 +1916,21 @@ public sealed class BrowserEngineBoundaryTests
                         "netcore.app"),
                     BrowserJsonContext.Default.BrowserPackageOpportunities));
         Assert.True(opportunities.IsComplete);
+        Assert.Equal(
+            BrowserCompileLibraryStatus.Selected,
+            opportunities.CompileLibrary.Status);
+        BrowserPackageMetadata metadata =
+            Assert.IsType<BrowserPackageMetadata>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPlatformMetadata(
+                        "net11.0",
+                        version,
+                        "InspectWeb.Engine.Tests.dll",
+                        "netcore.app"),
+                    BrowserJsonContext.Default.BrowserPackageMetadata));
+        Assert.Equal(
+            BrowserCompileLibraryStatus.Selected,
+            metadata.CompileLibrary.Status);
 
         var selected = siblingSurface.Types
             .SelectMany(type => type.Api.Select(member => (Type: type, Member: member)))
@@ -2841,6 +2972,239 @@ public sealed class BrowserEngineBoundaryTests
                 "asset:pending",
                 "Pending",
                 budget));
+    }
+
+    [Fact]
+    public async Task QueryPackage_ToolsPointerRetainsRootAndManifestDependencies()
+    {
+        const string packageId = "Tool.Pointer";
+        byte[] package = PackageEntries(
+            ($"{packageId}.nuspec", Encoding.UTF8.GetBytes(
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <id>Tool.Pointer</id>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <group targetFramework="net11.0">
+                        <dependency id="Tool.Payload" version="[1.0.0]" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """)),
+            ("README.md", Encoding.UTF8.GetBytes("# Tool Pointer")),
+            ("tools/net11.0/any/Tool.Pointer.dll", [0x01]));
+        BrowserPackageWorkspace.RegisterAcquiredPackage(
+            new BrowserPackage(packageId, "1.0.0", package, fromCache: false));
+
+        BrowserInspectionScope rootScope =
+            await BrowserPackageWorkspace.OpenScopeAsync(
+                packageId,
+                "1.0.0",
+                "net11.0",
+                TestContext.Current.CancellationToken);
+        BrowserPackageCoordinate coordinate = Assert.Single(rootScope.Coordinates);
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.NoCompileAssets,
+            coordinate.Root.AssetSelection.Status);
+        Assert.Equal(
+            coordinate.Package.Content.FromCache,
+            coordinate.Root.FromCache);
+        Assert.Equal(
+            coordinate.Package.Content.ProducerKey,
+            coordinate.Root.ProducerKey);
+        Assert.True(
+            coordinate.Root.ReferencesContent(coordinate.Package.Content));
+        Assert.Empty(rootScope.SurfaceParticipants);
+        Assert.Empty(rootScope.ImplementationParticipants);
+
+        BrowserPackageSurface surface = Assert.IsType<BrowserPackageSurface>(
+            JsonSerializer.Deserialize(
+                await InspectionEngine.QueryPackage(
+                    packageId,
+                    "1.0.0",
+                    "net11.0"),
+                BrowserJsonContext.Default.BrowserPackageSurface));
+
+        Assert.Equal(
+            BrowserCompileLibraryStatus.NoCompileAssets,
+            surface.CompileLibrary.Status);
+        Assert.Null(surface.CompileLibrary.TargetFramework);
+        Assert.Null(surface.DefaultAssemblyId);
+        Assert.Empty(surface.Assemblies);
+        Assert.Empty(surface.Types);
+        Assert.Empty(surface.Accessibility);
+        Assert.Equal("README.md", Assert.Single(surface.Documents).Path);
+        Assert.Empty(surface.InspectionErrors);
+        Assert.Null(surface.InspectionError);
+
+        BrowserPackageDependencies dependencies =
+            Assert.IsType<BrowserPackageDependencies>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackageDependencies(
+                        packageId,
+                        "1.0.0",
+                        "net11.0",
+                        assemblyId: ""),
+                    BrowserJsonContext.Default.BrowserPackageDependencies));
+        Assert.Null(dependencies.Assembly);
+        Assert.Empty(dependencies.AssemblyReferences);
+        Assert.Equal(
+            BrowserCompileLibraryStatus.NoCompileAssets,
+            dependencies.CompileLibrary.Status);
+        Assert.Equal(
+            dependencies.CompileLibrary.Message,
+            dependencies.AssemblyReferenceError);
+        BrowserPackageDependency dependency = Assert.Single(
+            Assert.Single(dependencies.DependencyGroups).Dependencies);
+        Assert.Equal("Tool.Payload", dependency.Id);
+        InvalidOperationException metadataTableFailure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => InspectionEngine.QueryPackageMetadataTable(
+                    packageId,
+                    "1.0.0",
+                    "net11.0",
+                    assemblyFileName: "",
+                    tableIndex: 0,
+                    startRowId: 1,
+                    maxRows: 1));
+        Assert.Contains(
+            nameof(PackageCompileAssetSelectionStatus.NoCompileAssets),
+            metadataTableFailure.Message);
+        await AssertRootOnlyAggregateStatus(
+            packageId,
+            "net11.0",
+            BrowserCompileLibraryStatus.NoCompileAssets);
+    }
+
+    [Fact]
+    public async Task QueryPackage_ExplicitEmptyCompileGroupRetainsTypedAbsence()
+    {
+        const string packageId = "Empty.Compile.Group";
+        BrowserPackageWorkspace.RegisterAcquiredPackage(
+            new BrowserPackage(
+                packageId,
+                "1.0.0",
+                PackageEntries(
+                    ("ref/net11.0/_._", []),
+                    ("lib/net11.0/Empty.Compile.Group.dll", [0x01])),
+                fromCache: false));
+
+        BrowserPackageSurface surface = Assert.IsType<BrowserPackageSurface>(
+            JsonSerializer.Deserialize(
+                await InspectionEngine.QueryPackage(
+                    packageId,
+                    "1.0.0",
+                    "net11.0"),
+                BrowserJsonContext.Default.BrowserPackageSurface));
+
+        Assert.Equal(
+            BrowserCompileLibraryStatus.EmptyCompileGroup,
+            surface.CompileLibrary.Status);
+        Assert.Equal("net11.0", surface.CompileLibrary.TargetFramework);
+        Assert.Null(surface.DefaultAssemblyId);
+        Assert.Empty(surface.Assemblies);
+        Assert.Empty(surface.Types);
+        await AssertRootOnlyAggregateStatus(
+            packageId,
+            "net11.0",
+            BrowserCompileLibraryStatus.EmptyCompileGroup);
+    }
+
+    [Fact]
+    public async Task QueryPackage_NoMatchingFrameworkRetainsRequestedRoot()
+    {
+        const string packageId = "Future.Library";
+        BrowserPackageWorkspace.RegisterAcquiredPackage(
+            new BrowserPackage(
+                packageId,
+                "1.0.0",
+                PackageEntries(
+                    ("lib/net11.0/Future.Library.dll",
+                        File.ReadAllBytes(
+                            typeof(BrowserEngineBoundaryTests).Assembly.Location))),
+                fromCache: false));
+
+        BrowserPackageSurface surface = Assert.IsType<BrowserPackageSurface>(
+            JsonSerializer.Deserialize(
+                await InspectionEngine.QueryPackage(
+                    packageId,
+                    "1.0.0",
+                    "net10.0"),
+                BrowserJsonContext.Default.BrowserPackageSurface));
+
+        Assert.Equal(
+            BrowserCompileLibraryStatus.NoMatchingTargetFramework,
+            surface.CompileLibrary.Status);
+        Assert.Equal("net10.0", surface.ActiveFramework);
+        Assert.Equal("net10.0", surface.CompileLibrary.TargetFramework);
+        Assert.Null(surface.DefaultAssemblyId);
+        Assert.Empty(surface.Assemblies);
+        await AssertRootOnlyAggregateStatus(
+            packageId,
+            "net10.0",
+            BrowserCompileLibraryStatus.NoMatchingTargetFramework);
+    }
+
+    static async Task AssertRootOnlyAggregateStatus(
+        string packageId,
+        string framework,
+        BrowserCompileLibraryStatus expectedStatus)
+    {
+        BrowserPackageMetadata metadata =
+            Assert.IsType<BrowserPackageMetadata>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackageMetadata(
+                        packageId,
+                        "1.0.0",
+                        framework),
+                    BrowserJsonContext.Default.BrowserPackageMetadata));
+        Assert.Empty(metadata.Assemblies);
+        Assert.Null(metadata.InspectionError);
+        Assert.Equal(expectedStatus, metadata.CompileLibrary.Status);
+
+        BrowserPackageIntegrations integrations =
+            Assert.IsType<BrowserPackageIntegrations>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackageIntegrations(
+                        packageId,
+                        "1.0.0",
+                        framework),
+                    BrowserJsonContext.Default.BrowserPackageIntegrations));
+        Assert.Empty(integrations.Categories);
+        Assert.Equal(0, integrations.TotalSignals);
+        Assert.False(integrations.IsComplete);
+        Assert.Null(integrations.InspectionError);
+        Assert.Equal(expectedStatus, integrations.CompileLibrary.Status);
+
+        BrowserPackageOpportunities opportunities =
+            Assert.IsType<BrowserPackageOpportunities>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackageOpportunities(
+                        packageId,
+                        "1.0.0",
+                        framework),
+                    BrowserJsonContext.Default.BrowserPackageOpportunities));
+        Assert.Empty(opportunities.Categories);
+        Assert.Equal(0, opportunities.TotalOpportunities);
+        Assert.False(opportunities.IsComplete);
+        Assert.Null(opportunities.InspectionError);
+        Assert.Equal(expectedStatus, opportunities.CompileLibrary.Status);
+
+        BrowserPackagePerformance performance =
+            Assert.IsType<BrowserPackagePerformance>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackagePerformance(
+                        packageId,
+                        "1.0.0",
+                        framework),
+                    BrowserJsonContext.Default.BrowserPackagePerformance));
+        Assert.Empty(performance.Members);
+        Assert.Equal(0, performance.TotalOpportunities);
+        Assert.Null(performance.InspectionError);
+        Assert.Equal(expectedStatus, performance.CompileLibrary.Status);
     }
 
     [Fact]
@@ -4762,7 +5126,7 @@ public sealed class BrowserEngineBoundaryTests
     {
         var package = new BrowserPackage(id, "1.0.0", nupkg, fromCache: false);
         BrowserPackageWorkspace.RegisterAcquiredPackage(package);
-        var assemblyContext = new PackageAssemblyContextSelection(
+        var assemblyContext = new PackageRootRealization(
             package.Content,
             id,
             package.Version,
@@ -4799,6 +5163,24 @@ public sealed class BrowserEngineBoundaryTests
                     padding.Write(block, 0, count);
                     remaining -= count;
                 }
+            }
+        }
+
+        return content.ToArray();
+    }
+
+    static byte[] PackageEntries(
+        params (string Path, byte[] Content)[] entries)
+    {
+        using var content = new MemoryStream();
+        using (var archive = new ZipArchive(content, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach ((string path, byte[] bytes) in entries)
+            {
+                using Stream entry = archive
+                    .CreateEntry(path, CompressionLevel.NoCompression)
+                    .Open();
+                entry.Write(bytes);
             }
         }
 

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1614,6 +1614,64 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void PackageScope_RequestedFrameworkCannotForgeCompositeRegistryKey()
+    {
+        string suffix = Guid.NewGuid().ToString("N");
+        string firstId = $"Scope.Collision.First.{suffix}";
+        string secondId = $"Scope.Collision.Second.{suffix}";
+        var firstPackage = new BrowserPackage(
+            firstId,
+            "1.0.0",
+            PackageEntries(($"tools/net11.0/any/{firstId}.dll", [0x01])),
+            fromCache: false);
+        var secondPackage = new BrowserPackage(
+            secondId,
+            "1.0.0",
+            PackageEntries(($"tools/net11.0/any/{secondId}.dll", [0x02])),
+            fromCache: false);
+        BrowserPackageWorkspace.RegisterAcquiredPackage(firstPackage);
+        BrowserPackageWorkspace.RegisterAcquiredPackage(secondPackage);
+
+        BrowserPackageCoordinate crafted = new(
+            firstPackage,
+            new PackageRootRealization(
+                firstPackage.Content,
+                firstId,
+                "1.0.0",
+                $"net8.0|{secondId.ToLowerInvariant()}@1.0.0/net9.0"));
+        BrowserPackageCoordinate first = new(
+            firstPackage,
+            new PackageRootRealization(
+                firstPackage.Content,
+                firstId,
+                "1.0.0",
+                "net8.0"));
+        BrowserPackageCoordinate second = new(
+            secondPackage,
+            new PackageRootRealization(
+                secondPackage.Content,
+                secondId,
+                "1.0.0",
+                "net9.0"));
+
+        BrowserInspectionScope craftedScope =
+            BrowserPackageWorkspace.OpenScope([crafted]);
+        BrowserInspectionScope legitimateScope =
+            BrowserPackageWorkspace.OpenScope([first, second]);
+        try
+        {
+            Assert.NotSame(craftedScope, legitimateScope);
+            Assert.Single(craftedScope.Coordinates);
+            Assert.Equal(2, legitimateScope.Coordinates.Length);
+        }
+        finally
+        {
+            BrowserPackageWorkspace.RemoveScope(craftedScope);
+            BrowserPackageWorkspace.RemoveScope(legitimateScope);
+        }
+    }
+
+    [Fact]
     public void MixedPackageScope_RealizesOnlySelectedCoordinates()
     {
         byte[] image =
@@ -3610,6 +3668,57 @@ public sealed class BrowserEngineBoundaryTests
         Assert.Equal(
             JsonValueKind.Null,
             root.GetProperty("assemblyReferenceError").ValueKind);
+    }
+
+    [Fact]
+    public async Task PackageDependencies_BlankDeclaredFrameworkDoesNotAbortProjection()
+    {
+        string packageId = $"Blank.Dependency.Framework.{Guid.NewGuid():N}";
+        byte[] image = File.ReadAllBytes(
+            typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        byte[] nupkg = PackageWithManifest(
+            image,
+            $"lib/net11.0/{packageId}.dll",
+            $"""
+             <package>
+               <metadata>
+                 <id>{packageId}</id>
+                 <version>1.0.0</version>
+                 <dependencies>
+                   <group targetFramework="net11.0">
+                     <dependency id="Valid.Dependency" version="[1.0.0]" />
+                   </group>
+                   <group targetFramework="" />
+                 </dependencies>
+               </metadata>
+             </package>
+             """);
+        BrowserPackageWorkspace.RegisterAcquiredPackage(
+            new BrowserPackage(
+                packageId,
+                "1.0.0",
+                nupkg,
+                fromCache: false));
+
+        BrowserPackageDependencies dependencies =
+            Assert.IsType<BrowserPackageDependencies>(
+                JsonSerializer.Deserialize(
+                    await InspectionEngine.QueryPackageDependencies(
+                        packageId,
+                        "1.0.0",
+                        "net11.0",
+                        $"{packageId}.dll"),
+                    BrowserJsonContext.Default.BrowserPackageDependencies));
+
+        Assert.Equal(2, dependencies.DependencyGroups.Length);
+        Assert.Equal("net11.0", dependencies.DependencyGroups[0].Framework);
+        Assert.Equal("any", dependencies.DependencyGroups[1].Framework);
+        Assert.Equal(
+            "Valid.Dependency",
+            Assert.Single(dependencies.DependencyGroups[0].Dependencies).Id);
+        Assert.Equal(
+            BrowserCompileLibraryStatus.Selected,
+            dependencies.CompileLibrary.Status);
     }
 
     [Fact]

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1480,6 +1480,69 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void PackageScope_DoesNotCollapseDifferentContentAtSameCoordinate()
+    {
+        string packageId = $"Exact.Scope.{Guid.NewGuid():N}";
+        byte[] firstImage =
+            File.ReadAllBytes(typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        byte[] secondImage =
+            File.ReadAllBytes(typeof(PackageAssemblyContextRealization).Assembly.Location);
+        var firstPackage = new BrowserPackage(
+            packageId,
+            "1.0.0",
+            Package(firstImage, $"lib/net11.0/{packageId}.dll"),
+            fromCache: false);
+        var secondPackage = new BrowserPackage(
+            packageId,
+            "1.0.0",
+            Package(secondImage, $"lib/net11.0/{packageId}.dll"),
+            fromCache: false);
+        var firstCoordinate = new BrowserPackageCoordinate(
+            firstPackage,
+            new PackageRootRealization(
+                firstPackage.Content,
+                packageId,
+                "1.0.0",
+                "net11.0"));
+        var secondCoordinate = new BrowserPackageCoordinate(
+            secondPackage,
+            new PackageRootRealization(
+                secondPackage.Content,
+                packageId,
+                "1.0.0",
+                "net11.0"));
+
+        Assert.Throws<ArgumentException>(
+            () => new BrowserInspectionScope(
+                [firstCoordinate, secondCoordinate]));
+        using var directScope =
+            new BrowserInspectionScope([firstCoordinate]);
+        Assert.False(
+            directScope.ContainsExactCoordinates([secondCoordinate]));
+        Assert.Throws<InvalidOperationException>(
+            () => directScope.Coordinate(secondCoordinate));
+
+        BrowserPackageWorkspace.RegisterAcquiredPackage(firstPackage);
+        BrowserInspectionScope retained =
+            BrowserPackageWorkspace.OpenScope([firstCoordinate]);
+        try
+        {
+            BrowserPackageWorkspace.RegisterAcquiredPackage(secondPackage);
+            InvalidOperationException cacheFailure =
+                Assert.Throws<InvalidOperationException>(
+                    () => BrowserPackageWorkspace.OpenScope(
+                        [secondCoordinate]));
+            Assert.Contains(
+                "exact requested package content",
+                cacheFailure.Message);
+        }
+        finally
+        {
+            BrowserPackageWorkspace.RemoveScope(retained);
+        }
+    }
+
+    [Fact]
     public void MixedPackageScope_RealizesOnlySelectedCoordinates()
     {
         byte[] image =

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -21,12 +21,28 @@ namespace InspectWeb.Engine;
 /// The participants the workspace could not project, if any. A partial surface says so rather
 /// than reading as a complete one.
 /// </param>
+public sealed record BrowserCompileLibraryAvailability(
+    BrowserCompileLibraryStatus Status,
+    string? TargetFramework,
+    string? Message);
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserCompileLibraryStatus>))]
+public enum BrowserCompileLibraryStatus
+{
+    Selected,
+    NoCompileAssets,
+    NoMatchingTargetFramework,
+    EmptyCompileGroup,
+    InvalidImplementationAssets,
+}
+
 public sealed record BrowserPackageSurface(
     string Package,
     string Version,
     string[] Frameworks,
     string ActiveFramework,
-    string DefaultAssemblyId,
+    string? DefaultAssemblyId,
+    BrowserCompileLibraryAvailability CompileLibrary,
     BrowserAssemblySurface[] Assemblies,
     BrowserTypeSurface[] Types,
     BrowserAccessibilityDescriptor[] Accessibility,
@@ -414,7 +430,8 @@ public sealed record BrowserTypeGraphEdge(string FromId, string ToId, string Kin
 
 public sealed record BrowserPackageMetadata(
     BrowserAssemblyMetadata[] Assemblies,
-    string? InspectionError);
+    string? InspectionError,
+    BrowserCompileLibraryAvailability CompileLibrary);
 
 public sealed record BrowserAssemblyMetadata(
     string Assembly,
@@ -513,11 +530,12 @@ public sealed record BrowserPackageDependencies(
     string Package,
     string Version,
     string ActiveFramework,
-    string Assembly,
+    string? Assembly,
     BrowserPackageDependencyGroup[] DependencyGroups,
     BrowserAssemblyReference[] AssemblyReferences,
     string? DependencyGroupError,
-    string? AssemblyReferenceError);
+    string? AssemblyReferenceError,
+    BrowserCompileLibraryAvailability CompileLibrary);
 
 public sealed record BrowserPackageDependencyGroup(
     int Index,
@@ -612,7 +630,8 @@ public sealed record BrowserPackageIntegrations(
     BrowserIntegrationCategory[] Categories,
     int TotalSignals,
     bool IsComplete,
-    string? InspectionError);
+    string? InspectionError,
+    BrowserCompileLibraryAvailability CompileLibrary);
 
 public sealed record BrowserIntegrationCategory(
     string Integration,
@@ -632,7 +651,8 @@ public sealed record BrowserPackageOpportunities(
     BrowserOpportunityCategory[] Categories,
     int TotalOpportunities,
     bool IsComplete,
-    string? InspectionError);
+    string? InspectionError,
+    BrowserCompileLibraryAvailability CompileLibrary);
 
 public sealed record BrowserOpportunityCategory(
     string Integration,
@@ -652,7 +672,8 @@ public sealed record BrowserPackagePerformance(
     BrowserPerformanceMember[] Members,
     string? InspectionError,
     int NonPublicOpportunities,
-    int TotalOpportunities);
+    int TotalOpportunities,
+    BrowserCompileLibraryAvailability CompileLibrary);
 
 public sealed record BrowserPerformanceMember(
     string Assembly,

--- a/prototypes/inspect-web/engine/BrowserInspectionScope.cs
+++ b/prototypes/inspect-web/engine/BrowserInspectionScope.cs
@@ -66,6 +66,15 @@ internal sealed class BrowserInspectionScope : IDisposable
     public BrowserInspectionScope(IReadOnlyList<BrowserPackageCoordinate> coordinates)
     {
         ArgumentNullException.ThrowIfNull(coordinates);
+        if (coordinates
+            .GroupBy(coordinate => coordinate.Key, StringComparer.Ordinal)
+            .Any(group => group.Skip(1).Any()))
+        {
+            throw new ArgumentException(
+                "A browser workspace cannot contain the same package coordinate twice.",
+                nameof(coordinates));
+        }
+
         Coordinates = [.. coordinates];
 
         PackageAssemblyContextRealization? realization = null;
@@ -194,9 +203,20 @@ internal sealed class BrowserInspectionScope : IDisposable
     {
         ArgumentNullException.ThrowIfNull(requested);
         return Coordinates.FirstOrDefault(
-                candidate => candidate.Key.Equals(requested.Key, StringComparison.Ordinal))
+                candidate => candidate.HasExactContentAs(requested))
             ?? throw new InvalidOperationException(
-                $"{requested.PackageId} {requested.Version} is not part of this workspace.");
+                $"{requested.PackageId} {requested.Version} with its exact package content "
+                + "is not part of this workspace.");
+    }
+
+    public bool ContainsExactCoordinates(
+        IReadOnlyList<BrowserPackageCoordinate> requested)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+        return requested.Count == Coordinates.Length
+            && requested.All(candidate =>
+                Coordinates.Any(retained =>
+                    retained.HasExactContentAs(candidate)));
     }
 
     /// <summary>The participant for one coordinate's assembly, or a visible failure.</summary>
@@ -244,9 +264,9 @@ internal sealed class BrowserInspectionScope : IDisposable
         }
 
         return SurfaceParticipants.SingleOrDefault(surface =>
-            surface.Coordinate.Key.Equals(
-                implementationParticipant.Coordinate.Key,
-                StringComparison.Ordinal)
+            ReferenceEquals(
+                surface.Coordinate.Root.Identity,
+                implementationParticipant.Coordinate.Root.Identity)
             && surface.Coordinate.Selection
                 .FindImplementationAsset(surface.Asset)
                 ?.Path.Equals(
@@ -371,7 +391,9 @@ internal sealed class BrowserWorkspaceRole
         ArgumentNullException.ThrowIfNull(coordinate);
         ArgumentNullException.ThrowIfNull(asset);
         return Participants.FirstOrDefault(candidate =>
-                candidate.Coordinate.Key.Equals(coordinate.Key, StringComparison.Ordinal)
+                ReferenceEquals(
+                    candidate.Coordinate.Root.Identity,
+                    coordinate.Root.Identity)
                 && candidate.Asset.Path.Equals(asset.Path, StringComparison.Ordinal))
             ?? throw new InvalidOperationException(
                 $"The requested participant is not part of the {coordinate.PackageId} "

--- a/prototypes/inspect-web/engine/BrowserInspectionScope.cs
+++ b/prototypes/inspect-web/engine/BrowserInspectionScope.cs
@@ -60,7 +60,7 @@ internal sealed class BrowserInspectionScope : IDisposable
 
     readonly InspectionWorkspace _workspace = new();
     readonly PackageAssemblyContextRealization _realization;
-    readonly BrowserWorkspaceRole _surface;
+    readonly BrowserWorkspaceRole? _surface;
     readonly BrowserWorkspaceRole? _implementation;
 
     public BrowserInspectionScope(IReadOnlyList<BrowserPackageCoordinate> coordinates)
@@ -72,7 +72,7 @@ internal sealed class BrowserInspectionScope : IDisposable
         try
         {
             realization = _workspace.RealizePackageAssemblyContextRoles(
-                Coordinates.Select(coordinate => coordinate.AssemblyContext),
+                Coordinates.Select(coordinate => coordinate.Root),
                 new PackageAssemblyContextRealizationOptions
                 {
                     MaxAssembliesPerRole = MaxAssembliesPerRole,
@@ -81,15 +81,17 @@ internal sealed class BrowserInspectionScope : IDisposable
                     RequireDeclaredEntryLengths = true,
                 });
             _realization = realization;
-            _surface = new BrowserWorkspaceRole(
-                realization.SurfaceGroup,
-                realization.SurfaceParticipants,
-                Coordinates);
-            _implementation = realization.ImplementationGroup is null
-                ? null
-                : realization.SharesGroup
-                    ? _surface
-                    : new BrowserWorkspaceRole(
+                _surface = realization.HasAssemblyContexts
+                    ? new BrowserWorkspaceRole(
+                        realization.SurfaceGroup,
+                        realization.SurfaceParticipants,
+                        Coordinates)
+                    : null;
+                _implementation = realization.ImplementationGroup is null
+                    ? null
+                    : realization.SharesGroup
+                        ? Surface
+                        : new BrowserWorkspaceRole(
                         realization.ImplementationGroup,
                         realization.ImplementationParticipants,
                         Coordinates);
@@ -112,7 +114,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     public ImmutableArray<BrowserPackageCoordinate> Coordinates { get; }
 
     public ImmutableArray<BrowserWorkspaceParticipant> SurfaceParticipants =>
-        _surface.Participants;
+        _surface?.Participants ?? [];
 
     public ImmutableArray<BrowserWorkspaceParticipant> ImplementationParticipants =>
         _implementation?.Participants ?? [];
@@ -128,7 +130,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     /// authoritative API surface when the package ships them.
     /// </summary>
     public TResult UseSurface<TResult>(Func<AssemblyContextGroup, TResult> query) =>
-        _surface.Use(query);
+        Surface.Use(query);
 
     /// <summary>
     /// Hands one compile-asset participant to a participant-scoped product query.
@@ -136,7 +138,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     public TResult UseSurfaceParticipant<TResult>(
         BrowserWorkspaceParticipant participant,
         Func<AssemblyContextGroup, AssemblyContextParticipant, TResult> query) =>
-        _surface.UseParticipant(participant, query);
+        Surface.UseParticipant(participant, query);
 
     /// <summary>Hands the implementation group to a body-backed product query.</summary>
     public TResult UseImplementation<TResult>(Func<AssemblyContextGroup, TResult> query) =>
@@ -148,7 +150,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     /// </summary>
     public TResult UseImplementationOrSurface<TResult>(
         Func<AssemblyContextGroup, TResult> query) =>
-        (_implementation ?? _surface).Use(query);
+        (_implementation ?? Surface).Use(query);
 
     /// <summary>
     /// Runs the product-owned Integration roll-up across the complete realized
@@ -170,7 +172,7 @@ internal sealed class BrowserInspectionScope : IDisposable
         if (_implementation?.Participants.Contains(participant) is true)
             return _implementation.UseParticipant(participant, query);
         if (ReferenceOnlySurfaceParticipants.Contains(participant))
-            return _surface.UseParticipant(participant, query);
+            return Surface.UseParticipant(participant, query);
 
         throw new ArgumentException(
             "The participant does not belong to a metadata workspace role.",
@@ -201,7 +203,7 @@ internal sealed class BrowserInspectionScope : IDisposable
     public BrowserWorkspaceParticipant SurfaceParticipant(
         BrowserPackageCoordinate coordinate,
         PackageCompileAsset asset)
-        => _surface.FindParticipant(coordinate, asset);
+        => Surface.FindParticipant(coordinate, asset);
 
     public BrowserWorkspaceParticipant ImplementationParticipant(
         BrowserPackageCoordinate coordinate,
@@ -302,6 +304,11 @@ internal sealed class BrowserInspectionScope : IDisposable
         ?? throw new InvalidOperationException(
             "The selected packages ship no managed implementation assembly for their selected "
             + "frameworks, so this operation has no method bodies to inspect.");
+
+    BrowserWorkspaceRole Surface => _surface
+        ?? throw new InvalidOperationException(
+            "The selected packages have no compile libraries, so this operation has no "
+            + "assembly surface to inspect.");
 }
 
 /// <summary>
@@ -327,7 +334,7 @@ internal sealed class BrowserWorkspaceRole
                 new BrowserWorkspaceParticipant(
                     coordinates.First(coordinate =>
                         ReferenceEquals(
-                            coordinate.AssemblyContext,
+                            coordinate.Root.Identity,
                             participant.Package)),
                     participant)),
         ];

--- a/prototypes/inspect-web/engine/BrowserMetadataOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserMetadataOperations.cs
@@ -21,6 +21,18 @@ public static partial class InspectionEngine
                 version,
                 targetFramework);
         BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
+        if (!coordinate.Selection.IsSelected)
+        {
+            return JsonSerializer.Serialize(
+                new BrowserPackageMetadata(
+                    Assemblies: [],
+                    InspectionError: null,
+                    compileLibrary),
+                BrowserJsonContext.Default.BrowserPackageMetadata);
+        }
+
         var assemblies = new List<BrowserAssemblyMetadata>();
         var failures = new List<string>();
         foreach (BrowserWorkspaceParticipant participant
@@ -51,7 +63,8 @@ public static partial class InspectionEngine
         return JsonSerializer.Serialize(
             new BrowserPackageMetadata(
                 [.. assemblies],
-                failures.Count == 0 ? null : string.Join("; ", failures)),
+                failures.Count == 0 ? null : string.Join("; ", failures),
+                compileLibrary),
             BrowserJsonContext.Default.BrowserPackageMetadata);
     }
 
@@ -146,10 +159,12 @@ public static partial class InspectionEngine
             AssemblyContextEntry<MetadataImageOverview>.Available available =>
                 new BrowserPackageMetadata(
                     [ProjectMetadataAssembly(assembly, available.Value)],
-                    null),
+                    null,
+                    SelectedCompileLibrary(resolution.Scope.Framework)),
             _ => new BrowserPackageMetadata(
                 [],
-                MetadataFailure(result)),
+                MetadataFailure(result),
+                SelectedCompileLibrary(resolution.Scope.Framework)),
         };
         return JsonSerializer.Serialize(
             metadata,
@@ -443,6 +458,13 @@ public static partial class InspectionEngine
         BrowserPackageCoordinate coordinate,
         string assemblyFileName)
     {
+        if (!coordinate.Selection.IsSelected)
+        {
+            throw new InvalidOperationException(
+                $"{coordinate.PackageId} {coordinate.Version} has no selected "
+                + $"compile library ({coordinate.Selection.Status}).");
+        }
+
         BrowserWorkspaceParticipant[] matches =
         [
             .. MetadataParticipants(scope, coordinate).Where(participant =>

--- a/prototypes/inspect-web/engine/BrowserMetadataOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserMetadataOperations.cs
@@ -448,9 +448,9 @@ public static partial class InspectionEngine
     [
         .. scope.ImplementationParticipants
             .Concat(scope.ReferenceOnlySurfaceParticipants)
-            .Where(participant => participant.Coordinate.Key.Equals(
-                coordinate.Key,
-                StringComparison.Ordinal)),
+            .Where(participant => ReferenceEquals(
+                participant.Coordinate.Root.Identity,
+                coordinate.Root.Identity)),
     ];
 
     static BrowserWorkspaceParticipant MetadataParticipant(

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -257,8 +257,9 @@ internal static class BrowserPackageWorkspace
     }
 
     /// <summary>
-    /// Resolves one exact package/version/framework identity into a selected, acquirable
-    /// coordinate. The result carries typed participants but performs no inspection.
+    /// Resolves one exact package/version/framework identity into an acquirable package Root.
+    /// The result preserves the product's compile-library outcome and carries assembly
+    /// participants only when compile assets were selected.
     /// </summary>
     public static async Task<BrowserPackageCoordinate> ResolveAsync(
         string packageId,
@@ -270,34 +271,12 @@ internal static class BrowserPackageWorkspace
             packageId,
             version,
             cancellationToken);
-        var assemblyContext = new PackageAssemblyContextSelection(
+        var root = new PackageRootRealization(
             package.Content,
             packageId,
             package.Version,
             targetFramework);
-        PackageCompileAssetSelection selection = assemblyContext.AssetSelection;
-        return selection.Status switch
-        {
-            PackageCompileAssetSelectionStatus.NoCompileAssets =>
-                throw new InvalidOperationException(
-                    $"{package.PackageId} {package.Version} has no compile-time assemblies, so it "
-                    + "has no inspection workspace."),
-            PackageCompileAssetSelectionStatus.EmptyCompileGroup =>
-                throw new InvalidOperationException(
-                    $"{package.PackageId} {package.Version} declares an empty compile group for "
-                    + "the selected framework, so it ships no API surface for that framework."),
-            PackageCompileAssetSelectionStatus.NoMatchingTargetFramework =>
-                throw new InvalidOperationException(
-                    $"Framework '{targetFramework}' is not present in "
-                    + $"{package.PackageId} {package.Version}."),
-            PackageCompileAssetSelectionStatus.InvalidImplementationAssets =>
-                throw new InvalidOperationException(
-                    "The package has an invalid implementation-asset layout."),
-            PackageCompileAssetSelectionStatus.Selected when selection.IsSelected =>
-                new BrowserPackageCoordinate(package, assemblyContext),
-            _ => throw new InvalidOperationException(
-                "Package compile-asset selection returned an unknown outcome."),
-        };
+        return new BrowserPackageCoordinate(package, root);
     }
 
     /// <summary>
@@ -1466,8 +1445,8 @@ internal sealed class BrowserPackage
 }
 
 /// <summary>
-/// One resolved package/version/framework coordinate and the compile assets the product selector
-/// chose for it. This is acquisition state: it names what a workspace would contain, and inspects
+/// One resolved package/version/framework Root and the compile outcome the product selector chose
+/// for it. This is acquisition state: it names what a workspace would contain, and inspects
 /// nothing.
 /// </summary>
 [SupportedOSPlatform("browser")]
@@ -1475,38 +1454,43 @@ internal sealed class BrowserPackageCoordinate
 {
     public BrowserPackageCoordinate(
         BrowserPackage package,
-        PackageAssemblyContextSelection assemblyContext)
+        PackageRootRealization root)
     {
         ArgumentNullException.ThrowIfNull(package);
-        ArgumentNullException.ThrowIfNull(assemblyContext);
+        ArgumentNullException.ThrowIfNull(root);
         if (!package.PackageId.Equals(
-                assemblyContext.PackageId,
+                root.PackageId,
                 StringComparison.OrdinalIgnoreCase)
             || !package.Version.Equals(
-                assemblyContext.PackageVersion,
-                StringComparison.OrdinalIgnoreCase))
+                root.PackageVersion,
+                StringComparison.OrdinalIgnoreCase)
+            || !root.ReferencesContent(package.Content))
         {
             throw new ArgumentException(
-                "The product package selection must describe the acquired Browser package.",
-                nameof(assemblyContext));
+                "The product package Root must describe the acquired Browser package and its "
+                + "exact content.",
+                nameof(root));
         }
 
         Package = package;
-        AssemblyContext = assemblyContext;
+        Root = root;
     }
 
     public BrowserPackage Package { get; }
 
-    public PackageAssemblyContextSelection AssemblyContext { get; }
+    public PackageRootRealization Root { get; }
 
     public PackageCompileAssetSelection Selection =>
-        AssemblyContext.AssetSelection;
+        Root.AssetSelection;
 
     public string PackageId => Package.PackageId;
 
     public string Version => Package.Version;
 
-    public string Framework => Selection.TargetFramework!;
+    public string Framework =>
+        Selection.TargetFramework
+        ?? Root.RequestedTargetFramework
+        ?? "";
 
     /// <summary>
     /// The exact coordinate this workspace answers for. It is the registry key, so two requests
@@ -1516,7 +1500,7 @@ internal sealed class BrowserPackageCoordinate
     public string Key =>
         $"{PackageId.ToLowerInvariant()}@{Version.ToLowerInvariant()}/{Framework.ToLowerInvariant()}";
 
-    public PackageCompileAsset DefaultAsset => Selection.DefaultAsset!;
+    public PackageCompileAsset? DefaultAsset => Selection.DefaultAsset;
 
     /// <summary>Every assembly the package ships for the selected framework.</summary>
     public IReadOnlyList<PackageCompileAsset> FrameworkAssets => Selection.FrameworkAssets;
@@ -1529,6 +1513,12 @@ internal sealed class BrowserPackageCoordinate
     public PackageCompileAsset CompileAsset(string assemblyIdOrName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(assemblyIdOrName);
+        if (!Selection.IsSelected)
+        {
+            throw new InvalidOperationException(
+                $"{PackageId} {Version} has no selected compile library "
+                + $"({Selection.Status}).");
+        }
         return Selection.FindAsset(assemblyIdOrName)
             ?? Selection.Assets.FirstOrDefault(asset => MatchesAssembly(asset, assemblyIdOrName))
             ?? throw new InvalidOperationException(

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -297,9 +297,7 @@ internal static class BrowserPackageWorkspace
         if (coordinates.Count == 0)
             throw new ArgumentException("A workspace requires at least one package coordinate.");
 
-        string key = "packages|" + string.Join(
-            "|",
-            coordinates.Select(coordinate => coordinate.Key).Order(StringComparer.Ordinal));
+        string key = PackageScopeKey(coordinates);
         if (Scopes.TryGetValue(key, out ScopeEntry? entry))
         {
             if (entry.Scope is not BrowserInspectionScope retained)
@@ -1098,6 +1096,29 @@ internal static class BrowserPackageWorkspace
     internal static string PackageKey(string packageId, string version) =>
         $"{packageId.ToLowerInvariant()}@{version.ToLowerInvariant()}";
 
+    static string PackageScopeKey(
+        IReadOnlyList<BrowserPackageCoordinate> coordinates) =>
+        CompositeKey(
+            [
+                "packages",
+                .. coordinates
+                .Select(coordinate => coordinate.Key)
+                .Order(StringComparer.Ordinal),
+            ]);
+
+    internal static string CompositeKey(params string[] components)
+    {
+        var key = new StringBuilder();
+        foreach (string component in components)
+        {
+            key.Append(component.Length);
+            key.Append(':');
+            key.Append(component);
+        }
+
+        return key.ToString();
+    }
+
     internal static void ValidateArchive(byte[] archive)
     {
         if (PackageArchiveValidator.Validate(archive, PayloadLimits)
@@ -1500,12 +1521,14 @@ internal sealed class BrowserPackageCoordinate
         ?? "";
 
     /// <summary>
-    /// The exact coordinate this workspace answers for. It is the registry key, so two requests
-    /// for the same package, resolved version, and framework reuse one open workspace rather than
-    /// reacquiring every image.
+    /// The exact coordinate this workspace answers for. Each component is length-prefixed so
+    /// caller-controlled framework text cannot alter coordinate or workspace key boundaries.
     /// </summary>
     public string Key =>
-        $"{PackageId.ToLowerInvariant()}@{Version.ToLowerInvariant()}/{Framework.ToLowerInvariant()}";
+        BrowserPackageWorkspace.CompositeKey(
+            PackageId.ToLowerInvariant(),
+            Version.ToLowerInvariant(),
+            Framework.ToLowerInvariant());
 
     public bool HasExactContentAs(BrowserPackageCoordinate other)
     {

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -307,6 +307,12 @@ internal static class BrowserPackageWorkspace
                 throw new InvalidOperationException(
                     "The browser scope registry key names a different scope kind.");
             }
+            if (!retained.ContainsExactCoordinates(coordinates))
+            {
+                throw new InvalidOperationException(
+                    "The retained browser workspace does not match the exact requested "
+                    + "package content.");
+            }
             Scopes[key] = entry with { LastAccess = ++_clock };
             TouchPackages(entry.PackageKeys);
             return retained;
@@ -1499,6 +1505,16 @@ internal sealed class BrowserPackageCoordinate
     /// </summary>
     public string Key =>
         $"{PackageId.ToLowerInvariant()}@{Version.ToLowerInvariant()}/{Framework.ToLowerInvariant()}";
+
+    public bool HasExactContentAs(BrowserPackageCoordinate other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+        return Key.Equals(other.Key, StringComparison.Ordinal)
+            && ReferenceEquals(Package.RetainedBytes, other.Package.RetainedBytes)
+            && Root.ProducerKey.Equals(
+                other.Root.ProducerKey,
+                StringComparison.Ordinal);
+    }
 
     public PackageCompileAsset? DefaultAsset => Selection.DefaultAsset;
 

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -897,24 +897,25 @@ internal static class BrowserPackageWorkspace
     static ImmutableHashSet<string> RetainCoordinatePackages(
         IReadOnlyList<BrowserPackageCoordinate> coordinates)
     {
-        Dictionary<string, BrowserPackage> packages = coordinates
-            .GroupBy(PackageKey, StringComparer.Ordinal)
-            .ToDictionary(
-                group => group.Key,
-                group => group.First().Package,
-                StringComparer.Ordinal);
-        if (packages.Count > MaxCachedPackages)
+        ImmutableHashSet<string> packageKeys = coordinates
+            .Select(PackageKey)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+        if (packageKeys.Count > MaxCachedPackages)
         {
             throw new InvalidOperationException(
                 "The requested workspace's package count exceeds the browser package-cache limit.");
         }
 
-        ImmutableHashSet<string> packageKeys =
-            packages.Keys.ToImmutableHashSet(StringComparer.Ordinal);
-        foreach ((string packageKey, BrowserPackage package) in packages)
+        foreach (BrowserPackageCoordinate coordinate in coordinates)
         {
+            string packageKey = PackageKey(coordinate);
             if (!Cache.TryGetValue(packageKey, out CacheEntry? entry)
-                || !ReferenceEquals(entry.Bytes, package.RetainedBytes))
+                || !ReferenceEquals(
+                    entry.Bytes,
+                    coordinate.Package.RetainedBytes)
+                || !entry.ProducerKey.Equals(
+                    coordinate.Root.ProducerKey,
+                    StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
                     "A resolved browser package escaped aggregate cache accounting before its "

--- a/prototypes/inspect-web/engine/BrowserPlatformOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserPlatformOperations.cs
@@ -686,13 +686,15 @@ public static partial class InspectionEngine
                     ?? "The workspace reported no failure."));
         }
 
+        string framework = RequiredBrowserFramework(resolution.Scope.Framework);
         return JsonSerializer.Serialize(
             new BrowserPackageSurface(
                 PlatformPackageName,
                 resolution.Coordinate.Version,
-                [resolution.Scope.Framework],
-                resolution.Scope.Framework,
+                [framework],
+                framework,
                 assembly,
+                SelectedCompileLibrary(framework),
                 projected.Assemblies,
                 projected.Types,
                 projected.Accessibility,

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -241,6 +241,11 @@ public static partial class InspectionEngine
         ?? throw new InvalidOperationException(
             "A framework identifier cannot be represented safely.");
 
+    static string BrowserDependencyGroupFramework(string framework) =>
+        string.IsNullOrWhiteSpace(framework)
+            ? "any"
+            : RequiredBrowserFramework(framework);
+
     static string? BrowserFramework(string? framework)
     {
         if (string.IsNullOrWhiteSpace(framework)
@@ -730,7 +735,7 @@ public static partial class InspectionEngine
                     .. dependencies.Groups.Select((group, index) =>
                         new BrowserPackageDependencyGroup(
                             index,
-                            RequiredBrowserFramework(group.TargetFramework),
+                            BrowserDependencyGroupFramework(group.TargetFramework),
                             index == dependencies.SelectedGroupIndex,
                             [
                                 .. group.Dependencies.Select(dependency =>

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -106,7 +106,9 @@ public static partial class InspectionEngine
         BrowserWorkspaceParticipant[] requested =
         [
             .. scope.SurfaceParticipants.Where(candidate =>
-                candidate.Coordinate.Key.Equals(coordinate.Key, StringComparison.Ordinal)),
+                ReferenceEquals(
+                    candidate.Coordinate.Root.Identity,
+                    coordinate.Root.Identity)),
         ];
 
         // The site's default path shows public types by default and reaches non-public ones

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -75,6 +75,31 @@ public static partial class InspectionEngine
     {
         ArgumentNullException.ThrowIfNull(scope);
         ArgumentNullException.ThrowIfNull(coordinate);
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
+        if (!coordinate.Selection.IsSelected)
+        {
+            return new BrowserPackageProjection(
+                new BrowserPackageSurface(
+                    coordinate.PackageId,
+                    coordinate.Version,
+                    BrowserFrameworks(coordinate.Selection),
+                    BrowserFramework(coordinate),
+                    DefaultAssemblyId: null,
+                    compileLibrary,
+                    Assemblies: [],
+                    Types: [],
+                    Accessibility: [],
+                    TotalMembers: 0,
+                    [.. coordinate.Package.Documents()],
+                    InspectionErrors: [],
+                    InspectionError: null),
+                ApiSurfaces: null);
+        }
+
+        PackageCompileAsset defaultAsset = coordinate.DefaultAsset
+            ?? throw new InvalidOperationException(
+                "A selected compile-library outcome did not identify its default asset.");
         // Only this coordinate's assemblies are projected. A composite workspace may hold several
         // packages, and projecting all of them here materialized every other package's surface
         // only to discard it.
@@ -117,19 +142,20 @@ public static partial class InspectionEngine
 
         string defaultAssemblyId = projected.Assemblies.FirstOrDefault(
                 assembly => assembly.Id.Equals(
-                    coordinate.DefaultAsset.Id,
+                    defaultAsset.Id,
                     StringComparison.Ordinal))
             ?.Id
             ?? projected.Assemblies.FirstOrDefault()?.Id
-            ?? coordinate.DefaultAsset.Id;
+            ?? defaultAsset.Id;
 
         return new BrowserPackageProjection(
             new BrowserPackageSurface(
                 coordinate.PackageId,
                 coordinate.Version,
-                [.. coordinate.Selection.AvailableTargetFrameworks],
-                coordinate.Framework,
+                BrowserFrameworks(coordinate.Selection),
+                BrowserFramework(coordinate),
                 defaultAssemblyId,
+                compileLibrary,
                 projected.Assemblies,
                 projected.Types,
                 projected.Accessibility,
@@ -142,7 +168,99 @@ public static partial class InspectionEngine
 
     sealed record BrowserPackageProjection(
         BrowserPackageSurface Surface,
-        AssemblyContextApiSurfaceResult ApiSurfaces);
+        AssemblyContextApiSurfaceResult? ApiSurfaces);
+
+    static BrowserCompileLibraryAvailability CompileLibrary(
+        PackageCompileAssetSelection selection)
+    {
+        string? framework = BrowserFramework(selection.TargetFramework);
+        if (selection.IsSelected && framework is null)
+        {
+            throw new InvalidOperationException(
+                "The selected compile-library framework cannot be represented safely.");
+        }
+
+        return new(
+            selection.Status switch
+            {
+                PackageCompileAssetSelectionStatus.Selected =>
+                    BrowserCompileLibraryStatus.Selected,
+                PackageCompileAssetSelectionStatus.NoCompileAssets =>
+                    BrowserCompileLibraryStatus.NoCompileAssets,
+                PackageCompileAssetSelectionStatus.NoMatchingTargetFramework =>
+                    BrowserCompileLibraryStatus.NoMatchingTargetFramework,
+                PackageCompileAssetSelectionStatus.EmptyCompileGroup =>
+                    BrowserCompileLibraryStatus.EmptyCompileGroup,
+                PackageCompileAssetSelectionStatus.InvalidImplementationAssets =>
+                    BrowserCompileLibraryStatus.InvalidImplementationAssets,
+                _ => throw new InvalidOperationException(
+                    "Package compile-asset selection returned an unknown outcome."),
+            },
+            framework,
+            selection.Status switch
+            {
+                PackageCompileAssetSelectionStatus.Selected => null,
+                PackageCompileAssetSelectionStatus.NoCompileAssets =>
+                    "The package contains no compile assets.",
+                PackageCompileAssetSelectionStatus.NoMatchingTargetFramework =>
+                    "No compatible target framework was selected.",
+                PackageCompileAssetSelectionStatus.EmptyCompileGroup =>
+                    "The selected target framework declares an empty compile group.",
+                PackageCompileAssetSelectionStatus.InvalidImplementationAssets =>
+                    "The package has an invalid implementation-asset layout.",
+                _ => throw new InvalidOperationException(
+                    "Package compile-asset selection returned an unknown outcome."),
+            });
+    }
+
+    static BrowserCompileLibraryAvailability SelectedCompileLibrary(
+        string framework)
+    {
+        string projectedFramework = RequiredBrowserFramework(framework);
+        return new(
+            BrowserCompileLibraryStatus.Selected,
+            projectedFramework,
+            Message: null);
+    }
+
+    static string[] BrowserFrameworks(PackageCompileAssetSelection selection) =>
+    [
+        .. selection.AvailableTargetFrameworks
+            .Select(BrowserFramework)
+            .OfType<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase),
+    ];
+
+    static string BrowserFramework(BrowserPackageCoordinate coordinate) =>
+        BrowserFramework(coordinate.Framework) ?? "";
+
+    static string RequiredBrowserFramework(string framework) =>
+        BrowserFramework(framework)
+        ?? throw new InvalidOperationException(
+            "A framework identifier cannot be represented safely.");
+
+    static string? BrowserFramework(string? framework)
+    {
+        if (string.IsNullOrWhiteSpace(framework)
+            || framework.Length > 128)
+        {
+            return null;
+        }
+
+        foreach (char character in framework)
+        {
+            if (!(character is >= 'a' and <= 'z')
+                && !(character is >= 'A' and <= 'Z')
+                && !(character is >= '0' and <= '9')
+                && character is not
+                    ('.' or '-' or '+' or '_' or ',' or '=' or ' '))
+            {
+                return null;
+            }
+        }
+
+        return framework;
+    }
 
     /// <summary>
     /// One type's metadata projection, produced by
@@ -512,10 +630,12 @@ public static partial class InspectionEngine
             version,
             targetFramework);
         BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
 
         PackageDependencyGroupsResult dependencyResult =
             await PackageDependencyGroupsQuery.ExecuteAsync(
-                coordinate.Package.Content,
+        coordinate.Package.Content,
                 coordinate.PackageId,
                 coordinate.Version,
                 coordinate.Framework);
@@ -533,55 +653,64 @@ public static partial class InspectionEngine
                 "Unknown package dependency-group query result."),
         };
 
-        PackageCompileAsset asset = coordinate.CompileAsset(assemblyId);
-        BrowserWorkspaceParticipant participant =
-            scope.SurfaceParticipant(coordinate, asset);
-        AssemblyContextEntry<ImmutableArray<AssemblyReferenceIdentity>> referenceResult =
-            scope.UseSurfaceParticipant(
-                participant,
-                AssemblyContextReferencesQuery.ExecuteParticipant);
-
+        string? assembly = null;
         BrowserAssemblyReference[] assemblyReferences = [];
         string? assemblyReferenceError = null;
-        switch (referenceResult)
+        if (coordinate.Selection.IsSelected)
         {
-            case AssemblyContextEntry<
-                ImmutableArray<AssemblyReferenceIdentity>>.Available available:
-                assemblyReferences =
-                [
-                    .. available.Value
-                        .Select(reference => reference.ToReference())
-                        .OrderBy(
-                            reference => reference.Name,
-                            StringComparer.OrdinalIgnoreCase)
-                        .ThenBy(
-                            reference => reference.Version,
-                            StringComparer.Ordinal)
-                        .ThenBy(
-                            reference => reference.Culture,
-                            StringComparer.OrdinalIgnoreCase)
-                        .ThenBy(
-                            reference => reference.PublicKeyToken,
-                            StringComparer.OrdinalIgnoreCase)
-                        .Select(reference => new BrowserAssemblyReference(
-                            reference.Name,
-                            reference.Version,
-                            reference.Culture,
-                            reference.PublicKeyToken)),
-                ];
-                break;
-            case AssemblyContextEntry<
-                ImmutableArray<AssemblyReferenceIdentity>>.Rejected rejected:
-                assemblyReferenceError =
-                    $"{rejected.Failure.Kind} ({rejected.Failure.Detail})";
-                break;
-            case AssemblyContextEntry<
-                ImmutableArray<AssemblyReferenceIdentity>>.Failed failed:
-                assemblyReferenceError = failed.Error.Message;
-                break;
-            default:
-                throw new InvalidOperationException(
-                    "Unknown assembly-context reference query result.");
+            PackageCompileAsset asset = coordinate.CompileAsset(assemblyId);
+            assembly = asset.AssemblyName;
+            BrowserWorkspaceParticipant participant =
+                scope.SurfaceParticipant(coordinate, asset);
+            AssemblyContextEntry<ImmutableArray<AssemblyReferenceIdentity>> referenceResult =
+                scope.UseSurfaceParticipant(
+                    participant,
+                    AssemblyContextReferencesQuery.ExecuteParticipant);
+
+            switch (referenceResult)
+            {
+                case AssemblyContextEntry<
+                    ImmutableArray<AssemblyReferenceIdentity>>.Available available:
+                    assemblyReferences =
+                    [
+                        .. available.Value
+                            .Select(reference => reference.ToReference())
+                            .OrderBy(
+                                reference => reference.Name,
+                                StringComparer.OrdinalIgnoreCase)
+                            .ThenBy(
+                                reference => reference.Version,
+                                StringComparer.Ordinal)
+                            .ThenBy(
+                                reference => reference.Culture,
+                                StringComparer.OrdinalIgnoreCase)
+                            .ThenBy(
+                                reference => reference.PublicKeyToken,
+                                StringComparer.OrdinalIgnoreCase)
+                            .Select(reference => new BrowserAssemblyReference(
+                                reference.Name,
+                                reference.Version,
+                                reference.Culture,
+                                reference.PublicKeyToken)),
+                    ];
+                    break;
+                case AssemblyContextEntry<
+                    ImmutableArray<AssemblyReferenceIdentity>>.Rejected rejected:
+                    assemblyReferenceError =
+                        $"{rejected.Failure.Kind} ({rejected.Failure.Detail})";
+                    break;
+                case AssemblyContextEntry<
+                    ImmutableArray<AssemblyReferenceIdentity>>.Failed failed:
+                    assemblyReferenceError = failed.Error.Message;
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        "Unknown assembly-context reference query result.");
+            }
+        }
+        else
+        {
+            assemblyReferenceError = compileLibrary.Message;
         }
 
         string? dependencyGroupError =
@@ -593,13 +722,13 @@ public static partial class InspectionEngine
             new BrowserPackageDependencies(
                 coordinate.PackageId,
                 coordinate.Version,
-                coordinate.Framework,
-                asset.AssemblyName,
+                BrowserFramework(coordinate),
+                assembly,
                 [
                     .. dependencies.Groups.Select((group, index) =>
                         new BrowserPackageDependencyGroup(
                             index,
-                            group.TargetFramework,
+                            RequiredBrowserFramework(group.TargetFramework),
                             index == dependencies.SelectedGroupIndex,
                             [
                                 .. group.Dependencies.Select(dependency =>
@@ -610,7 +739,8 @@ public static partial class InspectionEngine
                 ],
                 assemblyReferences,
                 dependencyGroupError,
-                assemblyReferenceError),
+                assemblyReferenceError,
+                compileLibrary),
             BrowserJsonContext.Default.BrowserPackageDependencies);
     }
 
@@ -633,6 +763,22 @@ public static partial class InspectionEngine
             version,
             targetFramework);
         BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
+        if (!coordinate.Selection.IsSelected)
+        {
+            return JsonSerializer.Serialize(
+                new BrowserPackageIntegrations(
+                    coordinate.PackageId,
+                    coordinate.Version,
+                    BrowserFramework(coordinate),
+                    Categories: [],
+                    TotalSignals: 0,
+                    IsComplete: false,
+                    InspectionError: null,
+                    compileLibrary),
+                BrowserJsonContext.Default.BrowserPackageIntegrations);
+        }
 
         PackageWorkspaceIntegrationsResult result =
             scope.QueryIntegrations();
@@ -642,7 +788,8 @@ public static partial class InspectionEngine
                 coordinate.PackageId,
                 coordinate.Version,
                 coordinate.Framework,
-                result.Libraries.Select(entry => entry.Integrations)),
+                result.Libraries.Select(entry => entry.Integrations),
+                compileLibrary),
             BrowserJsonContext.Default.BrowserPackageIntegrations);
     }
 
@@ -662,6 +809,22 @@ public static partial class InspectionEngine
             version,
             targetFramework);
         BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
+        if (!coordinate.Selection.IsSelected)
+        {
+            return JsonSerializer.Serialize(
+                new BrowserPackageOpportunities(
+                    coordinate.PackageId,
+                    coordinate.Version,
+                    BrowserFramework(coordinate),
+                    Categories: [],
+                    TotalOpportunities: 0,
+                    IsComplete: false,
+                    InspectionError: null,
+                    compileLibrary),
+                BrowserJsonContext.Default.BrowserPackageOpportunities);
+        }
 
         var registry = new InspectionQueryRegistry<AssemblyContextGroup>()
             .Add(
@@ -683,7 +846,8 @@ public static partial class InspectionEngine
                 coordinate.PackageId,
                 coordinate.Version,
                 coordinate.Framework,
-                result.Assemblies),
+                result.Assemblies,
+                compileLibrary),
             BrowserJsonContext.Default.BrowserPackageOpportunities);
     }
 
@@ -691,7 +855,8 @@ public static partial class InspectionEngine
         string package,
         string version,
         string framework,
-        IEnumerable<AssemblyIntegrationsEntry> entries)
+        IEnumerable<AssemblyIntegrationsEntry> entries,
+        BrowserCompileLibraryAvailability? compileLibrary = null)
     {
         AssemblyIntegrationsEntry[] materialized = [.. entries];
         var failures = new List<string>();
@@ -721,7 +886,7 @@ public static partial class InspectionEngine
         return new BrowserPackageIntegrations(
                 package,
                 version,
-                framework,
+                RequiredBrowserFramework(framework),
                 [
                     .. signals
                         .GroupBy(
@@ -754,14 +919,16 @@ public static partial class InspectionEngine
                         is AssemblyIntegrationsEntry.Available),
                 failures.Count == 0
                     ? null
-                    : string.Join("; ", failures));
+                    : string.Join("; ", failures),
+                compileLibrary ?? SelectedCompileLibrary(framework));
     }
 
     internal static BrowserPackageOpportunities CreateOpportunities(
         string package,
         string version,
         string framework,
-        IEnumerable<AssemblyIntegrationOpportunitiesEntry> entries)
+        IEnumerable<AssemblyIntegrationOpportunitiesEntry> entries,
+        BrowserCompileLibraryAvailability? compileLibrary = null)
     {
         AssemblyIntegrationOpportunitiesEntry[] materialized =
             [.. entries];
@@ -808,7 +975,7 @@ public static partial class InspectionEngine
         return new BrowserPackageOpportunities(
                 package,
                 version,
-                framework,
+                RequiredBrowserFramework(framework),
                 [
                     .. distinctOpportunities
                         .GroupBy(
@@ -845,7 +1012,8 @@ public static partial class InspectionEngine
                         is AssemblyIntegrationOpportunitiesEntry.Available),
                 failures.Count == 0
                     ? null
-                    : string.Join("; ", failures));
+                    : string.Join("; ", failures),
+                compileLibrary ?? SelectedCompileLibrary(framework));
     }
 
     /// <summary>
@@ -864,6 +1032,21 @@ public static partial class InspectionEngine
                 packageId,
                 version,
                 targetFramework);
+        BrowserPackageCoordinate coordinate = scope.Coordinates[0];
+        BrowserCompileLibraryAvailability compileLibrary =
+            CompileLibrary(coordinate.Selection);
+        if (!coordinate.Selection.IsSelected)
+        {
+            return JsonSerializer.Serialize(
+                new BrowserPackagePerformance(
+                    Members: [],
+                    InspectionError: null,
+                    NonPublicOpportunities: 0,
+                    TotalOpportunities: 0,
+                    compileLibrary),
+                BrowserJsonContext.Default.BrowserPackagePerformance);
+        }
+
         ImmutableArray<BrowserWorkspaceParticipant> participants =
             scope.ImplementationParticipants.Length > 0
                 ? scope.ImplementationParticipants
@@ -887,7 +1070,7 @@ public static partial class InspectionEngine
                             AssemblyContextOptimizationOpportunitiesQuery
                                 .Definition));
         BrowserPackageSurface surface =
-            ProjectPackageSurface(scope, scope.Coordinates[0]);
+            ProjectPackageSurface(scope, coordinate);
         HashSet<(
             string Assembly,
             string Type,
@@ -960,7 +1143,8 @@ public static partial class InspectionEngine
                     ? null
                     : string.Join("; ", failures),
                 result.NonPublicOpportunities,
-                result.TotalOpportunities),
+                result.TotalOpportunities,
+                compileLibrary),
             BrowserJsonContext.Default.BrowserPackagePerformance);
     }
 
@@ -1560,7 +1744,10 @@ public static partial class InspectionEngine
 
         (ApiType Type, AssemblyContextSubject Subject)[] apiTypes =
         [
-            .. focusProjection.ApiSurfaces.Assemblies.Assemblies
+            .. (focusProjection.ApiSurfaces
+                ?? throw new InvalidOperationException(
+                    "The product home demo focus has no compile-library API surface."))
+                .Assemblies.Assemblies
                 .OfType<AssemblyContextEntry<AssemblyApiSurface>.Available>()
                 .SelectMany(entry => entry.Value.Surface.Types
                     .Where(candidate => string.Equals(

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -4,6 +4,8 @@
 //   eng/generate-inspect-web-engine-dts.sh
 // CI fails if the committed file drifts from this output.
 
+export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
+
 export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Ambiguous" | number;
 
 export type BrowserDependencyCoordinateProvenance = "NuGetPackage" | "PlatformRuntime" | number;
@@ -138,6 +140,12 @@ export interface BrowserCallGraphTarget {
   readonly selectorKey: string;
   readonly kind: string;
   readonly platformPack: string | null;
+}
+
+export interface BrowserCompileLibraryAvailability {
+  readonly status: BrowserCompileLibraryStatus;
+  readonly targetFramework: string | null;
+  readonly message: string | null;
 }
 
 export interface BrowserDependencyCoordinateCandidate {
@@ -424,11 +432,12 @@ export interface BrowserPackageDependencies {
   readonly package: string;
   readonly version: string;
   readonly activeFramework: string;
-  readonly assembly: string;
+  readonly assembly: string | null;
   readonly dependencyGroups: ReadonlyArray<BrowserPackageDependencyGroup>;
   readonly assemblyReferences: ReadonlyArray<BrowserAssemblyReference>;
   readonly dependencyGroupError: string | null;
   readonly assemblyReferenceError: string | null;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
 }
 
 export interface BrowserPackageDependency {
@@ -465,11 +474,13 @@ export interface BrowserPackageIntegrations {
   readonly totalSignals: number;
   readonly isComplete: boolean;
   readonly inspectionError: string | null;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
 }
 
 export interface BrowserPackageMetadata {
   readonly assemblies: ReadonlyArray<BrowserAssemblyMetadata>;
   readonly inspectionError: string | null;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
 }
 
 export interface BrowserPackageOpportunities {
@@ -480,6 +491,7 @@ export interface BrowserPackageOpportunities {
   readonly totalOpportunities: number;
   readonly isComplete: boolean;
   readonly inspectionError: string | null;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
 }
 
 export interface BrowserPackagePerformance {
@@ -487,6 +499,7 @@ export interface BrowserPackagePerformance {
   readonly inspectionError: string | null;
   readonly nonPublicOpportunities: number;
   readonly totalOpportunities: number;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
 }
 
 export interface BrowserPackageSurface {
@@ -494,7 +507,8 @@ export interface BrowserPackageSurface {
   readonly version: string;
   readonly frameworks: ReadonlyArray<string>;
   readonly activeFramework: string;
-  readonly defaultAssemblyId: string;
+  readonly defaultAssemblyId: string | null;
+  readonly compileLibrary: BrowserCompileLibraryAvailability;
   readonly assemblies: ReadonlyArray<BrowserAssemblySurface>;
   readonly types: ReadonlyArray<BrowserTypeSurface>;
   readonly accessibility: ReadonlyArray<BrowserAccessibilityDescriptor>;

--- a/prototypes/inspect-web/src/package-acquisition.ts
+++ b/prototypes/inspect-web/src/package-acquisition.ts
@@ -150,13 +150,13 @@ function surfaceInspectionErrors(result: BrowserPackageSurface): string[] {
 // The two validations are separate because they belong on different paths, and round 6
 // review (GPT-5.6 Sol) showed what collapsing them costs.
 //
-// A *blank* identity is never legitimate: `defaultAssemblyId` is declared non-optional,
-// and a surface without one produces a package model with a blank identity whatever is
-// done with it. An *unmatched* identity is legitimate -- `InspectionEngine.cs` permits an
-// empty `assemblies` list whenever extraction truncates and then falls back to
-// `coordinate.DefaultAsset.Id`, an id matching no descriptor. The producer commits each
-// descriptor and its types atomically, but that truncated result still carries a visible
-// inspection notice worth merging into a compatible resident.
+// A *blank* identity is never legitimate for a surface whose compile library is selected.
+// Root-only package surfaces declare typed compile-library unavailability and bypass this
+// helper. An *unmatched* selected identity is legitimate -- `InspectionEngine.cs` permits
+// an empty `assemblies` list whenever extraction truncates and then falls back to the
+// selected asset id, which matches no descriptor. The producer commits each descriptor and
+// its types atomically, but that truncated result still carries a visible inspection notice
+// worth merging into a compatible resident.
 //
 // Round 5 moved the whole check after the merge branch to stop rejecting that truncated
 // surface, which also stopped rejecting blank identities on the resident-merge path.
@@ -200,6 +200,11 @@ function defaultAssembly(
 export function createNuGetPackageModel(
   result: BrowserPackageSurface,
 ): AppPackage {
+  if (result.compileLibrary.status !== "Selected") {
+    throw new Error(
+      result.compileLibrary.message
+      || `The package Root has no selected compile library (${result.compileLibrary.status}).`);
+  }
   const assembly = defaultAssembly(
     result,
     "The package query did not return its selected assembly descriptor.");

--- a/prototypes/inspect-web/test/package-acquisition.test.ts
+++ b/prototypes/inspect-web/test/package-acquisition.test.ts
@@ -110,6 +110,7 @@ function packageSurface(
     frameworks: ["net9.0", "net10.0"],
     activeFramework: "net10.0",
     defaultAssemblyId: primary.id,
+    compileLibrary: { status: "Selected", targetFramework: "net10.0", message: null },
     assemblies: [primary],
     types: [typeSurface("Example.Widget")],
     accessibility: [{
@@ -142,6 +143,24 @@ function generatedPackageSurfaceRejectsMutation(
   type.api[0] = member;
 }
 void generatedPackageSurfaceRejectsMutation;
+
+test("root-only package surfaces preserve typed unavailability at the UI boundary", () => {
+  assert.throws(
+    () => createNuGetPackageModel(packageSurface({
+      defaultAssemblyId: null,
+      compileLibrary: {
+        status: "NoCompileAssets",
+        targetFramework: null,
+        message: null,
+      },
+      assemblies: [],
+      types: [],
+      accessibility: [],
+      totalMembers: 0,
+    })),
+    /NoCompileAssets/,
+  );
+});
 
 test("graph-only implementation bodies select, switch, and clear", () => {
   const overload = {

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -22,6 +22,12 @@ import type {
 } from "../src/inspect-web-engine.d.ts";
 import type { PackageMetadata } from "../src/metadata-viewer.ts";
 
+const selectedCompileLibrary = {
+  status: "Selected" as const,
+  targetFramework: "net10.0",
+  message: null,
+};
+
 function packageModel(
   overrides: Partial<AppPackage> = {},
 ): AppPackage {
@@ -97,6 +103,7 @@ function dependencyResult(
     assemblyReferences: [],
     dependencyGroupError: error,
     assemblyReferenceError: null,
+    compileLibrary: selectedCompileLibrary,
   };
 }
 
@@ -109,6 +116,7 @@ function integrationsResult(): BrowserPackageIntegrations {
     totalSignals: 0,
     isComplete: true,
     inspectionError: null,
+    compileLibrary: selectedCompileLibrary,
   };
 }
 
@@ -121,6 +129,7 @@ function opportunitiesResult(): BrowserPackageOpportunities {
     totalOpportunities: 0,
     isComplete: true,
     inspectionError: null,
+    compileLibrary: selectedCompileLibrary,
   };
 }
 
@@ -130,6 +139,7 @@ function performanceResult(): PackagePerformance {
     inspectionError: null,
     nonPublicOpportunities: 0,
     totalOpportunities: 0,
+    compileLibrary: selectedCompileLibrary,
   };
 }
 

--- a/src/DotnetInspector.PackageQueries/PackageWorkspaceIntegrationsQuery.cs
+++ b/src/DotnetInspector.PackageQueries/PackageWorkspaceIntegrationsQuery.cs
@@ -9,9 +9,13 @@ namespace DotnetInspector.PackageQueries;
 /// Package and asset identity for one library in an Integration roll-up.
 /// </summary>
 public sealed record PackageWorkspaceIntegrationsSubject(
-    string PackageId,
-    string PackageVersion,
-    PackageCompileAsset Asset);
+    PackageRootIdentity Package,
+    PackageCompileAsset Asset)
+{
+    public string PackageId => Package.PackageId;
+
+    public string PackageVersion => Package.PackageVersion;
+}
 
 /// <summary>
 /// One package library's Integration outcome in a realized package workspace.
@@ -122,7 +126,6 @@ public static class PackageWorkspaceIntegrationsQuery
     static PackageWorkspaceIntegrationsSubject Subject(
         PackageAssemblyRoleParticipant participant) =>
         new(
-            participant.Package.PackageId,
-            participant.Package.PackageVersion,
+            participant.Package,
             participant.Asset);
 }

--- a/src/DotnetInspector.PackageQueries/PackageWorkspaceIntegrationsQuery.cs
+++ b/src/DotnetInspector.PackageQueries/PackageWorkspaceIntegrationsQuery.cs
@@ -55,6 +55,12 @@ public static class PackageWorkspaceIntegrationsQuery
         PackageAssemblyContextRealization realization)
     {
         ArgumentNullException.ThrowIfNull(realization);
+        if (!realization.HasAssemblyContexts)
+        {
+            throw new InvalidOperationException(
+                "Package workspace integration analysis requires at least one "
+                + "selected compile asset.");
+        }
 
         var entries =
             ImmutableArray.CreateBuilder<PackageWorkspaceIntegrationsEntry>();

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationConcurrentDemandTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationConcurrentDemandTests.cs
@@ -40,7 +40,7 @@ public sealed class PackageAssemblyContextRealizationConcurrentDemandTests
                     .Assembly.Location);
         const string path = "lib/net11.0/Dedup.Sample.dll";
         var content = new CountingPackageContent(Archive((path, image)));
-        var package = new PackageAssemblyContextSelection(
+        var package = new PackageRootRealization(
             content,
             "Dedup.Sample",
             "1.0.0",

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -468,6 +468,40 @@ public sealed class PackageAssemblyContextRealizationTests
     }
 
     [Fact]
+    public void PackageWorkspaceIntegrationsQuery_PreservesExactRootIdentity()
+    {
+        PackageRootRealization first = Selection(
+            "Same.Package",
+            ("lib/net11.0/Same.dll", IntegrationAssembly(
+                "First.Same",
+                "Microsoft.Extensions.Logging.First")));
+        PackageRootRealization second = Selection(
+            "Same.Package",
+            ("lib/net11.0/Same.dll", IntegrationAssembly(
+                "Second.Same",
+                "OpenTelemetry.Second")));
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [first, second],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        PackageWorkspaceIntegrationsResult result =
+            PackageWorkspaceIntegrationsQuery.Execute(realization);
+
+        Assert.Equal(2, result.Libraries.Length);
+        Assert.Contains(
+            result.Libraries,
+            entry => ReferenceEquals(entry.Subject.Package, first.Identity));
+        Assert.Contains(
+            result.Libraries,
+            entry => ReferenceEquals(entry.Subject.Package, second.Identity));
+        Assert.NotEqual(
+            result.Libraries[0].Subject,
+            result.Libraries[1].Subject);
+    }
+
+    [Fact]
     public void ReferenceCorrespondence_UsesPackageIdentityAndCaseInsensitiveName()
     {
         byte[] firstImage =

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -14,13 +14,168 @@ public sealed class PackageAssemblyContextRealizationTests
     const string Framework = "net11.0";
 
     [Fact]
+    public void PackageWithoutCompileAssets_RetainsRootWithoutAssemblyRoles()
+    {
+        PackageRootRealization package = RootSelection(
+            "Tool.Pointer",
+            ("tools/net11.0/any/Tool.Pointer.dll", [0x01]));
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.NoCompileAssets,
+            package.AssetSelection.Status);
+
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(realization.HasAssemblyContexts);
+        Assert.Empty(realization.SurfaceParticipants);
+        Assert.Empty(realization.ImplementationParticipants);
+        Assert.Null(realization.ImplementationGroup);
+        Assert.False(realization.SharesGroup);
+        Assert.Throws<InvalidOperationException>(() => realization.SurfaceGroup);
+        Assert.Equal(Framework, package.RequestedTargetFramework);
+        Assert.Equal("tests", package.ProducerKey);
+        Assert.False(package.FromCache);
+    }
+
+    [Fact]
+    public void PackageWorkspaceIntegrationsQuery_RejectsRootOnlyRealization()
+    {
+        PackageRootRealization package = RootSelection(
+            "Tool.Pointer",
+            ("tools/net11.0/any/Tool.Pointer.dll", [0x01]));
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        InvalidOperationException error = Assert.Throws<InvalidOperationException>(
+            () => PackageWorkspaceIntegrationsQuery.Execute(realization));
+
+        Assert.Contains("selected compile asset", error.Message);
+    }
+
+    [Fact]
+    public void ExplicitEmptyCompileGroup_RetainsRootWithoutAssemblyRoles()
+    {
+        PackageRootRealization package = RootSelection(
+            "Empty.Compile.Group",
+            ("ref/net11.0/_._", []),
+            ("lib/net11.0/Empty.Compile.Group.dll", [0x01]));
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.EmptyCompileGroup,
+            package.AssetSelection.Status);
+
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(realization.HasAssemblyContexts);
+        Assert.Empty(realization.SurfaceParticipants);
+        Assert.Empty(realization.ImplementationParticipants);
+    }
+
+    [Fact]
+    public void NoMatchingFramework_RetainsRequestedRootWithoutAssemblyRoles()
+    {
+        PackageRootRealization package = RootSelection(
+            "Future.Library",
+            "net10.0",
+            ("lib/net11.0/Future.Library.dll", [0x01]));
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.NoMatchingTargetFramework,
+            package.AssetSelection.Status);
+
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(realization.HasAssemblyContexts);
+        Assert.Equal("net10.0", package.RequestedTargetFramework);
+        Assert.Equal("net10.0", package.AssetSelection.TargetFramework);
+    }
+
+    [Fact]
+    public void InvalidImplementationLayout_RetainsFailedRootWithoutAssemblyRoles()
+    {
+        PackageRootRealization package = RootSelection(
+            "Invalid.Layout",
+            ("lib/net11.0/Invalid.Layout.dll", [0x01]),
+            ("LIB/NET11.0/invalid.layout.dll", [0x02]));
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.InvalidImplementationAssets,
+            package.AssetSelection.Status);
+        Assert.NotNull(package.AssetSelection.Message);
+
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(realization.HasAssemblyContexts);
+        Assert.Empty(realization.SurfaceParticipants);
+    }
+
+    [Fact]
+    public void MixedPackages_CreateRolesOnlyForSelectedCompileAssets()
+    {
+        byte[] image =
+            File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
+        PackageRootRealization selected = Selection(
+            "Library.Package",
+            ("lib/net11.0/Library.Package.dll", image));
+        PackageRootRealization rootOnly = RootSelection(
+            "Tool.Pointer",
+            ("tools/net11.0/any/Tool.Pointer.dll", [0x01]));
+
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [selected, rootOnly],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(realization.HasAssemblyContexts);
+        PackageAssemblyRoleParticipant participant =
+            Assert.Single(realization.SurfaceParticipants);
+        Assert.Same(selected.Identity, participant.Package);
+        Assert.DoesNotContain(
+            realization.SurfaceParticipants,
+            candidate => ReferenceEquals(candidate.Package, rootOnly.Identity));
+    }
+
+    [Fact]
+    public void PackageRootIdentity_DistinguishesRequestedFrameworksByReference()
+    {
+        PackageRootRealization net10 = RootSelection(
+            "Multi.Targeted",
+            "net10.0",
+            ("tools/net10.0/any/Multi.Targeted.dll", [0x01]));
+        PackageRootRealization net11 = RootSelection(
+            "Multi.Targeted",
+            "net11.0",
+            ("tools/net11.0/any/Multi.Targeted.dll", [0x01]));
+
+        Assert.NotSame(net10.Identity, net11.Identity);
+        Assert.Equal("net10.0", net10.Identity.RequestedTargetFramework);
+        Assert.Equal("net11.0", net11.Identity.RequestedTargetFramework);
+    }
+
+    [Fact]
     public void ReferenceAndLibraryAssets_ProduceExactSeparateRoleAssociations()
     {
         byte[] surfaceAndImplementation =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         byte[] implementationOnly =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Role.Sample",
             ("ref/net11.0/Role.Sample.dll", surfaceAndImplementation),
             ("lib/net11.0/Role.Sample.dll", surfaceAndImplementation),
@@ -34,7 +189,7 @@ public sealed class PackageAssemblyContextRealizationTests
         Assert.False(realization.SharesGroup);
         PackageAssemblyRoleParticipant surface =
             Assert.Single(realization.SurfaceParticipants);
-        Assert.Same(package, surface.Package);
+        Assert.Same(package.Identity, surface.Package);
         Assert.Equal(
             "ref/net11.0/Role.Sample.dll",
             surface.Asset.Path);
@@ -59,7 +214,7 @@ public sealed class PackageAssemblyContextRealizationTests
     {
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Shared.Sample",
             ("lib/net11.0/Shared.Sample.dll", image));
         using var workspace = new InspectionWorkspace();
@@ -89,7 +244,7 @@ public sealed class PackageAssemblyContextRealizationTests
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         byte[] secondImage =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Shared.Ordering",
             ("lib/net11.0/Zebra.dll", firstImage),
             ("lib/net11.0/apple.dll", secondImage));
@@ -127,7 +282,7 @@ public sealed class PackageAssemblyContextRealizationTests
     {
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Reference.Only",
             ("ref/net11.0/Reference.Only.dll", image));
         using var workspace = new InspectionWorkspace();
@@ -150,10 +305,10 @@ public sealed class PackageAssemblyContextRealizationTests
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         byte[] secondImage =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
-        PackageAssemblyContextSelection first = Selection(
+        PackageRootRealization first = Selection(
             "First.Package",
             ("lib/net11.0/Common.dll", firstImage));
-        PackageAssemblyContextSelection second = Selection(
+        PackageRootRealization second = Selection(
             "Second.Package",
             ("lib/net11.0/Common.dll", secondImage));
         using var workspace = new InspectionWorkspace();
@@ -164,10 +319,10 @@ public sealed class PackageAssemblyContextRealizationTests
 
         PackageAssemblyRoleParticipant firstParticipant =
             realization.SurfaceParticipants.Single(participant =>
-                ReferenceEquals(participant.Package, first));
+                ReferenceEquals(participant.Package, first.Identity));
         PackageAssemblyRoleParticipant secondParticipant =
             realization.SurfaceParticipants.Single(participant =>
-                ReferenceEquals(participant.Package, second));
+                ReferenceEquals(participant.Package, second.Identity));
         var firstProvenance =
             Assert.IsType<AssemblyResolutionProvenance.PackageAsset>(
                 firstParticipant.Participant.Assembly.Provenance);
@@ -199,12 +354,12 @@ public sealed class PackageAssemblyContextRealizationTests
         byte[] referenceOnly = IntegrationAssembly(
             "Reference.Only.Integrations",
             "Microsoft.Extensions.DependencyInjection.IServiceCollection");
-        PackageAssemblyContextSelection primary = Selection(
+        PackageRootRealization primary = Selection(
             "Primary.Package",
             ("ref/net11.0/Primary.Integrations.dll", surface),
             ("lib/net11.0/Primary.Integrations.dll", implementation),
             ("lib/net11.0/Primary.Integrations.Helper.dll", helper));
-        PackageAssemblyContextSelection secondary = Selection(
+        PackageRootRealization secondary = Selection(
             "Secondary.Package",
             ("ref/net11.0/Reference.Only.Integrations.dll", referenceOnly));
         using var workspace = new InspectionWorkspace();
@@ -290,7 +445,7 @@ public sealed class PackageAssemblyContextRealizationTests
         byte[] implementation = IntegrationAssembly(
             "Shared.Integrations",
             "Microsoft.Extensions.Logging.CustomLogger");
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Shared.Package",
             ("lib/net11.0/Shared.Integrations.dll", implementation));
         using var workspace = new InspectionWorkspace();
@@ -319,11 +474,11 @@ public sealed class PackageAssemblyContextRealizationTests
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         byte[] secondImage =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
-        PackageAssemblyContextSelection first = Selection(
+        PackageRootRealization first = Selection(
             "First.Reference.Package",
             ("ref/net11.0/COMMON.dll", firstImage),
             ("lib/net11.0/common.dll", firstImage));
-        PackageAssemblyContextSelection second = Selection(
+        PackageRootRealization second = Selection(
             "Second.Reference.Package",
             ("ref/net11.0/COMMON.dll", secondImage),
             ("lib/net11.0/common.dll", secondImage));
@@ -350,7 +505,7 @@ public sealed class PackageAssemblyContextRealizationTests
     [Fact]
     public void MalformedSelectedAsset_RemainsARejectedParticipant()
     {
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Malformed.Sample",
             ("lib/net11.0/Malformed.Sample.dll", new byte[] { 1, 2, 3 }));
         using var workspace = new InspectionWorkspace();
@@ -373,7 +528,7 @@ public sealed class PackageAssemblyContextRealizationTests
     [Fact]
     public void MalformedAssets_UseSafeUniqueRejectionCarrierIdentities()
     {
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Whitespace.Sample",
             ("lib/net11.0/ .dll", new byte[] { 1, 2, 3 }),
             ("lib/net11.0/RejectedPackageAsset0.dll", new byte[] { 4, 5, 6 }));
@@ -405,7 +560,7 @@ public sealed class PackageAssemblyContextRealizationTests
         byte[] healthy =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
         byte[] malformed = [1, 2, 3];
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Mixed.Health",
             (
                 "ref/net11.0/ILInspector.Metadata.dll",
@@ -461,7 +616,7 @@ public sealed class PackageAssemblyContextRealizationTests
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         byte[] implementation =
             File.ReadAllBytes(typeof(AssemblyReferenceIdentity).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Mismatch.Sample",
             ("ref/net11.0/Mismatch\u202e.Sample.dll", surface),
             ("lib/net11.0/Mismatch\u202e.Sample.dll", implementation));
@@ -486,7 +641,7 @@ public sealed class PackageAssemblyContextRealizationTests
     {
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Collision.Sample",
             ("lib/net11.0/Collision.Sample.dll", image),
             ("lib/net11.0/Collision.Sample.Second.dll", image));
@@ -510,7 +665,7 @@ public sealed class PackageAssemblyContextRealizationTests
     {
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Budget.Sample",
             ("lib/net11.0/Budget.Sample.dll", image));
         using var workspace = new InspectionWorkspace();
@@ -543,7 +698,7 @@ public sealed class PackageAssemblyContextRealizationTests
                 index => $"lib/net11.0/Asset{index:D3}.dll"),
         ];
         var content = new CountingPackageContent(paths);
-        var package = new PackageAssemblyContextSelection(
+        var package = new PackageRootRealization(
             content,
             "Count.Sample",
             "1.0.0",
@@ -575,7 +730,7 @@ public sealed class PackageAssemblyContextRealizationTests
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         const string path = "lib/net11.0/Budget\u202e.Sample.dll";
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Budget.Sample",
             (path, image));
         using var workspace = new InspectionWorkspace();
@@ -608,7 +763,7 @@ public sealed class PackageAssemblyContextRealizationTests
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
         const string path = "lib/net11.0/Underreported\u202e.Sample.dll";
         var content = new UnderreportingPackageContent(path, image);
-        var package = new PackageAssemblyContextSelection(
+        var package = new PackageRootRealization(
             content,
             "Underreported.Sample",
             "1.0.0",
@@ -644,7 +799,7 @@ public sealed class PackageAssemblyContextRealizationTests
     {
         byte[] image =
             File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
-        PackageAssemblyContextSelection package = Selection(
+        PackageRootRealization package = Selection(
             "Cancelled.Sample",
             ("lib/net11.0/Cancelled.Sample.dll", image));
         using var workspace = new InspectionWorkspace();
@@ -658,22 +813,33 @@ public sealed class PackageAssemblyContextRealizationTests
         Assert.Equal(0, GroupCount(workspace));
     }
 
-    static PackageAssemblyContextSelection Selection(
+    static PackageRootRealization Selection(
         string packageId,
         params (string Path, byte[] Content)[] entries)
     {
-        var content = new InMemoryPackageContent(
-            Archive(entries),
-            fromCache: false,
-            producerKey: "tests");
-        var selection = new PackageAssemblyContextSelection(
-            content,
-            packageId,
-            "1.0.0",
-            Framework);
+        PackageRootRealization selection =
+            RootSelection(packageId, entries);
         Assert.True(selection.AssetSelection.IsSelected);
         return selection;
     }
+
+    static PackageRootRealization RootSelection(
+        string packageId,
+        params (string Path, byte[] Content)[] entries) =>
+        RootSelection(packageId, Framework, entries);
+
+    static PackageRootRealization RootSelection(
+        string packageId,
+        string targetFramework,
+        params (string Path, byte[] Content)[] entries) =>
+        new(
+            new InMemoryPackageContent(
+                Archive(entries),
+                fromCache: false,
+                producerKey: "tests"),
+            packageId,
+            "1.0.0",
+            targetFramework);
 
     static byte[] IntegrationAssembly(
         string assemblyName,

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
@@ -8,13 +8,36 @@ using ILInspector.Metadata;
 namespace DotnetInspector.Queries;
 
 /// <summary>
-/// Product-selected assembly assets for one exact, already-acquired package.
+/// Opaque reference identity for one exact realized package Root. Descriptive
+/// fields do not define equality; consumers correlate Roots by object identity.
 /// </summary>
-public sealed class PackageAssemblyContextSelection
+public sealed class PackageRootIdentity
+{
+    internal PackageRootIdentity(
+        string packageId,
+        string packageVersion,
+        string? requestedTargetFramework)
+    {
+        PackageId = packageId;
+        PackageVersion = packageVersion;
+        RequestedTargetFramework = requestedTargetFramework;
+    }
+
+    public string PackageId { get; }
+
+    public string PackageVersion { get; }
+
+    public string? RequestedTargetFramework { get; }
+}
+
+/// <summary>
+/// One exact, already-acquired package Root and its compile-asset selection outcome.
+/// </summary>
+public sealed class PackageRootRealization
 {
     readonly IPackageContent _content;
 
-    public PackageAssemblyContextSelection(
+    public PackageRootRealization(
         IPackageContent content,
         string packageId,
         string packageVersion,
@@ -27,6 +50,11 @@ public sealed class PackageAssemblyContextSelection
         _content = content;
         PackageId = packageId;
         PackageVersion = packageVersion;
+        RequestedTargetFramework = targetFramework;
+        Identity = new PackageRootIdentity(
+            packageId,
+            packageVersion,
+            targetFramework);
         AssetSelection = PackageCompileAssetSelector.Select(
             content,
             packageId,
@@ -37,9 +65,23 @@ public sealed class PackageAssemblyContextSelection
 
     public string PackageVersion { get; }
 
+    public PackageRootIdentity Identity { get; }
+
+    public string? RequestedTargetFramework { get; }
+
+    public string ProducerKey => _content.ProducerKey;
+
+    public bool FromCache => _content.FromCache;
+
     public PackageCompileAssetSelection AssetSelection { get; }
 
     internal IPackageContent Content => _content;
+
+    public bool ReferencesContent(IPackageContent content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        return ReferenceEquals(_content, content);
+    }
 }
 
 /// <summary>Resource admission policy for acquired-package role realization.</summary>
@@ -81,16 +123,16 @@ public sealed record PackageAssemblyContextRealizationOptions
 public sealed class PackageAssemblyRoleParticipant
 {
     internal PackageAssemblyRoleParticipant(
-        PackageAssemblyContextSelection package,
+        PackageRootRealization package,
         PackageCompileAsset asset,
         AssemblyContextParticipant participant)
     {
-        Package = package;
+        Package = package.Identity;
         Asset = asset;
         Participant = participant;
     }
 
-    public PackageAssemblyContextSelection Package { get; }
+    public PackageRootIdentity Package { get; }
 
     public PackageCompileAsset Asset { get; }
 
@@ -103,10 +145,10 @@ public sealed class PackageAssemblyRoleParticipant
 /// </summary>
 public sealed class PackageAssemblyContextRealization : IDisposable
 {
-    readonly PackageAssemblyContextRoles _roles;
+    readonly PackageAssemblyContextRoles? _roles;
 
     internal PackageAssemblyContextRealization(
-        PackageAssemblyContextRoles roles,
+        PackageAssemblyContextRoles? roles,
         ImmutableArray<PackageAssemblyRoleParticipant> surfaceParticipants,
         ImmutableArray<PackageAssemblyRoleParticipant> implementationParticipants)
     {
@@ -115,12 +157,17 @@ public sealed class PackageAssemblyContextRealization : IDisposable
         ImplementationParticipants = implementationParticipants;
     }
 
-    public AssemblyContextGroup SurfaceGroup => _roles.SurfaceGroup;
+    public bool HasAssemblyContexts => _roles is not null;
+
+    public AssemblyContextGroup SurfaceGroup =>
+        _roles?.SurfaceGroup
+        ?? throw new InvalidOperationException(
+            "The package realization has no selected compile assemblies.");
 
     public AssemblyContextGroup? ImplementationGroup =>
-        _roles.ImplementationGroup;
+        _roles?.ImplementationGroup;
 
-    public bool SharesGroup => _roles.SharesGroup;
+    public bool SharesGroup => _roles?.SharesGroup ?? false;
 
     public ImmutableArray<PackageAssemblyRoleParticipant> SurfaceParticipants
     {
@@ -142,15 +189,15 @@ public sealed class PackageAssemblyContextRealization : IDisposable
             ?? throw new ArgumentException(
                 "The participant does not belong to the surface package role.",
                 nameof(surface));
-        AssemblyContextParticipant? implementation =
-            _roles.ImplementationParticipant(selected.Participant);
+        AssemblyContextParticipant? implementation = _roles!
+            .ImplementationParticipant(selected.Participant);
         return implementation is null
             ? null
             : ImplementationParticipants.First(candidate =>
                 ReferenceEquals(candidate.Participant, implementation));
     }
 
-    public void Dispose() => _roles.Dispose();
+    public void Dispose() => _roles?.Dispose();
 }
 
 public sealed partial class InspectionWorkspace
@@ -160,7 +207,7 @@ public sealed partial class InspectionWorkspace
     /// surface and body-bearing implementation roles.
     /// </summary>
     public PackageAssemblyContextRealization RealizePackageAssemblyContextRoles(
-        IEnumerable<PackageAssemblyContextSelection> packages,
+        IEnumerable<PackageRootRealization> packages,
         PackageAssemblyContextRealizationOptions? options = null,
         CancellationToken cancellationToken = default)
     {
@@ -169,27 +216,28 @@ public sealed partial class InspectionWorkspace
         options.Validate();
         cancellationToken.ThrowIfCancellationRequested();
 
-        ImmutableArray<PackageAssemblyContextSelection> selectedPackages =
+        ImmutableArray<PackageRootRealization> packageRoots =
             [.. packages];
-        if (selectedPackages.IsEmpty)
+        if (packageRoots.IsEmpty)
         {
             throw new InvalidOperationException(
-                "Package assembly-context realization requires at least one package.");
+                "Package realization requires at least one package.");
         }
-        if (selectedPackages.Any(static package => package is null))
+        if (packageRoots.Any(static package => package is null))
         {
             throw new ArgumentException(
-                "Package assembly-context realization cannot contain a null package.",
+                "Package realization cannot contain a null package.",
                 nameof(packages));
         }
-        foreach (PackageAssemblyContextSelection package in selectedPackages)
+        ImmutableArray<PackageRootRealization> selectedPackages =
+            [.. packageRoots.Where(package => package.AssetSelection.IsSelected)];
+
+        if (selectedPackages.IsEmpty)
         {
-            if (!package.AssetSelection.IsSelected)
-            {
-                throw new InvalidOperationException(
-                    $"{package.PackageId} {package.PackageVersion} does not have a selected "
-                    + "compile-assembly set.");
-            }
+            return new PackageAssemblyContextRealization(
+                roles: null,
+                [],
+                []);
         }
 
         ImmutableArray<RoleAsset> surfaceAssets =
@@ -528,11 +576,11 @@ public sealed partial class InspectionWorkspace
     }
 
     sealed record RoleAsset(
-        PackageAssemblyContextSelection Package,
+        PackageRootRealization Package,
         PackageCompileAsset Asset);
 
     sealed record ImplementationNameKey(
-        PackageAssemblyContextSelection Package,
+        PackageRootRealization Package,
         string AssemblyName);
 
     sealed class RoleAssetIdentityComparer : IEqualityComparer<RoleAsset>
@@ -577,7 +625,7 @@ public sealed partial class InspectionWorkspace
     }
 
     sealed record RoleAssembly(
-        PackageAssemblyContextSelection Package,
+        PackageRootRealization Package,
         PackageCompileAsset Asset,
         ResolvedAssemblyReference Assembly,
         bool IdentityDecoded);


### PR DESCRIPTION
## Summary

- Realize every exact acquired package as a host-neutral `PackageRootRealization`, preserving identity, provenance, content correspondence, requested framework, and the product selector's typed compile-library outcome.
- Project assembly-context roles only for packages with selected compile assets; Root-only and mixed workspaces no longer fabricate or require an assembly group.
- Carry typed compile-library availability through inspect-web package, metadata, dependency, integration, opportunity, and performance contracts while preserving ordinary selected-package and platform behavior.
- Keep Root-owned package documents and manifest dependency queries available, contain package-controlled framework and diagnostic text at the browser boundary, and preserve exact Root identity and cache provenance through workspace admission and query results.

Closes #4829.

## Demo

Using the real tools-v2 package `dotnet-ef` 10.0.11 with the source engine call:

```csharp
await InspectionEngine.QueryPackage("dotnet-ef", "10.0.11", "net10.0");
```

Before, at base `7b07eb5de`:

```text
InvalidOperationException: dotnet-ef 10.0.11 has no compile-time assemblies, so it has no inspection workspace.
```

After, at candidate `d58904194`:

```text
package: dotnet-ef 10.0.11
compileLibrary: NoCompileAssets
assemblies: 0
types: 0
documents: 0
dependencyGroups: 0
assemblyReferences: 0
```

Notice that the package Root and typed compile-library absence survive without a fake Library or empty successful API surface. The manifest dependency operation also executes without requiring an assembly. Neighboring purpose-built cases cover explicit empty compile groups, no matching framework, malformed selected assemblies, mixed selected/Root-only workspaces, exact content/Root/cache-provenance correlation, and unsafe framework text.

## Architecture

Owner: Artifact Acquisition and Workspace Composition, documented in `docs/design/artifact-acquisition-and-workspaces.md`.

This change does not choose the active UI subject or lens, define canonical URLs, implement Root-view presentation, or redefine package-document selection. Inspection Subject Navigation, the View Facet Registry, and Inspect Web UI retain those responsibilities; the legacy TypeScript application-model boundary rejects Root-only surfaces with their typed reason until that presentation work lands. Manifest-declared nested README discovery is tracked separately by #5029.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build` — 714 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release --no-build` — 168 passed
- `npm run build`
- `node --test test/package-acquisition.test.ts test/package-inspection.test.ts` — 58 passed
- `npm run lint`
- `eng/generate-inspect-web-engine-dts.sh --check`
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md`

The complete `npm test` run passes 749/750 locally; its unchanged source-inventory test expects `probe.ts` and `probe.TS` to be distinct files and fails on the default case-insensitive macOS filesystem. Typecheck, build, lint, and all affected frontend tests pass.
