### PR TITLE
Narrow the caret to the changed sub-region, not the enclosing statement (#5022 items 2, 7)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -461,6 +461,103 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void CompareStructure_NarrowsUsingStatementSpanToHeaderAndStopsAnnotatingUnchangedBody()
+    {
+        // Reproduces the #4113 shape recorded in #4952 (issue #5022, items 2
+        // and 7): a disposed-only `using` resource is raised to the
+        // variable-less form. Only the header line's variable declaration
+        // changes; the body (`{`, `n = 1;`, `}`) is untouched. Previously the
+        // matched UsingStatement row's spans covered the whole construct, so
+        // RenderAnnotatedBody repeated a "construct; text changed"
+        // annotation on all four lines. Narrowing the row's spans to the
+        // printer's own recorded Header sub-region (a) confines the caret to
+        // the header line (item 2) and (b) stops annotating the unchanged
+        // body lines as a side effect, with no separate propagation step to
+        // suppress (item 7).
+        const string beforeText = """
+            int n = 0;
+            using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+            {
+                n = 1;
+            }
+            return n;
+            """;
+        const string afterText = """
+            int n = 0;
+            using (DisposableFromObjectSpan([a, b]))
+            {
+                n = 1;
+            }
+            return n;
+            """;
+
+        var before = UsingStatementDocument(beforeText);
+        var after = UsingStatementDocument(afterText);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        Assert.Equal(CSharpStructuralChangeKind.Changed, row.Change);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal(
+            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.Equal(
+            "using (DisposableFromObjectSpan([a, b]))",
+            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.After);
+
+        AssertCaret(
+            beforeBody,
+            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            "raise: UsingStatement;");
+        AssertCaret(
+            afterBody,
+            "using (DisposableFromObjectSpan([a, b]))",
+            "raise: UsingStatement;");
+        Assert.DoesNotContain("raise: UsingStatement construct", beforeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("raise: UsingStatement construct", afterBody, StringComparison.Ordinal);
+        foreach (string unchangedLine in new[] { "{", "n = 1;", "}" })
+        {
+            Assert.DoesNotContain($"raise: {unchangedLine}", beforeBody, StringComparison.Ordinal);
+            Assert.DoesNotContain($"raise: {unchangedLine}", afterBody, StringComparison.Ordinal);
+        }
+    }
+
+    static AnnotatedSourceDocument UsingStatementDocument(string text)
+    {
+        int headerStart = text.IndexOf("using (", StringComparison.Ordinal);
+        int headerEnd = text.IndexOf('\n', headerStart);
+        int bodyStart = text.IndexOf('{', headerEnd);
+        int bodyEnd = text.IndexOf('}', bodyStart) + 1;
+
+        var node = new AnnotatedSourceNode(
+            0,
+            "UsingStatement",
+            SourceLineKind.CSharp,
+            [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]);
+        var regions = (AnnotatedSourceRegion[])
+        [
+            new(PrintedRegionRole.Header, [new AnnotatedSourceSpan(headerStart, headerEnd - headerStart)]),
+            new(PrintedRegionRole.Body, [new AnnotatedSourceSpan(bodyStart, bodyEnd - bodyStart)]),
+        ];
+        return new AnnotatedSourceDocument(text, [node], regions, [], []);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_DescribesQualifierArgumentRoleTransition()
     {
         // Item 3 (issue #5022): once item 1 collapses #4942's stacked rows to

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -513,6 +513,14 @@ public class CSharpStructuralComparisonTests
             "using (DisposableFromObjectSpan([a, b]))",
             after.Text.Substring(afterSpan.Start, afterSpan.Length));
 
+        // Round-2 review: the row's reported region role must reflect the
+        // narrowed spans it actually renders (Header), not the full
+        // statement's Construct region the node used to span before
+        // narrowing -- otherwise the caret narrows but the label still says
+        // "construct", contradicting itself.
+        Assert.Equal(PrintedRegionRole.Header, row.BeforeRegion);
+        Assert.Equal(PrintedRegionRole.Header, row.AfterRegion);
+
         string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
             comparison,
             CSharpStructuralSide.Before);
@@ -523,11 +531,11 @@ public class CSharpStructuralComparisonTests
         AssertCaret(
             beforeBody,
             "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
-            "raise: UsingStatement;");
+            "raise: UsingStatement header;");
         AssertCaret(
             afterBody,
             "using (DisposableFromObjectSpan([a, b]))",
-            "raise: UsingStatement;");
+            "raise: UsingStatement header;");
         Assert.DoesNotContain("raise: UsingStatement construct", beforeBody, StringComparison.Ordinal);
         Assert.DoesNotContain("raise: UsingStatement construct", afterBody, StringComparison.Ordinal);
         foreach (string unchangedLine in new[] { "{", "n = 1;", "}" })
@@ -668,8 +676,12 @@ public class CSharpStructuralComparisonTests
             [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]);
         var regions = (AnnotatedSourceRegion[])
         [
-            // TryStatement never records its own Header region -- only the
-            // nested UsingStatement does.
+            // Matches real printer output: TryCatch is in HasNamedRegions and
+            // so records its own Construct region (spanning the whole
+            // try/catch), but -- per HasNamedRegions -- never a Header
+            // region; only the nested UsingStatement does.
+            new(PrintedRegionRole.Construct, [new AnnotatedSourceSpan(tryStart, tryEnd - tryStart)]),
+            new(PrintedRegionRole.Construct, [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]),
             new(PrintedRegionRole.Header, [new AnnotatedSourceSpan(headerStart, headerEnd - headerStart)]),
             new(PrintedRegionRole.Body, [new AnnotatedSourceSpan(bodyStart, bodyEnd - bodyStart)]),
         ];
@@ -690,6 +702,10 @@ public class CSharpStructuralComparisonTests
             [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]);
         var regions = (AnnotatedSourceRegion[])
         [
+            // Matches real printer output (CSharpPrinter.cs, HasNamedRegions):
+            // every header-bearing statement also records a Construct region
+            // spanning the whole statement, alongside its own Header region.
+            new(PrintedRegionRole.Construct, [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]),
             new(PrintedRegionRole.Header, [new AnnotatedSourceSpan(headerStart, headerEnd - headerStart)]),
             new(PrintedRegionRole.Body, [new AnnotatedSourceSpan(bodyStart, bodyEnd - bodyStart)]),
         ];

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -537,6 +537,145 @@ public class CSharpStructuralComparisonTests
         }
     }
 
+    [Fact]
+    public void CompareStructure_DoesNotNarrowMovedOnlyRowsWithUnchangedHeaderText()
+    {
+        // Round-1 review (both reviewers, independently): NarrowToChangedHeader
+        // ran for every matched pair, including Moved-only rows whose text is
+        // completely unchanged on both sides -- the prefix/suffix equality
+        // checks trivially pass in that case, so a moved statement's row would
+        // be narrowed down to just its header even though nothing about the
+        // header itself changed. Narrowing is now gated on the row actually
+        // carrying the Changed flag; a Moved-only row keeps the node's full
+        // span.
+        const string text = """
+            using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+            {
+                n = 1;
+            }
+            """;
+
+        var before = UsingStatementDocument(text);
+        var after = UsingStatementDocument(text);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0, Moved: true)]));
+
+        var row = Assert.Single(comparison.Rows);
+        Assert.Equal(CSharpStructuralChangeKind.Moved, row.Change);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal(before.Nodes[0].Spans[0], beforeSpan);
+        Assert.Equal(after.Nodes[0].Spans[0], afterSpan);
+    }
+
+    [Fact]
+    public void CompareStructure_DoesNotAdoptNestedConstructHeaderForHeaderlessAncestor()
+    {
+        // Round-1 review (both reviewers, independently): document.Regions is
+        // a flat, node-identity-free list of positional spans, so containment
+        // alone cannot prove a Header region belongs to the node being
+        // narrowed rather than to a nested construct inside its body.
+        // TryCatch/TryFinally never record their own Header region (see
+        // HasNamedRegions in CSharpPrinter.cs), so a naive containment search
+        // could mistake a nested UsingStatement's header for the enclosing
+        // TryStatement's own header. Both node kinds are matched here, with
+        // only the nested using's header text changing; the TryStatement row
+        // must keep its full span (so item 1's ancestor-suppression -- which
+        // requires the ancestor to strictly contain the descendant -- still
+        // recognizes and suppresses it), never the nested header's span.
+        const string beforeText = """
+            try
+            {
+                using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+                {
+                    n = 1;
+                }
+            }
+            catch
+            {
+                Recover();
+            }
+            """;
+        const string afterText = """
+            try
+            {
+                using (DisposableFromObjectSpan([a, b]))
+                {
+                    n = 1;
+                }
+            }
+            catch
+            {
+                Recover();
+            }
+            """;
+
+        var before = TryStatementWithNestedUsingDocument(beforeText);
+        var after = TryStatementWithNestedUsingDocument(afterText);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0, 1],
+            [0, 1],
+            [
+                new CSharpNodeCorrespondence(0, 0),
+                new CSharpNodeCorrespondence(1, 1),
+            ]));
+
+        // Item 1 (ancestor collapsing) recognizes the nested UsingStatement's
+        // narrowed header row as the sole explanation for the TryStatement's
+        // text change and suppresses the redundant ancestor row.
+        var row = Assert.Single(comparison.Rows);
+        Assert.Equal(1, row.BeforeNodeId);
+        Assert.Equal(1, row.AfterNodeId);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal(
+            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.Equal(
+            "using (DisposableFromObjectSpan([a, b]))",
+            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+    }
+
+    static AnnotatedSourceDocument TryStatementWithNestedUsingDocument(string text)
+    {
+        int tryStart = text.IndexOf("try", StringComparison.Ordinal);
+        int tryEnd = text.Length;
+
+        int headerStart = text.IndexOf("using (", StringComparison.Ordinal);
+        int headerEnd = text.IndexOf('\n', headerStart);
+        int bodyStart = text.IndexOf('{', headerEnd);
+        int bodyEnd = text.IndexOf('}', bodyStart) + 1;
+
+        var tryNode = new AnnotatedSourceNode(
+            0,
+            "TryStatement",
+            SourceLineKind.CSharp,
+            [new AnnotatedSourceSpan(tryStart, tryEnd - tryStart)]);
+        var usingNode = new AnnotatedSourceNode(
+            1,
+            "UsingStatement",
+            SourceLineKind.CSharp,
+            [new AnnotatedSourceSpan(headerStart, bodyEnd - headerStart)]);
+        var regions = (AnnotatedSourceRegion[])
+        [
+            // TryStatement never records its own Header region -- only the
+            // nested UsingStatement does.
+            new(PrintedRegionRole.Header, [new AnnotatedSourceSpan(headerStart, headerEnd - headerStart)]),
+            new(PrintedRegionRole.Body, [new AnnotatedSourceSpan(bodyStart, bodyEnd - bodyStart)]),
+        ];
+        return new AnnotatedSourceDocument(text, [tryNode, usingNode], regions, [], []);
+    }
+
     static AnnotatedSourceDocument UsingStatementDocument(string text)
     {
         int headerStart = text.IndexOf("using (", StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -708,7 +708,9 @@ public static partial class CSharpBodyDiff
     {
         ImmutableArray<AnnotatedSourceSpan> beforeSpans;
         ImmutableArray<AnnotatedSourceSpan> afterSpans;
-        if (beforeNode is not null && afterNode is not null)
+        if (beforeNode is not null
+            && afterNode is not null
+            && change.HasFlag(CSharpStructuralChangeKind.Changed))
         {
             (beforeSpans, afterSpans) = NarrowToChangedHeader(
                 beforeDocument!, beforeNode, afterDocument!, afterNode);
@@ -744,6 +746,29 @@ public static partial class CSharpBodyDiff
     // is byte-for-byte identical on both sides. That second check is what
     // also resolves item 7: once the row's spans no longer cover the
     // unchanged body lines, RenderAnnotatedBody stops annotating them.
+    //
+    // `document.Regions` is a flat, node-identity-free list of positional
+    // spans, so containment alone cannot prove a `Header` region belongs to
+    // this node rather than to a nested construct inside its body (round-1
+    // review, both reviewers independently: a headerless ancestor such as
+    // `TryStatement` -- `TryCatch`/`TryFinally` never record their own
+    // `Header` -- could otherwise adopt a nested `using`'s header as if it
+    // were its own). `KindsWithOwnHeaderRegion` is the exact, closed set of
+    // rendered kinds `CSharpPrinter.cs` emits a `Header` region for; only
+    // matched pairs of those kinds are considered at all, so a headerless
+    // ancestor can never reach the containment search in the first place.
+    static readonly ImmutableHashSet<string> KindsWithOwnHeaderRegion = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "UsingStatement",
+        "ForeachStatement",
+        "LockStatement",
+        "FixedStatement",
+        "IfStatement",
+        "ForStatement",
+        "WhileStatement",
+        "DoStatement",
+        "SwitchStatement");
+
     static (ImmutableArray<AnnotatedSourceSpan> BeforeSpans, ImmutableArray<AnnotatedSourceSpan> AfterSpans)
         NarrowToChangedHeader(
             AnnotatedSourceDocument beforeDocument,
@@ -757,6 +782,11 @@ public static partial class CSharpBodyDiff
 
         if (beforeNode.Spans.Count != 1 || afterNode.Spans.Count != 1)
             return fallback;
+        if (!KindsWithOwnHeaderRegion.Contains(beforeNode.Kind)
+            || !KindsWithOwnHeaderRegion.Contains(afterNode.Kind))
+        {
+            return fallback;
+        }
 
         var beforeHeader = FindSoleContainedHeaderRegion(beforeDocument, beforeNode);
         var afterHeader = FindSoleContainedHeaderRegion(afterDocument, afterNode);

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -729,8 +729,8 @@ public static partial class CSharpBodyDiff
             afterNode?.Kind,
             beforeNode is null ? null : AnnotatedSourceNodeKinds.GetDisplayLabel(beforeNode.Kind),
             afterNode is null ? null : AnnotatedSourceNodeKinds.GetDisplayLabel(afterNode.Kind),
-            beforeNode is null ? null : EnclosingRegion(beforeDocument!, beforeNode),
-            afterNode is null ? null : EnclosingRegion(afterDocument!, afterNode),
+            beforeNode is null ? null : EnclosingRegion(beforeDocument!, beforeSpans),
+            afterNode is null ? null : EnclosingRegion(afterDocument!, afterSpans),
             beforeSpans,
             afterSpans);
     }
@@ -856,11 +856,15 @@ public static partial class CSharpBodyDiff
             .SequenceEqual(afterDocument.Text.AsSpan(afterSpan.Value.Start, afterSpan.Value.Length));
     }
 
+    // Takes the row's final spans (after any header-narrowing), not the raw
+    // node's full span, so a narrowed row's reported region role (e.g.
+    // "header") matches the caret it actually renders instead of describing
+    // the enclosing statement's full "construct" region it no longer spans.
     static PrintedRegionRole? EnclosingRegion(
         AnnotatedSourceDocument document,
-        AnnotatedSourceNode node)
+        IReadOnlyList<AnnotatedSourceSpan> spans)
         => document.Regions
-            .Where(region => ContainsAll(region.Spans, node.Spans))
+            .Where(region => ContainsAll(region.Spans, spans))
             .OrderBy(static region => region.Spans.Sum(static span => (long)span.Length))
             .ThenBy(static region => region.Spans[0].Start)
             .ThenBy(static region => region.Role)

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -705,7 +705,21 @@ public static partial class CSharpBodyDiff
         AnnotatedSourceNode? beforeNode,
         AnnotatedSourceDocument? afterDocument,
         AnnotatedSourceNode? afterNode)
-        => new(
+    {
+        ImmutableArray<AnnotatedSourceSpan> beforeSpans;
+        ImmutableArray<AnnotatedSourceSpan> afterSpans;
+        if (beforeNode is not null && afterNode is not null)
+        {
+            (beforeSpans, afterSpans) = NarrowToChangedHeader(
+                beforeDocument!, beforeNode, afterDocument!, afterNode);
+        }
+        else
+        {
+            beforeSpans = beforeNode is null ? [] : [.. beforeNode.Spans];
+            afterSpans = afterNode is null ? [] : [.. afterNode.Spans];
+        }
+
+        return new(
             change,
             beforeNode?.Id,
             afterNode?.Id,
@@ -715,8 +729,102 @@ public static partial class CSharpBodyDiff
             afterNode is null ? null : AnnotatedSourceNodeKinds.GetDisplayLabel(afterNode.Kind),
             beforeNode is null ? null : EnclosingRegion(beforeDocument!, beforeNode),
             afterNode is null ? null : EnclosingRegion(afterDocument!, afterNode),
-            beforeNode is null ? [] : [.. beforeNode.Spans],
-            afterNode is null ? [] : [.. afterNode.Spans]);
+            beforeSpans,
+            afterSpans);
+    }
+
+    // Items 2 and 7 (issue #5022): a matched pair's full node spans (e.g. an
+    // entire `using (...) { ... }` statement) over-attribute the caret to
+    // every line the node touches, even when only the header clause differs.
+    // Rather than a blanket text diff -- which would corrupt item 3's
+    // full-call-text requirement for InvocationExpression rows -- this narrows
+    // only wrapper constructs that the printer already records a `Header`
+    // sub-region for (see `HasNamedRegions` in CSharpPrinter.cs), and only
+    // when everything outside that header (indentation, body, closing brace)
+    // is byte-for-byte identical on both sides. That second check is what
+    // also resolves item 7: once the row's spans no longer cover the
+    // unchanged body lines, RenderAnnotatedBody stops annotating them.
+    static (ImmutableArray<AnnotatedSourceSpan> BeforeSpans, ImmutableArray<AnnotatedSourceSpan> AfterSpans)
+        NarrowToChangedHeader(
+            AnnotatedSourceDocument beforeDocument,
+            AnnotatedSourceNode beforeNode,
+            AnnotatedSourceDocument afterDocument,
+            AnnotatedSourceNode afterNode)
+    {
+        ImmutableArray<AnnotatedSourceSpan> unnarrowedBefore = [.. beforeNode.Spans];
+        ImmutableArray<AnnotatedSourceSpan> unnarrowedAfter = [.. afterNode.Spans];
+        var fallback = (unnarrowedBefore, unnarrowedAfter);
+
+        if (beforeNode.Spans.Count != 1 || afterNode.Spans.Count != 1)
+            return fallback;
+
+        var beforeHeader = FindSoleContainedHeaderRegion(beforeDocument, beforeNode);
+        var afterHeader = FindSoleContainedHeaderRegion(afterDocument, afterNode);
+        if (beforeHeader is not { } beforeHeaderSpan || afterHeader is not { } afterHeaderSpan)
+            return fallback;
+
+        var beforeNodeSpan = beforeNode.Spans[0];
+        var afterNodeSpan = afterNode.Spans[0];
+
+        if (!SideTextEqual(
+                beforeDocument, PrefixOutsideHeader(beforeNodeSpan, beforeHeaderSpan),
+                afterDocument, PrefixOutsideHeader(afterNodeSpan, afterHeaderSpan))
+            || !SideTextEqual(
+                beforeDocument, SuffixOutsideHeader(beforeNodeSpan, beforeHeaderSpan),
+                afterDocument, SuffixOutsideHeader(afterNodeSpan, afterHeaderSpan)))
+        {
+            return fallback;
+        }
+
+        return ([beforeHeaderSpan], [afterHeaderSpan]);
+    }
+
+    static AnnotatedSourceSpan? FindSoleContainedHeaderRegion(
+        AnnotatedSourceDocument document,
+        AnnotatedSourceNode node)
+    {
+        AnnotatedSourceSpan? found = null;
+        foreach (var region in document.Regions)
+        {
+            if (region.Role != PrintedRegionRole.Header
+                || region.Spans.Count != 1
+                || !ContainsAll(node.Spans, region.Spans))
+            {
+                continue;
+            }
+            if (found is not null)
+                return null; // Ambiguous: more than one contained header region.
+            found = region.Spans[0];
+        }
+        return found;
+    }
+
+    static AnnotatedSourceSpan? PrefixOutsideHeader(AnnotatedSourceSpan node, AnnotatedSourceSpan header)
+    {
+        int length = header.Start - node.Start;
+        return length <= 0 ? null : new AnnotatedSourceSpan(node.Start, length);
+    }
+
+    static AnnotatedSourceSpan? SuffixOutsideHeader(AnnotatedSourceSpan node, AnnotatedSourceSpan header)
+    {
+        int headerEnd = header.Start + header.Length;
+        int length = node.Start + node.Length - headerEnd;
+        return length <= 0 ? null : new AnnotatedSourceSpan(headerEnd, length);
+    }
+
+    static bool SideTextEqual(
+        AnnotatedSourceDocument beforeDocument,
+        AnnotatedSourceSpan? beforeSpan,
+        AnnotatedSourceDocument afterDocument,
+        AnnotatedSourceSpan? afterSpan)
+    {
+        if (beforeSpan is null || afterSpan is null)
+            return beforeSpan is null && afterSpan is null;
+        if (beforeSpan.Value.Length != afterSpan.Value.Length)
+            return false;
+        return beforeDocument.Text.AsSpan(beforeSpan.Value.Start, beforeSpan.Value.Length)
+            .SequenceEqual(afterDocument.Text.AsSpan(afterSpan.Value.Start, afterSpan.Value.Length));
+    }
 
     static PrintedRegionRole? EnclosingRegion(
         AnnotatedSourceDocument document,


### PR DESCRIPTION
## Summary

Implements items 2 and 7 of #5022's plan: narrow a matched row's caret to
the sub-region that actually changed, rather than the whole node span.

Items 2 and 7 share the same root cause. `CreateRow` passed a matched
pair's full node spans straight through as `BeforeSpans`/`AfterSpans`, so
a wrapper construct like `UsingStatement` attributed its caret to every
line the node touches — including unchanged body lines — even when only
the header clause differed (#4113's evidence).

## Change

`CreateRow` now narrows a matched pair's spans to the printer's own
recorded `Header` region when:

1. That region is the *sole* `Header` region contained within the node's
   span, on both sides.
2. Everything outside it (indentation, body, closing brace) is
   byte-for-byte identical between before and after.

This confines the caret to the header line (item 2) and, as a direct
consequence, stops repeating the "construct changed" annotation on the
unchanged body lines — there is no separate propagation step to suppress
(item 7), matching the issue's own description of these two items.

The narrowing only fires for node kinds the printer already records a
`Header` sub-region for (`UsingStatement`, `ForeachStatement`,
`CatchClause`, etc. — see `HasNamedRegions` in `CSharpPrinter.cs`).
`InvocationExpression` rows never have a `Header` region, so item 3's
full-call-text requirement for #4942-style rows is untouched.

## Scope note

This does not yet reach the byte-exact `Type variable =` caret width the
issue's aspirational #4113 mockup shows for a declaration removal. That
width — plus representing the row as a proper `Added`/`Removed`
declaration pair with per-side captions — is item 5's higher-effort
follow-up (explicitly the "highest-effort" deferred item). This PR narrows
the caret to the changed header line and eliminates body-line
over-annotation; it does not implement item 5.

## Demo

Before this change, a real #4113-shaped example (from #4952) rendered:

```
using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: UsingStatement construct; text changed
{
^
raise: UsingStatement construct; text changed
    n = 1;
//  ^^^^^^
//  raise: UsingStatement construct; text changed
}
^
raise: UsingStatement construct; text changed
```

After this change:

```
using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: UsingStatement; changed to `using (DisposableFromObjectSpan([a, b]))`
{
    n = 1;
}
```

One row instead of four; the unchanged body no longer gets annotated at
all.

## Validation

- New regression test
  `CompareStructure_NarrowsUsingStatementSpanToHeaderAndStopsAnnotatingUnchangedBody`
  reproduces #4113's exact before/after text, asserting the narrowed caret
  covers only the header line and the unchanged body lines
  (`{`, `n = 1;`, `}`) get no annotation on either side.
- Focused suite:
  `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests"`
  — 49 passed.
- Full local suite: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
  — 6009 tests, 1 pre-existing unrelated failure
  (`CoreLibOrdinalCasingCrossArmPredecessorPreservesFallbackPath`), no
  regressions.
- `dotnet build dotnet-inspect.slnx -c Release` — succeeded, 0 warnings.

## Related

Issue #5022, items 2 and 7. Follows #5040 (items 1, 3, 4, 6, merged as
b0060110d).
