### PR TITLE
Close credential-plugin request admission atomically

### DIFF
--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -134,7 +134,7 @@ product behavior:
 | A malformed response header does not end the read loop | `PluginProtocolTests.AProtocolMessageWithNonStringHeadersIsIgnoredRatherThanEndingTheConversation` |
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |
-| Pipe loss closes admission before pending requests are collected | `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot` |
+| Pipe loss closes admission before pending requests are collected | `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout`, `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, and `PluginProtocolTests.AdmissionCannotRegisterDuringTheTerminalPendingSnapshot` |
 | A stalled in-progress write is bounded by terminating the connection | Not implemented; `CurrentStalledWrite.cfg` abstracts the current control flow. |
 | Malformed plugin-originated payloads settle inbound work | `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse` |
 

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -130,7 +130,7 @@ product behavior:
 | Initialization follows the required wire sequence | `PluginProtocolTests.InitializationFollowsTheProtocolSequence` |
 | The symmetric handshake accepts only protocol 2.0.0 | `PluginProtocolTests.CompatibleInboundHandshakeUsesProtocolTwo`, `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse`, and `PluginProtocolTests.InvalidOrUnsupportedOutboundHandshakeStopsInitialization` |
 | A dying process settles the current request as plugin failure | `PluginProtocolTests.WhenOnePluginDiesDuringTheRequest_TheNextIsTried` |
-| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate` and `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation` |
+| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate`, `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`, and `PluginProtocolTests.CancellationWhileWaitingForClosedAdmissionRemainsCancellation` |
 | A malformed response header does not end the read loop | `PluginProtocolTests.AProtocolMessageWithNonStringHeadersIsIgnoredRatherThanEndingTheConversation` |
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -130,7 +130,7 @@ product behavior:
 | Initialization follows the required wire sequence | `PluginProtocolTests.InitializationFollowsTheProtocolSequence` |
 | The symmetric handshake accepts only protocol 2.0.0 | `PluginProtocolTests.CompatibleInboundHandshakeUsesProtocolTwo`, `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse`, and `PluginProtocolTests.InvalidOrUnsupportedOutboundHandshakeStopsInitialization` |
 | A dying process settles the current request as plugin failure | `PluginProtocolTests.WhenOnePluginDiesDuringTheRequest_TheNextIsTried` |
-| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate` |
+| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate` and `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation` |
 | A malformed response header does not end the read loop | `PluginProtocolTests.AProtocolMessageWithNonStringHeadersIsIgnoredRatherThanEndingTheConversation` |
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -134,7 +134,7 @@ product behavior:
 | A malformed response header does not end the read loop | `PluginProtocolTests.AProtocolMessageWithNonStringHeadersIsIgnoredRatherThanEndingTheConversation` |
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |
-| Pipe loss closes admission before pending requests are collected | Not implemented; `CurrentShutdownAdmission.cfg` and `CurrentShutdownSnapshot.cfg` abstract the current ordering. |
+| Pipe loss closes admission before pending requests are collected | `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot` |
 | A stalled in-progress write is bounded by terminating the connection | Not implemented; `CurrentStalledWrite.cfg` abstracts the current control flow. |
 | Malformed plugin-originated payloads settle inbound work | `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse` |
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -170,8 +170,10 @@ abandoned work, checked by `InboundFailureIsContained` and
 `MalformedInboundEventuallySettles`. The current implementation does not yet enforce the
 stalled-write rule. Terminal admission and pending settlement are enforced by
 `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and
-`PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`. Malformed
-inbound Handshake and Log payload handling is enforced by
+`PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, with the
+atomic overlap enforced by
+`PluginProtocolTests.AdmissionCannotRegisterDuringTheTerminalPendingSnapshot`. Malformed inbound
+Handshake and Log payload handling is enforced by
 `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and
 `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse`.
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -192,7 +192,9 @@ start plus five round trips. A plugin that fails to start, or that does not clai
 A plugin process or pipe that dies during a request is likewise treated as no credential from
 that plugin. Timeouts, malformed responses, I/O failures, disposed pipes, and invalid process
 state are contained at the request boundary so another provider can answer or the feed's 401 can
-surface normally. Caller cancellation is not a plugin fault and continues to propagate.
+surface normally. Caller cancellation is not a plugin fault and continues to propagate, enforced
+before and after receiver loss by `PluginProtocolTests.CallerCancellationContinuesToPropagate` and
+`PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`.
 
 ### Unattended by default
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -194,7 +194,9 @@ that plugin. Timeouts, malformed responses, I/O failures, disposed pipes, and in
 state are contained at the request boundary so another provider can answer or the feed's 401 can
 surface normally. Caller cancellation is not a plugin fault and continues to propagate, enforced
 before and after receiver loss by `PluginProtocolTests.CallerCancellationContinuesToPropagate` and
-`PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`.
+`PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`, including the
+admission-monitor race checked by
+`PluginProtocolTests.CancellationWhileWaitingForClosedAdmissionRemainsCancellation`.
 
 ### Unattended by default
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -168,8 +168,10 @@ closes request admission before the read loop collects and settles pending reque
 plugin-originated request receives an error response or the connection terminates; it never becomes
 abandoned work, checked by `InboundFailureIsContained` and
 `MalformedInboundEventuallySettles`. The current implementation does not yet enforce the
-stalled-write or shutdown-admission rules. Malformed inbound Handshake and Log payload handling is
-enforced by
+stalled-write rule. Terminal admission and pending settlement are enforced by
+`PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and
+`PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`. Malformed
+inbound Handshake and Log payload handling is enforced by
 `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and
 `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse`.
 
@@ -177,9 +179,9 @@ Implementation: [`PluginConnection`](../../src/NuGetFetch/Plugins/PluginConnecti
 [`PluginCredentialProvider`](../../src/NuGetFetch/Plugins/PluginCredentialProvider.cs).
 The concurrent conversation and shutdown rules are checked by the
 [NuGet credential-plugin session lifecycle model](models/nuget-plugin-session-lifecycle/README.md).
-The model checks the design under finite bounds; implementation correspondence
-for progress renewal, concurrent correlation, and pipe-loss admission remains
-unverified.
+The model checks the design under finite bounds; implementation correspondence for progress
+renewal and concurrent correlation remains unverified. Terminal admission and pending settlement
+are enforced by the gates named above.
 
 Plugins are started lazily and kept for the process lifetime, because a launch costs a process
 start plus five round trips. A plugin that fails to start, or that does not claim the

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -550,11 +550,11 @@ public sealed class PluginProtocolTests : IDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseAdmission = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestRegistered = new TaskCompletionSource(
+        var requestRegistered = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var settlementAttempted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var snapshotCaptured = new TaskCompletionSource(
+        var snapshotCaptured = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var hooksEnabled = new ManualResetEventSlim();
         var hooks = new PluginConnection.PluginConnectionTestHooks
@@ -572,11 +572,11 @@ public sealed class PluginProtocolTests : IDisposable
                         .GetResult();
                 }
             },
-            RequestRegistered = () =>
+            RequestRegistered = gateHeld =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    requestRegistered.TrySetResult();
+                    requestRegistered.TrySetResult(gateHeld);
                 }
             },
             TerminalSettlementAttempted = () =>
@@ -586,11 +586,11 @@ public sealed class PluginProtocolTests : IDisposable
                     settlementAttempted.TrySetResult();
                 }
             },
-            PendingSnapshotCaptured = () =>
+            PendingSnapshotCaptured = gateHeld =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    snapshotCaptured.TrySetResult();
+                    snapshotCaptured.TrySetResult(gateHeld);
                 }
             },
         };
@@ -636,10 +636,10 @@ public sealed class PluginProtocolTests : IDisposable
 
                 releaseAdmission.TrySetResult();
 
-                await requestRegistered.Task.WaitAsync(
+                bool registrationHeldGate = await requestRegistered.Task.WaitAsync(
                     TimeSpan.FromSeconds(1),
                     TestContext.Current.CancellationToken);
-                await snapshotCaptured.Task.WaitAsync(
+                bool snapshotHeldGate = await snapshotCaptured.Task.WaitAsync(
                     TimeSpan.FromSeconds(1),
                     TestContext.Current.CancellationToken);
 
@@ -648,6 +648,8 @@ public sealed class PluginProtocolTests : IDisposable
                     TestContext.Current.CancellationToken);
 
                 Assert.Null(response);
+                Assert.True(registrationHeldGate);
+                Assert.True(snapshotHeldGate);
             }
             finally
             {

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -546,22 +546,30 @@ public sealed class PluginProtocolTests : IDisposable
     [Fact]
     public async Task AdmissionCannotRegisterDuringTheTerminalPendingSnapshot()
     {
-        var admissionAttempted = new TaskCompletionSource(
+        var admissionAccepted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAdmission = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var requestRegistered = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var snapshotCaptured = new TaskCompletionSource(
+        var settlementAttempted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var releaseSnapshot = new TaskCompletionSource(
+        var snapshotCaptured = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var hooksEnabled = new ManualResetEventSlim();
         var hooks = new PluginConnection.PluginConnectionTestHooks
         {
-            RequestAdmissionAttempted = () =>
+            RequestAdmissionAccepted = () =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    admissionAttempted.TrySetResult();
+                    admissionAccepted.TrySetResult();
+                    releaseAdmission.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(5),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
                 }
             },
             RequestRegistered = () =>
@@ -571,12 +579,18 @@ public sealed class PluginProtocolTests : IDisposable
                     requestRegistered.TrySetResult();
                 }
             },
+            TerminalSettlementAttempted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    settlementAttempted.TrySetResult();
+                }
+            },
             PendingSnapshotCaptured = () =>
             {
                 if (hooksEnabled.IsSet)
                 {
                     snapshotCaptured.TrySetResult();
-                    releaseSnapshot.Task.GetAwaiter().GetResult();
                 }
             },
         };
@@ -585,7 +599,8 @@ public sealed class PluginProtocolTests : IDisposable
             username: "u",
             password: "p",
             afterSetLogLevel:
-                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""");
+                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""",
+            exitOnCredentialRequest: true);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -595,40 +610,82 @@ public sealed class PluginProtocolTests : IDisposable
         await using (connection)
         {
             hooksEnabled.Set();
-            File.WriteAllText(plugin.RecordPath + ".close", string.Empty);
 
-            await snapshotCaptured.Task.WaitAsync(
+            try
+            {
+                Task<GetAuthenticationCredentialsResponse?> request = Task.Run(
+                    () => connection.GetCredentialsAsync(
+                        new Uri("https://feed.example/v3/index.json"),
+                        isRetry: false,
+                        isNonInteractive: true,
+                        canShowDialog: false,
+                        TestContext.Current.CancellationToken),
+                    TestContext.Current.CancellationToken);
+
+                await admissionAccepted.Task.WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+                File.WriteAllText(plugin.RecordPath + ".close", string.Empty);
+
+                await settlementAttempted.Task.WaitAsync(
+                    TimeSpan.FromSeconds(2),
+                    TestContext.Current.CancellationToken);
+
+                Assert.False(snapshotCaptured.Task.IsCompleted);
+
+                releaseAdmission.TrySetResult();
+
+                await requestRegistered.Task.WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+                await snapshotCaptured.Task.WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+                GetAuthenticationCredentialsResponse? response = await request.WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+                Assert.Null(response);
+            }
+            finally
+            {
+                releaseAdmission.TrySetResult();
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CanceledRequestAfterReceiverLossRemainsCancellation()
+    {
+        FakePlugin plugin = CreatePlugin(
+            "canceled-after-receiver-loss",
+            username: "u",
+            password: "p",
+            afterSetLogLevel: "exec 1>&-");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            await connection.Closed.WaitAsync(
                 TimeSpan.FromSeconds(2),
                 TestContext.Current.CancellationToken);
 
-            Task<GetAuthenticationCredentialsResponse?> request = Task.Run(
-                () => connection.GetCredentialsAsync(
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                connection.GetCredentialsAsync(
                     new Uri("https://feed.example/v3/index.json"),
                     isRetry: false,
                     isNonInteractive: true,
                     canShowDialog: false,
-                    TestContext.Current.CancellationToken),
-                TestContext.Current.CancellationToken);
+                    cancellation.Token));
 
-            await admissionAttempted.Task.WaitAsync(
-                TimeSpan.FromSeconds(1),
-                TestContext.Current.CancellationToken);
-            Task registrationRace = await Task.WhenAny(
-                requestRegistered.Task,
-                Task.Delay(
-                    TimeSpan.FromMilliseconds(250),
-                    TestContext.Current.CancellationToken));
-
-            Assert.NotSame(requestRegistered.Task, registrationRace);
-
-            releaseSnapshot.SetResult();
-
-            GetAuthenticationCredentialsResponse? response = await request.WaitAsync(
-                TimeSpan.FromSeconds(1),
-                TestContext.Current.CancellationToken);
-
-            Assert.Null(response);
-            Assert.False(requestRegistered.Task.IsCompleted);
             Assert.DoesNotContain(
                 plugin.ReceivedRequests(),
                 recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -554,7 +554,7 @@ public sealed class PluginProtocolTests : IDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseAdmission = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestRegistered = new TaskCompletionSource<long>(
+        var requestRegistered = new TaskCompletionSource<(long GateEntry, bool GateHeld)>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var settlementAttempted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -576,11 +576,11 @@ public sealed class PluginProtocolTests : IDisposable
                         .GetResult();
                 }
             },
-            RequestRegistered = gateEntry =>
+            RequestRegistered = observation =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    requestRegistered.TrySetResult(gateEntry);
+                    requestRegistered.TrySetResult(observation);
                 }
             },
             TerminalSettlementAttempted = () =>
@@ -640,7 +640,8 @@ public sealed class PluginProtocolTests : IDisposable
 
                 releaseAdmission.TrySetResult();
 
-                long registeredGateEntry = await requestRegistered.Task.WaitAsync(
+                (long registeredGateEntry, bool registrationHeldGate) =
+                    await requestRegistered.Task.WaitAsync(
                     TimeSpan.FromSeconds(1),
                     TestContext.Current.CancellationToken);
                 bool snapshotHeldGate = await snapshotCaptured.Task.WaitAsync(
@@ -653,6 +654,7 @@ public sealed class PluginProtocolTests : IDisposable
 
                 Assert.Null(response);
                 Assert.Equal(acceptedGateEntry, registeredGateEntry);
+                Assert.True(registrationHeldGate);
                 Assert.True(snapshotHeldGate);
             }
             finally

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -480,19 +480,22 @@ public sealed class PluginProtocolTests : IDisposable
             "closed-admission",
             username: "u",
             password: "p",
-            afterSetLogLevel: "exec 1>&-");
+            afterSetLogLevel: "exec 1>&-",
+            exitOnCredentialRequest: true);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
                 log: null,
                 TestContext.Current.CancellationToken));
+        GetAuthenticationCredentialsResponse? response;
+
         await using (connection)
         {
             await connection.Closed.WaitAsync(
                 TimeSpan.FromSeconds(2),
                 TestContext.Current.CancellationToken);
 
-            GetAuthenticationCredentialsResponse? response = await connection
+            response = await connection
                 .GetCredentialsAsync(
                     new Uri("https://feed.example/v3/index.json"),
                     isRetry: false,
@@ -504,10 +507,11 @@ public sealed class PluginProtocolTests : IDisposable
                     TestContext.Current.CancellationToken);
 
             Assert.Null(response);
-            Assert.DoesNotContain(
-                plugin.ReceivedRequests(),
-                request => request.Method == MessageMethods.GetAuthenticationCredentials);
         }
+
+        Assert.DoesNotContain(
+            plugin.ReceivedRequests(),
+            request => request.Method == MessageMethods.GetAuthenticationCredentials);
     }
 
     [Fact]
@@ -692,6 +696,95 @@ public sealed class PluginProtocolTests : IDisposable
                 plugin.ReceivedRequests(),
                 recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);
         }
+    }
+
+    [Fact]
+    public async Task CancellationWhileWaitingForClosedAdmissionRemainsCancellation()
+    {
+        var admissionAttempted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var snapshotCaptured = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSnapshot = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestAdmissionAttempted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    admissionAttempted.TrySetResult();
+                }
+            },
+            PendingSnapshotCaptured = _ =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    snapshotCaptured.TrySetResult();
+                    releaseSnapshot.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(5),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+        };
+        FakePlugin plugin = CreatePlugin(
+            "canceled-while-waiting-for-closed-admission",
+            username: "u",
+            password: "p",
+            afterSetLogLevel:
+                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""",
+            exitOnCredentialRequest: true);
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+        await using (connection)
+        {
+            hooksEnabled.Set();
+
+            try
+            {
+                File.WriteAllText(plugin.RecordPath + ".close", string.Empty);
+                await snapshotCaptured.Task.WaitAsync(
+                    TimeSpan.FromSeconds(2),
+                    TestContext.Current.CancellationToken);
+
+                using var cancellation = new CancellationTokenSource();
+                Task<GetAuthenticationCredentialsResponse?> request = Task.Run(
+                    () => connection.GetCredentialsAsync(
+                        new Uri("https://feed.example/v3/index.json"),
+                        isRetry: false,
+                        isNonInteractive: true,
+                        canShowDialog: false,
+                        cancellation.Token),
+                    TestContext.Current.CancellationToken);
+
+                await admissionAttempted.Task.WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+                cancellation.Cancel();
+                releaseSnapshot.TrySetResult();
+
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                    await request.WaitAsync(
+                        TimeSpan.FromSeconds(1),
+                        TestContext.Current.CancellationToken));
+            }
+            finally
+            {
+                releaseSnapshot.TrySetResult();
+            }
+        }
+
+        Assert.DoesNotContain(
+            plugin.ReceivedRequests(),
+            recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);
     }
 
     [Fact]

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -544,6 +544,98 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task AdmissionCannotRegisterDuringTheTerminalPendingSnapshot()
+    {
+        var admissionAttempted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestRegistered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var snapshotCaptured = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseSnapshot = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestAdmissionAttempted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    admissionAttempted.TrySetResult();
+                }
+            },
+            RequestRegistered = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    requestRegistered.TrySetResult();
+                }
+            },
+            PendingSnapshotCaptured = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    snapshotCaptured.TrySetResult();
+                    releaseSnapshot.Task.GetAwaiter().GetResult();
+                }
+            },
+        };
+        FakePlugin plugin = CreatePlugin(
+            "admission-during-terminal-snapshot",
+            username: "u",
+            password: "p",
+            afterSetLogLevel:
+                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+        await using (connection)
+        {
+            hooksEnabled.Set();
+            File.WriteAllText(plugin.RecordPath + ".close", string.Empty);
+
+            await snapshotCaptured.Task.WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+
+            Task<GetAuthenticationCredentialsResponse?> request = Task.Run(
+                () => connection.GetCredentialsAsync(
+                    new Uri("https://feed.example/v3/index.json"),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    TestContext.Current.CancellationToken),
+                TestContext.Current.CancellationToken);
+
+            await admissionAttempted.Task.WaitAsync(
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken);
+            Task registrationRace = await Task.WhenAny(
+                requestRegistered.Task,
+                Task.Delay(
+                    TimeSpan.FromMilliseconds(250),
+                    TestContext.Current.CancellationToken));
+
+            Assert.NotSame(requestRegistered.Task, registrationRace);
+
+            releaseSnapshot.SetResult();
+
+            GetAuthenticationCredentialsResponse? response = await request.WaitAsync(
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken);
+
+            Assert.Null(response);
+            Assert.False(requestRegistered.Task.IsCompleted);
+            Assert.DoesNotContain(
+                plugin.ReceivedRequests(),
+                recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);
+        }
+    }
+
+    [Fact]
     public async Task CallerCancellationContinuesToPropagate()
     {
         FakePlugin plugin = CreatePlugin("cancelled-request", username: "u", password: "p");

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -550,11 +550,11 @@ public sealed class PluginProtocolTests : IDisposable
     [Fact]
     public async Task AdmissionCannotRegisterDuringTheTerminalPendingSnapshot()
     {
-        var admissionAccepted = new TaskCompletionSource(
+        var admissionAccepted = new TaskCompletionSource<long>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseAdmission = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var requestRegistered = new TaskCompletionSource<bool>(
+        var requestRegistered = new TaskCompletionSource<long>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var settlementAttempted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -563,11 +563,11 @@ public sealed class PluginProtocolTests : IDisposable
         using var hooksEnabled = new ManualResetEventSlim();
         var hooks = new PluginConnection.PluginConnectionTestHooks
         {
-            RequestAdmissionAccepted = () =>
+            RequestAdmissionAccepted = gateEntry =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    admissionAccepted.TrySetResult();
+                    admissionAccepted.TrySetResult(gateEntry);
                     releaseAdmission.Task
                         .WaitAsync(
                             TimeSpan.FromSeconds(5),
@@ -576,11 +576,11 @@ public sealed class PluginProtocolTests : IDisposable
                         .GetResult();
                 }
             },
-            RequestRegistered = gateHeld =>
+            RequestRegistered = gateEntry =>
             {
                 if (hooksEnabled.IsSet)
                 {
-                    requestRegistered.TrySetResult(gateHeld);
+                    requestRegistered.TrySetResult(gateEntry);
                 }
             },
             TerminalSettlementAttempted = () =>
@@ -626,7 +626,7 @@ public sealed class PluginProtocolTests : IDisposable
                         TestContext.Current.CancellationToken),
                     TestContext.Current.CancellationToken);
 
-                await admissionAccepted.Task.WaitAsync(
+                long acceptedGateEntry = await admissionAccepted.Task.WaitAsync(
                     TimeSpan.FromSeconds(1),
                     TestContext.Current.CancellationToken);
 
@@ -640,7 +640,7 @@ public sealed class PluginProtocolTests : IDisposable
 
                 releaseAdmission.TrySetResult();
 
-                bool registrationHeldGate = await requestRegistered.Task.WaitAsync(
+                long registeredGateEntry = await requestRegistered.Task.WaitAsync(
                     TimeSpan.FromSeconds(1),
                     TestContext.Current.CancellationToken);
                 bool snapshotHeldGate = await snapshotCaptured.Task.WaitAsync(
@@ -652,7 +652,7 @@ public sealed class PluginProtocolTests : IDisposable
                     TestContext.Current.CancellationToken);
 
                 Assert.Null(response);
-                Assert.True(registrationHeldGate);
+                Assert.Equal(acceptedGateEntry, registeredGateEntry);
                 Assert.True(snapshotHeldGate);
             }
             finally

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -474,6 +474,76 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout()
+    {
+        FakePlugin plugin = CreatePlugin(
+            "closed-admission",
+            username: "u",
+            password: "p",
+            afterSetLogLevel: "exec 1>&-");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            await connection.Closed.WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+
+            GetAuthenticationCredentialsResponse? response = await connection
+                .GetCredentialsAsync(
+                    new Uri("https://feed.example/v3/index.json"),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    TestContext.Current.CancellationToken)
+                .WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+            Assert.Null(response);
+            Assert.DoesNotContain(
+                plugin.ReceivedRequests(),
+                request => request.Method == MessageMethods.GetAuthenticationCredentials);
+        }
+    }
+
+    [Fact]
+    public async Task ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot()
+    {
+        FakePlugin plugin = CreatePlugin(
+            "closed-with-pending-request",
+            username: "u",
+            password: "p",
+            closeOutputOnCredentialRequest: true);
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            GetAuthenticationCredentialsResponse? response = await connection
+                .GetCredentialsAsync(
+                    new Uri("https://feed.example/v3/index.json"),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    TestContext.Current.CancellationToken)
+                .WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+            Assert.Null(response);
+            Assert.Contains(
+                plugin.ReceivedRequests(),
+                request => request.Method == MessageMethods.GetAuthenticationCredentials);
+        }
+    }
+
+    [Fact]
     public async Task CallerCancellationContinuesToPropagate()
     {
         FakePlugin plugin = CreatePlugin("cancelled-request", username: "u", password: "p");
@@ -528,6 +598,7 @@ public sealed class PluginProtocolTests : IDisposable
         string? inboundHandshakePayload = null,
         string? outboundHandshakePayload = null,
         string? afterSetLogLevel = null,
+        bool closeOutputOnCredentialRequest = false,
         bool exitOnCredentialRequest = false)
     {
         // Values are embedded in a double-quoted bash string, so every JSON quote needs a
@@ -542,11 +613,13 @@ public sealed class PluginProtocolTests : IDisposable
                 + "," + Quoted("AuthenticationTypes") + ":" + types
                 + "," + Quoted("ResponseCode") + ":" + Quoted("Success") + "}"
             : "{" + Quoted("ResponseCode") + ":" + Quoted(responseCode) + "}";
-        string credentialAction = exitOnCredentialRequest
-            ? "exit 0"
-            : """
-              emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
-              """;
+        string credentialAction = closeOutputOnCredentialRequest
+            ? "exec 1>&-"
+            : exitOnCredentialRequest
+                ? "exit 0"
+                : """
+                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
+                  """;
 
         // A non-interpolated raw string with tokens: the script is dense with braces, and
         // interpolation holes would be indistinguishable from JSON.

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -693,11 +693,11 @@ public sealed class PluginProtocolTests : IDisposable
                     isNonInteractive: true,
                     canShowDialog: false,
                     cancellation.Token));
-
-            Assert.DoesNotContain(
-                plugin.ReceivedRequests(),
-                recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);
         }
+
+        Assert.DoesNotContain(
+            plugin.ReceivedRequests(),
+            recorded => recorded.Method == MessageMethods.GetAuthenticationCredentials);
     }
 
     [Fact]

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -249,7 +249,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
                 _testHooks?.RequestAdmissionAccepted?.Invoke();
                 _pending[requestId] = pending;
-                _testHooks?.RequestRegistered?.Invoke();
+                _testHooks?.RequestRegistered?.Invoke(Monitor.IsEntered(_pendingGate));
             }
 
             await WriteAsync(
@@ -349,7 +349,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             _acceptingRequests = false;
             pending = [.. _pending.Values];
-            _testHooks?.PendingSnapshotCaptured?.Invoke();
+            _testHooks?.PendingSnapshotCaptured?.Invoke(Monitor.IsEntered(_pendingGate));
             _pending.Clear();
         }
 
@@ -366,11 +366,11 @@ internal sealed class PluginConnection : IAsyncDisposable
     {
         public Action? RequestAdmissionAccepted { get; init; }
 
-        public Action? RequestRegistered { get; init; }
+        public Action<bool>? RequestRegistered { get; init; }
 
         public Action? TerminalSettlementAttempted { get; init; }
 
-        public Action? PendingSnapshotCaptured { get; init; }
+        public Action<bool>? PendingSnapshotCaptured { get; init; }
     }
 
     /// <summary>

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -41,6 +41,7 @@ internal sealed class PluginConnection : IAsyncDisposable
     private readonly TimeSpan _requestTimeout;
     private readonly Action<string>? _log;
     private Task? _readLoop;
+    private long _pendingGateEntry;
     private bool _acceptingRequests = true;
     private bool _disposed;
 
@@ -244,6 +245,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
             lock (_pendingGate)
             {
+                long gateEntry = ++_pendingGateEntry;
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (!_acceptingRequests)
@@ -251,9 +253,9 @@ internal sealed class PluginConnection : IAsyncDisposable
                     throw new IOException("Credential plugin closed the connection.");
                 }
 
-                _testHooks?.RequestAdmissionAccepted?.Invoke();
+                _testHooks?.RequestAdmissionAccepted?.Invoke(gateEntry);
                 _pending[requestId] = pending;
-                _testHooks?.RequestRegistered?.Invoke(Monitor.IsEntered(_pendingGate));
+                _testHooks?.RequestRegistered?.Invoke(gateEntry);
             }
 
             await WriteAsync(
@@ -351,6 +353,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         lock (_pendingGate)
         {
+            _pendingGateEntry++;
             _acceptingRequests = false;
             pending = [.. _pending.Values];
             _testHooks?.PendingSnapshotCaptured?.Invoke(Monitor.IsEntered(_pendingGate));
@@ -370,9 +373,9 @@ internal sealed class PluginConnection : IAsyncDisposable
     {
         public Action? RequestAdmissionAttempted { get; init; }
 
-        public Action? RequestAdmissionAccepted { get; init; }
+        public Action<long>? RequestAdmissionAccepted { get; init; }
 
-        public Action<bool>? RequestRegistered { get; init; }
+        public Action<long>? RequestRegistered { get; init; }
 
         public Action? TerminalSettlementAttempted { get; init; }
 

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -233,13 +233,13 @@ internal sealed class PluginConnection : IAsyncDisposable
         CancellationToken cancellationToken)
         where TResponse : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         string requestId = Guid.NewGuid().ToString();
         var pending = new PendingRequest(_requestTimeout);
 
         try
         {
-            _testHooks?.RequestAdmissionAttempted?.Invoke();
-
             lock (_pendingGate)
             {
                 if (!_acceptingRequests)
@@ -247,6 +247,7 @@ internal sealed class PluginConnection : IAsyncDisposable
                     throw new IOException("Credential plugin closed the connection.");
                 }
 
+                _testHooks?.RequestAdmissionAccepted?.Invoke();
                 _pending[requestId] = pending;
                 _testHooks?.RequestRegistered?.Invoke();
             }
@@ -342,6 +343,8 @@ internal sealed class PluginConnection : IAsyncDisposable
     {
         PendingRequest[] pending;
 
+        _testHooks?.TerminalSettlementAttempted?.Invoke();
+
         lock (_pendingGate)
         {
             _acceptingRequests = false;
@@ -361,9 +364,11 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     internal sealed class PluginConnectionTestHooks
     {
-        public Action? RequestAdmissionAttempted { get; init; }
+        public Action? RequestAdmissionAccepted { get; init; }
 
         public Action? RequestRegistered { get; init; }
+
+        public Action? TerminalSettlementAttempted { get; init; }
 
         public Action? PendingSnapshotCaptured { get; init; }
     }

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -32,11 +32,15 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     private readonly Process _process;
     private readonly ConcurrentDictionary<string, PendingRequest> _pending = new(StringComparer.Ordinal);
+    private readonly object _pendingGate = new();
     private readonly SemaphoreSlim _writeLock = new(1, 1);
     private readonly CancellationTokenSource _shutdown = new();
+    private readonly TaskCompletionSource _closed =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TimeSpan _requestTimeout;
     private readonly Action<string>? _log;
     private Task? _readLoop;
+    private bool _acceptingRequests = true;
     private bool _disposed;
 
     private PluginConnection(Process process, TimeSpan requestTimeout, Action<string>? log)
@@ -212,6 +216,8 @@ internal sealed class PluginConnection : IAsyncDisposable
             PluginJsonContext.Default.GetAuthenticationCredentialsResponse,
             cancellationToken);
 
+    internal Task Closed => _closed.Task;
+
     private async Task<TResponse?> SendAsync<TRequest, TResponse>(
         string method,
         TRequest payload,
@@ -222,10 +228,19 @@ internal sealed class PluginConnection : IAsyncDisposable
     {
         string requestId = Guid.NewGuid().ToString();
         var pending = new PendingRequest(_requestTimeout);
-        _pending[requestId] = pending;
 
         try
         {
+            lock (_pendingGate)
+            {
+                if (!_acceptingRequests)
+                {
+                    throw new IOException("Credential plugin closed the connection.");
+                }
+
+                _pending[requestId] = pending;
+            }
+
             await WriteAsync(
                 new Envelope<TRequest>(requestId, MessageTypes.Request, method, payload),
                 requestType,
@@ -309,11 +324,27 @@ internal sealed class PluginConnection : IAsyncDisposable
         }
         finally
         {
-            // The pipe is gone, so nothing outstanding can ever be answered.
-            foreach (PendingRequest pending in _pending.Values)
-            {
-                pending.Completion.TrySetException(new IOException("Credential plugin closed the connection."));
-            }
+            SettleClosedConnection();
+        }
+    }
+
+    private void SettleClosedConnection()
+    {
+        PendingRequest[] pending;
+
+        lock (_pendingGate)
+        {
+            _acceptingRequests = false;
+            pending = [.. _pending.Values];
+            _pending.Clear();
+        }
+
+        _closed.TrySetResult();
+
+        foreach (PendingRequest request in pending)
+        {
+            request.Completion.TrySetException(
+                new IOException("Credential plugin closed the connection."));
         }
     }
 
@@ -534,6 +565,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         }
 
         _disposed = true;
+        SettleClosedConnection();
 
         try
         {

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -37,17 +37,23 @@ internal sealed class PluginConnection : IAsyncDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private readonly TaskCompletionSource _closed =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly PluginConnectionTestHooks? _testHooks;
     private readonly TimeSpan _requestTimeout;
     private readonly Action<string>? _log;
     private Task? _readLoop;
     private bool _acceptingRequests = true;
     private bool _disposed;
 
-    private PluginConnection(Process process, TimeSpan requestTimeout, Action<string>? log)
+    private PluginConnection(
+        Process process,
+        TimeSpan requestTimeout,
+        Action<string>? log,
+        PluginConnectionTestHooks? testHooks)
     {
         _process = process;
         _requestTimeout = requestTimeout;
         _log = log;
+        _testHooks = testHooks;
     }
 
     /// <summary>
@@ -62,7 +68,8 @@ internal sealed class PluginConnection : IAsyncDisposable
     public static async Task<PluginConnection?> StartAsync(
         PluginExecutable plugin,
         Action<string>? log,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PluginConnectionTestHooks? testHooks = null)
     {
         TimeSpan requestTimeout = ReadTimeoutOverride("NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS", DefaultRequestTimeout);
         var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
@@ -112,7 +119,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             return null;
         }
 
-        var connection = new PluginConnection(process, requestTimeout, log);
+        var connection = new PluginConnection(process, requestTimeout, log, testHooks);
         connection._readLoop = Task.Run(connection.ReadLoopAsync, CancellationToken.None);
 
         try
@@ -231,6 +238,8 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         try
         {
+            _testHooks?.RequestAdmissionAttempted?.Invoke();
+
             lock (_pendingGate)
             {
                 if (!_acceptingRequests)
@@ -239,6 +248,7 @@ internal sealed class PluginConnection : IAsyncDisposable
                 }
 
                 _pending[requestId] = pending;
+                _testHooks?.RequestRegistered?.Invoke();
             }
 
             await WriteAsync(
@@ -336,6 +346,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             _acceptingRequests = false;
             pending = [.. _pending.Values];
+            _testHooks?.PendingSnapshotCaptured?.Invoke();
             _pending.Clear();
         }
 
@@ -346,6 +357,15 @@ internal sealed class PluginConnection : IAsyncDisposable
             request.Completion.TrySetException(
                 new IOException("Credential plugin closed the connection."));
         }
+    }
+
+    internal sealed class PluginConnectionTestHooks
+    {
+        public Action? RequestAdmissionAttempted { get; init; }
+
+        public Action? RequestRegistered { get; init; }
+
+        public Action? PendingSnapshotCaptured { get; init; }
     }
 
     /// <summary>

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -243,9 +243,8 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             _testHooks?.RequestAdmissionAttempted?.Invoke();
 
-            lock (_pendingGate)
+            using (PendingGateLease gate = EnterPendingGate())
             {
-                long gateEntry = ++_pendingGateEntry;
                 cancellationToken.ThrowIfCancellationRequested();
 
                 if (!_acceptingRequests)
@@ -253,10 +252,10 @@ internal sealed class PluginConnection : IAsyncDisposable
                     throw new IOException("Credential plugin closed the connection.");
                 }
 
-                _testHooks?.RequestAdmissionAccepted?.Invoke(gateEntry);
+                _testHooks?.RequestAdmissionAccepted?.Invoke(gate.Entry);
                 _pending[requestId] = pending;
                 _testHooks?.RequestRegistered?.Invoke(
-                    (gateEntry, Monitor.IsEntered(_pendingGate)));
+                    (gate.Entry, Monitor.IsEntered(_pendingGate)));
             }
 
             await WriteAsync(
@@ -352,9 +351,8 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         _testHooks?.TerminalSettlementAttempted?.Invoke();
 
-        lock (_pendingGate)
+        using (EnterPendingGate())
         {
-            _pendingGateEntry++;
             _acceptingRequests = false;
             pending = [.. _pending.Values];
             _testHooks?.PendingSnapshotCaptured?.Invoke(Monitor.IsEntered(_pendingGate));
@@ -368,6 +366,24 @@ internal sealed class PluginConnection : IAsyncDisposable
             request.Completion.TrySetException(
                 new IOException("Credential plugin closed the connection."));
         }
+    }
+
+    private PendingGateLease EnterPendingGate() => new(this);
+
+    private readonly struct PendingGateLease : IDisposable
+    {
+        private readonly PluginConnection _owner;
+
+        public PendingGateLease(PluginConnection owner)
+        {
+            _owner = owner;
+            Monitor.Enter(owner._pendingGate);
+            Entry = ++owner._pendingGateEntry;
+        }
+
+        public long Entry { get; }
+
+        public void Dispose() => Monitor.Exit(_owner._pendingGate);
     }
 
     internal sealed class PluginConnectionTestHooks

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -240,8 +240,12 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         try
         {
+            _testHooks?.RequestAdmissionAttempted?.Invoke();
+
             lock (_pendingGate)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (!_acceptingRequests)
                 {
                     throw new IOException("Credential plugin closed the connection.");
@@ -364,6 +368,8 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     internal sealed class PluginConnectionTestHooks
     {
+        public Action? RequestAdmissionAttempted { get; init; }
+
         public Action? RequestAdmissionAccepted { get; init; }
 
         public Action<bool>? RequestRegistered { get; init; }

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -255,7 +255,8 @@ internal sealed class PluginConnection : IAsyncDisposable
 
                 _testHooks?.RequestAdmissionAccepted?.Invoke(gateEntry);
                 _pending[requestId] = pending;
-                _testHooks?.RequestRegistered?.Invoke(gateEntry);
+                _testHooks?.RequestRegistered?.Invoke(
+                    (gateEntry, Monitor.IsEntered(_pendingGate)));
             }
 
             await WriteAsync(
@@ -375,7 +376,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         public Action<long>? RequestAdmissionAccepted { get; init; }
 
-        public Action<long>? RequestRegistered { get; init; }
+        public Action<(long GateEntry, bool GateHeld)>? RequestRegistered { get; init; }
 
         public Action? TerminalSettlementAttempted { get; init; }
 


### PR DESCRIPTION
Closes #5036.

Middle slice of the credential-plugin lifecycle stack.

- Parent: #5044
- Base branch: `fix/plugin-malformed-inbound`
- Remaining top slice: #5035

Terminal receiver loss now closes request admission atomically before the
pending set is captured. Calls after closure receive an immediate visible
connection-closed result, while every call admitted before closure is included
in prompt settlement.

This implements the shutdown-admission obligations modeled by #5026 without
changing the valid request/response protocol.

## Demo

The real-process protocol tests exercise a fake plugin that closes stdout while
keeping stdin open:

```text
receiver closes before request -> request is rejected without writing
receiver closes after request  -> admitted request is settled immediately
```

The one-second test bounds are intentionally much shorter than the ordinary
30-second plugin request timeout, demonstrating that neither path falls back to
timeout recovery.

## Validation

- `dotnet run --project src/NuGetFetch.Tests -c Release -- -method '*ReceiverLoss*' -method '*AConnectionDisposedBeforeARequest*'`
- `dotnet run --project src/NuGetFetch.Tests -c Release --no-build`
- `npx markdownlint-cli docs/design/nuget-authentication.md docs/design/models/nuget-plugin-session-lifecycle/README.md`
- `git diff --check`
