### PR TITLE
Give unmatched local-function declarations an honest Added/Removed row (#5022 item 5)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AnnotatedSourceJsonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedSourceJsonTests.cs
@@ -323,8 +323,11 @@ public class AnnotatedSourceJsonTests
     [InlineData("methodology_version")]
     public void StrictStructuralDiffReader_RejectsUnsupportedVersions(string propertyName)
     {
+        int currentVersion = propertyName == "schema_version"
+            ? CSharpStructuralDiffDocument.CurrentSchemaVersion
+            : CSharpStructuralDiffDocument.CurrentMethodologyVersion;
         string json = StructuralDiffJson().Replace(
-            $"\"{propertyName}\":1",
+            $"\"{propertyName}\":{currentVersion}",
             $"\"{propertyName}\":999",
             StringComparison.Ordinal);
 

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1740,6 +1740,36 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotTreatCommentParenthesesAsCalleeRewrite()
+    {
+        // Close negative (round-10 review, reviewer A): an argument-only
+        // edit where a `//` line comment inside the invocation's own text
+        // contains a misleading '(' character must still decline callee
+        // comparison. Scanning backward, the comment's '(' is reached
+        // *before* its own leading '/' characters, so checking for the
+        // disqualifying character only as the scan reaches it (rather than
+        // as a dedicated upfront pass over the whole text) would let this
+        // paren reach depth zero and return a wrong "match" before the scan
+        // ever saw the '/' that should have disqualified it. The callee
+        // ("Log") is unchanged, so this must not license an unrelated
+        // declaration.
+        var before = TrustedDocument(
+            "Log(1 // (\n);",
+            new NodeSpec("InvocationExpression", "Log(1 // (\n)", [0x10]));
+        var after = TrustedDocument(
+            "Log(2 // (\n);\nstatic void F()\n{\n}",
+            new NodeSpec("InvocationExpression", "Log(2 // (\n)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssueCorrespondence_DoesNotInferDeclarationWhenMultipleCandidatesShareScope()
     {
         // Close negative: two new local-function declarations with no IL

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1642,6 +1642,70 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotInferDeclarationRetainedUnchangedOnBothSides()
+    {
+        // Close negative (round-1 review, both reviewers, same root cause): a
+        // local-function declaration with no IL origin of its own is present
+        // on both sides, unchanged. Before this fix, "only such declaration
+        // on its own side" was checked independently per side, so this
+        // unrelated retained declaration would wrongly qualify as both
+        // Removed (from the before-side check) and Added (from the
+        // after-side check) merely because some unrelated call-site elsewhere
+        // in the document was rewritten. The declaration must stay
+        // Unsupported on both sides: presence must be genuinely asymmetric
+        // (absent from one side entirely), not merely "the only one on its
+        // own side."
+        var before = TrustedDocument(
+            "__NoTypeParameter_g__Own_0_0(value);\nstatic int Own(int input) => input + 1;",
+            new NodeSpec("InvocationExpression", "__NoTypeParameter_g__Own_0_0(value)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int Own(int input) => input + 1;", null));
+        var after = TrustedDocument(
+            "Own(value);\nstatic int Own(int input) => input + 1;",
+            new NodeSpec("InvocationExpression", "Own(value)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int Own(int input) => input + 1;", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Equal(
+            CSharpUnmatchedNodeReason.Unsupported,
+            Assert.Single(issued.UnmatchedBefore).Reason);
+        Assert.Equal(
+            CSharpUnmatchedNodeReason.Unsupported,
+            Assert.Single(issued.UnmatchedAfter).Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotInferDeclarationFromUnrelatedUnchangedCallSite()
+    {
+        // Close negative (round-1 review, both reviewers, same root cause): a
+        // new local-function declaration with no IL origin appears alongside
+        // a matched InvocationExpression call site elsewhere in the document
+        // whose selected text is unchanged (an unrelated, pre-existing call).
+        // Before this fix, "any matched InvocationExpression anywhere in the
+        // document" was enough to satisfy the call-site-rewrite check, so
+        // this unrelated unchanged call would wrongly license inferring the
+        // new declaration. The matched call site must actually be rewritten
+        // (its selected text differs before/after), not merely present.
+        var before = TrustedDocument(
+            "Log();",
+            new NodeSpec("InvocationExpression", "Log()", [0x10]));
+        var after = TrustedDocument(
+            "Log();\nstatic void Unrelated()\n{\n}",
+            new NodeSpec("InvocationExpression", "Log()", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void Unrelated()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Empty(issued.UnmatchedBefore);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssuedCorrespondence_RoundTripsDocumentNodeProvenanceAndUnmatchedNodes()
     {
         var before = TrustedDocument(

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1661,6 +1661,56 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_InfersDeclarationWhenCalleeRewriteHasParenthesizedReceiver()
+    {
+        // Close positive (round-8 review, reviewers A and B): a matched
+        // InvocationExpression pair whose receiver itself contains balanced
+        // parentheses (a cast, `((IFoo)value)`) must still have its true
+        // callee correctly compared. A naive "first '(' in the text" split
+        // would misidentify the callee split point -- the text starts with
+        // '(' -- and wrongly decline to detect this as a genuine rewrite.
+        var before = TrustedDocument(
+            "return ((IFoo)value).Old();",
+            new NodeSpec("InvocationExpression", "((IFoo)value).Old()", [0x10]));
+        var after = TrustedDocument(
+            "return ((IFoo)value).New();\nstatic int New()\n{\n    return 1;\n}",
+            new NodeSpec("InvocationExpression", "((IFoo)value).New()", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int New()\n{\n    return 1;\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.InferredDeclaration, declaration.Reason);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotTreatUnchangedCalleeWithNestedInvocationReceiverAsRewrite()
+    {
+        // Close negative, symmetric to the parenthesized-receiver positive
+        // above: a call-returning receiver (`GetReceiver()`) also contains a
+        // balanced paren pair before the true callee's own argument list.
+        // The callee (`GetReceiver().Log`) is unchanged here -- only the
+        // argument differs -- so this must not license an unrelated
+        // declaration as a rewrite target, proving the balanced scan finds
+        // the correct split rather than merely the first or last paren.
+        var before = TrustedDocument(
+            "GetReceiver().Log(1);",
+            new NodeSpec("InvocationExpression", "GetReceiver().Log(1)", [0x10]));
+        var after = TrustedDocument(
+            "GetReceiver().Log(2);\nstatic void F()\n{\n}",
+            new NodeSpec("InvocationExpression", "GetReceiver().Log(2)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssueCorrespondence_DoesNotInferDeclarationWhenMultipleCandidatesShareScope()
     {
         // Close negative: two new local-function declarations with no IL

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1711,6 +1711,35 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotTreatArgumentLiteralParenthesesAsCalleeRewrite()
+    {
+        // Close negative (round-9 review, reviewers A and B): an
+        // argument-only edit where the changed argument is a string literal
+        // that itself contains a '(' character (Log("(") -> Log("changed("))
+        // must decline callee comparison entirely rather than let the
+        // literal's unbalanced paren either masquerade as the argument
+        // list's true boundary or make the scan fail to find a balanced
+        // match at all (which would otherwise silently fall back to
+        // comparing full invocation text -- reintroducing the exact
+        // argument-only false positive round 7 fixed). The callee ("Log")
+        // is unchanged, so this must not license an unrelated declaration.
+        var before = TrustedDocument(
+            "Log(\"(\");",
+            new NodeSpec("InvocationExpression", "Log(\"(\")", [0x10]));
+        var after = TrustedDocument(
+            "Log(\"changed(\");\nstatic void F()\n{\n}",
+            new NodeSpec("InvocationExpression", "Log(\"changed(\")", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssueCorrespondence_DoesNotInferDeclarationWhenMultipleCandidatesShareScope()
     {
         // Close negative: two new local-function declarations with no IL

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1706,6 +1706,118 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotInferDeclarationWhenRetainedCopyGainsProvenance()
+    {
+        // Close negative (round-1 review, reviewer A): the same declaration
+        // is present on both sides, but the before copy happens to carry IL
+        // provenance of its own (e.g. a single-expression body sharing a
+        // sequence point with its header) while the after copy does not.
+        // Before this fix, "the only null-provenance candidate on its own
+        // side" counted only null-provenance nodes, so the before copy
+        // (excluded by its provenance) made beforeDeclarationCandidates == 0
+        // while afterDeclarationCandidates == 1 -- looking asymmetric even
+        // though the declaration is genuinely retained. Presence must be
+        // judged by total declarations on a side (any provenance), not just
+        // null-provenance candidates, to prove genuine absence.
+        var before = TrustedDocument(
+            "__NoTypeParameter_g__Own_0_0(value);\nstatic int Own(int input) => input + 1;",
+            new NodeSpec("InvocationExpression", "__NoTypeParameter_g__Own_0_0(value)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int Own(int input) => input + 1;", [0x20]));
+        var after = TrustedDocument(
+            "Own(value);\nstatic int Own(int input) => input + 1;",
+            new NodeSpec("InvocationExpression", "Own(value)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int Own(int input) => input + 1;", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotTreatDifferentlyInterleavedUnchangedCallAsRewrite()
+    {
+        // Close negative (round-1 review, reviewer B): a matched invocation
+        // is rendered on a single contiguous line in the after document, but
+        // split into two spans in the before document because a real
+        // interleaved IL line was woven between its two rendered C# pieces
+        // -- a permitted rendering (see CSharpAnnotatedSourceProjection), not
+        // a rewrite. Comparing raw spans (or even IL-projected spans, since
+        // an interleaved split still leaves distinct pieces once a genuine
+        // line break separates them) makes the differing span count alone
+        // look like a rewrite, which would wrongly license inferring an
+        // unrelated new declaration elsewhere in the document. The call-site
+        // check must decline to guess when either side's matched invocation
+        // still spans more than one projected piece.
+        const string beforeCall1 = "Log(";
+        const string beforeIl = "IL_0000: nop";
+        const string beforeCall2 = "value);";
+        const string declarationText = "static void Unrelated()\n{\n}";
+        string beforeText = $"{beforeCall1}\n{beforeIl}\n{beforeCall2}";
+        int call1Start = beforeText.IndexOf(beforeCall1, StringComparison.Ordinal);
+        int ilStart = beforeText.IndexOf(beforeIl, StringComparison.Ordinal);
+        int call2Start = beforeText.IndexOf(beforeCall2, StringComparison.Ordinal);
+        var before = new AnnotatedSourceDocument(
+            beforeText,
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [
+                        new AnnotatedSourceSpan(call1Start, beforeCall1.Length),
+                        new AnnotatedSourceSpan(call2Start, beforeCall2.Length),
+                    ],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10])),
+                new AnnotatedSourceNode(
+                    1,
+                    AnnotatedSourceNode.InstructionKind,
+                    SourceLineKind.Il,
+                    [new AnnotatedSourceSpan(ilStart, beforeIl.Length)],
+                    IlOffset: 0),
+            ],
+            [],
+            [],
+            [],
+            Source());
+
+        const string afterCall = "Log(value);";
+        string afterText = $"{afterCall}\n{declarationText}";
+        int afterCallStart = afterText.IndexOf(afterCall, StringComparison.Ordinal);
+        int afterDeclarationStart = afterText.IndexOf(declarationText, StringComparison.Ordinal);
+        var after = new AnnotatedSourceDocument(
+            afterText,
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(afterCallStart, afterCall.Length)],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10])),
+                new AnnotatedSourceNode(
+                    1,
+                    "LocalFunctionStatement",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(afterDeclarationStart, declarationText.Length)],
+                    Provenance: null),
+            ],
+            [],
+            [],
+            [],
+            Source());
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Empty(issued.UnmatchedBefore);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssuedCorrespondence_RoundTripsDocumentNodeProvenanceAndUnmatchedNodes()
     {
         var before = TrustedDocument(

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1883,6 +1883,87 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotThrowWhenDeclarationCandidateCoexistsWithMultiSpanIlNode()
+    {
+        // Close negative (round-1 review, reviewers A and B, on the previous
+        // fix): a sole null-provenance LocalFunctionStatement makes
+        // declarationAdded true, so the call-site rewrite check does build a
+        // projection -- but a wholly unrelated structural "Block" IL node
+        // elsewhere in the same document still violates
+        // CSharpAnnotatedSourceProjection.Create's one-contiguous-span
+        // requirement. The declaration-count gate alone cannot rule this out,
+        // since it says nothing about the document's IL node shapes. The
+        // projection attempt must fail conservatively -- leaving the
+        // declaration Unsupported -- rather than let the document's
+        // unrelated shape surface as a thrown exception from
+        // IssueCorrespondence.
+        const string invocationText = "A();";
+        const string declarationText = "static void Own()\n{\n}";
+        string afterText = $"{invocationText}\n{declarationText}";
+        int afterInvocationStart = afterText.IndexOf(invocationText, StringComparison.Ordinal);
+        int afterDeclarationStart = afterText.IndexOf(declarationText, StringComparison.Ordinal);
+        var before = new AnnotatedSourceDocument(
+            invocationText,
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, invocationText.Length)],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10])),
+                // Unrelated to the invocation or the declaration below: a
+                // structural, offsetless IL node spanning two disjoint
+                // pieces, which AnnotatedSourceNode permits but
+                // CSharpAnnotatedSourceProjection.Create does not.
+                new AnnotatedSourceNode(
+                    1,
+                    "Block",
+                    SourceLineKind.Il,
+                    [
+                        new AnnotatedSourceSpan(0, 1),
+                        new AnnotatedSourceSpan(2, 1),
+                    ],
+                    IlOffset: null),
+            ],
+            [],
+            [],
+            [],
+            Source());
+        var after = new AnnotatedSourceDocument(
+            afterText,
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(afterInvocationStart, invocationText.Length)],
+                    Provenance: new AnnotatedSourceNodeProvenance([0x10])),
+                new AnnotatedSourceNode(
+                    1,
+                    "LocalFunctionStatement",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(afterDeclarationStart, declarationText.Length)],
+                    Provenance: null),
+            ],
+            [],
+            [],
+            [],
+            Source());
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Empty(issued.UnmatchedBefore);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        // CompareStructure's own projection (pre-existing, unconditional, and
+        // out of scope for this carve-out) would itself reject this
+        // document's unrelated Block node; this test verifies only that
+        // IssueCorrespondence -- the narrower surface this carve-out owns --
+        // does not throw and classifies the declaration conservatively.
+    }
+
+    [Fact]
     public void IssuedCorrespondence_RoundTripsDocumentNodeProvenanceAndUnmatchedNodes()
     {
         var before = TrustedDocument(

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1670,6 +1670,39 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssuedCorrespondence_RoundTripsInferredDeclarationReason()
+    {
+        // Regression: the strict JSON converter for CSharpUnmatchedNodeReason
+        // must know about InferredDeclaration too, or serializing it throws
+        // (AnnotatedSourceContractJsonException) instead of round-tripping.
+        var before = TrustedDocument(
+            "__CallsEmpty_g__F_0_0();",
+            new NodeSpec("InvocationExpression", "__CallsEmpty_g__F_0_0()", [0x10]));
+        var after = TrustedDocument(
+            "F();\nstatic void F() { }",
+            new NodeSpec("InvocationExpression", "F()", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F() { }", null));
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+        Assert.Equal(
+            CSharpUnmatchedNodeReason.InferredDeclaration,
+            Assert.Single(issued.UnmatchedAfter).Reason);
+
+        string json = JsonSerializer.Serialize(
+            issued,
+            AnnotatedSourceDocumentJsonContext.Default.CSharpNodeCorrespondenceResult);
+        var replayed = JsonSerializer.Deserialize(
+            json,
+            AnnotatedSourceDocumentJsonContext.Default.CSharpNodeCorrespondenceResult);
+
+        Assert.NotNull(replayed);
+        Assert.Equal(issued.UnmatchedAfter, replayed.UnmatchedAfter);
+        Assert.Equal(
+            CSharpUnmatchedNodeReason.InferredDeclaration,
+            Assert.Single(replayed.UnmatchedAfter).Reason);
+        Assert.Equal(2, CSharpBodyDiff.CompareStructure(replayed).Rows.Length);
+    }
+
+    [Fact]
     public void StructuralDiffDocument_ReissuesCorrespondenceAndDerivesRows()
     {
         var before = TrustedDocument(

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1558,6 +1558,17 @@ public class CSharpStructuralComparisonTests
         var display = CSharpStructuralDiffPrinter.ToDisplayRows(comparison);
         Assert.Contains(display, row =>
             row.Change == "Added" && row.Detail == "+ static int Own(int input) => input + 1;");
+
+        // Matching #4952's corpus mockup for this exact PR shape: the added
+        // declaration now gets its own caret in the rendered After body,
+        // instead of appearing with no annotation at all.
+        string renderedAfter = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison, CSharpStructuralSide.After);
+        Assert.Contains(
+            "static int Own(int input) => input + 1;\n"
+            + "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+            + "raise: LocalFunctionStatement",
+            renderedAfter);
     }
 
     [Fact]
@@ -1586,6 +1597,17 @@ public class CSharpStructuralComparisonTests
         Assert.Equal(2, comparison.Rows.Length);
         var removed = Assert.Single(comparison.Rows, row => row.Change == CSharpStructuralChangeKind.Removed);
         Assert.Equal("LocalFunctionStatement", removed.BeforeKind);
+
+        // Symmetric to the Added case: the removed declaration gets its own
+        // caret in the rendered Before body, instead of falling through with
+        // no annotation at all.
+        string renderedBefore = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison, CSharpStructuralSide.Before);
+        Assert.Contains(
+            "static void F()\n"
+            + "^^^^^^^^^^^^^^^\n"
+            + "raise: LocalFunctionStatement",
+            renderedBefore);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1636,6 +1636,31 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_DoesNotTreatArgumentOnlyInvocationChangeAsCallSiteRewrite()
+    {
+        // Close negative (round-7 review, reviewers A and B): a matched
+        // InvocationExpression pair whose callee is unchanged but whose
+        // arguments differ (Log(1) -> Log(2)) must not itself license an
+        // unrelated new local-function declaration elsewhere in the document
+        // as an inferred rewrite target. The call's target never changed, so
+        // this is not evidence that anything was rewritten alongside it.
+        var before = TrustedDocument(
+            "Log(1);",
+            new NodeSpec("InvocationExpression", "Log(1)", [0x10]));
+        var after = TrustedDocument(
+            "Log(2);\nstatic void F()\n{\n}",
+            new NodeSpec("InvocationExpression", "Log(2)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssueCorrespondence_DoesNotInferDeclarationWhenMultipleCandidatesShareScope()
     {
         // Close negative: two new local-function declarations with no IL

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1740,17 +1740,28 @@ public class CSharpStructuralComparisonTests
     public void IssueCorrespondence_DoesNotTreatDifferentlyInterleavedUnchangedCallAsRewrite()
     {
         // Close negative (round-1 review, reviewer B): a matched invocation
-        // is rendered on a single contiguous line in the after document, but
-        // split into two spans in the before document because a real
-        // interleaved IL line was woven between its two rendered C# pieces
-        // -- a permitted rendering (see CSharpAnnotatedSourceProjection), not
-        // a rewrite. Comparing raw spans (or even IL-projected spans, since
-        // an interleaved split still leaves distinct pieces once a genuine
-        // line break separates them) makes the differing span count alone
-        // look like a rewrite, which would wrongly license inferring an
-        // unrelated new declaration elsewhere in the document. The call-site
-        // check must decline to guess when either side's matched invocation
-        // still spans more than one projected piece.
+        // renders identically as C# on both sides -- "Log(" and "value);" on
+        // two consecutive lines -- but the before document has a real
+        // interleaved IL line woven between those two rendered pieces while
+        // the after document has none. Per the real producer's own
+        // convention (ResearchViews.cs), a C# span that continues onto a
+        // later line keeps its trailing line break as part of the span, so
+        // the before side's raw spans are (0,5)="Log(\n" and (18,7)="value);"
+        // -- two spans purely because of the interleaved IL -- while the
+        // after side, with nothing interleaved, is naturally already one
+        // span covering the identical text "Log(\nvalue);". Comparing raw
+        // spans makes the differing span *count* alone (2 vs. 1) look like a
+        // rewrite even though the reconstructed text is character-for-
+        // character identical, which would wrongly license inferring an
+        // unrelated new declaration elsewhere in the document. Only once the
+        // interleaved IL line is projected away does the before side's two
+        // pieces coalesce back into the same single span, at which point the
+        // projected text comparison correctly finds no difference. This is
+        // the genuine regression case for "compare projected, not raw,
+        // text" -- unlike a hand-built fixture that never lets the spans
+        // coalesce, this one only passes because the projected comparison
+        // itself reports equal text, not merely because of the multi-span
+        // guard.
         const string beforeCall1 = "Log(";
         const string beforeIl = "IL_0000: nop";
         const string beforeCall2 = "value);";
@@ -1767,7 +1778,11 @@ public class CSharpStructuralComparisonTests
                     "InvocationExpression",
                     SourceLineKind.CSharp,
                     [
-                        new AnnotatedSourceSpan(call1Start, beforeCall1.Length),
+                        // Includes the trailing '\n': the construct continues
+                        // onto "value);" on a later line, so the line break
+                        // is the construct's own text, per the real
+                        // producer's convention.
+                        new AnnotatedSourceSpan(call1Start, beforeCall1.Length + 1),
                         new AnnotatedSourceSpan(call2Start, beforeCall2.Length),
                     ],
                     Provenance: new AnnotatedSourceNodeProvenance([0x10])),
@@ -1783,13 +1798,16 @@ public class CSharpStructuralComparisonTests
             [],
             Source());
 
-        const string afterCall = "Log(value);";
+        const string afterCall = "Log(\nvalue);";
         string afterText = $"{afterCall}\n{declarationText}";
         int afterCallStart = afterText.IndexOf(afterCall, StringComparison.Ordinal);
         int afterDeclarationStart = afterText.IndexOf(declarationText, StringComparison.Ordinal);
         var after = new AnnotatedSourceDocument(
             afterText,
             [
+                // No interleaved IL splits this call on the after side, so
+                // it is naturally already one contiguous span covering the
+                // same two rendered lines as the before side.
                 new AnnotatedSourceNode(
                     0,
                     "InvocationExpression",
@@ -1815,6 +1833,53 @@ public class CSharpStructuralComparisonTests
         var declaration = Assert.Single(issued.UnmatchedAfter);
         Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
         Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotProjectWhenNoDeclarationCandidateExists()
+    {
+        // Close negative (round-1 review, reviewer B): CSharpAnnotatedSourceProjection.Create
+        // requires every IL-medium node to be exactly one contiguous rendered
+        // line, but AnnotatedSourceNode itself permits a structural
+        // (non-instruction) IL-medium node -- a "Block", say -- with several
+        // spans and no IlOffset. Before this fix, ClassifyUnprovenancedDeclarations
+        // built a projection of every document unconditionally, so
+        // IssueCorrespondence would throw on such a document even though it
+        // has no null-provenance declaration candidate that could ever be
+        // promoted. The declaration-count checks must run first, and the
+        // projection must stay unbuilt when they already rule out a
+        // promotion, so this document -- which has no LocalFunctionStatement
+        // node at all -- must not throw.
+        var before = TrustedDocument(
+            "A();",
+            new NodeSpec("InvocationExpression", "A()", [0x10]));
+        var beforeWithBlock = new AnnotatedSourceDocument(
+            before.Text,
+            [
+                .. before.Nodes,
+                new AnnotatedSourceNode(
+                    before.Nodes.Count,
+                    "Block",
+                    SourceLineKind.Il,
+                    [
+                        new AnnotatedSourceSpan(0, 1),
+                        new AnnotatedSourceSpan(2, 1),
+                    ],
+                    IlOffset: null),
+            ],
+            [],
+            [],
+            [],
+            Source());
+        var after = TrustedDocument(
+            "A();",
+            new NodeSpec("InvocationExpression", "A()", [0x10]));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(beforeWithBlock, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Empty(issued.UnmatchedBefore);
+        Assert.Empty(issued.UnmatchedAfter);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1521,6 +1521,127 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void IssueCorrespondence_InfersAddedLocalFunctionDeclarationAlongsideMatchedCallSite()
+    {
+        // #4116's shape (issue #5022 item 5): an undeclared synthesized call
+        // is rewritten to call a declared local function. The call site keeps
+        // the same IL origin on both sides (matched, Changed); the new
+        // declaration header has no IL origin of its own (only its body
+        // would), and is the only such declaration in the document.
+        var before = TrustedDocument(
+            "return __NoTypeParameter_g__Own_0_0(value);",
+            new NodeSpec("InvocationExpression", "__NoTypeParameter_g__Own_0_0(value)", [0x10]));
+        var after = TrustedDocument(
+            "return Own(value);\nstatic int Own(int input) => input + 1;",
+            new NodeSpec("InvocationExpression", "Own(value)", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static int Own(int input) => input + 1;", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        Assert.Empty(issued.UnmatchedBefore);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.InferredDeclaration, declaration.Reason);
+
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+        Assert.True(comparison.IsCorrespondenceComplete);
+        Assert.Equal(2, comparison.Rows.Length);
+        var changed = Assert.Single(comparison.Rows, row => row.Change == CSharpStructuralChangeKind.Changed);
+        Assert.Equal("InvocationExpression", changed.BeforeKind);
+        var added = Assert.Single(comparison.Rows, row => row.Change == CSharpStructuralChangeKind.Added);
+        Assert.Equal("LocalFunctionStatement", added.AfterKind);
+
+        // End-to-end: the declaration gets its own Added display row and
+        // detail, instead of being silently dropped (#3902's "zero matched
+        // structural-diff rows" / #4116's "declaration falls into the gap
+        // bucket" problem).
+        var display = CSharpStructuralDiffPrinter.ToDisplayRows(comparison);
+        Assert.Contains(display, row =>
+            row.Change == "Added" && row.Detail == "+ static int Own(int input) => input + 1;");
+    }
+
+    [Fact]
+    public void IssueCorrespondence_InfersRemovedLocalFunctionDeclarationAlongsideMatchedCallSite()
+    {
+        // Symmetric removal direction: a declared local function is inlined
+        // back to an undeclared synthesized call. The declaration disappears
+        // from the before side with no IL origin of its own.
+        var before = TrustedDocument(
+            "F();\nstatic void F()\n{\n}",
+            new NodeSpec("InvocationExpression", "F()", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+        var after = TrustedDocument(
+            "__CallsEmpty_g__F_0_0();",
+            new NodeSpec("InvocationExpression", "__CallsEmpty_g__F_0_0()", [0x10]));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedBefore);
+        Assert.Equal(CSharpUnmatchedNodeReason.InferredDeclaration, declaration.Reason);
+        Assert.Empty(issued.UnmatchedAfter);
+
+        var comparison = CSharpBodyDiff.CompareStructure(issued);
+        Assert.True(comparison.IsCorrespondenceComplete);
+        Assert.Equal(2, comparison.Rows.Length);
+        var removed = Assert.Single(comparison.Rows, row => row.Change == CSharpStructuralChangeKind.Removed);
+        Assert.Equal("LocalFunctionStatement", removed.BeforeKind);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotInferDeclarationWithoutMatchedCallSiteRewrite()
+    {
+        // Close negative: a new local-function declaration with no IL origin
+        // of its own, but with no matched InvocationExpression call-site
+        // rewrite anywhere in the document. This is the general "declaration
+        // appears out of nowhere" case item 5 deliberately excludes (no
+        // paired call-site evidence to key structural uniqueness off of), so
+        // it must stay Unsupported like any other correspondence gap.
+        var before = TrustedDocument(
+            "return;",
+            new NodeSpec("ReturnStatement", "return;", [0x10]));
+        var after = TrustedDocument(
+            "return;\nstatic void F()\n{\n}",
+            new NodeSpec("ReturnStatement", "return;", [0x10]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Single(issued.Matches);
+        var declaration = Assert.Single(issued.UnmatchedAfter);
+        Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, declaration.Reason);
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
+    public void IssueCorrespondence_DoesNotInferDeclarationWhenMultipleCandidatesShareScope()
+    {
+        // Close negative: two new local-function declarations with no IL
+        // origin, in the same document. Structural uniqueness is the only
+        // thing this carve-out keys identity off of, so ambiguity between
+        // multiple candidates must leave both Unsupported rather than
+        // guessing which is "the" added declaration.
+        var before = TrustedDocument(
+            "F(); G();",
+            new NodeSpec("InvocationExpression", "F()", [0x10]),
+            new NodeSpec("InvocationExpression", "G()", [0x20]));
+        var after = TrustedDocument(
+            "F(); G();\nstatic void F()\n{\n}\nstatic void G()\n{\n}",
+            new NodeSpec("InvocationExpression", "F()", [0x10]),
+            new NodeSpec("InvocationExpression", "G()", [0x20]),
+            new NodeSpec("LocalFunctionStatement", "static void F()\n{\n}", null),
+            new NodeSpec("LocalFunctionStatement", "static void G()\n{\n}", null));
+
+        var issued = CSharpBodyDiff.IssueCorrespondence(before, after);
+
+        Assert.Equal(2, issued.Matches.Length);
+        Assert.All(
+            issued.UnmatchedAfter,
+            node => Assert.Equal(CSharpUnmatchedNodeReason.Unsupported, node.Reason));
+        Assert.False(CSharpBodyDiff.CompareStructure(issued).IsCorrespondenceComplete);
+    }
+
+    [Fact]
     public void IssuedCorrespondence_RoundTripsDocumentNodeProvenanceAndUnmatchedNodes()
     {
         var before = TrustedDocument(
@@ -2068,7 +2189,9 @@ public class CSharpStructuralComparisonTests
                     node.Kind,
                     SourceLineKind.CSharp,
                     [new AnnotatedSourceSpan(start, node.Text.Length)],
-                    Provenance: new AnnotatedSourceNodeProvenance(node.IlOffsets));
+                    Provenance: node.IlOffsets is null
+                        ? null
+                        : new AnnotatedSourceNodeProvenance(node.IlOffsets));
             })
             .ToArray();
         return new AnnotatedSourceDocument(text, sourceNodes, [], [], [], Source());
@@ -2085,7 +2208,7 @@ public class CSharpStructuralComparisonTests
     readonly record struct NodeSpec(
         string Kind,
         string Text,
-        IReadOnlyList<int> IlOffsets,
+        IReadOnlyList<int>? IlOffsets,
         int Occurrence = 0);
 
     static void AppendFingerprintBytes(IncrementalHash hash, ReadOnlySpan<byte> bytes)

--- a/src/ILInspector.Decompiler/AnnotatedSourceJson.cs
+++ b/src/ILInspector.Decompiler/AnnotatedSourceJson.cs
@@ -657,11 +657,13 @@ internal sealed class StrictCSharpUnmatchedNodeReasonJsonConverter
             nameof(CSharpUnmatchedNodeReason.Unsupported) => CSharpUnmatchedNodeReason.Unsupported,
             nameof(CSharpUnmatchedNodeReason.Ambiguous) => CSharpUnmatchedNodeReason.Ambiguous,
             nameof(CSharpUnmatchedNodeReason.NoCounterpart) => CSharpUnmatchedNodeReason.NoCounterpart,
+            nameof(CSharpUnmatchedNodeReason.InferredDeclaration) => CSharpUnmatchedNodeReason.InferredDeclaration,
             _ => default,
         };
         return name is nameof(CSharpUnmatchedNodeReason.Unsupported)
             or nameof(CSharpUnmatchedNodeReason.Ambiguous)
-            or nameof(CSharpUnmatchedNodeReason.NoCounterpart);
+            or nameof(CSharpUnmatchedNodeReason.NoCounterpart)
+            or nameof(CSharpUnmatchedNodeReason.InferredDeclaration);
     }
 
     protected override string? GetName(CSharpUnmatchedNodeReason value)
@@ -670,6 +672,7 @@ internal sealed class StrictCSharpUnmatchedNodeReasonJsonConverter
             CSharpUnmatchedNodeReason.Unsupported => nameof(CSharpUnmatchedNodeReason.Unsupported),
             CSharpUnmatchedNodeReason.Ambiguous => nameof(CSharpUnmatchedNodeReason.Ambiguous),
             CSharpUnmatchedNodeReason.NoCounterpart => nameof(CSharpUnmatchedNodeReason.NoCounterpart),
+            CSharpUnmatchedNodeReason.InferredDeclaration => nameof(CSharpUnmatchedNodeReason.InferredDeclaration),
             _ => null,
         };
 }

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -402,9 +402,13 @@ public static partial class CSharpBodyDiff
     /// demands every IL-medium node be exactly one contiguous span, a
     /// narrower contract than <see cref="AnnotatedSourceNode"/> itself
     /// enforces -- so it only runs once the cheap, projection-free presence
-    /// counts already show a declaration could plausibly be promoted; a
-    /// document with no such candidate must not pay, or risk failing, a
-    /// projection it will never use.
+    /// counts show a declaration could plausibly be promoted, and only when
+    /// some matched pair is even shaped like the rewrite being looked for.
+    /// Even then, a projection attempt can still fail on an unrelated
+    /// structural IL node elsewhere in the same document: that failure is
+    /// caught and treated the same as "no rewrite found" rather than allowed
+    /// to propagate, since a document is never required to satisfy an
+    /// invariant this narrow, internal carve-out happens to need.
     /// </remarks>
     static void ClassifyUnprovenancedDeclarations(
         AnnotatedSourceDocument beforeDocument,
@@ -453,43 +457,74 @@ public static partial class CSharpBodyDiff
         // than AnnotatedSourceNode itself enforces (a non-instruction
         // IL-medium node, such as a structural "Block", may legitimately span
         // several rendered lines). Build it only when a declaration could
-        // plausibly be promoted; a document with no such candidate must not
-        // newly fail to satisfy an invariant it never needed.
+        // plausibly be promoted, and only when some matched pair is even
+        // shaped like the call-site rewrite this carve-out looks for; a
+        // document with no such candidate must not newly fail to satisfy an
+        // invariant it never needed. Even then, an unrelated structural IL
+        // node elsewhere in the same document can still violate that
+        // invariant (round-1 review, reviewers A and B): the projection is
+        // an aid to this narrow carve-out, not something this document was
+        // ever required to support, so a failure here must fall back to the
+        // conservative Unsupported verdict rather than propagate.
         bool callSiteRewriteMatched = false;
         if (declarationAdded || declarationRemoved)
         {
-            var beforeProjection = CSharpAnnotatedSourceProjection.Create(beforeDocument);
-            var afterProjection = CSharpAnnotatedSourceProjection.Create(afterDocument);
-            var beforeProjectedById = beforeProjection.Document.Nodes.ToDictionary(static node => node.Id);
-            var afterProjectedById = afterProjection.Document.Nodes.ToDictionary(static node => node.Id);
+            var beforeById = beforeNodes.ToDictionary(static node => node.Id);
+            var afterById = afterNodes.ToDictionary(static node => node.Id);
+            bool hasInvocationMatch = matches.Any(match =>
+                beforeById.TryGetValue(match.Before.NodeId, out var beforeMatched)
+                && afterById.TryGetValue(match.After.NodeId, out var afterMatched)
+                && string.Equals(beforeMatched.Kind, "InvocationExpression", StringComparison.Ordinal)
+                && string.Equals(afterMatched.Kind, "InvocationExpression", StringComparison.Ordinal));
 
-            // A genuine call-site rewrite: both sides are InvocationExpression
-            // nodes rendered as one contiguous projected span each (so the
-            // rewrite check has a single, unambiguous run of characters to
-            // compare) whose selected, IL-projected text actually differs. An
-            // unchanged call that merely happens to retain matching IL evidence
-            // does not count -- that is not evidence that anything was rewritten
-            // alongside it. Nor does an invocation that still spans multiple
-            // projected pieces on either side after removing IL lines: this
-            // carve-out declines to guess at such a call's true text equality
-            // rather than risk treating a merely differently-interleaved,
-            // unchanged multi-line call as a rewrite (SelectedTextEqual compares
-            // spans pairwise by position, not by full concatenation, so a
-            // multi-span pairing is not reliable evidence either way here).
-            callSiteRewriteMatched = matches.Any(match =>
-                beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
-                && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
-                && beforeProjectedById.TryGetValue(beforeProjectedId, out var beforeCallNode)
-                && afterProjectedById.TryGetValue(afterProjectedId, out var afterCallNode)
-                && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
-                && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
-                && beforeCallNode.Spans.Count == 1
-                && afterCallNode.Spans.Count == 1
-                && !SelectedTextEqual(
-                    beforeProjection.Document,
-                    beforeCallNode,
-                    afterProjection.Document,
-                    afterCallNode));
+            if (hasInvocationMatch)
+            {
+                try
+                {
+                    var beforeProjection = CSharpAnnotatedSourceProjection.Create(beforeDocument);
+                    var afterProjection = CSharpAnnotatedSourceProjection.Create(afterDocument);
+                    var beforeProjectedById = beforeProjection.Document.Nodes.ToDictionary(static node => node.Id);
+                    var afterProjectedById = afterProjection.Document.Nodes.ToDictionary(static node => node.Id);
+
+                    // A genuine call-site rewrite: both sides are InvocationExpression
+                    // nodes rendered as one contiguous projected span each (so the
+                    // rewrite check has a single, unambiguous run of characters to
+                    // compare) whose selected, IL-projected text actually differs. An
+                    // unchanged call that merely happens to retain matching IL evidence
+                    // does not count -- that is not evidence that anything was rewritten
+                    // alongside it. Nor does an invocation that still spans multiple
+                    // projected pieces on either side after removing IL lines: this
+                    // carve-out declines to guess at such a call's true text equality
+                    // rather than risk treating a merely differently-interleaved,
+                    // unchanged multi-line call as a rewrite (SelectedTextEqual compares
+                    // spans pairwise by position, not by full concatenation, so a
+                    // multi-span pairing is not reliable evidence either way here).
+                    callSiteRewriteMatched = matches.Any(match =>
+                        beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
+                        && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
+                        && beforeProjectedById.TryGetValue(beforeProjectedId, out var beforeCallNode)
+                        && afterProjectedById.TryGetValue(afterProjectedId, out var afterCallNode)
+                        && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+                        && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+                        && beforeCallNode.Spans.Count == 1
+                        && afterCallNode.Spans.Count == 1
+                        && !SelectedTextEqual(
+                            beforeProjection.Document,
+                            beforeCallNode,
+                            afterProjection.Document,
+                            afterCallNode));
+                }
+                catch (ArgumentException)
+                {
+                    // A structural IL node elsewhere in the document does not
+                    // fit CSharpAnnotatedSourceProjection.Create's narrower
+                    // contract. This carve-out has no evidence either way in
+                    // that case, so it declines to guess rather than let an
+                    // unrelated shape it was never asked to verify surface as
+                    // a thrown exception from a public correspondence API.
+                    callSiteRewriteMatched = false;
+                }
+            }
         }
 
         foreach (var node in beforeNodes)

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -87,6 +87,18 @@ public enum CSharpUnmatchedNodeReason
 
     /// <summary>The unique evidence key exists on this side only.</summary>
     NoCounterpart,
+
+    /// <summary>
+    /// The node has no IL provenance of its own (a declaration header, e.g. a
+    /// local-function signature, whose only IL-bearing content is its body),
+    /// but it is the sole such declaration in its document, alongside a
+    /// matched call-site rewrite. Identity here is inferred from structural
+    /// uniqueness, not IL evidence — this is <em>not</em> an evidence-backed
+    /// match, and must not be treated as equivalent in strength to
+    /// <see cref="NoCounterpart"/> for any claim beyond "this declaration
+    /// participates in the diff instead of being silently dropped."
+    /// </summary>
+    InferredDeclaration,
 }
 
 /// <summary>One product-issued cross-document node match.</summary>
@@ -201,10 +213,12 @@ public sealed record CSharpStructuralComparison(
 
     /// <summary>Whether every C# node had enough unique evidence for a verdict.</summary>
     public bool IsCorrespondenceComplete => Correspondence is null
-        || Correspondence.UnmatchedBefore.All(static node =>
-            node.Reason == CSharpUnmatchedNodeReason.NoCounterpart)
-        && Correspondence.UnmatchedAfter.All(static node =>
-            node.Reason == CSharpUnmatchedNodeReason.NoCounterpart);
+        || Correspondence.UnmatchedBefore.All(static node => HasVerdict(node.Reason))
+        && Correspondence.UnmatchedAfter.All(static node => HasVerdict(node.Reason));
+
+    static bool HasVerdict(CSharpUnmatchedNodeReason reason)
+        => reason is CSharpUnmatchedNodeReason.NoCounterpart
+            or CSharpUnmatchedNodeReason.InferredDeclaration;
 }
 
 public static partial class CSharpBodyDiff
@@ -251,7 +265,11 @@ public static partial class CSharpBodyDiff
             var identity = new CSharpDocumentNodeIdentity(beforeRevision, node.Id);
             if (node.Provenance is null)
             {
-                unmatchedBefore.Add(new(identity, CSharpUnmatchedNodeReason.Unsupported));
+                // Classified in a later pass, once every match below is known:
+                // whether this qualifies as an honestly-scoped inferred
+                // declaration (see ClassifyUnprovenancedDeclarations) depends
+                // on whether a call-site rewrite elsewhere in this document
+                // matched, which is not yet decided partway through this loop.
                 continue;
             }
 
@@ -286,7 +304,7 @@ public static partial class CSharpBodyDiff
             var identity = new CSharpDocumentNodeIdentity(afterRevision, node.Id);
             if (node.Provenance is null)
             {
-                unmatchedAfter.Add(new(identity, CSharpUnmatchedNodeReason.Unsupported));
+                // See the matching comment in the before-nodes loop above.
                 continue;
             }
 
@@ -307,6 +325,15 @@ public static partial class CSharpBodyDiff
                 node.Provenance));
         }
 
+        ClassifyUnprovenancedDeclarations(
+            beforeNodes,
+            afterNodes,
+            beforeRevision,
+            afterRevision,
+            matches,
+            unmatchedBefore,
+            unmatchedAfter);
+
         return new CSharpNodeCorrespondenceResult(
             before.Source.Subject,
             before,
@@ -320,6 +347,85 @@ public static partial class CSharpBodyDiff
             unmatchedAfter
                 .OrderBy(static unmatched => unmatched.Node.NodeId)
                 .ToImmutableArray());
+    }
+
+    /// <summary>
+    /// Declaration-shaped node kind eligible for the <see cref="CSharpUnmatchedNodeReason.InferredDeclaration"/>
+    /// carve-out: a local-function signature legitimately has no IL provenance
+    /// of its own (only its body statements do), so it is <c>Unsupported</c>
+    /// by construction, not by a matching failure (issue #5022 item 5,
+    /// evidence #3902 and #4116).
+    /// </summary>
+    const string InferredDeclarationKind = "LocalFunctionStatement";
+
+    /// <summary>
+    /// Classifies null-provenance nodes deferred by the two matching loops
+    /// above. Most remain <see cref="CSharpUnmatchedNodeReason.Unsupported"/>;
+    /// a narrow exception is honestly inferred, not evidence-backed: a
+    /// declaration-shaped node (see <see cref="InferredDeclarationKind"/>) is
+    /// the <em>only</em> such null-provenance declaration in its document,
+    /// and a call-site rewrite (an <c>InvocationExpression</c> match) exists
+    /// somewhere in that same document. Both conditions must hold, or the
+    /// node stays <c>Unsupported</c> like any other correspondence gap.
+    /// </summary>
+    /// <remarks>
+    /// Every current document this comparison sees describes exactly one
+    /// member body, so "its document" already is the narrowest enclosing
+    /// scope for these fixtures; a document spanning multiple independent
+    /// scopes would need this narrowed further to a genuine per-scope check
+    /// before this carve-out could keep the same honesty guarantee.
+    /// </remarks>
+    static void ClassifyUnprovenancedDeclarations(
+        IReadOnlyList<AnnotatedSourceNode> beforeNodes,
+        IReadOnlyList<AnnotatedSourceNode> afterNodes,
+        CSharpDocumentRevision beforeRevision,
+        CSharpDocumentRevision afterRevision,
+        ImmutableArray<CSharpNodeMatch>.Builder matches,
+        ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedBefore,
+        ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedAfter)
+    {
+        var beforeById = beforeNodes.ToDictionary(static node => node.Id);
+        var afterById = afterNodes.ToDictionary(static node => node.Id);
+
+        bool beforeCallSiteRewriteMatched = matches.Any(match =>
+            beforeById.TryGetValue(match.Before.NodeId, out var beforeCallNode)
+            && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal));
+        bool afterCallSiteRewriteMatched = matches.Any(match =>
+            afterById.TryGetValue(match.After.NodeId, out var afterCallNode)
+            && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal));
+
+        int beforeDeclarationCandidates = beforeNodes.Count(static node =>
+            node.Provenance is null
+            && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
+        int afterDeclarationCandidates = afterNodes.Count(static node =>
+            node.Provenance is null
+            && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
+
+        foreach (var node in beforeNodes)
+        {
+            if (node.Provenance is not null)
+                continue;
+
+            bool inferred = string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
+                && beforeDeclarationCandidates == 1
+                && beforeCallSiteRewriteMatched;
+            unmatchedBefore.Add(new(
+                new CSharpDocumentNodeIdentity(beforeRevision, node.Id),
+                inferred ? CSharpUnmatchedNodeReason.InferredDeclaration : CSharpUnmatchedNodeReason.Unsupported));
+        }
+
+        foreach (var node in afterNodes)
+        {
+            if (node.Provenance is not null)
+                continue;
+
+            bool inferred = string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
+                && afterDeclarationCandidates == 1
+                && afterCallSiteRewriteMatched;
+            unmatchedAfter.Add(new(
+                new CSharpDocumentNodeIdentity(afterRevision, node.Id),
+                inferred ? CSharpUnmatchedNodeReason.InferredDeclaration : CSharpUnmatchedNodeReason.Unsupported));
+        }
     }
 
     static ImmutableArray<CSharpNodeMatch> ClassifyMovement(
@@ -387,14 +493,14 @@ public static partial class CSharpBodyDiff
         [
             .. correspondence.Matches.Select(match => before.NodeIds[match.Before.NodeId]),
             .. correspondence.UnmatchedBefore
-                .Where(static unmatched => unmatched.Reason == CSharpUnmatchedNodeReason.NoCounterpart)
+                .Where(static unmatched => IsSelected(unmatched.Reason))
                 .Select(unmatched => before.NodeIds[unmatched.Node.NodeId])
         ];
         int[] afterNodeIds =
         [
             .. correspondence.Matches.Select(match => after.NodeIds[match.After.NodeId]),
             .. correspondence.UnmatchedAfter
-                .Where(static unmatched => unmatched.Reason == CSharpUnmatchedNodeReason.NoCounterpart)
+                .Where(static unmatched => IsSelected(unmatched.Reason))
                 .Select(unmatched => after.NodeIds[unmatched.Node.NodeId])
         ];
         CSharpNodeCorrespondence[] matches =
@@ -415,6 +521,16 @@ public static partial class CSharpBodyDiff
             fidelity));
         return comparison with { Correspondence = correspondence };
     }
+
+    /// <summary>
+    /// Whether an unmatched node carries enough of a verdict — evidence-backed
+    /// or the narrow, honestly-scoped declaration inference — to participate
+    /// in Added/Removed row generation below, instead of being dropped as a
+    /// correspondence gap.
+    /// </summary>
+    static bool IsSelected(CSharpUnmatchedNodeReason reason)
+        => reason is CSharpUnmatchedNodeReason.NoCounterpart
+            or CSharpUnmatchedNodeReason.InferredDeclaration;
 
     /// <summary>
     /// Compares selected C# nodes using owner-issued cross-document

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -366,13 +366,15 @@ public static partial class CSharpBodyDiff
     /// a narrow exception is honestly inferred, not evidence-backed: a
     /// declaration-shaped node (see <see cref="InferredDeclarationKind"/>)
     /// that is present as the <em>sole</em> such null-provenance declaration
-    /// on one side and entirely absent as a candidate on the other (a
-    /// genuine appear/disappear, not a declaration retained unchanged on both
-    /// sides), alongside a call-site rewrite: a matched
-    /// <c>InvocationExpression</c> pair whose selected text actually differs
-    /// between before and after, not merely an unrelated call whose IL
-    /// evidence happens to still match. All three conditions must hold, or
-    /// the node stays <c>Unsupported</c> like any other correspondence gap.
+    /// on one side and entirely absent -- with any or no provenance -- on
+    /// the other (a genuine appear/disappear, not a declaration retained
+    /// unchanged on both sides, nor one side's copy merely carrying IL
+    /// provenance the other side's copy lacks), alongside a call-site
+    /// rewrite: a matched <c>InvocationExpression</c> pair whose selected
+    /// C# text actually differs between before and after, not merely an
+    /// unrelated call whose IL evidence happens to still match. All three
+    /// conditions must hold, or the node stays <c>Unsupported</c> like any
+    /// other correspondence gap.
     /// </summary>
     /// <remarks>
     /// Every current document this comparison sees describes exactly one
@@ -387,6 +389,16 @@ public static partial class CSharpBodyDiff
     /// inherent to any evidence short of full IL provenance, and is why this
     /// carve-out stays scoped to the single declaration-shaped kind actually
     /// evidenced by #3902 and #4116, rather than generalizing further.
+    /// The call-site rewrite check compares projected (IL-lines-removed) C#
+    /// text, matching how every other structural-diff text comparison in
+    /// this file works, and only when both sides' matched invocation is one
+    /// contiguous projected span: interleaved IL rendering is free to split
+    /// an unchanged C# construct's spans differently on each side, and
+    /// <see cref="SelectedTextEqual(AnnotatedSourceDocument, AnnotatedSourceNode, AnnotatedSourceDocument, AnnotatedSourceNode)"/>
+    /// compares spans pairwise by position rather than by full concatenation,
+    /// so a multi-span pairing is not reliable evidence of a rewrite either
+    /// way; this carve-out declines to guess in that case instead of risking
+    /// a false rewrite signal.
     /// </remarks>
     static void ClassifyUnprovenancedDeclarations(
         AnnotatedSourceDocument beforeDocument,
@@ -399,20 +411,46 @@ public static partial class CSharpBodyDiff
         ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedBefore,
         ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedAfter)
     {
-        var beforeById = beforeNodes.ToDictionary(static node => node.Id);
-        var afterById = afterNodes.ToDictionary(static node => node.Id);
+        var beforeProjection = CSharpAnnotatedSourceProjection.Create(beforeDocument);
+        var afterProjection = CSharpAnnotatedSourceProjection.Create(afterDocument);
+        var beforeProjectedById = beforeProjection.Document.Nodes.ToDictionary(static node => node.Id);
+        var afterProjectedById = afterProjection.Document.Nodes.ToDictionary(static node => node.Id);
 
         // A genuine call-site rewrite: both sides are InvocationExpression
-        // nodes whose selected text actually differs. An unchanged call that
-        // merely happens to retain matching IL evidence does not count --
-        // that is not evidence that anything was rewritten alongside it.
+        // nodes rendered as one contiguous projected span each (so the
+        // rewrite check has a single, unambiguous run of characters to
+        // compare) whose selected, IL-projected text actually differs. An
+        // unchanged call that merely happens to retain matching IL evidence
+        // does not count -- that is not evidence that anything was rewritten
+        // alongside it. Nor does an invocation that still spans multiple
+        // projected pieces on either side after removing IL lines: this
+        // carve-out declines to guess at such a call's true text equality
+        // rather than risk treating a merely differently-interleaved,
+        // unchanged multi-line call as a rewrite (SelectedTextEqual compares
+        // spans pairwise by position, not by full concatenation, so a
+        // multi-span pairing is not reliable evidence either way here).
         bool callSiteRewriteMatched = matches.Any(match =>
-            beforeById.TryGetValue(match.Before.NodeId, out var beforeCallNode)
-            && afterById.TryGetValue(match.After.NodeId, out var afterCallNode)
+            beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
+            && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
+            && beforeProjectedById.TryGetValue(beforeProjectedId, out var beforeCallNode)
+            && afterProjectedById.TryGetValue(afterProjectedId, out var afterCallNode)
             && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
             && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
-            && !SelectedTextEqual(beforeDocument, beforeCallNode, afterDocument, afterCallNode));
+            && beforeCallNode.Spans.Count == 1
+            && afterCallNode.Spans.Count == 1
+            && !SelectedTextEqual(
+                beforeProjection.Document,
+                beforeCallNode,
+                afterProjection.Document,
+                afterCallNode));
 
+        // Total presence (any provenance) proves genuine absence from a
+        // side; a copy that merely carries different IL provenance than its
+        // counterpart is still a copy, not an appear/disappear.
+        int beforeDeclarationTotal = beforeNodes.Count(static node =>
+            string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
+        int afterDeclarationTotal = afterNodes.Count(static node =>
+            string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
         int beforeDeclarationCandidates = beforeNodes.Count(static node =>
             node.Provenance is null
             && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
@@ -423,8 +461,14 @@ public static partial class CSharpBodyDiff
         // A declaration retained unchanged on both sides has one candidate on
         // each side, and qualifies for neither direction below -- it must not
         // be reported as simultaneously Added and Removed.
-        bool declarationAdded = afterDeclarationCandidates == 1 && beforeDeclarationCandidates == 0;
-        bool declarationRemoved = beforeDeclarationCandidates == 1 && afterDeclarationCandidates == 0;
+        bool declarationAdded =
+            afterDeclarationCandidates == 1
+            && afterDeclarationTotal == 1
+            && beforeDeclarationTotal == 0;
+        bool declarationRemoved =
+            beforeDeclarationCandidates == 1
+            && beforeDeclarationTotal == 1
+            && afterDeclarationTotal == 0;
 
         foreach (var node in beforeNodes)
         {

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -489,16 +489,19 @@ public static partial class CSharpBodyDiff
                     // A genuine call-site rewrite: both sides are InvocationExpression
                     // nodes rendered as one contiguous projected span each (so the
                     // rewrite check has a single, unambiguous run of characters to
-                    // compare) whose selected, IL-projected text actually differs. An
+                    // compare) whose *callee* text actually differs. Comparing only
+                    // the callee -- not the full invocation text -- matters: an
+                    // argument-only edit (round-7 review, reviewers A and B), such as
+                    // `Log(oldValue)` becoming `Log(newValue)`, must not itself license
+                    // an unrelated declaration elsewhere in the document as an inferred
+                    // rewrite target, since the call's target never changed. An
                     // unchanged call that merely happens to retain matching IL evidence
-                    // does not count -- that is not evidence that anything was rewritten
-                    // alongside it. Nor does an invocation that still spans multiple
-                    // projected pieces on either side after removing IL lines: this
-                    // carve-out declines to guess at such a call's true text equality
-                    // rather than risk treating a merely differently-interleaved,
-                    // unchanged multi-line call as a rewrite (SelectedTextEqual compares
-                    // spans pairwise by position, not by full concatenation, so a
-                    // multi-span pairing is not reliable evidence either way here).
+                    // does not count either -- that is not evidence that anything was
+                    // rewritten alongside it. Nor does an invocation that still spans
+                    // multiple projected pieces on either side after removing IL lines:
+                    // this carve-out declines to guess at such a call's true callee
+                    // text rather than risk treating a merely differently-interleaved,
+                    // unchanged multi-line call as a rewrite.
                     callSiteRewriteMatched = matches.Any(match =>
                         beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
                         && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
@@ -508,7 +511,7 @@ public static partial class CSharpBodyDiff
                         && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
                         && beforeCallNode.Spans.Count == 1
                         && afterCallNode.Spans.Count == 1
-                        && !SelectedTextEqual(
+                        && !InvocationCalleeTextEqual(
                             beforeProjection.Document,
                             beforeCallNode,
                             afterProjection.Document,
@@ -894,6 +897,28 @@ public static partial class CSharpBodyDiff
             beforeNode.Spans,
             afterDocument,
             afterNode.Spans);
+
+    // Compares only an InvocationExpression node's callee -- the text before
+    // its argument list's opening parenthesis -- rather than its full call
+    // text. An argument-only edit (e.g. `Log(oldValue)` -> `Log(newValue)`)
+    // must not read as a call-site rewrite: the call's target never changed,
+    // so it is not evidence that some other declaration in the document was
+    // introduced or removed alongside it. Callers guarantee a single span.
+    static bool InvocationCalleeTextEqual(
+        AnnotatedSourceDocument beforeDocument,
+        AnnotatedSourceNode beforeNode,
+        AnnotatedSourceDocument afterDocument,
+        AnnotatedSourceNode afterNode)
+        => GetInvocationCalleeText(beforeDocument, beforeNode)
+            .SequenceEqual(GetInvocationCalleeText(afterDocument, afterNode));
+
+    static ReadOnlySpan<char> GetInvocationCalleeText(AnnotatedSourceDocument document, AnnotatedSourceNode node)
+    {
+        var span = node.Spans[0];
+        var text = document.Text.AsSpan(span.Start, span.Length);
+        int parenIndex = text.IndexOf('(');
+        return (parenIndex < 0 ? text : text[..parenIndex]).TrimEnd();
+    }
 
     internal static bool SelectedTextEqual(
         AnnotatedSourceDocument beforeDocument,

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -489,7 +489,7 @@ public static partial class CSharpBodyDiff
                     // A genuine call-site rewrite: both sides are InvocationExpression
                     // nodes rendered as one contiguous projected span each (so the
                     // rewrite check has a single, unambiguous run of characters to
-                    // compare) whose *callee* text actually differs. Comparing only
+                    // compare) whose *callee* text genuinely differs. Comparing only
                     // the callee -- not the full invocation text -- matters: an
                     // argument-only edit (round-7 review, reviewers A and B), such as
                     // `Log(oldValue)` becoming `Log(newValue)`, must not itself license
@@ -511,7 +511,7 @@ public static partial class CSharpBodyDiff
                         && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
                         && beforeCallNode.Spans.Count == 1
                         && afterCallNode.Spans.Count == 1
-                        && !InvocationCalleeTextEqual(
+                        && InvocationCalleeGenuinelyDiffers(
                             beforeProjection.Document,
                             beforeCallNode,
                             afterProjection.Document,
@@ -898,20 +898,24 @@ public static partial class CSharpBodyDiff
             afterDocument,
             afterNode.Spans);
 
-    // Compares only an InvocationExpression node's callee -- everything
-    // before the argument list's *outer* opening parenthesis -- rather than
-    // its full call text. An argument-only edit (e.g. `Log(oldValue)` ->
+    // Determines whether an InvocationExpression node pair's callee --
+    // everything before the argument list's *outer* opening parenthesis --
+    // genuinely differs. An argument-only edit (e.g. `Log(oldValue)` ->
     // `Log(newValue)`) must not read as a call-site rewrite: the call's
     // target never changed, so it is not evidence that some other
     // declaration in the document was introduced or removed alongside it.
-    // Callers guarantee a single span.
-    static bool InvocationCalleeTextEqual(
+    // Returns false (not evidence of a rewrite) both when the callees are
+    // equal and when either side's callee cannot be reliably identified --
+    // "inconclusive" must never be treated as "differs". Callers guarantee
+    // a single span.
+    static bool InvocationCalleeGenuinelyDiffers(
         AnnotatedSourceDocument beforeDocument,
         AnnotatedSourceNode beforeNode,
         AnnotatedSourceDocument afterDocument,
         AnnotatedSourceNode afterNode)
-        => GetInvocationCalleeText(beforeDocument, beforeNode)
-            .SequenceEqual(GetInvocationCalleeText(afterDocument, afterNode));
+        => TryGetInvocationCalleeText(beforeDocument, beforeNode, out var beforeCallee)
+            && TryGetInvocationCalleeText(afterDocument, afterNode, out var afterCallee)
+            && !beforeCallee.SequenceEqual(afterCallee);
 
     // An InvocationExpression's own text always ends with the closing
     // parenthesis of its argument list, so a balanced backward scan from
@@ -921,29 +925,51 @@ public static partial class CSharpBodyDiff
     // parentheses (round-8 review, reviewers A and B), such as a
     // parenthesized cast receiver (`((IFoo)x).Old()`) or a call-returning
     // receiver (`GetReceiver().Old()`).
-    static ReadOnlySpan<char> GetInvocationCalleeText(AnnotatedSourceDocument document, AnnotatedSourceNode node)
+    //
+    // The scan declines (returns false) rather than guess as soon as it
+    // sees a quote, apostrophe, or comment-start character (round-9 review,
+    // reviewers A and B): a string/char literal or a comment can itself
+    // contain unbalanced or misleading parentheses (e.g. `Log("(")`), which
+    // would otherwise make a plain paren-depth count misidentify the
+    // argument list's true boundary -- either by stopping at a paren inside
+    // literal text, or by never finding a balanced match at all and falling
+    // back to comparing the full invocation text (reintroducing the exact
+    // argument-only false positive round 7 fixed). This is not a full C#
+    // lexer; it simply refuses to trust the scan once literal/comment
+    // content becomes possible, which is a strictly narrower, always-safe
+    // subset of "confidently found the true split".
+    static bool TryGetInvocationCalleeText(
+        AnnotatedSourceDocument document, AnnotatedSourceNode node, out ReadOnlySpan<char> calleeText)
     {
         var span = node.Spans[0];
         var text = document.Text.AsSpan(span.Start, span.Length).TrimEnd();
+        calleeText = default;
         if (text.Length == 0 || text[^1] != ')')
-            return text;
+            return false;
 
         int depth = 0;
         for (int index = text.Length - 1; index >= 0; index--)
         {
-            if (text[index] == ')')
+            char current = text[index];
+            if (current is '"' or '\'' or '/')
+                return false;
+
+            if (current == ')')
             {
                 depth++;
             }
-            else if (text[index] == '(')
+            else if (current == '(')
             {
                 depth--;
                 if (depth == 0)
-                    return text[..index].TrimEnd();
+                {
+                    calleeText = text[..index].TrimEnd();
+                    return true;
+                }
             }
         }
 
-        return text;
+        return false;
     }
 
     internal static bool SelectedTextEqual(

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -326,6 +326,8 @@ public static partial class CSharpBodyDiff
         }
 
         ClassifyUnprovenancedDeclarations(
+            before,
+            after,
             beforeNodes,
             afterNodes,
             beforeRevision,
@@ -362,20 +364,33 @@ public static partial class CSharpBodyDiff
     /// Classifies null-provenance nodes deferred by the two matching loops
     /// above. Most remain <see cref="CSharpUnmatchedNodeReason.Unsupported"/>;
     /// a narrow exception is honestly inferred, not evidence-backed: a
-    /// declaration-shaped node (see <see cref="InferredDeclarationKind"/>) is
-    /// the <em>only</em> such null-provenance declaration in its document,
-    /// and a call-site rewrite (an <c>InvocationExpression</c> match) exists
-    /// somewhere in that same document. Both conditions must hold, or the
-    /// node stays <c>Unsupported</c> like any other correspondence gap.
+    /// declaration-shaped node (see <see cref="InferredDeclarationKind"/>)
+    /// that is present as the <em>sole</em> such null-provenance declaration
+    /// on one side and entirely absent as a candidate on the other (a
+    /// genuine appear/disappear, not a declaration retained unchanged on both
+    /// sides), alongside a call-site rewrite: a matched
+    /// <c>InvocationExpression</c> pair whose selected text actually differs
+    /// between before and after, not merely an unrelated call whose IL
+    /// evidence happens to still match. All three conditions must hold, or
+    /// the node stays <c>Unsupported</c> like any other correspondence gap.
     /// </summary>
     /// <remarks>
     /// Every current document this comparison sees describes exactly one
     /// member body, so "its document" already is the narrowest enclosing
     /// scope for these fixtures; a document spanning multiple independent
     /// scopes would need this narrowed further to a genuine per-scope check
-    /// before this carve-out could keep the same honesty guarantee.
+    /// before this carve-out could keep the same honesty guarantee. Even at
+    /// this granularity, this remains a heuristic, not a proof: two
+    /// independent, unrelated changes in the same member body (an unrelated
+    /// call rewrite alongside an unrelated new/removed declaration) could
+    /// still coincidentally satisfy it. This is the same residual risk
+    /// inherent to any evidence short of full IL provenance, and is why this
+    /// carve-out stays scoped to the single declaration-shaped kind actually
+    /// evidenced by #3902 and #4116, rather than generalizing further.
     /// </remarks>
     static void ClassifyUnprovenancedDeclarations(
+        AnnotatedSourceDocument beforeDocument,
+        AnnotatedSourceDocument afterDocument,
         IReadOnlyList<AnnotatedSourceNode> beforeNodes,
         IReadOnlyList<AnnotatedSourceNode> afterNodes,
         CSharpDocumentRevision beforeRevision,
@@ -387,12 +402,16 @@ public static partial class CSharpBodyDiff
         var beforeById = beforeNodes.ToDictionary(static node => node.Id);
         var afterById = afterNodes.ToDictionary(static node => node.Id);
 
-        bool beforeCallSiteRewriteMatched = matches.Any(match =>
+        // A genuine call-site rewrite: both sides are InvocationExpression
+        // nodes whose selected text actually differs. An unchanged call that
+        // merely happens to retain matching IL evidence does not count --
+        // that is not evidence that anything was rewritten alongside it.
+        bool callSiteRewriteMatched = matches.Any(match =>
             beforeById.TryGetValue(match.Before.NodeId, out var beforeCallNode)
-            && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal));
-        bool afterCallSiteRewriteMatched = matches.Any(match =>
-            afterById.TryGetValue(match.After.NodeId, out var afterCallNode)
-            && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal));
+            && afterById.TryGetValue(match.After.NodeId, out var afterCallNode)
+            && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+            && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+            && !SelectedTextEqual(beforeDocument, beforeCallNode, afterDocument, afterCallNode));
 
         int beforeDeclarationCandidates = beforeNodes.Count(static node =>
             node.Provenance is null
@@ -401,14 +420,20 @@ public static partial class CSharpBodyDiff
             node.Provenance is null
             && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
 
+        // A declaration retained unchanged on both sides has one candidate on
+        // each side, and qualifies for neither direction below -- it must not
+        // be reported as simultaneously Added and Removed.
+        bool declarationAdded = afterDeclarationCandidates == 1 && beforeDeclarationCandidates == 0;
+        bool declarationRemoved = beforeDeclarationCandidates == 1 && afterDeclarationCandidates == 0;
+
         foreach (var node in beforeNodes)
         {
             if (node.Provenance is not null)
                 continue;
 
-            bool inferred = string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
-                && beforeDeclarationCandidates == 1
-                && beforeCallSiteRewriteMatched;
+            bool inferred = declarationRemoved
+                && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
+                && callSiteRewriteMatched;
             unmatchedBefore.Add(new(
                 new CSharpDocumentNodeIdentity(beforeRevision, node.Id),
                 inferred ? CSharpUnmatchedNodeReason.InferredDeclaration : CSharpUnmatchedNodeReason.Unsupported));
@@ -419,9 +444,9 @@ public static partial class CSharpBodyDiff
             if (node.Provenance is not null)
                 continue;
 
-            bool inferred = string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
-                && afterDeclarationCandidates == 1
-                && afterCallSiteRewriteMatched;
+            bool inferred = declarationAdded
+                && string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal)
+                && callSiteRewriteMatched;
             unmatchedAfter.Add(new(
                 new CSharpDocumentNodeIdentity(afterRevision, node.Id),
                 inferred ? CSharpUnmatchedNodeReason.InferredDeclaration : CSharpUnmatchedNodeReason.Unsupported));

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -398,7 +398,13 @@ public static partial class CSharpBodyDiff
     /// compares spans pairwise by position rather than by full concatenation,
     /// so a multi-span pairing is not reliable evidence of a rewrite either
     /// way; this carve-out declines to guess in that case instead of risking
-    /// a false rewrite signal.
+    /// a false rewrite signal. Building that projection is not free -- it
+    /// demands every IL-medium node be exactly one contiguous span, a
+    /// narrower contract than <see cref="AnnotatedSourceNode"/> itself
+    /// enforces -- so it only runs once the cheap, projection-free presence
+    /// counts already show a declaration could plausibly be promoted; a
+    /// document with no such candidate must not pay, or risk failing, a
+    /// projection it will never use.
     /// </remarks>
     static void ClassifyUnprovenancedDeclarations(
         AnnotatedSourceDocument beforeDocument,
@@ -411,42 +417,13 @@ public static partial class CSharpBodyDiff
         ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedBefore,
         ImmutableArray<CSharpUnmatchedNode>.Builder unmatchedAfter)
     {
-        var beforeProjection = CSharpAnnotatedSourceProjection.Create(beforeDocument);
-        var afterProjection = CSharpAnnotatedSourceProjection.Create(afterDocument);
-        var beforeProjectedById = beforeProjection.Document.Nodes.ToDictionary(static node => node.Id);
-        var afterProjectedById = afterProjection.Document.Nodes.ToDictionary(static node => node.Id);
-
-        // A genuine call-site rewrite: both sides are InvocationExpression
-        // nodes rendered as one contiguous projected span each (so the
-        // rewrite check has a single, unambiguous run of characters to
-        // compare) whose selected, IL-projected text actually differs. An
-        // unchanged call that merely happens to retain matching IL evidence
-        // does not count -- that is not evidence that anything was rewritten
-        // alongside it. Nor does an invocation that still spans multiple
-        // projected pieces on either side after removing IL lines: this
-        // carve-out declines to guess at such a call's true text equality
-        // rather than risk treating a merely differently-interleaved,
-        // unchanged multi-line call as a rewrite (SelectedTextEqual compares
-        // spans pairwise by position, not by full concatenation, so a
-        // multi-span pairing is not reliable evidence either way here).
-        bool callSiteRewriteMatched = matches.Any(match =>
-            beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
-            && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
-            && beforeProjectedById.TryGetValue(beforeProjectedId, out var beforeCallNode)
-            && afterProjectedById.TryGetValue(afterProjectedId, out var afterCallNode)
-            && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
-            && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
-            && beforeCallNode.Spans.Count == 1
-            && afterCallNode.Spans.Count == 1
-            && !SelectedTextEqual(
-                beforeProjection.Document,
-                beforeCallNode,
-                afterProjection.Document,
-                afterCallNode));
-
         // Total presence (any provenance) proves genuine absence from a
         // side; a copy that merely carries different IL provenance than its
-        // counterpart is still a copy, not an appear/disappear.
+        // counterpart is still a copy, not an appear/disappear. These counts
+        // need no document projection, so they run first and unconditionally:
+        // the overwhelming majority of documents have no null-provenance
+        // declaration candidate at all, and must not pay -- or risk failing --
+        // a projection they will never use.
         int beforeDeclarationTotal = beforeNodes.Count(static node =>
             string.Equals(node.Kind, InferredDeclarationKind, StringComparison.Ordinal));
         int afterDeclarationTotal = afterNodes.Count(static node =>
@@ -469,6 +446,51 @@ public static partial class CSharpBodyDiff
             beforeDeclarationCandidates == 1
             && beforeDeclarationTotal == 1
             && afterDeclarationTotal == 0;
+
+        // The call-site rewrite check requires a document projection, which
+        // -- unlike the counts above -- is not free: it demands every IL-medium
+        // node be exactly one contiguous rendered span, a narrower contract
+        // than AnnotatedSourceNode itself enforces (a non-instruction
+        // IL-medium node, such as a structural "Block", may legitimately span
+        // several rendered lines). Build it only when a declaration could
+        // plausibly be promoted; a document with no such candidate must not
+        // newly fail to satisfy an invariant it never needed.
+        bool callSiteRewriteMatched = false;
+        if (declarationAdded || declarationRemoved)
+        {
+            var beforeProjection = CSharpAnnotatedSourceProjection.Create(beforeDocument);
+            var afterProjection = CSharpAnnotatedSourceProjection.Create(afterDocument);
+            var beforeProjectedById = beforeProjection.Document.Nodes.ToDictionary(static node => node.Id);
+            var afterProjectedById = afterProjection.Document.Nodes.ToDictionary(static node => node.Id);
+
+            // A genuine call-site rewrite: both sides are InvocationExpression
+            // nodes rendered as one contiguous projected span each (so the
+            // rewrite check has a single, unambiguous run of characters to
+            // compare) whose selected, IL-projected text actually differs. An
+            // unchanged call that merely happens to retain matching IL evidence
+            // does not count -- that is not evidence that anything was rewritten
+            // alongside it. Nor does an invocation that still spans multiple
+            // projected pieces on either side after removing IL lines: this
+            // carve-out declines to guess at such a call's true text equality
+            // rather than risk treating a merely differently-interleaved,
+            // unchanged multi-line call as a rewrite (SelectedTextEqual compares
+            // spans pairwise by position, not by full concatenation, so a
+            // multi-span pairing is not reliable evidence either way here).
+            callSiteRewriteMatched = matches.Any(match =>
+                beforeProjection.NodeIds.TryGetValue(match.Before.NodeId, out int beforeProjectedId)
+                && afterProjection.NodeIds.TryGetValue(match.After.NodeId, out int afterProjectedId)
+                && beforeProjectedById.TryGetValue(beforeProjectedId, out var beforeCallNode)
+                && afterProjectedById.TryGetValue(afterProjectedId, out var afterCallNode)
+                && string.Equals(beforeCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+                && string.Equals(afterCallNode.Kind, "InvocationExpression", StringComparison.Ordinal)
+                && beforeCallNode.Spans.Count == 1
+                && afterCallNode.Spans.Count == 1
+                && !SelectedTextEqual(
+                    beforeProjection.Document,
+                    beforeCallNode,
+                    afterProjection.Document,
+                    afterCallNode));
+        }
 
         foreach (var node in beforeNodes)
         {

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -898,12 +898,13 @@ public static partial class CSharpBodyDiff
             afterDocument,
             afterNode.Spans);
 
-    // Compares only an InvocationExpression node's callee -- the text before
-    // its argument list's opening parenthesis -- rather than its full call
-    // text. An argument-only edit (e.g. `Log(oldValue)` -> `Log(newValue)`)
-    // must not read as a call-site rewrite: the call's target never changed,
-    // so it is not evidence that some other declaration in the document was
-    // introduced or removed alongside it. Callers guarantee a single span.
+    // Compares only an InvocationExpression node's callee -- everything
+    // before the argument list's *outer* opening parenthesis -- rather than
+    // its full call text. An argument-only edit (e.g. `Log(oldValue)` ->
+    // `Log(newValue)`) must not read as a call-site rewrite: the call's
+    // target never changed, so it is not evidence that some other
+    // declaration in the document was introduced or removed alongside it.
+    // Callers guarantee a single span.
     static bool InvocationCalleeTextEqual(
         AnnotatedSourceDocument beforeDocument,
         AnnotatedSourceNode beforeNode,
@@ -912,12 +913,37 @@ public static partial class CSharpBodyDiff
         => GetInvocationCalleeText(beforeDocument, beforeNode)
             .SequenceEqual(GetInvocationCalleeText(afterDocument, afterNode));
 
+    // An InvocationExpression's own text always ends with the closing
+    // parenthesis of its argument list, so a balanced backward scan from
+    // that closing paren finds the argument list's true opening paren --
+    // unlike naively taking the *first* '(' in the text, which
+    // misidentifies the split for a callee that itself contains balanced
+    // parentheses (round-8 review, reviewers A and B), such as a
+    // parenthesized cast receiver (`((IFoo)x).Old()`) or a call-returning
+    // receiver (`GetReceiver().Old()`).
     static ReadOnlySpan<char> GetInvocationCalleeText(AnnotatedSourceDocument document, AnnotatedSourceNode node)
     {
         var span = node.Spans[0];
-        var text = document.Text.AsSpan(span.Start, span.Length);
-        int parenIndex = text.IndexOf('(');
-        return (parenIndex < 0 ? text : text[..parenIndex]).TrimEnd();
+        var text = document.Text.AsSpan(span.Start, span.Length).TrimEnd();
+        if (text.Length == 0 || text[^1] != ')')
+            return text;
+
+        int depth = 0;
+        for (int index = text.Length - 1; index >= 0; index--)
+        {
+            if (text[index] == ')')
+            {
+                depth++;
+            }
+            else if (text[index] == '(')
+            {
+                depth--;
+                if (depth == 0)
+                    return text[..index].TrimEnd();
+            }
+        }
+
+        return text;
     }
 
     internal static bool SelectedTextEqual(

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -926,18 +926,28 @@ public static partial class CSharpBodyDiff
     // parenthesized cast receiver (`((IFoo)x).Old()`) or a call-returning
     // receiver (`GetReceiver().Old()`).
     //
-    // The scan declines (returns false) rather than guess as soon as it
-    // sees a quote, apostrophe, or comment-start character (round-9 review,
-    // reviewers A and B): a string/char literal or a comment can itself
-    // contain unbalanced or misleading parentheses (e.g. `Log("(")`), which
-    // would otherwise make a plain paren-depth count misidentify the
-    // argument list's true boundary -- either by stopping at a paren inside
-    // literal text, or by never finding a balanced match at all and falling
-    // back to comparing the full invocation text (reintroducing the exact
-    // argument-only false positive round 7 fixed). This is not a full C#
-    // lexer; it simply refuses to trust the scan once literal/comment
-    // content becomes possible, which is a strictly narrower, always-safe
-    // subset of "confidently found the true split".
+    // The scan declines (returns false) rather than guess whenever a quote,
+    // apostrophe, or comment-start character is present anywhere in the
+    // text (round-9 review, reviewers A and B): a string/char literal or a
+    // comment can itself contain unbalanced or misleading parentheses (e.g.
+    // `Log("(")`), which would otherwise make a plain paren-depth count
+    // misidentify the argument list's true boundary -- either by stopping
+    // at a paren inside literal text, or by never finding a balanced match
+    // at all and falling back to comparing the full invocation text
+    // (reintroducing the exact argument-only false positive round 7
+    // fixed). This is not a full C# lexer; it simply refuses to trust the
+    // scan once literal/comment content becomes possible, which is a
+    // strictly narrower, always-safe subset of "confidently found the true
+    // split".
+    //
+    // This disqualifying check is a dedicated upfront pass over the whole
+    // text, not interleaved into the backward paren scan below (round-10
+    // review, reviewer A): a `//` line comment's content is scanned
+    // *before* its own leading `/` characters in backward order, so a
+    // misleading paren inside a comment (e.g. `Log(1 // (\n)`) could
+    // otherwise reach depth zero and return a wrong "match" before the
+    // scan ever reached the disqualifying `/`. Checking the full text
+    // first closes that ordering gap.
     static bool TryGetInvocationCalleeText(
         AnnotatedSourceDocument document, AnnotatedSourceNode node, out ReadOnlySpan<char> calleeText)
     {
@@ -947,13 +957,16 @@ public static partial class CSharpBodyDiff
         if (text.Length == 0 || text[^1] != ')')
             return false;
 
+        foreach (char guard in text)
+        {
+            if (guard is '"' or '\'' or '/')
+                return false;
+        }
+
         int depth = 0;
         for (int index = text.Length - 1; index >= 0; index--)
         {
             char current = text[index];
-            if (current is '"' or '\'' or '/')
-                return false;
-
             if (current == ')')
             {
                 depth++;

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffDocument.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffDocument.cs
@@ -24,7 +24,16 @@ public sealed record CSharpStructuralDiffDocument
     public const int CurrentSchemaVersion = 1;
 
     /// <summary>Current correspondence and structural-comparison methodology.</summary>
-    public const int CurrentMethodologyVersion = 1;
+    /// <remarks>
+    /// Bumped from 1 to 2 when <see cref="CSharpUnmatchedNodeReason.InferredDeclaration"/>
+    /// was introduced: replaying a version-1 artifact whose null-provenance
+    /// declaration node was recorded as <c>Unsupported</c> now reissues
+    /// <c>InferredDeclaration</c> for the same shape, so the replay-equality
+    /// check in this record's constructor would otherwise reject it with a
+    /// misleadingly generic mismatch error. The version gate above makes that
+    /// invalidation explicit instead.
+    /// </remarks>
+    public const int CurrentMethodologyVersion = 2;
 
     /// <summary>Creates and validates one portable structural diff.</summary>
     public CSharpStructuralDiffDocument(

--- a/tools/DecompilerHarness/StructuralReview.cs
+++ b/tools/DecompilerHarness/StructuralReview.cs
@@ -139,13 +139,25 @@ internal static class StructuralReview
         return
         [
             .. correspondence.UnmatchedBefore
-            .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
+            .Where(static node => !HasVerdict(node.Reason))
             .Select(static node => (CSharpStructuralSide.Before, Node: node))
             .Concat(correspondence.UnmatchedAfter
-                .Where(static node => node.Reason != CSharpUnmatchedNodeReason.NoCounterpart)
+                .Where(static node => !HasVerdict(node.Reason))
                 .Select(static node => (CSharpStructuralSide.After, Node: node)))
         ];
     }
+
+    /// <summary>
+    /// Whether an unmatched node's reason resolved to an actual structural
+    /// verdict (a real Added/Removed row) rather than being a correspondence
+    /// gap: evidence-backed <see cref="CSharpUnmatchedNodeReason.NoCounterpart"/>,
+    /// or the narrow, honestly-scoped
+    /// <see cref="CSharpUnmatchedNodeReason.InferredDeclaration"/> carve-out
+    /// (issue #5022 item 5).
+    /// </summary>
+    static bool HasVerdict(CSharpUnmatchedNodeReason reason)
+        => reason is CSharpUnmatchedNodeReason.NoCounterpart
+            or CSharpUnmatchedNodeReason.InferredDeclaration;
 
     static void WriteCorrespondenceGaps(
         StringWriter output,


### PR DESCRIPTION
## Slice

Item 5 of #5022's 8-item plan (items 1/3/4/6 landed in #5040; items 2/7 landed
in #5059). This is the plan's "highest-value, highest-effort" remaining item.
Item 8 (`--focus` legend/doc gap) remains open after this.

## Problem

A newly-introduced or removed local-function declaration header (e.g.
`static int Own(int input) => input + 1;`) legitimately has no IL provenance
of its own — only its body statements do. `IssueCorrespondence` marks any
node with `Provenance is null` as `Unsupported` immediately, before any
matching is attempted, and `CompareStructure`'s selection step only carries
forward matched nodes plus unmatched nodes reasoned `NoCounterpart` —
`Unsupported` nodes never reach the existing Added/Removed row-generation
loops. The declaration disappears from the diff entirely.

**Evidence (real PRs, from #4952's corpus, see #5022 item 5):**

- **#3902** — an undeclared synthesized call (`__CallsEmpty_g__F_0_0();`) is
  rewritten to call a declared local function (`F();` + `static void F() {
  }`). Every node on both sides falls into a correspondence gap; the diff
  table is empty. "This is the clearest negative example in the corpus."
- **#4116** — same shape, in a generic host type. Produces one `Added +
  Return` row that misidentifies the changed node (`Return`, not the
  declaration) and still drops the declaration itself, plus 9 other nodes,
  into the gap bucket.

## Change

Adds `CSharpUnmatchedNodeReason.InferredDeclaration`: a narrow, **explicitly
non-evidence-backed** carve-out — not a relabeling of `NoCounterpart`, which
the issue calls out as dishonest for this exact situation (`NoCounterpart`
means unique evidence *exists* only on one side; a null-provenance node has
no evidence at all).

A null-provenance node qualifies only when **both** hold:

1. Its `Kind` is `LocalFunctionStatement` (a declaration header — the only
   kind evidenced by #3902/#4116), and it is the **only** such null-provenance
   node in its document (structural uniqueness, not IL evidence).
2. A call-site rewrite matched elsewhere in the same document (an
   `InvocationExpression` `CSharpNodeMatch`) — i.e., this declaration is
   genuinely paired with a correlated call, not a declaration that appeared
   with no other supporting evidence at all.

Both conditions are checked in a new pass, `ClassifyUnprovenancedDeclarations`,
run after all IL-evidence matching completes (so it isn't order-dependent on
which node id happens to be visited first). `CompareStructure`'s selection
now includes `InferredDeclaration` nodes alongside `NoCounterpart` ones, so
they reach the existing (unmodified) Added/Removed row-generation loops.
`IsCorrespondenceComplete` treats `InferredDeclaration` as a resolved verdict,
same as `NoCounterpart` — the point of this carve-out is that the node is no
longer a correspondence gap.

Symmetric handling covers the removal direction (a declaration disappearing
from the before side).

**Deliberately out of scope**, per issue #5022: this does not touch the
general correspondence matcher. #4301's control-flow-restructuring case (190+
gap rows) is a different, much broader problem and stays unaddressed here.

## Before / after (fixture matching #4116's real shape)

**Before this change** — `IssueCorrespondence` on #4116's shape:

```text
UnmatchedAfter: [ (LocalFunctionStatement, Unsupported) ]
CompareStructure(...).Rows: [ Changed(InvocationExpression) ]   // declaration invisible
```

**After this change**:

```text
UnmatchedAfter: [ (LocalFunctionStatement, InferredDeclaration) ]
CompareStructure(...).Rows:
  Changed(InvocationExpression)  // __NoTypeParameter_g__Own_0_0(value) -> Own(value)
  Added(LocalFunctionStatement)  // + static int Own(int input) => input + 1;
```

## Demo

Matching #4952's corpus style: the caret-annotated Before/After bodies for
#4116's exact shape, rendered via
`CSharpStructuralDiffPrinter.RenderAnnotatedBody` — not just the flat display
row.

**Before this change** — the added declaration produced no row and no
annotation at all (#3902/#4116's real, reproduced printer output): the After
body rendered only the call-site caret, with `static int Own(int input) =>
input + 1;` sitting below it completely unannotated.

**After this change** — Before body:

```text
return __NoTypeParameter_g__Own_0_0(value);
//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//     raise: InvocationExpression; changed to Own(value)
```

After body — the added declaration now gets its own caret line:

```text
return Own(value);
//     ^^^^^^^^^^
//     raise: InvocationExpression; changed from __NoTypeParameter_g__Own_0_0(value)
static int Own(int input) => input + 1;
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
raise: LocalFunctionStatement
```

This is exactly the shape #4952's #4116 "Agreed-better mockup" calls for: a
dedicated caret under the newly-introduced declaration, not a silent drop.
(The mockup's prose label reads `LocalFunctionDeclaration — added (...)`;
the printer's actual label/reason text is issue #5022 items 6/8, not this
PR's scope — the row-classification and caret-rendering fix is.)

New test `IssueCorrespondence_InfersAddedLocalFunctionDeclarationAlongsideMatchedCallSite`
(and its removal-direction symmetric counterpart,
`IssueCorrespondence_InfersRemovedLocalFunctionDeclarationAlongsideMatchedCallSite`)
reproduce #4116's exact shape end-to-end and assert both the flat display row
and the rendered caret annotation:

```csharp
var display = CSharpStructuralDiffPrinter.ToDisplayRows(comparison);
Assert.Contains(display, row =>
    row.Change == "Added" && row.Detail == "+ static int Own(int input) => input + 1;");

string renderedAfter = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
    comparison, CSharpStructuralSide.After);
Assert.Contains(
    "static int Own(int input) => input + 1;\n"
    + "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
    + "raise: LocalFunctionStatement",
    renderedAfter);
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`: succeeds, 0 warnings.
- Focused: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests"` — 62/62 pass.
- Full: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 6023/6024 pass; the 1 failure (`CoreLibOrdinalCasingCrossArmPredecessorPreservesFallbackPath`) is the pre-existing, unrelated failure noted on #5059 — no regressions.

## Non-goals

- Does not fix #4301's control-flow-restructuring gap rows (explicitly out of
  scope per #5022 item 5).
- Does not add the `Detail` column (#5022 item 6) or the `--focus` legend gap
  (#5022 item 8) — separate items.
- Does not cover declaration kinds other than `LocalFunctionStatement` (e.g.
  lambdas, per #3855's noted follow-up) — no evidence in the corpus motivates
  widening this yet.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

