### PR TITLE
Extract generic constraint classifier

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -830,6 +830,14 @@ Research overlay bridge, and the application layer:
   acquiring method bodies itself;
   `OptimizationOpportunities_StableReceiverGetter_IsClassifiedOnce` gates the
   shared cache.
+  `LibraryBodyGenericConstraintClassifier` owns generic-constraint presence
+  over any supplied metadata reader and primary-image generic-parameter
+  value-type eligibility. The primary resolver and async-sibling services
+  consume those two judgments without duplicating constraint policy;
+  `OptimizationOpportunities_GenericObjectEqualsBox_IsReported`,
+  `OptimizationOpportunities_GenericObjectEqualsNearMiss_NotReported`, and
+  `OptimizationOpportunities_FindSyncCallsWithAsyncSiblings` gate the shared
+  behavior.
   `CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn`,
   `OptimizationOpportunities_AsyncStateMachine_IsAmortized`, and
   `Allocations_ClassifiesCrossAndInAssemblyValueTypeNewobj_ByShape` gate

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -326,6 +326,14 @@ PE-backed readonly-field getter judgment and its acquisition-scoped cache;
 `OptimizationOpportunities_StableReceiverGetter_IsClassifiedOnce` gates that
 the optimization adapter shares one classification. The classifier does not
 own optimization policy or general method-body scheduling.
+`LibraryBodyGenericConstraintClassifier` owns generic-constraint presence for
+reader-relative async-sibling analysis and primary-image generic-parameter
+value-type eligibility for optimization analysis. It does not own sibling
+selection or opportunity policy.
+`OptimizationOpportunities_GenericObjectEqualsBox_IsReported`,
+`OptimizationOpportunities_GenericObjectEqualsNearMiss_NotReported`, and
+`OptimizationOpportunities_FindSyncCallsWithAsyncSiblings` gate those
+judgments.
 `LibraryBodyMethodReferenceResolver` owns the acquisition-scoped
 structural signature and generic-scope identities, canonical
 `MemberRef`/`MethodSpec` resolution caches, and their shared assembly work

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
@@ -25,6 +24,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
     readonly PEReader _peReader;
     readonly LibraryBodyPrimaryMetadataResolver
         _primaryMetadataResolver;
+    readonly LibraryBodyGenericConstraintClassifier
+        _genericConstraintClassifier;
     readonly LibraryBodyStableReceiverGetterClassifier
         _stableReceiverGetterClassifier;
     readonly LibraryBodyMethodReferenceResolver
@@ -95,6 +96,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
             new LibraryBodyMethodReferenceResolver(
                 reader,
                 methodReferenceResolved);
+        _genericConstraintClassifier =
+            new LibraryBodyGenericConstraintClassifier(reader);
         _stableReceiverGetterClassifier =
             new LibraryBodyStableReceiverGetterClassifier(
                 reader,
@@ -106,7 +109,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                 _assemblyName,
                 _mvid,
                 _methodReferenceResolver.ResolveMethod,
-                GenericParameterCanBeValueType,
+                _genericConstraintClassifier
+                    .GenericParameterCanBeValueType,
                 _stableReceiverGetterClassifier
                     .IsStableReceiverGetter,
                 asyncStateMachineTypesBuilt);
@@ -148,7 +152,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                 reader,
                 ResolveExternalAsyncSiblingTypeDefinition,
                 _asyncSiblingMethodIndex,
-                HasGenericConstraints);
+                _genericConstraintClassifier
+                    .HasGenericConstraints);
         _asyncSiblingAccessibilityAnalyzer =
             new LibraryBodyAsyncSiblingAccessibilityAnalyzer(
                 reader,
@@ -162,7 +167,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                 _asyncSiblingMethodIndex,
                 _asyncSiblingDispatchAnalyzer,
                 _asyncSiblingAccessibilityAnalyzer,
-                HasGenericConstraints);
+                _genericConstraintClassifier
+                    .HasGenericConstraints);
     }
 
     public void Dispose() =>
@@ -666,23 +672,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
         return inherited;
     }
 
-    static bool HasGenericConstraints(
-        MetadataReader reader,
-        MethodDefinition method)
-    {
-        foreach (var handle in method.GetGenericParameters())
-        {
-            var parameter = reader.GetGenericParameter(handle);
-            if (parameter.Attributes
-                    != GenericParameterAttributes.None
-                || parameter.GetConstraints().Count > 0)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
     (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
     {
         if (constructor.Kind == HandleKind.MemberReference
@@ -697,79 +686,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
             return (_reader.GetString(declType.Namespace), _reader.GetString(declType.Name));
         }
         return ("", "");
-    }
-
-    bool GenericParameterCanBeValueType(
-        TypeRef genericParameter,
-        MethodIdentity caller)
-    {
-        try
-        {
-            var methodHandle = (MethodDefinitionHandle)
-                MetadataTokens.EntityHandle(caller.MetadataToken);
-            var method = _reader.GetMethodDefinition(methodHandle);
-            GenericParameterHandleCollection handles =
-                genericParameter.Kind == TypeRefKind.MethodGenericParameter
-                    ? method.GetGenericParameters()
-                    : _reader.GetTypeDefinition(method.GetDeclaringType())
-                        .GetGenericParameters();
-            if (genericParameter.GenericParameterIndex < 0
-                || genericParameter.GenericParameterIndex >= handles.Count)
-            {
-                return false;
-            }
-
-            var handle = handles.ElementAt(
-                genericParameter.GenericParameterIndex);
-            var parameter = _reader.GetGenericParameter(handle);
-            if ((parameter.Attributes
-                    & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
-            {
-                return false;
-            }
-
-            foreach (var constraintHandle in parameter.GetConstraints())
-            {
-                EntityHandle constraint =
-                    _reader.GetGenericParameterConstraint(constraintHandle).Type;
-                if (!ConstraintCanIncludeValueType(constraint))
-                    return false;
-            }
-            return true;
-        }
-        catch (Exception ex) when (ex is BadImageFormatException
-            or InvalidOperationException
-            or ArgumentException
-            or OverflowException
-            or InvalidCastException)
-        {
-            return false;
-        }
-    }
-
-    bool ConstraintCanIncludeValueType(EntityHandle constraint)
-    {
-        if (constraint.Kind == HandleKind.TypeDefinition)
-        {
-            TypeAttributes attributes = _reader
-                .GetTypeDefinition((TypeDefinitionHandle)constraint)
-                .Attributes;
-            return (attributes & TypeAttributes.Interface) != 0;
-        }
-
-        if (constraint.Kind == HandleKind.TypeReference)
-        {
-            var reference = _reader.GetTypeReference(
-                (TypeReferenceHandle)constraint);
-            string @namespace = _reader.GetString(reference.Namespace);
-            string name = _reader.GetString(reference.Name);
-            return @namespace == "System"
-                && name is "ValueType" or "Enum";
-        }
-
-        // Type specifications and generic-parameter constraints cannot be
-        // proven here to admit a value-type instantiation.
-        return false;
     }
 
     TypeRef TypeFromEntity(EntityHandle handle)

--- a/src/ILInspector.Analysis/LibraryBodyGenericConstraintClassifier.cs
+++ b/src/ILInspector.Analysis/LibraryBodyGenericConstraintClassifier.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Classifies generic-constraint facts for primary-image optimization analysis
+/// and reader-relative async-sibling analysis.
+/// </summary>
+internal sealed class LibraryBodyGenericConstraintClassifier(
+    MetadataReader reader)
+{
+    readonly MetadataReader _reader = reader;
+
+    internal bool HasGenericConstraints(
+        MetadataReader declaringReader,
+        MethodDefinition method)
+    {
+        foreach (var handle in method.GetGenericParameters())
+        {
+            var parameter =
+                declaringReader.GetGenericParameter(handle);
+            if (parameter.Attributes
+                    != GenericParameterAttributes.None
+                || parameter.GetConstraints().Count > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    internal bool GenericParameterCanBeValueType(
+        TypeRef genericParameter,
+        MethodIdentity caller)
+    {
+        try
+        {
+            var methodHandle = (MethodDefinitionHandle)
+                MetadataTokens.EntityHandle(caller.MetadataToken);
+            var method = _reader.GetMethodDefinition(methodHandle);
+            GenericParameterHandleCollection handles =
+                genericParameter.Kind == TypeRefKind.MethodGenericParameter
+                    ? method.GetGenericParameters()
+                    : _reader.GetTypeDefinition(method.GetDeclaringType())
+                        .GetGenericParameters();
+            if (genericParameter.GenericParameterIndex < 0
+                || genericParameter.GenericParameterIndex >= handles.Count)
+            {
+                return false;
+            }
+
+            var handle = handles.ElementAt(
+                genericParameter.GenericParameterIndex);
+            var parameter = _reader.GetGenericParameter(handle);
+            if ((parameter.Attributes
+                    & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+            {
+                return false;
+            }
+
+            foreach (var constraintHandle in parameter.GetConstraints())
+            {
+                EntityHandle constraint =
+                    _reader.GetGenericParameterConstraint(
+                        constraintHandle).Type;
+                if (!ConstraintCanIncludeValueType(constraint))
+                    return false;
+            }
+            return true;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException
+            or InvalidOperationException
+            or ArgumentException
+            or OverflowException
+            or InvalidCastException)
+        {
+            return false;
+        }
+    }
+
+    bool ConstraintCanIncludeValueType(EntityHandle constraint)
+    {
+        if (constraint.Kind == HandleKind.TypeDefinition)
+        {
+            TypeAttributes attributes = _reader
+                .GetTypeDefinition((TypeDefinitionHandle)constraint)
+                .Attributes;
+            return (attributes & TypeAttributes.Interface) != 0;
+        }
+
+        if (constraint.Kind == HandleKind.TypeReference)
+        {
+            var reference = _reader.GetTypeReference(
+                (TypeReferenceHandle)constraint);
+            string @namespace = _reader.GetString(reference.Namespace);
+            string name = _reader.GetString(reference.Name);
+            return @namespace == "System"
+                && name is "ValueType" or "Enum";
+        }
+
+        // Type specifications and generic-parameter constraints cannot be
+        // proven here to admit a value-type instantiation.
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

Extract shared generic-constraint classification from
`LibraryBodyAnalysisBuilder` into
`LibraryBodyGenericConstraintClassifier`.

The classifier owns two related metadata judgments:

- generic-constraint presence over a caller-supplied `MetadataReader`, used by
  async-sibling dispatch and candidate resolution, including external
  acquisition-scoped images;
- primary-image generic-parameter value-type eligibility, used by optimization
  analysis.

The builder now composes the classifier and passes its judgments to the
existing consumers. It retains metadata/image lifetime, scheduling, external
resolution synchronization, and generated-provenance classification.

No constraint semantics, async-sibling selection, optimization policy,
diagnostic, output, public API, dependency, platform, or metadata-lifetime
change is intended.

## Demo

The composition root now names one shared owner for policy that was previously
embedded in the builder:

```csharp
_genericConstraintClassifier =
    new LibraryBodyGenericConstraintClassifier(reader);
```

Its reader-relative judgment is shared by both async-sibling services, while
the primary resolver receives the primary-image value-type judgment. This
preserves external metadata correctness instead of accidentally classifying an
external method with the root image's reader.

`LibraryBodyAnalysisBuilder` shrinks from 803 to 709 lines. The extracted
classifier is 109 lines.

## Validation

- Release Analysis test-project build: zero warnings/errors.
- Focused generic-object-equals and async-sibling constraint gates: 8/8
  passed, zero skipped.
- Full Release Analysis suite: 1284/1284 passed, zero skipped, with
  `ilasm`/`ildasm` active.
- Five unrelated call-tree/image-retention failures from an earlier full-suite
  attempt passed unchanged in isolation before the clean full rerun.
- Post-`main` integration focused gate: 8/8 passed, zero skipped. The integrated
  range changed release/CLI documentation and decompiler code, not Analysis or
  its owning documents.
- Changed Markdown passes `markdownlint`.
- `git diff --check`.
