### PR TITLE
Retarget IL tools documentation gate

### DIFF
--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -615,22 +615,23 @@ public class IlToolsActivationTests
     /// mentions `export` and would otherwise sail through.
     /// </summary>
     [Fact]
-    public void AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript()
+    public void DevelopmentEnvironmentMarkdown_DelegatesIlToolsPathAssemblyToTheScript()
     {
-        var agents = File.ReadAllText(Path.Combine(RepoRoot, "AGENTS.md"));
+        var developmentEnvironment = File.ReadAllText(
+            Path.Combine(RepoRoot, "docs", "dev-environment.md"));
 
-        Assert.Contains("source eng/activate-iltools.sh", agents);
+        Assert.Contains("source eng/activate-iltools.sh", developmentEnvironment);
 
-        foreach (var block in FencedBashBlocks(agents).Where(b => b.Contains("iltools")))
+        foreach (var block in FencedBashBlocks(developmentEnvironment).Where(b => b.Contains("iltools")))
         {
             Assert.False(
                 block.Contains("restore-iltools.sh"),
-                $"AGENTS.md tells the reader to run the producer directly instead of sourcing\n" +
+                $"docs/dev-environment.md tells the reader to run the producer directly instead of sourcing\n" +
                 $"eng/activate-iltools.sh, which puts the PATH assembly back outside the gate:\n{block}");
 
             Assert.False(
                 block.Contains("PATH="),
-                $"AGENTS.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
+                $"docs/dev-environment.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
         }
     }
 


### PR DESCRIPTION
The IL-tools documentation gate now validates `docs/dev-environment.md`, where #5079 moved the detailed activation guidance. This removes the inherited Ubuntu PR failure without restoring duplicate guidance to `AGENTS.md`.

## Demo

Before, `IlToolsActivationTests.AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript` failed because `AGENTS.md` no longer contains `source eng/activate-iltools.sh`. Afterward, the renamed gate reads the owning document and passes while retaining the direct-producer and hand-written-`PATH` protections.

## Validation

`dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*DevelopmentEnvironmentMarkdown_DelegatesIlToolsPathAssemblyToTheScript*'`\n\nFixes #5101.\n\nUnblocks #5031.