### PR TITLE
Bound stalled credential-plugin writes

### DIFF
--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -99,9 +99,9 @@ point after which no further Progress arrives are environment actions and are
 not required to occur.
 
 The positive model makes request timeout effective from registration through
-the serialized write and response wait. `CurrentStalledWrite.cfg` instead
-matches the current control flow, where the timer may expire but `SendAsync`
-does not observe it until `WriteAsync` returns. With no fairness assumption that
+the serialized write and response wait. `CurrentStalledWrite.cfg` mutates that
+rule to defer timeout observation until the serialized write returns. With no
+fairness assumption that
 the plugin drains stdin, TLC finds that a request can remain in the writer
 forever after Progress has stopped. The positive rule does not abandon that
 writer and reuse the pipe: timeout or caller cancellation while a request owns

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -135,7 +135,7 @@ product behavior:
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |
 | Pipe loss closes admission before pending requests are collected | `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout`, `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, and `PluginProtocolTests.AdmissionCannotRegisterDuringTheTerminalPendingSnapshot` |
-| A stalled in-progress write is bounded by terminating the connection | Not implemented; `CurrentStalledWrite.cfg` abstracts the current control flow. |
+| A stalled in-progress write is bounded by terminating the connection | `PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests` and `PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation` |
 | Malformed plugin-originated payloads settle inbound work | `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse` |
 
 Formal model-to-implementation correspondence is unverified. In particular,

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -130,7 +130,7 @@ product behavior:
 | Initialization follows the required wire sequence | `PluginProtocolTests.InitializationFollowsTheProtocolSequence` |
 | The symmetric handshake accepts only protocol 2.0.0 | `PluginProtocolTests.CompatibleInboundHandshakeUsesProtocolTwo`, `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse`, and `PluginProtocolTests.InvalidOrUnsupportedOutboundHandshakeStopsInitialization` |
 | A dying process settles the current request as plugin failure | `PluginProtocolTests.WhenOnePluginDiesDuringTheRequest_TheNextIsTried` |
-| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate`, `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`, and `PluginProtocolTests.CancellationWhileWaitingForClosedAdmissionRemainsCancellation` |
+| Caller cancellation remains caller cancellation | `PluginProtocolTests.CallerCancellationContinuesToPropagate`, `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`, `PluginProtocolTests.CancellationWhileWaitingForClosedAdmissionRemainsCancellation`, and `PluginProtocolTests.CancellationWhileReplacingAClosedConnectionRemainsCancellation` |
 | A malformed response header does not end the read loop | `PluginProtocolTests.AProtocolMessageWithNonStringHeadersIsIgnoredRatherThanEndingTheConversation` |
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |

--- a/docs/design/models/nuget-plugin-session-lifecycle/README.md
+++ b/docs/design/models/nuget-plugin-session-lifecycle/README.md
@@ -135,7 +135,11 @@ product behavior:
 | Concurrent request-ID correlation and out-of-order replies | Unverified. |
 | Progress renews the matching implementation timer | Unverified; the design previously described this as tested, but no matching test exists. |
 | Pipe loss closes admission before pending requests are collected | `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout`, `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, and `PluginProtocolTests.AdmissionCannotRegisterDuringTheTerminalPendingSnapshot` |
-| A stalled in-progress write is bounded by terminating the connection | `PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests` and `PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation` |
+| A stalled in-progress write is bounded by terminating the connection | `PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests`, `PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation`, and `PluginProtocolTests.AResponseCannotLeaveItsRequestWriterStalled` |
+| Concurrent write-fault and caller-cancellation outcomes are arbitrated once | `PluginProtocolTests.CallerCancellationWinsAConcurrentWriteFailure` |
+| Terminal connections quiesce before synchronization resources are disposed | `PluginProtocolTests.ConnectionResourcesWaitForInterruptedRequestsToQuiesce` and `PluginProtocolTests.ConnectionResourcesWaitForInboundResponseWritersToQuiesce` |
+| An interrupted write that remains unobservable cannot race disposed connection resources | `PluginProtocolTests.AnUnfinishedInterruptedWriteRetainsConnectionResources` |
+| A request racing terminal publication retries on a replacement connection | `PluginProtocolTests.ARequestRacingTerminalPublicationRetriesOnAReplacementConnection` |
 | Malformed plugin-originated payloads settle inbound work | `PluginProtocolTests.InvalidOrUnsupportedInboundHandshakeReceivesAnErrorResponse` and `PluginProtocolTests.MalformedInboundLogReceivesAnErrorResponse` |
 
 Formal model-to-implementation correspondence is unverified. In particular,

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -212,6 +212,8 @@ before and after receiver loss by `PluginProtocolTests.CallerCancellationContinu
 `PluginProtocolTests.CanceledRequestAfterReceiverLossRemainsCancellation`, including the
 admission-monitor race checked by
 `PluginProtocolTests.CancellationWhileWaitingForClosedAdmissionRemainsCancellation`.
+Cancellation while a terminal cached connection is being replaced likewise propagates, enforced by
+`PluginProtocolTests.CancellationWhileReplacingAClosedConnectionRemainsCancellation`.
 
 ### Unattended by default
 

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -167,10 +167,18 @@ closes request admission before the read loop collects and settles pending reque
 `RequestAdmissionHasLiveReceiver` and `ShutdownSettlementIsComplete`. A malformed
 plugin-originated request receives an error response or the connection terminates; it never becomes
 abandoned work, checked by `InboundFailureIsContained` and
-`MalformedInboundEventuallySettles`. Active-writer timeout and cancellation containment are
-enforced by `PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests`
-and `PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation`. Terminal
-admission and pending settlement are enforced by
+`MalformedInboundEventuallySettles`. Active-writer timeout, cancellation, response, and write-fault
+containment are enforced by
+`PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests`,
+`PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation`,
+`PluginProtocolTests.AResponseCannotLeaveItsRequestWriterStalled`, and
+`PluginProtocolTests.CallerCancellationWinsAConcurrentWriteFailure`. Connection resources remain
+alive until admitted requests and inbound response writers have unwound, enforced by
+`PluginProtocolTests.ConnectionResourcesWaitForInterruptedRequestsToQuiesce` and
+`PluginProtocolTests.ConnectionResourcesWaitForInboundResponseWritersToQuiesce`; if a terminated
+transport write cannot be observed completing, its resources remain retained, enforced by
+`PluginProtocolTests.AnUnfinishedInterruptedWriteRetainsConnectionResources`. Terminal admission
+and pending settlement are enforced by
 `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and
 `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, with the
 atomic overlap enforced by
@@ -188,8 +196,10 @@ renewal and concurrent correlation remains unverified. Writer preemption, termin
 pending settlement are enforced by the gates named above.
 
 Plugins are started lazily and kept until their connection closes, because a launch costs a process
-start plus five round trips. A later request restarts a plugin whose prior live connection
-terminated, enforced by
+start plus five round trips. A request that loses a race with terminal publication retries once on
+a replacement connection, and later requests likewise replace a cached terminal connection. These
+rules are enforced by
+`PluginProtocolTests.ARequestRacingTerminalPublicationRetriesOnAReplacementConnection` and
 `PluginProtocolTests.AClosedCachedPluginConnectionIsRestartedOnTheNextRequest`. A plugin that fails
 to start, or that does not claim the `Authentication` operation, is remembered as unusable rather
 than retried.

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -167,8 +167,10 @@ closes request admission before the read loop collects and settles pending reque
 `RequestAdmissionHasLiveReceiver` and `ShutdownSettlementIsComplete`. A malformed
 plugin-originated request receives an error response or the connection terminates; it never becomes
 abandoned work, checked by `InboundFailureIsContained` and
-`MalformedInboundEventuallySettles`. The current implementation does not yet enforce the
-stalled-write rule. Terminal admission and pending settlement are enforced by
+`MalformedInboundEventuallySettles`. Active-writer timeout and cancellation containment are
+enforced by `PluginProtocolTests.AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests`
+and `PluginProtocolTests.CallerCancellationOfAStalledWriterRemainsCancellation`. Terminal
+admission and pending settlement are enforced by
 `PluginProtocolTests.ARequestAfterReceiverLossIsRejectedWithoutWaitingForItsTimeout` and
 `PluginProtocolTests.ReceiverLossSettlesARequestAdmittedBeforeThePendingSnapshot`, with the
 atomic overlap enforced by
@@ -182,12 +184,15 @@ Implementation: [`PluginConnection`](../../src/NuGetFetch/Plugins/PluginConnecti
 The concurrent conversation and shutdown rules are checked by the
 [NuGet credential-plugin session lifecycle model](models/nuget-plugin-session-lifecycle/README.md).
 The model checks the design under finite bounds; implementation correspondence for progress
-renewal and concurrent correlation remains unverified. Terminal admission and pending settlement
-are enforced by the gates named above.
+renewal and concurrent correlation remains unverified. Writer preemption, terminal admission, and
+pending settlement are enforced by the gates named above.
 
-Plugins are started lazily and kept for the process lifetime, because a launch costs a process
-start plus five round trips. A plugin that fails to start, or that does not claim the
-`Authentication` operation, is remembered as unusable rather than retried.
+Plugins are started lazily and kept until their connection closes, because a launch costs a process
+start plus five round trips. A later request restarts a plugin whose prior live connection
+terminated, enforced by
+`PluginProtocolTests.AClosedCachedPluginConnectionIsRestartedOnTheNextRequest`. A plugin that fails
+to start, or that does not claim the `Authentication` operation, is remembered as unusable rather
+than retried.
 
 A plugin process or pipe that dies during a request is likewise treated as no credential from
 that plugin. Timeouts, malformed responses, I/O failures, disposed pipes, and invalid process

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -352,6 +352,65 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task CancellationWhileReplacingAClosedConnectionRemainsCancellation()
+    {
+        var quiescenceAwaiting = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseQuiescence = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        int blockNextQuiescence = 1;
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            ConnectionQuiescenceAwaiting = () =>
+            {
+                if (hooksEnabled.IsSet
+                    && Interlocked.Exchange(ref blockNextQuiescence, 0) == 1)
+                {
+                    quiescenceAwaiting.TrySetResult();
+                    releaseQuiescence.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+        };
+        FakePlugin plugin = CreatePlugin(
+            "cancel-closed-replacement",
+            username: "right",
+            password: "token",
+            exitOnFirstCredentialRequest: true);
+
+        await using var provider = new PluginCredentialProvider(null, [plugin.Executable], hooks);
+        Assert.Null(await provider.GetCredentialsAsync(
+            new Uri("https://first.example/v3/index.json"),
+            false,
+            TestContext.Current.CancellationToken));
+
+        hooksEnabled.Set();
+        using var cancellation = new CancellationTokenSource();
+        Task<PackageSourceCredential?> replacement = Task.Run(
+            () => provider.GetCredentialsAsync(
+                new Uri("https://second.example/v3/index.json"),
+                false,
+                cancellation.Token),
+            TestContext.Current.CancellationToken);
+
+        await quiescenceAwaiting.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+        releaseQuiescence.TrySetResult();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await replacement.WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task CredentialsRestrictedToOtherAuthSchemesAreNotUsed()
     {
         FakePlugin plugin = CreatePlugin("negotiate", username: "u", password: "p", authenticationTypes: "negotiate");

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using NuGetFetch;
 using NuGetFetch.Plugins;
@@ -18,6 +19,7 @@ namespace NuGetFetch.Tests;
 /// The contract is defined by NuGet/NuGet.Client, src/NuGet.Core/NuGet.Protocol/Plugins/.
 /// </para>
 /// </remarks>
+[Collection(ThreadPoolDeadlineCollection.Name)]
 public sealed class PluginProtocolTests : IDisposable
 {
     private readonly string _root = Directory.CreateTempSubdirectory("plugin-protocol").FullName;
@@ -193,6 +195,31 @@ public sealed class PluginProtocolTests : IDisposable
 
         Assert.NotNull(credential);
         Assert.Equal("right", credential.Username);
+    }
+
+    [Fact]
+    public async Task AClosedCachedPluginConnectionIsRestartedOnTheNextRequest()
+    {
+        FakePlugin plugin = CreatePlugin(
+            "restarts-after-death",
+            username: "right",
+            password: "token",
+            exitOnFirstCredentialRequest: true);
+
+        await using var provider = new PluginCredentialProvider(null, [plugin.Executable]);
+
+        PackageSourceCredential? first = await provider.GetCredentialsAsync(
+            new Uri("https://first.example/v3/index.json"),
+            false,
+            TestContext.Current.CancellationToken);
+        PackageSourceCredential? second = await provider.GetCredentialsAsync(
+            new Uri("https://second.example/v3/index.json"),
+            false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(first);
+        Assert.NotNull(second);
+        Assert.Equal("right", second.Username);
     }
 
     [Fact]
@@ -790,6 +817,129 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task AStalledWriterTimeoutTerminatesTheConnectionAndSettlesQueuedRequests()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "2");
+        var log = new ConcurrentQueue<string>();
+        FakePlugin plugin = CreatePlugin(
+            "stalled-writer-timeout",
+            username: "u",
+            password: "p",
+            afterSetLogLevel: "sleep 30");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log.Enqueue,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            Task<GetAuthenticationCredentialsResponse?> active = connection.GetCredentialsAsync(
+                CreateLargeFeedUri(),
+                isRetry: false,
+                isNonInteractive: true,
+                canShowDialog: false,
+                TestContext.Current.CancellationToken);
+
+            await Task.Delay(
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken);
+
+            Task<GetAuthenticationCredentialsResponse?> queued = connection.GetCredentialsAsync(
+                new Uri("https://queued.example/v3/index.json"),
+                isRetry: false,
+                isNonInteractive: true,
+                canShowDialog: false,
+                TestContext.Current.CancellationToken);
+
+            GetAuthenticationCredentialsResponse?[] responses = await Task
+                .WhenAll(active, queued)
+                .WaitAsync(
+                    TimeSpan.FromSeconds(6),
+                    TestContext.Current.CancellationToken);
+
+            Assert.All(responses, Assert.Null);
+            Assert.Contains(log, message => message.Contains(
+                "did not respond in time",
+                StringComparison.Ordinal));
+            Assert.Contains(log, message => message.Contains(
+                "closed the connection",
+                StringComparison.Ordinal));
+
+            GetAuthenticationCredentialsResponse? later = await connection
+                .GetCredentialsAsync(
+                    new Uri("https://later.example/v3/index.json"),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    TestContext.Current.CancellationToken)
+                .WaitAsync(
+                    TimeSpan.FromSeconds(1),
+                    TestContext.Current.CancellationToken);
+
+            Assert.Null(later);
+        }
+    }
+
+    [Fact]
+    public async Task CallerCancellationOfAStalledWriterRemainsCancellation()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "10");
+        var log = new ConcurrentQueue<string>();
+        FakePlugin plugin = CreatePlugin(
+            "stalled-writer-cancellation",
+            username: "u",
+            password: "p",
+            afterSetLogLevel: "sleep 30");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log.Enqueue,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            using var cancellation = new CancellationTokenSource();
+            Task<GetAuthenticationCredentialsResponse?> active = connection.GetCredentialsAsync(
+                CreateLargeFeedUri(),
+                isRetry: false,
+                isNonInteractive: true,
+                canShowDialog: false,
+                cancellation.Token);
+
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+
+            Task<GetAuthenticationCredentialsResponse?> queued = connection.GetCredentialsAsync(
+                new Uri("https://queued.example/v3/index.json"),
+                isRetry: false,
+                isNonInteractive: true,
+                canShowDialog: false,
+                TestContext.Current.CancellationToken);
+
+            cancellation.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await active.WaitAsync(
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken));
+
+            GetAuthenticationCredentialsResponse? peer = await queued.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+            Assert.Null(peer);
+            Assert.DoesNotContain(log, message => message.Contains(
+                "did not respond in time",
+                StringComparison.Ordinal));
+            Assert.Contains(log, message => message.Contains(
+                "closed the connection",
+                StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
     public async Task CallerCancellationContinuesToPropagate()
     {
         FakePlugin plugin = CreatePlugin("cancelled-request", username: "u", password: "p");
@@ -833,6 +983,9 @@ public sealed class PluginProtocolTests : IDisposable
             new ArgumentException()));
     }
 
+    private static Uri CreateLargeFeedUri() =>
+        new("https://feed.example/" + new string('a', 4 * 1024 * 1024));
+
     private FakePlugin CreatePlugin(
         string name,
         string username,
@@ -845,6 +998,7 @@ public sealed class PluginProtocolTests : IDisposable
         string? outboundHandshakePayload = null,
         string? afterSetLogLevel = null,
         bool closeOutputOnCredentialRequest = false,
+        bool exitOnFirstCredentialRequest = false,
         bool exitOnCredentialRequest = false)
     {
         // Values are embedded in a double-quoted bash string, so every JSON quote needs a
@@ -859,13 +1013,26 @@ public sealed class PluginProtocolTests : IDisposable
                 + "," + Quoted("AuthenticationTypes") + ":" + types
                 + "," + Quoted("ResponseCode") + ":" + Quoted("Success") + "}"
             : "{" + Quoted("ResponseCode") + ":" + Quoted(responseCode) + "}";
+        string credentialResponse = """
+            emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
+            """;
         string credentialAction = closeOutputOnCredentialRequest
             ? "exec 1>&-"
+            : exitOnFirstCredentialRequest
+                ? """
+                  starts_file="$RECORD.starts"
+                  starts=0
+                  [ -f "$starts_file" ] && starts=$(cat "$starts_file")
+                  starts=$((starts + 1))
+                  printf '%s' "$starts" > "$starts_file"
+                  if [ "$starts" -eq 1 ]; then
+                    exit 0
+                  fi
+                  __CREDENTIAL_RESPONSE__
+                  """
             : exitOnCredentialRequest
                 ? "exit 0"
-                : """
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
-                  """;
+                : credentialResponse;
 
         // A non-interpolated raw string with tokens: the script is dense with braces, and
         // interpolation holes would be indistinguishable from JSON.
@@ -899,6 +1066,7 @@ public sealed class PluginProtocolTests : IDisposable
             """
             .Replace("__CLAIMS__", Quoted(claims))
             .Replace("__AUTH_ACTION__", credentialAction)
+            .Replace("__CREDENTIAL_RESPONSE__", credentialResponse)
             .Replace("__CREDENTIAL__", credentialPayload)
             .Replace(
                 "__INBOUND_HANDSHAKE__",
@@ -1036,4 +1204,19 @@ public sealed class PluginProtocolTests : IDisposable
         string Type,
         string Method,
         JsonElement Payload);
+
+    private sealed class EnvironmentVariable : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _original;
+
+        public EnvironmentVariable(string name, string? value)
+        {
+            _name = name;
+            _original = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(_name, _original);
+    }
 }

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -200,18 +200,56 @@ public sealed class PluginProtocolTests : IDisposable
     [Fact]
     public async Task AClosedCachedPluginConnectionIsRestartedOnTheNextRequest()
     {
+        var credentialLineWritten = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var connectionClosed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLineWriter = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestLineWritten = method =>
+            {
+                if (hooksEnabled.IsSet
+                    && method == MessageMethods.GetAuthenticationCredentials)
+                {
+                    credentialLineWritten.TrySetResult();
+                    releaseLineWriter.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+            ConnectionAdmissionClosed = _ => connectionClosed.TrySetResult(),
+        };
         FakePlugin plugin = CreatePlugin(
             "restarts-after-death",
             username: "right",
             password: "token",
             exitOnFirstCredentialRequest: true);
 
-        await using var provider = new PluginCredentialProvider(null, [plugin.Executable]);
+        await using var provider = new PluginCredentialProvider(null, [plugin.Executable], hooks);
 
-        PackageSourceCredential? first = await provider.GetCredentialsAsync(
-            new Uri("https://first.example/v3/index.json"),
-            false,
+        hooksEnabled.Set();
+        Task<PackageSourceCredential?> firstRequest = Task.Run(
+            () => provider.GetCredentialsAsync(
+                new Uri("https://first.example/v3/index.json"),
+                false,
+                TestContext.Current.CancellationToken),
             TestContext.Current.CancellationToken);
+
+        await credentialLineWritten.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        await connectionClosed.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        releaseLineWriter.TrySetResult();
+
+        PackageSourceCredential? first = await firstRequest;
         PackageSourceCredential? second = await provider.GetCredentialsAsync(
             new Uri("https://second.example/v3/index.json"),
             false,
@@ -220,6 +258,97 @@ public sealed class PluginProtocolTests : IDisposable
         Assert.Null(first);
         Assert.NotNull(second);
         Assert.Equal("right", second.Username);
+    }
+
+    [Fact]
+    public async Task ARequestRacingTerminalPublicationRetriesOnAReplacementConnection()
+    {
+        var admissionClosed = new TaskCompletionSource<(bool ClosedPublished, bool GateHeld)>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var publicationStarting = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondAdmissionAttempted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseClosure = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var trackSecondAdmission = new ManualResetEventSlim();
+        int blockNextClosure = 1;
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            TerminalPublicationStarting = () =>
+            {
+                if (Interlocked.Exchange(ref blockNextClosure, 0) == 1)
+                {
+                    publicationStarting.TrySetResult();
+                    releaseClosure.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+            ConnectionAdmissionClosed = observation =>
+            {
+                admissionClosed.TrySetResult(observation);
+            },
+            RequestAdmissionAttempted = () =>
+            {
+                if (trackSecondAdmission.IsSet)
+                {
+                    secondAdmissionAttempted.TrySetResult();
+                }
+            },
+        };
+        FakePlugin plugin = CreatePlugin(
+            "retry-terminal-publication",
+            username: "right",
+            password: "token",
+            exitOnFirstCredentialRequest: true);
+
+        await using var provider = new PluginCredentialProvider(null, [plugin.Executable], hooks);
+        Task<PackageSourceCredential?> first = Task.Run(
+            () => provider.GetCredentialsAsync(
+                new Uri("https://first.example/v3/index.json"),
+                false,
+                TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+
+        await publicationStarting.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+
+        trackSecondAdmission.Set();
+        Task<PackageSourceCredential?> second = Task.Run(
+            () => provider.GetCredentialsAsync(
+                new Uri("https://second.example/v3/index.json"),
+                false,
+                TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+
+        try
+        {
+            await secondAdmissionAttempted.Task.WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            releaseClosure.TrySetResult();
+        }
+
+        (bool closedPublished, bool gateHeld) = await admissionClosed.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        Assert.True(closedPublished);
+        Assert.True(gateHeld);
+
+        Assert.Null(await first);
+        PackageSourceCredential? credential = await second.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+        Assert.NotNull(credential);
+        Assert.Equal("right", credential.Username);
     }
 
     [Fact]
@@ -940,6 +1069,333 @@ public sealed class PluginProtocolTests : IDisposable
     }
 
     [Fact]
+    public async Task AResponseCannotLeaveItsRequestWriterStalled()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "10");
+        FakePlugin plugin = CreatePlugin(
+            "response-before-complete-write",
+            username: "right",
+            password: "token",
+            respondBeforeCredentialLineCompletes: true);
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken));
+        await using (connection)
+        {
+            GetAuthenticationCredentialsResponse? response = await connection
+                .GetCredentialsAsync(
+                    CreateLargeFeedUri(),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    TestContext.Current.CancellationToken)
+                .WaitAsync(
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken);
+
+            Assert.NotNull(response);
+            Assert.Equal("right", response.Username);
+            await connection.Closed.WaitAsync(
+                TimeSpan.FromSeconds(1),
+                TestContext.Current.CancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task CallerCancellationWinsAConcurrentWriteFailure()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "10");
+        var writeFailed = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeStarting = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseWrite = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFailure = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestWriteStarting = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    writeStarting.TrySetResult();
+                    releaseWrite.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                    throw new IOException("Injected write failure.");
+                }
+            },
+            RequestWriteFailed = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    writeFailed.TrySetResult();
+                    releaseFailure.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+        };
+        FakePlugin plugin = CreatePlugin(
+            "write-failure-cancellation",
+            username: "u",
+            password: "p");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+        await using (connection)
+        {
+            using var cancellation = new CancellationTokenSource();
+            hooksEnabled.Set();
+            Task<GetAuthenticationCredentialsResponse?> request = Task.Run(
+                () => connection.GetCredentialsAsync(
+                    CreateLargeFeedUri(),
+                    isRetry: false,
+                    isNonInteractive: true,
+                    canShowDialog: false,
+                    cancellation.Token),
+                TestContext.Current.CancellationToken);
+
+            await writeStarting.Task.WaitAsync(
+                TimeSpan.FromSeconds(2),
+                TestContext.Current.CancellationToken);
+            releaseWrite.TrySetResult();
+
+            await writeFailed.Task.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+            cancellation.Cancel();
+            releaseFailure.TrySetResult();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await request.WaitAsync(
+                    TimeSpan.FromSeconds(5),
+                    TestContext.Current.CancellationToken));
+        }
+    }
+
+    [Fact]
+    public async Task ConnectionResourcesWaitForInterruptedRequestsToQuiesce()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "10");
+        var writeInterrupted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseInterruption = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var resourcesDisposing = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestWriteInterrupted = () =>
+            {
+                writeInterrupted.TrySetResult();
+                releaseInterruption.Task
+                    .WaitAsync(
+                        TimeSpan.FromSeconds(2),
+                        TestContext.Current.CancellationToken)
+                    .GetAwaiter()
+                    .GetResult();
+            },
+            ConnectionResourcesDisposing = value => resourcesDisposing.TrySetResult(value),
+        };
+        FakePlugin plugin = CreatePlugin(
+            "quiesce-before-dispose",
+            username: "u",
+            password: "p",
+            afterSetLogLevel: "sleep 30");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+        using var cancellation = new CancellationTokenSource();
+        Task<GetAuthenticationCredentialsResponse?> request = connection.GetCredentialsAsync(
+            CreateLargeFeedUri(),
+            isRetry: false,
+            isNonInteractive: true,
+            canShowDialog: false,
+            cancellation.Token);
+
+        cancellation.Cancel();
+        await writeInterrupted.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Task disposal = connection.DisposeAsync().AsTask();
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
+                await resourcesDisposing.Task.WaitAsync(
+                    TimeSpan.FromMilliseconds(200),
+                    TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            releaseInterruption.TrySetResult();
+        }
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await request.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken));
+        await disposal.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+        Assert.True(await resourcesDisposing.Task);
+    }
+
+    [Fact]
+    public async Task ConnectionResourcesWaitForInboundResponseWritersToQuiesce()
+    {
+        var responseWriteStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResponseWrite = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var resourcesDisposing = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            ResponseWriteStarted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    responseWriteStarted.TrySetResult();
+                    releaseResponseWrite.Task
+                        .WaitAsync(
+                            TimeSpan.FromSeconds(2),
+                            TestContext.Current.CancellationToken)
+                        .GetAwaiter()
+                        .GetResult();
+                }
+            },
+            ConnectionResourcesDisposing = value => resourcesDisposing.TrySetResult(value),
+        };
+        FakePlugin plugin = CreatePlugin(
+            "quiesce-inbound-response",
+            username: "u",
+            password: "p",
+            afterSetLogLevel:
+                """
+                while [ ! -f "$RECORD.log" ]; do sleep 0.01; done
+                emit '{"RequestId":"quiesce-log","Type":"Request","Method":"Log","Payload":{"LogLevel":"Information","Message":"hello"}}'
+                sleep 30
+                """);
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+
+        hooksEnabled.Set();
+        File.WriteAllText(plugin.RecordPath + ".log", string.Empty);
+        await responseWriteStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+
+        Task disposal = connection.DisposeAsync().AsTask();
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(async () =>
+                await resourcesDisposing.Task.WaitAsync(
+                    TimeSpan.FromMilliseconds(200),
+                    TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            releaseResponseWrite.TrySetResult();
+        }
+
+        await disposal.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+        Assert.True(await resourcesDisposing.Task);
+    }
+
+    [Fact]
+    public async Task AnUnfinishedInterruptedWriteRetainsConnectionResources()
+    {
+        using var timeout = new EnvironmentVariable(
+            "NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS",
+            "10");
+        var neverCompletes = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var resourcesDisposing = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
+        var hooks = new PluginConnection.PluginConnectionTestHooks
+        {
+            RequestWriteOverride = () => hooksEnabled.IsSet ? neverCompletes.Task : null,
+            RequestWriteStarted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    writeStarted.TrySetResult();
+                }
+            },
+            ConnectionResourcesDisposing = value => resourcesDisposing.TrySetResult(value),
+        };
+        FakePlugin plugin = CreatePlugin(
+            "retain-unfinished-write-resources",
+            username: "u",
+            password: "p");
+        PluginConnection connection = Assert.IsType<PluginConnection>(
+            await PluginConnection.StartAsync(
+                plugin.Executable,
+                log: null,
+                TestContext.Current.CancellationToken,
+                hooks));
+        using var cancellation = new CancellationTokenSource();
+        hooksEnabled.Set();
+        Task<GetAuthenticationCredentialsResponse?> request = connection.GetCredentialsAsync(
+            new Uri("https://feed.example/v3/index.json"),
+            isRetry: false,
+            isNonInteractive: true,
+            canShowDialog: false,
+            cancellation.Token);
+
+        await writeStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await request.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken));
+        await connection.DisposeAsync().AsTask().WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+        Assert.False(await resourcesDisposing.Task);
+    }
+
+    [Fact]
     public async Task CallerCancellationContinuesToPropagate()
     {
         FakePlugin plugin = CreatePlugin("cancelled-request", username: "u", password: "p");
@@ -997,6 +1453,7 @@ public sealed class PluginProtocolTests : IDisposable
         string? inboundHandshakePayload = null,
         string? outboundHandshakePayload = null,
         string? afterSetLogLevel = null,
+        bool respondBeforeCredentialLineCompletes = false,
         bool closeOutputOnCredentialRequest = false,
         bool exitOnFirstCredentialRequest = false,
         bool exitOnCredentialRequest = false)
@@ -1033,6 +1490,17 @@ public sealed class PluginProtocolTests : IDisposable
             : exitOnCredentialRequest
                 ? "exit 0"
                 : credentialResponse;
+        string afterSetLogLevelAction = respondBeforeCredentialLineCompletes
+            ? """
+              IFS= read -r -n 256 prefix
+              id=$(field "$prefix" RequestId)
+              __CREDENTIAL_RESPONSE__
+              sleep 30
+              exit 0
+              """
+                .Replace("__CREDENTIAL_RESPONSE__", credentialResponse)
+                .Replace("__CREDENTIAL__", credentialPayload)
+            : afterSetLogLevel ?? string.Empty;
 
         // A non-interpolated raw string with tokens: the script is dense with braces, and
         // interpolation holes would be indistinguishable from JSON.
@@ -1077,7 +1545,7 @@ public sealed class PluginProtocolTests : IDisposable
                 (outboundHandshakePayload
                     ?? """{"ResponseCode":"Success","ProtocolVersion":"2.0.0"}""")
                     .Replace("\"", "\\\"", StringComparison.Ordinal))
-            .Replace("__AFTER_SET_LOG_LEVEL__", afterSetLogLevel ?? string.Empty)
+            .Replace("__AFTER_SET_LOG_LEVEL__", afterSetLogLevelAction)
             .Replace("__PREAMBLE__", preamble ?? string.Empty);
 
         return CreateRawPlugin(name, body);

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -217,7 +217,7 @@ public sealed class PluginProtocolTests : IDisposable
                     credentialLineWritten.TrySetResult();
                     releaseLineWriter.Task
                         .WaitAsync(
-                            TimeSpan.FromSeconds(2),
+                            TimeSpan.FromSeconds(10),
                             TestContext.Current.CancellationToken)
                         .GetAwaiter()
                         .GetResult();
@@ -315,7 +315,7 @@ public sealed class PluginProtocolTests : IDisposable
             TestContext.Current.CancellationToken);
 
         await publicationStarting.Task.WaitAsync(
-            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(5),
             TestContext.Current.CancellationToken);
 
         trackSecondAdmission.Set();
@@ -329,7 +329,7 @@ public sealed class PluginProtocolTests : IDisposable
         try
         {
             await secondAdmissionAttempted.Task.WaitAsync(
-                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(5),
                 TestContext.Current.CancellationToken);
         }
         finally
@@ -338,7 +338,7 @@ public sealed class PluginProtocolTests : IDisposable
         }
 
         (bool closedPublished, bool gateHeld) = await admissionClosed.Task.WaitAsync(
-            TimeSpan.FromSeconds(2),
+            TimeSpan.FromSeconds(5),
             TestContext.Current.CancellationToken);
         Assert.True(closedPublished);
         Assert.True(gateHeld);

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -1259,12 +1259,17 @@ public sealed class PluginProtocolTests : IDisposable
             "10");
         var writeInterrupted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseInterruption = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var quiescenceAwaiting = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var resourcesDisposing = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var hooks = new PluginConnection.PluginConnectionTestHooks
         {
+            RequestWriteStarted = () => writeStarted.TrySetResult(),
             RequestWriteInterrupted = () =>
             {
                 writeInterrupted.TrySetResult();
@@ -1275,6 +1280,7 @@ public sealed class PluginProtocolTests : IDisposable
                     .GetAwaiter()
                     .GetResult();
             },
+            ConnectionQuiescenceAwaiting = () => quiescenceAwaiting.TrySetResult(),
             ConnectionResourcesDisposing = value => resourcesDisposing.TrySetResult(value),
         };
         FakePlugin plugin = CreatePlugin(
@@ -1296,6 +1302,9 @@ public sealed class PluginProtocolTests : IDisposable
             canShowDialog: false,
             cancellation.Token);
 
+        await writeStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
         cancellation.Cancel();
         await writeInterrupted.Task.WaitAsync(
             TimeSpan.FromSeconds(5),
@@ -1305,10 +1314,10 @@ public sealed class PluginProtocolTests : IDisposable
 
         try
         {
-            await Assert.ThrowsAsync<TimeoutException>(async () =>
-                await resourcesDisposing.Task.WaitAsync(
-                    TimeSpan.FromMilliseconds(200),
-                    TestContext.Current.CancellationToken));
+            await quiescenceAwaiting.Task.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            Assert.False(resourcesDisposing.Task.IsCompleted);
         }
         finally
         {

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -1273,6 +1273,8 @@ public sealed class PluginProtocolTests : IDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseResponseWrite = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var quiescenceAwaiting = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var resourcesDisposing = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var hooksEnabled = new ManualResetEventSlim();
@@ -1285,12 +1287,13 @@ public sealed class PluginProtocolTests : IDisposable
                     responseWriteStarted.TrySetResult();
                     releaseResponseWrite.Task
                         .WaitAsync(
-                            TimeSpan.FromSeconds(2),
+                            TimeSpan.FromSeconds(10),
                             TestContext.Current.CancellationToken)
                         .GetAwaiter()
                         .GetResult();
                 }
             },
+            ConnectionQuiescenceAwaiting = () => quiescenceAwaiting.TrySetResult(),
             ConnectionResourcesDisposing = value => resourcesDisposing.TrySetResult(value),
         };
         FakePlugin plugin = CreatePlugin(
@@ -1320,10 +1323,10 @@ public sealed class PluginProtocolTests : IDisposable
 
         try
         {
-            await Assert.ThrowsAsync<TimeoutException>(async () =>
-                await resourcesDisposing.Task.WaitAsync(
-                    TimeSpan.FromMilliseconds(200),
-                    TestContext.Current.CancellationToken));
+            await quiescenceAwaiting.Task.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+            Assert.False(resourcesDisposing.Task.IsCompleted);
         }
         finally
         {

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -37,11 +37,15 @@ internal sealed class PluginConnection : IAsyncDisposable
     private readonly CancellationTokenSource _shutdown = new();
     private readonly TaskCompletionSource _closed =
         new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _quiesced =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly PluginConnectionTestHooks? _testHooks;
     private readonly TimeSpan _requestTimeout;
     private readonly Action<string>? _log;
     private Task? _readLoop;
     private long _pendingGateEntry;
+    private int _activeOperations;
+    private bool _hasUnobservedWrite;
     private bool _acceptingRequests = true;
     private bool _terminated;
     private bool _disposed;
@@ -121,6 +125,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             return null;
         }
 
+        process.StandardInput.AutoFlush = true;
         var connection = new PluginConnection(process, requestTimeout, log, testHooks);
         connection._readLoop = Task.Run(connection.ReadLoopAsync, CancellationToken.None);
 
@@ -218,27 +223,61 @@ internal sealed class PluginConnection : IAsyncDisposable
         bool isNonInteractive,
         bool canShowDialog,
         CancellationToken cancellationToken) =>
+        GetCredentialsAsync(
+            uri,
+            isRetry,
+            isNonInteractive,
+            canShowDialog,
+            retryConnectionClosed: false,
+            cancellationToken);
+
+    internal Task<GetAuthenticationCredentialsResponse?> GetCredentialsForProviderAsync(
+        Uri uri,
+        bool isRetry,
+        bool isNonInteractive,
+        bool canShowDialog,
+        CancellationToken cancellationToken) =>
+        GetCredentialsAsync(
+            uri,
+            isRetry,
+            isNonInteractive,
+            canShowDialog,
+            retryConnectionClosed: true,
+            cancellationToken);
+
+    private Task<GetAuthenticationCredentialsResponse?> GetCredentialsAsync(
+        Uri uri,
+        bool isRetry,
+        bool isNonInteractive,
+        bool canShowDialog,
+        bool retryConnectionClosed,
+        CancellationToken cancellationToken) =>
         SendAsync(
             MessageMethods.GetAuthenticationCredentials,
             new GetAuthenticationCredentialsRequest(uri.ToString(), isRetry, isNonInteractive, canShowDialog),
             PluginJsonContext.Default.EnvelopeGetAuthenticationCredentialsRequest,
             PluginJsonContext.Default.GetAuthenticationCredentialsResponse,
-            cancellationToken);
+            cancellationToken,
+            retryConnectionClosed);
 
     internal Task Closed => _closed.Task;
+
+    internal Task Quiesced => _quiesced.Task;
 
     private async Task<TResponse?> SendAsync<TRequest, TResponse>(
         string method,
         TRequest payload,
         JsonTypeInfo<Envelope<TRequest>> requestType,
         JsonTypeInfo<TResponse> responseType,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool retryConnectionClosed = false)
         where TResponse : class
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         string requestId = Guid.NewGuid().ToString();
         var pending = new PendingRequest(_requestTimeout, cancellationToken);
+        bool registered = false;
 
         try
         {
@@ -250,11 +289,18 @@ internal sealed class PluginConnection : IAsyncDisposable
 
                 if (!_acceptingRequests)
                 {
+                    if (retryConnectionClosed)
+                    {
+                        throw new ConnectionClosedBeforeRequestException();
+                    }
+
                     throw new IOException("Credential plugin closed the connection.");
                 }
 
                 _testHooks?.RequestAdmissionAccepted?.Invoke(gate.Entry);
                 _pending[requestId] = pending;
+                _activeOperations++;
+                registered = true;
                 _testHooks?.RequestRegistered?.Invoke(
                     (gate.Entry, Monitor.IsEntered(_pendingGate)));
             }
@@ -268,14 +314,31 @@ internal sealed class PluginConnection : IAsyncDisposable
 
             return responsePayload?.Deserialize(responseType);
         }
+        catch (ConnectionClosedBeforeRequestException)
+        {
+            throw;
+        }
         catch (Exception ex) when (IsRecoverableRequestFailure(ex))
         {
+            if (retryConnectionClosed && pending.ShouldRetryClosedConnection)
+            {
+                throw new ConnectionClosedBeforeRequestException(ex);
+            }
+
             _log?.Invoke($"Credential plugin request '{method}' failed: {ex.Message}");
             return null;
         }
         finally
         {
-            _pending.TryRemove(requestId, out _);
+            if (registered)
+            {
+                lock (_pendingGate)
+                {
+                    _pending.TryRemove(requestId, out _);
+                    CompleteActiveOperationUnderLock();
+                }
+            }
+
             pending.Dispose();
         }
     }
@@ -291,6 +354,19 @@ internal sealed class PluginConnection : IAsyncDisposable
             _ => false,
         };
 
+    internal sealed class ConnectionClosedBeforeRequestException : Exception
+    {
+        public ConnectionClosedBeforeRequestException()
+            : base("Credential plugin closed before the request could be sent.")
+        {
+        }
+
+        public ConnectionClosedBeforeRequestException(Exception innerException)
+            : base("Credential plugin closed before the request could be sent.", innerException)
+        {
+        }
+    }
+
     private async Task WriteRequestAsync<T>(
         Envelope<T> envelope,
         JsonTypeInfo<Envelope<T>> type,
@@ -299,7 +375,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         string json = JsonSerializer.Serialize(envelope, type);
         bool lockTaken = false;
         bool releaseWriteLock = true;
-        bool preempted = false;
+        bool completionWon = false;
 
         try
         {
@@ -310,41 +386,52 @@ internal sealed class PluginConnection : IAsyncDisposable
             {
                 if (!_acceptingRequests)
                 {
+                    pending.TrySetConnectionClosed();
                     throw new IOException("Credential plugin closed the connection.");
                 }
             }
 
-            Task write = WriteLineAndFlushAsync(json, pending.WriteCancellation);
-            Task completed = await Task.WhenAny(write, pending.Preemption).ConfigureAwait(false);
+            _testHooks?.RequestWriteStarting?.Invoke();
+            Task write = _testHooks?.RequestWriteOverride?.Invoke()
+                ?? WriteLineAsync(
+                    json,
+                    pending.WriteCancellation,
+                    () =>
+                    {
+                        pending.MarkWriteCompleted();
+                        _testHooks?.RequestLineWritten?.Invoke(envelope.Method);
+                    });
+            _testHooks?.RequestWriteStarted?.Invoke();
+            Task completed = await Task.WhenAny(write, pending.Completion).ConfigureAwait(false);
 
             if (!ReferenceEquals(completed, write))
             {
-                preempted = true;
+                completionWon = true;
                 TerminateConnection();
+                _testHooks?.RequestWriteInterrupted?.Invoke();
                 releaseWriteLock = await ObserveTerminatedWriteAsync(write).ConfigureAwait(false);
+
+                if (!releaseWriteLock)
+                {
+                    MarkUnobservedWrite();
+                }
             }
             else
             {
                 await write.ConfigureAwait(false);
             }
         }
-        catch (Exception) when (pending.IsPreempted)
+        catch (Exception ex)
         {
-            preempted = true;
+            _testHooks?.RequestWriteFailed?.Invoke();
+            pending.TrySetException(ex);
 
             if (lockTaken)
             {
                 TerminateConnection();
             }
-        }
-        catch
-        {
-            if (lockTaken)
-            {
-                TerminateConnection();
-            }
 
-            throw;
+            await pending.Completion.ConfigureAwait(false);
         }
         finally
         {
@@ -354,9 +441,9 @@ internal sealed class PluginConnection : IAsyncDisposable
             }
         }
 
-        if (preempted)
+        if (completionWon)
         {
-            await pending.ThrowCompletionAsync().ConfigureAwait(false);
+            _ = await pending.Completion.ConfigureAwait(false);
         }
     }
 
@@ -394,7 +481,8 @@ internal sealed class PluginConnection : IAsyncDisposable
                 }
             }
 
-            Task write = WriteLineAndFlushAsync(json, writeCancellation);
+            Task write = WriteLineAsync(json, writeCancellation);
+            _testHooks?.ResponseWriteStarted?.Invoke();
             Task cancellation = Task.Delay(Timeout.InfiniteTimeSpan, writeCancellation);
             Task completed = await Task.WhenAny(write, cancellation).ConfigureAwait(false);
 
@@ -402,6 +490,12 @@ internal sealed class PluginConnection : IAsyncDisposable
             {
                 TerminateConnection();
                 releaseWriteLock = await ObserveTerminatedWriteAsync(write).ConfigureAwait(false);
+
+                if (!releaseWriteLock)
+                {
+                    MarkUnobservedWrite();
+                }
+
                 writeCancellation.ThrowIfCancellationRequested();
             }
 
@@ -425,10 +519,13 @@ internal sealed class PluginConnection : IAsyncDisposable
         }
     }
 
-    private async Task WriteLineAndFlushAsync(string json, CancellationToken cancellationToken)
+    private async Task WriteLineAsync(
+        string json,
+        CancellationToken cancellationToken,
+        Action? lineWritten = null)
     {
         await _process.StandardInput.WriteLineAsync(json.AsMemory(), cancellationToken).ConfigureAwait(false);
-        await _process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+        lineWritten?.Invoke();
     }
 
     private static async Task<bool> ObserveTerminatedWriteAsync(Task write)
@@ -446,6 +543,14 @@ internal sealed class PluginConnection : IAsyncDisposable
             || ex is OperationCanceledException)
         {
             return true;
+        }
+    }
+
+    private void MarkUnobservedWrite()
+    {
+        lock (_pendingGate)
+        {
+            _hasUnobservedWrite = true;
         }
     }
 
@@ -494,14 +599,21 @@ internal sealed class PluginConnection : IAsyncDisposable
         using (EnterPendingGate())
         {
             canSendClose = _acceptingRequests && _pending.IsEmpty;
-            _acceptingRequests = false;
             _terminated |= terminated;
+            _testHooks?.TerminalPublicationStarting?.Invoke();
+            _closed.TrySetResult();
+            _acceptingRequests = false;
+            _testHooks?.ConnectionAdmissionClosed?.Invoke(
+                (_closed.Task.IsCompleted, Monitor.IsEntered(_pendingGate)));
             pending = [.. _pending.Values];
             _testHooks?.PendingSnapshotCaptured?.Invoke(Monitor.IsEntered(_pendingGate));
             _pending.Clear();
-        }
 
-        _closed.TrySetResult();
+            if (_activeOperations == 0)
+            {
+                _quiesced.TrySetResult();
+            }
+        }
 
         foreach (PendingRequest request in pending)
         {
@@ -568,7 +680,27 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         public Action? TerminalSettlementAttempted { get; init; }
 
+        public Action? TerminalPublicationStarting { get; init; }
+
         public Action<bool>? PendingSnapshotCaptured { get; init; }
+
+        public Action<(bool ClosedPublished, bool GateHeld)>? ConnectionAdmissionClosed { get; init; }
+
+        public Action? RequestWriteStarted { get; init; }
+
+        public Action? RequestWriteStarting { get; init; }
+
+        public Action? RequestWriteInterrupted { get; init; }
+
+        public Action? RequestWriteFailed { get; init; }
+
+        public Action? ResponseWriteStarted { get; init; }
+
+        public Action<string>? RequestLineWritten { get; init; }
+
+        public Func<Task?>? RequestWriteOverride { get; init; }
+
+        public Action<bool>? ConnectionResourcesDisposing { get; init; }
     }
 
     /// <summary>
@@ -656,8 +788,54 @@ internal sealed class PluginConnection : IAsyncDisposable
                 break;
 
             case MessageTypes.Request:
-                _ = Task.Run(() => HandleInboundRequestAsync(requestId, method, payload));
+                if (TryBeginInboundOperation())
+                {
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await HandleInboundRequestAsync(requestId, method, payload).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            CompleteActiveOperation();
+                        }
+                    });
+                }
+
                 break;
+        }
+    }
+
+    private bool TryBeginInboundOperation()
+    {
+        lock (_pendingGate)
+        {
+            if (!_acceptingRequests)
+            {
+                return false;
+            }
+
+            _activeOperations++;
+            return true;
+        }
+    }
+
+    private void CompleteActiveOperation()
+    {
+        lock (_pendingGate)
+        {
+            CompleteActiveOperationUnderLock();
+        }
+    }
+
+    private void CompleteActiveOperationUnderLock()
+    {
+        _activeOperations--;
+
+        if (!_acceptingRequests && _activeOperations == 0)
+        {
+            _quiesced.TrySetResult();
         }
     }
 
@@ -837,6 +1015,23 @@ internal sealed class PluginConnection : IAsyncDisposable
             }
         }
 
+        await Quiesced.ConfigureAwait(false);
+        bool resourcesCanDispose;
+
+        lock (_pendingGate)
+        {
+            resourcesCanDispose = _activeOperations == 0 && !_hasUnobservedWrite;
+        }
+
+        _testHooks?.ConnectionResourcesDisposing?.Invoke(resourcesCanDispose);
+
+        if (!resourcesCanDispose)
+        {
+            // A transport write remained blocked even after process termination. Retain every
+            // resource it may still touch; the terminal connection is never reused.
+            return;
+        }
+
         _process.Dispose();
         _writeLock.Dispose();
         _shutdown.Dispose();
@@ -857,8 +1052,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         private readonly CancellationTokenSource _writeCancellation = new();
         private readonly TaskCompletionSource<JsonElement?> _completion =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _preemption =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _writeCompleted;
         private int _state;
 
         public PendingRequest(TimeSpan timeout, CancellationToken callerCancellation)
@@ -877,11 +1071,13 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         public Task<JsonElement?> Completion => _completion.Task;
 
-        public bool IsPreempted => Volatile.Read(ref _state) is TimedOut or CallerCanceled or ConnectionClosed;
-
-        public Task Preemption => _preemption.Task;
+        public bool ShouldRetryClosedConnection =>
+            Volatile.Read(ref _state) == ConnectionClosed
+            && Volatile.Read(ref _writeCompleted) == 0;
 
         public CancellationToken WriteCancellation => _writeCancellation.Token;
+
+        public void MarkWriteCompleted() => Volatile.Write(ref _writeCompleted, 1);
 
         public void Extend()
         {
@@ -904,6 +1100,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (TryTransition(Completed))
             {
+                SignalWriteCancellation();
                 _completion.TrySetResult(payload);
             }
         }
@@ -912,6 +1109,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (TryTransition(Completed))
             {
+                SignalWriteCancellation();
                 _completion.TrySetException(exception);
             }
         }
@@ -920,16 +1118,10 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (TryTransition(ConnectionClosed))
             {
-                SignalPreemption();
+                SignalWriteCancellation();
                 _completion.TrySetException(
                     new IOException("Credential plugin closed the connection."));
             }
-        }
-
-        public async Task ThrowCompletionAsync()
-        {
-            _ = await _completion.Task.ConfigureAwait(false);
-            throw new InvalidOperationException("A preempted plugin request completed successfully.");
         }
 
         private bool TryTransition(int state) =>
@@ -939,7 +1131,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (TryTransition(TimedOut))
             {
-                SignalPreemption();
+                SignalWriteCancellation();
                 _completion.TrySetException(
                     new TimeoutException("Credential plugin did not respond in time."));
             }
@@ -949,15 +1141,13 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (TryTransition(CallerCanceled))
             {
-                SignalPreemption();
+                SignalWriteCancellation();
                 _completion.TrySetCanceled(_callerCancellation);
             }
         }
 
-        private void SignalPreemption()
+        private void SignalWriteCancellation()
         {
-            _preemption.TrySetResult();
-
             try
             {
                 _writeCancellation.Cancel();

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -701,6 +701,8 @@ internal sealed class PluginConnection : IAsyncDisposable
         public Func<Task?>? RequestWriteOverride { get; init; }
 
         public Action<bool>? ConnectionResourcesDisposing { get; init; }
+
+        public Action? ConnectionQuiescenceAwaiting { get; init; }
     }
 
     /// <summary>
@@ -1015,6 +1017,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             }
         }
 
+        _testHooks?.ConnectionQuiescenceAwaiting?.Invoke();
         await Quiesced.ConfigureAwait(false);
         bool resourcesCanDispose;
 

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -337,7 +337,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         {
             if (registered)
             {
-                lock (_pendingGate)
+                using (EnterPendingGate())
                 {
                     _pending.TryRemove(requestId, out _);
                     CompleteActiveOperationUnderLock();
@@ -387,7 +387,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             await _writeLock.WaitAsync(pending.WriteCancellation).ConfigureAwait(false);
             lockTaken = true;
 
-            lock (_pendingGate)
+            using (EnterPendingGate())
             {
                 if (!_acceptingRequests)
                 {
@@ -478,7 +478,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             await _writeLock.WaitAsync(writeCancellation).ConfigureAwait(false);
             lockTaken = true;
 
-            lock (_pendingGate)
+            using (EnterPendingGate())
             {
                 if (_terminated || (!_acceptingRequests && !allowClosedConnection))
                 {
@@ -553,7 +553,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     private void MarkUnobservedWrite()
     {
-        lock (_pendingGate)
+        using (EnterPendingGate())
         {
             _hasUnobservedWrite = true;
         }
@@ -816,7 +816,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     private bool TryBeginInboundOperation()
     {
-        lock (_pendingGate)
+        using (EnterPendingGate())
         {
             if (!_acceptingRequests)
             {
@@ -830,7 +830,7 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     private void CompleteActiveOperation()
     {
-        lock (_pendingGate)
+        using (EnterPendingGate())
         {
             CompleteActiveOperationUnderLock();
         }
@@ -1026,7 +1026,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         await Quiesced.ConfigureAwait(false);
         bool resourcesCanDispose;
 
-        lock (_pendingGate)
+        using (EnterPendingGate())
         {
             resourcesCanDispose = _activeOperations == 0 && !_hasUnobservedWrite;
         }

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -43,6 +43,7 @@ internal sealed class PluginConnection : IAsyncDisposable
     private Task? _readLoop;
     private long _pendingGateEntry;
     private bool _acceptingRequests = true;
+    private bool _terminated;
     private bool _disposed;
 
     private PluginConnection(
@@ -237,7 +238,7 @@ internal sealed class PluginConnection : IAsyncDisposable
         cancellationToken.ThrowIfCancellationRequested();
 
         string requestId = Guid.NewGuid().ToString();
-        var pending = new PendingRequest(_requestTimeout);
+        var pending = new PendingRequest(_requestTimeout, cancellationToken);
 
         try
         {
@@ -258,14 +259,12 @@ internal sealed class PluginConnection : IAsyncDisposable
                     (gate.Entry, Monitor.IsEntered(_pendingGate)));
             }
 
-            await WriteAsync(
+            await WriteRequestAsync(
                 new Envelope<TRequest>(requestId, MessageTypes.Request, method, payload),
                 requestType,
-                cancellationToken).ConfigureAwait(false);
+                pending).ConfigureAwait(false);
 
-            JsonElement? responsePayload = await pending.Completion.Task
-                .WaitAsync(cancellationToken)
-                .ConfigureAwait(false);
+            JsonElement? responsePayload = await pending.Completion.ConfigureAwait(false);
 
             return responsePayload?.Deserialize(responseType);
         }
@@ -292,21 +291,161 @@ internal sealed class PluginConnection : IAsyncDisposable
             _ => false,
         };
 
-    private async Task WriteAsync<T>(Envelope<T> envelope, JsonTypeInfo<Envelope<T>> type, CancellationToken cancellationToken)
+    private async Task WriteRequestAsync<T>(
+        Envelope<T> envelope,
+        JsonTypeInfo<Envelope<T>> type,
+        PendingRequest pending)
     {
         string json = JsonSerializer.Serialize(envelope, type);
-
-        // Writes are serialized so two concurrent requests cannot interleave halves of a line.
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        bool lockTaken = false;
+        bool releaseWriteLock = true;
+        bool preempted = false;
 
         try
         {
-            await _process.StandardInput.WriteLineAsync(json.AsMemory(), cancellationToken).ConfigureAwait(false);
-            await _process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await _writeLock.WaitAsync(pending.WriteCancellation).ConfigureAwait(false);
+            lockTaken = true;
+
+            lock (_pendingGate)
+            {
+                if (!_acceptingRequests)
+                {
+                    throw new IOException("Credential plugin closed the connection.");
+                }
+            }
+
+            Task write = WriteLineAndFlushAsync(json, pending.WriteCancellation);
+            Task completed = await Task.WhenAny(write, pending.Preemption).ConfigureAwait(false);
+
+            if (!ReferenceEquals(completed, write))
+            {
+                preempted = true;
+                TerminateConnection();
+                releaseWriteLock = await ObserveTerminatedWriteAsync(write).ConfigureAwait(false);
+            }
+            else
+            {
+                await write.ConfigureAwait(false);
+            }
+        }
+        catch (Exception) when (pending.IsPreempted)
+        {
+            preempted = true;
+
+            if (lockTaken)
+            {
+                TerminateConnection();
+            }
+        }
+        catch
+        {
+            if (lockTaken)
+            {
+                TerminateConnection();
+            }
+
+            throw;
         }
         finally
         {
-            _writeLock.Release();
+            if (lockTaken && releaseWriteLock)
+            {
+                _writeLock.Release();
+            }
+        }
+
+        if (preempted)
+        {
+            await pending.ThrowCompletionAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task WriteAsync<T>(
+        Envelope<T> envelope,
+        JsonTypeInfo<Envelope<T>> type,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout = null,
+        bool allowClosedConnection = false)
+    {
+        string json = JsonSerializer.Serialize(envelope, type);
+        using CancellationTokenSource? timeoutCancellation = timeout is null
+            ? null
+            : new CancellationTokenSource(timeout.Value);
+        using CancellationTokenSource? linkedCancellation = timeoutCancellation is null
+            ? null
+            : CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                timeoutCancellation.Token);
+        CancellationToken writeCancellation = linkedCancellation?.Token ?? cancellationToken;
+        bool lockTaken = false;
+        bool releaseWriteLock = true;
+
+        // Writes are serialized so two concurrent requests cannot interleave halves of a line.
+        try
+        {
+            await _writeLock.WaitAsync(writeCancellation).ConfigureAwait(false);
+            lockTaken = true;
+
+            lock (_pendingGate)
+            {
+                if (_terminated || (!_acceptingRequests && !allowClosedConnection))
+                {
+                    throw new IOException("Credential plugin closed the connection.");
+                }
+            }
+
+            Task write = WriteLineAndFlushAsync(json, writeCancellation);
+            Task cancellation = Task.Delay(Timeout.InfiniteTimeSpan, writeCancellation);
+            Task completed = await Task.WhenAny(write, cancellation).ConfigureAwait(false);
+
+            if (!ReferenceEquals(completed, write))
+            {
+                TerminateConnection();
+                releaseWriteLock = await ObserveTerminatedWriteAsync(write).ConfigureAwait(false);
+                writeCancellation.ThrowIfCancellationRequested();
+            }
+
+            await write.ConfigureAwait(false);
+        }
+        catch
+        {
+            if (lockTaken || timeoutCancellation?.IsCancellationRequested is true)
+            {
+                TerminateConnection();
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (lockTaken && releaseWriteLock)
+            {
+                _writeLock.Release();
+            }
+        }
+    }
+
+    private async Task WriteLineAndFlushAsync(string json, CancellationToken cancellationToken)
+    {
+        await _process.StandardInput.WriteLineAsync(json.AsMemory(), cancellationToken).ConfigureAwait(false);
+        await _process.StandardInput.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<bool> ObserveTerminatedWriteAsync(Task write)
+    {
+        try
+        {
+            await write.WaitAsync(ExitWaitAfterClose).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+        catch (Exception ex) when (IsRecoverableRequestFailure(ex)
+            || ex is OperationCanceledException)
+        {
+            return true;
         }
     }
 
@@ -341,19 +480,22 @@ internal sealed class PluginConnection : IAsyncDisposable
         }
         finally
         {
-            SettleClosedConnection();
+            _ = SettleClosedConnection();
         }
     }
 
-    private void SettleClosedConnection()
+    private bool SettleClosedConnection(bool terminated = false)
     {
         PendingRequest[] pending;
+        bool canSendClose;
 
         _testHooks?.TerminalSettlementAttempted?.Invoke();
 
         using (EnterPendingGate())
         {
+            canSendClose = _acceptingRequests && _pending.IsEmpty;
             _acceptingRequests = false;
+            _terminated |= terminated;
             pending = [.. _pending.Values];
             _testHooks?.PendingSnapshotCaptured?.Invoke(Monitor.IsEntered(_pendingGate));
             _pending.Clear();
@@ -363,8 +505,38 @@ internal sealed class PluginConnection : IAsyncDisposable
 
         foreach (PendingRequest request in pending)
         {
-            request.Completion.TrySetException(
-                new IOException("Credential plugin closed the connection."));
+            request.TrySetConnectionClosed();
+        }
+
+        return canSendClose;
+    }
+
+    private void TerminateConnection()
+    {
+        _ = SettleClosedConnection(terminated: true);
+
+        try
+        {
+            _shutdown.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposal already completed the same terminal transition.
+        }
+
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException
+            or NotSupportedException
+            or AggregateException
+            or System.ComponentModel.Win32Exception)
+        {
+            // The process exited concurrently or does not support tree termination.
         }
     }
 
@@ -459,7 +631,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             case MessageTypes.Response:
                 if (_pending.TryGetValue(requestId, out PendingRequest? completed))
                 {
-                    completed.Completion.TrySetResult(payload);
+                    completed.TrySetResult(payload);
                 }
 
                 break;
@@ -477,7 +649,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             case MessageTypes.Fault:
                 if (_pending.TryGetValue(requestId, out PendingRequest? faulted))
                 {
-                    faulted.Completion.TrySetException(
+                    faulted.TrySetException(
                         new IOException($"Credential plugin faulted on '{method}'."));
                 }
 
@@ -504,7 +676,8 @@ internal sealed class PluginConnection : IAsyncDisposable
                             MessageMethods.Handshake,
                             NegotiateHandshake(payload)),
                         PluginJsonContext.Default.EnvelopeHandshakeResponse,
-                        _shutdown.Token).ConfigureAwait(false);
+                        _shutdown.Token,
+                        _requestTimeout).ConfigureAwait(false);
                     break;
 
                 case MessageMethods.Log:
@@ -532,7 +705,8 @@ internal sealed class PluginConnection : IAsyncDisposable
                                     ? ResponseCodes.Error
                                     : ResponseCodes.Success)),
                         PluginJsonContext.Default.EnvelopeLogResponse,
-                        _shutdown.Token).ConfigureAwait(false);
+                        _shutdown.Token,
+                        _requestTimeout).ConfigureAwait(false);
                     break;
             }
         }
@@ -616,17 +790,21 @@ internal sealed class PluginConnection : IAsyncDisposable
         }
 
         _disposed = true;
-        SettleClosedConnection();
+        bool canSendClose = SettleClosedConnection();
 
         try
         {
             // Close carries no payload and expects no response; NuGet sends it, waits briefly,
             // then kills the process regardless.
-            using var closeTimeout = new CancellationTokenSource(CloseTimeout);
-            await WriteAsync(
-                new Envelope<object>(Guid.NewGuid().ToString(), MessageTypes.Request, MessageMethods.Close, null),
-                PluginJsonContext.Default.EnvelopeObject,
-                closeTimeout.Token).ConfigureAwait(false);
+            if (canSendClose)
+            {
+                using var closeTimeout = new CancellationTokenSource(CloseTimeout);
+                await WriteAsync(
+                    new Envelope<object>(Guid.NewGuid().ToString(), MessageTypes.Request, MessageMethods.Close, null),
+                    PluginJsonContext.Default.EnvelopeObject,
+                    closeTimeout.Token,
+                    allowClosedConnection: true).ConfigureAwait(false);
+            }
         }
         catch
         {
@@ -666,25 +844,52 @@ internal sealed class PluginConnection : IAsyncDisposable
 
     private sealed class PendingRequest : IDisposable
     {
+        private const int Active = 0;
+        private const int Completed = 1;
+        private const int TimedOut = 2;
+        private const int CallerCanceled = 3;
+        private const int ConnectionClosed = 4;
+
         private readonly TimeSpan _timeout;
         private readonly Timer _timer;
+        private readonly CancellationToken _callerCancellation;
+        private readonly CancellationTokenRegistration _callerRegistration;
+        private readonly CancellationTokenSource _writeCancellation = new();
+        private readonly TaskCompletionSource<JsonElement?> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _preemption =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _state;
 
-        public PendingRequest(TimeSpan timeout)
+        public PendingRequest(TimeSpan timeout, CancellationToken callerCancellation)
         {
             _timeout = timeout;
-            Completion = new TaskCompletionSource<JsonElement?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _callerCancellation = callerCancellation;
             _timer = new Timer(
-                static state => ((PendingRequest)state!).Completion.TrySetException(
-                    new TimeoutException("Credential plugin did not respond in time.")),
+                static state => ((PendingRequest)state!).OnTimeout(),
                 this,
                 timeout,
                 Timeout.InfiniteTimeSpan);
+            _callerRegistration = callerCancellation.Register(
+                static state => ((PendingRequest)state!).CancelByCaller(),
+                this);
         }
 
-        public TaskCompletionSource<JsonElement?> Completion { get; }
+        public Task<JsonElement?> Completion => _completion.Task;
+
+        public bool IsPreempted => Volatile.Read(ref _state) is TimedOut or CallerCanceled or ConnectionClosed;
+
+        public Task Preemption => _preemption.Task;
+
+        public CancellationToken WriteCancellation => _writeCancellation.Token;
 
         public void Extend()
         {
+            if (Volatile.Read(ref _state) != Active)
+            {
+                return;
+            }
+
             try
             {
                 _timer.Change(_timeout, Timeout.InfiniteTimeSpan);
@@ -695,6 +900,79 @@ internal sealed class PluginConnection : IAsyncDisposable
             }
         }
 
-        public void Dispose() => _timer.Dispose();
+        public void TrySetResult(JsonElement? payload)
+        {
+            if (TryTransition(Completed))
+            {
+                _completion.TrySetResult(payload);
+            }
+        }
+
+        public void TrySetException(Exception exception)
+        {
+            if (TryTransition(Completed))
+            {
+                _completion.TrySetException(exception);
+            }
+        }
+
+        public void TrySetConnectionClosed()
+        {
+            if (TryTransition(ConnectionClosed))
+            {
+                SignalPreemption();
+                _completion.TrySetException(
+                    new IOException("Credential plugin closed the connection."));
+            }
+        }
+
+        public async Task ThrowCompletionAsync()
+        {
+            _ = await _completion.Task.ConfigureAwait(false);
+            throw new InvalidOperationException("A preempted plugin request completed successfully.");
+        }
+
+        private bool TryTransition(int state) =>
+            Interlocked.CompareExchange(ref _state, state, Active) == Active;
+
+        private void OnTimeout()
+        {
+            if (TryTransition(TimedOut))
+            {
+                SignalPreemption();
+                _completion.TrySetException(
+                    new TimeoutException("Credential plugin did not respond in time."));
+            }
+        }
+
+        private void CancelByCaller()
+        {
+            if (TryTransition(CallerCanceled))
+            {
+                SignalPreemption();
+                _completion.TrySetCanceled(_callerCancellation);
+            }
+        }
+
+        private void SignalPreemption()
+        {
+            _preemption.TrySetResult();
+
+            try
+            {
+                _writeCancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The request finished while preemption was being delivered.
+            }
+        }
+
+        public void Dispose()
+        {
+            _callerRegistration.Dispose();
+            _timer.Dispose();
+            _writeCancellation.Dispose();
+        }
     }
 }

--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -136,6 +136,11 @@ internal sealed class PluginConnection : IAsyncDisposable
                 return connection;
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
         catch (Exception ex)
         {
             log?.Invoke($"Credential plugin initialization failed ({plugin.Path}): {ex.Message}");

--- a/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
+++ b/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
@@ -195,6 +195,7 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
                 }
 
                 await existing.DisposeAsync().ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
                 _connections.Remove(executable.Path);
             }
 

--- a/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
+++ b/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
@@ -24,6 +24,7 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
     private readonly SemaphoreSlim _gate = new(1, 1);
     private readonly Lazy<IReadOnlyList<PluginExecutable>> _executables;
     private readonly Dictionary<string, PluginConnection?> _connections = new(StringComparer.Ordinal);
+    private readonly PluginConnection.PluginConnectionTestHooks? _testHooks;
     private bool _disposed;
 
     /// <summary>Creates a provider over the plugins visible to this process.</summary>
@@ -37,9 +38,13 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
     }
 
     /// <summary>Creates a provider over an explicit plugin list, bypassing discovery. For tests.</summary>
-    internal PluginCredentialProvider(Action<string>? log, IReadOnlyList<PluginExecutable> executables)
+    internal PluginCredentialProvider(
+        Action<string>? log,
+        IReadOnlyList<PluginExecutable> executables,
+        PluginConnection.PluginConnectionTestHooks? testHooks = null)
     {
         _log = log;
+        _testHooks = testHooks;
         PluginExecutable[] snapshot = [.. executables];
         _executables = new(() => snapshot, LazyThreadSafetyMode.ExecutionAndPublication);
     }
@@ -102,16 +107,39 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
 
         foreach (PluginExecutable executable in executables)
         {
-            PluginConnection? connection = await GetConnectionAsync(executable, cancellationToken).ConfigureAwait(false);
+            GetAuthenticationCredentialsResponse? response = null;
 
-            if (connection is null)
+            for (int attempt = 0; attempt < 2; attempt++)
             {
-                continue;
-            }
+                PluginConnection? connection = await GetConnectionAsync(executable, cancellationToken).ConfigureAwait(false);
 
-            GetAuthenticationCredentialsResponse? response = await connection
-                .GetCredentialsAsync(uri, isRetry, !AllowInteractive, AllowInteractive, cancellationToken)
-                .ConfigureAwait(false);
+                if (connection is null)
+                {
+                    break;
+                }
+
+                try
+                {
+                    response = await connection
+                        .GetCredentialsForProviderAsync(
+                            uri,
+                            isRetry,
+                            !AllowInteractive,
+                            AllowInteractive,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    break;
+                }
+                catch (PluginConnection.ConnectionClosedBeforeRequestException) when (attempt == 0)
+                {
+                    // The selected connection closed before this request reached the pipe.
+                    // The next iteration replaces it and retries exactly once.
+                }
+                catch (PluginConnection.ConnectionClosedBeforeRequestException)
+                {
+                    break;
+                }
+            }
 
             if (response is null)
             {
@@ -171,7 +199,7 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
             }
 
             PluginConnection? connection = await PluginConnection
-                .StartAsync(executable, _log, cancellationToken)
+                .StartAsync(executable, _log, cancellationToken, _testHooks)
                 .ConfigureAwait(false);
 
             _connections[executable.Path] = connection;

--- a/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
+++ b/src/NuGetFetch/Plugins/PluginCredentialProvider.cs
@@ -11,7 +11,8 @@ namespace NuGetFetch.Plugins;
 /// environment macros, and clear text.
 /// </para>
 /// <para>
-/// Plugins are discovered and started lazily, then kept for the lifetime of this object.
+/// Plugins are discovered and started lazily, then kept until the connection closes or this
+/// object is disposed. A later request restarts a plugin whose prior connection terminated.
 /// Discovery scans the NuGet convention directory and <c>PATH</c>, while starting one costs a
 /// process launch plus a five-message initialization handshake. Deferring both means commands
 /// that never receive an authentication challenge pay neither cost.
@@ -160,7 +161,13 @@ public sealed class PluginCredentialProvider : ICredentialSource, IAsyncDisposab
             // not claim Authentication. Either way there is no point paying to launch it again.
             if (_connections.TryGetValue(executable.Path, out PluginConnection? existing))
             {
-                return existing;
+                if (existing is null || !existing.Closed.IsCompleted)
+                {
+                    return existing;
+                }
+
+                await existing.DisposeAsync().ConfigureAwait(false);
+                _connections.Remove(executable.Path);
             }
 
             PluginConnection? connection = await PluginConnection


### PR DESCRIPTION
Closes #5035.

Top slice of the credential-plugin lifecycle stack.

- Parent: #5045
- Base branch: `fix/plugin-terminal-admission`
- Bottom slice: #5044

Plugin request deadlines and caller cancellation now cover waiting for the
serialized writer, an in-progress pipe write, and the response. If timeout or
cancellation preempts an active writer, the connection terminates before the
writer can be reused, the initiating request keeps its timeout or cancellation
outcome, and queued peers settle as connection-closed.

Inbound protocol-response writes are bounded by the same connection teardown
rule. A later credential request lazily restarts a cached plugin whose previous
connection terminated.

This implements the stalled-writer containment obligations modeled by #5026.

## Demo

The real-process fixture completes plugin initialization, stops consuming
stdin, and receives a multi-megabyte credential request that fills the pipe:

```text
active writer times out -> connection terminated -> queued peer: connection closed
active writer canceled  -> caller cancellation   -> queued peer: connection closed
later request            -> no write to old pipe -> plugin may restart cleanly
```

The tests use bounds well below the plugin's ordinary stalled behavior, showing
that completion comes from teardown rather than eventual pipe progress.

## Validation

- `dotnet run --project src/NuGetFetch.Tests -c Release -- -method '*StalledWriter*' -method '*ClosedCachedPluginConnection*' -method '*ReceiverLoss*'`
- `dotnet run --project src/NuGetFetch.Tests -c Release --no-build`
- `npx markdownlint-cli docs/design/nuget-authentication.md docs/design/models/nuget-plugin-session-lifecycle/README.md`
- `git diff --check`
