### PR TITLE
Collapse redundant raise rows, add Detail column, describe qualifier/argument role transitions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusHarnessProcessTests.cs
@@ -74,10 +74,11 @@ public class AuthoredCorpusHarnessProcessTests
                 "raise: Break case body; changed from return;",
                 run.Output,
                 StringComparison.Ordinal);
-            Assert.Contains("| Change | Structure | Region | Fidelity |", run.Output, StringComparison.Ordinal);
+            Assert.Contains("| Change | Structure | Region | Detail | Fidelity |", run.Output, StringComparison.Ordinal);
             Assert.DoesNotContain("Before spans", run.Output, StringComparison.Ordinal);
             Assert.DoesNotContain("After spans", run.Output, StringComparison.Ordinal);
             Assert.Contains("Return -&gt; Break", run.Output, StringComparison.Ordinal);
+            Assert.Contains("return; -&gt; break;", run.Output, StringComparison.Ordinal);
             Assert.Contains("OpcodeDiff -&gt; Exact", run.Output, StringComparison.Ordinal);
         }
         finally

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -88,6 +88,7 @@ public class CSharpStructuralComparisonTests
         Assert.Equal("Changed", display.Change);
         Assert.Equal("Return -> Break", display.Structure);
         Assert.Equal("Case", display.Region);
+        Assert.Equal("return; -> break;", display.Detail);
         Assert.Equal("OpcodeDiff -> Exact; terminal IL_0072: ret", display.Fidelity);
     }
 
@@ -132,18 +133,15 @@ public class CSharpStructuralComparisonTests
             comparison,
             CSharpStructuralSide.After);
 
-        Assert.Contains(
-            "raise: Return; changed to return Read(ref value);",
-            beforeBody,
-            StringComparison.Ordinal);
+        // The enclosing Return row is collapsed (issue #5022 item 1): its only
+        // diff is the InvocationExpression's own "value" -> "ref value" change,
+        // so it adds no information beyond the more specific row below.
+        Assert.DoesNotContain("raise: Return", beforeBody, StringComparison.Ordinal);
         Assert.Contains(
             "raise: InvocationExpression; changed to Read(ref value)",
             beforeBody,
             StringComparison.Ordinal);
-        Assert.Contains(
-            "raise: Return; changed from return Read(value);",
-            afterBody,
-            StringComparison.Ordinal);
+        Assert.DoesNotContain("raise: Return", afterBody, StringComparison.Ordinal);
         Assert.Contains(
             "raise: InvocationExpression; changed from Read(value)",
             afterBody,
@@ -359,6 +357,161 @@ public class CSharpStructuralComparisonTests
         Assert.Contains(display, row => row.Change == "Added");
         Assert.Contains(display, row => row.Change == "Removed");
         Assert.Contains(display, row => row.Change == "Moved");
+
+        // Detail column: Changed rows summarize the text transition inline;
+        // Added/Removed rows use the same "+"/"-" convention as FormatTransition;
+        // a Moved-only row (no text or kind change) carries no Detail.
+        Assert.Contains(display, row => row.Change == "Changed, Moved" && row.Detail == "B() -> D()");
+        Assert.Contains(display, row => row.Change == "Added" && row.Detail == "+ E()");
+        Assert.Contains(display, row => row.Change == "Removed" && row.Detail == "- C()");
+        Assert.Contains(display, row => row.Change == "Moved" && row.Detail == "");
+    }
+
+    [Fact]
+    public void CompareStructure_CollapsesSubsumedAncestorRowsToMostSpecificNode()
+    {
+        // Reproduces the #4942 shape recorded in #4952 (issue #5022, item 1):
+        // a receiver-qualification rewrite (instance-call -> static-call
+        // syntax) nested three levels deep (Return > InvocationExpression >
+        // InvocationExpression) previously produced three stacked, redundant
+        // rows. Only the innermost node's text actually differs; the two
+        // ancestor rows re-quote the same change inside a larger span.
+        const string beforeText =
+            "return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();";
+        const string afterText =
+            "return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();";
+
+        var before = Document(
+            beforeText,
+            ("Return", "return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();"),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true)"));
+        var after = Document(
+            afterText,
+            ("Return", "return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();"),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true)"));
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0, 1, 2],
+            [0, 1, 2],
+            [
+                new CSharpNodeCorrespondence(0, 0),
+                new CSharpNodeCorrespondence(1, 1),
+                new CSharpNodeCorrespondence(2, 2),
+            ]));
+
+        var row = Assert.Single(comparison.Rows);
+        Assert.Equal(CSharpStructuralChangeKind.Changed, row.Change);
+        Assert.Equal(2, row.BeforeNodeId);
+        Assert.Equal(2, row.AfterNodeId);
+    }
+
+    [Fact]
+    public void RenderAnnotatedBody_DescribesQualifierArgumentRoleTransition()
+    {
+        // Item 3 (issue #5022): once item 1 collapses #4942's stacked rows to
+        // the single most-specific InvocationExpression row, its caption
+        // should describe each side's own role ("qualifier" vs "argument 1"),
+        // not dump the other side's entire text.
+        const string beforeText = "receiver.Values(typeof(Attribute), true)";
+        const string afterText = "Values(receiver, typeof(Attribute), true)";
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.After);
+
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: used as extension-call qualifier",
+            beforeBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: moved to argument 1 (static call)",
+            afterBody,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("changed to", beforeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("changed from", afterBody, StringComparison.Ordinal);
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal(
+            "receiver: qualifier -> argument 1 (extension -> static call)",
+            display.Detail);
+    }
+
+    [Fact]
+    public void RenderAnnotatedBody_DescribesReverseArgumentQualifierRoleTransition()
+    {
+        // Mirror direction: a static call's first argument becomes the
+        // extension-call qualifier.
+        const string beforeText = "Values(receiver, typeof(Attribute), true)";
+        const string afterText = "receiver.Values(typeof(Attribute), true)";
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.After);
+
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: argument 1 (static call)",
+            beforeBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: moved to extension-call qualifier",
+            afterBody,
+            StringComparison.Ordinal);
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal(
+            "receiver: argument 1 -> qualifier (static -> extension call)",
+            display.Detail);
+    }
+
+    [Fact]
+    public void RenderAnnotatedBody_FallsBackToTextDumpWhenQualifierRoleShapeIsNotRecognized()
+    {
+        // A callee rename is not the narrow "receiver becomes an argument"
+        // shape item 3 targets, so this must fall back to the honest
+        // "changed to/from" text dump rather than guessing.
+        const string beforeText = "receiver.Values(typeof(Attribute), true)";
+        const string afterText = "receiver.OtherValues(typeof(Attribute), true)";
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+
+        Assert.Contains(
+            $"raise: InvocationExpression; changed to {afterText}",
+            beforeBody,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -681,8 +834,12 @@ public class CSharpStructuralComparisonTests
     [Fact]
     public void RenderAnnotatedBody_EarlyColumnSpansUseExactGutterFreeCarets()
     {
+        // The InvocationExpression's callee ("a" -> "z") differs independently
+        // of the nested NameExpression's own text ("b" -> "c"), so its row is
+        // not subsumed by item 1's ancestor-collapsing (issue #5022): both
+        // rows carry genuinely distinct information and both must still stack.
         const string beforeText = "a(b);";
-        const string afterText = "a(c);";
+        const string afterText = "z(c);";
         var before = new AnnotatedSourceDocument(
             beforeText,
             [

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -411,6 +411,56 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void CompareStructure_DoesNotCollapseAncestorWhenItCarriesIndependentMovedInformation()
+    {
+        // Regression for round-1 review: an ancestor's Moved flag is
+        // owner-issued and independent of whatever text change a nested
+        // descendant explains. If the descendant satisfies the ancestor's
+        // text-containment check but the ancestor is Changed|Moved (not
+        // plain Changed), suppressing it would silently discard the only row
+        // reporting the move. The same nested-call shape as the item-1 test
+        // is reused here, but the outer InvocationExpression correspondence
+        // is now also flagged Moved.
+        const string beforeText =
+            "return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();";
+        const string afterText =
+            "return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();";
+
+        var before = Document(
+            beforeText,
+            ("Return", "return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();"),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true)"));
+        var after = Document(
+            afterText,
+            ("Return", "return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();"),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true)"));
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0, 1, 2],
+            [0, 1, 2],
+            [
+                new CSharpNodeCorrespondence(0, 0),
+                new CSharpNodeCorrespondence(1, 1, Moved: true),
+                new CSharpNodeCorrespondence(2, 2),
+            ]));
+
+        Assert.Contains(comparison.Rows, row =>
+            row.Change == (CSharpStructuralChangeKind.Changed | CSharpStructuralChangeKind.Moved)
+            && row.BeforeNodeId == 1
+            && row.AfterNodeId == 1);
+        Assert.Contains(comparison.Rows, row =>
+            row.Change == CSharpStructuralChangeKind.Changed
+            && row.BeforeNodeId == 2
+            && row.AfterNodeId == 2);
+        Assert.DoesNotContain(comparison.Rows, row => row.BeforeNodeId == 0);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_DescribesQualifierArgumentRoleTransition()
     {
         // Item 3 (issue #5022): once item 1 collapses #4942's stacked rows to
@@ -512,6 +562,39 @@ public class CSharpStructuralComparisonTests
             $"raise: InvocationExpression; changed to {afterText}",
             beforeBody,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderAnnotatedBody_FallsBackToTextDumpWhenArgumentChangeAccompaniesQualifierMove()
+    {
+        // Regression for round-1 review: the qualifier looks like it moved
+        // into the argument list, but a *different* argument also changed
+        // ("old" -> "new"). Confirming only that the qualifier's text occurs
+        // somewhere in the other side's arguments (without checking the rest
+        // of the argument list is preserved) would produce a role caption
+        // that silently hides the unrelated argument change. This must fall
+        // back to the literal text dump instead.
+        const string beforeText = "receiver.Values(old)";
+        const string afterText = "Values(new, receiver)";
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+
+        Assert.Contains(
+            $"raise: InvocationExpression; changed to {afterText}",
+            beforeBody,
+            StringComparison.Ordinal);
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal($"{beforeText} -> {afterText}", display.Detail);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -453,7 +453,7 @@ public static partial class CSharpBodyDiff
 
         var matchedBefore = new HashSet<int>();
         var matchedAfter = new HashSet<int>();
-        var rows = ImmutableArray.CreateBuilder<CSharpStructuralDiffRow>();
+        var matchedRows = ImmutableArray.CreateBuilder<CSharpStructuralDiffRow>();
 
         foreach (var correspondence in input.Correspondences)
         {
@@ -495,13 +495,16 @@ public static partial class CSharpBodyDiff
             if (change == 0)
                 continue;
 
-            rows.Add(CreateRow(
+            matchedRows.Add(CreateRow(
                 change,
                 input.Before,
                 beforeNode,
                 input.After,
                 afterNode));
         }
+
+        var rows = ImmutableArray.CreateBuilder<CSharpStructuralDiffRow>();
+        rows.AddRange(SuppressSubsumedAncestorRows(matchedRows, input.Before, input.After));
 
         foreach (int nodeId in beforeSelection)
         {
@@ -737,4 +740,88 @@ public static partial class CSharpBodyDiff
         => row.BeforeSpans.IsEmpty
             ? row.AfterSpans[0].Start
             : row.BeforeSpans[0].Start;
+
+    // Item 1 (issue #5022): a stacked ancestor node (e.g. Return wrapping an
+    // InvocationExpression wrapping another InvocationExpression) re-quotes
+    // the entire statement as its own "changed" row even though every
+    // character it reports as different lives inside a more specific
+    // descendant row's own span. Drop an ancestor row exactly when some other
+    // row's span is strictly contained within it on both sides and the
+    // ancestor's text outside that contained range is identical between
+    // before and after -- i.e. the ancestor adds no information beyond the
+    // descendant it wraps. This is a plain text-containment check, not a
+    // parent/child pointer walk: the annotated-source model carries no
+    // explicit parent id, so span containment is the only honest signal
+    // available here.
+    static IEnumerable<CSharpStructuralDiffRow> SuppressSubsumedAncestorRows(
+        IReadOnlyList<CSharpStructuralDiffRow> rows,
+        AnnotatedSourceDocument before,
+        AnnotatedSourceDocument after)
+    {
+        for (int i = 0; i < rows.Count; i++)
+        {
+            var candidate = rows[i];
+            bool subsumed = false;
+            for (int j = 0; j < rows.Count; j++)
+            {
+                if (i == j)
+                    continue;
+                if (IsSubsumedByDescendant(candidate, rows[j], before, after))
+                {
+                    subsumed = true;
+                    break;
+                }
+            }
+            if (!subsumed)
+                yield return candidate;
+        }
+    }
+
+    static bool IsSubsumedByDescendant(
+        CSharpStructuralDiffRow ancestor,
+        CSharpStructuralDiffRow descendant,
+        AnnotatedSourceDocument before,
+        AnnotatedSourceDocument after)
+    {
+        if (!ancestor.Change.HasFlag(CSharpStructuralChangeKind.Changed)
+            || !descendant.Change.HasFlag(CSharpStructuralChangeKind.Changed))
+        {
+            return false;
+        }
+
+        // Only a single contiguous span per side is eligible: a discontinuous
+        // node's "outside the descendant" region is not a simple prefix/suffix
+        // pair, and widening this check to that shape is out of scope here.
+        if (ancestor.BeforeSpans.Length != 1 || ancestor.AfterSpans.Length != 1
+            || descendant.BeforeSpans.Length != 1 || descendant.AfterSpans.Length != 1)
+        {
+            return false;
+        }
+
+        var ancestorBefore = ancestor.BeforeSpans[0];
+        var ancestorAfter = ancestor.AfterSpans[0];
+        var descendantBefore = descendant.BeforeSpans[0];
+        var descendantAfter = descendant.AfterSpans[0];
+
+        if (!StrictlyContains(ancestorBefore, descendantBefore)
+            || !StrictlyContains(ancestorAfter, descendantAfter))
+        {
+            return false;
+        }
+
+        int beforePrefixLength = descendantBefore.Start - ancestorBefore.Start;
+        int afterPrefixLength = descendantAfter.Start - ancestorAfter.Start;
+        int beforeSuffixLength = (ancestorBefore.Start + ancestorBefore.Length) - (descendantBefore.Start + descendantBefore.Length);
+        int afterSuffixLength = (ancestorAfter.Start + ancestorAfter.Length) - (descendantAfter.Start + descendantAfter.Length);
+
+        return before.Text.AsSpan(ancestorBefore.Start, beforePrefixLength)
+                .SequenceEqual(after.Text.AsSpan(ancestorAfter.Start, afterPrefixLength))
+            && before.Text.AsSpan(descendantBefore.Start + descendantBefore.Length, beforeSuffixLength)
+                .SequenceEqual(after.Text.AsSpan(descendantAfter.Start + descendantAfter.Length, afterSuffixLength));
+    }
+
+    static bool StrictlyContains(AnnotatedSourceSpan outer, AnnotatedSourceSpan inner)
+        => inner.Start >= outer.Start
+            && inner.Start + inner.Length <= outer.Start + outer.Length
+            && inner.Length < outer.Length;
 }

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -789,6 +789,17 @@ public static partial class CSharpBodyDiff
             return false;
         }
 
+        // Moved is owner-issued and independent of the text-containment check
+        // below: a nested descendant explains the ancestor's text difference,
+        // but it does not know about (and cannot vouch for) an independent
+        // movement result the ancestor's own correspondence carries. Suppress
+        // only when the ancestor's entire change is explained by text, i.e.
+        // its change kind is exactly Changed.
+        if (ancestor.Change != CSharpStructuralChangeKind.Changed)
+        {
+            return false;
+        }
+
         // Only a single contiguous span per side is eligible: a discontinuous
         // node's "outside the descendant" region is not a simple prefix/suffix
         // pair, and widening this check to that shape is out of scope here.

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -17,6 +17,10 @@ public enum CSharpStructuralSide
 /// <param name="Change">Explicit structural outcome or outcomes.</param>
 /// <param name="Structure">Stable-kind display transition.</param>
 /// <param name="Region">Enclosing-region transition.</param>
+/// <param name="Detail">
+/// One-line before/after text transition, empty when no single-span inline
+/// text is available or the selected text did not change.
+/// </param>
 /// <param name="BeforeSpans">Before absolute UTF-16 spans.</param>
 /// <param name="AfterSpans">After absolute UTF-16 spans.</param>
 /// <param name="Fidelity">Independent compile-back transition and optional note.</param>
@@ -24,6 +28,7 @@ public sealed record CSharpStructuralDiffDisplayRow(
     string Change,
     string Structure,
     string Region,
+    string Detail,
     string BeforeSpans,
     string AfterSpans,
     string Fidelity);
@@ -46,6 +51,7 @@ public static class CSharpStructuralDiffPrinter
                 FormatChange(row.Change),
                 FormatTransition(Contain(row.BeforeLabel), Contain(row.AfterLabel)),
                 FormatTransition(row.BeforeRegion?.ToString(), row.AfterRegion?.ToString()),
+                FormatDetail(comparison, row),
                 FormatSpans(row.BeforeSpans),
                 FormatSpans(row.AfterSpans),
                 FormatFidelity(comparison.Fidelity)))
@@ -199,6 +205,53 @@ public static class CSharpStructuralDiffPrinter
             _ => "",
         };
 
+    /// <summary>
+    /// One-line before/after text transition for the <c>Detail</c> column,
+    /// reusing the same single-span, length, and well-formedness guards as
+    /// the inline "changed to/from" caret suffix. Empty when the selected
+    /// text is not eligible for inline display or did not change. When the
+    /// row matches the item-3 qualifier/argument role transition (see
+    /// <see cref="TryDescribeQualifierArgumentRoleTransition"/>), the semantic
+    /// summary replaces the literal before/after text dump.
+    /// </summary>
+    static string FormatDetail(CSharpStructuralComparison comparison, CSharpStructuralDiffRow row)
+    {
+        bool textChanged = row.Change.HasFlag(CSharpStructuralChangeKind.Changed)
+            && !CSharpBodyDiff.SelectedTextEqual(
+                comparison.Before,
+                row.BeforeSpans,
+                comparison.After,
+                row.AfterSpans);
+        bool added = row.Change.HasFlag(CSharpStructuralChangeKind.Added);
+        bool removed = row.Change.HasFlag(CSharpStructuralChangeKind.Removed);
+        if (!textChanged && !added && !removed)
+            return "";
+
+        string? beforeText = InlineText(comparison.Before, row.BeforeSpans);
+        string? afterText = InlineText(comparison.After, row.AfterSpans);
+        if (textChanged
+            && IsInvocationRoleCandidate(row)
+            && beforeText is not null
+            && afterText is not null
+            && TryDescribeQualifierArgumentRoleTransition(beforeText, afterText, out var transition))
+        {
+            return transition.DetailSummary;
+        }
+
+        return beforeText is null && afterText is null
+            ? ""
+            : FormatTransition(beforeText, afterText);
+    }
+
+    static string? InlineText(AnnotatedSourceDocument document, ImmutableArray<AnnotatedSourceSpan> spans)
+    {
+        if (spans.Length != 1 || spans[0].Length > MaximumInlineTransitionLength)
+            return null;
+
+        string text = SelectText(document, spans[0]);
+        return CanRenderExactInline(text) ? Contain(text) : null;
+    }
+
     static string TextTransitionSuffix(
         CSharpStructuralComparison comparison,
         CSharpStructuralDiffRow row,
@@ -228,6 +281,17 @@ public static class CSharpStructuralDiffPrinter
         if (!CanRenderExactInline(beforeText) || !CanRenderExactInline(afterText))
             return "; text changed";
 
+        if (IsInvocationRoleCandidate(row)
+            && TryDescribeQualifierArgumentRoleTransition(
+                Contain(beforeText)!,
+                Contain(afterText)!,
+                out var transition))
+        {
+            return side == CSharpStructuralSide.Before
+                ? $"; {transition.BeforeDescription}"
+                : $"; {transition.AfterDescription}";
+        }
+
         string counterpart = side == CSharpStructuralSide.Before
             ? afterText
             : beforeText;
@@ -235,6 +299,243 @@ public static class CSharpStructuralDiffPrinter
         return side == CSharpStructuralSide.Before
             ? $"; changed to {Contain(counterpart)}"
             : $"; changed from {Contain(counterpart)}";
+    }
+
+    static bool IsInvocationRoleCandidate(CSharpStructuralDiffRow row)
+        => string.Equals(row.BeforeKind, "InvocationExpression", StringComparison.Ordinal)
+            && string.Equals(row.AfterKind, "InvocationExpression", StringComparison.Ordinal);
+
+    /// <summary>
+    /// Item 3 (issue #5022): a side-local role description for the narrow,
+    /// well-evidenced "receiver becomes an argument" call-rewrite shape --
+    /// <c>q.Callee(args)</c> (extension/instance-style) rewritten to
+    /// <c>Callee(q, args)</c> (static-style) with the same callee name, or the
+    /// reverse -- derived purely from each side's own selected text. This is a
+    /// textual role classification, not a semantic-model lookup: it never
+    /// asserts anything the two sides' literal text does not already show,
+    /// and it recognizes nothing outside this one shape.
+    /// </summary>
+    readonly record struct QualifierArgumentRoleTransition(
+        string BeforeDescription,
+        string AfterDescription,
+        string DetailSummary);
+
+    static bool TryDescribeQualifierArgumentRoleTransition(
+        string beforeText,
+        string afterText,
+        out QualifierArgumentRoleTransition transition)
+    {
+        transition = default;
+        if (!TryParseQualifiedCall(beforeText, out string? beforeQualifier, out string beforeCallee, out var beforeArgs)
+            || !TryParseQualifiedCall(afterText, out string? afterQualifier, out string afterCallee, out var afterArgs))
+        {
+            return false;
+        }
+
+        if (beforeCallee.Length == 0
+            || !string.Equals(beforeCallee, afterCallee, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (beforeQualifier is { } qualifier && afterQualifier is null)
+        {
+            int argIndex = afterArgs.IndexOf(qualifier);
+            if (argIndex < 0)
+                return false;
+
+            transition = new QualifierArgumentRoleTransition(
+                $"{qualifier}: used as extension-call qualifier",
+                $"{qualifier}: moved to argument {argIndex + 1} (static call)",
+                $"{qualifier}: qualifier -> argument {argIndex + 1} (extension -> static call)");
+            return true;
+        }
+
+        if (afterQualifier is { } movedQualifier && beforeQualifier is null)
+        {
+            int argIndex = beforeArgs.IndexOf(movedQualifier);
+            if (argIndex < 0)
+                return false;
+
+            transition = new QualifierArgumentRoleTransition(
+                $"{movedQualifier}: argument {argIndex + 1} (static call)",
+                $"{movedQualifier}: moved to extension-call qualifier",
+                $"{movedQualifier}: argument {argIndex + 1} -> qualifier (static -> extension call)");
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> as <c>[qualifier.]callee(arguments)</c>
+    /// when it is exactly one call expression (no trailing text after the
+    /// closing paren beyond an optional statement-terminating <c>;</c>).
+    /// <paramref name="qualifier"/> is <see langword="null"/> for a static
+    /// (unqualified) call. Returns <see langword="false"/> for any shape this
+    /// narrow heuristic does not recognize -- callers must treat that as "no
+    /// opinion", not as evidence the shape does not exist.
+    /// </summary>
+    static bool TryParseQualifiedCall(
+        string text,
+        out string? qualifier,
+        out string callee,
+        out ImmutableArray<string> arguments)
+    {
+        qualifier = null;
+        callee = "";
+        arguments = [];
+
+        int openParen = FindUnquotedIndexOf(text, '(', 0);
+        if (openParen < 0)
+            return false;
+
+        int closeParen = FindMatchingClose(text, openParen);
+        if (closeParen < 0)
+            return false;
+
+        if (text.AsSpan(closeParen + 1).TrimEnd(';').TrimEnd().Length > 0)
+            return false;
+
+        int dotIndex = -1;
+        for (int index = openParen - 1; index >= 0; index--)
+        {
+            char character = text[index];
+            if (character == '.')
+            {
+                dotIndex = index;
+                break;
+            }
+            if (!char.IsLetterOrDigit(character) && character != '_')
+                break;
+        }
+
+        callee = text[(dotIndex + 1)..openParen];
+        if (callee.Length == 0)
+            return false;
+
+        if (dotIndex > 0)
+        {
+            string candidateQualifier = text[..dotIndex];
+            if (!IsSimpleIdentifierPath(candidateQualifier))
+                return false;
+            qualifier = candidateQualifier;
+        }
+
+        arguments = SplitTopLevelArguments(text[(openParen + 1)..closeParen]);
+        return true;
+    }
+
+    static bool IsSimpleIdentifierPath(string text)
+    {
+        if (text.Length == 0 || (!char.IsLetter(text[0]) && text[0] != '_'))
+            return false;
+
+        foreach (char character in text)
+        {
+            if (!char.IsLetterOrDigit(character) && character != '_' && character != '.')
+                return false;
+        }
+        return true;
+    }
+
+    static int FindUnquotedIndexOf(string text, char target, int start)
+    {
+        bool inString = false;
+        bool inChar = false;
+        for (int index = start; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (inString)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '"') inString = false;
+                continue;
+            }
+            if (inChar)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '\'') inChar = false;
+                continue;
+            }
+            if (character == '"') { inString = true; continue; }
+            if (character == '\'') { inChar = true; continue; }
+            if (character == target)
+                return index;
+        }
+        return -1;
+    }
+
+    static int FindMatchingClose(string text, int openIndex)
+    {
+        int depth = 0;
+        bool inString = false;
+        bool inChar = false;
+        for (int index = openIndex; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (inString)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '"') inString = false;
+                continue;
+            }
+            if (inChar)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '\'') inChar = false;
+                continue;
+            }
+            if (character == '"') { inString = true; continue; }
+            if (character == '\'') { inChar = true; continue; }
+            if (character == '(') depth++;
+            else if (character == ')')
+            {
+                depth--;
+                if (depth == 0)
+                    return index;
+            }
+        }
+        return -1;
+    }
+
+    static ImmutableArray<string> SplitTopLevelArguments(string argsText)
+    {
+        if (argsText.Trim().Length == 0)
+            return [];
+
+        var results = ImmutableArray.CreateBuilder<string>();
+        int depth = 0;
+        bool inString = false;
+        bool inChar = false;
+        int start = 0;
+        for (int index = 0; index < argsText.Length; index++)
+        {
+            char character = argsText[index];
+            if (inString)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '"') inString = false;
+                continue;
+            }
+            if (inChar)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '\'') inChar = false;
+                continue;
+            }
+            if (character == '"') { inString = true; continue; }
+            if (character == '\'') { inChar = true; continue; }
+            if (character is '(' or '[' or '{') depth++;
+            else if (character is ')' or ']' or '}') depth--;
+            else if (character == ',' && depth == 0)
+            {
+                results.Add(argsText[start..index].Trim());
+                start = index + 1;
+            }
+        }
+        results.Add(argsText[start..].Trim());
+        return results.ToImmutable();
     }
 
     static bool CanRenderExactInline(string text)

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -340,8 +340,7 @@ public static class CSharpStructuralDiffPrinter
 
         if (beforeQualifier is { } qualifier && afterQualifier is null)
         {
-            int argIndex = afterArgs.IndexOf(qualifier);
-            if (argIndex < 0)
+            if (!TryFindInsertedArgumentIndex(beforeArgs, afterArgs, qualifier, out int argIndex))
                 return false;
 
             transition = new QualifierArgumentRoleTransition(
@@ -353,8 +352,7 @@ public static class CSharpStructuralDiffPrinter
 
         if (afterQualifier is { } movedQualifier && beforeQualifier is null)
         {
-            int argIndex = beforeArgs.IndexOf(movedQualifier);
-            if (argIndex < 0)
+            if (!TryFindInsertedArgumentIndex(afterArgs, beforeArgs, movedQualifier, out int argIndex))
                 return false;
 
             transition = new QualifierArgumentRoleTransition(
@@ -365,6 +363,71 @@ public static class CSharpStructuralDiffPrinter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="larger"/> is exactly
+    /// <paramref name="smaller"/> with one occurrence of <paramref name="value"/>
+    /// inserted, and returns that occurrence's index in
+    /// <paramref name="larger"/>. This is required, not optional: without it,
+    /// merely finding <paramref name="value"/> somewhere in
+    /// <paramref name="larger"/>'s arguments would let an unrelated argument
+    /// change (or a coincidental duplicate value) hide behind a false
+    /// "qualifier moved to argument N" claim. Returns <see langword="false"/>
+    /// -- forcing the caller to fall back to the literal text transition --
+    /// when no removal position reproduces <paramref name="smaller"/>
+    /// exactly, or when more than one position does (an ambiguous match is
+    /// not an honest one).
+    /// </summary>
+    static bool TryFindInsertedArgumentIndex(
+        ImmutableArray<string> smaller,
+        ImmutableArray<string> larger,
+        string value,
+        out int index)
+    {
+        index = -1;
+        if (larger.Length != smaller.Length + 1)
+            return false;
+
+        int found = -1;
+        for (int candidate = 0; candidate < larger.Length; candidate++)
+        {
+            if (!string.Equals(larger[candidate], value, StringComparison.Ordinal))
+                continue;
+
+            bool matches = true;
+            int smallerIndex = 0;
+            for (int largerIndex = 0; largerIndex < larger.Length; largerIndex++)
+            {
+                if (largerIndex == candidate)
+                    continue;
+                if (!string.Equals(smaller[smallerIndex], larger[largerIndex], StringComparison.Ordinal))
+                {
+                    matches = false;
+                    break;
+                }
+                smallerIndex++;
+            }
+
+            if (!matches)
+                continue;
+
+            if (found >= 0)
+            {
+                // More than one removal position reproduces `smaller` exactly
+                // (possible with duplicate argument text): the position is
+                // ambiguous, so no specific claim is honest.
+                index = -1;
+                return false;
+            }
+            found = candidate;
+        }
+
+        if (found < 0)
+            return false;
+
+        index = found;
+        return true;
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/StructuralReview.cs
+++ b/tools/DecompilerHarness/StructuralReview.cs
@@ -90,13 +90,20 @@ internal static class StructuralReview
         }
         else
         {
+            bool includeDetail = rows.Any(static row => row.Detail.Length > 0);
             bool includeFidelity = rows.Any(static row => row.Fidelity.Length > 0);
-            output.WriteLine(includeFidelity
-                ? "| Change | Structure | Region | Fidelity |"
-                : "| Change | Structure | Region |");
-            output.WriteLine(includeFidelity
-                ? "| --- | --- | --- | --- |"
-                : "| --- | --- | --- |");
+            output.Write("| Change | Structure | Region");
+            if (includeDetail)
+                output.Write(" | Detail");
+            if (includeFidelity)
+                output.Write(" | Fidelity");
+            output.WriteLine(" |");
+            output.Write("| --- | --- | ---");
+            if (includeDetail)
+                output.Write(" | ---");
+            if (includeFidelity)
+                output.Write(" | ---");
+            output.WriteLine(" |");
             foreach (var row in rows)
             {
                 output.Write("| ");
@@ -105,6 +112,11 @@ internal static class StructuralReview
                 output.Write(TableCell(row.Structure));
                 output.Write(" | ");
                 output.Write(TableCell(row.Region));
+                if (includeDetail)
+                {
+                    output.Write(" | ");
+                    output.Write(TableCell(row.Detail));
+                }
                 if (includeFidelity)
                 {
                     output.Write(" | ");


### PR DESCRIPTION
## Summary

Implements items 1, 3, 4, and 6 of the raise-annotator printer plan (#5022),
derived from the mockup-vs-actual evidence gathered in #4952. Items 2, 5, and 7
(span narrowing and the broader correspondence-model gap-handling change) are
deliberately deferred — see #5022 for their root-cause writeups.

## Demo — #4942's exact recorded shape, before and after this change

**Before this change** (recorded in #4952): #4942's receiver-qualification
rewrite produced three stacked, near-duplicate rows, each re-quoting the
entire statement:

```csharp
return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: Return; changed to return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       raise: InvocationExpression; changed to Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       raise: InvocationExpression; changed to Values(receiver, typeof(Attribute), true)
```

| Change | Structure | Region |
| --- | --- | --- |
| Changed | Return |  |
| Changed | InvocationExpression |  |
| Changed | InvocationExpression |  |

**After this change**, the same real evidence (proven by a unit test using
#4942's exact recorded text) collapses to one row with a side-local caption:

```csharp
return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       raise: InvocationExpression; receiver: used as extension-call qualifier
```

```csharp
return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       raise: InvocationExpression; receiver: moved to argument 1 (static call)
```

| Change | Structure | Detail |
| --- | --- | --- |
| Changed | InvocationExpression | receiver: qualifier -> argument 1 (extension -> static call) |

Note what to notice: one row instead of three, and each side's caption
describes only that side's own state instead of dumping the other side's
entire text. The reverse direction (static call's argument becomes the
extension-call qualifier) is also covered and produces the mirrored caption.

## Changes

### Item 1 — collapse duplicate ancestor rows to the most specific node

In `CSharpBodyDiff.CompareStructure`, a matched row is now suppressed when
another matched row's span is strictly contained within it on both sides and
the ancestor's text *outside* that contained range is identical before/after
— i.e. the ancestor adds no information beyond the descendant it wraps. This
is a plain text-containment check (the annotated-source model carries no
explicit parent pointer), so it only fires when it can prove the ancestor is
fully redundant; it does not touch rows whose ancestor carries independent
information (verified by an updated test where the callee is *also* renamed
alongside the nested argument — that row correctly still stacks).

### Item 3 — per-side captions describe that side's own state

Recognizes the narrow, well-evidenced "receiver becomes an argument"
call-rewrite shape — `q.Callee(args)` (extension/instance-style) rewritten to
`Callee(q, args)` (static-style) with the same callee name, or the reverse —
purely from each side's own selected text (a small parenthesis/comma
depth-aware scanner, string/char-literal aware). This replaces the "changed
to/from `<other side's full text>`" caption with a side-local role
description. It is a textual classification, not a semantic-model lookup: it
asserts nothing the two sides' literal text doesn't already show, and falls
back to the existing literal text-dump caption for any shape outside this one
pattern (verified by a negative test: a callee rename is correctly *not*
misclassified).

Per the plan, the `Detail` column (item 6) also prefers this role summary
when recognized, instead of the raw before/after text.

### Item 4 — column-align each side's caret explanation independently

Investigated, not changed. `RenderAnnotatedBody` already computes each side's
caption indent from that side's own caret column independently — confirmed
correct with both a flat and a realistic indented fixture. The `// ^^^^`
comment-gutter style (vs. a bare `^^^^`) is intentional, not a bug: the
annotation line is rendered *inside* the C# body text, so it needs the `//`
prefix to remain syntactically valid C# if the block is copied out verbatim.
Confirmed with the reporter before closing this item.

### Item 6 — add a `Detail` column to the structural diff table

`CSharpStructuralDiffDisplayRow` gains a `Detail` field: a one-line
before/after text transition (or the item-3 role summary when recognized),
surfaced in the harness's Markdown table renderer.

## Validation

- New unit tests in `CSharpStructuralComparisonTests.cs` reproduce #4942's
  exact recorded text for items 1 and 3, both call-rewrite directions, and a
  negative case (unrecognized shape falls back to the honest text dump).
- Two pre-existing tests whose fixtures happened to rely on the item-1 defect
  as an implicit "feature" (a redundant wrapper row) were updated to reflect
  the corrected behavior; one was adjusted so its ancestor row carries
  genuinely independent information and legitimately still stacks, preserving
  that coverage.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` (full
  suite): 6003 tests, 1 pre-existing failure unrelated to this change
  (`RetainedMergeStructuringTests.CoreLibOrdinalCasingCrossArmPredecessorPreservesFallbackPath`,
  confirmed failing identically on an unmodified `origin/main` — depends on
  the installed .NET runtime's CoreLib, not on this branch).
- `dotnet build dotnet-inspect.slnx -c Release`: 0 warnings, 0 errors.

## Non-action boundary

Items 2, 5, and 7 are out of scope for this PR (see #5022). In particular,
carets in this PR still cover the full matched node (e.g. the whole
`InvocationExpression`), not narrowed to the single changed token — that
narrowing is item 2's job.
