### PR TITLE
Define navigation lens recommendation semantics

### DIFF
--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -547,7 +547,7 @@ retaining a navigation session.
 
 | Model | Checked design properties |
 | --- | --- |
-| `NavigationSession.tla` | Latest explicit intent wins; completed unavailable and failed revision behavior follows complete-snapshot change; Navigation preparation failure retains snapshot and revision; maintenance is request ordered; abort and acknowledgement preserve liveness; stale authority has no effect |
+| `NavigationSession.tla` | Latest explicit intent wins; completed unavailable and failed revision behavior follows complete-snapshot change; Navigation preparation failure retains snapshot and revision with a distinct source and fresh retained authority; maintenance is request ordered; abort and acknowledgement preserve liveness; stale authority has no effect |
 | `AtomicRestoration.tla` | One exact requested subject+lens pair is prepared atomically; failed or superseded preparation is not published |
 | `SnapshotAuthority.tla` | Retained state comes only from the installed snapshot; applied lens results equal the independently retained request; stale or foreign authority is rejected |
 

--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -383,12 +383,17 @@ after an available registry result remains distinguishable from a
 Registry-owned failed result. Neither failure is rewritten as unavailable.
 A valid exact request that completes as Registry `Unavailable` or `Failed`
 installs its exact-request basis and evidence whenever that replacement differs
-from the prior snapshot. It does not retain an earlier recommendation basis.
+from the prior snapshot and its bound subject remains active. It does not
+retain an earlier recommendation basis.
 
 An unavailable request never silently activates a sibling, ancestor, or
 recommended Type. If the already committed subject became invalid
 independently, automatic reconciliation may change it before the unavailable
-outcome is returned.
+outcome is returned. When that reconciliation changes the exact subject, its
+structural consistency takes precedence: the replacement snapshot installs a
+recommendation basis for the replacement subject, while the operation result
+still returns the original exact request's non-success outcome and evidence.
+It never installs an exact-request basis bound to the inactive subject.
 
 Outcome labels do not determine revision behavior. Every semantically changed
 snapshot advances the state revision, including an unavailable result with
@@ -542,7 +547,7 @@ retaining a navigation session.
 
 | Model | Checked design properties |
 | --- | --- |
-| `NavigationSession.tla` | Latest explicit intent wins; unavailable revision behavior follows complete-snapshot change; maintenance is request ordered; abort and acknowledgement preserve liveness; stale authority has no effect |
+| `NavigationSession.tla` | Latest explicit intent wins; completed unavailable and failed revision behavior follows complete-snapshot change; Navigation preparation failure retains snapshot and revision; maintenance is request ordered; abort and acknowledgement preserve liveness; stale authority has no effect |
 | `AtomicRestoration.tla` | One exact requested subject+lens pair is prepared atomically; failed or superseded preparation is not published |
 | `SnapshotAuthority.tla` | Retained state comes only from the installed snapshot; applied lens results equal the independently retained request; stale or foreign authority is rejected |
 
@@ -578,14 +583,19 @@ The eventual subject-navigation implementation must include named gates for:
 - `ExplicitLensResolution_RetainsExactRegistryEvidence`
 - `ExactNonSuccess_InstallsExactRequestBasis`
 - `NavigationPreparationFailure_RemainsDistinctFromRegistryFailure`
+- `NavigationPreparationFailure_RetainsSnapshotAndRevision`
 - `RecommendationBasis_RefreshRerunsRecommendation`
 - `ExactNonSuccessLens_RefreshReresolvesExactIdentityWithoutFallback`
+- `ExactNonSuccessDuringSubjectReconciliation_InstallsReplacementSubjectRecommendationBasis`
 - `EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`
 - `UnavailableDescriptor_HasNoTargetOrActionId`
 - `ExplicitUnavailableTransition_DoesNotApplyFallback`
 - `UnavailableReplacement_AdvancesStateRevision`
 - `UnavailableUnchangedSnapshot_RetainsStateRevision`
 - `UnavailableResult_InstalledRevisionMatchesRecordedResultRevision`
+- `FailedReplacement_AdvancesStateRevision`
+- `FailedUnchangedSnapshot_RetainsStateRevision`
+- `FailedResult_InstalledRevisionMatchesRecordedResultRevision`
 - `SameCoordinateReconciliation_FollowsSubjectTable`
 - `CoordinateVariation_UsesTypedCorrespondence`
 - `LensReconciliation_PreservesExactSubjectScopedIdentity`
@@ -622,7 +632,15 @@ the correlated pair to abort before a throwing Registry-resolution sentinel.
 The exact-non-success gate begins with a recommendation basis, submits an exact
 request returning `Unavailable` and `Failed` in separate cases, and requires
 the installed replacement basis and evidence to equal the independent request
-and Registry result before the refresh gate re-resolves that identity.
+and Registry result before the refresh gate re-resolves that identity. The
+subject-reconciliation gate invalidates the bound subject during those same
+non-success cases and instead requires the installed snapshot to carry the
+replacement subject's independently computed recommendation basis while the
+operation result retains the original exact-request evidence.
+The preparation-failure retention gate starts with an installed snapshot,
+forces Navigation preparation to fail after Registry availability, and
+requires the complete snapshot and revision to remain unchanged while the
+result identifies Navigation as the failure source.
 
 ## Acceptance cases
 
@@ -640,6 +658,8 @@ and Registry result before the refresh gate re-resolves that identity.
 | Failed recommendation becomes available on refresh | Recommendation reruns and installs the newly effective exact lens |
 | Recommended fallback then preferred role becomes available | Recommendation replaces the fallback with the preferred exact lens |
 | Explicit unavailable lens becomes available on refresh | Exact identity is re-resolved without considering a sibling fallback |
+| Exact non-success while its subject disappears | Result retains the exact request evidence; installed snapshot uses the replacement subject's recommendation basis |
+| Navigation preparation fails after Registry availability | Failed result identifies Navigation; snapshot and revision remain unchanged |
 | Multi-library package | Aggregate then primary then declaration-order Library descriptors |
 | Libraries with no Types | Library with References; Type is validly unavailable |
 | Tools-v2 pointer package | Root with Package Overview; lower subjects unavailable |

--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -8,9 +8,10 @@ rules.
 
 ## Status
 
-This is the target architecture for issue #4794. Product implementation remains
-unverified until the implementation gates in
-[Verification](#verification) land.
+This is the target architecture for issue #4794. Issue #5013 completes its
+focused lens-recommendation semantics. Product implementation remains
+unverified until the implementation gates in [Verification](#verification)
+land.
 
 The concurrency claims are specified separately as executable TLA+ models under
 [`models/inspection-subject-navigation/`](models/inspection-subject-navigation/).
@@ -46,7 +47,7 @@ Inspection Subject Navigation owns:
 
 - structural subject identity and hierarchy composition;
 - subject applicability, availability, and failure classification;
-- initial subject and lens recommendation;
+- initial subject recommendation and subject-scoped lens recommendation;
 - hierarchy, Library, Type, Member, and lens navigation descriptors;
 - exact subject and lens activation outcomes;
 - same-coordinate and coordinate-variation reconciliation;
@@ -163,10 +164,21 @@ The conceptual subject identity family is:
 Identity equality never uses display text, filename, list position, metadata
 token alone, or backend arrival order.
 
-A navigation lens identity combines a structural subject kind with one
-view-facet registry identity. The registry owns the stable facet identity;
-Inspection Subject Navigation owns the subject binding. Library Metadata and
-Type Metadata can therefore share a label without sharing identity.
+A navigation lens identity combines one exact structural subject identity with
+one view-facet registry identity:
+
+```text
+NavigationLensIdentity
+  Subject  StructuralSubjectIdentity
+  Facet    ViewFacetId
+```
+
+The registry owns the stable facet identity; Inspection Subject Navigation
+owns the exact subject binding. `type.api` on two exact Types therefore names
+two navigation lenses, while Library Metadata and Type Metadata can share a
+label without sharing either facet or navigation identity. Consumers treat the
+combined identity as opaque and never reconstruct it from kind, display text,
+or active UI state.
 
 ### Snapshot
 
@@ -262,20 +274,48 @@ coordinates, including the tools-v2 pointer-package case tracked by #4829.
 
 ### Lens recommendation
 
-The initial semantic recommendations are:
+Lens recommendation is a pure policy over one exact structural subject and the
+target-aware options returned for that subject by one View Facet Registry
+snapshot. It runs when an initial snapshot needs a lens and when activation or
+reconciliation changes the exact subject without an explicit lens request.
+Reactivating the unchanged current subject does not reset an effective lens. A
+directly activated Member therefore receives the same owner-issued
+recommendation as an initially recommended subject.
+
+The preferred semantic roles are:
 
 | Subject | Preferred lens role |
 | --- | --- |
-| Type | API |
-| Library | References |
-| Package Root | Package Overview |
-| Other Root | Root owner's recommendation |
+| Type | Type API |
+| Member | Member overview |
+| Library | Library references |
+| Package-capable Root | Package overview |
+| Other Root | Root overview |
 
-The exact identities and membership come from the View Facet Registry. If the
-preferred descriptor is unavailable or failed, navigation selects the first
-available descriptor in registry order and retains the non-success evidence.
-When none is available, the subject remains active and the lens outcome is
-unavailable or failed according to the underlying results.
+Recommendation applies these rules in order:
+
+1. Find the one applicable option carrying the subject's preferred role.
+   Missing preferred-role or empty option input is a typed Navigation policy
+   failure; it does not silently turn registry order into policy.
+2. If the preferred option is available, select its exact subject-bound
+   navigation lens even when another available option appears first.
+3. If the preferred option is unavailable or failed, select the first
+   available option in registry order. Preserve the preferred option's
+   non-success evidence and every returned descriptor.
+4. If no option is available and any option is failed, return a failed lens
+   outcome with every failed and unavailable result retained.
+5. Otherwise return an unavailable lens outcome with every unavailable result
+   retained.
+
+Navigation consumes Registry order as returned and never re-sorts by role,
+title, ID, or local host preference. Registry `Retired` is one unavailable
+reason and follows the same fallback rule. Failure dominates unavailability
+when no available fallback exists because Navigation cannot claim that no lens
+is available while an applicable option could not be evaluated.
+
+Recommendation never changes the active subject. An unavailable or failed
+recommendation leaves that exact subject active and installs the corresponding
+lens outcome with no effective lens.
 
 ### Type-inventory Library context
 
@@ -304,6 +344,21 @@ Subject and lens activation return one of these semantic outcomes:
 | Failed | Retains state because navigation evaluation failed |
 | Superseded | Produces no visible effect because a newer explicit intent owns the session |
 
+Exact lens activation maps the View Facet Registry result without fallback:
+
+| Registry result | Navigation outcome |
+| --- | --- |
+| Available | `Applied` with the exact requested subject-bound lens, unless later Navigation preparation fails or the operation is superseded |
+| Unavailable | `Unavailable` with the exact registry reason |
+| Failed | `Failed` with the registry diagnostic identified as the source |
+| Inapplicable | `Rejected` as structurally invalid for the exact subject |
+| Unknown | `Rejected` as an unknown facet ID |
+
+Every outcome retains the exact registry result and request identity, including
+the absent descriptor in `Unknown`. A Navigation-owned preparation failure
+after an available registry result remains distinguishable from a
+Registry-owned failed result. Neither failure is rewritten as unavailable.
+
 An unavailable request never silently activates a sibling, ancestor, or
 recommended Type. If the already committed subject became invalid
 independently, automatic reconciliation may change it before the unavailable
@@ -318,6 +373,10 @@ unchanged.
 Selecting a Library does not also select a Type. Selecting a Type or Member
 directly returns its complete ancestor context.
 
+Activating a different exact subject without an explicit lens runs lens
+recommendation for that subject. A prior lens is never carried to a different
+subject merely because its registry facet ID or structural kind matches.
+
 ### Same-coordinate reconciliation
 
 | Current subject | Reconciled subject |
@@ -330,6 +389,14 @@ directly returns its complete ancestor context.
 
 No arbitrary Member replaces a missing Member. Inventory refresh never promotes
 an explicitly selected Root or Library to Type.
+
+Lens reconciliation evaluates the exact subject-bound lens identity. When the
+active subject is unchanged, an available exact lens is retained; an
+unavailable or failed exact result preserves that outcome and evidence without
+recommendation fallback. When subject reconciliation changes the exact
+subject, the prior lens identity no longer matches and Navigation runs
+recommendation for the replacement subject unless the operation supplied an
+explicit lens request.
 
 ### Coordinate variation
 
@@ -444,6 +511,11 @@ retaining a navigation session.
 The model README records the TLC commands and scope. Model checking validates
 these finite specifications, not the implementation.
 
+Lens ranking and Registry-result classification are intentionally absent from
+the models: lenses remain opaque values there. The pure recommendation and
+mapping rules above are enforced by the implementation gates below rather than
+claimed as model-checked behavior.
+
 ### Required implementation gates
 
 The eventual subject-navigation implementation must include named gates for:
@@ -451,6 +523,18 @@ The eventual subject-navigation implementation must include named gates for:
 - `InitialRecommendation_PrefersTypeThenLibraryThenRoot`
 - `TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder`
 - `InitialRecommendation_NeverChoosesMember`
+- `LensIdentity_BindsExactStructuralSubjectAndFacet`
+- `LensRecommendation_UsesPreferredRoleBeforeRegistryOrder`
+- `LensRecommendation_FallsBackToFirstAvailableInRegistryOrder`
+- `LensRecommendation_ConsumesRegistryOrderWithoutResorting`
+- `LensRecommendation_MissingPreferredRoleFails`
+- `LensRecommendation_EmptyOptionsFails`
+- `LensRecommendation_FailedDominatesUnavailableWhenNoOptionIsAvailable`
+- `LensRecommendation_AllUnavailableReturnsUnavailable`
+- `MemberRecommendation_UsesMemberOverviewRole`
+- `ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`
+- `ExplicitLensResolution_RetainsExactRegistryEvidence`
+- `NavigationPreparationFailure_RemainsDistinctFromRegistryFailure`
 - `EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`
 - `UnavailableDescriptor_HasNoTargetOrActionId`
 - `ExplicitUnavailableTransition_DoesNotApplyFallback`
@@ -474,11 +558,25 @@ The eventual subject-navigation implementation must include named gates for:
 - `CanonicalRestoration_PreparedPairEqualsExactRequest`
 - `CanonicalRestoration_FailedPreparationSettlesAsAbort`
 
+`LensRecommendation_UsesPreferredRoleBeforeRegistryOrder` is the role-policy
+non-vacuity gate: its preferred available descriptor is deliberately not first
+in Registry order, and replacing role selection with first-available selection
+must fail it. The mapping gate covers all five exact Registry results, and the
+evidence gate compares each returned result with independently retained input
+evidence rather than reconstructing expected evidence from Navigation output.
+
 ## Acceptance cases
 
 | Case | Expected result |
 | --- | --- |
 | Ordinary package | Highest-ranked trustworthy Type with API lens |
+| Preferred role is not first | Preferred available role, not the earlier available descriptor |
+| Preferred lens unavailable | First available registry-ordered fallback with preferred evidence retained |
+| No lens available and one evaluation failed | Failed lens outcome with all non-success evidence retained |
+| Preferred role missing or options empty | Typed Navigation policy failure, never implicit first-option selection |
+| Direct Member activation without a lens | Exact Member with Member Overview recommendation |
+| Same facet on two exact Types | Two distinct subject-bound navigation lens identities |
+| Explicit inapplicable or unknown lens | Rejected with exact Registry evidence and no fallback |
 | Multi-library package | Aggregate then primary then declaration-order Library descriptors |
 | Libraries with no Types | Library with References; Type is validly unavailable |
 | Tools-v2 pointer package | Root with Package Overview; lower subjects unavailable |

--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -194,11 +194,27 @@ One navigation snapshot contains:
 | Library descriptors | Aggregate, primary, then declaration order |
 | Type and Member rows | Producer rows plus product activation state |
 | Lens descriptors | Registry order, subject-scoped identity, and availability |
-| Lens outcome | Effective, unavailable, or failed |
+| Lens outcome | Effective identity or non-effective outcome, evaluation basis, and exact Registry evidence |
 | Diagnostics | Partial evidence and scoped failures |
 
 The snapshot is the retained session's only committed subject and lens state.
 A host cannot supply a second retained-state value.
+
+A lens outcome retains one evaluation basis:
+
+| Basis | Retained input |
+| --- | --- |
+| Recommendation | Exact subject, preferred role, and complete target-aware Registry options |
+| Exact request | Exact subject-bound navigation lens identity and exact Registry result |
+
+An effective outcome carries the selected exact navigation lens. A
+non-effective recommendation outcome carries no invented lens identity; a
+non-effective exact-request outcome retains the requested identity without
+making it effective. This basis is product state used by reconciliation, not a
+host hint. Recommendation installs a recommendation basis whether it selects a
+lens or not. An explicit lens command installs an exact-request basis even when
+it selects the same lens, recording that subsequent refresh must preserve the
+exact request rather than resume automatic fallback.
 
 ### Descriptor states
 
@@ -344,7 +360,14 @@ Subject and lens activation return one of these semantic outcomes:
 | Failed | Retains state because navigation evaluation failed |
 | Superseded | Produces no visible effect because a newer explicit intent owns the session |
 
-Exact lens activation maps the View Facet Registry result without fallback:
+Standalone lens activation first requires the request's exact subject to equal
+the snapshot's active subject. A mismatch is `Rejected` with the complete
+request identity retained, before Registry resolution or fallback. It cannot
+change the active subject. Canonical restoration's separately validated atomic
+subject+lens pair remains governed by the restoration participant contract.
+
+After that precondition succeeds, exact lens activation maps the View Facet
+Registry result without fallback:
 
 | Registry result | Navigation outcome |
 | --- | --- |
@@ -390,13 +413,22 @@ subject merely because its registry facet ID or structural kind matches.
 No arbitrary Member replaces a missing Member. Inventory refresh never promotes
 an explicitly selected Root or Library to Type.
 
-Lens reconciliation evaluates the exact subject-bound lens identity. When the
-active subject is unchanged, an available exact lens is retained; an
-unavailable or failed exact result preserves that outcome and evidence without
-recommendation fallback. When subject reconciliation changes the exact
-subject, the prior lens identity no longer matches and Navigation runs
-recommendation for the replacement subject unless the operation supplied an
-explicit lens request.
+Lens reconciliation follows the retained evaluation basis:
+
+- a recommendation-basis outcome, effective or non-effective, reruns
+  recommendation for its retained exact subject against the refreshed complete
+  Registry options;
+- an exact-request-basis outcome, effective or non-effective, re-resolves its
+  exact subject-bound lens identity and never applies recommendation fallback;
+  and
+- when subject reconciliation changes the exact subject, the prior basis no
+  longer matches and Navigation runs recommendation for the replacement
+  subject unless canonical restoration supplied an atomic exact pair.
+
+This lets a recommendation recover when refreshed facts make a facet available
+or replace a fallback with the now-available preferred role, without turning an
+explicit request into a different lens. Every replacement outcome retains its
+new basis and complete evidence.
 
 ### Coordinate variation
 
@@ -462,10 +494,12 @@ resolution, the canonical-state owner supplies one realized coordinate and the
 optional exact subject and navigation lens requested for it.
 
 Inspection Subject Navigation independently retains that requested payload,
+requires the lens identity's exact subject to equal the requested subject,
 resolves its subject and lens halves, and publishes one complete prepared
-snapshot only when both halves succeed. A half-failure aborts the preparation,
-and supersession prevents an older preparation from being published. The
-focused participant state machine is
+snapshot only when both halves succeed. A mismatched pair fails before Registry
+resolution and aborts preparation. Any half-failure likewise aborts, and
+supersession prevents an older preparation from being published. The focused
+participant state machine is
 [`AtomicRestoration.tla`](models/inspection-subject-navigation/AtomicRestoration.tla).
 
 This owner does not install the prepared snapshot or coordinate other
@@ -511,10 +545,11 @@ retaining a navigation session.
 The model README records the TLC commands and scope. Model checking validates
 these finite specifications, not the implementation.
 
-Lens ranking and Registry-result classification are intentionally absent from
-the models: lenses remain opaque values there. The pure recommendation and
-mapping rules above are enforced by the implementation gates below rather than
-claimed as model-checked behavior.
+Lens ranking, Registry-result classification, and the exact subject-plus-facet
+identity structure are intentionally absent from the models: lenses remain
+opaque values there. The pure recommendation, mapping, and identity-binding
+rules above are enforced by the implementation gates below rather than claimed
+as model-checked behavior.
 
 ### Required implementation gates
 
@@ -524,17 +559,22 @@ The eventual subject-navigation implementation must include named gates for:
 - `TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder`
 - `InitialRecommendation_NeverChoosesMember`
 - `LensIdentity_BindsExactStructuralSubjectAndFacet`
+- `LensOutcome_RetainsRecommendationOrExactRequestBasis`
 - `LensRecommendation_UsesPreferredRoleBeforeRegistryOrder`
 - `LensRecommendation_FallsBackToFirstAvailableInRegistryOrder`
 - `LensRecommendation_ConsumesRegistryOrderWithoutResorting`
+- `LensRecommendation_RetainsAllRegistryOptionsAndEvidence`
 - `LensRecommendation_MissingPreferredRoleFails`
 - `LensRecommendation_EmptyOptionsFails`
 - `LensRecommendation_FailedDominatesUnavailableWhenNoOptionIsAvailable`
 - `LensRecommendation_AllUnavailableReturnsUnavailable`
 - `MemberRecommendation_UsesMemberOverviewRole`
+- `StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`
 - `ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`
 - `ExplicitLensResolution_RetainsExactRegistryEvidence`
 - `NavigationPreparationFailure_RemainsDistinctFromRegistryFailure`
+- `RecommendationBasis_RefreshRerunsRecommendation`
+- `ExactNonSuccessLens_RefreshReresolvesExactIdentityWithoutFallback`
 - `EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`
 - `UnavailableDescriptor_HasNoTargetOrActionId`
 - `ExplicitUnavailableTransition_DoesNotApplyFallback`
@@ -556,14 +596,20 @@ The eventual subject-navigation implementation must include named gates for:
 - `EffectAuthority_RequiresExactCurrentSessionRevisionIntentAndEpoch`
 - `ExternalIntentAbort_ReleasesMaintenanceAfterAcknowledgement`
 - `CanonicalRestoration_PreparedPairEqualsExactRequest`
+- `CanonicalRestoration_RejectsMismatchedSubjectBoundLens`
 - `CanonicalRestoration_FailedPreparationSettlesAsAbort`
 
 `LensRecommendation_UsesPreferredRoleBeforeRegistryOrder` is the role-policy
 non-vacuity gate: its preferred available descriptor is deliberately not first
 in Registry order, and replacing role selection with first-available selection
-must fail it. The mapping gate covers all five exact Registry results, and the
-evidence gate compares each returned result with independently retained input
+must fail it. `LensRecommendation_RetainsAllRegistryOptionsAndEvidence`
+compares the complete result with independently retained input options,
+including non-selected unavailable and failed peers that cannot affect the
+chosen lens. The exact mapping gate covers all five Registry results, and its
+evidence gate likewise compares each result with independently retained input
 evidence rather than reconstructing expected evidence from Navigation output.
+The cross-subject activation gate uses the same facet ID on two exact subjects
+and requires rejection before a throwing Registry-resolution sentinel.
 
 ## Acceptance cases
 
@@ -576,7 +622,11 @@ evidence rather than reconstructing expected evidence from Navigation output.
 | Preferred role missing or options empty | Typed Navigation policy failure, never implicit first-option selection |
 | Direct Member activation without a lens | Exact Member with Member Overview recommendation |
 | Same facet on two exact Types | Two distinct subject-bound navigation lens identities |
+| Lens request bound to another exact Type | Rejected before Registry resolution with active subject unchanged |
 | Explicit inapplicable or unknown lens | Rejected with exact Registry evidence and no fallback |
+| Failed recommendation becomes available on refresh | Recommendation reruns and installs the newly effective exact lens |
+| Recommended fallback then preferred role becomes available | Recommendation replaces the fallback with the preferred exact lens |
+| Explicit unavailable lens becomes available on refresh | Exact identity is re-resolved without considering a sibling fallback |
 | Multi-library package | Aggregate then primary then declaration-order Library descriptors |
 | Libraries with no Types | Library with References; Type is validly unavailable |
 | Tools-v2 pointer package | Root with Package Overview; lower subjects unavailable |
@@ -589,6 +639,7 @@ evidence rather than reconstructing expected evidence from Navigation output.
 | Refresh and reconciliation complete out of order | Maintenance request order determines final snapshot |
 | Coordinate acquisition fails | Prior snapshot retained; abort effect visible; maintenance eventually resumes |
 | Canonical subject plus non-default lens | One prepared snapshot returns the exact requested pair with no partial result |
+| Canonical subject plus lens bound to another subject | Preparation aborts before Registry resolution |
 
 ## Non-goals
 

--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -355,9 +355,9 @@ Subject and lens activation return one of these semantic outcomes:
 | Outcome | State effect |
 | --- | --- |
 | Applied | Installs the exact requested subject or lens in a replacement snapshot |
-| Unavailable | Returns current availability without substituting another requested target; installs a replacement when refreshed facts or reconciliation change the snapshot |
+| Unavailable | Applies no target or fallback; a completed exact lens evaluation installs its non-effective exact-request basis and evidence when either differs, while other operations install a replacement only when evaluation or reconciliation changes the snapshot |
 | Rejected | Retains state because the command is stale, foreign, or invalid |
-| Failed | Retains state because navigation evaluation failed |
+| Failed | A completed Registry or Navigation-policy lens evaluation installs its non-effective basis and evidence when either differs; Navigation preparation failure retains the prior snapshot |
 | Superseded | Produces no visible effect because a newer explicit intent owns the session |
 
 Standalone lens activation first requires the request's exact subject to equal
@@ -372,8 +372,8 @@ Registry result without fallback:
 | Registry result | Navigation outcome |
 | --- | --- |
 | Available | `Applied` with the exact requested subject-bound lens, unless later Navigation preparation fails or the operation is superseded |
-| Unavailable | `Unavailable` with the exact registry reason |
-| Failed | `Failed` with the registry diagnostic identified as the source |
+| Unavailable | `Unavailable` with the exact registry reason and a non-effective exact-request basis |
+| Failed | `Failed` with the registry diagnostic identified as the source and a non-effective exact-request basis |
 | Inapplicable | `Rejected` as structurally invalid for the exact subject |
 | Unknown | `Rejected` as an unknown facet ID |
 
@@ -381,6 +381,9 @@ Every outcome retains the exact registry result and request identity, including
 the absent descriptor in `Unknown`. A Navigation-owned preparation failure
 after an available registry result remains distinguishable from a
 Registry-owned failed result. Neither failure is rewritten as unavailable.
+A valid exact request that completes as Registry `Unavailable` or `Failed`
+installs its exact-request basis and evidence whenever that replacement differs
+from the prior snapshot. It does not retain an earlier recommendation basis.
 
 An unavailable request never silently activates a sibling, ancestor, or
 recommended Type. If the already committed subject became invalid
@@ -389,9 +392,10 @@ outcome is returned.
 
 Outcome labels do not determine revision behavior. Every semantically changed
 snapshot advances the state revision, including an unavailable result with
-refreshed descriptors or a reconciled active subject. An unavailable result
-shares the unchanged-snapshot outcome class only when the complete snapshot is
-unchanged.
+refreshed descriptors, a reconciled active subject, or a changed lens basis or
+evidence. The same rule applies to a completed Registry or policy `Failed`
+outcome. A non-success result shares the unchanged-snapshot outcome class only
+when the complete snapshot is unchanged.
 
 Selecting a Library does not also select a Type. Selecting a Type or Member
 directly returns its complete ancestor context.
@@ -572,6 +576,7 @@ The eventual subject-navigation implementation must include named gates for:
 - `StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`
 - `ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`
 - `ExplicitLensResolution_RetainsExactRegistryEvidence`
+- `ExactNonSuccess_InstallsExactRequestBasis`
 - `NavigationPreparationFailure_RemainsDistinctFromRegistryFailure`
 - `RecommendationBasis_RefreshRerunsRecommendation`
 - `ExactNonSuccessLens_RefreshReresolvesExactIdentityWithoutFallback`
@@ -609,7 +614,15 @@ chosen lens. The exact mapping gate covers all five Registry results, and its
 evidence gate likewise compares each result with independently retained input
 evidence rather than reconstructing expected evidence from Navigation output.
 The cross-subject activation gate uses the same facet ID on two exact subjects
-and requires rejection before a throwing Registry-resolution sentinel.
+and requires rejection before a throwing Registry-resolution sentinel. It
+compares the returned complete request identity with independently retained
+input. The canonical mismatch gate independently retains the requested subject,
+the differently bound lens, and the restoration operation identity; it requires
+the correlated pair to abort before a throwing Registry-resolution sentinel.
+The exact-non-success gate begins with a recommendation basis, submits an exact
+request returning `Unavailable` and `Failed` in separate cases, and requires
+the installed replacement basis and evidence to equal the independent request
+and Registry result before the refresh gate re-resolves that identity.
 
 ## Acceptance cases
 

--- a/docs/design/models/inspection-subject-navigation/NavigationSession.cfg
+++ b/docs/design/models/inspection-subject-navigation/NavigationSession.cfg
@@ -21,7 +21,8 @@ INVARIANTS
   MaintenanceRegatherDiscipline
   MaintenanceRequestOrder
   NoStaleVisibleEffect
-  UnavailableRevisionMatchesSnapshotChange
+  NonSuccessRevisionMatchesSnapshotChange
+  PreparationFailureRetainsSnapshotAndRevision
 
 PROPERTIES
   ExplicitWorkEventuallyResolves

--- a/docs/design/models/inspection-subject-navigation/NavigationSession.tla
+++ b/docs/design/models/inspection-subject-navigation/NavigationSession.tla
@@ -257,6 +257,8 @@ ExplicitNonSuccess(outcome, returnedSnapshot) ==
 NavigationPreparationFailure ==
   /\ explicit # NoExplicitWork
   /\ explicit.token = currentIntent
+  /\ installedSnapshot' = installedSnapshot
+  /\ installedRev' = installedRev
   /\ effectEpoch' = effectEpoch + 1
   /\ effect' =
        Authority("retained", installedRev, currentIntent, effectEpoch + 1)
@@ -265,12 +267,20 @@ NavigationPreparationFailure ==
        Result("failed", "navigationPreparation",
               installedSnapshot, installedSnapshot,
               installedRev, installedRev)
+  /\ revisionWitness' =
+       /\ revisionWitness
+       /\ installedSnapshot' = installedSnapshot
+       /\ installedRev' = installedRev
+       /\ lastResult'.priorSnapshot = installedSnapshot
+       /\ lastResult'.resultSnapshot = installedSnapshot'
+       /\ lastResult'.priorRev = installedRev
+       /\ lastResult'.resultRev = installedRev'
   /\ explicit' = NoExplicitWork
-  /\ UNCHANGED << installedSnapshot, installedRev, currentIntent, superseded,
-                  nextMaintenance, maintenanceQueue, lastAdmitted,
+  /\ UNCHANGED << currentIntent, superseded, nextMaintenance,
+                  maintenanceQueue, lastAdmitted,
                   admittedRequests,
-                  admissionWitness, regatherWitness, revisionWitness,
-                  orderWitness, visibleWitness >>
+                  admissionWitness, regatherWitness, orderWitness,
+                  visibleWitness >>
 
 \* A rejected navigation result retains the installed snapshot but receives a
 \* fresh effect epoch so delayed outcome work cannot surface later.
@@ -584,15 +594,16 @@ NonSuccessRevisionMatchesSnapshotChange ==
 \* before/after state, and the live result authority names that retained
 \* revision.
 PreparationFailureRetainsSnapshotAndRevision ==
-  lastResult.source = "navigationPreparation" =>
-    /\ ~lastResult.snapshotChanged
-    /\ lastResult.resultSnapshot = lastResult.priorSnapshot
-    /\ lastResult.resultRev = lastResult.priorRev
-    /\ (effect # NoAuthority =>
-          /\ effect.outcome = "retained"
-          /\ effect.rev = lastResult.resultRev
-          /\ installedSnapshot = lastResult.resultSnapshot
-          /\ installedRev = lastResult.resultRev)
+  /\ revisionWitness
+  /\ (lastResult.source = "navigationPreparation" =>
+        /\ ~lastResult.snapshotChanged
+        /\ lastResult.resultSnapshot = lastResult.priorSnapshot
+        /\ lastResult.resultRev = lastResult.priorRev
+        /\ (effect # NoAuthority =>
+              /\ effect.outcome = "retained"
+              /\ effect.rev = lastResult.resultRev
+              /\ installedSnapshot = lastResult.resultSnapshot
+              /\ installedRev = lastResult.resultRev))
 
 (***************************************************************************)
 (* Liveness.                                                               *)

--- a/docs/design/models/inspection-subject-navigation/NavigationSession.tla
+++ b/docs/design/models/inspection-subject-navigation/NavigationSession.tla
@@ -114,6 +114,7 @@ Dispositions == {"current", "synchronizationRequired"}
 NoResult ==
   [ outcome         |-> "none",
     source          |-> "none",
+    preparationFailureOccurred |-> FALSE,
     disposition     |-> "none",
     receiptSnapshot |-> InitialSnapshot,
     receiptRev      |-> 0,
@@ -128,10 +129,12 @@ ConsumerDisposition(resultSnapshot, resultRev) ==
     THEN "current"
     ELSE "synchronizationRequired"
 
-Result(outcome, source, disposition, receiptSnapshot, receiptRev,
+Result(outcome, source, preparationFailureOccurred,
+       disposition, receiptSnapshot, receiptRev,
        priorSnapshot, resultSnapshot, priorRev, resultRev) ==
   [ outcome         |-> outcome,
     source          |-> source,
+    preparationFailureOccurred |-> preparationFailureOccurred,
     disposition     |-> disposition,
     receiptSnapshot |-> receiptSnapshot,
     receiptRev      |-> receiptRev,
@@ -205,6 +208,7 @@ TypeOK ==
   /\ admittedRequests \subseteq 1 .. MaxMaintenance
   /\ lastResult.outcome \in SemanticOutcomes \cup {"none"}
   /\ lastResult.source \in ResultSources
+  /\ lastResult.preparationFailureOccurred \in BOOLEAN
   /\ lastResult.disposition \in Dispositions \cup {"none"}
   /\ lastResult.receiptSnapshot \in SnapshotValues
   /\ lastResult.receiptRev \in Nat
@@ -313,7 +317,7 @@ ExplicitResultInstalls(returnedSnapshot) ==
   /\ effect' = Authority("applied", installedRev + 1, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("applied", "none",
+       Result("applied", "none", FALSE,
               ConsumerDisposition(returnedSnapshot, installedRev + 1),
               acknowledgedSnapshot, acknowledgedRev,
               installedSnapshot, returnedSnapshot,
@@ -351,6 +355,7 @@ ExplicitNonSuccess(outcome, returnedSnapshot) ==
        /\ lastResult' =
             Result(outcome,
                    IF outcome = "failed" THEN "evaluation" ELSE "none",
+                   FALSE,
                    ConsumerDisposition(returnedSnapshot, installedRev'),
                    acknowledgedSnapshot, acknowledgedRev,
                    installedSnapshot, returnedSnapshot,
@@ -389,7 +394,7 @@ NavigationPreparationFailure ==
        Authority("retained", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("failed", "navigationPreparation",
+       Result("failed", "navigationPreparation", TRUE,
               ConsumerDisposition(installedSnapshot, installedRev),
               acknowledgedSnapshot, acknowledgedRev,
               installedSnapshot, installedSnapshot,
@@ -431,7 +436,7 @@ ExplicitRejected ==
        Authority("retained", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("rejected", "none",
+       Result("rejected", "none", FALSE,
               ConsumerDisposition(installedSnapshot, installedRev),
               acknowledgedSnapshot, acknowledgedRev,
               installedSnapshot, installedSnapshot,
@@ -464,7 +469,7 @@ ExternalPrerequisiteAbort ==
   /\ effect' = Authority("aborted", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("aborted", "none",
+       Result("aborted", "none", FALSE,
               ConsumerDisposition(installedSnapshot, installedRev),
               acknowledgedSnapshot, acknowledgedRev,
               installedSnapshot, installedSnapshot,
@@ -607,7 +612,7 @@ AdmitMaintenance ==
      IN
        /\ installedSnapshot' = replacement
        /\ lastResult' =
-            Result("maintenance", "none",
+            Result("maintenance", "none", FALSE,
                    ConsumerDisposition(replacement, installedRev + 1),
                    acknowledgedSnapshot, acknowledgedRev,
                    installedSnapshot, replacement,
@@ -682,7 +687,7 @@ SynchronizeConsumer ==
        Authority("synchronize", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("synchronize", "none",
+       Result("synchronize", "none", FALSE,
               ConsumerDisposition(installedSnapshot, installedRev),
               acknowledgedSnapshot, acknowledgedRev,
               installedSnapshot, installedSnapshot,
@@ -941,11 +946,14 @@ NonSuccessRevisionMatchesSnapshotChange ==
 \* Navigation preparation failure has no complete replacement snapshot to
 \* install.  Its distinguishable result therefore records identical
 \* before/after state, and the live result authority names that retained
-\* revision.  The pre-state witness also independently latches the source and
-\* full returned authority.
+\* revision.  A model-only occurrence field identifies the action independently
+\* from its result source, while the pre-state witness independently latches
+\* the source and full returned authority.
 PreparationFailureRetainsSnapshotAndRevision ==
   /\ revisionWitness
-  /\ (lastResult.source = "navigationPreparation" =>
+  /\ lastResult.preparationFailureOccurred =
+       (lastResult.source = "navigationPreparation")
+  /\ (lastResult.preparationFailureOccurred =>
         /\ ~lastResult.snapshotChanged
         /\ lastResult.resultSnapshot = lastResult.priorSnapshot
         /\ lastResult.resultRev = lastResult.priorRev

--- a/docs/design/models/inspection-subject-navigation/NavigationSession.tla
+++ b/docs/design/models/inspection-subject-navigation/NavigationSession.tla
@@ -275,6 +275,11 @@ NavigationPreparationFailure ==
        /\ lastResult'.resultSnapshot = installedSnapshot'
        /\ lastResult'.priorRev = installedRev
        /\ lastResult'.resultRev = installedRev'
+       /\ lastResult'.outcome = "failed"
+       /\ lastResult'.source = "navigationPreparation"
+       /\ effect' =
+            Authority("retained", installedRev, currentIntent, effectEpoch + 1)
+       /\ hostAuthority' = effect'
   /\ explicit' = NoExplicitWork
   /\ UNCHANGED << currentIntent, superseded, nextMaintenance,
                   maintenanceQueue, lastAdmitted,
@@ -592,7 +597,8 @@ NonSuccessRevisionMatchesSnapshotChange ==
 \* Navigation preparation failure has no complete replacement snapshot to
 \* install.  Its distinguishable result therefore records identical
 \* before/after state, and the live result authority names that retained
-\* revision.
+\* revision.  The pre-state witness also independently latches the source and
+\* full returned authority.
 PreparationFailureRetainsSnapshotAndRevision ==
   /\ revisionWitness
   /\ (lastResult.source = "navigationPreparation" =>

--- a/docs/design/models/inspection-subject-navigation/NavigationSession.tla
+++ b/docs/design/models/inspection-subject-navigation/NavigationSession.tla
@@ -4,7 +4,7 @@
 (*                                                                         *)
 (* The model checks the ordering, supersession, and authority rules of the *)
 (* design in `docs/design/inspection-subject-navigation.md`.  It models    *)
-(* unavailable revision behavior, but not descriptor classification,       *)
+(* non-success revision behavior, but not descriptor classification,       *)
 (* identity ranking, lens contents, rendering, or any implementation.       *)
 (*                                                                         *)
 (* Product concept                    Model variable                       *)
@@ -77,17 +77,20 @@ vars == << installedSnapshot, installedRev, currentIntent, explicit,
 Outcomes == {"applied", "retained", "aborted", "maintenance"}
 SemanticOutcomes ==
   {"applied", "unavailable", "rejected", "failed", "aborted", "maintenance"}
+ResultSources == {"none", "evaluation", "navigationPreparation"}
 
 NoResult ==
   [ outcome         |-> "none",
+    source          |-> "none",
     snapshotChanged |-> FALSE,
     priorSnapshot   |-> InitialSnapshot,
     resultSnapshot  |-> InitialSnapshot,
     priorRev        |-> 0,
     resultRev       |-> 0 ]
 
-Result(outcome, priorSnapshot, resultSnapshot, priorRev, resultRev) ==
+Result(outcome, source, priorSnapshot, resultSnapshot, priorRev, resultRev) ==
   [ outcome         |-> outcome,
+    source          |-> source,
     snapshotChanged |-> resultSnapshot # priorSnapshot,
     priorSnapshot   |-> priorSnapshot,
     resultSnapshot  |-> resultSnapshot,
@@ -132,6 +135,7 @@ TypeOK ==
   /\ lastAdmitted \in 0 .. MaxMaintenance
   /\ admittedRequests \subseteq 1 .. MaxMaintenance
   /\ lastResult.outcome \in SemanticOutcomes \cup {"none"}
+  /\ lastResult.source \in ResultSources
   /\ lastResult.snapshotChanged \in BOOLEAN
   /\ lastResult.priorSnapshot \in SnapshotValues
   /\ lastResult.resultSnapshot \in SnapshotValues
@@ -206,7 +210,7 @@ ExplicitResultInstalls(returnedSnapshot) ==
   /\ effect' = Authority("applied", installedRev + 1, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("applied", installedSnapshot, returnedSnapshot,
+       Result("applied", "none", installedSnapshot, returnedSnapshot,
               installedRev, installedRev + 1)
   /\ explicit' = NoExplicitWork
   /\ UNCHANGED << currentIntent, superseded, nextMaintenance,
@@ -215,10 +219,11 @@ ExplicitResultInstalls(returnedSnapshot) ==
                   regatherWitness, revisionWitness, orderWitness,
                   visibleWitness >>
 
-\* An unavailable request returns a complete snapshot value.  Change is
-\* derived by comparing that value with the installed snapshot, not supplied
-\* as an independent choice.
-ExplicitUnavailable(returnedSnapshot) ==
+\* A completed unavailable or failed result returns a complete snapshot value.
+\* Change is derived by comparing that value with the installed snapshot, not
+\* supplied as an independent choice.
+ExplicitNonSuccess(outcome, returnedSnapshot) ==
+  /\ outcome \in {"unavailable", "failed"}
   /\ explicit # NoExplicitWork
   /\ explicit.token = currentIntent
   /\ LET changed == returnedSnapshot # installedSnapshot IN
@@ -230,7 +235,9 @@ ExplicitUnavailable(returnedSnapshot) ==
                       installedRev', currentIntent, effectEpoch + 1)
        /\ hostAuthority' = effect'
        /\ lastResult' =
-            Result("unavailable", installedSnapshot, returnedSnapshot,
+            Result(outcome,
+                   IF outcome = "failed" THEN "evaluation" ELSE "none",
+                   installedSnapshot, returnedSnapshot,
                    installedRev, installedRev')
        /\ revisionWitness' =
             /\ revisionWitness
@@ -244,10 +251,10 @@ ExplicitUnavailable(returnedSnapshot) ==
                   admissionWitness,
                   regatherWitness, orderWitness, visibleWitness >>
 
-\* Rejected and failed navigation results retain the installed snapshot but
-\* receive a fresh effect epoch so delayed outcome work cannot surface later.
-ExplicitResultRetains(outcome) ==
-  /\ outcome \in {"rejected", "failed"}
+\* Navigation preparation can fail after Registry evaluation succeeds.  It
+\* returns a distinguishable failed result and retains the complete snapshot
+\* and revision because it has no installable replacement snapshot.
+NavigationPreparationFailure ==
   /\ explicit # NoExplicitWork
   /\ explicit.token = currentIntent
   /\ effectEpoch' = effectEpoch + 1
@@ -255,7 +262,27 @@ ExplicitResultRetains(outcome) ==
        Authority("retained", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result(outcome, installedSnapshot, installedSnapshot,
+       Result("failed", "navigationPreparation",
+              installedSnapshot, installedSnapshot,
+              installedRev, installedRev)
+  /\ explicit' = NoExplicitWork
+  /\ UNCHANGED << installedSnapshot, installedRev, currentIntent, superseded,
+                  nextMaintenance, maintenanceQueue, lastAdmitted,
+                  admittedRequests,
+                  admissionWitness, regatherWitness, revisionWitness,
+                  orderWitness, visibleWitness >>
+
+\* A rejected navigation result retains the installed snapshot but receives a
+\* fresh effect epoch so delayed outcome work cannot surface later.
+ExplicitRejected ==
+  /\ explicit # NoExplicitWork
+  /\ explicit.token = currentIntent
+  /\ effectEpoch' = effectEpoch + 1
+  /\ effect' =
+       Authority("retained", installedRev, currentIntent, effectEpoch + 1)
+  /\ hostAuthority' = effect'
+  /\ lastResult' =
+       Result("rejected", "none", installedSnapshot, installedSnapshot,
               installedRev, installedRev)
   /\ explicit' = NoExplicitWork
   /\ UNCHANGED << installedSnapshot, installedRev, currentIntent, superseded,
@@ -275,7 +302,7 @@ ExternalPrerequisiteAbort ==
   /\ effect' = Authority("aborted", installedRev, currentIntent, effectEpoch + 1)
   /\ hostAuthority' = effect'
   /\ lastResult' =
-       Result("aborted", installedSnapshot, installedSnapshot,
+       Result("aborted", "none", installedSnapshot, installedSnapshot,
               installedRev, installedRev)
   /\ explicit' = NoExplicitWork
   /\ UNCHANGED << installedSnapshot, installedRev, currentIntent, superseded,
@@ -375,7 +402,7 @@ AdmitMaintenance ==
      IN
        /\ installedSnapshot' = replacement
        /\ lastResult' =
-            Result("maintenance", installedSnapshot, replacement,
+            Result("maintenance", "none", installedSnapshot, replacement,
                    installedRev, installedRev + 1)
   /\ installedRev' = installedRev + 1
   /\ effectEpoch' = effectEpoch + 1
@@ -465,9 +492,11 @@ ForeignAuthorityOffered ==
 ResolveExplicit ==
   \/ \E returnedSnapshot \in SnapshotValues :
        ExplicitResultInstalls(returnedSnapshot)
-  \/ \E returnedSnapshot \in SnapshotValues :
-       ExplicitUnavailable(returnedSnapshot)
-  \/ \E outcome \in {"rejected", "failed"} : ExplicitResultRetains(outcome)
+  \/ \E outcome \in {"unavailable", "failed"},
+          returnedSnapshot \in SnapshotValues :
+       ExplicitNonSuccess(outcome, returnedSnapshot)
+  \/ NavigationPreparationFailure
+  \/ ExplicitRejected
   \/ ExternalPrerequisiteAbort
 
 Next ==
@@ -537,17 +566,33 @@ MaintenanceRegatherDiscipline ==
   /\ regatherWitness
   /\ \A e \in Range(maintenanceQueue) : e.needsRegather => ~e.ready
 
-\* An unavailable outcome advances the state revision exactly when the
-\* complete returned snapshot changed.  The semantic outcome and change bit
-\* are explicit model currencies rather than inferred from apply/retain class.
-UnavailableRevisionMatchesSnapshotChange ==
+\* A completed unavailable or failed outcome advances the state revision
+\* exactly when the complete returned snapshot changed.  The semantic outcome
+\* and change bit are explicit model currencies rather than inferred from
+\* apply/retain class.
+NonSuccessRevisionMatchesSnapshotChange ==
   /\ revisionWitness
-  /\ (lastResult.outcome = "unavailable" =>
+  /\ (lastResult.outcome \in {"unavailable", "failed"} =>
         /\ lastResult.snapshotChanged =
              (lastResult.resultSnapshot # lastResult.priorSnapshot)
         /\ IF lastResult.snapshotChanged
              THEN lastResult.resultRev = lastResult.priorRev + 1
              ELSE lastResult.resultRev = lastResult.priorRev)
+
+\* Navigation preparation failure has no complete replacement snapshot to
+\* install.  Its distinguishable result therefore records identical
+\* before/after state, and the live result authority names that retained
+\* revision.
+PreparationFailureRetainsSnapshotAndRevision ==
+  lastResult.source = "navigationPreparation" =>
+    /\ ~lastResult.snapshotChanged
+    /\ lastResult.resultSnapshot = lastResult.priorSnapshot
+    /\ lastResult.resultRev = lastResult.priorRev
+    /\ (effect # NoAuthority =>
+          /\ effect.outcome = "retained"
+          /\ effect.rev = lastResult.resultRev
+          /\ installedSnapshot = lastResult.resultSnapshot
+          /\ installedRev = lastResult.resultRev)
 
 (***************************************************************************)
 (* Liveness.                                                               *)

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -425,6 +425,7 @@ records how to reproduce them.
 | NS33 | Advance the Navigation preparation-failure revision and coherently rewrite its result and authority to the post-state | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS34 | Rewrite the Navigation preparation-failure source as evaluation | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS35 | Omit product and host authority from Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS36 | Rewrite both Navigation preparation failure and its witness to use applied authority | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -451,13 +452,13 @@ records how to reproduce them.
 | SA17 | Return a result that does not record its operation ID | `OperationAndResultAreCorrelated` | violated |
 | SA18 | Install and return another admissible session lens instead of the exact requested lens | `AppliedResultEqualsExactRequest` | violated |
 
-Sixty probes, fifty-nine expected violations and one expected pass. `SA6`
+Sixty-one probes, sixty expected violations and one expected pass. `SA6`
 is the one probe expected not to fire: it applies the same mutation as `SA5`
 and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why
 `NonApplyStepsPreserveInstalledSnapshot` compares the record.
 
-Twenty-two probes exist specifically because a claim used to be satisfiable
+Twenty-three probes exist specifically because a claim used to be satisfiable
 by the wrong thing. `NS16` separates installed revision from a self-consistent
 result,
 `NS17` admits stale work without re-gathering, `NS18` lets a later admission
@@ -475,9 +476,11 @@ product-owned pre-state receipt, `NS28` makes post-install abandonment directly
 observable, and `NS29`/`NS30` protect synchronization admission relative to
 explicit work and queued maintenance. `NS33` rewrites preparation-failure
 authority and result to the wrong post-state, `NS34` erases its distinct
-source, and `NS35` erases its returned authority. `AR2` publishes a payload that differs
-from the retained request, `SA14` applies a later supplied-prior operation after
-an earlier one was rejected, `SA15` adopts only the stale same-session supplied
+source, `NS35` erases its returned authority, and `NS36` changes both the
+action and shared witness so only the dedicated preparation-failure invariant
+rejects the wrong authority class. `AR2` publishes a payload that differs from
+the retained request, `SA14` applies a later supplied-prior operation after an
+earlier one was rejected, `SA15` adopts only the stale same-session supplied
 snapshot whose origin and lens resemble session data, and `SA18` returns
 another admissible session lens under the correct operation ID.
 

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -213,9 +213,10 @@ remaining differences are deliberate abstractions rather than disagreements:
 - **Outcome classes.** Effect authority still uses the internal `applied` and
   `retained` execution classes, but `NavigationSession.tla` now separately
   records semantic outcome, complete-snapshot change, prior revision, and
-  result revision. This explicitly checks that changed `Unavailable` advances
-  revision while unchanged `Unavailable` retains it. `Rejected` and `Failed`
-  retain revision; superseded work returns no visible effect.
+  result revision. Changed `Unavailable` and Registry or policy `Failed`
+  results advance revision; unchanged ones retain it. `Rejected` and
+  Navigation preparation `Failed` results always retain revision; superseded
+  work returns no visible effect.
 - **Superseded maintenance results.** A newer explicit intent invalidates
   already gathered maintenance facts. The queued request remains, rebuilds
   from the replacement snapshot, and re-gathers before admission.
@@ -248,6 +249,11 @@ conjoins it into the witness. The paired invariant then asserts the witness was
 never falsified. If a future edit weakens an action guard, the witness still
 evaluates the real pre-state, so TLC reports a counterexample. Witnesses are
 model bookkeeping, not product state.
+
+`revisionWitness` independently compares complete non-success results with
+their pre-state installation and proves that Navigation preparation failure
+retained that pre-state even if its result and authority were coherently
+rewritten to a different post-state.
 
 `snapshotStabilityWitness` compares the whole installed snapshot record rather
 than its revision, so a step that rewrote the snapshot's lens or provenance
@@ -362,7 +368,7 @@ records how to reproduce them.
 | NS18 | Drop an earlier queued request while allowing a later request to be admitted | `EveryQueuedRequestIsAdmitted` | violated |
 | NS19 | Keep the revision unchanged for a changed-snapshot failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
 | NS20 | Advance the revision for an unchanged-snapshot Registry or policy failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
-| NS21 | Advance the installed revision during Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS21 | Advance the Navigation preparation-failure revision and coherently rewrite its result and authority to the post-state | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -395,14 +401,16 @@ and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why
 `NonApplyStepsPreserveInstalledSnapshot` compares the record.
 
-Seven probes exist specifically because a claim used to be satisfiable by the
+Eight probes exist specifically because a claim used to be satisfiable by the
 wrong thing. `NS16` separates installed revision from a self-consistent result,
 `NS17` admits stale work without re-gathering, `NS18` lets a later admission
-stand in for a lost earlier request, `AR2` publishes a payload that differs
-from the retained request, `SA14` applies a later supplied-prior operation
-after an earlier one was rejected, `SA15` adopts only the stale same-session
-supplied snapshot whose origin and lens resemble session data, and `SA18`
-returns another admissible session lens under the correct operation ID.
+stand in for a lost earlier request, `NS21` rewrites preparation-failure
+authority and result to the wrong post-state, `AR2` publishes a payload that
+differs from the retained request, `SA14` applies a later supplied-prior
+operation after an earlier one was rejected, `SA15` adopts only the stale
+same-session supplied snapshot whose origin and lens resemble session data,
+and `SA18` returns another admissible session lens under the correct operation
+ID.
 
 ## Changing a model
 

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -97,7 +97,7 @@ snapshots; Navigation preparation failure is a distinct retaining action.
 | `NoStaleVisibleEffect` | Every consumer-visible effect executed under exactly the session's current unconsumed authority |
 | `MaintenanceRegatherDiscipline` | A stale request cannot become ready or admit until rebuilding requires and gathering completes a re-gather |
 | `NonSuccessRevisionMatchesSnapshotChange` | A completed unavailable or failed result advances revision exactly when the complete returned snapshot changed |
-| `PreparationFailureRetainsSnapshotAndRevision` | Navigation preparation failure retains the complete installed snapshot and revision under retained effect authority |
+| `PreparationFailureRetainsSnapshotAndRevision` | Navigation preparation failure retains the complete installed snapshot and revision, identifies its source, and returns fresh retained product and host authority |
 
 Progress is stated per request and per intent token rather than only for the
 session as a whole. Each property below names a specific blocker or a specific
@@ -251,9 +251,10 @@ evaluates the real pre-state, so TLC reports a counterexample. Witnesses are
 model bookkeeping, not product state.
 
 `revisionWitness` independently compares complete non-success results with
-their pre-state installation and proves that Navigation preparation failure
-retained that pre-state even if its result and authority were coherently
-rewritten to a different post-state.
+their pre-state installation. For Navigation preparation failure it also
+latches the exact failure source and fresh retained product and host authority,
+so removing authority or coherently rewriting result and authority to another
+post-state is still caught.
 
 `snapshotStabilityWitness` compares the whole installed snapshot record rather
 than its revision, so a step that rewrote the snapshot's lens or provenance
@@ -369,6 +370,8 @@ records how to reproduce them.
 | NS19 | Keep the revision unchanged for a changed-snapshot failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
 | NS20 | Advance the revision for an unchanged-snapshot Registry or policy failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
 | NS21 | Advance the Navigation preparation-failure revision and coherently rewrite its result and authority to the post-state | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS22 | Rewrite the Navigation preparation-failure source as evaluation | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS23 | Omit product and host authority from Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -395,22 +398,22 @@ records how to reproduce them.
 | SA17 | Return a result that does not record its operation ID | `OperationAndResultAreCorrelated` | violated |
 | SA18 | Install and return another admissible session lens instead of the exact requested lens | `AppliedResultEqualsExactRequest` | violated |
 
-Forty-six probes, forty-five expected violations and one expected pass. `SA6`
+Forty-eight probes, forty-seven expected violations and one expected pass. `SA6`
 is the one probe expected not to fire: it applies the same mutation as `SA5`
 and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why
 `NonApplyStepsPreserveInstalledSnapshot` compares the record.
 
-Eight probes exist specifically because a claim used to be satisfiable by the
+Ten probes exist specifically because a claim used to be satisfiable by the
 wrong thing. `NS16` separates installed revision from a self-consistent result,
 `NS17` admits stale work without re-gathering, `NS18` lets a later admission
 stand in for a lost earlier request, `NS21` rewrites preparation-failure
-authority and result to the wrong post-state, `AR2` publishes a payload that
-differs from the retained request, `SA14` applies a later supplied-prior
-operation after an earlier one was rejected, `SA15` adopts only the stale
-same-session supplied snapshot whose origin and lens resemble session data,
-and `SA18` returns another admissible session lens under the correct operation
-ID.
+authority and result to the wrong post-state, `NS22` erases its distinct source,
+`NS23` erases its returned authority, `AR2` publishes a payload that differs
+from the retained request, `SA14` applies a later supplied-prior operation after
+an earlier one was rejected, `SA15` adopts only the stale same-session supplied
+snapshot whose origin and lens resemble session data, and `SA18` returns
+another admissible session lens under the correct operation ID.
 
 ## Changing a model
 

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -238,7 +238,9 @@ remaining differences are deliberate abstractions rather than disagreements:
   Navigation preparation `Failed` results always retain revision; superseded
   work returns no visible effect. The model-only `synchronize` class changes no
   semantic navigation state and carries the complete installed snapshot under
-  fresh authority.
+  fresh authority. A model-only occurrence field identifies a result produced
+  by the Navigation preparation-failure action independently from its reported
+  source.
 - **Consumer receipt.** The model records the complete snapshot and revision
   last acknowledged by one retained consumer separately from the consumer's
   installed snapshot, revision, and effect epoch. It abstracts host rendering
@@ -263,8 +265,8 @@ remaining differences are deliberate abstractions rather than disagreements:
 - **Unmodelled currencies.** Action IDs, generations, descriptor states,
   diagnostics, and correspondence are not modelled. Subjects, lenses, and
   snapshots are opaque values. Operation IDs, synchronization request numbers,
-  and retained request maps are model correlation currencies, not proposed
-  product fields.
+  retained request maps, and the preparation-failure occurrence field are model
+  correlation currencies, not proposed product fields.
 
 ## Guard witnesses
 
@@ -288,7 +290,11 @@ model bookkeeping, not product state.
 their pre-state installation. For Navigation preparation failure it also
 latches the exact failure source and fresh retained product and host authority,
 so removing authority or coherently rewriting result and authority to another
-post-state is still caught.
+post-state is still caught. The result's model-only
+`preparationFailureOccurred` field records that the preparation-failure action
+ran without deriving that fact from the reported source. The dedicated
+invariant correlates the independently recorded occurrence with the exact
+source.
 
 `snapshotStabilityWitness` compares the whole installed snapshot record rather
 than its revision, so a step that rewrote the snapshot's lens or provenance
@@ -340,15 +346,21 @@ rule.
 
 ### Exhaustive model checking
 
-Each run is an exhaustive breadth-first exploration of the shipped `.cfg`, so
-the counts are stable across repeated runs on the same tools version. All three
-report `Model checking completed. No error has been found.`
+Each run is an exhaustive breadth-first exploration of the shipped `.cfg`.
+Generated and distinct state counts are stable across repeated runs on the same
+tools version. All three report
+`Model checking completed. No error has been found.`
 
 | Model | States generated | Distinct states | Search depth |
 | --- | --- | --- | --- |
 | `NavigationSession.tla` | 668,938 | 116,745 | 23 |
 | `AtomicRestoration.tla` | 8,081 | 2,333 | 9 |
 | `SnapshotAuthority.tla` | 36,755 | 13,790 | 9 |
+
+The recorded `NavigationSession.tla` depth is from the single-worker action
+coverage run. Automatic-worker runs produced the same generated and distinct
+state counts with reported depths 23 and 24, so parallel traversal depth is not
+treated as stable evidence.
 
 The additional state records semantic unavailable and failed outcomes
 independently from their source and apply/retain execution class, retains
@@ -426,6 +438,7 @@ records how to reproduce them.
 | NS34 | Rewrite the Navigation preparation-failure source as evaluation | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS35 | Omit product and host authority from Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS36 | Rewrite both Navigation preparation failure and its witness to use applied authority | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS37 | Rewrite both Navigation preparation failure and its source witness as evaluation | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -452,13 +465,13 @@ records how to reproduce them.
 | SA17 | Return a result that does not record its operation ID | `OperationAndResultAreCorrelated` | violated |
 | SA18 | Install and return another admissible session lens instead of the exact requested lens | `AppliedResultEqualsExactRequest` | violated |
 
-Sixty-one probes, sixty expected violations and one expected pass. `SA6`
+Sixty-two probes, sixty-one expected violations and one expected pass. `SA6`
 is the one probe expected not to fire: it applies the same mutation as `SA5`
 and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why
 `NonApplyStepsPreserveInstalledSnapshot` compares the record.
 
-Twenty-three probes exist specifically because a claim used to be satisfiable
+Twenty-four probes exist specifically because a claim used to be satisfiable
 by the wrong thing. `NS16` separates installed revision from a self-consistent
 result,
 `NS17` admits stale work without re-gathering, `NS18` lets a later admission
@@ -478,11 +491,14 @@ explicit work and queued maintenance. `NS33` rewrites preparation-failure
 authority and result to the wrong post-state, `NS34` erases its distinct
 source, `NS35` erases its returned authority, and `NS36` changes both the
 action and shared witness so only the dedicated preparation-failure invariant
-rejects the wrong authority class. `AR2` publishes a payload that differs from
-the retained request, `SA14` applies a later supplied-prior operation after an
-earlier one was rejected, `SA15` adopts only the stale same-session supplied
-snapshot whose origin and lens resemble session data, and `SA18` returns
-another admissible session lens under the correct operation ID.
+rejects the wrong authority class. `NS37` changes both the action and source
+witness while the independent occurrence field still identifies preparation
+failure, proving the dedicated invariant rejects the source rewrite. `AR2`
+publishes a payload that differs from the retained request, `SA14` applies a
+later supplied-prior operation after an earlier one was rejected, `SA15` adopts
+only the stale same-session supplied snapshot whose origin and lens resemble
+session data, and `SA18` returns another admissible session lens under the
+correct operation ID.
 
 ## Changing a model
 

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -31,8 +31,11 @@ read that way:
   and lenses appear only as opaque values.
 - **Availability classification.** Descriptor classification and the
   reconciliation tables are not modelled. `NavigationSession.tla` does model
-  the narrower rule that an `Unavailable` result advances revision exactly
-  when its complete returned snapshot changed.
+  the narrower rule that a completed `Unavailable` or `Failed` result advances
+  revision exactly when its complete returned snapshot changed. The model
+  distinguishes Navigation preparation failure, which has no installable
+  replacement snapshot, from a failed Registry or policy evaluation. It does
+  not distinguish Registry failure from policy failure.
 - **UI accessibility.** Focus, roving `tabindex`, menu and tablist semantics,
   history, and rendering belong to [Inspect Web UI](../../inspect-web-ui.md)
   and appear here only as an abstract "consumer holds authority and executes a
@@ -80,7 +83,9 @@ Modelled behaviour includes: a newer explicit intent superseding older explicit
 and maintenance work; a superseded operation returning late; an external
 prerequisite abort that ends an intent without a navigation result; standalone
 maintenance queued in request order while its facts complete in any order; and
-a consumer holding authority that has since stopped being current.
+a consumer holding authority that has since stopped being current. Completed
+`Unavailable` and Registry or policy `Failed` results carry complete returned
+snapshots; Navigation preparation failure is a distinct retaining action.
 
 | Invariant | Claim |
 | --- | --- |
@@ -91,7 +96,8 @@ a consumer holding authority that has since stopped being current.
 | `MaintenanceRequestOrder` | Maintenance was admitted in owner-issued request order, never fact-completion order, and the queue stays ordered and outstanding |
 | `NoStaleVisibleEffect` | Every consumer-visible effect executed under exactly the session's current unconsumed authority |
 | `MaintenanceRegatherDiscipline` | A stale request cannot become ready or admit until rebuilding requires and gathering completes a re-gather |
-| `UnavailableRevisionMatchesSnapshotChange` | An unavailable result advances revision exactly when the complete returned snapshot changed |
+| `NonSuccessRevisionMatchesSnapshotChange` | A completed unavailable or failed result advances revision exactly when the complete returned snapshot changed |
+| `PreparationFailureRetainsSnapshotAndRevision` | Navigation preparation failure retains the complete installed snapshot and revision under retained effect authority |
 
 Progress is stated per request and per intent token rather than only for the
 session as a whole. Each property below names a specific blocker or a specific
@@ -281,7 +287,7 @@ The results below came from:
 - TLC `TLC2 Version 2026.08.21.155922 (rev: 9787e65)`, from the official
   `v1.8.0` `tla2tools.jar` asset downloaded on 2026-08-27.
 - OpenJDK `21.0.12+8-1-24.04`, Ubuntu Linux `amd64`.
-- Run on 2026-08-27.
+- Run on 2026-08-29.
 
 ## Evidence
 
@@ -299,15 +305,15 @@ report `Model checking completed. No error has been found.`
 
 | Model | States generated | Distinct states | Search depth |
 | --- | --- | --- | --- |
-| `NavigationSession.tla` | 31,586 | 5,114 | 15 |
+| `NavigationSession.tla` | 47,369 | 6,761 | 15 |
 | `AtomicRestoration.tla` | 8,081 | 2,333 | 9 |
 | `SnapshotAuthority.tla` | 36,755 | 13,790 | 9 |
 
-The additional state records semantic unavailable outcomes independently from
-their apply/retain execution class, retains canonical request payloads
-independently from prepared results, and retains each operation's requested
-lens independently from its result. Stale maintenance also records whether the
-same request still owes a re-gather before admission.
+The additional state records semantic unavailable and failed outcomes
+independently from their apply/retain execution class, retains canonical
+request payloads independently from prepared results, and retains each
+operation's requested lens independently from its result. Stale maintenance
+also records whether the same request still owes a re-gather before admission.
 
 Deadlock checking is disabled in all three configs. A behaviour that has issued
 every intent, drained its queue, and consumed its last effect has nothing left
@@ -349,11 +355,14 @@ records how to reproduce them.
 | NS11 | Stop releasing the effect on acknowledgement | `EffectEventuallyConsumed` | violated |
 | NS12 | Stop releasing the effect on acknowledgement | `MaintenanceEventuallyDrains` | violated |
 | NS13 | Let a superseded operation stay outstanding forever | `EveryExplicitIntentSettles` | violated |
-| NS14 | Keep the revision unchanged for a changed-snapshot unavailable result | `UnavailableRevisionMatchesSnapshotChange` | violated |
-| NS15 | Advance the revision for an unchanged-snapshot unavailable result | `UnavailableRevisionMatchesSnapshotChange` | violated |
-| NS16 | Install an unavailable result at a revision different from its recorded result revision | `UnavailableRevisionMatchesSnapshotChange` | violated |
+| NS14 | Keep the revision unchanged for a changed-snapshot unavailable result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
+| NS15 | Advance the revision for an unchanged-snapshot unavailable result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
+| NS16 | Install an unavailable result at a revision different from its recorded result revision | `NonSuccessRevisionMatchesSnapshotChange` | violated |
 | NS17 | Mark a stale request ready and clear its re-gather debt during rebuild | `MaintenanceRegatherDiscipline` | violated |
 | NS18 | Drop an earlier queued request while allowing a later request to be admitted | `EveryQueuedRequestIsAdmitted` | violated |
+| NS19 | Keep the revision unchanged for a changed-snapshot failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
+| NS20 | Advance the revision for an unchanged-snapshot Registry or policy failed result | `NonSuccessRevisionMatchesSnapshotChange` | violated |
+| NS21 | Advance the installed revision during Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -380,7 +389,7 @@ records how to reproduce them.
 | SA17 | Return a result that does not record its operation ID | `OperationAndResultAreCorrelated` | violated |
 | SA18 | Install and return another admissible session lens instead of the exact requested lens | `AppliedResultEqualsExactRequest` | violated |
 
-Forty-three probes, forty-two expected violations and one expected pass. `SA6`
+Forty-six probes, forty-five expected violations and one expected pass. `SA6`
 is the one probe expected not to fire: it applies the same mutation as `SA5`
 and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why

--- a/docs/design/models/inspection-subject-navigation/README.md
+++ b/docs/design/models/inspection-subject-navigation/README.md
@@ -439,6 +439,7 @@ records how to reproduce them.
 | NS35 | Omit product and host authority from Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS36 | Rewrite both Navigation preparation failure and its witness to use applied authority | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | NS37 | Rewrite both Navigation preparation failure and its source witness as evaluation | `PreparationFailureRetainsSnapshotAndRevision` | violated |
+| NS38 | Coherently install a changed snapshot and revision during Navigation preparation failure | `PreparationFailureRetainsSnapshotAndRevision` | violated |
 | AR1 | Drop the current-intent requirement from preparation publication | `PreparationRequiresReadyPairAndCurrentIntent` | violated |
 | AR2 | Publish a different subject than the independently retained request | `PreparedPairEqualsRequestedPayload` | violated |
 | AR3 | Allow a superseded preparation to publish | `NoSupersededPreparationResult` | violated |
@@ -465,13 +466,13 @@ records how to reproduce them.
 | SA17 | Return a result that does not record its operation ID | `OperationAndResultAreCorrelated` | violated |
 | SA18 | Install and return another admissible session lens instead of the exact requested lens | `AppliedResultEqualsExactRequest` | violated |
 
-Sixty-two probes, sixty-one expected violations and one expected pass. `SA6`
+Sixty-three probes, sixty-two expected violations and one expected pass. `SA6`
 is the one probe expected not to fire: it applies the same mutation as `SA5`
 and checks the revision-arithmetic invariant instead, which does not notice a
 snapshot rewritten in place. That pair is why
 `NonApplyStepsPreserveInstalledSnapshot` compares the record.
 
-Twenty-four probes exist specifically because a claim used to be satisfiable
+Twenty-five probes exist specifically because a claim used to be satisfiable
 by the wrong thing. `NS16` separates installed revision from a self-consistent
 result,
 `NS17` admits stale work without re-gathering, `NS18` lets a later admission
@@ -493,12 +494,15 @@ source, `NS35` erases its returned authority, and `NS36` changes both the
 action and shared witness so only the dedicated preparation-failure invariant
 rejects the wrong authority class. `NS37` changes both the action and source
 witness while the independent occurrence field still identifies preparation
-failure, proving the dedicated invariant rejects the source rewrite. `AR2`
-publishes a payload that differs from the retained request, `SA14` applies a
-later supplied-prior operation after an earlier one was rejected, `SA15` adopts
-only the stale same-session supplied snapshot whose origin and lens resemble
-session data, and `SA18` returns another admissible session lens under the
-correct operation ID.
+failure, proving the dedicated invariant rejects the source rewrite. `NS38`
+coherently rewrites the action, result, disposition, authority, and
+shared revision witness so only the dedicated invariant's named retention
+clauses reject the changed snapshot and revision. `AR2` publishes a payload
+that differs from the retained request, `SA14` applies a later supplied-prior
+operation after an earlier one was rejected, `SA15` adopts only the stale
+same-session supplied snapshot whose origin and lens resemble session data,
+and `SA18` returns another admissible session lens under the correct operation
+ID.
 
 ## Changing a model
 


### PR DESCRIPTION
## Summary

Complete Inspection Subject Navigation's focused lens policy: bind each navigation lens to one exact structural subject plus one Registry facet, choose preferred semantic roles before registry order, and define deterministic fallback and all-non-success outcomes.

The design now gives directly activated Members a Member Overview recommendation, treats missing preferred roles and empty option sets as visible policy failures, and maps every exact Registry result into a Navigation outcome without fallback. Standalone cross-subject lens requests are rejected before Registry resolution. Each outcome retains a recommendation or exact-request basis so refresh behavior remains owner-issued, while complete Registry evidence and distinct Navigation preparation failure stay visible.

Completed Registry and policy failures now install complete changed snapshots
under the same revision rule as unavailable outcomes. Navigation preparation
failure remains a distinct retaining result. If subject reconciliation removes
an exact request's subject before its non-success returns, the result keeps the
exact request evidence while the installed snapshot uses the replacement
subject's recommendation basis.

This remains one-owner work in `docs/design/inspection-subject-navigation.md`. View Facet Registry keeps membership, descriptors, order, roles, and availability; Inspect Web keeps presentation and interaction; #4787 keeps portable restoration composition.

## Demo

The role wins even when it is not first in Registry order:

| Registry order | Status | Role |
| ---: | --- | --- |
| `library.integrations` | Available | — |
| `library.references` | Available | Library references |

**Recommendation:** exact `{active library, library.references}` rather than the first available option.

Neighboring cases remain deterministic:

| Input | Navigation result |
| --- | --- |
| Preferred References unavailable; Integrations available | Integrations, with preferred evidence retained |
| Direct Member activation without a lens | Exact Member plus Member Overview |
| No available option and one failed evaluation | Failed, with all non-success evidence retained |
| Explicit Type Metadata request against a Library | Rejected as inapplicable; no fallback |
| Recommended fallback; preferred role later becomes available | Refresh reruns recommendation and selects the preferred role |
| Explicit lens bound to another exact subject | Rejected before Registry resolution |

## Compatibility

- No runtime implementation or user-visible command changes.
- Existing Registry IDs and descriptors are unchanged.
- `NavigationSession.tla` now models complete unavailable and failed snapshots
  plus distinct Navigation preparation failure within the retained-consumer
  synchronization model; it still treats subjects and lenses as opaque and
  does not model pure ranking or Registry-result classification.
- Browser rendering, accessibility, URL/history state, and portable packet semantics remain outside this claim.

## Validation

- `npx markdownlint-cli docs/design/inspection-subject-navigation.md docs/design/models/inspection-subject-navigation/README.md`
- `tlc2.TLC -workers 1 -coverage 1 NavigationSession.tla`: 668,938 generated / 116,745 distinct states / depth 23; every action live. Automatic-worker runs preserve the state counts but may report depth 23 or 24.
- Mutation probes: changed and unchanged failed revision, Navigation preparation retention/source/authority, and independent retention/authority/source attribution each behave as recorded
- `git diff --check origin/main...HEAD`
- MAI-Code early design feedback: clean

## Candidate

- Head: `d8970580b`
- Effective base: `636eb7307`

Closes #5013
