### PR TITLE
Define designated platform precedence

### DIFF
--- a/docs/design/platform-composition-and-overlays.md
+++ b/docs/design/platform-composition-and-overlays.md
@@ -212,11 +212,13 @@ designated artifact over the participant backed by the platform artifact**.
 For a designated participant in this arbitration, assembly version is
 descriptive rather than an eligibility barrier, including when no matching
 platform participant is present. Platform participants retain the resolver's
-existing version policy. The existing assembly-name, culture, and
+existing version policy, and an enabled installed-platform fallback
+participates under that policy. The existing assembly-name, culture, and
 public-key-token constraints remain binding, including their existing omitted
-value semantics. This exception is limited to the designated/platform
-name-owning domain; it does not weaken identity matching or promote package,
-project, sibling, discovered, or other non-designated candidates.
+value semantics; identity comes from metadata rather than the designated
+file's name. This exception is limited to the designated/platform name-owning
+domain; it does not weaken identity matching or promote package, project,
+sibling, discovered, or other non-designated candidates.
 
 The selection answer retains every other eligible entitled candidate as typed
 shadow evidence, so consumers can explain the composition without reconstructing
@@ -232,8 +234,9 @@ The designated-precedence cases in `AssemblyDependencyResolverTests` gate
 version and registration-order independence, identity constraints, typed
 ambiguity and shadow evidence, same-path provenance, and preservation of
 unrelated name-owning tiers. The
-`SharedCatalog_ReusesBindingManifestAndShadowsAcrossGenerations` test gates
-shadow propagation without activating the shadow descriptor.
+`SharedCatalog_ReusesBindingManifestAndShadowsAcrossGenerations` and
+`BindingFailure_PreservesShadowsWithoutOpeningThem` tests gate shadow
+propagation without activating the shadow descriptor.
 
 ### Executable interaction model
 

--- a/docs/design/platform-composition-and-overlays.md
+++ b/docs/design/platform-composition-and-overlays.md
@@ -209,6 +209,15 @@ both can satisfy the same reference.
 The precedence rule for this case is simple: **when resolving a reference that
 can bind to both, the binding policy selects the participant backed by the
 designated artifact over the participant backed by the platform artifact**.
+For a designated participant in this arbitration, assembly version is
+descriptive rather than an eligibility barrier, including when no matching
+platform participant is present. Platform participants retain the resolver's
+existing version policy. The existing assembly-name, culture, and
+public-key-token constraints remain binding, including their existing omitted
+value semantics. This exception is limited to the designated/platform
+name-owning domain; it does not weaken identity matching or promote package,
+project, sibling, discovered, or other non-designated candidates.
+
 The selection answer retains every other eligible entitled candidate as typed
 shadow evidence, so consumers can explain the composition without reconstructing
 policy from enumeration order. A shadowed candidate is evidence, not an active
@@ -216,8 +225,15 @@ participant.
 That gives every acquisition system the same well-defined graph to compose
 with; it does not require specifying the current resolver's case-by-case
 accidents. Any other tie between entitled candidates needs its own stated rule
-or a diagnostic rather than a silent pick. The current resolver does not yet
-enforce this contract; tracked as **#4593**.
+or a diagnostic rather than a silent pick. Multiple eligible designated
+candidates remain ambiguous rather than being chosen by registration order.
+
+The designated-precedence cases in `AssemblyDependencyResolverTests` gate
+version and registration-order independence, identity constraints, typed
+ambiguity and shadow evidence, same-path provenance, and preservation of
+unrelated name-owning tiers. The
+`SharedCatalog_ReusesBindingManifestAndShadowsAcrossGenerations` test gates
+shadow propagation without activating the shadow descriptor.
 
 ### Executable interaction model
 

--- a/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
@@ -981,7 +981,8 @@ public static class AssemblyContextSourceQuery
             {
                 AssemblyBindingSelection.Selected selected =>
                     AssemblyBindingSelection.Found(
-                        Observe(selected.Assembly)),
+                        Observe(selected.Assembly),
+                        [.. selected.ShadowedAssemblies.Select(Observe)]),
                 AssemblyBindingSelection.Ambiguous ambiguous =>
                     AssemblyBindingSelection.Multiple(
                         [.. ambiguous.Assemblies.Select(Observe)]),

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -883,7 +883,7 @@ public class AssemblyDependencyResolverTests
     }
 
     [Fact]
-    public void AssemblyGroup_SkewedAmbiguityPreservesOriginFailure()
+    public void AssemblyGroup_DesignatedAmbiguityPreservesOriginFailure()
     {
         var requested = new AssemblyReferenceIdentity(
             "Platform.Library",
@@ -898,7 +898,7 @@ public class AssemblyDependencyResolverTests
                 null),
             AssemblyResolutionProvenance.Local("owner"));
         ResolvedAssemblyReference first = Descriptor(
-            requested with { Version = new Version(2, 0, 0, 0) },
+            requested,
             AssemblyResolutionProvenance.Designated(
                 "first group overlay"));
         ResolvedAssemblyReference second = Descriptor(
@@ -976,6 +976,104 @@ public class AssemblyDependencyResolverTests
         Assert.Equal(2, ambiguous.Assemblies.Length);
         Assert.Contains(root, ambiguous.Assemblies);
         Assert.Contains(policyCandidate, ambiguous.Assemblies);
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
+    [Fact]
+    public void AssemblyGroup_ExactPolicyDesignatedCandidateJoinsAmbiguity()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        ResolvedAssemblyReference root = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Designated(
+                "root group overlay"));
+        ResolvedAssemblyReference policyCandidate = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Designated(
+                "policy group overlay"));
+        var policy = new FixedSelectionPolicy(
+            AssemblyBindingSelection.Found(policyCandidate));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (root, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+            group.Select(request));
+
+        Assert.Equal(2, ambiguous.Assemblies.Length);
+        Assert.Contains(root, ambiguous.Assemblies);
+        Assert.Contains(policyCandidate, ambiguous.Assemblies);
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
+    [Fact]
+    public void AssemblyGroup_ExactDesignatedRetainsAllPlatformShadows()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Designated(
+                "root group overlay"));
+        ResolvedAssemblyReference rootPlatform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "runtime",
+                frameworkVersion: null,
+                "root platform"));
+        ResolvedAssemblyReference policyPlatform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "runtime",
+                frameworkVersion: null,
+                "policy platform"));
+        var policy = new FixedSelectionPolicy(
+            AssemblyBindingSelection.Found(policyPlatform));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (designated, (IAssemblyBindingPolicy)policy),
+                (rootPlatform, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(designated, selected.Assembly);
+        Assert.Equal(2, selected.ShadowedAssemblies.Length);
+        Assert.Contains(rootPlatform, selected.ShadowedAssemblies);
+        Assert.Contains(policyPlatform, selected.ShadowedAssemblies);
         Assert.Equal(1, policy.SelectionCount);
     }
 

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -648,6 +648,448 @@ public class AssemblyDependencyResolverTests
         Assert.Same(selected, result.Assembly);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AssemblyGroup_DesignatedPrecedenceIsRegistrationOrderIndependent(
+        bool designatedFirst)
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference platform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "group precedence test"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "group precedence test"));
+        (ResolvedAssemblyReference, IAssemblyBindingPolicy)[] participants =
+            designatedFirst
+                ? [
+                    (designated, MissingPolicy.Instance),
+                    (platform, MissingPolicy.Instance),
+                ]
+                : [
+                    (platform, MissingPolicy.Instance),
+                    (designated, MissingPolicy.Instance),
+                ];
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            participants);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(platform),
+            AssemblyResolutionScope.Any);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(designated, selected.Assembly);
+        Assert.Same(platform, Assert.Single(selected.ShadowedAssemblies));
+    }
+
+    [Fact]
+    public void AssemblyGroup_MultipleDesignatedCandidatesAreAmbiguous()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference platform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "group ambiguity test"));
+        ResolvedAssemblyReference first = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "first group ambiguity candidate"));
+        ResolvedAssemblyReference second = Descriptor(
+            requested with { Version = new Version(3, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "second group ambiguity candidate"));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (platform, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+                (first, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+                (second, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(platform),
+            AssemblyResolutionScope.Any);
+
+        var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+            group.Select(request));
+
+        Assert.Equal(2, ambiguous.Assemblies.Length);
+        Assert.Contains(first, ambiguous.Assemblies);
+        Assert.Contains(second, ambiguous.Assemblies);
+        Assert.DoesNotContain(platform, ambiguous.Assemblies);
+    }
+
+    [Fact]
+    public void AssemblyGroup_LoneDesignatedCandidateIgnoresVersion()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "lone designated candidate"));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(designated, (IAssemblyBindingPolicy)MissingPolicy.Instance)]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(designated),
+            AssemblyResolutionScope.Platform);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(designated, selected.Assembly);
+        Assert.Empty(selected.ShadowedAssemblies);
+    }
+
+    [Fact]
+    public void AssemblyGroup_PlatformShadowRetainsVersionEligibility()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference platform = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "group shadow eligibility test"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with { Version = new Version(3, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "group shadow eligibility test"));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (platform, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+                (designated, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(platform),
+            AssemblyResolutionScope.Platform);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(designated, selected.Assembly);
+        Assert.Empty(selected.ShadowedAssemblies);
+    }
+
+    [Theory]
+    [InlineData("fr-FR", "001122aabbccddee")]
+    [InlineData("en-US", "ffeeddccbbaa1100")]
+    public void AssemblyGroup_DesignatedPrecedenceRetainsIdentityConstraints(
+        string? designatedCulture,
+        string designatedToken)
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            "en-US",
+            "001122aabbccddee");
+        ResolvedAssemblyReference platform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "group identity test"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with
+            {
+                Version = new Version(2, 0, 0, 0),
+                Culture = designatedCulture,
+                PublicKeyToken = designatedToken,
+            },
+            AssemblyResolutionProvenance.Designated(
+                "group identity test"));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (platform, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+                (designated, (IAssemblyBindingPolicy)MissingPolicy.Instance),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(platform),
+            AssemblyResolutionScope.Any);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(platform, selected.Assembly);
+        Assert.Empty(selected.ShadowedAssemblies);
+    }
+
+    [Theory]
+    [InlineData(false, AssemblyResolutionScope.Any)]
+    [InlineData(true, AssemblyResolutionScope.Any)]
+    [InlineData(true, AssemblyResolutionScope.Platform)]
+    public void Select_DesignatedOverlayWinsWithEqualOrUnequalVersion(
+        bool versionSkewed,
+        AssemblyResolutionScope scope)
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-designated-overlay-").FullName;
+        try
+        {
+            string targetPath = Path.Combine(root, "Target.dll");
+            File.Copy(
+                typeof(AssemblyDependencyResolverTests).Assembly.Location,
+                targetPath);
+            string platformPath = (AppContext.GetData(
+                    "TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+                .Split(
+                    Path.PathSeparator,
+                    StringSplitOptions.RemoveEmptyEntries)
+                .Single(path => Path.GetFileName(path).Equals(
+                    "System.Runtime.dll",
+                    StringComparison.OrdinalIgnoreCase));
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            byte[] publicKey =
+                AssemblyName.GetAssemblyName(platformPath).GetPublicKey()
+                ?? throw new InvalidOperationException(
+                    "The platform fixture must carry a full public key.");
+            Version designatedVersion = versionSkewed
+                ? new Version(
+                    (platformIdentity.Version?.Major ?? 1) + 1,
+                    0,
+                    0,
+                    0)
+                : platformIdentity.Version
+                    ?? new Version(1, 0, 0, 0);
+            string designatedPath = Path.Combine(
+                root,
+                $"{platformIdentity.Name}.dll");
+            File.WriteAllBytes(
+                designatedPath,
+                BuildAssembly(
+                    platformIdentity.Name,
+                    publicKey,
+                    designatedVersion));
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(targetPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                scope);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.Equal(designatedPath, selected.Assembly.Path);
+            Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+                selected.Assembly.Provenance);
+            ResolvedAssemblyReference shadow =
+                Assert.Single(selected.ShadowedAssemblies);
+            Assert.Equal(platformPath, shadow.Path);
+            Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+                shadow.Provenance);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_DuplicateSamePathRetainsDesignatedAndPlatformRoles()
+    {
+        string platformPath = typeof(System.Runtime.GCSettings)
+            .Assembly.Location;
+        using var stream = File.OpenRead(platformPath);
+        using var peReader = new PEReader(stream);
+        AssemblyReferenceIdentity platformIdentity =
+            AssemblyReferenceIdentity.FromAssemblyDefinition(
+                peReader.GetMetadataReader());
+        var resolver = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(
+                typeof(AssemblyDependencyResolverTests).Assembly.Location)
+            {
+                PackageRoots = [],
+                CorpusAssemblyPaths = [platformPath, platformPath],
+                IncludeSiblingAssemblies = false,
+                IncludeAspNetCoreSharedFramework = false,
+                IncludeDepsJsonAssets = false,
+            });
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(platformIdentity),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            resolver.Select(request));
+
+        Assert.Equal(platformPath, selected.Assembly.Path);
+        Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+            selected.Assembly.Provenance);
+        ResolvedAssemblyReference shadow =
+            Assert.Single(selected.ShadowedAssemblies);
+        Assert.Equal(platformPath, shadow.Path);
+        Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+            shadow.Provenance);
+        Assert.NotSame(selected.Assembly, shadow);
+    }
+
+    [Fact]
+    public void Select_MultipleDesignatedOverlaysAreAmbiguous()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-designated-ambiguity-").FullName;
+        try
+        {
+            string targetPath = Path.Combine(root, "Target.dll");
+            File.Copy(
+                typeof(AssemblyDependencyResolverTests).Assembly.Location,
+                targetPath);
+            string platformPath = (AppContext.GetData(
+                    "TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+                .Split(
+                    Path.PathSeparator,
+                    StringSplitOptions.RemoveEmptyEntries)
+                .Single(path => Path.GetFileName(path).Equals(
+                    "System.Runtime.dll",
+                    StringComparison.OrdinalIgnoreCase));
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            byte[] publicKey =
+                AssemblyName.GetAssemblyName(platformPath).GetPublicKey()
+                ?? throw new InvalidOperationException(
+                    "The platform fixture must carry a full public key.");
+            var designatedPaths = new List<string>();
+            for (int index = 0; index < 2; index++)
+            {
+                string directory = Path.Combine(root, $"overlay-{index}");
+                Directory.CreateDirectory(directory);
+                string path = Path.Combine(
+                    directory,
+                    $"{platformIdentity.Name}.dll");
+                File.WriteAllBytes(
+                    path,
+                    BuildAssembly(
+                        platformIdentity.Name,
+                        publicKey,
+                        new Version(index + 20, 0, 0, 0)));
+                designatedPaths.Add(path);
+            }
+
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(targetPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = designatedPaths,
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Any);
+
+            var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+                resolver.Select(request));
+
+            Assert.Equal(2, ambiguous.Assemblies.Length);
+            Assert.All(
+                ambiguous.Assemblies,
+                candidate => Assert.IsType<
+                    AssemblyResolutionProvenance.DesignatedAsset>(
+                        candidate.Provenance));
+            Assert.Equal(
+                designatedPaths.Order(),
+                ambiguous.Assemblies
+                    .Select(candidate => candidate.Path)
+                    .Order());
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_AnyScopeDesignatedOverlayDoesNotBypassSiblingTier()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-designated-tier-").FullName;
+        try
+        {
+            string targetPath = Path.Combine(root, "Target.dll");
+            File.Copy(
+                typeof(AssemblyDependencyResolverTests).Assembly.Location,
+                targetPath);
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string siblingPath = Path.Combine(
+                root,
+                Path.GetFileName(platformPath));
+            File.Copy(platformPath, siblingPath);
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(targetPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [platformPath],
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Any);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.Equal(siblingPath, selected.Assembly.Path);
+            Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(
+                selected.Assembly.Provenance);
+            Assert.Empty(selected.ShadowedAssemblies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     [Fact]
     public void Resolve_PlatformReference_RollsForwardToInstalledAssembly()
     {
@@ -1054,7 +1496,9 @@ public class AssemblyDependencyResolverTests
 
     static byte[] BuildAssembly(
         string assemblyName,
-        byte[] publicKey)
+        byte[] publicKey,
+        Version? version = null,
+        string? culture = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -1065,8 +1509,10 @@ public class AssemblyDependencyResolverTests
             encBaseId: default);
         metadata.AddAssembly(
             metadata.GetOrAddString(assemblyName),
-            new Version(1, 0, 0, 0),
-            culture: default,
+            version ?? new Version(1, 0, 0, 0),
+            culture is null
+                ? default
+                : metadata.GetOrAddString(culture),
             publicKey: metadata.GetOrAddBlob(publicKey),
             flags: AssemblyFlags.PublicKey,
             hashAlgorithm: default);
@@ -1086,6 +1532,19 @@ public class AssemblyDependencyResolverTests
         var image = new BlobBuilder();
         builder.Serialize(image);
         return image.ToArray();
+    }
+
+    static ResolvedAssemblyReference Descriptor(
+        AssemblyReferenceIdentity identity,
+        AssemblyResolutionProvenance provenance)
+    {
+        string path = typeof(AssemblyDependencyResolverTests)
+            .Assembly.Location;
+        return ResolvedAssemblyReference.Create(
+            identity,
+            path,
+            () => File.OpenRead(path),
+            provenance);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -1009,7 +1009,7 @@ public class AssemblyDependencyResolverTests
     }
 
     [Fact]
-    public void Select_DuplicateSamePathRetainsDesignatedAndPlatformRoles()
+    public void Select_DuplicateSamePathSharesSnapshotAcrossProvenance()
     {
         string platformPath = typeof(System.Runtime.GCSettings)
             .Assembly.Location;
@@ -1027,6 +1027,9 @@ public class AssemblyDependencyResolverTests
                 IncludeSiblingAssemblies = false,
                 IncludeAspNetCoreSharedFramework = false,
                 IncludeDepsJsonAssets = false,
+                SnapshotAssemblyImages = true,
+                MaxSnapshotImageBytes =
+                    new FileInfo(platformPath).Length,
             });
         var request = new AssemblyBindingRequest(
             AssemblyBindingTarget.Reference(platformIdentity),
@@ -1045,6 +1048,58 @@ public class AssemblyDependencyResolverTests
         Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
             shadow.Provenance);
         Assert.NotSame(selected.Assembly, shadow);
+    }
+
+    [Fact]
+    public void Select_SnapshotBudgetCannotFallBackFromDesignatedToPlatform()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-overlay-budget-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string designatedPath = Path.Combine(
+                root,
+                Path.GetFileName(platformPath));
+            File.Copy(platformPath, designatedPath);
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                    SnapshotAssemblyImages = true,
+                    MaxSnapshotImageBytes =
+                        new FileInfo(platformPath).Length,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform);
+
+            var unavailable =
+                Assert.IsType<AssemblyBindingSelection.Unavailable>(
+                    resolver.Select(request));
+
+            Assert.Equal(
+                AssemblyBindingFailureKind.CandidateUnavailable,
+                unavailable.Failure.Kind);
+            Assert.Equal(
+                CandidateOpenFailureKind.ResourceBudget,
+                unavailable.Failure.CandidateFailureKind);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -882,6 +882,103 @@ public class AssemblyDependencyResolverTests
         Assert.Equal(1, policy.SelectionCount);
     }
 
+    [Fact]
+    public void AssemblyGroup_SkewedAmbiguityPreservesOriginFailure()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        ResolvedAssemblyReference first = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "first group overlay"));
+        ResolvedAssemblyReference second = Descriptor(
+            requested with { Version = new Version(3, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "second group overlay"));
+        var policy = new FixedSelectionPolicy(
+            AssemblyBindingSelection.CannotSelect(
+                new AssemblyBindingFailure(
+                    AssemblyBindingFailureKind.CandidateUnavailable,
+                    CandidateOpenFailureKind.Unreadable)));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (first, (IAssemblyBindingPolicy)policy),
+                (second, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
+            group.Select(request));
+
+        Assert.Equal(
+            AssemblyBindingFailureKind.CandidateUnavailable,
+            unavailable.Failure.Kind);
+        Assert.Equal(
+            CandidateOpenFailureKind.Unreadable,
+            unavailable.Failure.CandidateFailureKind);
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
+    [Fact]
+    public void AssemblyGroup_PolicyDesignatedCandidateJoinsAmbiguity()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        AssemblyReferenceIdentity designatedIdentity =
+            requested with { Version = new Version(2, 0, 0, 0) };
+        ResolvedAssemblyReference root = Descriptor(
+            designatedIdentity,
+            AssemblyResolutionProvenance.Designated(
+                "root group overlay"));
+        ResolvedAssemblyReference policyCandidate = Descriptor(
+            designatedIdentity,
+            AssemblyResolutionProvenance.Designated(
+                "policy group overlay"));
+        var policy = new FixedSelectionPolicy(
+            AssemblyBindingSelection.Found(policyCandidate));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (root, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+            group.Select(request));
+
+        Assert.Equal(2, ambiguous.Assemblies.Length);
+        Assert.Contains(root, ambiguous.Assemblies);
+        Assert.Contains(policyCandidate, ambiguous.Assemblies);
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
     [Theory]
     [InlineData("fr-FR", "001122aabbccddee")]
     [InlineData("en-US", "ffeeddccbbaa1100")]
@@ -1062,6 +1159,56 @@ public class AssemblyDependencyResolverTests
             string designatedPath = Path.Combine(
                 root,
                 Path.GetFileName(platformPath));
+            File.Copy(platformPath, designatedPath);
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                    SnapshotAssemblyImages = true,
+                    MaxSnapshotImageBytes =
+                        new FileInfo(platformPath).Length,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform);
+
+            var unavailable =
+                Assert.IsType<AssemblyBindingSelection.Unavailable>(
+                    resolver.Select(request));
+
+            Assert.Equal(
+                AssemblyBindingFailureKind.CandidateUnavailable,
+                unavailable.Failure.Kind);
+            Assert.Equal(
+                CandidateOpenFailureKind.ResourceBudget,
+                unavailable.Failure.CandidateFailureKind);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_RenamedSnapshotBudgetCannotFallBackToPlatform()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-renamed-overlay-budget-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string designatedPath = Path.Combine(root, "overlay.dll");
             File.Copy(platformPath, designatedPath);
             using var stream = File.OpenRead(platformPath);
             using var peReader = new PEReader(stream);
@@ -1526,6 +1673,21 @@ public class AssemblyDependencyResolverTests
         public AssemblyBindingSelection Select(
             AssemblyBindingRequest request) =>
             AssemblyBindingSelection.NotFound();
+    }
+
+    sealed class FixedSelectionPolicy(
+        AssemblyBindingSelection selection) : IAssemblyBindingPolicy
+    {
+        internal int SelectionCount { get; private set; }
+
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelection Select(
+            AssemblyBindingRequest request)
+        {
+            SelectionCount++;
+            return selection;
+        }
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -962,6 +962,134 @@ public class AssemblyDependencyResolverTests
     }
 
     [Fact]
+    public void Select_RenamedDesignatedOverlayUsesMetadataIdentity()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-renamed-overlay-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string designatedPath = Path.Combine(root, "overlay.dll");
+            File.Copy(platformPath, designatedPath);
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.Equal(designatedPath, selected.Assembly.Path);
+            Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+                selected.Assembly.Provenance);
+            Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+                Assert.Single(selected.ShadowedAssemblies).Provenance);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_DesignatedOverlayRetainsInstalledPlatformShadow()
+    {
+        string platformPath = typeof(System.Runtime.GCSettings)
+            .Assembly.Location;
+        using var stream = File.OpenRead(platformPath);
+        using var peReader = new PEReader(stream);
+        AssemblyReferenceIdentity platformIdentity =
+            AssemblyReferenceIdentity.FromAssemblyDefinition(
+                peReader.GetMetadataReader());
+        var resolver = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(platformPath)
+            {
+                PackageRoots = [],
+                CorpusAssemblyPaths = [platformPath],
+                IncludeSiblingAssemblies = false,
+                IncludeTrustedPlatformAssemblies = false,
+                IncludeAspNetCoreSharedFramework = false,
+                IncludeDepsJsonAssets = false,
+            });
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(platformIdentity),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            resolver.Select(request));
+
+        Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+            selected.Assembly.Provenance);
+        ResolvedAssemblyReference shadow =
+            Assert.Single(selected.ShadowedAssemblies);
+        Assert.Equal(platformPath, shadow.Path);
+        Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+            shadow.Provenance);
+    }
+
+    [Fact]
+    public void Select_UnreadableNonEligibleOverlayDoesNotVetoPlatform()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-unreadable-overlay-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string designatedPath = Path.Combine(
+                root,
+                Path.GetFileName(platformPath));
+            File.WriteAllText(designatedPath, "not a managed assembly");
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.Equal(platformPath, selected.Assembly.Path);
+            Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+                selected.Assembly.Provenance);
+            Assert.Empty(selected.ShadowedAssemblies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Select_MultipleDesignatedOverlaysAreAmbiguous()
     {
         string root = Directory.CreateTempSubdirectory(

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -796,6 +796,92 @@ public class AssemblyDependencyResolverTests
         Assert.Empty(selected.ShadowedAssemblies);
     }
 
+    [Fact]
+    public void AssemblyGroup_SkewedDesignatedPreservesOriginNameOwner()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "group origin-policy test"));
+        ResolvedAssemblyReference sibling = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Local("sibling"));
+        var policy = new SelectedPolicy(sibling);
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (designated, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
+            group.Select(request));
+
+        Assert.Equal(
+            AssemblyBindingFailureKind.IdentityPolicyRequired,
+            unavailable.Failure.Kind);
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
+    [Fact]
+    public void AssemblyGroup_SkewedDesignatedShadowsOriginPlatformSelection()
+    {
+        var requested = new AssemblyReferenceIdentity(
+            "Platform.Library",
+            new Version(1, 0, 0, 0),
+            null,
+            "001122aabbccddee");
+        ResolvedAssemblyReference owner = Descriptor(
+            new AssemblyReferenceIdentity(
+                "Owner",
+                new Version(1, 0, 0, 0),
+                null,
+                null),
+            AssemblyResolutionProvenance.Local("owner"));
+        ResolvedAssemblyReference designated = Descriptor(
+            requested with { Version = new Version(2, 0, 0, 0) },
+            AssemblyResolutionProvenance.Designated(
+                "group origin-policy test"));
+        ResolvedAssemblyReference platform = Descriptor(
+            requested,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "group origin-policy test"));
+        var policy = new SelectedPolicy(platform);
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (owner, (IAssemblyBindingPolicy)policy),
+                (designated, (IAssemblyBindingPolicy)policy),
+            ]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(requested),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            group.Select(request));
+
+        Assert.Same(designated, selected.Assembly);
+        Assert.Same(platform, Assert.Single(selected.ShadowedAssemblies));
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
     [Theory]
     [InlineData("fr-FR", "001122aabbccddee")]
     [InlineData("en-US", "ffeeddccbbaa1100")]
@@ -1082,6 +1168,112 @@ public class AssemblyDependencyResolverTests
             Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
                 selected.Assembly.Provenance);
             Assert.Empty(selected.ShadowedAssemblies);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_UnreadablePeerDoesNotVetoDesignatedOverlay()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-unreadable-peer-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string unreadableDirectory = Path.Combine(root, "unreadable");
+            Directory.CreateDirectory(unreadableDirectory);
+            string unreadablePath = Path.Combine(
+                unreadableDirectory,
+                Path.GetFileName(platformPath));
+            File.WriteAllText(unreadablePath, "not a managed assembly");
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths =
+                        [platformPath, unreadablePath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(platformIdentity),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Platform);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.Equal(platformPath, selected.Assembly.Path);
+            Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+                selected.Assembly.Provenance);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Select_AnyScopeInstalledShadowRetainsRollForwardPolicy()
+    {
+        string root = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-any-fallback-shadow-").FullName;
+        try
+        {
+            string platformPath = typeof(System.Runtime.GCSettings)
+                .Assembly.Location;
+            string designatedPath = Path.Combine(root, "overlay.dll");
+            File.Copy(platformPath, designatedPath);
+            using var stream = File.OpenRead(platformPath);
+            using var peReader = new PEReader(stream);
+            AssemblyReferenceIdentity platformIdentity =
+                AssemblyReferenceIdentity.FromAssemblyDefinition(
+                    peReader.GetMetadataReader());
+            var requested = platformIdentity with
+            {
+                Version = new Version(
+                    platformIdentity.Version!.Major - 1,
+                    0,
+                    0,
+                    0),
+            };
+            var resolver = new AssemblyDependencyResolver(
+                new AssemblyDependencyResolutionOptions(platformPath)
+                {
+                    PackageRoots = [],
+                    CorpusAssemblyPaths = [designatedPath],
+                    IncludeSiblingAssemblies = false,
+                    IncludeTrustedPlatformAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                    IncludeInstalledPlatformFallback = true,
+                    AllowPlatformAssemblyVersionRollForward = true,
+                });
+            var request = new AssemblyBindingRequest(
+                AssemblyBindingTarget.Reference(requested),
+                AssemblyBindingOrigin.Global(),
+                AssemblyResolutionScope.Any);
+
+            var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(request));
+
+            Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
+                selected.Assembly.Provenance);
+            ResolvedAssemblyReference shadow =
+                Assert.Single(selected.ShadowedAssemblies);
+            Assert.Equal(platformPath, shadow.Path);
+            Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
+                shadow.Provenance);
         }
         finally
         {

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Text.Json;
 using System.Xml.Linq;
 using System.Runtime.InteropServices;
@@ -96,9 +97,9 @@ public sealed partial class AssemblyDependencyResolver :
 
     readonly AssemblyDependencyResolutionOptions _options;
     readonly ConcurrentDictionary<
-        string,
+        AssemblyDescriptorKey,
         Lazy<AssemblyDescriptorResolution>> _descriptors =
-            new(StringComparer.Ordinal);
+            [];
     IReadOnlyList<ResolvedAssemblyDependency>? _resolved;
     IReadOnlyList<ResolvedAssemblyDependency>? _allCandidates;
     readonly ConcurrentDictionary<
@@ -248,6 +249,15 @@ public sealed partial class AssemblyDependencyResolver :
     {
         var candidates =
             _allCandidates ??= CollectDependencies(deduplicate: false);
+        if (ResolveDesignatedOverlay(
+                candidates,
+                identity,
+                scope)
+            is { } overlayAttempt)
+        {
+            return overlayAttempt;
+        }
+
         CandidateOpenFailureKind? candidateFailure = null;
         CandidateTier? activeTier = null;
 
@@ -355,6 +365,95 @@ public sealed partial class AssemblyDependencyResolver :
             candidateFailure);
     }
 
+    AssemblyResolutionAttempt? ResolveDesignatedOverlay(
+        IReadOnlyList<ResolvedAssemblyDependency> candidates,
+        AssemblyReferenceIdentity identity,
+        AssemblyResolutionScope scope)
+    {
+        ResolvedAssemblyDependency? nameOwner = candidates.FirstOrDefault(
+            dependency =>
+                Path.GetFileNameWithoutExtension(dependency.Path).Equals(
+                    identity.Name,
+                    StringComparison.OrdinalIgnoreCase)
+                && (scope != AssemblyResolutionScope.Platform
+                    || IsEntitled(dependency.Provenance)));
+        if (nameOwner is null
+            || !IsEntitled(nameOwner.Provenance)
+            || !candidates.Any(dependency =>
+                dependency.Provenance
+                    is AssemblyDependencyProvenance.CorpusAssembly
+                && Path.GetFileNameWithoutExtension(dependency.Path).Equals(
+                    identity.Name,
+                    StringComparison.OrdinalIgnoreCase)))
+        {
+            return null;
+        }
+
+        var entitled = new List<ResolvedAssemblyReference>();
+        CandidateOpenFailureKind? candidateFailure = null;
+        foreach (ResolvedAssemblyDependency dependency in candidates)
+        {
+            if (!IsEntitled(dependency.Provenance)
+                || !Path.GetFileNameWithoutExtension(dependency.Path).Equals(
+                    identity.Name,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            AssemblyDescriptorResolution descriptor = DescriptorResult(
+                dependency.Path,
+                ResolutionProvenance(dependency));
+            if (descriptor.Assembly is { } assembly)
+            {
+                entitled.Add(assembly);
+            }
+            else
+            {
+                candidateFailure ??=
+                    descriptor.FailureKind
+                    ?? CandidateOpenFailureKind.Unreadable;
+            }
+        }
+
+        if (candidateFailure is not null)
+        {
+            return new AssemblyResolutionAttempt(
+                Assembly: null,
+                candidateFailure);
+        }
+
+        return DesignatedAssemblyBindingPrecedence.TrySelect(
+                identity,
+                entitled,
+                allowPlatformVersionRollForward:
+                    scope == AssemblyResolutionScope.Platform
+                    && _options.AllowPlatformAssemblyVersionRollForward,
+                ignorePlatformVersion:
+                    _options.IgnoreAssemblyVersion)
+            switch
+            {
+                AssemblyBindingSelection.Selected selected =>
+                    new AssemblyResolutionAttempt(
+                        selected.Assembly,
+                        CandidateFailure: null,
+                        selected.ShadowedAssemblies),
+                AssemblyBindingSelection.Ambiguous ambiguous =>
+                    new AssemblyResolutionAttempt(
+                        Assembly: null,
+                        CandidateFailure: null,
+                        AmbiguousAssemblies: ambiguous.Assemblies),
+                _ => null,
+            };
+    }
+
+    static bool IsEntitled(
+        AssemblyDependencyProvenance provenance) =>
+        provenance is
+            AssemblyDependencyProvenance.TrustedPlatformAssembly
+            or AssemblyDependencyProvenance.SharedFramework
+            or AssemblyDependencyProvenance.CorpusAssembly;
+
     static CandidateTier TierFor(
         AssemblyDependencyProvenance provenance) =>
         provenance switch
@@ -419,8 +518,15 @@ public sealed partial class AssemblyDependencyResolver :
         AssemblyResolutionScope scope)
     {
         AssemblyResolutionAttempt attempt = ResolveCore(identity, scope);
+        if (!attempt.AmbiguousAssemblies.IsDefaultOrEmpty)
+            return AssemblyBindingSelection.Multiple(
+                attempt.AmbiguousAssemblies);
         if (attempt.Assembly is { } assembly)
-            return AssemblyBindingSelection.Found(assembly);
+        {
+            return AssemblyBindingSelection.Found(
+                assembly,
+                attempt.ShadowedAssemblies);
+        }
         return attempt.CandidateFailure is { } candidateFailure
             ? AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
@@ -505,12 +611,14 @@ public sealed partial class AssemblyDependencyResolver :
         string path,
         AssemblyResolutionProvenance provenance) =>
         _descriptors.GetOrAdd(
-            path,
-            (path, provenance) =>
+            new AssemblyDescriptorKey(path, provenance),
+            static (key, resolver) =>
                 new Lazy<AssemblyDescriptorResolution>(
-                    () => CreateDescriptor(path, provenance),
+                    () => resolver.CreateDescriptor(
+                        key.Path,
+                        key.Provenance),
                     LazyThreadSafetyMode.ExecutionAndPublication),
-            provenance).Value;
+            this).Value;
 
     AssemblyDescriptorResolution CreateDescriptor(
         string path,
@@ -654,7 +762,13 @@ public sealed partial class AssemblyDependencyResolver :
 
     readonly record struct AssemblyResolutionAttempt(
         ResolvedAssemblyReference? Assembly,
-        CandidateOpenFailureKind? CandidateFailure);
+        CandidateOpenFailureKind? CandidateFailure,
+        ImmutableArray<ResolvedAssemblyReference> ShadowedAssemblies = default,
+        ImmutableArray<ResolvedAssemblyReference> AmbiguousAssemblies = default);
+
+    readonly record struct AssemblyDescriptorKey(
+        string Path,
+        AssemblyResolutionProvenance Provenance);
 
     sealed record AssemblyDescriptorResolution(
         ResolvedAssemblyReference? Assembly,

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -100,6 +100,10 @@ public sealed partial class AssemblyDependencyResolver :
         AssemblyDescriptorKey,
         Lazy<AssemblyDescriptorResolution>> _descriptors =
             [];
+    readonly ConcurrentDictionary<
+        string,
+        Lazy<SnapshotImageResolution>> _snapshotImages =
+            new(StringComparer.Ordinal);
     IReadOnlyList<ResolvedAssemblyDependency>? _resolved;
     IReadOnlyList<ResolvedAssemblyDependency>? _allCandidates;
     readonly ConcurrentDictionary<
@@ -391,6 +395,7 @@ public sealed partial class AssemblyDependencyResolver :
             return null;
         }
         var entitled = new List<ResolvedAssemblyReference>();
+        CandidateOpenFailureKind? budgetFailure = null;
         foreach (ResolvedAssemblyDependency dependency in candidates)
         {
             bool designated =
@@ -410,6 +415,13 @@ public sealed partial class AssemblyDependencyResolver :
             {
                 entitled.Add(assembly);
             }
+            else if (PathNameMatches(dependency, identity)
+                && descriptor.FailureKind
+                    is CandidateOpenFailureKind.ResourceBudget)
+            {
+                budgetFailure =
+                    CandidateOpenFailureKind.ResourceBudget;
+            }
         }
 
         bool allowPlatformVersionRollForward =
@@ -421,6 +433,12 @@ public sealed partial class AssemblyDependencyResolver :
                 entitled,
                 allowPlatformVersionRollForward,
                 _options.IgnoreAssemblyVersion);
+        if (budgetFailure is not null)
+        {
+            return new AssemblyResolutionAttempt(
+                Assembly: null,
+                budgetFailure);
+        }
         if (selection is null)
             return null;
 
@@ -685,6 +703,35 @@ public sealed partial class AssemblyDependencyResolver :
                         ?? new BadImageFormatException()));
         }
 
+        SnapshotImageResolution snapshot =
+            _snapshotImages.GetOrAdd(
+                path,
+                static (path, resolver) =>
+                    new Lazy<SnapshotImageResolution>(
+                        () => resolver.CreateSnapshotImage(path),
+                        LazyThreadSafetyMode.ExecutionAndPublication),
+                this).Value;
+        if (snapshot.Image is null
+            || snapshot.Identity is null)
+        {
+            return new(
+                Assembly: null,
+                snapshot.FailureKind
+                ?? CandidateOpenFailureKind.Unreadable);
+        }
+
+        byte[] image = snapshot.Image;
+        return new(
+            ResolvedAssemblyReference.Create(
+                snapshot.Identity,
+                Path.GetFullPath(path),
+                () => new MemoryStream(image, writable: false),
+                provenance),
+            FailureKind: null);
+    }
+
+    SnapshotImageResolution CreateSnapshotImage(string path)
+    {
         long reservedBytes = 0;
         try
         {
@@ -708,24 +755,22 @@ public sealed partial class AssemblyDependencyResolver :
             if (!reader.HasMetadata)
             {
                 return new(
-                    Assembly: null,
+                    Identity: null,
+                    Image: null,
                     CandidateOpenFailureKind.InvalidImage);
             }
 
-            ResolvedAssemblyReference result =
-                ResolvedAssemblyReference.Create(
+            AssemblyReferenceIdentity identity =
                 AssemblyReferenceIdentity.FromAssemblyDefinition(
-                    reader.GetMetadataReader()),
-                Path.GetFullPath(path),
-                () => new MemoryStream(image, writable: false),
-                provenance);
+                    reader.GetMetadataReader());
             reservedBytes = 0;
-            return new(result, FailureKind: null);
+            return new(identity, image, FailureKind: null);
         }
         catch (AssemblyDependencySnapshotBudgetExceededException)
         {
             return new(
-                Assembly: null,
+                Identity: null,
+                Image: null,
                 CandidateOpenFailureKind.ResourceBudget);
         }
         catch (Exception ex) when (
@@ -738,7 +783,8 @@ public sealed partial class AssemblyDependencyResolver :
                 or OverflowException)
         {
             return new(
-                Assembly: null,
+                Identity: null,
+                Image: null,
                 ClassifyCandidateOpenFailure(ex));
         }
         finally
@@ -817,6 +863,11 @@ public sealed partial class AssemblyDependencyResolver :
 
     sealed record AssemblyDescriptorResolution(
         ResolvedAssemblyReference? Assembly,
+        CandidateOpenFailureKind? FailureKind);
+
+    sealed record SnapshotImageResolution(
+        AssemblyReferenceIdentity? Identity,
+        byte[]? Image,
         CandidateOpenFailureKind? FailureKind);
 
 }

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -415,9 +415,10 @@ public sealed partial class AssemblyDependencyResolver :
             {
                 entitled.Add(assembly);
             }
-            else if (PathNameMatches(dependency, identity)
-                && descriptor.FailureKind
-                    is CandidateOpenFailureKind.ResourceBudget)
+            else if (descriptor.FailureKind
+                    is CandidateOpenFailureKind.ResourceBudget
+                && (designated
+                    || PathNameMatches(dependency, identity)))
             {
                 budgetFailure =
                     CandidateOpenFailureKind.ResourceBudget;

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -390,9 +390,7 @@ public sealed partial class AssemblyDependencyResolver :
         {
             return null;
         }
-
         var entitled = new List<ResolvedAssemblyReference>();
-        CandidateOpenFailureKind? candidateFailure = null;
         foreach (ResolvedAssemblyDependency dependency in candidates)
         {
             bool designated =
@@ -412,12 +410,6 @@ public sealed partial class AssemblyDependencyResolver :
             {
                 entitled.Add(assembly);
             }
-            else if (PathNameMatches(dependency, identity))
-            {
-                candidateFailure ??=
-                    descriptor.FailureKind
-                    ?? CandidateOpenFailureKind.Unreadable;
-            }
         }
 
         bool allowPlatformVersionRollForward =
@@ -431,12 +423,6 @@ public sealed partial class AssemblyDependencyResolver :
                 _options.IgnoreAssemblyVersion);
         if (selection is null)
             return null;
-        if (candidateFailure is not null)
-        {
-            return new AssemblyResolutionAttempt(
-                Assembly: null,
-                candidateFailure);
-        }
 
         bool useInstalledPlatformFallback =
             scope == AssemblyResolutionScope.Platform
@@ -455,16 +441,17 @@ public sealed partial class AssemblyDependencyResolver :
             && InstalledPlatformDescriptor(identity)
                 is { } installedPlatform)
         {
-            if (installedPlatform.Assembly is { } assembly)
+            if (installedPlatform.Assembly is { } assembly
+                && identity.MatchesCandidate(
+                    assembly.Identity,
+                    _options.AllowPlatformAssemblyVersionRollForward,
+                    _options.IgnoreAssemblyVersion)
+                && selection
+                    is AssemblyBindingSelection.Selected selected)
             {
-                entitled.Add(assembly);
-                selection =
-                    DesignatedAssemblyBindingPrecedence.TrySelect(
-                        identity,
-                        entitled,
-                        allowPlatformVersionRollForward,
-                        _options.IgnoreAssemblyVersion)
-                    ?? selection;
+                selection = AssemblyBindingSelection.Found(
+                    selected.Assembly,
+                    selected.ShadowedAssemblies.Add(assembly));
             }
         }
 

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -370,21 +370,23 @@ public sealed partial class AssemblyDependencyResolver :
         AssemblyReferenceIdentity identity,
         AssemblyResolutionScope scope)
     {
+        static bool PathNameMatches(
+            ResolvedAssemblyDependency dependency,
+            AssemblyReferenceIdentity identity) =>
+            Path.GetFileNameWithoutExtension(dependency.Path).Equals(
+                identity.Name,
+                StringComparison.OrdinalIgnoreCase);
+
         ResolvedAssemblyDependency? nameOwner = candidates.FirstOrDefault(
             dependency =>
-                Path.GetFileNameWithoutExtension(dependency.Path).Equals(
-                    identity.Name,
-                    StringComparison.OrdinalIgnoreCase)
+                PathNameMatches(dependency, identity)
                 && (scope != AssemblyResolutionScope.Platform
                     || IsEntitled(dependency.Provenance)));
-        if (nameOwner is null
-            || !IsEntitled(nameOwner.Provenance)
+        if ((nameOwner is not null
+                && !IsEntitled(nameOwner.Provenance))
             || !candidates.Any(dependency =>
                 dependency.Provenance
-                    is AssemblyDependencyProvenance.CorpusAssembly
-                && Path.GetFileNameWithoutExtension(dependency.Path).Equals(
-                    identity.Name,
-                    StringComparison.OrdinalIgnoreCase)))
+                    is AssemblyDependencyProvenance.CorpusAssembly))
         {
             return null;
         }
@@ -393,10 +395,12 @@ public sealed partial class AssemblyDependencyResolver :
         CandidateOpenFailureKind? candidateFailure = null;
         foreach (ResolvedAssemblyDependency dependency in candidates)
         {
-            if (!IsEntitled(dependency.Provenance)
-                || !Path.GetFileNameWithoutExtension(dependency.Path).Equals(
-                    identity.Name,
-                    StringComparison.OrdinalIgnoreCase))
+            bool designated =
+                dependency.Provenance
+                    is AssemblyDependencyProvenance.CorpusAssembly;
+            if (!designated
+                && (!IsEntitled(dependency.Provenance)
+                    || !PathNameMatches(dependency, identity)))
             {
                 continue;
             }
@@ -408,7 +412,7 @@ public sealed partial class AssemblyDependencyResolver :
             {
                 entitled.Add(assembly);
             }
-            else
+            else if (PathNameMatches(dependency, identity))
             {
                 candidateFailure ??=
                     descriptor.FailureKind
@@ -416,6 +420,17 @@ public sealed partial class AssemblyDependencyResolver :
             }
         }
 
+        bool allowPlatformVersionRollForward =
+            scope == AssemblyResolutionScope.Platform
+            && _options.AllowPlatformAssemblyVersionRollForward;
+        AssemblyBindingSelection? selection =
+            DesignatedAssemblyBindingPrecedence.TrySelect(
+                identity,
+                entitled,
+                allowPlatformVersionRollForward,
+                _options.IgnoreAssemblyVersion);
+        if (selection is null)
+            return null;
         if (candidateFailure is not null)
         {
             return new AssemblyResolutionAttempt(
@@ -423,28 +438,71 @@ public sealed partial class AssemblyDependencyResolver :
                 candidateFailure);
         }
 
-        return DesignatedAssemblyBindingPrecedence.TrySelect(
-                identity,
-                entitled,
-                allowPlatformVersionRollForward:
-                    scope == AssemblyResolutionScope.Platform
-                    && _options.AllowPlatformAssemblyVersionRollForward,
-                ignorePlatformVersion:
-                    _options.IgnoreAssemblyVersion)
-            switch
+        bool useInstalledPlatformFallback =
+            scope == AssemblyResolutionScope.Platform
+            || scope == AssemblyResolutionScope.Any
+                && _options.IncludeInstalledPlatformFallback
+                && nameOwner is null;
+        bool hasEligiblePlatform = entitled.Any(candidate =>
+            candidate.Provenance
+                is AssemblyResolutionProvenance.PlatformAsset
+            && identity.MatchesCandidate(
+                candidate.Identity,
+                allowPlatformVersionRollForward,
+                _options.IgnoreAssemblyVersion));
+        if (useInstalledPlatformFallback
+            && !hasEligiblePlatform
+            && InstalledPlatformDescriptor(identity)
+                is { } installedPlatform)
+        {
+            if (installedPlatform.Assembly is { } assembly)
             {
-                AssemblyBindingSelection.Selected selected =>
-                    new AssemblyResolutionAttempt(
-                        selected.Assembly,
-                        CandidateFailure: null,
-                        selected.ShadowedAssemblies),
-                AssemblyBindingSelection.Ambiguous ambiguous =>
-                    new AssemblyResolutionAttempt(
-                        Assembly: null,
-                        CandidateFailure: null,
-                        AmbiguousAssemblies: ambiguous.Assemblies),
-                _ => null,
-            };
+                entitled.Add(assembly);
+                selection =
+                    DesignatedAssemblyBindingPrecedence.TrySelect(
+                        identity,
+                        entitled,
+                        allowPlatformVersionRollForward,
+                        _options.IgnoreAssemblyVersion)
+                    ?? selection;
+            }
+        }
+
+        return selection switch
+        {
+            AssemblyBindingSelection.Selected selected =>
+                new AssemblyResolutionAttempt(
+                    selected.Assembly,
+                    CandidateFailure: null,
+                    selected.ShadowedAssemblies),
+            AssemblyBindingSelection.Ambiguous ambiguous =>
+                new AssemblyResolutionAttempt(
+                    Assembly: null,
+                    CandidateFailure: null,
+                    AmbiguousAssemblies: ambiguous.Assemblies),
+            _ => null,
+        };
+    }
+
+    AssemblyDescriptorResolution? InstalledPlatformDescriptor(
+        AssemblyReferenceIdentity identity)
+    {
+        if (!PlatformResolver.IsPlatformCandidate(identity.Name))
+            return null;
+
+        var (path, framework, _, _) = PlatformResolver.ResolveAssembly(
+            identity.Name,
+            useRuntimeAssemblies: _options.PreferImplementationAssemblies);
+        return path is null
+            ? null
+            : DescriptorResult(
+                path,
+                AssemblyResolutionProvenance.Platform(
+                    framework ?? "InstalledPlatform",
+                    frameworkVersion: null,
+                    AssemblyDependencyProvenance
+                        .InstalledPlatformAssembly
+                        .ToString()));
     }
 
     static bool IsEntitled(

--- a/src/DotnetInspector.Services/DesignatedAssemblyBindingPrecedence.cs
+++ b/src/DotnetInspector.Services/DesignatedAssemblyBindingPrecedence.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services;
+
+internal static class DesignatedAssemblyBindingPrecedence
+{
+    internal static AssemblyBindingSelection? TrySelect(
+        AssemblyReferenceIdentity requested,
+        IEnumerable<ResolvedAssemblyReference> candidates,
+        bool allowPlatformVersionRollForward = false,
+        bool ignorePlatformVersion = false)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var seen = new HashSet<AssemblyAcquisitionRegistration>(
+            ReferenceEqualityComparer.Instance);
+        ImmutableArray<ResolvedAssemblyReference> eligible =
+        [
+            .. candidates.Where(candidate =>
+                candidate.Provenance switch
+                {
+                    AssemblyResolutionProvenance.DesignatedAsset =>
+                        requested.MatchesCandidate(
+                            candidate.Identity,
+                            allowVersionRollForward: false,
+                            ignoreVersion: true),
+                    AssemblyResolutionProvenance.PlatformAsset =>
+                        requested.MatchesCandidate(
+                            candidate.Identity,
+                            allowPlatformVersionRollForward,
+                            ignorePlatformVersion),
+                    _ => false,
+                }
+                && seen.Add(candidate.Registration)),
+        ];
+        ImmutableArray<ResolvedAssemblyReference> designated =
+        [
+            .. eligible.Where(candidate =>
+                candidate.Provenance
+                    is AssemblyResolutionProvenance.DesignatedAsset),
+        ];
+
+        return designated.Length switch
+        {
+            0 => null,
+            1 => AssemblyBindingSelection.Found(
+                designated[0],
+                [
+                    .. eligible.Where(candidate =>
+                        candidate.Provenance
+                            is AssemblyResolutionProvenance.PlatformAsset),
+                ]),
+            _ => AssemblyBindingSelection.Multiple(designated),
+        };
+    }
+}

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -88,6 +88,26 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             request.Target as AssemblyBindingTarget.AssemblyReference;
         if (reference is not null)
         {
+            bool nonEntitledNameOwner =
+                request.Scope == AssemblyResolutionScope.Any
+                && _roots.Any(root =>
+                    root.Provenance
+                        is not (
+                            AssemblyResolutionProvenance.DesignatedAsset
+                            or AssemblyResolutionProvenance.PlatformAsset)
+                    && string.Equals(
+                        root.Identity.Name,
+                        reference.Identity.Name,
+                        StringComparison.OrdinalIgnoreCase));
+            if (!nonEntitledNameOwner
+                && DesignatedAssemblyBindingPrecedence.TrySelect(
+                        reference.Identity,
+                        _roots)
+                    is { } precedenceSelection)
+            {
+                return precedenceSelection;
+            }
+
             ImmutableArray<ResolvedAssemblyReference> matches =
             [
                 .. _roots.Where(

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -86,6 +86,7 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
 
         AssemblyBindingTarget.AssemblyReference? reference =
             request.Target as AssemblyBindingTarget.AssemblyReference;
+        AssemblyBindingSelection.Selected? pendingDesignated = null;
         if (reference is not null)
         {
             bool nonEntitledNameOwner =
@@ -105,7 +106,23 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                         _roots)
                     is { } precedenceSelection)
             {
-                return precedenceSelection;
+                if (precedenceSelection
+                    is AssemblyBindingSelection.Ambiguous)
+                {
+                    return precedenceSelection;
+                }
+
+                var selected = (AssemblyBindingSelection.Selected)
+                    precedenceSelection;
+                if (!selected.ShadowedAssemblies.IsEmpty
+                    || SameIdentity(
+                        selected.Assembly.Identity,
+                        reference.Identity))
+                {
+                    return selected;
+                }
+
+                pendingDesignated = selected;
             }
 
             ImmutableArray<ResolvedAssemblyReference> matches =
@@ -122,6 +139,14 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
         }
 
         AssemblyBindingSelection selection = policy.Select(request);
+        if (reference is not null
+            && pendingDesignated is not null)
+        {
+            selection = ComposePendingDesignated(
+                reference.Identity,
+                pendingDesignated,
+                selection);
+        }
         if (reference is not null
             && selection
                 is AssemblyBindingSelection.Missing
@@ -151,6 +176,59 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
 
         return selection;
     }
+
+    static AssemblyBindingSelection ComposePendingDesignated(
+        AssemblyReferenceIdentity requested,
+        AssemblyBindingSelection.Selected designated,
+        AssemblyBindingSelection policySelection)
+    {
+        ImmutableArray<ResolvedAssemblyReference> platforms =
+            policySelection switch
+            {
+                AssemblyBindingSelection.Selected selected
+                    when IsCompatiblePlatform(
+                        requested,
+                        selected.Assembly) =>
+                    [
+                        selected.Assembly,
+                        .. selected.ShadowedAssemblies.Where(
+                            shadow => IsCompatiblePlatform(
+                                requested,
+                                shadow)),
+                    ],
+                AssemblyBindingSelection.Ambiguous ambiguous
+                    when ambiguous.Assemblies.All(
+                        candidate => IsCompatiblePlatform(
+                            requested,
+                            candidate)) =>
+                    ambiguous.Assemblies,
+                _ => [],
+            };
+        if (!platforms.IsEmpty)
+        {
+            return AssemblyBindingSelection.Found(
+                designated.Assembly,
+                [
+                    .. designated.ShadowedAssemblies,
+                    .. platforms,
+                ]);
+        }
+
+        return policySelection
+            is AssemblyBindingSelection.Missing
+                ? designated
+                : policySelection;
+    }
+
+    static bool IsCompatiblePlatform(
+        AssemblyReferenceIdentity requested,
+        ResolvedAssemblyReference candidate) =>
+        candidate.Provenance
+            is AssemblyResolutionProvenance.PlatformAsset
+        && requested.MatchesCandidate(
+            candidate.Identity,
+            allowVersionRollForward: false,
+            ignoreVersion: true);
 
     AssemblyBindingSelection? IdentityMismatchSelection(
         AssemblyReferenceIdentity requested,

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -106,36 +106,23 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                         _roots)
                     is { } precedenceSelection)
             {
-                ImmutableArray<ResolvedAssemblyReference> designated =
-                    DesignatedCandidates(precedenceSelection);
-                bool hasExactDesignated = designated.Any(candidate =>
-                    SameIdentity(
-                        candidate.Identity,
-                        reference.Identity));
-                bool hasEligiblePlatform = _roots.Any(candidate =>
-                    IsCompatiblePlatform(
-                        reference.Identity,
-                        candidate,
-                        ignoreVersion: false));
-                if (hasExactDesignated || hasEligiblePlatform)
-                {
-                    return precedenceSelection;
-                }
-
                 pendingDesignated = precedenceSelection;
             }
 
-            ImmutableArray<ResolvedAssemblyReference> matches =
-            [
-                .. _roots.Where(
-                    root => SameIdentity(
-                        root.Identity,
-                        reference.Identity)),
-            ];
-            if (matches.Length == 1)
-                return AssemblyBindingSelection.Found(matches[0]);
-            if (matches.Length > 1)
-                return AssemblyBindingSelection.Multiple(matches);
+            if (pendingDesignated is null)
+            {
+                ImmutableArray<ResolvedAssemblyReference> matches =
+                [
+                    .. _roots.Where(
+                        root => SameIdentity(
+                            root.Identity,
+                            reference.Identity)),
+                ];
+                if (matches.Length == 1)
+                    return AssemblyBindingSelection.Found(matches[0]);
+                if (matches.Length > 1)
+                    return AssemblyBindingSelection.Multiple(matches);
+            }
         }
 
         AssemblyBindingSelection selection = policy.Select(request);
@@ -228,9 +215,15 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                 is AssemblyBindingSelection.Selected selectedWithShadows
                     ? selectedWithShadows.ShadowedAssemblies
                     : [];
+        IEnumerable<ResolvedAssemblyReference> designatedShadows =
+            designated
+                is AssemblyBindingSelection.Selected selectedDesignated
+                    ? selectedDesignated.ShadowedAssemblies
+                    : [];
         ImmutableArray<ResolvedAssemblyReference> platforms =
             DistinctRegistrations(
-                policyCandidates
+                designatedShadows
+                    .Concat(policyCandidates)
                     .Concat(policyShadows)
                     .Where(candidate => IsCompatiblePlatform(
                         requested,

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -86,7 +86,7 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
 
         AssemblyBindingTarget.AssemblyReference? reference =
             request.Target as AssemblyBindingTarget.AssemblyReference;
-        AssemblyBindingSelection.Selected? pendingDesignated = null;
+        AssemblyBindingSelection? pendingDesignated = null;
         if (reference is not null)
         {
             bool nonEntitledNameOwner =
@@ -106,23 +106,23 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                         _roots)
                     is { } precedenceSelection)
             {
-                if (precedenceSelection
-                    is AssemblyBindingSelection.Ambiguous)
+                ImmutableArray<ResolvedAssemblyReference> designated =
+                    DesignatedCandidates(precedenceSelection);
+                bool hasExactDesignated = designated.Any(candidate =>
+                    SameIdentity(
+                        candidate.Identity,
+                        reference.Identity));
+                bool hasEligiblePlatform = _roots.Any(candidate =>
+                    IsCompatiblePlatform(
+                        reference.Identity,
+                        candidate,
+                        ignoreVersion: false));
+                if (hasExactDesignated || hasEligiblePlatform)
                 {
                     return precedenceSelection;
                 }
 
-                var selected = (AssemblyBindingSelection.Selected)
-                    precedenceSelection;
-                if (!selected.ShadowedAssemblies.IsEmpty
-                    || SameIdentity(
-                        selected.Assembly.Identity,
-                        reference.Identity))
-                {
-                    return selected;
-                }
-
-                pendingDesignated = selected;
+                pendingDesignated = precedenceSelection;
             }
 
             ImmutableArray<ResolvedAssemblyReference> matches =
@@ -179,56 +179,119 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
 
     static AssemblyBindingSelection ComposePendingDesignated(
         AssemblyReferenceIdentity requested,
-        AssemblyBindingSelection.Selected designated,
+        AssemblyBindingSelection designated,
         AssemblyBindingSelection policySelection)
     {
-        ImmutableArray<ResolvedAssemblyReference> platforms =
+        if (policySelection is AssemblyBindingSelection.Missing)
+        {
+            return designated;
+        }
+
+        if (policySelection
+            is AssemblyBindingSelection.Unavailable
+                or AssemblyBindingSelection.Rejected)
+        {
+            return policySelection;
+        }
+
+        ImmutableArray<ResolvedAssemblyReference> policyCandidates =
             policySelection switch
             {
-                AssemblyBindingSelection.Selected selected
-                    when IsCompatiblePlatform(
-                        requested,
-                        selected.Assembly) =>
-                    [
-                        selected.Assembly,
-                        .. selected.ShadowedAssemblies.Where(
-                            shadow => IsCompatiblePlatform(
-                                requested,
-                                shadow)),
-                    ],
-                AssemblyBindingSelection.Ambiguous ambiguous
-                    when ambiguous.Assemblies.All(
-                        candidate => IsCompatiblePlatform(
-                            requested,
-                            candidate)) =>
+                AssemblyBindingSelection.Selected selected =>
+                    [selected.Assembly],
+                AssemblyBindingSelection.Ambiguous ambiguous =>
                     ambiguous.Assemblies,
                 _ => [],
             };
-        if (!platforms.IsEmpty)
+        if (policyCandidates.IsEmpty
+            || policyCandidates.Any(candidate =>
+                !IsCompatibleEntitled(requested, candidate)))
         {
-            return AssemblyBindingSelection.Found(
-                designated.Assembly,
-                [
-                    .. designated.ShadowedAssemblies,
-                    .. platforms,
-                ]);
+            return policySelection;
         }
 
-        return policySelection
-            is AssemblyBindingSelection.Missing
-                ? designated
-                : policySelection;
+        ImmutableArray<ResolvedAssemblyReference> designatedCandidates =
+            DistinctRegistrations(
+                DesignatedCandidates(designated)
+                    .Concat(policyCandidates.Where(candidate =>
+                        candidate.Provenance
+                            is AssemblyResolutionProvenance
+                                .DesignatedAsset)));
+        if (designatedCandidates.Length > 1)
+        {
+            return AssemblyBindingSelection.Multiple(
+                designatedCandidates);
+        }
+
+        IEnumerable<ResolvedAssemblyReference> policyShadows =
+            policySelection
+                is AssemblyBindingSelection.Selected selectedWithShadows
+                    ? selectedWithShadows.ShadowedAssemblies
+                    : [];
+        ImmutableArray<ResolvedAssemblyReference> platforms =
+            DistinctRegistrations(
+                policyCandidates
+                    .Concat(policyShadows)
+                    .Where(candidate => IsCompatiblePlatform(
+                        requested,
+                        candidate,
+                        ignoreVersion: true)));
+        return AssemblyBindingSelection.Found(
+            designatedCandidates[0],
+            platforms);
     }
+
+    static ImmutableArray<ResolvedAssemblyReference> DesignatedCandidates(
+        AssemblyBindingSelection selection) =>
+        selection switch
+        {
+            AssemblyBindingSelection.Selected selected
+                when selected.Assembly.Provenance
+                    is AssemblyResolutionProvenance.DesignatedAsset =>
+                [selected.Assembly],
+            AssemblyBindingSelection.Ambiguous ambiguous =>
+                [
+                    .. ambiguous.Assemblies.Where(candidate =>
+                        candidate.Provenance
+                            is AssemblyResolutionProvenance
+                                .DesignatedAsset),
+                ],
+            _ => [],
+        };
+
+    static ImmutableArray<ResolvedAssemblyReference> DistinctRegistrations(
+        IEnumerable<ResolvedAssemblyReference> candidates)
+    {
+        var seen = new HashSet<AssemblyAcquisitionRegistration>(
+            ReferenceEqualityComparer.Instance);
+        return
+        [
+            .. candidates.Where(candidate =>
+                seen.Add(candidate.Registration)),
+        ];
+    }
+
+    static bool IsCompatibleEntitled(
+        AssemblyReferenceIdentity requested,
+        ResolvedAssemblyReference candidate) =>
+        candidate.Provenance is (
+            AssemblyResolutionProvenance.DesignatedAsset
+            or AssemblyResolutionProvenance.PlatformAsset)
+        && requested.MatchesCandidate(
+            candidate.Identity,
+            allowVersionRollForward: false,
+            ignoreVersion: true);
 
     static bool IsCompatiblePlatform(
         AssemblyReferenceIdentity requested,
-        ResolvedAssemblyReference candidate) =>
+        ResolvedAssemblyReference candidate,
+        bool ignoreVersion) =>
         candidate.Provenance
             is AssemblyResolutionProvenance.PlatformAsset
         && requested.MatchesCandidate(
             candidate.Identity,
             allowVersionRollForward: false,
-            ignoreVersion: true);
+            ignoreVersion);
 
     AssemblyBindingSelection? IdentityMismatchSelection(
         AssemblyReferenceIdentity requested,

--- a/src/ILInspector.Metadata/AssemblyBinding.cs
+++ b/src/ILInspector.Metadata/AssemblyBinding.cs
@@ -469,10 +469,22 @@ public abstract class AssemblyBindingOutcome
     /// </summary>
     public sealed class Unavailable : AssemblyBindingOutcome
     {
-        internal Unavailable(AssemblyBindingFailure failure) =>
+        internal Unavailable(
+            AssemblyBindingFailure failure,
+            ImmutableArray<ResolvedAssemblyReference> shadowedAssemblies =
+                default)
+        {
             Failure = failure;
+            ShadowedAssemblies = shadowedAssemblies.IsDefault
+                ? []
+                : shadowedAssemblies;
+        }
 
         public AssemblyBindingFailure Failure { get; }
+        public ImmutableArray<ResolvedAssemblyReference> ShadowedAssemblies
+        {
+            get;
+        }
     }
 
     /// <summary>Several catalog candidates remain plausible.</summary>

--- a/src/ILInspector.Metadata/AssemblyBinding.cs
+++ b/src/ILInspector.Metadata/AssemblyBinding.cs
@@ -181,12 +181,25 @@ public abstract class AssemblyBindingSelection
     {
     }
 
-    /// <summary>Returns one selected acquisition descriptor.</summary>
+    /// <summary>
+    /// Returns one selected acquisition descriptor and optional descriptors
+    /// retained as inactive shadow evidence.
+    /// </summary>
     public static AssemblyBindingSelection Found(
-        ResolvedAssemblyReference assembly)
+        ResolvedAssemblyReference assembly,
+        ImmutableArray<ResolvedAssemblyReference> shadowedAssemblies = default)
     {
         ArgumentNullException.ThrowIfNull(assembly);
-        return new Selected(assembly);
+        if (shadowedAssemblies.IsDefault)
+            shadowedAssemblies = [];
+        if (shadowedAssemblies.Any(static shadow => shadow is null))
+        {
+            throw new ArgumentException(
+                "Shadow evidence cannot contain null descriptors.",
+                nameof(shadowedAssemblies));
+        }
+
+        return new Selected(assembly, shadowedAssemblies);
     }
 
     /// <summary>Reports that policy found no candidate.</summary>
@@ -228,13 +241,25 @@ public abstract class AssemblyBindingSelection
         return new Rejected(failure);
     }
 
-    /// <summary>A policy selection containing one descriptor.</summary>
+    /// <summary>
+    /// A policy selection containing one descriptor and inactive shadow
+    /// evidence.
+    /// </summary>
     public sealed class Selected : AssemblyBindingSelection
     {
-        internal Selected(ResolvedAssemblyReference assembly) =>
+        internal Selected(
+            ResolvedAssemblyReference assembly,
+            ImmutableArray<ResolvedAssemblyReference> shadowedAssemblies)
+        {
             Assembly = assembly;
+            ShadowedAssemblies = shadowedAssemblies;
+        }
 
         public ResolvedAssemblyReference Assembly { get; }
+        public ImmutableArray<ResolvedAssemblyReference> ShadowedAssemblies
+        {
+            get;
+        }
     }
 
     /// <summary>A policy selection with no matching descriptor.</summary>
@@ -298,6 +323,8 @@ public interface IAssemblyBindingPolicy
 public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
 {
     readonly IAssemblyReferenceResolver _resolver;
+    readonly IAssemblyBindingPolicy? _bindingPolicy;
+    readonly AssemblyBindingPolicyVersion _version = new();
     readonly ConcurrentDictionary<
         SelectionKey,
         Lazy<AssemblyBindingSelection>> _selections = new();
@@ -306,14 +333,16 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
     {
         ArgumentNullException.ThrowIfNull(resolver);
         _resolver = resolver;
+        _bindingPolicy = resolver as IAssemblyBindingPolicy;
     }
 
-    public AssemblyBindingPolicyVersion Version { get; } = new();
+    public AssemblyBindingPolicyVersion Version =>
+        _bindingPolicy?.Version ?? _version;
 
     public AssemblyBindingSelection Select(AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var key = SelectionKey.From(request);
+        var key = SelectionKey.From(request, Version);
         return _selections.GetOrAdd(
             key,
             _ => new Lazy<AssemblyBindingSelection>(
@@ -328,7 +357,8 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
             return request.Target switch
             {
                 AssemblyBindingTarget.AssemblyReference reference =>
-                    SelectReference(reference.Identity, request.Scope),
+                    _bindingPolicy?.Select(request)
+                    ?? SelectReference(reference.Identity, request.Scope),
                 AssemblyBindingTarget.IntrinsicCoreLibrary =>
                     AssemblyBindingSelection.CannotSelect(
                         new AssemblyBindingFailure(
@@ -363,20 +393,28 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
         AssemblyBindingTarget Target,
         AssemblyAcquisitionRegistration? Origin,
         bool GlobalOrigin,
-        AssemblyResolutionScope Scope)
+        AssemblyResolutionScope Scope,
+        AssemblyBindingPolicyVersion PolicyVersion)
     {
         internal static SelectionKey From(
-            AssemblyBindingRequest request) =>
+            AssemblyBindingRequest request,
+            AssemblyBindingPolicyVersion policyVersion) =>
             request.Origin switch
             {
                 AssemblyBindingOrigin.GlobalOrigin =>
-                    new(request.Target, null, true, request.Scope),
+                    new(
+                        request.Target,
+                        null,
+                        true,
+                        request.Scope,
+                        policyVersion),
                 AssemblyBindingOrigin.RequestingAssembly requesting =>
                     new(
                         request.Target,
                         requesting.Registration,
                         false,
-                        request.Scope),
+                        request.Scope,
+                        policyVersion),
                 _ => throw new InvalidOperationException(
                     "Unknown assembly-binding origin."),
             };
@@ -387,7 +425,9 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
 /// Catalog-interned binding result stored in a frozen
 /// <see cref="TypeResolutionContext"/>. Unlike
 /// <see cref="AssemblyBindingSelection"/>, successful and ambiguous arms carry
-/// catalog candidates. Policies cannot construct these outcomes.
+/// catalog candidates. A resolved outcome retains descriptor-level shadow
+/// evidence without interning it as active candidates. Policies cannot
+/// construct these outcomes.
 /// </summary>
 public abstract class AssemblyBindingOutcome
 {
@@ -395,13 +435,25 @@ public abstract class AssemblyBindingOutcome
     {
     }
 
-    /// <summary>One descriptor was interned as a catalog candidate.</summary>
+    /// <summary>
+    /// One descriptor was interned as a catalog candidate; any shadow
+    /// descriptors remain inactive evidence.
+    /// </summary>
     public sealed class Resolved : AssemblyBindingOutcome
     {
-        internal Resolved(ResolvedAssemblyCandidate candidate) =>
+        internal Resolved(
+            ResolvedAssemblyCandidate candidate,
+            ImmutableArray<ResolvedAssemblyReference> shadowedAssemblies)
+        {
             Candidate = candidate;
+            ShadowedAssemblies = shadowedAssemblies;
+        }
 
         public ResolvedAssemblyCandidate Candidate { get; }
+        public ImmutableArray<ResolvedAssemblyReference> ShadowedAssemblies
+        {
+            get;
+        }
     }
 
     /// <summary>The policy found no candidate.</summary>

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -2495,7 +2495,8 @@ public sealed class TypeResolutionContext : IDisposable
                 return new(
                     new AssemblyBindingOutcome.Unavailable(
                         new AssemblyBindingFailure(
-                            AssemblyBindingFailureKind.CandidateUnavailable)),
+                            AssemblyBindingFailureKind.CandidateUnavailable),
+                        shadowedAssemblies),
                     assembly,
                     strictFailure,
                     [assembly]);
@@ -2516,7 +2517,8 @@ public sealed class TypeResolutionContext : IDisposable
             return new(
                 new AssemblyBindingOutcome.Unavailable(
                     new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.CandidateUnavailable)),
+                        AssemblyBindingFailureKind.CandidateUnavailable),
+                    shadowedAssemblies),
                 assembly,
                 failure,
                 [assembly]);

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -2455,7 +2455,9 @@ public sealed class TypeResolutionContext : IDisposable
             CachedBindingEvaluation evaluation = selection switch
             {
                 AssemblyBindingSelection.Selected selected =>
-                    SelectOne(selected.Assembly),
+                    SelectOne(
+                        selected.Assembly,
+                        selected.ShadowedAssemblies),
                 AssemblyBindingSelection.Missing =>
                     new(new AssemblyBindingOutcome.Missing()),
                 AssemblyBindingSelection.Unavailable unavailable =>
@@ -2481,7 +2483,9 @@ public sealed class TypeResolutionContext : IDisposable
             return evaluation;
         }
 
-        CachedBindingEvaluation SelectOne(ResolvedAssemblyReference assembly)
+        CachedBindingEvaluation SelectOne(
+            ResolvedAssemblyReference assembly,
+            ImmutableArray<ResolvedAssemblyReference> shadowedAssemblies)
         {
             Register(assembly);
             if (_strictRegistrationFailures.TryGetValue(
@@ -2501,7 +2505,9 @@ public sealed class TypeResolutionContext : IDisposable
                     out ResolvedAssemblyCandidate? candidate))
             {
                 return new(
-                    new AssemblyBindingOutcome.Resolved(candidate),
+                    new AssemblyBindingOutcome.Resolved(
+                        candidate,
+                        shadowedAssemblies),
                     Registrations: [assembly]);
             }
 
@@ -2570,7 +2576,8 @@ public sealed class TypeResolutionContext : IDisposable
             {
                 AssemblyBindingOutcome.Resolved resolved =>
                     SelectOne(
-                        resolved.Candidate.Assembly),
+                        resolved.Candidate.Assembly,
+                        resolved.ShadowedAssemblies),
                 AssemblyBindingOutcome.Ambiguous =>
                     SelectMany(evaluation.Registrations),
                 _ => evaluation,

--- a/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
@@ -81,6 +81,50 @@ public class AssemblyReferenceBindingPolicyTests
     }
 
     [Fact]
+    public void Select_PreservesBindingPolicyShadows()
+    {
+        ResolvedAssemblyReference selected = Descriptor(
+            AssemblyResolutionProvenance.Designated("selected"));
+        ResolvedAssemblyReference shadow = Descriptor(
+            AssemblyResolutionProvenance.Platform(
+                "platform",
+                frameworkVersion: null,
+                "shadow"));
+        var resolver = new RecordingResolverPolicy(
+            AssemblyBindingSelection.Found(selected, [shadow]));
+        var policy = new AssemblyReferenceBindingPolicy(resolver);
+
+        var result = Assert.IsType<AssemblyBindingSelection.Selected>(
+            policy.Select(
+                Request(AssemblyBindingTarget.Reference(Reference))));
+
+        Assert.Same(selected, result.Assembly);
+        Assert.Same(shadow, Assert.Single(result.ShadowedAssemblies));
+        Assert.Equal(1, resolver.SelectionCount);
+        Assert.Equal(0, resolver.ResolutionCount);
+    }
+
+    [Fact]
+    public void Select_PreservesBindingPolicyAmbiguity()
+    {
+        ResolvedAssemblyReference first = Descriptor(
+            AssemblyResolutionProvenance.Designated("first"));
+        ResolvedAssemblyReference second = Descriptor(
+            AssemblyResolutionProvenance.Designated("second"));
+        var resolver = new RecordingResolverPolicy(
+            AssemblyBindingSelection.Multiple([first, second]));
+        var policy = new AssemblyReferenceBindingPolicy(resolver);
+
+        var result = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+            policy.Select(
+                Request(AssemblyBindingTarget.Reference(Reference))));
+
+        Assert.Equal([first, second], result.Assemblies);
+        Assert.Equal(1, resolver.SelectionCount);
+        Assert.Equal(0, resolver.ResolutionCount);
+    }
+
+    [Fact]
     public void NoResolverPolicy_NeverSelectsAnyBindingTarget()
     {
         Assert.IsType<AssemblyBindingSelection.Missing>(
@@ -104,6 +148,15 @@ public class AssemblyReferenceBindingPolicyTests
             AssemblyBindingOrigin.Global(),
             AssemblyResolutionScope.Any);
 
+    static ResolvedAssemblyReference Descriptor(
+        AssemblyResolutionProvenance provenance) =>
+        ResolvedAssemblyReference.Create(
+            Reference,
+            path: null,
+            () => throw new InvalidOperationException(
+                "The adapter must not open binding descriptors."),
+            provenance);
+
     sealed class RecordingResolver(
         Func<AssemblyReferenceIdentity, AssemblyResolutionScope, ResolvedAssemblyReference?> resolve)
         : IAssemblyReferenceResolver
@@ -116,6 +169,30 @@ public class AssemblyReferenceBindingPolicyTests
         {
             Requests.Add((identity, scope));
             return resolve(identity, scope);
+        }
+    }
+
+    sealed class RecordingResolverPolicy(
+        AssemblyBindingSelection selection)
+        : IAssemblyReferenceResolver, IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+        public int ResolutionCount { get; private set; }
+        public int SelectionCount { get; private set; }
+
+        public ResolvedAssemblyReference? Resolve(
+            AssemblyReferenceIdentity identity,
+            AssemblyResolutionScope scope)
+        {
+            ResolutionCount++;
+            return null;
+        }
+
+        public AssemblyBindingSelection Select(
+            AssemblyBindingRequest request)
+        {
+            SelectionCount++;
+            return selection;
         }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
@@ -1789,6 +1789,49 @@ public class TypeResolutionContextTests
     }
 
     [Fact]
+    public void BindingFailure_PreservesShadowsWithoutOpeningThem()
+    {
+        byte[] ownerImage = BuildAssembly("Owner", definesType: false);
+        byte[] targetImage = BuildAssembly("Target", definesType: true);
+        ResolvedAssemblyReference owner = Descriptor(ownerImage);
+        ResolvedAssemblyReference selected =
+            ResolvedAssemblyReference.Create(
+                ReadIdentity(targetImage),
+                path: null,
+                () => throw new IOException("unreadable"),
+                AssemblyResolutionProvenance.Designated(
+                    "unreadable selected assembly"));
+        int shadowOpens = 0;
+        ResolvedAssemblyReference shadow = Descriptor(
+            targetImage,
+            () => shadowOpens++,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "shadow test assembly"));
+        var binding = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(ReadIdentity(targetImage)),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Platform);
+        var policy = new RecordingPolicy(
+            _ => AssemblyBindingSelection.Found(selected, [shadow]));
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            policy,
+            roots: [owner],
+            bindingRequests: [binding],
+            requests: []);
+
+        var unavailable = Assert.IsType<AssemblyBindingOutcome.Unavailable>(
+            context.Bind(binding));
+
+        Assert.Same(
+            shadow,
+            Assert.Single(unavailable.ShadowedAssemblies));
+        Assert.Equal(0, shadowOpens);
+    }
+
+    [Fact]
     public void SharedCatalog_ResolvesNewTypeThroughCachedBinding()
     {
         byte[] ownerImage = BuildAssembly("Owner", definesType: false);

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
@@ -1734,18 +1734,29 @@ public class TypeResolutionContextTests
     }
 
     [Fact]
-    public void SharedCatalog_ReusesBindingManifestAcrossGenerations()
+    public void SharedCatalog_ReusesBindingManifestAndShadowsAcrossGenerations()
     {
         byte[] ownerImage = BuildAssembly("Owner", definesType: false);
         byte[] targetImage = BuildAssembly("Target", definesType: true);
         ResolvedAssemblyReference owner = Descriptor(ownerImage);
-        ResolvedAssemblyReference target = Descriptor(targetImage);
+        ResolvedAssemblyReference target = Descriptor(
+            targetImage,
+            provenance: AssemblyResolutionProvenance.Designated(
+                "selected test assembly"));
+        int shadowOpens = 0;
+        ResolvedAssemblyReference shadow = Descriptor(
+            targetImage,
+            () => shadowOpens++,
+            AssemblyResolutionProvenance.Platform(
+                "test platform",
+                frameworkVersion: null,
+                "shadow test assembly"));
         var binding = new AssemblyBindingRequest(
             AssemblyBindingTarget.Reference(Identity("Target")),
             AssemblyBindingOrigin.FromAssembly(owner),
             AssemblyResolutionScope.Any);
         var policy = new RecordingPolicy(
-            _ => AssemblyBindingSelection.Found(target));
+            _ => AssemblyBindingSelection.Found(target, [shadow]));
         using var catalog = new TypeResolutionCatalog();
 
         using TypeResolutionContext first = catalog.CreateContext(
@@ -1759,12 +1770,21 @@ public class TypeResolutionContextTests
             bindingRequests: [binding],
             requests: []);
 
-        Assert.IsType<AssemblyBindingOutcome.Resolved>(
+        var firstResolved = Assert.IsType<AssemblyBindingOutcome.Resolved>(
             first.Bind(binding));
+        Assert.Same(
+            shadow,
+            Assert.Single(firstResolved.ShadowedAssemblies));
         Assert.Same(
             target,
             Assert.IsType<AssemblyBindingOutcome.Resolved>(
                 second.Bind(binding)).Candidate.Assembly);
+        Assert.Same(
+            shadow,
+            Assert.Single(
+                Assert.IsType<AssemblyBindingOutcome.Resolved>(
+                    second.Bind(binding)).ShadowedAssemblies));
+        Assert.Equal(0, shadowOpens);
         Assert.Single(policy.Requests);
     }
 
@@ -2479,7 +2499,8 @@ public class TypeResolutionContextTests
 
     static ResolvedAssemblyReference Descriptor(
         byte[] image,
-        Action? opened = null) =>
+        Action? opened = null,
+        AssemblyResolutionProvenance? provenance = null) =>
         ResolvedAssemblyReference.Create(
             ReadIdentity(image),
             path: null,
@@ -2488,7 +2509,8 @@ public class TypeResolutionContextTests
                 opened?.Invoke();
                 return new MemoryStream(image, writable: false);
             },
-            provenance: AssemblyResolutionProvenance.Local("test"));
+            provenance: provenance
+                ?? AssemblyResolutionProvenance.Local("test"));
 
     static AssemblyReferenceIdentity ReadIdentity(byte[] image)
     {


### PR DESCRIPTION
## Summary

Explicitly designated platform overlays now outrank ambient platform candidates
without depending on version equality or registration order. The binding result
retains eligible platform candidates as typed, inactive shadow evidence and
reports multiple distinct designated candidates as ambiguity.

The exception remains narrow: designated candidates still match assembly name,
culture, and public-key token; platform candidates keep their existing version
policy; and earlier sibling/package name-owning tiers in `Any` scope are
unchanged. Descriptor caching now distinguishes acquisition provenance so the
same physical file can truthfully represent both designated and platform roles.

Closes #4593.

## Demo

Before this change, an equal-version designated `System.Runtime` fixture lost to
the ambient platform copy, while a version change could flip the winner. After
the change, the same product resolver selects `DesignatedAsset` for equal and
skewed versions in both supported scopes and returns the `PlatformAsset` as
shadow evidence:

| Scope | Versions | Selected | Shadow |
| --- | --- | --- | --- |
| `Any` | equal | `DesignatedAsset` | `PlatformAsset` |
| `Any` | skewed | `DesignatedAsset` | `PlatformAsset` |
| `Platform` | skewed | `DesignatedAsset` | `PlatformAsset` |

```bash
dotnet run --project src/DotnetInspector.Services.Tests -c Release \
  --no-build -- \
  -method '*Select_DesignatedOverlayWinsWithEqualOrUnequalVersion*'
```

```text
DotnetInspector.Services.Tests  Total: 3, Errors: 0, Failed: 0, Skipped: 0
```

The neighboring tier case remains unchanged:

```bash
dotnet run --project src/DotnetInspector.Services.Tests -c Release \
  --no-build -- \
  -method '*Select_AnyScopeDesignatedOverlayDoesNotBypassSiblingTier*'
```

```text
DotnetInspector.Services.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `DotnetInspector.Services.Tests`: 1022 passed
- `ILInspector.Metadata.Tests`: 2290 passed
- `DotnetInspector.Queries.Tests`: 706 passed
- Focused resolver and metadata binding gates: 123 passed
- Post-integration cross-assembly decompiler gates: 78 passed
- `npx markdownlint-cli docs/design/platform-composition-and-overlays.md`
