### PR TITLE
Refresh platform framework discovery after cache changes

### DIFF
--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -104,6 +104,10 @@ public sealed partial class AssemblyDependencyResolver :
     readonly ConcurrentDictionary<
         AssemblyBindingRequestKey,
         Lazy<AssemblyBindingSelection>> _bindingSelections = [];
+    readonly Lazy<IReadOnlyList<FrameworkInfo>> _installedPlatformFrameworks =
+        new(
+            () => PlatformResolver.GetInstalledFrameworks(),
+            LazyThreadSafetyMode.ExecutionAndPublication);
     readonly object _snapshotBudgetLock = new();
     long _snapshotImageBytes;
 
@@ -320,9 +324,14 @@ public sealed partial class AssemblyDependencyResolver :
         if (useInstalledPlatformFallback
             && PlatformResolver.IsPlatformCandidate(identity.Name))
         {
-            var (path, framework, _, _) = PlatformResolver.ResolveAssembly(
-                identity.Name,
-                useRuntimeAssemblies: _options.PreferImplementationAssemblies);
+            var (path, framework, _, _) =
+                _options.PreferImplementationAssemblies
+                    ? PlatformResolver.ResolveAssembly(
+                        identity.Name,
+                        useRuntimeAssemblies: true)
+                    : PlatformResolver.ResolveAssemblyFromFrameworks(
+                        identity.Name,
+                        _installedPlatformFrameworks.Value);
             if (path is not null)
             {
                 AssemblyDescriptorResolution descriptor = DescriptorResult(

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -104,9 +104,9 @@ public sealed partial class AssemblyDependencyResolver :
     readonly ConcurrentDictionary<
         AssemblyBindingRequestKey,
         Lazy<AssemblyBindingSelection>> _bindingSelections = [];
-    readonly Lazy<IReadOnlyList<FrameworkInfo>> _installedPlatformFrameworks =
+    readonly Lazy<PlatformFrameworkSnapshot> _installedPlatformFrameworkSnapshot =
         new(
-            () => PlatformResolver.GetInstalledFrameworks(),
+            PlatformResolver.GetInstalledFrameworkSnapshot,
             LazyThreadSafetyMode.ExecutionAndPublication);
     readonly object _snapshotBudgetLock = new();
     long _snapshotImageBytes;
@@ -329,9 +329,9 @@ public sealed partial class AssemblyDependencyResolver :
                     ? PlatformResolver.ResolveAssembly(
                         identity.Name,
                         useRuntimeAssemblies: true)
-                    : PlatformResolver.ResolveAssemblyFromFrameworks(
+                    : PlatformResolver.ResolveAssemblyFromSnapshot(
                         identity.Name,
-                        _installedPlatformFrameworks.Value);
+                        _installedPlatformFrameworkSnapshot.Value);
             if (path is not null)
             {
                 AssemblyDescriptorResolution descriptor = DescriptorResult(

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -4,7 +4,6 @@ using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Collections.Immutable;
 using CSharpText;
-using DotnetInspector.Core;
 using DotnetInspector.Packages;
 using ILInspector.Metadata;
 using NuGet.Versioning;
@@ -16,12 +15,6 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class PlatformResolver
 {
-    /// <summary>
-    /// Process-lifetime cache for the parameterless GetInstalledFrameworks() overload.
-    /// Framework installations don't change during a CLI invocation.
-    /// </summary>
-    private static List<FrameworkInfo>? _cachedFrameworks;
-
     /// <summary>
     /// Returns true if the name looks like a platform assembly.
     /// </summary>
@@ -282,38 +275,13 @@ public static class PlatformResolver
 
     /// <summary>
     /// Discovers all installed frameworks with their versions across all packs directories.
+    /// Default discovery is live because the active cache root, DOTNET_ROOT,
+    /// and pack contents can change during a process. Gated by
+    /// GetInstalledFrameworks_DefaultDiscoveryRefreshesAfterCoreCacheRootChanges.
     /// </summary>
-    public static List<FrameworkInfo> GetInstalledFrameworks(string? packsDirectory = null)
-    {
-        // Use process-lifetime cache for the common no-arg path
-        if (packsDirectory == null)
-        {
-            var cached = Volatile.Read(ref _cachedFrameworks);
-            if (cached != null)
-            {
-                using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PlatformResolution);
-                CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Hit);
-                return cached;
-            }
-        }
-
-        if (packsDirectory == null)
-        {
-            using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PlatformResolution);
-            CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Miss);
-        }
-
-        var result = GetInstalledFrameworksCore(packsDirectory);
-
-        if (packsDirectory == null)
-        {
-            Volatile.Write(ref _cachedFrameworks, result);
-            using var cacheScope = NetworkTelemetry.Scope(NetworkTrafficKind.PlatformResolution);
-            CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Store);
-        }
-
-        return result;
-    }
+    public static List<FrameworkInfo> GetInstalledFrameworks(
+        string? packsDirectory = null) =>
+        GetInstalledFrameworksCore(packsDirectory);
 
     private static List<FrameworkInfo> GetInstalledFrameworksCore(string? packsDirectory)
     {

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -283,6 +283,11 @@ public static class PlatformResolver
         string? packsDirectory = null) =>
         GetInstalledFrameworksCore(packsDirectory);
 
+    internal static PlatformFrameworkSnapshot GetInstalledFrameworkSnapshot() =>
+        new(
+            GetInstalledFrameworks(),
+            GetInstalledRuntimeFrameworks());
+
     private static List<FrameworkInfo> GetInstalledFrameworksCore(string? packsDirectory)
     {
         List<string> packsDirs;
@@ -354,6 +359,32 @@ public static class PlatformResolver
         }
 
         return [.. frameworkMap.Values];
+    }
+
+    private static List<RuntimeFrameworkInfo> GetInstalledRuntimeFrameworks()
+    {
+        var sharedDirectory = GetSharedDirectory();
+        if (sharedDirectory is null)
+            return [];
+
+        List<RuntimeFrameworkInfo> frameworks = [];
+        foreach (var (shortName, sharedFrameworkName) in SharedFrameworkMappings)
+        {
+            string frameworkPath =
+                Path.Combine(sharedDirectory, sharedFrameworkName);
+            string? latestVersion =
+                GetInstalledVersions(frameworkPath).FirstOrDefault();
+            if (latestVersion is null)
+                continue;
+
+            frameworks.Add(
+                new RuntimeFrameworkInfo(
+                    shortName,
+                    latestVersion,
+                    Path.Combine(frameworkPath, latestVersion)));
+        }
+
+        return frameworks;
     }
 
     /// <summary>
@@ -586,21 +617,23 @@ public static class PlatformResolver
             packsDirectory,
             useRuntimeAssemblies,
             platformVersion,
-            installedFrameworks: null);
+            installedFrameworks: null,
+            installedRuntimeFrameworks: null);
 
     internal static (string? AssemblyPath, string? Framework, string? Version, string? Error)
-        ResolveAssemblyFromFrameworks(
+        ResolveAssemblyFromSnapshot(
             string assemblyName,
-            IReadOnlyList<FrameworkInfo> installedFrameworks)
+            PlatformFrameworkSnapshot snapshot)
     {
-        ArgumentNullException.ThrowIfNull(installedFrameworks);
+        ArgumentNullException.ThrowIfNull(snapshot);
         return ResolveAssemblyCore(
             assemblyName,
             frameworkSpec: null,
             packsDirectory: null,
             useRuntimeAssemblies: false,
             platformVersion: null,
-            installedFrameworks);
+            snapshot.ReferenceFrameworks,
+            snapshot.RuntimeFrameworks);
     }
 
     private static (string? AssemblyPath, string? Framework, string? Version, string? Error)
@@ -610,7 +643,8 @@ public static class PlatformResolver
             string? packsDirectory,
             bool useRuntimeAssemblies,
             string? platformVersion,
-            IReadOnlyList<FrameworkInfo>? installedFrameworks)
+            IReadOnlyList<FrameworkInfo>? installedFrameworks,
+            IReadOnlyList<RuntimeFrameworkInfo>? installedRuntimeFrameworks)
     {
         // Detect framework names passed as assembly names (e.g., --platform Microsoft.AspNetCore.App)
         // and provide a helpful error message
@@ -698,7 +732,12 @@ public static class PlatformResolver
                 continue;
 
             // Check if the runtime has a newer (or equal) version
-            var rt = ResolveRuntimeAssembly(assemblyName, shortName);
+            var rt = installedRuntimeFrameworks is null
+                ? ResolveRuntimeAssembly(assemblyName, shortName)
+                : ResolveRuntimeAssembly(
+                    assemblyName,
+                    shortName,
+                    installedRuntimeFrameworks);
             if (rt.AssemblyPath != null && rt.Version != null)
             {
                 var rtVer = ParseVersion(rt.Version);
@@ -714,7 +753,12 @@ public static class PlatformResolver
         // live in the shared runtime but have no ref-pack counterpart.
         foreach (var shortName in new[] { "runtime", "aspnetcore" })
         {
-            var rt = ResolveRuntimeAssembly(assemblyName, shortName);
+            var rt = installedRuntimeFrameworks is null
+                ? ResolveRuntimeAssembly(assemblyName, shortName)
+                : ResolveRuntimeAssembly(
+                    assemblyName,
+                    shortName,
+                    installedRuntimeFrameworks);
             if (rt.AssemblyPath != null)
                 return rt;
         }
@@ -819,6 +863,35 @@ public static class PlatformResolver
         }
 
         return (assemblyPath, frameworkName, version, null);
+    }
+
+    private static (string? AssemblyPath, string? Framework, string? Version, string? Error)
+        ResolveRuntimeAssembly(
+            string assemblyName,
+            string frameworkName,
+            IReadOnlyList<RuntimeFrameworkInfo> installedFrameworks)
+    {
+        RuntimeFrameworkInfo? framework =
+            installedFrameworks.FirstOrDefault(
+                candidate => candidate.ShortName.Equals(
+                    frameworkName,
+                    StringComparison.OrdinalIgnoreCase));
+        if (framework is null)
+        {
+            return (null, null, null,
+                frameworkName.Equals(
+                    "netstandard",
+                    StringComparison.OrdinalIgnoreCase)
+                    ? "netstandard does not have runtime libraries (ref-only)"
+                    : $"Framework '{frameworkName}' runtime is not installed");
+        }
+
+        string? assemblyPath =
+            FindAssemblyCaseInsensitive(framework.DirectoryPath, assemblyName);
+        return assemblyPath is null
+            ? (null, null, null,
+                $"Library '{assemblyName}' not found in {frameworkName} runtime {framework.Version}")
+            : (assemblyPath, framework.ShortName, framework.Version, null);
     }
 
     private static (string? AssemblyPath, string? Framework, string? Version, string? Error) ResolveRuntimeAssemblyAcrossFrameworks(
@@ -1199,6 +1272,15 @@ public class FrameworkInfo
     public int AssemblyCount { get; set; }
     public string Path { get; set; } = "";
 }
+
+internal sealed record PlatformFrameworkSnapshot(
+    IReadOnlyList<FrameworkInfo> ReferenceFrameworks,
+    IReadOnlyList<RuntimeFrameworkInfo> RuntimeFrameworks);
+
+internal sealed record RuntimeFrameworkInfo(
+    string ShortName,
+    string Version,
+    string DirectoryPath);
 
 /// <summary>
 /// Information about a reference assembly.

--- a/src/DotnetInspector.Services/PlatformResolver.cs
+++ b/src/DotnetInspector.Services/PlatformResolver.cs
@@ -579,7 +579,38 @@ public static class PlatformResolver
         string? frameworkSpec = null,
         string? packsDirectory = null,
         bool useRuntimeAssemblies = false,
-        string? platformVersion = null)
+        string? platformVersion = null) =>
+        ResolveAssemblyCore(
+            assemblyName,
+            frameworkSpec,
+            packsDirectory,
+            useRuntimeAssemblies,
+            platformVersion,
+            installedFrameworks: null);
+
+    internal static (string? AssemblyPath, string? Framework, string? Version, string? Error)
+        ResolveAssemblyFromFrameworks(
+            string assemblyName,
+            IReadOnlyList<FrameworkInfo> installedFrameworks)
+    {
+        ArgumentNullException.ThrowIfNull(installedFrameworks);
+        return ResolveAssemblyCore(
+            assemblyName,
+            frameworkSpec: null,
+            packsDirectory: null,
+            useRuntimeAssemblies: false,
+            platformVersion: null,
+            installedFrameworks);
+    }
+
+    private static (string? AssemblyPath, string? Framework, string? Version, string? Error)
+        ResolveAssemblyCore(
+            string assemblyName,
+            string? frameworkSpec,
+            string? packsDirectory,
+            bool useRuntimeAssemblies,
+            string? platformVersion,
+            IReadOnlyList<FrameworkInfo>? installedFrameworks)
     {
         // Detect framework names passed as assembly names (e.g., --platform Microsoft.AspNetCore.App)
         // and provide a helpful error message
@@ -648,7 +679,8 @@ public static class PlatformResolver
         // Search all frameworks across all packs dirs and runtime,
         // returning the assembly from whichever source has the newest version.
         // When versions are equal, runtime wins (has debug info for SourceLink).
-        var frameworks = GetInstalledFrameworks(packsDirectory);
+        var frameworks =
+            installedFrameworks ?? GetInstalledFrameworks(packsDirectory);
         var searchOrder = new[] { "runtime", "aspnetcore", "netstandard" };
 
         foreach (var shortName in searchOrder)

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1022,21 +1022,21 @@ public class PlatformResolverTests
     [Fact]
     public void GetInstalledFrameworks_DefaultDiscoveryRefreshesAfterCoreCacheRootChanges()
     {
-        CoreCache.Initialize("dotnet-inspect");
-        var (baselineRefPath, _, baselineError) =
-            PlatformResolver.ResolveFramework("runtime");
-        if (baselineRefPath is null)
-        {
-            Assert.Skip($"Runtime reference pack not available: {baselineError}");
-            return;
-        }
-
         const string SyntheticVersion = "999.0.0";
         string temporaryCache = Directory.CreateTempSubdirectory(
             "dotnet-inspect-platform-cache-").FullName;
         try
         {
             CoreCache.Initialize("dotnet-inspect-test", temporaryCache);
+            var (baselineRefPath, _, baselineError) =
+                PlatformResolver.ResolveFramework("runtime");
+            if (baselineRefPath is null)
+            {
+                Assert.Skip(
+                    $"Runtime reference pack not available: {baselineError}");
+                return;
+            }
+
             string packsDirectory =
                 Assert.IsType<string>(PlatformPackService.GetPacksCachePath());
             string syntheticRefPath = Path.Combine(
@@ -1062,7 +1062,7 @@ public class PlatformResolverTests
         }
         finally
         {
-            CoreCache.Initialize("dotnet-inspect");
+            CoreCache.Initialize("dotnet-inspect-test");
             Directory.Delete(temporaryCache, recursive: true);
         }
 
@@ -1079,33 +1079,40 @@ public class PlatformResolverTests
     [Fact]
     public void AssemblyDependencyResolver_InstalledFallbackUsesOneFrameworkSnapshotPerResolver()
     {
-        CoreCache.Initialize("dotnet-inspect");
-        var (baselineRefPath, _, baselineError) =
-            PlatformResolver.ResolveFramework("runtime");
-        if (baselineRefPath is null)
-        {
-            Assert.Skip($"Runtime reference pack not available: {baselineError}");
-            return;
-        }
-
-        string runtimeSource = Path.Combine(
-            baselineRefPath,
-            "System.Runtime.dll");
-        string consoleSource = Path.Combine(
-            baselineRefPath,
-            "System.Console.dll");
-        if (!File.Exists(runtimeSource) || !File.Exists(consoleSource))
-        {
-            Assert.Skip(
-                $"Runtime reference pack is incomplete: {baselineRefPath}");
-            return;
-        }
-
-        string temporaryCache = Directory.CreateTempSubdirectory(
+        string? originalDotnetRoot =
+            Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        string temporaryRoot = Directory.CreateTempSubdirectory(
             "dotnet-inspect-platform-snapshot-").FullName;
         try
         {
-            CoreCache.Initialize("dotnet-inspect-test", temporaryCache);
+            CoreCache.Initialize(
+                "dotnet-inspect-test",
+                Path.Combine(temporaryRoot, "cache"));
+            var (baselineRefPath, _, baselineError) =
+                PlatformResolver.ResolveFramework("runtime");
+            if (baselineRefPath is null)
+            {
+                Assert.Skip(
+                    $"Runtime reference pack not available: {baselineError}");
+                return;
+            }
+
+            string runtimeSource = Path.Combine(
+                baselineRefPath,
+                "System.Runtime.dll");
+            string consoleSource = Path.Combine(
+                baselineRefPath,
+                "System.Console.dll");
+            string coreLibrarySource = typeof(object).Assembly.Location;
+            if (!File.Exists(runtimeSource)
+                || !File.Exists(consoleSource)
+                || !File.Exists(coreLibrarySource))
+            {
+                Assert.Skip(
+                    $"Runtime installation is incomplete: {baselineRefPath}");
+                return;
+            }
+
             string packsDirectory =
                 Assert.IsType<string>(PlatformPackService.GetPacksCachePath());
             string firstRefPath = Path.Combine(
@@ -1121,6 +1128,26 @@ public class PlatformResolverTests
             File.Copy(
                 consoleSource,
                 Path.Combine(firstRefPath, "System.Console.dll"));
+
+            string firstDotnetRoot = Path.Combine(temporaryRoot, "first");
+            string firstRuntimePath = Path.Combine(
+                firstDotnetRoot,
+                "shared",
+                "Microsoft.NETCore.App",
+                "998.0.0");
+            Directory.CreateDirectory(firstRuntimePath);
+            File.Copy(
+                runtimeSource,
+                Path.Combine(firstRuntimePath, "System.Runtime.dll"));
+            File.Copy(
+                consoleSource,
+                Path.Combine(firstRuntimePath, "System.Console.dll"));
+            File.Copy(
+                coreLibrarySource,
+                Path.Combine(firstRuntimePath, "System.Private.CoreLib.dll"));
+            Environment.SetEnvironmentVariable(
+                "DOTNET_ROOT",
+                firstDotnetRoot);
 
             AssemblyDependencyResolver resolver = CreateResolver();
             Assert.Equal(
@@ -1138,17 +1165,51 @@ public class PlatformResolverTests
                 runtimeSource,
                 Path.Combine(secondRefPath, "System.Runtime.dll"));
 
+            string secondDotnetRoot = Path.Combine(temporaryRoot, "second");
+            string secondRuntimePath = Path.Combine(
+                secondDotnetRoot,
+                "shared",
+                "Microsoft.NETCore.App",
+                "999.5.0");
+            Directory.CreateDirectory(secondRuntimePath);
+            File.Copy(
+                consoleSource,
+                Path.Combine(secondRuntimePath, "System.Console.dll"));
+            File.Copy(
+                coreLibrarySource,
+                Path.Combine(secondRuntimePath, "System.Private.CoreLib.dll"));
+            Environment.SetEnvironmentVariable(
+                "DOTNET_ROOT",
+                secondDotnetRoot);
+
             Assert.Equal(
                 Path.Combine(firstRefPath, "System.Console.dll"),
                 Select(resolver, "System.Console").Assembly.Path);
             Assert.Equal(
+                Path.Combine(
+                    firstRuntimePath,
+                    "System.Private.CoreLib.dll"),
+                Select(resolver, "System.Private.CoreLib").Assembly.Path);
+
+            AssemblyDependencyResolver refreshedResolver = CreateResolver();
+            Assert.Equal(
                 Path.Combine(secondRefPath, "System.Runtime.dll"),
-                Select(CreateResolver(), "System.Runtime").Assembly.Path);
+                Select(refreshedResolver, "System.Runtime").Assembly.Path);
+            Assert.Equal(
+                Path.Combine(
+                    secondRuntimePath,
+                    "System.Private.CoreLib.dll"),
+                Select(
+                    refreshedResolver,
+                    "System.Private.CoreLib").Assembly.Path);
         }
         finally
         {
-            CoreCache.Initialize("dotnet-inspect");
-            Directory.Delete(temporaryCache, recursive: true);
+            Environment.SetEnvironmentVariable(
+                "DOTNET_ROOT",
+                originalDotnetRoot);
+            CoreCache.Initialize("dotnet-inspect-test");
+            Directory.Delete(temporaryRoot, recursive: true);
         }
 
         AssemblyDependencyResolver CreateResolver() =>

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using DotnetInspector.Core;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
 
@@ -1016,6 +1017,63 @@ public class PlatformResolverTests
             if (Directory.Exists(tempPacksDir))
                 Directory.Delete(tempPacksDir, recursive: true);
         }
+    }
+
+    [Fact]
+    public void GetInstalledFrameworks_DefaultDiscoveryRefreshesAfterCoreCacheRootChanges()
+    {
+        CoreCache.Initialize("dotnet-inspect");
+        var (baselineRefPath, _, baselineError) =
+            PlatformResolver.ResolveFramework("runtime");
+        if (baselineRefPath is null)
+        {
+            Assert.Skip($"Runtime reference pack not available: {baselineError}");
+            return;
+        }
+
+        const string SyntheticVersion = "999.0.0";
+        string temporaryCache = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-platform-cache-").FullName;
+        try
+        {
+            CoreCache.Initialize("dotnet-inspect-test", temporaryCache);
+            string packsDirectory =
+                Assert.IsType<string>(PlatformPackService.GetPacksCachePath());
+            string syntheticRefPath = Path.Combine(
+                packsDirectory,
+                "Microsoft.NETCore.App.Ref",
+                SyntheticVersion,
+                "ref",
+                "net999.0");
+            Directory.CreateDirectory(syntheticRefPath);
+            File.Copy(
+                typeof(PlatformResolverTests).Assembly.Location,
+                Path.Combine(syntheticRefPath, "System.Runtime.dll"));
+
+            FrameworkInfo runtime = Assert.Single(
+                PlatformResolver.GetInstalledFrameworks(),
+                framework => framework.ShortName == "runtime");
+            Assert.Equal(SyntheticVersion, runtime.LatestVersion);
+            Assert.Equal(
+                Path.Combine(
+                    packsDirectory,
+                    "Microsoft.NETCore.App.Ref"),
+                runtime.Path);
+        }
+        finally
+        {
+            CoreCache.Initialize("dotnet-inspect");
+            Directory.Delete(temporaryCache, recursive: true);
+        }
+
+        var resolved = Assert.IsType<PlatformTypeLookupOutcome.Resolved>(
+            PlatformResolver.LookupType("System.String"));
+        Assert.NotNull(resolved.Candidate.Assembly.Path);
+        Assert.True(File.Exists(resolved.Candidate.Assembly.Path));
+        Assert.False(
+            resolved.Candidate.Assembly.Path.StartsWith(
+                temporaryCache,
+                StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1076,6 +1076,111 @@ public class PlatformResolverTests
                 StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void AssemblyDependencyResolver_InstalledFallbackUsesOneFrameworkSnapshotPerResolver()
+    {
+        CoreCache.Initialize("dotnet-inspect");
+        var (baselineRefPath, _, baselineError) =
+            PlatformResolver.ResolveFramework("runtime");
+        if (baselineRefPath is null)
+        {
+            Assert.Skip($"Runtime reference pack not available: {baselineError}");
+            return;
+        }
+
+        string runtimeSource = Path.Combine(
+            baselineRefPath,
+            "System.Runtime.dll");
+        string consoleSource = Path.Combine(
+            baselineRefPath,
+            "System.Console.dll");
+        if (!File.Exists(runtimeSource) || !File.Exists(consoleSource))
+        {
+            Assert.Skip(
+                $"Runtime reference pack is incomplete: {baselineRefPath}");
+            return;
+        }
+
+        string temporaryCache = Directory.CreateTempSubdirectory(
+            "dotnet-inspect-platform-snapshot-").FullName;
+        try
+        {
+            CoreCache.Initialize("dotnet-inspect-test", temporaryCache);
+            string packsDirectory =
+                Assert.IsType<string>(PlatformPackService.GetPacksCachePath());
+            string firstRefPath = Path.Combine(
+                packsDirectory,
+                "Microsoft.NETCore.App.Ref",
+                "999.0.0",
+                "ref",
+                "net999.0");
+            Directory.CreateDirectory(firstRefPath);
+            File.Copy(
+                runtimeSource,
+                Path.Combine(firstRefPath, "System.Runtime.dll"));
+            File.Copy(
+                consoleSource,
+                Path.Combine(firstRefPath, "System.Console.dll"));
+
+            AssemblyDependencyResolver resolver = CreateResolver();
+            Assert.Equal(
+                Path.Combine(firstRefPath, "System.Runtime.dll"),
+                Select(resolver, "System.Runtime").Assembly.Path);
+
+            string secondRefPath = Path.Combine(
+                packsDirectory,
+                "Microsoft.NETCore.App.Ref",
+                "1000.0.0",
+                "ref",
+                "net1000.0");
+            Directory.CreateDirectory(secondRefPath);
+            File.Copy(
+                runtimeSource,
+                Path.Combine(secondRefPath, "System.Runtime.dll"));
+
+            Assert.Equal(
+                Path.Combine(firstRefPath, "System.Console.dll"),
+                Select(resolver, "System.Console").Assembly.Path);
+            Assert.Equal(
+                Path.Combine(secondRefPath, "System.Runtime.dll"),
+                Select(CreateResolver(), "System.Runtime").Assembly.Path);
+        }
+        finally
+        {
+            CoreCache.Initialize("dotnet-inspect");
+            Directory.Delete(temporaryCache, recursive: true);
+        }
+
+        AssemblyDependencyResolver CreateResolver() =>
+            new(
+                new AssemblyDependencyResolutionOptions(
+                    typeof(PlatformResolverTests).Assembly.Location)
+                {
+                    PackageRoots = [],
+                    IncludeSiblingAssemblies = false,
+                    IncludeTrustedPlatformAssemblies = false,
+                    IncludeAspNetCoreSharedFramework = false,
+                    IncludeDepsJsonAssets = false,
+                    IncludeInstalledPlatformFallback = true,
+                    IgnoreAssemblyVersion = true,
+                });
+
+        static AssemblyBindingSelection.Selected Select(
+            AssemblyDependencyResolver resolver,
+            string assemblyName) =>
+            Assert.IsType<AssemblyBindingSelection.Selected>(
+                resolver.Select(
+                    new AssemblyBindingRequest(
+                        AssemblyBindingTarget.Reference(
+                            new AssemblyReferenceIdentity(
+                                assemblyName,
+                                Version: null,
+                                Culture: null,
+                                PublicKeyToken: null)),
+                        AssemblyBindingOrigin.Global(),
+                        AssemblyResolutionScope.Any)));
+    }
+
     /// <summary>
     /// Tests that multiple framework versions are detected and sorted correctly.
     /// </summary>


### PR DESCRIPTION
Fixes #4956.

Platform framework discovery now reflects the active `CoreCache`,
`DOTNET_ROOT`, and on-disk reference-pack and shared-runtime inventory. The
removed process-lifetime cache could retain a temporary pack path after tests
or package operations deleted its root, causing all later platform type lookups
to report `CatalogUnavailable`.

Direct discovery remains live. A reference-mode `AssemblyDependencyResolver`
now takes one coherent resolver-local snapshot of both reference packs and
shared runtimes, avoiding a full installation scan for every platform identity
without mixing later runtime state into an existing binding pass. A new
resolver observes later cache, environment, and filesystem changes.

Implementation-mode resolution remains live. The expensive immutable metadata
catalogs also remain cached by `PlatformTypeCatalog`.

**Owner:** platform library discovery in `PlatformResolver`.
**Owning document:** `docs/design/platform-assemblies.md`.

## Demo

The new regression test performs the same state transition that poisoned the
full suite:

1. Publish a synthetic runtime reference pack under a temporary active
   `CoreCache`.
2. Prove default discovery selected that pack.
3. Restore the normal cache and delete the temporary root.
4. Resolve `System.String` through default platform discovery.

On `main`, step 4 fails:

```text
Expected: PlatformTypeLookupOutcome.Resolved
Actual:   PlatformTypeLookupOutcome.Rejected
```

With this change, the lookup resolves from an existing platform assembly
outside the deleted root.

The resolver-snapshot regression also creates synthetic initial reference-pack
and shared-runtime inventories, resolves from both, changes both the cache and
`DOTNET_ROOT`, and then proves:

- the existing resolver continues to use both initial sources; and
- a new resolver observes both replacement sources.

The round-2 implementation failed this neighboring scenario by combining its
initial reference-pack snapshot with the later shared runtime.

## Validation

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- \
  -class DotnetInspector.Tests.PlatformResolverTests
Total: 62, Errors: 0, Failed: 0, Skipped: 0

dotnet build dotnet-inspect.slnx -c Release
0 warnings, 0 errors

dotnet run --project src/dotnet-inspect.Tests -c Release --no-build
Total: 5089, Errors: 0, Failed: 0, Skipped: 30
```

`depends --library` remained inventory-size invariant: 1.12/0.71 seconds
baseline and 0.72/0.73 seconds with 200 non-winning synthetic pack versions.

## Non-claims

- No platform precedence, overlay, entitlement, or version-selection policy
  changes.
- No metadata catalog invalidation change; failed catalogs already evict
  themselves, and successful immutable catalogs remain cached.
- No cache-telemetry replacement. The removed hit/miss/store events described
  the deleted process cache, not platform resolution success.
