### PR TITLE
Version InertText path-redaction output contract

### DIFF
--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -175,7 +175,17 @@ must not pass an unseparated URL or reconstruct removed components from the
 safe result. Producer identity, endpoint validation, cache authority, and
 presentation policy remain outside this owner.
 
+`UrlRedaction.PathComponentContractVersion` is the InertText-owned semantic
+compatibility discriminator for the encoded text returned by
+`ForPathComponent`. Its current value is `1`. Increment it before merging any
+change for which an admitted path can produce different `ToString()` output,
+including changes to the credential-slot grammar, `RedactedMarker`,
+`TextPolicy.Field`, or visual spelling. It is independent of assembly and
+package versions. Changes to `InertString` metadata or APIs that leave the
+encoded text unchanged do not increment it.
+
 This contract is gated by
+`ForPathComponent_ContractVersionPinsCurrentOutput`,
 `ForPathComponent_PreservesNonCredentialPathText`,
 `ForPathComponent_RedactsCredentialSlots`, and
 `ForPathComponent_EncodesNonGraphicScalars` in the Release

--- a/src/InertText.Tests/UrlRedactionTests.cs
+++ b/src/InertText.Tests/UrlRedactionTests.cs
@@ -7,6 +7,23 @@ public class UrlRedactionTests
     private const string Secret = "VERY-SECRET-TOKEN";
 
     [Fact]
+    public void ForPathComponent_ContractVersionPinsCurrentOutput()
+    {
+        Assert.Equal(1, UrlRedaction.PathComponentContractVersion);
+        Assert.Equal(
+            "/F/auth/REDACTED/api",
+            UrlRedaction.ForPathComponent($"/F/auth/{Secret}/api").ToString());
+        Assert.Equal(
+            "/proxy/https://feed.test/%20",
+            UrlRedaction.ForPathComponent(
+                "/proxy/https://feed.test/%20").ToString());
+        Assert.Equal(
+            "/flat/\\u202Egnp.evil",
+            UrlRedaction.ForPathComponent(
+                "/flat/\u202Egnp.evil").ToString());
+    }
+
+    [Fact]
     public void ForPathComponent_DeclarationIsTypedAndPathOnly()
     {
         MethodInfo method = Assert.Single(

--- a/src/InertText/UrlRedaction.cs
+++ b/src/InertText/UrlRedaction.cs
@@ -49,6 +49,20 @@ namespace InertText;
 public static class UrlRedaction
 {
     /// <summary>
+    /// The semantic version of the encoded text returned by
+    /// <see cref="ForPathComponent"/>.
+    /// </summary>
+    /// <remarks>
+    /// Increment this value before changing the path grammar, replacement text,
+    /// field encoding, or any other behavior that can change the encoded output
+    /// for an admitted path. This is independent of assembly and package
+    /// versions.
+    ///
+    /// Gated by <c>ForPathComponent_ContractVersionPinsCurrentOutput</c>.
+    /// </remarks>
+    public const int PathComponentContractVersion = 1;
+
+    /// <summary>
     /// What replaces a query or credential-bearing path segment. It keeps the
     /// redaction visible without carrying any of the removed text.
     /// </summary>


### PR DESCRIPTION
Closes #4972.

Issues an InertText-owned semantic compatibility discriminator for
`UrlRedaction.ForPathComponent`. Consumers that persist the encoded output can
now pin the whole owner contract instead of inferring compatibility from an
assembly version or duplicating the path grammar.

The latest InertString containment helpers do not rotate this initial version:
they add metadata-facing behavior without changing any admitted path's encoded
text.

## Demo

Before this change, a consumer could pin individual examples:

```text
/F/auth/SECRET/api       -> /F/auth/REDACTED/api
/flat/<U+202E>gnp.evil   -> /flat/\u202Egnp.evil
```

It had no owner-issued value saying whether those examples still represented
the complete path-redaction contract.

After this change:

```csharp
UrlRedaction.PathComponentContractVersion // 1
```

Version `1` is tied by a Release gate to credential-slot redaction,
authority-shaped path preservation, and `TextPolicy.Field` visual spelling.
Any future change that alters `ForPathComponent(...).ToString()` for an
admitted path must increment the value before merging.

What to notice: metadata-only InertString API changes do not create false key
rotations, while any path grammar, replacement marker, field policy, or visual
spelling change requires an explicit compatibility decision.

## Contract

- `UrlRedaction.PathComponentContractVersion` is independent of assembly and
  package versions.
- The current value is `1`.
- The discriminator rotates exactly when an admitted path can produce different
  encoded text.
- `ForPathComponent_ContractVersionPinsCurrentOutput` binds the value to
  representative redaction, preservation, and visual-encoding behavior.
- The existing detailed path tests remain the owner gates for the full current
  grammar.
- NuGetFetch producer-key framing and version selection remain outside this
  owner under #4795.

## Validation

- `dotnet run --project src/InertText.Tests -c Release`
- `npx markdownlint-cli docs/design/untrusted-data-threat-model.md`
- `git diff --check origin/main...HEAD`
