### PR TITLE
Specify the CoreCache mechanism contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,6 +80,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, which flow supplies the credential in each environment, which credential forms are supported, and the hermetic/live test tiers. See [Private NuGet Feeds](private-feeds.md) for setup instructions. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Cache concurrency and publication](design/cache-concurrency.md) | Process-local single-flight, cross-process atomic publication, dependency overlap, and filesystem guarantees. |
+| [CoreCache mechanism](design/corecache-mechanism.md) | `CoreCache`'s own contract: category/key/extension trust boundary, path-context containment, initialization lifecycle, and versioned category retirement. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |
 | [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill. |
 | [Inspection Layers](design/inspection-layers.md) | Layering and consumer-boundary rules between Metadata, Analysis, CSharpText, CSharp, Research, and the CLI. |

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -200,27 +200,20 @@ noncanonical NuGet.org URL shortcut.
 ## Versioned cache retirement
 
 The [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
-owns the scheduling, scanning, draining, suffix-selection, and accounting
-mechanics — see that document for the exact rule. This section states only
+owns the scheduling, scanning, draining, suffix-selection, accounting, and
+overlapping-prefix-failure mechanics — see that document for the exact
+rules and their own Gaps. This section states only
 the cross-process rationale those mechanics exist to satisfy: **automatic
 versioned retirement** is intended to never destroy a cache contract written
 by a newer process,
 and a newer process must tolerate an older one still running
 concurrently and recreating a contract the newer process just retired. That
-intent is not an enforced guarantee within a single registered family
-either, though: it depends on registered version prefixes being disjoint,
-which nothing in the mechanism enforces (see
-[CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)'s
-own Gap on overlapping prefixes) — a family whose prefix is a strict
-substring of another's own prefix can have its cleanup delete a directory
-that is actually the *other*, unrelated family's current contract, written
-by any process regardless of relative age. This rationale governs only the
-automatic retirement path; it does not extend to
-an operator-requested `dotnet-inspect cache clear`, which deletes the entire
-active cache root unconditionally (`CoreCache.Clear()`, with no
-version-aware filtering) — an older process can still destroy a newer
-contract that way, by explicit operator request rather than by the
-versioned-retirement mechanism this section describes.
+intent is not an enforced guarantee, as the linked document's own
+overlapping-prefix Gap describes; this section states the rationale only,
+not the mechanics that can violate it. It also governs only the automatic
+retirement path — [CoreCache's `Clear`](corecache-mechanism.md#clear-and-concurrent-writers)
+and its CLI-level `cache clear` caller are separate, unconditional deletion
+paths this rationale does not extend to.
 
 ## Filesystem coordination
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -199,21 +199,14 @@ noncanonical NuGet.org URL shortcut.
 
 ## Versioned cache retirement
 
-See also the [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
-for the mechanism-level contract this section's cross-process rationale relies on.
-
-Each versioned cache family registers its prefix and current numeric contract.
-Registration starts best-effort background cleanup, and cache initialization
-rechecks every known family. Cleanup deletes only lower numeric contracts.
-Current, future, and malformed directory suffixes are preserved, so running an
-older dotnet-inspect cannot destroy a cache written by a newer one.
-
-Cleanup scans on every initialization rather than trusting a persisted
-high-water mark. An older executable can still be running and can recreate an
-old contract after a newer process removes it; the next initialization must
-therefore check again. Routine cleanup is silent. An explicit `cache clear`
-waits for in-flight maintenance and includes its reclaimed bytes in the
-reported total.
+See the [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
+for the full scheduling, scanning, draining, and accounting mechanics this
+section owns. The cross-process rationale: retirement deletes only lower
+numeric contracts and preserves current, future, and malformed directory
+suffixes, so running an older dotnet-inspect cannot destroy a cache written
+by a newer one, and an older executable recreating a retired contract after
+a newer process removed it is expected — the next initialization checks
+again rather than trusting a persisted high-water mark.
 
 ## Filesystem coordination
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -205,9 +205,7 @@ mechanics — see that document for the exact rule. This section states only
 the cross-process rationale those mechanics exist to satisfy: an older
 `dotnet-inspect` process must never destroy a cache contract written by a
 newer one, and a newer process must tolerate an older one still running
-concurrently and recreating a contract the newer process just retired —
-which is why retirement re-scans on every initialization rather than
-trusting a persisted high-water mark.
+concurrently and recreating a contract the newer process just retired.
 
 ## Filesystem coordination
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -203,11 +203,19 @@ The [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
 owns the scheduling, scanning, draining, suffix-selection, and accounting
 mechanics — see that document for the exact rule. This section states only
 the cross-process rationale those mechanics exist to satisfy: **automatic
-versioned retirement** must never destroy a cache contract written by a
-newer process,
+versioned retirement** is intended to never destroy a cache contract written
+by a newer process,
 and a newer process must tolerate an older one still running
-concurrently and recreating a contract the newer process just retired. This
-rationale governs only the automatic retirement path; it does not extend to
+concurrently and recreating a contract the newer process just retired. That
+intent is not an enforced guarantee within a single registered family
+either, though: it depends on registered version prefixes being disjoint,
+which nothing in the mechanism enforces (see
+[CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)'s
+own Gap on overlapping prefixes) — a family whose prefix is a strict
+substring of another's own prefix can have its cleanup delete a directory
+that is actually the *other*, unrelated family's current contract, written
+by any process regardless of relative age. This rationale governs only the
+automatic retirement path; it does not extend to
 an operator-requested `dotnet-inspect cache clear`, which deletes the entire
 active cache root unconditionally (`CoreCache.Clear()`, with no
 version-aware filtering) — an older process can still destroy a newer

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -199,14 +199,15 @@ noncanonical NuGet.org URL shortcut.
 
 ## Versioned cache retirement
 
-See the [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
-for the full scheduling, scanning, draining, and accounting mechanics this
-section owns. The cross-process rationale: retirement deletes only lower
-numeric contracts and preserves current, future, and malformed directory
-suffixes, so running an older dotnet-inspect cannot destroy a cache written
-by a newer one, and an older executable recreating a retired contract after
-a newer process removed it is expected — the next initialization checks
-again rather than trusting a persisted high-water mark.
+The [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
+owns the scheduling, scanning, draining, suffix-selection, and accounting
+mechanics — see that document for the exact rule. This section states only
+the cross-process rationale those mechanics exist to satisfy: an older
+`dotnet-inspect` process must never destroy a cache contract written by a
+newer one, and a newer process must tolerate an older one still running
+concurrently and recreating a contract the newer process just retired —
+which is why retirement re-scans on every initialization rather than
+trusting a persisted high-water mark.
 
 ## Filesystem coordination
 

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -199,6 +199,9 @@ noncanonical NuGet.org URL shortcut.
 
 ## Versioned cache retirement
 
+See also the [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
+for the mechanism-level contract this section's cross-process rationale relies on.
+
 Each versioned cache family registers its prefix and current numeric contract.
 Registration starts best-effort background cleanup, and cache initialization
 rechecks every known family. Cleanup deletes only lower numeric contracts.

--- a/docs/design/cache-concurrency.md
+++ b/docs/design/cache-concurrency.md
@@ -202,10 +202,17 @@ noncanonical NuGet.org URL shortcut.
 The [CoreCache mechanism](corecache-mechanism.md#versioned-category-retirement)
 owns the scheduling, scanning, draining, suffix-selection, and accounting
 mechanics — see that document for the exact rule. This section states only
-the cross-process rationale those mechanics exist to satisfy: an older
-`dotnet-inspect` process must never destroy a cache contract written by a
-newer one, and a newer process must tolerate an older one still running
-concurrently and recreating a contract the newer process just retired.
+the cross-process rationale those mechanics exist to satisfy: **automatic
+versioned retirement** must never destroy a cache contract written by a
+newer process,
+and a newer process must tolerate an older one still running
+concurrently and recreating a contract the newer process just retired. This
+rationale governs only the automatic retirement path; it does not extend to
+an operator-requested `dotnet-inspect cache clear`, which deletes the entire
+active cache root unconditionally (`CoreCache.Clear()`, with no
+version-aware filtering) — an older process can still destroy a newer
+contract that way, by explicit operator request rather than by the
+versioned-retirement mechanism this section describes.
 
 ## Filesystem coordination
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -70,7 +70,13 @@ differently, but the difference is enforced for only one of them:
 - **`key`** is always SHA-256 hashed before it reaches the filesystem
   (`GetFilePath`'s `hashString[..2]/hashString[2..].{extension}` layout). A
   key built from untrusted content — a package id, a URL, source text — can
-  never produce a path outside the two-level hash bucket.
+  never produce a path outside the two-level hash bucket. The filesystem path
+  is not `key`'s only sink, though: every read/write operation also forwards
+  the original, unhashed `key` to `CacheTelemetry.Record` (see
+  [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
+  below) — that is a second, independent path for the same untrusted input,
+  contained by a different owner's mechanism (`CacheTelemetry`'s own
+  redaction), not by the hashing described here.
 - **`category`** is concatenated into the path verbatim (`GetCategoryPath` is
   `Path.Combine(GetBasePath(), category)`), and `GetCacheInfo(category)` uses
   the same unguarded path to recursively measure and enumerate files. Every
@@ -274,7 +280,26 @@ a different location than the one actually checked. No current caller
 changes the working directory during a commit/cleanup cycle, but the guard
 does not itself close this window; it assumes a stable current directory
 and an absolute (or effectively unchanging) resolved path across the reused
-call.
+call. This particular exposure (a guard's coverage going stale before the
+guarded string is used) is not the only consequence of an unresolved
+relative root, either: because `CoreCache` stores and forwards `basePath`
+verbatim rather than resolving it to an absolute path once at
+`Initialize` time, *every* operation that constructs a path from
+`GetBasePath()` and then performs a filesystem call against that same
+unresolved string — not just the guard-reuse case above — depends on the
+process's current directory being the one in effect when that later call
+actually runs, not when the string was built. `Set`/`SetBytes`'s
+`WriteAtomically` builds a temp-file path and later moves it to the
+original path in a separate operation on the same relative string; `Clear`
+validates, measures, and deletes the same unresolved `targetPath` across
+three separate filesystem calls; and versioned-category retirement (see
+below) captures `root = GetBasePath()` synchronously when scheduling, then
+resolves and deletes against that captured string later, from a background
+`Task.Run` that can execute an arbitrary amount of time afterward — the
+asynchronous case with the widest window of any of these. A stable current
+directory is therefore an unstated precondition for the mechanism as a
+whole whenever `basePath` is relative, not only for the NuGetCache/
+PlatformPackService guard-reuse pattern described above.
 Only `PlatformPackService`'s separate `destDir` guard (inside its
 content-copy helper, before overwriting an existing destination
 subdirectory) and `PackageCacheService`'s legacy-cache guard are dedicated
@@ -573,14 +598,24 @@ from `GetBasePath` at all, only from whichever of `GetCategoryPath`/
 enumeration — none of which touch `AppName` a second time once `GetBasePath`
 has already returned. `Clear` reaches the same exception while deriving its
 `targetPath` (after its own maintenance wait, which does not depend on
-`AppName` — see below). `CancelAndWaitForMaintenance` is the one public
-method that does *not* propagate this exception pre-initialization: it calls
+`AppName` — see below). `CancelAndWaitForMaintenance` does not propagate
+this exception pre-initialization either, and for a distinct reason from
+`Set`/`SetBytes`'s swallowing `catch` or `IsPathInCacheContext`'s
+`false`-returning `catch` above: it calls
 `WaitForMaintenance`, which calls `RequestVersionedCategoryCleanupAsync`,
 which checks `_appName is null` explicitly and returns a completed
 `default(CacheMaintenanceResult)` task rather than touching the throwing
 `AppName` property — so `CancelAndWaitForMaintenance(timeout)` called before
-`Initialize` returns a zeroed result instead of throwing, unlike every other
-lock-free method discussed here. There is no single
+`Initialize` returns a zeroed result instead of throwing, without ever
+depending on a `catch` to do so. `RegisterVersionedCategory` similarly does
+not require prior `Initialize`: it validates and stores its `prefix`/
+`current` pair unconditionally, then calls
+`ScheduleVersionedCategoryCleanup`, which itself checks `_appName is null`
+and returns immediately without scheduling anything — so registering a
+versioned category before `Initialize` succeeds and takes effect
+retroactively once `Initialize` eventually runs (the category is already in
+`s_versionedCategories` for `Initialize`'s own generation-scheduling pass to
+pick up). There is no single
 "every lock-free method does X" pre-initialization rule; each method's
 documented behavior above already states its own case.
 
@@ -594,8 +629,21 @@ be non-null and non-whitespace, and `current` must start with `prefix`
 case-insensitively and have the remainder parse as a non-negative integer
 via `int.TryParse(..., NumberStyles.None, ...)` (so no leading `+`/`-` sign,
 no thousands separator, and no leading/trailing whitespace in the suffix) —
-any violation throws `ArgumentException` synchronously from the call itself,
-before any background work is scheduled. Retirement:
+any violation throws synchronously from the call itself, before any
+background work is scheduled, but not uniformly as `ArgumentException`: a
+`null` `prefix` or `current` throws `ArgumentNullException` specifically
+(`ArgumentException.ThrowIfNullOrWhiteSpace`'s own behavior for a `null`
+argument), a whitespace-only value throws plain `ArgumentException`, and a
+`current` that does not start with `prefix` or whose suffix does not parse
+throws `ArgumentException` naming parameter `current`. A *second*
+registration of an already-registered `prefix` is a separate case with its
+own exception type: if the new call's `current`/parsed version disagrees
+with what was already registered for that `prefix`, `RegisterVersionedCategory`
+throws `InvalidOperationException` (not `ArgumentException`) — a
+conflicting-registration error, distinct from an invalid-argument one — while
+an identical repeat registration (same `prefix`, same `current`) succeeds
+silently and reschedules cleanup for that generation instead of throwing.
+Retirement:
 
 - deletes only sibling directories whose suffix parses as a non-negative
   integer strictly less than the current version;
@@ -613,10 +661,20 @@ before any background work is scheduled. Retirement:
 **Gap:** the retired-directory byte count is itself only a best-effort
 measurement, not a confirmed pre-deletion size — `CleanupVersionedCategory`
 measures each obsolete directory via `GetDirectorySizeBestEffort`, which
-catches any enumeration failure and returns `0` rather than propagating it,
-and then proceeds to `Directory.Delete` the directory regardless and record
+catches any enumeration failure and returns `0` rather than propagating it.
+A failed measurement does not, by itself, guarantee the directory is still
+deleted and counted, though: after measuring, `CleanupVersionedCategory`
+checks its `CancellationToken` again and returns without deleting or
+recording anything at all if cancellation was requested in the interim
+(the same token checked once already, before measurement began) — so a
+directory that failed to measure *and* whose generation was canceled in
+that same window is neither deleted nor counted, not "still deleted and
+still counted with a zero size." Only when cancellation is not requested at
+that second check does `CleanupVersionedCategory` proceed to
+`Directory.Delete` the directory and record
 a deletion with that (possibly `0`) size. A directory that fails to measure
-(permissions, a concurrent modification during enumeration) is still
+(permissions, a concurrent modification during enumeration) but is not
+racing a cancellation is still
 deleted and still counted as one retired directory, but contributes `0` to
 the accumulated byte total — so the maintenance byte counter that `Clear(null)`
 later consumes into its return value (see
@@ -664,16 +722,20 @@ alone whether the target survived untouched or was partially removed.
 
 **Gap:** the two counters `CacheMaintenanceProgress` tracks —
 `_bytesFreed` and `_directoriesDeleted` — are each individually
-thread-safe (`Interlocked.Add`/`Increment`/`Exchange`/`Read`), but the pair
+thread-safe, but not via the same primitive throughout, and the pair
 is not updated or read atomically together. `RecordDeletion` performs two
-separate `Interlocked` operations (bytes, then count), and both
-`Snapshot()`/`TakeSnapshot()` likewise read or reset the two fields with two
-separate `Interlocked` calls. Background cleanup (`CleanupVersionedCategory`)
+separate `Interlocked` operations (`Interlocked.Add` for bytes, then
+`Interlocked.Increment` for count); `TakeSnapshot()` similarly performs two
+separate `Interlocked.Exchange` calls; but `Snapshot()` reads bytes via
+`Interlocked.Read` and reads the directory count via a plain `Volatile.Read`
+— still a thread-safe read of that one field, just not the same
+`Interlocked` operation family the other methods use. Background cleanup (`CleanupVersionedCategory`)
 calls `RecordDeletion` without holding `s_maintenanceLock`, while
 `WaitForMaintenance` reads the pair via `Snapshot()`/`TakeSnapshot()` while
 holding that lock — the lock does not prevent a concurrent, lock-free
-`RecordDeletion` call from executing between the two `Interlocked`
-operations inside `Snapshot()`/`TakeSnapshot()`. A caller can therefore
+`RecordDeletion` call from executing between the two separate operations
+inside `Snapshot()`/`TakeSnapshot()`, regardless of which specific atomic
+primitive each one uses. A caller can therefore
 observe a `CacheMaintenanceResult` where one field reflects a deletion that
 just completed and the other does not yet (or, symmetrically, where
 `TakeSnapshot()`'s reset of one field races a deletion recorded between the
@@ -701,7 +763,15 @@ enforce and today's callers satisfy only by using prefixes that do not
 overlap in practice.
 
 `CancelAndWaitForMaintenance`/`Clear` are the only **public** ways a caller
-observes completed maintenance. The internal `RequestVersionedCategoryCleanupAsync`
+observes completed maintenance *and its accounting*. `Initialize` is also a
+completion barrier of a kind for the *previous* generation — a subsequent
+`Initialize` call cancels the outgoing generation's tasks and waits for them
+(`WaitForMaintenanceTasksBestEffort`'s `Task.WaitAll`) before installing the
+new one — but it does not return the drained `CacheMaintenanceResult` to its
+caller at all (only carrying the byte/directory counters forward internally,
+per [Initialization lifecycle](#initialization-lifecycle) above), so it is
+not a way to *observe* completed maintenance in the sense this section
+means. The internal `RequestVersionedCategoryCleanupAsync`
 is a third, assembly-internal path that test code uses directly to await
 maintenance — but calling what it returns "the real aggregate task"
 overstates what it actually returns: the
@@ -900,7 +970,16 @@ return/throw/counter behavior are unaffected.
 
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
 recorded on cache outcomes, but recording itself does nothing to protect a
-cache result: `CacheTelemetry.Record` first adds an `ActivityEvent` to
+cache result. `CoreCache` forwards the original, unhashed `key` (see the
+trust-boundary section above) to `CacheTelemetry.Record` as plain caller
+evidence — what happens to that call is the adjacent `CacheTelemetry`
+owner's own contract, cited here only because it is the first place the
+untrusted `key` is contained rather than hashed: `CacheObservation.Create`
+constructs the observation *before* either `Activity.Current?.AddEvent` or
+subscriber dispatch runs, and that construction routes `key` through
+`RedactCacheKey`, which returns a redacted `UrlRedaction` result for a
+URL-shaped key or wraps any other key in an `InertString(TextPolicy.Field,
+key)` — so by the time `Record` first adds an `ActivityEvent` to
 `Activity.Current` when one exists (`Activity.Current?.AddEvent(...)` — no
 event is added when there is no current activity, which is the ordinary
 state unless one has been established), then calls every subscribed
@@ -1010,16 +1089,27 @@ entry fresh whenever the future skew `δ` exceeds `M` — a small future skew
 can still be stale against a large-magnitude negative `maxAge`, but any
 future skew is read as fresh once `maxAge` is zero or positive. Any failure while resolving
 `FileInfo` or reading the file is caught by the same guarded region and
-*returns* a miss (`null`), exactly like the non-`maxAge` overloads' hit
-path — but the miss is not otherwise *recorded* the same way: the
+falls through toward a miss, exactly like the non-`maxAge` overloads' hit
+path — but the miss is not otherwise *recorded* the same way, and the
+*return value* is not unconditionally `null` either, unlike that comparison
+might suggest: the
 non-`maxAge` overloads' hit-path `catch` returns directly, so a read failure
 there is invisible to telemetry (no hit or miss observation, no
 `InfoTracker.RecordCacheMiss()`); the `maxAge` overloads' `catch` instead
 falls through to the same unguarded miss-telemetry call the missing-entry
-case uses, so a read failure there *is* recorded as a miss. A read failure
-under `maxAge` is therefore observable in telemetry in a way the equivalent
-failure under the plain overloads is not, even though both return `null` to
-the caller identically.
+case uses, so a read failure there *is* recorded as a miss — normally.
+"Normally" matters here: that miss-telemetry call is unguarded on this path
+just as it is on the missing-entry path (see
+[Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
+above), so a throwing miss-telemetry subscriber propagates out of the
+`maxAge` overload the same way it would out of the plain overload's miss
+path — the caller gets an exception, not `null`, in that case. So a read
+failure under `maxAge` is observable in telemetry in a way the equivalent
+failure under the plain overloads is not, and *usually* still returns `null`
+to the caller identically to the plain overloads — but not in every case,
+since reaching that return still passes through the same unguarded
+miss-telemetry call the plain overloads' *miss* path (not hit-failure path)
+shares.
 
 ## Non-claims
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -30,10 +30,14 @@ docs-only change.
   platform (or an override);
 - a collision-resistant, filesystem-safe path for a caller-chosen key within
   a category;
-- best-effort read/write/clear operations over that path;
-- containment so cache deletion can never escape the cache root; and
-- best-effort background retirement of superseded versioned category
-  directories.
+- best-effort read, write, and background-maintenance operations over that
+  path — failures are swallowed and observed only as a miss or as maintenance
+  making no progress;
+- a `Clear` operation that surfaces most failures rather than swallowing them
+  (see [Clear and concurrent writers](#clear-and-concurrent-writers)); and
+- a path-context guard, `EnsurePathInCacheContext`/`IsPathInCacheContext`,
+  that both `Clear` and other owners may call before their own deletions (see
+  [Path-context containment](#path-context-containment)).
 
 Everything else — what a category or key *means*, whether a hit is still
 valid, and whether a miss may trigger network work — belongs to the caller.
@@ -82,33 +86,47 @@ enforce against.
 
 ## Path-context containment
 
-`EnsurePathInCacheContext`/`IsPathInCacheContext` are the only guards against
+`EnsurePathInCacheContext`/`IsPathInCacheContext` are a public guard against
 deleting outside the cache: a path is in context when it equals or is a
 descendant of the active base path (`GetBasePath()`) or the legacy pre-XDG
 path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed — any
 exception while resolving the full path (malformed path, denied access)
-returns `false`, never `true`.
+returns `false`, never `true`. `Clear` calls it internally, and other owners
+call it directly before their own destructive filesystem operations —
+package-content and staging deletion (`NuGetCache`), platform-pack target and
+staging deletion (`PlatformPackService`), and legacy-cache deletion
+(`PackageCacheService`) all invoke it. It is the mechanism's one exported
+containment primitive; any future caller that deletes a path derived from
+`GetBasePath()`/`GetCategoryPath()` should call it too.
 
-**Gap:** the descendant check (`IsSameOrChildPath`) compares paths with
-`StringComparison.OrdinalIgnoreCase` unconditionally, on every platform. On a
-case-sensitive filesystem (ordinary Linux/macOS volumes), a path that differs
-from the cache root only in case is accepted as a descendant even though it
-names a distinct location outside the actual root — so the "cannot escape the
-cache root" guarantee below does not hold there. This document's containment
-claims describe the guard's intended behavior, not a verified guarantee on
-case-sensitive filesystems; treat that as an open, unenforced case, not as
-closed by `EnsurePathInCacheContext` alone.
+**Gap:** the descendant check (`IsSameOrChildPath`) and the root-equality
+check used to carry maintenance counters across re-`Initialize`
+(`IsSamePath`) both compare paths with `StringComparison.OrdinalIgnoreCase`
+unconditionally, on every platform. On a filesystem that is actually
+case-sensitive — ordinary Linux ext4, or a case-sensitive-formatted
+APFS/NTFS volume (the default macOS and Windows format is case-insensitive) —
+a path that differs from the cache root only in case is accepted as a
+descendant, or two re-`Initialize` roots differing only in case are treated
+as the same root, even though each names a distinct location on disk. So
+neither the "cannot escape the cache root" guarantee below, nor the
+counter-carry-forward rule in
+[Initialization lifecycle](#initialization-lifecycle), holds on such a
+filesystem. This document's containment claims describe the guard's intended
+behavior, not a verified guarantee on a case-sensitive filesystem; treat that
+as an open, unenforced case, not as closed by `EnsurePathInCacheContext`/
+`IsSamePath` alone.
 
-**Gap:** this guard runs only inside `Clear`, immediately before
-`Directory.Delete`. It does not run on the write path (`Set`/`SetBytes`
-create directories and move files into `GetFilePath`'s result without calling
-it) or the read path. Because `category` is contract-restricted to literals
-(see above), a conforming caller never needs the guard there today — but the
-guard's absence means a `category`/`extension`/`appName` contract violation
-on the write path is not caught by this mechanism at all, only a violation
-reached through `Clear`'s category argument is. A future defensive check on
-`category`/`extension`/`appName` (the gap above) would close both paths at
-once and make this asymmetry moot.
+**Gap:** `CoreCache`'s own read/write entry points (`TryGet`, `TryGetBytes`,
+`Set`, `SetBytes`, `GetFilePath`) never call the guard themselves — only
+`Clear` and the external callers above do. Because `category` is
+contract-restricted to literals (see above), a conforming caller never needs
+the guard on the read/write path today — but the guard's absence there means
+a `category`/`extension`/`appName` contract violation reaching `TryGet`/`Set`
+directly (rather than through `Clear` or one of the callers that already
+guards itself) is not caught by this mechanism at all. A future defensive
+check on `category`/`extension`/`appName` (the trust-boundary gap above)
+would close this without relying on every future write-path caller
+remembering to call the guard itself.
 
 ## Initialization lifecycle
 
@@ -117,7 +135,9 @@ call: it cancels and best-effort drains any in-flight versioned-category
 maintenance, replaces the maintenance generation, and re-schedules cleanup
 for every category registered so far — against the *new* base path if one was
 given. Reclaimed-byte/directory counters carry forward only when the new base
-path resolves to the same location as the old one; otherwise they reset,
+path resolves to the same location as the old one (`IsSamePath` — subject to
+the case-sensitivity gap in
+[Path-context containment](#path-context-containment)); otherwise they reset,
 because the counters describe one cache root's history and a root change
 starts a new one.
 
@@ -173,39 +193,64 @@ directory absent.
 
 ## `Clear` and concurrent writers
 
-**Gap:** `Clear` takes `s_maintenanceLock`, drains maintenance, validates the
-target path is in cache context, then deletes the directory tree. It does not
-coordinate with concurrent `Set`/`SetBytes` calls, which do not take
-`s_maintenanceLock` at all. A `Set` that created its category subdirectory
-before `Clear`'s `Directory.Delete` observes either a successful write that
-`Clear` then removes (consistent with "clear empties the cache") or a
-`WriteAtomically` `File.Move` into a directory `Clear` just deleted — caught
-by `Set`'s blanket `try`/`catch` and silently dropped. Neither outcome
-corrupts the cache, but the mechanism gives no delivery guarantee for a write
-that races a clear, and a caller relying on "the value I just set survives"
-immediately after a concurrent `Clear` has no contract to rely on. Today no
-caller clears a category while concurrently writing to it; a future one must
-either serialize its own writes around a `Clear` or accept that the write may
-be silently lost.
+`Clear` is not best-effort like the read/write paths: it takes
+`s_maintenanceLock`, drains maintenance, validates the target path is in
+cache context, measures the tree, and deletes it, catching only
+`DirectoryNotFoundException` for the specific case where another process
+already completed the same deletion. Any other failure — an authorization
+error, an `IOException` from a file another process still has open, or a
+directory-enumeration error while measuring size — propagates to `Clear`'s
+caller rather than being swallowed.
+
+**Gap:** `Clear` does not coordinate with concurrent `Set`/`SetBytes` calls,
+which do not take `s_maintenanceLock` at all. A `Set` that created its
+category subdirectory before `Clear`'s `Directory.Delete` can produce three
+outcomes, none of them a contract this mechanism enforces: a successful write
+that `Clear` then removes (consistent with "clear empties the cache"); a
+`WriteAtomically` `File.Move` into a directory `Clear` just deleted, caught by
+`Set`'s blanket `try`/`catch` and silently dropped; or a filesystem error
+surfaced *from `Clear` itself* (for example `Directory.Delete` encountering
+the writer's still-open temporary file) that is not the narrow
+already-deleted case `Clear` catches, and so propagates to `Clear`'s caller.
+A caller relying on "the value I just set survives" immediately after a
+concurrent `Clear`, or relying on `Clear` never throwing because reads and
+writes elsewhere are best-effort, has no contract to rely on. Today no caller
+clears a category while concurrently writing to it; a future one must either
+serialize its own writes around a `Clear` or accept both the silent-loss and
+the `Clear`-throws possibilities.
 
 ## Telemetry is fire-and-forget but not exception-isolated
 
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
-recorded on every `TryGet`/`TryGetBytes`/`Set`/`SetBytes` outcome. Recording
-itself does nothing to protect a cache result: `CacheTelemetry.Record` calls
-every subscribed `IObserver<CacheObservation>.OnNext` synchronously, with no
-surrounding `try`/`catch`. A throwing subscriber therefore changes cache
-behavior at the call site — on a `TryGet` hit, the call happens inside the
-method's own blanket `catch`, so a subscriber exception silently turns a hit
-into a miss (`null`); on a `TryGet` miss, the call happens outside any
-`catch`, so a subscriber exception propagates to the cache caller. This
-mechanism does not isolate telemetry from the operation it is recording;
-"fire-and-forget" describes the caller's intent, not an enforced boundary.
-Telemetry may also undercount (a `Set` that never reaches the `try` body's
-`CacheTelemetry.Record` call because an earlier line threw is silently
-uncounted) and must not be read as an audit trail of cache correctness — only
-as an operational signal, and only when every subscriber is known not to
-throw.
+recorded on cache outcomes, but recording itself does nothing to protect a
+cache result: `CacheTelemetry.Record` calls every subscribed
+`IObserver<CacheObservation>.OnNext` synchronously, with no surrounding
+`try`/`catch`. A throwing subscriber changes cache behavior differently
+depending on which method and overload observed it:
+
+- **`TryGet`/`TryGetBytes` without `maxAge`:** the hit-telemetry call is
+  inside the method's own blanket `catch`, so a throwing subscriber silently
+  turns a hit into a miss (`null`) with no miss recorded; a throwing
+  subscriber on the (separate, unguarded) miss path propagates to the caller.
+- **`TryGet`/`TryGetBytes` *with* `maxAge`:** the hit-telemetry call is inside
+  a `catch` that swallows the exception and falls through to the *same*
+  unguarded miss-telemetry call below it. A subscriber that throws on the
+  hit observation therefore still reaches the miss observation; if that
+  subscriber (or another) also throws on the miss observation, the exception
+  propagates out of the method — unlike the non-`maxAge` overloads, a
+  throwing hit subscriber does not reliably degrade to a silent `null` here.
+- **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
+  `catch`, so a throwing subscriber is swallowed the same way any other write
+  failure is, and the write telemetry is simply never recorded.
+
+This mechanism does not isolate telemetry from the operation it is
+recording; "fire-and-forget" describes the caller's intent, not an enforced
+boundary, and it is not true that every outcome is guaranteed to be recorded.
+Telemetry may also undercount for reasons unrelated to a subscriber (a `Set`
+that never reaches the `try` body's `CacheTelemetry.Record` call because an
+earlier line threw is silently uncounted) and must not be read as an audit
+trail of cache correctness — only as an operational signal, and only when
+every subscriber is known not to throw.
 
 ## Non-claims
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -937,10 +937,13 @@ maintenance generation before deleting anything; only `Clear(null)` also
 waits the same way but reports `0` maintenance bytes, and neither overload's
 return value includes the directory-deleted count — see
 [Clear and concurrent writers](#clear-and-concurrent-writers)).
-Routine (non-`Clear`) maintenance is silent: a caller that never calls
+Routine (non-`Clear`) maintenance is silent to **public** callers: one that
+never calls
 `Clear` or `CancelAndWaitForMaintenance` never learns whether background
 retirement ran, succeeded, or was skipped because a prior run left the
-directory absent.
+directory absent — the only exception is the assembly-internal
+`RequestVersionedCategoryCleanupAsync` path (see above), which test code can
+await directly to observe maintenance completion and its accounting.
 
 ## `Clear` and concurrent writers
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -146,7 +146,9 @@ differently, but the difference is enforced for only one of them:
   Neither environment-controlled root is the sole anchor `IsPathInCacheContext`
   checks against, either — see the `appName` bullet above and
   [Path-context containment](#path-context-containment) for the
-  independently-anchored legacy root.
+  legacy root and the caveat that it is checked only when the active-root
+  check completes without throwing and simply doesn't match, not truly
+  independently.
 
 The contract is: **`category`, `extension`, and `appName` are caller-owned
 values that every current producer restricts to a fixed literal or a
@@ -186,8 +188,19 @@ escapes the cache root — the existing traversal test only covers the
 root-escaping case (`Clear("..")`, correctly rejected) — so this is a
 distinct failure mode from the path-traversal gap above: a non-conforming
 `category` can silently retarget a destructive operation to a different
-in-root location, not just widen it outside the root. `basePath` is exempt
-from the path-traversal framing of this gap since it is already the accepted
+in-root location, not just widen it outside the root. That "correctly
+rejected" traversal result is also configuration-dependent, not universal: the
+guard accepts a path under *either* the active root or the legacy root (see
+[Path-context containment](#path-context-containment) below), and those two
+roots are derived independently — nothing prevents an operator-supplied
+`basePath` override from placing the active root as a subdirectory *of* the
+legacy root. In that configuration, `Clear("..")` resolves to the legacy
+root itself, which the guard accepts as a legitimate containment target, and
+the deletion proceeds — the traversal succeeds by landing on the *other*
+accepted anchor rather than by escaping both. This is the same
+"root-escaping" case, but its rejection depends on the active and legacy
+roots not being nested inside one another, which nothing here enforces.
+`basePath` is exempt from the path-traversal framing of this gap since it is already the accepted
 exception above, but `GetBasePath`/`Initialize` still place no containment
 constraint on it at all — a `basePath` sourced from untrusted *content*
 rather than trusted operator configuration would be unconstrained in a
@@ -221,7 +234,21 @@ moment it (or a path derived from it) is passed as the *candidate* to
 not silently no-op or contain some unexpected path; it fails
 `EnsurePathInCacheContext`'s guard and throws, because the guard cannot
 distinguish "root not supplied" from "candidate not supplied" once both
-happen to be the same blank string. `Clear` calls it internally before deleting;
+happen to be the same blank string. The legacy root is not evaluated
+independently of the active-root check succeeding cleanly, either:
+`IsPathInCacheContext` checks the active root (`IsSameOrChildPath(fullPath,
+GetBasePath())`) first, and only evaluates `GetLegacyBasePath()`/the legacy
+comparison if that first check *returns* `false` — normally, not
+exceptionally. Because one `catch` wraps both stages, an exception while
+resolving the *active* root (`IsSameOrChildPath` calls
+`Path.GetFullPath(root)` on `GetBasePath()`'s result, which throws for a
+malformed override — see the trust-boundary section above on `basePath`
+having no format validation) is caught and returns `false` immediately,
+without ever reaching the legacy-root comparison. So the legacy root is not
+truly an "independent" second anchor in the sense of being checked
+regardless of what happens to the active-root check; it is checked only
+when active-root resolution completes without throwing and simply doesn't
+match. `Clear` calls it internally before deleting;
 other owners call it directly, but not exclusively before deletion. The
 following description of `NuGetCache`'s and `PlatformPackService`'s call
 sites is cited only as evidence for a `CoreCache`-owned claim — that this
@@ -687,8 +714,22 @@ has released `s_maintenanceLock` and returned, can schedule a new cleanup
 task and reset `s_maintenanceTask` to `null` — but that clears the memoized
 field for the *next* caller of `RequestVersionedCategoryCleanupAsync`; it
 does not, and cannot, add the new task into the array a previously returned
-task already captured. Whoever is still awaiting that earlier task
-therefore never learns about maintenance scheduled after they obtained it.
+task already captured. That does not mean the earlier task's *result* is
+unaffected by the later registration, though: `AwaitMaintenanceAsync`
+captures the task array by reference but reads `progress.Snapshot()` only
+after that array completes — and `progress` is the same
+`CacheMaintenanceProgress` instance shared by every task in the generation,
+including ones registered (against the same root, via
+`ScheduleVersionedCategoryCleanup`) after the earlier call already captured
+its array. So the earlier caller's `CacheMaintenanceResult` can include
+byte/directory counts recorded by a task it never waited for, if that later
+task happens to record its result before the earlier array finishes and
+`Snapshot()` runs — the *waiting* is scoped to the captured array, but the
+*reported counters* are scoped to the whole generation's shared progress
+object, and those two scopes can diverge. Whoever is still awaiting that earlier task
+therefore never learns about maintenance scheduled after they obtained it
+*by waiting for its completion* — but may still observe its accounting
+folded into the numbers the earlier task reports.
 The public `WaitForMaintenance` path does not have this exposure: it holds
 `s_maintenanceLock` for its entire wait, so no `RegisterVersionedCategory`
 call can interleave and schedule additional work while it is in progress.
@@ -879,7 +920,18 @@ overload observed it:
   turns a hit into a `null` return — this `catch` returns directly, so the
   separate miss path (including its own telemetry call and
   `InfoTracker.RecordCacheMiss()`) never runs; a hit that fails this way is
-  not counted as a miss either.
+  not counted as a miss either, but it is not left uncounted altogether:
+  `InfoTracker.RecordCacheHit()` runs, unconditionally, *before*
+  `CacheTelemetry.Record(..., Hit)` inside the same `try`, so the hit counter
+  is already incremented by the time a throwing hit subscriber turns the
+  return value into `null` — the caller observes a miss-shaped result
+  (`null`) while `InfoTracker` still recorded a hit. The miss path has no
+  equivalent guard at all: `CacheTelemetry.Record(..., Miss)` runs
+  unconditionally before `RecordCacheMiss()`, and neither call is wrapped in
+  any `try`/`catch` on this path — so a throwing miss subscriber propagates
+  out of the method entirely (the caller gets an exception, not `null`), and
+  `RecordCacheMiss()` never runs, leaving that access entirely uncounted
+  rather than double-counted or undercounted in a bounded way.
 - **`TryGet`/`TryGetBytes` *with* `maxAge`:** the hit-telemetry call is inside
   a `catch` that swallows the exception and falls through to the *same*
   unguarded miss-telemetry call below it. A subscriber that throws on the

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -71,10 +71,14 @@ differently, but the difference is enforced for only one of them:
   (`GetFilePath`'s `hashString[..2]/hashString[2..].{extension}` layout). A
   key built from untrusted content — a package id, a URL, source text — can
   never produce a path outside the two-level hash bucket. The filesystem path
-  is not `key`'s only sink, though: every read/write operation also forwards
-  the original, unhashed `key` to `CacheTelemetry.Record` (see
+  is not `key`'s only sink, though: every telemetry event that *is* produced
+  (not every operation reaches telemetry — a read that fails before its own
+  telemetry call, or a write that fails before publication, produces no
+  event at all; see
   [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
-  below) — that is a second, independent path for the same untrusted input,
+  below) carries
+  the original, unhashed `key` to `CacheTelemetry.Record` — that is a second,
+  independent path for the same untrusted input,
   contained by a different owner's mechanism (`CacheTelemetry`'s own
   redaction), not by the hashing described here.
 - **`category`** is concatenated into the path verbatim (`GetCategoryPath` is
@@ -88,12 +92,21 @@ differently, but the difference is enforced for only one of them:
   forwards its `category`/`extension` interface parameters straight through
   to `CoreCache.TryGet`/`Set`, so the literal-only property holds only
   transitively, at each producer's own call site, not at every direct call
-  into `CoreCache`.
+  into `CoreCache`. Like `key`, `category` has a telemetry sink distinct from
+  the filesystem path — every telemetry event that *is* produced (the same
+  caveat as `key`'s above) carries it (via
+  `GetTelemetryCategory`, below) to `CacheTelemetry.Record` — but unlike
+  `key`, nothing contains or redacts it there; it is recorded exactly as
+  received.
 - **`extension`** is concatenated verbatim after the hash suffix. Most call
   sites pass a literal (`"json"`, `"forbidden"`, `"miss"`, `"md"`, `"tsv"`),
   but `SymbolPackageDownloader.Storage.cs` passes a local variable selected
   from a fixed two-value set, and the `CoreSourceLinkQueryCache` forwarding
   above applies to `extension` too — the same transitive-only caveat holds.
+  `extension` also reaches the same telemetry sink as `category`, but only
+  for the `"symbol-misses"` category (`GetTelemetryCategory` folds it into
+  `category` there — see [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
+  below), and, like `category`, uncontained.
 - **`appName`** (`Initialize`'s first parameter) is concatenated verbatim into
   every platform's default base path (`GetDefaultBasePath`'s
   `Path.Combine(..., AppName)` on each branch); `Initialize` only rejects a
@@ -642,8 +655,10 @@ with what was already registered for that `prefix`, `RegisterVersionedCategory`
 throws `InvalidOperationException` (not `ArgumentException`) — a
 conflicting-registration error, distinct from an invalid-argument one — while
 an identical repeat registration (same `prefix`, same `current`) succeeds
-silently and reschedules cleanup for that generation instead of throwing.
-Retirement:
+silently and calls the same idempotent scheduler as the first registration
+instead of throwing — see the repeated-registration retry caveat below for
+what that scheduler actually does (normally nothing, within the same
+generation for the same root). Retirement:
 
 - deletes only sibling directories whose suffix parses as a non-negative
   integer strictly less than the current version;
@@ -670,12 +685,18 @@ recording anything at all if cancellation was requested in the interim
 directory that failed to measure *and* whose generation was canceled in
 that same window is neither deleted nor counted, not "still deleted and
 still counted with a zero size." Only when cancellation is not requested at
-that second check does `CleanupVersionedCategory` proceed to
+that second check does `CleanupVersionedCategory` *attempt* to
 `Directory.Delete` the directory and record
-a deletion with that (possibly `0`) size. A directory that fails to measure
-(permissions, a concurrent modification during enumeration) but is not
-racing a cancellation is still
-deleted and still counted as one retired directory, but contributes `0` to
+a deletion with that (possibly `0`) size — but the attempt itself is not
+guaranteed to succeed either: `Directory.Delete` and `RecordDeletion` are
+both wrapped in the same blanket `catch` (see the next Gap below), so a
+directory that fails to measure and then also fails to delete (for example,
+a concurrent writer still holding a file inside it) contributes neither
+bytes nor a directory count, having failed at both steps rather than only
+the first. A directory that fails to measure
+(permissions, a concurrent modification during enumeration), is not
+racing a cancellation, and *does* delete successfully is
+counted as one retired directory, but contributes `0` to
 the accumulated byte total — so the maintenance byte counter that `Clear(null)`
 later consumes into its return value (see
 [Clear and concurrent writers](#clear-and-concurrent-writers)) can
@@ -957,40 +978,20 @@ accept both the silent-loss and the `Clear`-throws possibilities.
 
 ## Telemetry is fire-and-forget but not exception-isolated
 
-This section describes `CacheTelemetry`'s and `InfoTracker`'s *current*
-implementation only as evidence for a claim this document does own — what
-happens to a `CoreCache` read/write operation when telemetry recording
-fails. `CacheTelemetry`'s subscriber-dispatch mechanics (ordering,
-delivery guarantees, `ActivityEvent` behavior) and `InfoTracker`'s counter
-implementation are those types' own contracts, specified by their owning
-code, not normatively defined here; if either changes internally without
-changing where its call sites sit relative to `CoreCache`'s own
-`try`/`catch` blocks, this document's claims about `CoreCache`'s resulting
-return/throw/counter behavior are unaffected.
+This section states a `CoreCache`-owned claim only: what happens to a
+`CoreCache` read/write operation when telemetry recording fails. Where
+`CacheTelemetry.Record` sits relative to `CoreCache`'s own `try`/`catch`
+blocks and counter increments is this document's claim; `CacheTelemetry`'s
+own construction, redaction, activity-event, and subscriber-delivery
+mechanics are that type's own contract, owned and specified by its own
+code — not normatively redefined here, and not needed to support the claim
+below.
 
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
 recorded on cache outcomes, but recording itself does nothing to protect a
-cache result. `CoreCache` forwards the original, unhashed `key` (see the
-trust-boundary section above) to `CacheTelemetry.Record` as plain caller
-evidence — what happens to that call is the adjacent `CacheTelemetry`
-owner's own contract, cited here only because it is the first place the
-untrusted `key` is contained rather than hashed: `CacheObservation.Create`
-constructs the observation *before* either `Activity.Current?.AddEvent` or
-subscriber dispatch runs, and that construction routes `key` through
-`RedactCacheKey`, which returns a redacted `UrlRedaction` result for a
-URL-shaped key or wraps any other key in an `InertString(TextPolicy.Field,
-key)` — so by the time `Record` first adds an `ActivityEvent` to
-`Activity.Current` when one exists (`Activity.Current?.AddEvent(...)` — no
-event is added when there is no current activity, which is the ordinary
-state unless one has been established), then calls every subscribed
-`IObserver<CacheObservation>.OnNext` synchronously and in registration order,
-with no surrounding `try`/`catch`. When a current activity does exist, its
-event and every subscriber before a throwing one have already observed the
-outcome by the time an exception surfaces; only subscribers *after* the
-throwing one are not invoked at all, and `Record` itself does not complete
-normally. (The throwing subscriber's own `OnNext` *was* called — it received
-the observation before throwing; "not invoked" describes only the
-subscribers after it, not the throwing one itself.) A throwing subscriber
+cache result: `CacheTelemetry.Record` executes synchronously and can throw
+(from subscriber code it dispatches to, or from its own internals) before
+returning control to its caller. A throwing `Record` call
 then changes cache behavior differently depending on which method and
 overload observed it:
 
@@ -1033,14 +1034,11 @@ overload observed it:
   only the hit counter is incremented, not both.)
 - **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
   `catch`, so a throwing subscriber is swallowed the same way any other write
-  failure is — the activity event (if any) and any subscribers up to and
-  including the throwing one were still invoked with the observation; only
-  subscribers *after* the throwing one are not.
+  failure is.
 
 This mechanism does not isolate telemetry from the operation it is
 recording; "fire-and-forget" describes the caller's intent, not an enforced
-boundary, and delivery to any given subscriber is not guaranteed once an
-earlier subscriber throws. Telemetry may also undercount for reasons
+boundary. Telemetry may also undercount for reasons
 unrelated to a subscriber (a `Set` that never reaches the `try` body's
 `CacheTelemetry.Record` call because an earlier line threw is silently
 uncounted) and must not be read as an audit trail of cache correctness —

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -95,7 +95,14 @@ differently, but the difference is enforced for only one of them:
   end user or their shell environment) that controls `basePath` controls the
   cache root itself, which is a strictly larger trust concession than
   `category` or `extension` — and it is exercised in production, not merely
-  hypothetical.
+  hypothetical. `basePath` is not the only environment-controlled root
+  input, either: when no override is supplied at all,
+  `GetDefaultBasePath`'s Linux branch reads `XDG_CACHE_HOME` directly and
+  uses it verbatim as the parent of `appName`, with the same absence of
+  validation. It is a narrower concession than an explicit `basePath`
+  override (since `appName` is still appended beneath it), but it is a
+  second, always-live environment-controlled root selector on Linux, not a
+  hypothetical one.
 
 The contract is: **`category`, `extension`, and `appName` are caller-owned
 values that every current producer restricts to a fixed literal or a
@@ -220,7 +227,34 @@ path resolves to the same location as the old one (`IsSamePath` — subject to
 the case-sensitivity gap in
 [Path-context containment](#path-context-containment)); otherwise they reset,
 because the counters describe one cache root's history and a root change
-starts a new one.
+starts a new one. Both sides of that comparison are *recomputed live* at the
+moment of the second `Initialize` call, not the location actually recorded
+against by the earlier maintenance: the "old" root is `GetBasePath()`
+evaluated with the previous `appName`/`basePath` but the *current* process
+environment, and the "new" root is `GetBasePath()` evaluated with the new
+values and that same current environment. If no explicit `basePath` override
+was ever given and `XDG_CACHE_HOME` (or another ambient input
+`GetDefaultBasePath` reads) changes between the first and second
+`Initialize` call, both sides of the comparison observe the *same* changed
+environment and so still compare equal — counters can carry forward across
+an actual root change that neither `Initialize` call's caller intended, and
+conversely cannot be relied on to always reset just because the ambient
+environment changed since the first call.
+
+**Gap:** re-initialization is not exception-safe against a malformed new
+root. `Initialize` mutates `_appName`, `_basePathOverride`, the maintenance
+cancellation source, the progress object, and the task dictionary to their
+new values *before* calling `IsSamePath` to decide whether to carry progress
+forward — and `IsSamePath` calls `Path.GetFullPath` on both sides, which
+throws for a sufficiently malformed path (invalid characters, exceeding
+platform path-length limits). Because `basePath` receives no validation (see
+the trust-boundary section above), a caller-supplied `basePath` that
+`Path.GetFullPath` rejects makes `Initialize` throw *after* the new fields
+are already committed and *before* the `foreach` loop re-schedules cleanup
+for previously registered categories. The result is partial, not
+all-or-nothing: the new root and app name take effect, but no versioned
+category's cleanup is rescheduled against it until some other call
+re-triggers scheduling.
 
 `RegisterVersionedCategory` may be called before or after `Initialize`, and
 repeated registration of the same prefix is idempotent only when `current`
@@ -296,15 +330,48 @@ before any background work is scheduled. Retirement:
   previous generation's tasks, waits for them best-effort, and starts a new
   generation rather than waiting for the old one to finish on its own.
 
+**Gap:** the retirement rule above is scoped to one registered family (one
+`prefix`) at a time; nothing prevents two *different* registered prefixes
+from overlapping, and a directory that is the current member of one family
+can parse as an obsolete member of another. For example, registering
+`("foo-v", "foo-v20")` and `("foo-v2", "foo-v21")` both succeed —
+`s_versionedCategories` keys by the literal prefix string, so `"foo-v"` and
+`"foo-v2"` are distinct entries — but the second family's cleanup sees
+directory `foo-v20`, matches its `"foo-v2"` prefix, parses suffix `0`, and
+deletes it as obsolete (`0 < 21`), even though `foo-v20` is the *current*,
+still-referenced directory for the first family. `prefix`/`current` are
+therefore not just validated strings but caller-controlled deletion
+selectors whose safety depends on every registered family's prefix language
+being disjoint from every other — an invariant this mechanism does not
+enforce and today's callers satisfy only by using prefixes that do not
+overlap in practice.
+
 `CancelAndWaitForMaintenance`/`Clear` are the only **public** ways a caller
 observes completed maintenance (the internal `RequestVersionedCategoryCleanupAsync`
 is a third, assembly-internal path that test code uses directly to await the
-real aggregate task). Both public APIs can also return *partial* progress
-rather than confirmation that maintenance fully drained: `WaitForMaintenance`
-waits for the timeout given, then — if the task has not completed — cancels
-it and waits only another 25ms before returning whatever progress has been
-recorded so far, regardless of whether the canceled task has actually
-finished exiting. **Every** `Clear` call — not only `Clear(category:
+real aggregate task). `CancelAndWaitForMaintenance(timeout)` can return
+*partial* progress rather than confirmation that maintenance fully drained:
+`WaitForMaintenance` waits for the timeout given, then — if the task has not
+completed — cancels it and waits only another 25ms before returning whatever
+progress has been recorded so far, regardless of whether the canceled task
+has actually finished exiting. That timeout bound applies only to a call
+that finds the current maintenance generation *not already canceled*: if a
+prior timed-out call already canceled the generation and its tasks are still
+exiting cooperatively, the next call that touches maintenance —
+`WaitForMaintenance` (and so `CancelAndWaitForMaintenance` or `Clear`),
+`RegisterVersionedCategory`, or internal cleanup scheduling — restarts the
+generation via `StartNewMaintenanceGenerationIfCanceled`, which performs an
+*unbounded* `Task.WaitAll` on the previous generation's tasks before doing
+anything else. A finite-timeout `CancelAndWaitForMaintenance` call made
+after such a restart is pending can therefore block for as long as the
+still-exiting canceled tasks take, regardless of the timeout it was given.
+`Clear` always passes `Timeout.InfiniteTimeSpan` to `WaitForMaintenance`
+(see below), so `Clear` cannot observe the 25ms partial-progress path at
+all — `task.Wait(Timeout.InfiniteTimeSpan)` cannot return `false`, so `Clear`
+always waits for the full maintenance generation (including any pending
+generation-restart drain) to either complete or fault before proceeding; it
+does not return early with partial progress the way a finite-timeout
+`CancelAndWaitForMaintenance` call can. **Every** `Clear` call — not only `Clear(category:
 null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
 maintenance generation before deleting anything; only `Clear(null)` also
 *consumes* the recorded byte counter into its return value (`Clear(category)`
@@ -325,9 +392,18 @@ cache context, measures the tree, and deletes it, catching only
 already completed the same deletion. Any other failure — an authorization
 error, an `IOException` from a file another process still has open, or a
 directory-enumeration error while measuring size — propagates to `Clear`'s
-caller rather than being swallowed. `Clear`'s `long` return value is not a
-confirmed bytes-freed count: it is the tree size *measured before deletion*,
-plus (for `Clear(null)` only) the consumed maintenance byte counter. That
+caller rather than being swallowed, *once `Clear` has begun measuring or
+deleting*. Before that point, `Clear` calls `Directory.Exists(targetPath)`
+and returns early (reporting only the maintenance byte counter, no tree
+size) when it reports `false` — and `Directory.Exists` is documented to
+return `false` both when the directory genuinely does not exist and when an
+error occurs while determining whether it exists. An authorization or other
+filesystem error at that existence check is therefore indistinguishable from
+"nothing to clear" and returns successfully with an undercounted result,
+rather than propagating like the failures above. `Clear`'s `long` return
+value is not a confirmed bytes-freed count: it is the tree size *measured
+before deletion*, plus (for `Clear(null)` only) the consumed maintenance byte
+counter. That
 measurement can diverge from what this `Clear` call actually removed in
 either direction, for different reasons: a concurrent deletion of some or
 all of the tree between the measurement and `Directory.Delete` (including
@@ -422,12 +498,19 @@ case-insensitively equals `"symbol-misses"`, but *rewrites* it as
 `$"{category}/{extension}"` — preserving the caller's original spelling and
 casing rather than canonicalizing it. `TryGet("symbol-misses", key,
 extension: "forbidden")` reports `symbol-misses/forbidden`, distinct from
-`symbol-misses/miss` — this extension-remapping behavior is covered by
-`HttpClientFactoryTests.CacheTelemetry_SymbolMissesIncludeExtensionInCategory`.
-A caller passing `"SYMBOL-MISSES"` would observe `SYMBOL-MISSES/forbidden`,
-not the lowercase form, per the `$"{category}/{extension}"` interpolation
-above — this casing-preservation consequence follows from reading the source
-and is not itself exercised by any existing test. Every other `category`
+`symbol-misses/miss` —
+`HttpClientFactoryTests.CacheTelemetry_SymbolMissesIncludeExtensionInCategory`
+exercises exactly this call sequence (`Set`, then `TryGet` for the
+`"forbidden"` extension, then `TryGet` for the `"miss"` extension) and
+asserts on the resulting `Set`-store and `TryGet`-miss telemetry categories,
+but it does not assert a `TryGet`-hit observation at all — the test proves
+the store and miss categories are remapped as described, not that a
+*successful hit* under `"forbidden"` is reported as `symbol-misses/forbidden`
+rather than plain `symbol-misses`. A caller passing `"SYMBOL-MISSES"` would
+observe `SYMBOL-MISSES/forbidden`, not the lowercase form, per the
+`$"{category}/{extension}"` interpolation above — this casing-preservation
+consequence, and the hit-path remapping itself, follow from reading the
+source and are not exercised by any existing test. Every other `category`
 passes through unchanged. This is an intentional part of the observable
 telemetry contract, not an undocumented side effect.
 
@@ -445,7 +528,16 @@ comparison is one-sided, a `LastWriteTimeUtc` in the future (a clock change, a
 restored backup, a manipulated file) makes an entry read as fresh for
 `maxAge`s of zero or even negative duration. Any failure while resolving
 `FileInfo` or reading the file is caught by the same guarded region and
-degrades to a miss, exactly like the non-`maxAge` overloads' hit path.
+*returns* a miss (`null`), exactly like the non-`maxAge` overloads' hit
+path — but the miss is not otherwise *recorded* the same way: the
+non-`maxAge` overloads' hit-path `catch` returns directly, so a read failure
+there is invisible to telemetry (no hit or miss observation, no
+`InfoTracker.RecordCacheMiss()`); the `maxAge` overloads' `catch` instead
+falls through to the same unguarded miss-telemetry call the missing-entry
+case uses, so a read failure there *is* recorded as a miss. A read failure
+under `maxAge` is therefore observable in telemetry in a way the equivalent
+failure under the plain overloads is not, even though both return `null` to
+the caller identically.
 
 ## Non-claims
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -93,18 +93,28 @@ differently, but the difference is enforced for only one of them:
   `Path.Combine(..., AppName)` on each branch); `Initialize` only rejects a
   null or all-whitespace value. The current production caller passes one
   fixed literal at process startup. `appName` also, independently of any
-  `basePath` override, controls a *second* root `IsPathInCacheContext`
-  anchors to: on non-Windows platforms `GetLegacyBasePath` builds
-  `{LocalApplicationData}/{AppName}` and `IsPathInCacheContext` accepts a
-  descendant of that legacy root unconditionally — even when an explicit
-  `basePath` override is active — so `appName` is not merely a default-path
-  input; it is a live containment anchor of its own.
+  `basePath` override, controls a *second* root `IsPathInCacheContext` can
+  anchor to: on non-Windows platforms `GetLegacyBasePath` builds
+  `{LocalApplicationData}/{AppName}` and — when that path is non-null —
+  `IsPathInCacheContext` accepts a descendant of it, even when an explicit
+  `basePath` override is active. `GetLegacyBasePath` returns `null`, though,
+  whenever the legacy path string equals the *current* `GetDefaultBasePath()`
+  result — not whichever root `basePath` overrides to. On Linux, for
+  example, if `XDG_CACHE_HOME` happens to equal `LocalApplicationData`, the
+  legacy and default paths coincide and the legacy check is suppressed
+  entirely, even while a separate explicit `basePath` override is active and
+  makes that coincidence irrelevant to the active root. So `appName` is not
+  merely a default-path input; it is a live containment anchor of its own,
+  but only when `GetLegacyBasePath` returns non-null — a condition that
+  depends on the current default path, not on whether an override is
+  active.
 - **`basePath`** (`Initialize`'s second, optional parameter) is returned
   verbatim by `GetBasePath()` with no validation at all — not even the
   null/whitespace check `appName` gets — and becomes the *active-root* anchor
-  `IsPathInCacheContext` checks a candidate path against; it is not the sole
-  anchor, though — the legacy root derived from `appName` above is checked
-  too, unconditionally. Unlike
+  `IsPathInCacheContext` checks a candidate path against; it is not
+  necessarily the sole anchor, though — the legacy root derived from
+  `appName` above is also checked whenever `GetLegacyBasePath` returns
+  non-null (see the caveat above). Unlike
   `category`/`extension`/`appName`, this is **not** a fixed-literal value in
   production today: `dotnet-inspect`'s CLI entry point
   (`src/dotnet-inspect/Program.cs`) resolves it with explicit precedence —
@@ -195,7 +205,12 @@ a descendant of the active base path (`GetBasePath()`) or the legacy
 pre-XDG path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed —
 any exception while resolving the full path (malformed path, denied access)
 returns `false`, never `true`. `Clear` calls it internally before deleting;
-other owners call it directly, but not exclusively before deletion —
+other owners call it directly, but not exclusively before deletion. The
+following description of `NuGetCache`'s and `PlatformPackService`'s call
+sites is cited only as evidence for a `CoreCache`-owned claim — that this
+guard's coverage of a reused local variable is point-in-time, not
+re-verified at each use — not as a specification of those callers' own
+publish/cleanup sequencing, which they own:
 `NuGetCache` and `PlatformPackService` each guard both their commit
 `targetPath` and their staging `stagingPath` once, before a *publish/write*
 operation begins (`Directory.CreateDirectory`, copying staged contents in);
@@ -314,8 +329,15 @@ from a different, newer one.
 ## Initialization lifecycle
 
 `Initialize(appName, basePath)` is not an idempotent no-op past the first
-call: it cancels and best-effort drains any in-flight versioned-category
-maintenance, replaces the maintenance generation, and re-schedules cleanup
+call: it cancels any in-flight versioned-category maintenance and then
+synchronously waits, *without a timeout*, for every task in the old
+generation to complete, cancel, or fault (`WaitForMaintenanceTasksBestEffort`'s
+unbounded `Task.WaitAll` — "best-effort" describes that a task failure is
+swallowed once the wait itself returns, not that the wait is bounded; a
+maintenance task that never observes its cancellation token and never
+returns can block `Initialize` indefinitely). Only after that drain
+completes does `Initialize` replace the maintenance generation, and
+re-schedule cleanup
 for every category registered so far — against the *new* base path if one was
 given. Reclaimed-byte/directory counters carry forward only when the new base
 path resolves to the same location as the old one (`IsSamePath` — subject to
@@ -349,16 +371,30 @@ ends in the old `appName`, the other in the new one — so this specific
 carry-forward-despite-environment-change case requires an unchanged
 `appName`, not merely an unchanged `basePath` override.)
 
-**Gap:** re-initialization is not exception-safe against a malformed new
-root, and the failure is destructive to more than scheduling. `Initialize`
+**Gap:** re-initialization is not exception-safe against a malformed root
+on *either side* of the comparison, and the failure is destructive to more
+than scheduling. `Initialize`
 mutates `_appName`, `_basePathOverride`, the maintenance cancellation
 source, the progress object, and the task dictionary to their new values —
 and, before that, takes a destructive snapshot of the *old* generation's
 reclaimed-byte/directory counters via `TakeSnapshot()` (which zeros them) —
 all *before* calling `IsSamePath` to decide whether to carry that snapshot
 forward into the new progress object. `IsSamePath` calls `Path.GetFullPath`
-on both sides, which throws for a sufficiently malformed path (invalid
-characters, exceeding platform path-length limits). Because `basePath`
+on *both* the old root and the new root, and it throws for a sufficiently
+malformed path on either one (invalid characters, exceeding platform
+path-length limits) — the failure is not limited to a malformed *new*
+`basePath`. The old root can be malformed too: a first `Initialize` call
+skips the `IsSamePath` comparison entirely (`previousRoot` is `null` when
+`_appName` was previously unset), so a `basePath` that would make
+`Path.GetFullPath` throw can be accepted, uncomplained-about, by that first
+call and persist as `_basePathOverride` until a later, otherwise-unrelated
+`Initialize` call finally exercises `IsSamePath` against it. And neither
+side is limited to an explicit `basePath` override: `appName` receives only
+a null/whitespace check, and `GetDefaultBasePath` concatenates it verbatim
+into every platform's default path with `Path.Combine`, which does not
+reject invalid path characters — so a default root derived from a
+sufficiently unusual `appName` has the identical exposure, on either the
+old or the new side of the comparison. Because `basePath`
 receives no validation (see the trust-boundary section above), a
 caller-supplied `basePath` that `Path.GetFullPath` rejects makes `Initialize`
 throw *after* the new fields are already committed, *after* the old
@@ -377,6 +413,25 @@ identical destructive-then-possibly-thrown pattern applies to
 performing the measurement/deletion — if either of those later steps
 throws, the already-consumed counters are lost with no return value to
 carry them.
+
+**Gap:** a maintenance generation does not necessarily describe one cache
+root's history, even though the counter-carry-forward rule above is framed
+that way. `ScheduleVersionedCategoryCleanup` — called both from
+`Initialize`'s `foreach` loop and from `RegisterVersionedCategory`/
+`RequestVersionedCategoryCleanupAsync` outside of any `Initialize` call —
+independently reads `GetBasePath()` as `root` on every invocation and keys
+its per-category task by `(root, prefix, currentVersion)`, but every task
+in the current generation, regardless of which root it was scheduled
+against, records into the *same* shared `s_maintenanceProgress` object. On
+Linux, an `XDG_CACHE_HOME` change between two calls that trigger scheduling
+— with no intervening `Initialize` call at all — can leave one generation
+containing cleanup tasks scheduled against two different roots, both
+contributing to one aggregate byte/directory count. `Clear` later derives
+its own deletion target by independently re-calling `GetBasePath()`/
+`GetCategoryPath()` at the time it runs, which may be neither of the roots
+that contributed to the aggregate it consumes — so `Clear`'s reported
+maintenance-byte count is not guaranteed to describe the root it actually
+deletes.
 
 `RegisterVersionedCategory` may be called before or after `Initialize`, and
 repeated registration of the same prefix is idempotent when `current`
@@ -560,20 +615,36 @@ does not return early with partial progress the way a finite-timeout
 `CancelAndWaitForMaintenance` call can.
 
 **Gap:** `CancelAndWaitForMaintenance`'s `timeout` parameter is not
-validated, and an out-of-range value silently skips both the cancellation
+validated, and a value `Task.Wait(TimeSpan)` rejects silently skips both the
+cancellation
 and the 25ms secondary wait rather than producing a documented error or the
-documented cancel-and-wait behavior. `task.Wait(TimeSpan)` throws
-`ArgumentOutOfRangeException` for a negative `TimeSpan` other than
-`Timeout.InfiniteTimeSpan` (`-1` ms) or one exceeding `int.MaxValue`
-milliseconds (about 24.8 days) — a plausible caller mistake, not only an
-adversarial input. `WaitForMaintenance` wraps `task.Wait(timeout)` and the
+documented cancel-and-wait behavior. The rejected range is narrower than "any
+negative `TimeSpan` other than exactly `-1`ms": `Task.Wait(TimeSpan)`
+truncates the `TimeSpan` to whole milliseconds via `(long)timeout.TotalMilliseconds`
+*before* range-checking, and only throws `ArgumentOutOfRangeException` when
+that truncated value is `< -1` or `> int.MaxValue`. Truncation is toward
+zero, not toward negative infinity, so a `TimeSpan` between `-1ms` and `0ms`
+exclusive (for example `-0.5ms`) truncates to `0` and is accepted as a
+zero-length wait, while one between `-2ms` and `-1ms` exclusive (for
+example `-1.5ms`) truncates to `-1` — the sentinel for
+`Timeout.InfiniteTimeSpan` — and is accepted as an *infinite* wait, not
+rejected. Only a truncated value at or below `-2`, or one whose
+`TotalMilliseconds` exceeds `int.MaxValue` (about 24.8 days, and note a
+fractionally-over value can itself truncate down to exactly `int.MaxValue`
+and be accepted), actually throws. `WaitForMaintenance` wraps `task.Wait(timeout)` and the
 subsequent cancel/25ms-wait in one blanket `try`/`catch`, so that exception
 is caught by the *same* handler that also swallows a legitimate
 cancellation-related exception; the method falls straight through to
 returning whatever progress is currently recorded, having neither canceled
-the task nor waited the documented 25ms. A caller who passes an
-out-of-range timeout observes an immediate, non-canceling progress read
-that looks identical to any other best-effort outcome, not a timeout error.
+the task nor waited the documented 25ms — but only after
+`RequestVersionedCategoryCleanupAsync` (called before the `try`, to obtain
+the task being waited on) has already returned, which can itself block
+indefinitely on the unbounded generation-restart drain described above; an
+invalid timeout does not bound or bypass that pending drain, only the
+subsequent cancel/wait step. A caller who passes a rejected timeout observes
+a non-canceling progress read — once any pending generation-restart drain
+has finished — that looks identical to any other best-effort outcome, not a
+timeout error.
 
 **Every** `Clear` call — not only `Clear(category:
 null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
@@ -593,18 +664,28 @@ directory absent.
 `s_maintenanceLock`, drains maintenance, validates the target path is in
 cache context, measures the tree, and deletes it, catching only
 `DirectoryNotFoundException` for the specific case where another process
-already completed the same deletion. Any other failure — an authorization
-error, an `IOException` from a file another process still has open, or a
-directory-enumeration error while measuring size — propagates to `Clear`'s
-caller rather than being swallowed, *once `Clear` has begun measuring or
-deleting*. Before that point, `Clear` calls `Directory.Exists(targetPath)`
-and returns early (reporting only the maintenance byte counter, no tree
-size) when it reports `false` — and `Directory.Exists` is documented to
+already completed the same deletion. Any other failure thrown by the
+directory-enumeration itself, or by `Directory.Delete`, propagates to
+`Clear`'s caller rather than being swallowed — but the measurement step's
+own existence check is a second, earlier place a filesystem error can be
+absorbed as a false negative, not just the initial probe below: `GetDirectorySize`
+(the measurement helper) calls its own `Directory.Exists(path)` and returns
+`0` when that reports `false`, and `Directory.Exists` is documented to
 return `false` both when the directory genuinely does not exist and when an
-error occurs while determining whether it exists. An authorization or other
-filesystem error at that existence check is therefore indistinguishable from
-"nothing to clear" and returns successfully with an undercounted result,
-rather than propagating like the failures above. `Clear`'s `long` return
+error occurs determining whether it exists. So an authorization or other
+filesystem error surfacing between `Clear`'s initial existence check and the
+measurement step can still be silently absorbed as "0 bytes" rather than
+propagating, even though `Clear` had already begun measuring. Before that point, `Clear` calls `Directory.Exists(targetPath)`
+and returns early (reporting only the maintenance byte counter, no tree
+size) when it reports `false` — the same ambiguous-`false` caveat applies
+here too, and also to the `DirectoryNotFoundException when
+!Directory.Exists(targetPath)` filter around the delete call: that filter's
+own `Directory.Exists` re-check cannot definitively prove another process
+completed the deletion, only that the directory is not currently observable,
+for whatever reason. An authorization or other
+filesystem error at any of these existence checks is therefore indistinguishable from
+"nothing to clear" (or "already deleted") and returns successfully with an undercounted result,
+rather than propagating like an enumeration or delete failure does. `Clear`'s `long` return
 value is not a confirmed bytes-freed count: it is the tree size *measured
 before deletion*, plus (for `Clear(null)` only) the consumed maintenance byte
 counter. That
@@ -649,6 +730,17 @@ cross-process) must either serialize its own writes around a `Clear` or
 accept both the silent-loss and the `Clear`-throws possibilities.
 
 ## Telemetry is fire-and-forget but not exception-isolated
+
+This section describes `CacheTelemetry`'s and `InfoTracker`'s *current*
+implementation only as evidence for a claim this document does own — what
+happens to a `CoreCache` read/write operation when telemetry recording
+fails. `CacheTelemetry`'s subscriber-dispatch mechanics (ordering,
+delivery guarantees, `ActivityEvent` behavior) and `InfoTracker`'s counter
+implementation are those types' own contracts, specified by their owning
+code, not normatively defined here; if either changes internally without
+changing where its call sites sit relative to `CoreCache`'s own
+`try`/`catch` blocks, this document's claims about `CoreCache`'s resulting
+return/throw/counter behavior are unaffected.
 
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
 recorded on cache outcomes, but recording itself does nothing to protect a

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -81,19 +81,31 @@ differently, but the difference is enforced for only one of them:
 - **`basePath`** (`Initialize`'s second, optional parameter) is returned
   verbatim by `GetBasePath()` with no validation at all — not even the
   null/whitespace check `appName` gets — and becomes the trusted root that
-  `IsPathInCacheContext` anchors every containment decision to. A caller that
-  passes an override derived from untrusted input controls the cache root
-  itself, which is a strictly larger trust concession than `category` or
-  `extension`.
+  `IsPathInCacheContext` anchors every containment decision to. Unlike
+  `category`/`extension`/`appName`, this is **not** a fixed-literal value in
+  production today: `dotnet-inspect`'s CLI entry point
+  (`src/dotnet-inspect/Program.cs`) reads it verbatim from the
+  `DOTNET_INSPECT_CACHE_DIR` environment variable, or — for `--isolated`/
+  `DOTNET_INSPECT_ISOLATED` — builds it by concatenating that environment
+  value into a temp-directory path, then forwards it unchanged through
+  `NuGetCache.Initialize` to `CoreCache.Initialize`. A caller (here, an
+  end user or their shell environment) that controls `basePath` controls the
+  cache root itself, which is a strictly larger trust concession than
+  `category` or `extension` — and it is exercised in production, not merely
+  hypothetical.
 
-The contract is: **`category`, `extension`, `appName`, and `basePath` are
-caller-owned values that every current producer restricts to a fixed literal
-or a bounded, hardcoded selection, never external content; `key` is the only
-parameter this mechanism defends by construction.** This must hold for every
-future caller, including one that builds a category name from a feed,
-package, or platform identifier, or a `basePath` from a configuration value
-of unknown provenance — those must be routed through `key`, not `category`,
-`extension`, `appName`, or `basePath`.
+The contract is: **`category`, `extension`, and `appName` are caller-owned
+values that every current producer restricts to a fixed literal or a
+bounded, hardcoded selection, never external content; `key` is the only
+parameter this mechanism defends by construction; `basePath` is the one
+exception — it is intentionally operator/environment-controlled configuration,
+accepted verbatim with no sanitization or containment constraint of its
+own.** This must hold for every future caller, including one that builds a
+category name from a feed, package, or platform identifier — that must be
+routed through `key`, not `category`, `extension`, or `appName`. A future
+`basePath` source should still avoid deriving it from untrusted *content*
+(as opposed to trusted operator configuration), since nothing here
+constrains it once accepted.
 
 **Gap:** the contract above is enforced only by code review convention today.
 `GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `GetCacheInfo`,
@@ -184,26 +196,38 @@ every previously registered category under that new root.
 — `RegisterVersionedCategory`, `Clear`, `WaitForMaintenance` (and therefore
 `CancelAndWaitForMaintenance`), and `RequestVersionedCategoryCleanupAsync` —
 is safely serialized against a concurrent `Initialize`; none of these can
-observe a partial field write. The unsynchronized race is narrower: the
-lock-free path/read/write/statistics surface —`GetBasePath`, `GetDefaultBasePath`,
-`GetCategoryPath`, `GetFilePath`, `TryGet`/`TryGetBytes`, `Set`/`SetBytes`, and
-`GetCacheInfo` — reads `_appName`/`_basePathOverride` without the lock and
-without `volatile`. **At most one `Initialize` call may be outstanding, and no
-lock-free method may run concurrently with it.** Today's callers satisfy this
-by calling `Initialize` once at process startup before any other cache use,
-but the contract is not stated anywhere and not enforced by an assertion. A
+observe a partial field write. The unsynchronized race is narrower but wider
+than only the read/write path: the lock-free surface — `GetBasePath`,
+`GetDefaultBasePath`, `GetLegacyBasePath`, `GetCategoryPath`, `GetFilePath`,
+`TryGet`/`TryGetBytes`, `Set`/`SetBytes`, `GetCacheInfo`,
+`IsPathInCacheContext`, and (transitively, since it calls
+`IsPathInCacheContext`) `EnsurePathInCacheContext` — reads
+`_appName`/`_basePathOverride` without the lock and without `volatile`. **At
+most one `Initialize` call may be outstanding, and no lock-free method may
+run concurrently with it.** Today's callers satisfy this by calling
+`Initialize` once at process startup before any other cache use, but the
+contract is not stated anywhere and not enforced by an assertion. A
 production build that calls `Initialize` a second time for any reason (for
 example, a hosted/long-lived process switching app identity) while a
-concurrent `TryGet`/`Set` is in flight has a data race on
-`_appName`/`_basePathOverride`.
+concurrent `TryGet`/`Set`/`IsPathInCacheContext` is in flight has a data race
+on `_appName`/`_basePathOverride` — including the possibility that
+`IsPathInCacheContext` combines an active-root check against one
+initialization generation with a legacy-root check against another.
 
-Before the first `Initialize` call, every lock-free method throws
-`InvalidOperationException` from the `AppName` property getter — this is not
-best-effort and not a miss; `Set`/`SetBytes` only *look* silent because that
+Before the first `Initialize` call, the lock-free surface does not behave
+uniformly, because each method's own exception handling (or lack of it)
+around the `AppName` property getter's `InvalidOperationException` differs:
+`TryGet`/`TryGetBytes` construct the path (and so throw) before entering any
+guarded region at all; `Set`/`SetBytes` only *look* silent because that same
 exception is caught by their own blanket `try`/`catch` (see
-[Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)),
-while `TryGet`/`TryGetBytes` construct the path (and so throw) before
-entering any guarded region at all.
+[Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated));
+`IsPathInCacheContext` catches it too and returns `false` rather than
+propagating, so `EnsurePathInCacheContext` throws its own refusal exception
+instead of the pre-initialization one; and `GetLegacyBasePath` reads `AppName`
+only on non-Windows platforms, so it throws there but returns `null` on
+Windows without touching `AppName` at all. There is no single
+"every lock-free method does X" pre-initialization rule; each method's
+documented behavior above already states its own case.
 
 ## Versioned category retirement
 
@@ -253,11 +277,17 @@ cache context, measures the tree, and deletes it, catching only
 already completed the same deletion. Any other failure — an authorization
 error, an `IOException` from a file another process still has open, or a
 directory-enumeration error while measuring size — propagates to `Clear`'s
-caller rather than being swallowed. `Clear`'s `long` return value is bytes
-freed only: `Clear(null)` consumes both the byte and directory counters from
-maintenance (see [Versioned category retirement](#versioned-category-retirement))
-but adds only the byte count to its return value — a caller that needs the
-directory count must use `CancelAndWaitForMaintenance` instead.
+caller rather than being swallowed. `Clear`'s `long` return value is not a
+confirmed bytes-freed count: it is the tree size *measured before deletion*,
+plus (for `Clear(null)` only) the consumed maintenance byte counter — if
+another process deletes some or all of the tree concurrently (the
+`DirectoryNotFoundException` case, or a race that removes only some files
+before `Clear` measures or deletes), the returned value can be higher or
+lower than what `Clear` itself actually removed. It also omits the
+directory-deleted count even when `Clear(null)` consumes it from maintenance
+(see [Versioned category retirement](#versioned-category-retirement)) — a
+caller that needs the directory count must use `CancelAndWaitForMaintenance`
+instead.
 
 **Gap:** `Clear` does not coordinate with concurrent `Set`/`SetBytes` calls,
 which do not take `s_maintenanceLock` at all — and `s_maintenanceLock` is a
@@ -290,20 +320,26 @@ accept both the silent-loss and the `Clear`-throws possibilities.
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
 recorded on cache outcomes, but recording itself does nothing to protect a
 cache result: `CacheTelemetry.Record` first adds an `ActivityEvent` to
-`Activity.Current` unconditionally, then calls every subscribed
+`Activity.Current` when one exists (`Activity.Current?.AddEvent(...)` — no
+event is added when there is no current activity, which is the ordinary
+state unless one has been established), then calls every subscribed
 `IObserver<CacheObservation>.OnNext` synchronously and in registration order,
-with no surrounding `try`/`catch`. The activity event and every subscriber
-before a throwing one have already observed the outcome by the time an
-exception surfaces; only subscribers *after* the throwing one are skipped,
-and `Record` itself does not complete normally. A throwing subscriber then
-changes cache behavior differently depending on which method and overload
-observed it:
+with no surrounding `try`/`catch`. When a current activity does exist, its
+event and every subscriber before a throwing one have already observed the
+outcome by the time an exception surfaces; only subscribers *after* the
+throwing one are not invoked at all, and `Record` itself does not complete
+normally. (The throwing subscriber's own `OnNext` *was* called — it received
+the observation before throwing; "not invoked" describes only the
+subscribers after it, not the throwing one itself.) A throwing subscriber
+then changes cache behavior differently depending on which method and
+overload observed it:
 
 - **`TryGet`/`TryGetBytes` without `maxAge`:** the hit-telemetry call is
   inside the method's own blanket `catch`, so a throwing subscriber silently
-  turns a hit into a miss (`null`); the miss path — including its own
-  telemetry call — then runs unguarded, so a throwing subscriber there
-  propagates to the caller instead.
+  turns a hit into a `null` return — this `catch` returns directly, so the
+  separate miss path (including its own telemetry call and
+  `InfoTracker.RecordCacheMiss()`) never runs; a hit that fails this way is
+  not counted as a miss either.
 - **`TryGet`/`TryGetBytes` *with* `maxAge`:** the hit-telemetry call is inside
   a `catch` that swallows the exception and falls through to the *same*
   unguarded miss-telemetry call below it. A subscriber that throws on the
@@ -313,9 +349,9 @@ observed it:
   throwing hit subscriber does not reliably degrade to a silent `null` here.
 - **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
   `catch`, so a throwing subscriber is swallowed the same way any other write
-  failure is — the activity event and any subscribers ahead of the throwing
-  one still observed the store; only the throwing subscriber and any after
-  it do not.
+  failure is — the activity event (if any) and any subscribers up to and
+  including the throwing one were still invoked with the observation; only
+  subscribers *after* the throwing one are not.
 
 This mechanism does not isolate telemetry from the operation it is
 recording; "fire-and-forget" describes the caller's intent, not an enforced
@@ -328,12 +364,15 @@ only as an operational signal, and only when every subscriber is known not
 to throw.
 
 `CoreCache` also remaps the observed `category` for one family before
-telemetry is recorded: `GetTelemetryCategory` rewrites a `category` that
-case-insensitively equals `"symbol-misses"` to `"symbol-misses/{extension}"`
-(so `TryGet("symbol-misses", key, extension: "forbidden")` reports
-`symbol-misses/forbidden`, distinct from `symbol-misses/miss`), and passes
-every other `category` through unchanged. This is an intentional, tested part
-of the observable telemetry contract, not an undocumented side effect.
+telemetry is recorded: `GetTelemetryCategory` *detects* a `category` that
+case-insensitively equals `"symbol-misses"`, but *rewrites* it as
+`$"{category}/{extension}"` — preserving the caller's original spelling and
+casing rather than canonicalizing it. `TryGet("symbol-misses", key,
+extension: "forbidden")` reports `symbol-misses/forbidden`, distinct from
+`symbol-misses/miss`, but a caller passing `"SYMBOL-MISSES"` would observe
+`SYMBOL-MISSES/forbidden`, not the lowercase form. Every other `category`
+passes through unchanged. This is an intentional, tested part of the
+observable telemetry contract, not an undocumented side effect.
 
 ## `maxAge` freshness is a mechanism-owned rule, not a caller policy
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -2,8 +2,8 @@
 
 This document owns the mechanism contract of `DotnetInspector.Core`'s
 `CoreCache`: the process-wide cache root, the filesystem key scheme,
-path-context containment, initialization lifecycle, and versioned category
-maintenance. It does not own `AsyncCache`, an unrelated in-memory
+path-context containment, initialization lifecycle, versioned category
+maintenance, and the `maxAge` freshness comparison. It does not own `AsyncCache`, an unrelated in-memory
 single-flight coalescer in the same project with no lifecycle dependency on
 `CoreCache` — see [Non-claims](#non-claims). It does not own cache
 semantics — the complete key,
@@ -30,9 +30,14 @@ docs-only change.
   platform (or an override);
 - a collision-resistant, filesystem-safe path for a caller-chosen key within
   a category;
-- best-effort read, write, and background-maintenance operations over that
-  path — failures are swallowed and observed only as a miss or as maintenance
-  making no progress;
+- read, write, and background-maintenance operations whose *filesystem-access*
+  failures are swallowed and observed only as a miss or as maintenance making
+  no progress. This is not a blanket best-effort guarantee: path construction
+  (which reads `AppName`, throwing before initialization) and miss-side
+  telemetry both run outside the guarded region and propagate — see
+  [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated) and
+  the pre-initialization note in
+  [Initialization lifecycle](#initialization-lifecycle);
 - a `Clear` operation that surfaces most failures rather than swallowing them
   (see [Clear and concurrent writers](#clear-and-concurrent-writers)); and
 - a path-context guard, `EnsurePathInCacheContext`/`IsPathInCacheContext`,
@@ -52,37 +57,58 @@ differently, but the difference is enforced for only one of them:
   key built from untrusted content — a package id, a URL, source text — can
   never produce a path outside the two-level hash bucket.
 - **`category`** is concatenated into the path verbatim (`GetCategoryPath` is
-  `Path.Combine(GetBasePath(), category)`). Every current call site passes a
-  literal or a `const string` (for example `SymbolMissCacheCategory`,
-  `"effective-v28"`, `"sources"`); none derive `category` from downloaded or
-  otherwise untrusted content.
-- **`extension`** is concatenated verbatim after the hash suffix. Every
-  current call site passes a literal (`"json"`, `"forbidden"`, `"miss"`,
-  `"md"`, `"tsv"`).
+  `Path.Combine(GetBasePath(), category)`), and `GetCacheInfo(category)` uses
+  the same unguarded path to recursively measure and enumerate files. Every
+  traced producer ultimately restricts `category` to a fixed literal or
+  `const string` (for example `SymbolMissCacheCategory`, `"effective-v28"`,
+  `"sources"`) — but `CoreCache` does not enforce this at its own boundary,
+  and at least one caller does not pass a literal at the `CoreCache` call
+  expression itself: `CoreSourceLinkQueryCache` (`SourceLinkQueryCache.cs`)
+  forwards its `category`/`extension` interface parameters straight through
+  to `CoreCache.TryGet`/`Set`, so the literal-only property holds only
+  transitively, at each producer's own call site, not at every direct call
+  into `CoreCache`.
+- **`extension`** is concatenated verbatim after the hash suffix. Most call
+  sites pass a literal (`"json"`, `"forbidden"`, `"miss"`, `"md"`, `"tsv"`),
+  but `SymbolPackageDownloader.Storage.cs` passes a local variable selected
+  from a fixed two-value set, and the `CoreSourceLinkQueryCache` forwarding
+  above applies to `extension` too — the same transitive-only caveat holds.
 - **`appName`** (`Initialize`'s first parameter) is concatenated verbatim into
   every platform's default base path (`GetDefaultBasePath`'s
   `Path.Combine(..., AppName)` on each branch); `Initialize` only rejects a
   null or all-whitespace value. The current production caller passes one
   fixed literal at process startup.
+- **`basePath`** (`Initialize`'s second, optional parameter) is returned
+  verbatim by `GetBasePath()` with no validation at all — not even the
+  null/whitespace check `appName` gets — and becomes the trusted root that
+  `IsPathInCacheContext` anchors every containment decision to. A caller that
+  passes an override derived from untrusted input controls the cache root
+  itself, which is a strictly larger trust concession than `category` or
+  `extension`.
 
-The contract is: **`category`, `extension`, and `appName` are caller-owned
-literals, never derived from external content; `key` is the only parameter
-this mechanism defends.** This must hold for every future caller, including
-one that builds a category name from a feed, package, or platform identifier
-— those must be routed through `key`, not `category`, `extension`, or
-`appName`.
+The contract is: **`category`, `extension`, `appName`, and `basePath` are
+caller-owned values that every current producer restricts to a fixed literal
+or a bounded, hardcoded selection, never external content; `key` is the only
+parameter this mechanism defends by construction.** This must hold for every
+future caller, including one that builds a category name from a feed,
+package, or platform identifier, or a `basePath` from a configuration value
+of unknown provenance — those must be routed through `key`, not `category`,
+`extension`, `appName`, or `basePath`.
 
 **Gap:** the contract above is enforced only by code review convention today.
-`GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `TryGet`,
-`TryGetBytes`, `Set`, and `SetBytes` do not reject a `category`, `extension`,
-or `appName` containing a path separator or a `..` segment, so a future
-caller that violates the contract (for example, building a category from a
-package id) would silently gain a path-traversal write/read primitive outside
-the cache root, undetected by any existing test. Closing this gap — for
-example, asserting all three parameters contain no directory separator and no
-`.` segment before every path computation — is recommended follow-up work;
-this document records the invariant so that follow-up has a contract to
-enforce against.
+`GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `GetCacheInfo`,
+`TryGet`, `TryGetBytes`, `Set`, and `SetBytes` do not reject a `category`,
+`extension`, or `appName` containing a path separator or a `..` segment, and
+`GetBasePath`/`Initialize` place no constraint on `basePath` at all, so a
+future caller that violates the contract (for example, building a category
+from a package id, or an `extension`/`basePath` from configuration) would
+silently gain a path-traversal write/read/enumerate primitive outside the
+intended cache root, undetected by any existing test. Closing this gap — for
+example, asserting `category`/`extension`/`appName` contain no directory
+separator and no `.` segment before every path computation, and constraining
+`basePath` to a directory the process already controls — is recommended
+follow-up work; this document records the invariant so that follow-up has a
+contract to enforce against.
 
 ## Path-context containment
 
@@ -116,17 +142,22 @@ behavior, not a verified guarantee on a case-sensitive filesystem; treat that
 as an open, unenforced case, not as closed by `EnsurePathInCacheContext`/
 `IsSamePath` alone.
 
-**Gap:** `CoreCache`'s own read/write entry points (`TryGet`, `TryGetBytes`,
-`Set`, `SetBytes`, `GetFilePath`) never call the guard themselves — only
-`Clear` and the external callers above do. Because `category` is
-contract-restricted to literals (see above), a conforming caller never needs
-the guard on the read/write path today — but the guard's absence there means
-a `category`/`extension`/`appName` contract violation reaching `TryGet`/`Set`
-directly (rather than through `Clear` or one of the callers that already
-guards itself) is not caught by this mechanism at all. A future defensive
-check on `category`/`extension`/`appName` (the trust-boundary gap above)
-would close this without relying on every future write-path caller
-remembering to call the guard itself.
+**Gap:** `CoreCache`'s own read/write/statistics entry points (`TryGet`,
+`TryGetBytes`, `Set`, `SetBytes`, `GetFilePath`, `GetCacheInfo`) never call
+the guard themselves — only `Clear` and the external callers above do.
+`GetCacheInfo(category)` in particular recursively measures and enumerates
+every file under `GetCategoryPath(category)` with no containment check and
+no exception handling of its own, so a category contract violation reaching
+it is also an out-of-root enumeration read, not just a write/delete
+primitive. Because `category` is contract-restricted to literals (see
+above), a conforming caller never needs the guard on the read/write/stats
+path today — but the guard's absence there means a
+`category`/`extension`/`appName` contract violation reaching `TryGet`/`Set`/
+`GetCacheInfo` directly (rather than through `Clear` or one of the callers
+that already guards itself) is not caught by this mechanism at all. A future
+defensive check on `category`/`extension`/`appName` (the trust-boundary gap
+above) would close this without relying on every future caller remembering
+to call the guard itself.
 
 ## Initialization lifecycle
 
@@ -148,18 +179,31 @@ known prefix throws. Registered categories are never forgotten across a later
 `Initialize` call — re-initializing to a different root replays cleanup for
 every previously registered category under that new root.
 
-**Gap:** `Initialize` is the only entry point that takes `s_maintenanceLock`
-around a change to `_appName`/`_basePathOverride`; every other method
-(`GetBasePath`, `TryGet`, `Set`, `GetFilePath`, ...) reads those two fields
-without the lock and without `volatile`. The mechanism is therefore
-single-writer: **at most one `Initialize` call may be outstanding, and no
-other `CoreCache` method may run concurrently with it.** Today's callers
-satisfy this by calling `Initialize` once at process startup before any
-other cache use, but the contract is not stated anywhere and not enforced by
-an assertion. A production build that calls `Initialize` a second time for
-any reason (for example, a hosted/long-lived process switching app identity)
-while a concurrent `TryGet`/`Set` is in flight has a data race on
+**Gap:** `_appName`/`_basePathOverride` are written only inside `Initialize`'s
+`lock (s_maintenanceLock)`, and every other method that also takes that lock
+— `RegisterVersionedCategory`, `Clear`, `WaitForMaintenance` (and therefore
+`CancelAndWaitForMaintenance`), and `RequestVersionedCategoryCleanupAsync` —
+is safely serialized against a concurrent `Initialize`; none of these can
+observe a partial field write. The unsynchronized race is narrower: the
+lock-free path/read/write/statistics surface —`GetBasePath`, `GetDefaultBasePath`,
+`GetCategoryPath`, `GetFilePath`, `TryGet`/`TryGetBytes`, `Set`/`SetBytes`, and
+`GetCacheInfo` — reads `_appName`/`_basePathOverride` without the lock and
+without `volatile`. **At most one `Initialize` call may be outstanding, and no
+lock-free method may run concurrently with it.** Today's callers satisfy this
+by calling `Initialize` once at process startup before any other cache use,
+but the contract is not stated anywhere and not enforced by an assertion. A
+production build that calls `Initialize` a second time for any reason (for
+example, a hosted/long-lived process switching app identity) while a
+concurrent `TryGet`/`Set` is in flight has a data race on
 `_appName`/`_basePathOverride`.
+
+Before the first `Initialize` call, every lock-free method throws
+`InvalidOperationException` from the `AppName` property getter — this is not
+best-effort and not a miss; `Set`/`SetBytes` only *look* silent because that
+exception is caught by their own blanket `try`/`catch` (see
+[Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)),
+while `TryGet`/`TryGetBytes` construct the path (and so throw) before
+entering any guarded region at all.
 
 ## Versioned category retirement
 
@@ -180,12 +224,21 @@ member's own integer suffix (for example prefix `pkg-index-v`, current
   previous generation's tasks, waits for them best-effort, and starts a new
   generation rather than waiting for the old one to finish on its own.
 
-`CancelAndWaitForMaintenance`/`Clear` are the only ways a caller observes
-completed maintenance. **Every** `Clear` call — not only `Clear(category:
+`CancelAndWaitForMaintenance`/`Clear` are the only **public** ways a caller
+observes completed maintenance (the internal `RequestVersionedCategoryCleanupAsync`
+is a third, assembly-internal path that test code uses directly to await the
+real aggregate task). Both public APIs can also return *partial* progress
+rather than confirmation that maintenance fully drained: `WaitForMaintenance`
+waits for the timeout given, then — if the task has not completed — cancels
+it and waits only another 25ms before returning whatever progress has been
+recorded so far, regardless of whether the canceled task has actually
+finished exiting. **Every** `Clear` call — not only `Clear(category:
 null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
 maintenance generation before deleting anything; only `Clear(null)` also
-*consumes* the recorded byte/directory counters into its return value
-(`Clear(category)` waits the same way but reports `0` maintenance bytes).
+*consumes* the recorded byte counter into its return value (`Clear(category)`
+waits the same way but reports `0` maintenance bytes, and neither overload's
+return value includes the directory-deleted count — see
+[Clear and concurrent writers](#clear-and-concurrent-writers)).
 Routine (non-`Clear`) maintenance is silent: a caller that never calls
 `Clear` or `CancelAndWaitForMaintenance` never learns whether background
 retirement ran, succeeded, or was skipped because a prior run left the
@@ -200,10 +253,21 @@ cache context, measures the tree, and deletes it, catching only
 already completed the same deletion. Any other failure — an authorization
 error, an `IOException` from a file another process still has open, or a
 directory-enumeration error while measuring size — propagates to `Clear`'s
-caller rather than being swallowed.
+caller rather than being swallowed. `Clear`'s `long` return value is bytes
+freed only: `Clear(null)` consumes both the byte and directory counters from
+maintenance (see [Versioned category retirement](#versioned-category-retirement))
+but adds only the byte count to its return value — a caller that needs the
+directory count must use `CancelAndWaitForMaintenance` instead.
 
 **Gap:** `Clear` does not coordinate with concurrent `Set`/`SetBytes` calls,
-which do not take `s_maintenanceLock` at all. A `Set` that created its
+which do not take `s_maintenanceLock` at all — and `s_maintenanceLock` is a
+process-local, in-memory lock that provides no cross-process coordination
+regardless. This is not a hypothetical future-caller concern: `dotnet-inspect
+cache clear` (`CacheCommand.cs` → `PackageCacheService.ClearCache()` →
+`CoreCache.Clear()`) is an independently invokable CLI command, so any other
+concurrently running `dotnet-inspect` process performing ordinary cache reads
+or writes already races with it today, in production, not only in a
+hypothetical future caller within the same process. A `Set` that created its
 category subdirectory before `Clear`'s `Directory.Delete` can produce three
 outcomes, none of them a contract this mechanism enforces: a successful write
 that `Clear` then removes (consistent with "clear empties the cache"); a
@@ -214,24 +278,32 @@ the writer's still-open temporary file) that is not the narrow
 already-deleted case `Clear` catches, and so propagates to `Clear`'s caller.
 A caller relying on "the value I just set survives" immediately after a
 concurrent `Clear`, or relying on `Clear` never throwing because reads and
-writes elsewhere are best-effort, has no contract to rely on. Today no caller
-clears a category while concurrently writing to it; a future one must either
-serialize its own writes around a `Clear` or accept both the silent-loss and
-the `Clear`-throws possibilities.
+writes elsewhere are best-effort, has no contract to rely on. No caller
+within a single process clears a category while concurrently writing to it
+today, but two separate `dotnet-inspect` invocations racing this way is
+already possible; closing this gap (a future caller, in-process or
+cross-process) must either serialize its own writes around a `Clear` or
+accept both the silent-loss and the `Clear`-throws possibilities.
 
 ## Telemetry is fire-and-forget but not exception-isolated
 
 `InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
 recorded on cache outcomes, but recording itself does nothing to protect a
-cache result: `CacheTelemetry.Record` calls every subscribed
-`IObserver<CacheObservation>.OnNext` synchronously, with no surrounding
-`try`/`catch`. A throwing subscriber changes cache behavior differently
-depending on which method and overload observed it:
+cache result: `CacheTelemetry.Record` first adds an `ActivityEvent` to
+`Activity.Current` unconditionally, then calls every subscribed
+`IObserver<CacheObservation>.OnNext` synchronously and in registration order,
+with no surrounding `try`/`catch`. The activity event and every subscriber
+before a throwing one have already observed the outcome by the time an
+exception surfaces; only subscribers *after* the throwing one are skipped,
+and `Record` itself does not complete normally. A throwing subscriber then
+changes cache behavior differently depending on which method and overload
+observed it:
 
 - **`TryGet`/`TryGetBytes` without `maxAge`:** the hit-telemetry call is
   inside the method's own blanket `catch`, so a throwing subscriber silently
-  turns a hit into a miss (`null`) with no miss recorded; a throwing
-  subscriber on the (separate, unguarded) miss path propagates to the caller.
+  turns a hit into a miss (`null`); the miss path — including its own
+  telemetry call — then runs unguarded, so a throwing subscriber there
+  propagates to the caller instead.
 - **`TryGet`/`TryGetBytes` *with* `maxAge`:** the hit-telemetry call is inside
   a `catch` that swallows the exception and falls through to the *same*
   unguarded miss-telemetry call below it. A subscriber that throws on the
@@ -241,16 +313,43 @@ depending on which method and overload observed it:
   throwing hit subscriber does not reliably degrade to a silent `null` here.
 - **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
   `catch`, so a throwing subscriber is swallowed the same way any other write
-  failure is, and the write telemetry is simply never recorded.
+  failure is — the activity event and any subscribers ahead of the throwing
+  one still observed the store; only the throwing subscriber and any after
+  it do not.
 
 This mechanism does not isolate telemetry from the operation it is
 recording; "fire-and-forget" describes the caller's intent, not an enforced
-boundary, and it is not true that every outcome is guaranteed to be recorded.
-Telemetry may also undercount for reasons unrelated to a subscriber (a `Set`
-that never reaches the `try` body's `CacheTelemetry.Record` call because an
-earlier line threw is silently uncounted) and must not be read as an audit
-trail of cache correctness — only as an operational signal, and only when
-every subscriber is known not to throw.
+boundary, and delivery to any given subscriber is not guaranteed once an
+earlier subscriber throws. Telemetry may also undercount for reasons
+unrelated to a subscriber (a `Set` that never reaches the `try` body's
+`CacheTelemetry.Record` call because an earlier line threw is silently
+uncounted) and must not be read as an audit trail of cache correctness —
+only as an operational signal, and only when every subscriber is known not
+to throw.
+
+`CoreCache` also remaps the observed `category` for one family before
+telemetry is recorded: `GetTelemetryCategory` rewrites a `category` that
+case-insensitively equals `"symbol-misses"` to `"symbol-misses/{extension}"`
+(so `TryGet("symbol-misses", key, extension: "forbidden")` reports
+`symbol-misses/forbidden`, distinct from `symbol-misses/miss`), and passes
+every other `category` through unchanged. This is an intentional, tested part
+of the observable telemetry contract, not an undocumented side effect.
+
+## `maxAge` freshness is a mechanism-owned rule, not a caller policy
+
+The *choice* of freshness policy (what `maxAge` to pass, and whether staleness
+should trigger a refetch) is the caller's responsibility, per
+[the `CoreCache` section of the inspection space](../inspection-space.md#corecache).
+But the `maxAge` overloads of `TryGet`/`TryGetBytes` implement one specific,
+mechanism-owned comparison that every caller inherits: freshness is judged
+solely by `FileInfo.LastWriteTimeUtc`, compared as
+`DateTime.UtcNow - info.LastWriteTimeUtc < maxAge`. The comparison is strict,
+so an entry written exactly `maxAge` ago is stale, not fresh; and because the
+comparison is one-sided, a `LastWriteTimeUtc` in the future (a clock change, a
+restored backup, a manipulated file) makes an entry read as fresh for
+`maxAge`s of zero or even negative duration. Any failure while resolving
+`FileInfo` or reading the file is caught by the same guarded region and
+degrades to a miss, exactly like the non-`maxAge` overloads' hit path.
 
 ## Non-claims
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -1,0 +1,189 @@
+# CoreCache mechanism
+
+This document owns the mechanism contract of `DotnetInspector.Core`'s
+`CoreCache`/`AsyncCache`: the process-wide cache root, the filesystem key
+scheme, path-context containment, initialization lifecycle, and versioned
+category maintenance. It does not own cache semantics — the complete key,
+freshness, validation, publication, and concurrency behavior each cached
+result requires is the calling owner's responsibility, per
+[the `CoreCache` section of the inspection space](../inspection-space.md#corecache).
+It also does not own package-content publication, single-flight, or
+cross-process atomicity; that is
+[cache concurrency and publication](cache-concurrency.md)'s `Directory.Move`
+staging protocol, which is built on top of this mechanism rather than part of
+it.
+
+Retro-spec note: this document was written against the existing
+`CoreCache.cs` implementation to give the mechanism an owning contract it
+never had. Sections marked **Gap** describe behavior the current code exhibits
+but does not enforce; closing a gap is follow-up work, not part of this
+docs-only change.
+
+## Responsibility
+
+`CoreCache` supplies, for any caller-chosen category:
+
+- a stable base directory scoped to the current application name and
+  platform (or an override);
+- a collision-resistant, filesystem-safe path for a caller-chosen key within
+  a category;
+- best-effort read/write/clear operations over that path;
+- containment so cache deletion can never escape the cache root; and
+- best-effort background retirement of superseded versioned category
+  directories.
+
+Everything else — what a category or key *means*, whether a hit is still
+valid, and whether a miss may trigger network work — belongs to the caller.
+
+## Trust boundary: category, key, and extension are not equally trusted
+
+`GetFilePath(category, key, extension)` treats its three string parameters
+differently, but the difference is enforced for only one of them:
+
+- **`key`** is always SHA-256 hashed before it reaches the filesystem
+  (`GetFilePath`'s `hashString[..2]/hashString[2..].{extension}` layout). A
+  key built from untrusted content — a package id, a URL, source text — can
+  never produce a path outside the two-level hash bucket.
+- **`category`** is concatenated into the path verbatim (`GetCategoryPath` is
+  `Path.Combine(GetBasePath(), category)`). Every current call site passes a
+  literal or a `const string` (for example `SymbolMissCacheCategory`,
+  `"effective-v28"`, `"sources"`); none derive `category` from downloaded or
+  otherwise untrusted content.
+- **`extension`** is concatenated verbatim after the hash suffix. Every
+  current call site passes a literal (`"json"`, `"forbidden"`, `"miss"`,
+  `"md"`, `"tsv"`).
+
+The contract is: **`category` and `extension` are caller-owned literals, never
+derived from external content; `key` is the only parameter this mechanism
+defends.** This must hold for every future caller, including one that builds a
+category name from a feed, package, or platform identifier — those must be
+routed through `key`, not `category` or `extension`.
+
+**Gap:** the contract above is enforced only by code review convention today.
+`GetCategoryPath`, `GetFilePath`, `TryGet`, `TryGetBytes`, `Set`, and
+`SetBytes` do not reject a `category` or `extension` containing a path
+separator or a `..` segment, so a future caller that violates the contract
+(for example, building a category from a package id) would silently gain a
+path-traversal write/read primitive outside the cache root, undetected by any
+existing test. Closing this gap — for example, asserting both parameters
+contain no directory separator and no `.` segment before every path
+computation — is recommended follow-up work; this document records the
+invariant so that follow-up has a contract to enforce against.
+
+## Path-context containment
+
+`EnsurePathInCacheContext`/`IsPathInCacheContext` are the only guards against
+deleting outside the cache: a path is in context when it equals or is a
+descendant of the active base path (`GetBasePath()`) or the legacy pre-XDG
+path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed — any
+exception while resolving the full path (malformed path, denied access)
+returns `false`, never `true`.
+
+**Gap:** this guard runs only inside `Clear`, immediately before
+`Directory.Delete`. It does not run on the write path (`Set`/`SetBytes`
+create directories and move files into `GetFilePath`'s result without calling
+it) or the read path. Because `category` is contract-restricted to literals
+(see above), a conforming caller never needs the guard there today — but the
+guard's absence means a `category`/`extension` contract violation on the
+write path is not caught by this mechanism at all, only a violation reached
+through `Clear`'s category argument is. A future defensive check on
+`category`/`extension` (the gap above) would close both paths at once and
+make this asymmetry moot.
+
+## Initialization lifecycle
+
+`Initialize(appName, basePath)` is not an idempotent no-op past the first
+call: it cancels and best-effort drains any in-flight versioned-category
+maintenance, replaces the maintenance generation, and re-schedules cleanup
+for every category registered so far — against the *new* base path if one was
+given. Reclaimed-byte/directory counters carry forward only when the new base
+path resolves to the same location as the old one; otherwise they reset,
+because the counters describe one cache root's history and a root change
+starts a new one.
+
+`RegisterVersionedCategory` may be called before or after `Initialize`, and
+repeated registration of the same prefix is idempotent only when `current`
+is unchanged; a second registration with a different `current` for a
+known prefix throws. Registered categories are never forgotten across a later
+`Initialize` call — re-initializing to a different root replays cleanup for
+every previously registered category under that new root.
+
+**Gap:** `Initialize` is the only entry point that takes `s_maintenanceLock`
+around a change to `_appName`/`_basePathOverride`; every other method
+(`GetBasePath`, `TryGet`, `Set`, `GetFilePath`, ...) reads those two fields
+without the lock and without `volatile`. The mechanism is therefore
+single-writer: **at most one `Initialize` call may be outstanding, and no
+other `CoreCache` method may run concurrently with it.** Today's callers
+satisfy this by calling `Initialize` once at process startup before any
+other cache use, but the contract is not stated anywhere and not enforced by
+an assertion. A production build that calls `Initialize` a second time for
+any reason (for example, a hosted/long-lived process switching app identity)
+while a concurrent `TryGet`/`Set` is in flight has a data race on
+`_appName`/`_basePathOverride`.
+
+## Versioned category retirement
+
+A versioned category family is identified by a `prefix` plus the current
+member's own integer suffix (for example prefix `pkg-index-v`, current
+`pkg-index-v8`). Retirement:
+
+- deletes only sibling directories whose suffix parses as a non-negative
+  integer strictly less than the current version;
+- leaves alone any sibling whose suffix is unparsable, equal to, or greater
+  than the current version — this is what lets an older executable run
+  beside or before a newer one without destroying a contract version it
+  does not recognize (see
+  [versioned cache retirement](cache-concurrency.md#versioned-cache-retirement)
+  for the cross-process rationale); and
+- runs as fire-and-forget background `Task.Run` work scoped to a
+  `CancellationTokenSource` generation; a new `Initialize` call cancels the
+  previous generation's tasks, waits for them best-effort, and starts a new
+  generation rather than waiting for the old one to finish on its own.
+
+`CancelAndWaitForMaintenance`/an implicit wait inside `Clear(category: null)`
+are the only ways a caller observes completed maintenance; both drain the
+current generation (or cancel it after a timeout) and consume the recorded
+byte/directory counters. Routine (non-`Clear`) maintenance is silent: a
+caller that never calls `Clear` or `CancelAndWaitForMaintenance` never learns
+whether background retirement ran, succeeded, or was skipped because a prior
+run left the directory absent.
+
+## `Clear` and concurrent writers
+
+**Gap:** `Clear` takes `s_maintenanceLock`, drains maintenance, validates the
+target path is in cache context, then deletes the directory tree. It does not
+coordinate with concurrent `Set`/`SetBytes` calls, which do not take
+`s_maintenanceLock` at all. A `Set` that created its category subdirectory
+before `Clear`'s `Directory.Delete` observes either a successful write that
+`Clear` then removes (consistent with "clear empties the cache") or a
+`WriteAtomically` `File.Move` into a directory `Clear` just deleted — caught
+by `Set`'s blanket `try`/`catch` and silently dropped. Neither outcome
+corrupts the cache, but the mechanism gives no delivery guarantee for a write
+that races a clear, and a caller relying on "the value I just set survives"
+immediately after a concurrent `Clear` has no contract to rely on. Today no
+caller clears a category while concurrently writing to it; a future one must
+either serialize its own writes around a `Clear` or accept that the write may
+be silently lost.
+
+## Telemetry is not a correctness signal
+
+`InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record`
+are recorded on every `TryGet`/`TryGetBytes`/`Set`/`SetBytes` outcome, but
+recording is fire-and-forget and never affects the return value or throws.
+Telemetry may undercount (a `Set` that never reaches the `try` body's
+`CacheTelemetry.Record` call because an earlier line threw is silently
+uncounted) and must not be read as an audit trail of cache correctness — only
+as an operational signal.
+
+## Non-claims
+
+This document does not define:
+
+- what any specific category's key, freshness, or validation contract is
+  (owned by each cache's caller — `SourceLinkQueryCache`, `MetadataFieldCache`,
+  `PackageExtractor`'s listing cache, and others each own their own);
+- package-content staging, single-flight, or cross-process publication
+  (owned by [cache concurrency and publication](cache-concurrency.md)); or
+- `AsyncCache`'s in-memory single-flight coalescing, which is a distinct,
+  smaller mechanism in the same project and may get its own focused section
+  if it accumulates enough undocumented behavior to warrant one.

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -1,9 +1,12 @@
 # CoreCache mechanism
 
 This document owns the mechanism contract of `DotnetInspector.Core`'s
-`CoreCache`/`AsyncCache`: the process-wide cache root, the filesystem key
-scheme, path-context containment, initialization lifecycle, and versioned
-category maintenance. It does not own cache semantics — the complete key,
+`CoreCache`: the process-wide cache root, the filesystem key scheme,
+path-context containment, initialization lifecycle, and versioned category
+maintenance. It does not own `AsyncCache`, an unrelated in-memory
+single-flight coalescer in the same project with no lifecycle dependency on
+`CoreCache` — see [Non-claims](#non-claims). It does not own cache
+semantics — the complete key,
 freshness, validation, publication, and concurrency behavior each cached
 result requires is the calling owner's responsibility, per
 [the `CoreCache` section of the inspection space](../inspection-space.md#corecache).
@@ -52,23 +55,30 @@ differently, but the difference is enforced for only one of them:
 - **`extension`** is concatenated verbatim after the hash suffix. Every
   current call site passes a literal (`"json"`, `"forbidden"`, `"miss"`,
   `"md"`, `"tsv"`).
+- **`appName`** (`Initialize`'s first parameter) is concatenated verbatim into
+  every platform's default base path (`GetDefaultBasePath`'s
+  `Path.Combine(..., AppName)` on each branch); `Initialize` only rejects a
+  null or all-whitespace value. The current production caller passes one
+  fixed literal at process startup.
 
-The contract is: **`category` and `extension` are caller-owned literals, never
-derived from external content; `key` is the only parameter this mechanism
-defends.** This must hold for every future caller, including one that builds a
-category name from a feed, package, or platform identifier — those must be
-routed through `key`, not `category` or `extension`.
+The contract is: **`category`, `extension`, and `appName` are caller-owned
+literals, never derived from external content; `key` is the only parameter
+this mechanism defends.** This must hold for every future caller, including
+one that builds a category name from a feed, package, or platform identifier
+— those must be routed through `key`, not `category`, `extension`, or
+`appName`.
 
 **Gap:** the contract above is enforced only by code review convention today.
-`GetCategoryPath`, `GetFilePath`, `TryGet`, `TryGetBytes`, `Set`, and
-`SetBytes` do not reject a `category` or `extension` containing a path
-separator or a `..` segment, so a future caller that violates the contract
-(for example, building a category from a package id) would silently gain a
-path-traversal write/read primitive outside the cache root, undetected by any
-existing test. Closing this gap — for example, asserting both parameters
-contain no directory separator and no `.` segment before every path
-computation — is recommended follow-up work; this document records the
-invariant so that follow-up has a contract to enforce against.
+`GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `TryGet`,
+`TryGetBytes`, `Set`, and `SetBytes` do not reject a `category`, `extension`,
+or `appName` containing a path separator or a `..` segment, so a future
+caller that violates the contract (for example, building a category from a
+package id) would silently gain a path-traversal write/read primitive outside
+the cache root, undetected by any existing test. Closing this gap — for
+example, asserting all three parameters contain no directory separator and no
+`.` segment before every path computation — is recommended follow-up work;
+this document records the invariant so that follow-up has a contract to
+enforce against.
 
 ## Path-context containment
 
@@ -79,16 +89,26 @@ path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed — any
 exception while resolving the full path (malformed path, denied access)
 returns `false`, never `true`.
 
+**Gap:** the descendant check (`IsSameOrChildPath`) compares paths with
+`StringComparison.OrdinalIgnoreCase` unconditionally, on every platform. On a
+case-sensitive filesystem (ordinary Linux/macOS volumes), a path that differs
+from the cache root only in case is accepted as a descendant even though it
+names a distinct location outside the actual root — so the "cannot escape the
+cache root" guarantee below does not hold there. This document's containment
+claims describe the guard's intended behavior, not a verified guarantee on
+case-sensitive filesystems; treat that as an open, unenforced case, not as
+closed by `EnsurePathInCacheContext` alone.
+
 **Gap:** this guard runs only inside `Clear`, immediately before
 `Directory.Delete`. It does not run on the write path (`Set`/`SetBytes`
 create directories and move files into `GetFilePath`'s result without calling
 it) or the read path. Because `category` is contract-restricted to literals
 (see above), a conforming caller never needs the guard there today — but the
-guard's absence means a `category`/`extension` contract violation on the
-write path is not caught by this mechanism at all, only a violation reached
-through `Clear`'s category argument is. A future defensive check on
-`category`/`extension` (the gap above) would close both paths at once and
-make this asymmetry moot.
+guard's absence means a `category`/`extension`/`appName` contract violation
+on the write path is not caught by this mechanism at all, only a violation
+reached through `Clear`'s category argument is. A future defensive check on
+`category`/`extension`/`appName` (the gap above) would close both paths at
+once and make this asymmetry moot.
 
 ## Initialization lifecycle
 
@@ -140,13 +160,16 @@ member's own integer suffix (for example prefix `pkg-index-v`, current
   previous generation's tasks, waits for them best-effort, and starts a new
   generation rather than waiting for the old one to finish on its own.
 
-`CancelAndWaitForMaintenance`/an implicit wait inside `Clear(category: null)`
-are the only ways a caller observes completed maintenance; both drain the
-current generation (or cancel it after a timeout) and consume the recorded
-byte/directory counters. Routine (non-`Clear`) maintenance is silent: a
-caller that never calls `Clear` or `CancelAndWaitForMaintenance` never learns
-whether background retirement ran, succeeded, or was skipped because a prior
-run left the directory absent.
+`CancelAndWaitForMaintenance`/`Clear` are the only ways a caller observes
+completed maintenance. **Every** `Clear` call — not only `Clear(category:
+null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
+maintenance generation before deleting anything; only `Clear(null)` also
+*consumes* the recorded byte/directory counters into its return value
+(`Clear(category)` waits the same way but reports `0` maintenance bytes).
+Routine (non-`Clear`) maintenance is silent: a caller that never calls
+`Clear` or `CancelAndWaitForMaintenance` never learns whether background
+retirement ran, succeeded, or was skipped because a prior run left the
+directory absent.
 
 ## `Clear` and concurrent writers
 
@@ -165,15 +188,24 @@ caller clears a category while concurrently writing to it; a future one must
 either serialize its own writes around a `Clear` or accept that the write may
 be silently lost.
 
-## Telemetry is not a correctness signal
+## Telemetry is fire-and-forget but not exception-isolated
 
-`InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record`
-are recorded on every `TryGet`/`TryGetBytes`/`Set`/`SetBytes` outcome, but
-recording is fire-and-forget and never affects the return value or throws.
-Telemetry may undercount (a `Set` that never reaches the `try` body's
+`InfoTracker.RecordCacheHit`/`RecordCacheMiss` and `CacheTelemetry.Record` are
+recorded on every `TryGet`/`TryGetBytes`/`Set`/`SetBytes` outcome. Recording
+itself does nothing to protect a cache result: `CacheTelemetry.Record` calls
+every subscribed `IObserver<CacheObservation>.OnNext` synchronously, with no
+surrounding `try`/`catch`. A throwing subscriber therefore changes cache
+behavior at the call site — on a `TryGet` hit, the call happens inside the
+method's own blanket `catch`, so a subscriber exception silently turns a hit
+into a miss (`null`); on a `TryGet` miss, the call happens outside any
+`catch`, so a subscriber exception propagates to the cache caller. This
+mechanism does not isolate telemetry from the operation it is recording;
+"fire-and-forget" describes the caller's intent, not an enforced boundary.
+Telemetry may also undercount (a `Set` that never reaches the `try` body's
 `CacheTelemetry.Record` call because an earlier line threw is silently
 uncounted) and must not be read as an audit trail of cache correctness — only
-as an operational signal.
+as an operational signal, and only when every subscriber is known not to
+throw.
 
 ## Non-claims
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -43,8 +43,14 @@ docs-only change.
   guarantee stays inside the hash bucket), but collision resistance is a
   claim about well-formed Unicode input, not every .NET string;
 - read, write, and background-maintenance operations whose *filesystem-access*
-  failures are swallowed and observed only as a miss or as maintenance making
-  no progress. This is not a blanket best-effort guarantee, and it is not
+  failures are swallowed. A read failure is observed as a miss (a `null`
+  result), and a maintenance failure is observed as no progress recorded for
+  that directory — but a write failure has no comparable observable outcome
+  at all: `Set`/`SetBytes` simply return, silently discarding the failure,
+  and a subsequent read can still be a hit if an existing entry from a prior
+  successful write is still in place (a failed write does not delete or
+  invalidate whatever was already stored under that key). This is not a
+  blanket best-effort guarantee, and it is not
   symmetric between reads and writes: on the read path, path construction
   (which reads `AppName`, throwing before initialization) and miss-side
   telemetry both run outside the guarded region and propagate; on the write
@@ -809,7 +815,18 @@ task it returns is only an aggregate of whatever was in `s_maintenanceTasks`
 *at the moment that call constructed it* (`AwaitMaintenanceAsync([..
 s_maintenanceTasks.Values], ...)` is a one-time array snapshot, not a live
 view), memoized in `s_maintenanceTask` so repeated calls return the same
-task instance. A later `RegisterVersionedCategory` call, after this method
+task instance *only while the maintenance generation and the resolved set of
+cleanup keys stay unchanged* — the method itself re-invokes
+`ScheduleVersionedCategoryCleanup` for every registered category on every
+call, before returning the memoized task, so a repeated call can still
+observe a fresh (non-memoized) task within its own invocation: if the
+current base root has changed since the last call (producing a new
+`(root, prefix, currentVersion)` key not yet in `s_maintenanceTasks`), or if
+the current generation was canceled and gets restarted
+(`StartNewMaintenanceGenerationIfCanceled`), either path resets
+`s_maintenanceTask` to `null` before the memoized return, and that same call
+builds and returns a new aggregate task rather than the previous one. A
+later `RegisterVersionedCategory` call, after this method
 has released `s_maintenanceLock` and returned, can schedule a new cleanup
 task and reset `s_maintenanceTask` to `null` — but that clears the memoized
 field for the *next* caller of `RequestVersionedCategoryCleanupAsync`; it
@@ -1032,8 +1049,7 @@ overload observed it:
   whether the *hit* telemetry subscriber itself is what throws:
   `InfoTracker.RecordCacheHit()` runs, unconditionally, *before*
   `CacheTelemetry.Record(..., Hit)` inside the same `try`; if that
-  `CacheTelemetry.Record` call throws for any reason (a hit subscriber, or
-  the `Activity.Current?.AddEvent` call itself), the already-incremented hit
+  `CacheTelemetry.Record` call throws, the already-incremented hit
   counter is not rolled back, and control falls through to the shared
   miss-path code below, which unconditionally calls
   `InfoTracker.RecordCacheMiss()` too — so one logical read increments both

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -26,8 +26,13 @@ docs-only change.
 
 `CoreCache` supplies, for any caller-chosen category:
 
-- a stable base directory scoped to the current application name and
-  platform (or an override);
+- a base directory scoped to the current application name and platform (or
+  an override) — not a *stable* one: `GetBasePath()` re-derives it on every
+  call rather than caching a value from `Initialize`, so on Linux, absent an
+  explicit override, changing `XDG_CACHE_HOME` in the process environment
+  changes every subsequent path, containment, and clear decision without any
+  `Initialize` call at all (see the trust-boundary and initialization-lifecycle
+  sections below for the concrete consequences);
 - a collision-resistant, filesystem-safe path for a caller-chosen key within
   a category;
 - read, write, and background-maintenance operations whose *filesystem-access*
@@ -87,12 +92,17 @@ differently, but the difference is enforced for only one of them:
   `IsPathInCacheContext` anchors every containment decision to. Unlike
   `category`/`extension`/`appName`, this is **not** a fixed-literal value in
   production today: `dotnet-inspect`'s CLI entry point
-  (`src/dotnet-inspect/Program.cs`) reads it verbatim from the
-  `DOTNET_INSPECT_CACHE_DIR` environment variable, or — for `--isolated`/
-  `DOTNET_INSPECT_ISOLATED` — builds it by concatenating that environment
-  value into a temp-directory path, then forwards it unchanged through
-  `NuGetCache.Initialize` to `CoreCache.Initialize`. A caller (here, an
-  end user or their shell environment) that controls `basePath` controls the
+  (`src/dotnet-inspect/Program.cs`) resolves it with explicit precedence —
+  the `DOTNET_INSPECT_CACHE_DIR` environment variable wins verbatim if set;
+  otherwise, when `--isolated`/`DOTNET_INSPECT_ISOLATED` selects an
+  isolation session name (from either the `--isolated <name>` command-line
+  argument or the `DOTNET_INSPECT_ISOLATED` environment variable — not only
+  the environment variable), it builds a temp-directory path from that
+  session name; otherwise `basePath` is `null` and `CoreCache` falls back to
+  its own platform default. Whichever value results is forwarded unchanged
+  through `NuGetCache.Initialize` to `CoreCache.Initialize`. A caller (here,
+  an end user or their shell environment, or a `--isolated` command-line
+  argument) that controls `basePath` controls the
   cache root itself, which is a strictly larger trust concession than
   `category` or `extension` — and it is exercised in production, not merely
   hypothetical. `basePath` is not the only environment-controlled root
@@ -119,20 +129,39 @@ constrains it once accepted.
 
 **Gap:** the contract above is enforced only by code review convention today.
 `GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `GetCacheInfo`,
-`TryGet`, `TryGetBytes`, `Set`, and `SetBytes` do not reject a `category`,
-`extension`, or `appName` containing a path separator or a `..` segment, so
-a future caller that violates the contract (for example, building a
-category from a package id, or an `extension` from configuration) would
-silently gain a path-traversal write/read/enumerate primitive outside the
-intended cache root, undetected by any existing test. `basePath` is exempt
-from this particular gap since it is already the accepted exception above,
-but `GetBasePath`/`Initialize` still place no containment constraint on it
-at all — a `basePath` sourced from untrusted *content* rather than trusted
-operator configuration would be unconstrained in a different way, as noted
-above. Closing the `category`/`extension`/`appName` gap — for example,
-asserting each contains no directory separator and no `.` segment before
-every path computation — is recommended follow-up work; this document
-records the invariant so that follow-up has a contract to enforce against.
+`TryGet`, `TryGetBytes`, `Set`, `SetBytes`, and `Clear` do not reject a
+`category`, `extension`, or `appName` containing a path separator or a `..`
+segment, so a future caller that violates the contract (for example,
+building a category from a package id, or an `extension` from
+configuration) would silently gain a path-traversal write/read/enumerate
+primitive outside the intended cache root, undetected by any existing test.
+`Clear` in particular does not merely gain a wider read/write primitive from
+a non-conforming `category` — an empty or entirely-`..`-normalizing
+`category` can *alias a different, unintended deletion target that is still
+inside the root*, which the containment guard cannot catch because the
+resulting path is genuinely contained: `Clear("")` computes
+`Path.Combine(GetBasePath(), "")`, which `Path.Combine` returns as the base
+path itself (an empty path segment is dropped, not appended), so `Clear("")`
+deletes the *entire* cache root rather than "the empty category" — indistinguishable
+from `Clear(null)`'s target path but without `Clear(null)`'s "clear
+everything" semantics being the caller's evident intent; and a `category`
+like `"a/../b"` combines and normalizes to sibling category `b`, so
+`Clear("a/../b")` clears an entirely different, existing category `b`
+instead of failing or clearing a nonexistent `"a/../b"` entry. Neither case
+escapes the cache root — the existing traversal test only covers the
+root-escaping case (`Clear("..")`, correctly rejected) — so this is a
+distinct failure mode from the path-traversal gap above: a non-conforming
+`category` can silently retarget a destructive operation to a different
+in-root location, not just widen it outside the root. `basePath` is exempt
+from the path-traversal framing of this gap since it is already the accepted
+exception above, but `GetBasePath`/`Initialize` still place no containment
+constraint on it at all — a `basePath` sourced from untrusted *content*
+rather than trusted operator configuration would be unconstrained in a
+different way, as noted above. Closing the `category`/`extension`/`appName`
+gap — for example, asserting each contains no directory separator and no
+`.` segment before every path computation — is recommended follow-up work;
+this document records the invariant so that follow-up has a contract to
+enforce against.
 
 ## Path-context containment
 
@@ -144,13 +173,16 @@ any exception while resolving the full path (malformed path, denied access)
 returns `false`, never `true`. `Clear` calls it internally before deleting;
 other owners call it directly, but not exclusively before deletion —
 `NuGetCache` and `PlatformPackService` each guard both their commit
-`targetPath` and their staging `stagingPath` before *publish/write*
-operations (`Directory.CreateDirectory`, copying staged contents in), not
-before deletion; only `PlatformPackService`'s separate `destDir` guard
-(inside its content-copy helper, before overwriting an existing destination
-subdirectory) and `PackageCacheService`'s legacy-cache guard precede an
-actual `Directory.Delete`. It is the
-mechanism's one exported containment primitive; any future caller that
+`targetPath` and their staging `stagingPath` once, before a *publish/write*
+operation begins (`Directory.CreateDirectory`, copying staged contents in);
+that same single guard call also covers the staging path's later, separate
+best-effort cleanup delete in a `finally` block once publication succeeds or
+fails, since the guarded local variable is reused rather than re-derived.
+Only `PlatformPackService`'s separate `destDir` guard (inside its
+content-copy helper, before overwriting an existing destination
+subdirectory) and `PackageCacheService`'s legacy-cache guard are dedicated
+guards whose sole purpose is preceding an actual `Directory.Delete`. It is
+the mechanism's one exported containment primitive; any future caller that
 writes, deletes, or otherwise mutates a path derived from
 `GetBasePath()`/`GetCategoryPath()` should call it too.
 
@@ -178,14 +210,23 @@ base path) is ever configured as a bare root such as `/`,
 `IsSameOrChildPath` compares an ordinary descendant path like `/tmp/x`
 against `"//"` (the root with its separator re-appended for the prefix
 check) rather than `"/"`, so the prefix match fails and a path that is in
-fact under the root is reported as **not** contained. This does not create a
-traversal exposure — the guard still fails closed, rejecting a legitimate
-path rather than admitting an illegitimate one — but it does mean
-`EnsurePathInCacheContext`/`Clear` would incorrectly refuse a legitimate,
-in-root operation whenever `basePath` is a filesystem root. This is a narrow
-edge case — no current caller configures `basePath` as a filesystem root —
-but it is unverified by any existing test and not stated as a constraint on
-`basePath` anywhere.
+fact under the root is reported as **not** contained — but this only
+affects a *descendant* path, not the root itself: `IsSameOrChildPath`
+checks exact equality first (`fullPath.Equals(fullRoot, ...)`), which is
+unaffected by the separator-trimming issue, so an operation that targets the
+root path directly — including `Clear()` (no category), whose target path
+*is* `GetBasePath()` — is correctly recognized as in-context and proceeds
+as designed (deleting the entire root), not incorrectly refused. Only a
+narrower, category-scoped operation such as `Clear("category")` or
+`EnsurePathInCacheContext` on some other descendant path would be
+incorrectly refused when `basePath` is a bare root. This does not create a
+traversal exposure either way — the guard still fails closed for the
+descendant case, rejecting a legitimate path rather than admitting an
+illegitimate one. No known caller currently configures `basePath` as a
+filesystem root, but nothing in `Initialize`/`GetBasePath` prevents it —
+`basePath` is accepted verbatim from an environment variable in production
+(see the trust-boundary section above) — so this is an unverified,
+narrow-but-reachable edge case, not a provably unreachable one.
 
 **Gap:** `CoreCache`'s own read/write/statistics entry points (`TryGet`,
 `TryGetBytes`, `Set`, `SetBytes`, `GetFilePath`, `GetCacheInfo`) never call
@@ -232,29 +273,47 @@ moment of the second `Initialize` call, not the location actually recorded
 against by the earlier maintenance: the "old" root is `GetBasePath()`
 evaluated with the previous `appName`/`basePath` but the *current* process
 environment, and the "new" root is `GetBasePath()` evaluated with the new
-values and that same current environment. If no explicit `basePath` override
-was ever given and `XDG_CACHE_HOME` (or another ambient input
-`GetDefaultBasePath` reads) changes between the first and second
-`Initialize` call, both sides of the comparison observe the *same* changed
-environment and so still compare equal — counters can carry forward across
-an actual root change that neither `Initialize` call's caller intended, and
-conversely cannot be relied on to always reset just because the ambient
-environment changed since the first call.
+values and that same current environment. If `appName` is unchanged across
+the two calls, and no explicit `basePath` override was ever given, and
+`XDG_CACHE_HOME` (or another ambient input `GetDefaultBasePath` reads)
+changes between the first and second `Initialize` call, both sides of the
+comparison observe the *same* changed environment and so still compare equal
+— counters can carry forward across an actual root change that neither
+`Initialize` call's caller intended, and conversely cannot be relied on to
+always reset just because the ambient environment changed since the first
+call. (If `appName` *does* change between calls, the two sides diverge — one
+ends in the old `appName`, the other in the new one — so this specific
+carry-forward-despite-environment-change case requires an unchanged
+`appName`, not merely an unchanged `basePath` override.)
 
 **Gap:** re-initialization is not exception-safe against a malformed new
-root. `Initialize` mutates `_appName`, `_basePathOverride`, the maintenance
-cancellation source, the progress object, and the task dictionary to their
-new values *before* calling `IsSamePath` to decide whether to carry progress
-forward — and `IsSamePath` calls `Path.GetFullPath` on both sides, which
-throws for a sufficiently malformed path (invalid characters, exceeding
-platform path-length limits). Because `basePath` receives no validation (see
-the trust-boundary section above), a caller-supplied `basePath` that
-`Path.GetFullPath` rejects makes `Initialize` throw *after* the new fields
-are already committed and *before* the `foreach` loop re-schedules cleanup
-for previously registered categories. The result is partial, not
-all-or-nothing: the new root and app name take effect, but no versioned
-category's cleanup is rescheduled against it until some other call
-re-triggers scheduling.
+root, and the failure is destructive to more than scheduling. `Initialize`
+mutates `_appName`, `_basePathOverride`, the maintenance cancellation
+source, the progress object, and the task dictionary to their new values —
+and, before that, takes a destructive snapshot of the *old* generation's
+reclaimed-byte/directory counters via `TakeSnapshot()` (which zeros them) —
+all *before* calling `IsSamePath` to decide whether to carry that snapshot
+forward into the new progress object. `IsSamePath` calls `Path.GetFullPath`
+on both sides, which throws for a sufficiently malformed path (invalid
+characters, exceeding platform path-length limits). Because `basePath`
+receives no validation (see the trust-boundary section above), a
+caller-supplied `basePath` that `Path.GetFullPath` rejects makes `Initialize`
+throw *after* the new fields are already committed, *after* the old
+counters have already been zeroed and captured only in a local variable,
+and *before* the `foreach` loop re-schedules cleanup for previously
+registered categories. The result is partial, not all-or-nothing: the new
+root and app name take effect, no versioned category's cleanup is
+rescheduled against it until some other call re-triggers scheduling, and the
+old generation's reclaimed-byte/directory counts are lost permanently — the
+captured local snapshot is discarded along with the exception, and the new
+`s_maintenanceProgress` object was already installed with zeros. The
+identical destructive-then-possibly-thrown pattern applies to
+`Clear(category: null)`, which passes `consumeProgress: true` to
+`WaitForMaintenance` (destructively zeroing the counters via the same
+`TakeSnapshot()`) before validating `EnsurePathInCacheContext` and
+performing the measurement/deletion — if either of those later steps
+throws, the already-consumed counters are lost with no return value to
+carry them.
 
 `RegisterVersionedCategory` may be called before or after `Initialize`, and
 repeated registration of the same prefix is idempotent only when `current`
@@ -330,6 +389,20 @@ before any background work is scheduled. Retirement:
   previous generation's tasks, waits for them best-effort, and starts a new
   generation rather than waiting for the old one to finish on its own.
 
+**Gap:** the retired-directory byte count is itself only a best-effort
+measurement, not a confirmed pre-deletion size — `CleanupVersionedCategory`
+measures each obsolete directory via `GetDirectorySizeBestEffort`, which
+catches any enumeration failure and returns `0` rather than propagating it,
+and then proceeds to `Directory.Delete` the directory regardless and record
+a deletion with that (possibly `0`) size. A directory that fails to measure
+(permissions, a concurrent modification during enumeration) is still
+deleted and still counted as one retired directory, but contributes `0` to
+the accumulated byte total — so the maintenance byte counter that `Clear(null)`
+later consumes into its return value (see
+[Clear and concurrent writers](#clear-and-concurrent-writers)) can
+undercount real reclaimed space for a reason distinct from the concurrent-write
+undercounting already described there.
+
 **Gap:** the retirement rule above is scoped to one registered family (one
 `prefix`) at a time; nothing prevents two *different* registered prefixes
 from overlapping, and a directory that is the current member of one family
@@ -371,7 +444,25 @@ all — `task.Wait(Timeout.InfiniteTimeSpan)` cannot return `false`, so `Clear`
 always waits for the full maintenance generation (including any pending
 generation-restart drain) to either complete or fault before proceeding; it
 does not return early with partial progress the way a finite-timeout
-`CancelAndWaitForMaintenance` call can. **Every** `Clear` call — not only `Clear(category:
+`CancelAndWaitForMaintenance` call can.
+
+**Gap:** `CancelAndWaitForMaintenance`'s `timeout` parameter is not
+validated, and an out-of-range value silently skips both the cancellation
+and the 25ms secondary wait rather than producing a documented error or the
+documented cancel-and-wait behavior. `task.Wait(TimeSpan)` throws
+`ArgumentOutOfRangeException` for a negative `TimeSpan` other than
+`Timeout.InfiniteTimeSpan` (`-1` ms) or one exceeding `int.MaxValue`
+milliseconds (about 24.8 days) — a plausible caller mistake, not only an
+adversarial input. `WaitForMaintenance` wraps `task.Wait(timeout)` and the
+subsequent cancel/25ms-wait in one blanket `try`/`catch`, so that exception
+is caught by the *same* handler that also swallows a legitimate
+cancellation-related exception; the method falls straight through to
+returning whatever progress is currently recorded, having neither canceled
+the task nor waited the documented 25ms. A caller who passes an
+out-of-range timeout observes an immediate, non-canceling progress read
+that looks identical to any other best-effort outcome, not a timeout error.
+
+**Every** `Clear` call — not only `Clear(category:
 null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
 maintenance generation before deleting anything; only `Clear(null)` also
 *consumes* the recorded byte counter into its return value (`Clear(category)`
@@ -525,8 +616,14 @@ solely by `FileInfo.LastWriteTimeUtc`, compared as
 `DateTime.UtcNow - info.LastWriteTimeUtc < maxAge`. The comparison is strict,
 so an entry written exactly `maxAge` ago is stale, not fresh; and because the
 comparison is one-sided, a `LastWriteTimeUtc` in the future (a clock change, a
-restored backup, a manipulated file) makes an entry read as fresh for
-`maxAge`s of zero or even negative duration. Any failure while resolving
+restored backup, a manipulated file) makes an entry read as fresh for any
+non-negative `maxAge` regardless of how far in the future it is. For a
+negative `maxAge` the same future-dated entry is fresh only conditionally:
+with `LastWriteTimeUtc` `δ` ahead of `UtcNow`, the comparison becomes
+`-δ < maxAge`, so a negative `maxAge` of magnitude `M` still reports the
+entry fresh whenever the future skew `δ` exceeds `M` — a small future skew
+can still be stale against a large-magnitude negative `maxAge`, but any
+future skew is read as fresh once `maxAge` is zero or positive. Any failure while resolving
 `FileInfo` or reading the file is caught by the same guarded region and
 *returns* a miss (`null`), exactly like the non-`maxAge` overloads' hit
 path — but the miss is not otherwise *recorded* the same way: the

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -926,9 +926,15 @@ the task being waited on) has already returned, which can itself block
 indefinitely on the unbounded generation-restart drain described above; an
 invalid timeout does not bound or bypass that pending drain, only the
 subsequent cancel/wait step. A caller who passes a rejected timeout observes
-a non-canceling progress read — once any pending generation-restart drain
-has finished — that looks identical to any other best-effort outcome, not a
-timeout error.
+a non-canceling *destructive* progress drain — once any pending
+generation-restart drain has finished — that looks identical to any other
+best-effort outcome, not a
+timeout error: `WaitForMaintenance` always calls `progress.TakeSnapshot()`
+with `consumeProgress: true`, which resets both counters via
+`Interlocked.Exchange(..., 0)`, regardless of whether the wait, the cancel,
+or neither actually ran — so the rejected-timeout path still consumes and
+resets the recorded progress, changing what a subsequent drain reports,
+even though it performed neither the requested wait nor cancellation.
 
 **Every** `Clear` call — not only `Clear(category:
 null)` — unconditionally waits (`Timeout.InfiniteTimeSpan`) for the current
@@ -962,17 +968,28 @@ return `false` both when the directory genuinely does not exist and when an
 error occurs determining whether it exists. So an authorization or other
 filesystem error surfacing between `Clear`'s initial existence check and the
 measurement step can still be silently absorbed as "0 bytes" rather than
-propagating, even though `Clear` had already begun measuring. Before that point, `Clear` calls `Directory.Exists(targetPath)`
+propagating — but unlike the other two existence checks below, this one
+does not itself cause `Clear` to return early: `Clear` still proceeds from
+an undercounted (possibly `0`) measurement straight into
+`Directory.Delete`, so a filesystem error absorbed here changes only the
+*measured size*, not whether `Clear` returns successfully — a subsequent
+`Directory.Delete` failure (for example, the same underlying authorization
+error recurring) still propagates normally. Before that point, `Clear` calls `Directory.Exists(targetPath)`
 and returns early (reporting only the maintenance byte counter, no tree
 size) when it reports `false` — the same ambiguous-`false` caveat applies
-here too, and also to the `DirectoryNotFoundException when
+here too, and this initial check *does* cause an early, successful return —
+and also to the `DirectoryNotFoundException when
 !Directory.Exists(targetPath)` filter around the delete call: that filter's
 own `Directory.Exists` re-check cannot definitively prove another process
 completed the deletion, only that the directory is not currently observable,
-for whatever reason. An authorization or other
-filesystem error at any of these existence checks is therefore indistinguishable from
-"nothing to clear" (or "already deleted") and returns successfully with an undercounted result,
-rather than propagating like an enumeration or delete failure does. `Clear`'s `long` return
+for whatever reason, and this check likewise causes `Clear` to return
+successfully (by suppressing the exception) rather than propagate. Of the
+three existence checks, then, only the initial probe and the
+delete-exception filter can turn a filesystem error into
+"nothing to clear" (or "already deleted") and a successful, undercounted
+return; the measurement-step check in the middle only undercounts the
+returned size and does not by itself prevent a later delete failure from
+propagating. `Clear`'s `long` return
 value is not a confirmed bytes-freed count: it is the tree size *measured
 before deletion*, plus (for `Clear(null)` only) the consumed maintenance byte
 counter. That

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -32,11 +32,14 @@ docs-only change.
   a category;
 - read, write, and background-maintenance operations whose *filesystem-access*
   failures are swallowed and observed only as a miss or as maintenance making
-  no progress. This is not a blanket best-effort guarantee: path construction
+  no progress. This is not a blanket best-effort guarantee, and it is not
+  symmetric between reads and writes: on the read path, path construction
   (which reads `AppName`, throwing before initialization) and miss-side
-  telemetry both run outside the guarded region and propagate — see
-  [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated) and
-  the pre-initialization note in
+  telemetry both run outside the guarded region and propagate; on the write
+  path, `Set`/`SetBytes` wrap path construction in their own blanket `catch`,
+  so the identical pre-initialization failure is swallowed there instead —
+  see [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
+  and the pre-initialization note in
   [Initialization lifecycle](#initialization-lifecycle);
 - a `Clear` operation that surfaces most failures rather than swallowing them
   (see [Clear and concurrent writers](#clear-and-concurrent-writers)); and
@@ -110,31 +113,38 @@ constrains it once accepted.
 **Gap:** the contract above is enforced only by code review convention today.
 `GetCategoryPath`, `GetFilePath`, `GetDefaultBasePath`, `GetCacheInfo`,
 `TryGet`, `TryGetBytes`, `Set`, and `SetBytes` do not reject a `category`,
-`extension`, or `appName` containing a path separator or a `..` segment, and
-`GetBasePath`/`Initialize` place no constraint on `basePath` at all, so a
-future caller that violates the contract (for example, building a category
-from a package id, or an `extension`/`basePath` from configuration) would
+`extension`, or `appName` containing a path separator or a `..` segment, so
+a future caller that violates the contract (for example, building a
+category from a package id, or an `extension` from configuration) would
 silently gain a path-traversal write/read/enumerate primitive outside the
-intended cache root, undetected by any existing test. Closing this gap — for
-example, asserting `category`/`extension`/`appName` contain no directory
-separator and no `.` segment before every path computation, and constraining
-`basePath` to a directory the process already controls — is recommended
-follow-up work; this document records the invariant so that follow-up has a
-contract to enforce against.
+intended cache root, undetected by any existing test. `basePath` is exempt
+from this particular gap since it is already the accepted exception above,
+but `GetBasePath`/`Initialize` still place no containment constraint on it
+at all — a `basePath` sourced from untrusted *content* rather than trusted
+operator configuration would be unconstrained in a different way, as noted
+above. Closing the `category`/`extension`/`appName` gap — for example,
+asserting each contains no directory separator and no `.` segment before
+every path computation — is recommended follow-up work; this document
+records the invariant so that follow-up has a contract to enforce against.
 
 ## Path-context containment
 
-`EnsurePathInCacheContext`/`IsPathInCacheContext` are a public guard against
-deleting outside the cache: a path is in context when it equals or is a
-descendant of the active base path (`GetBasePath()`) or the legacy pre-XDG
-path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed — any
-exception while resolving the full path (malformed path, denied access)
-returns `false`, never `true`. `Clear` calls it internally, and other owners
-call it directly before their own destructive filesystem operations —
-package-content and staging deletion (`NuGetCache`), platform-pack target and
-staging deletion (`PlatformPackService`), and legacy-cache deletion
-(`PackageCacheService`) all invoke it. It is the mechanism's one exported
-containment primitive; any future caller that deletes a path derived from
+`EnsurePathInCacheContext`/`IsPathInCacheContext` are a public guard that
+confines a path to the cache root: a path is in context when it equals or is
+a descendant of the active base path (`GetBasePath()`) or the legacy
+pre-XDG path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed —
+any exception while resolving the full path (malformed path, denied access)
+returns `false`, never `true`. `Clear` calls it internally before deleting;
+other owners call it directly, but not exclusively before deletion —
+`NuGetCache` and `PlatformPackService` each guard both their commit
+`targetPath` and their staging `stagingPath` before *publish/write*
+operations (`Directory.CreateDirectory`, copying staged contents in), not
+before deletion; only `PlatformPackService`'s separate `destDir` guard
+(inside its content-copy helper, before overwriting an existing destination
+subdirectory) and `PackageCacheService`'s legacy-cache guard precede an
+actual `Directory.Delete`. It is the
+mechanism's one exported containment primitive; any future caller that
+writes, deletes, or otherwise mutates a path derived from
 `GetBasePath()`/`GetCategoryPath()` should call it too.
 
 **Gap:** the descendant check (`IsSameOrChildPath`) and the root-equality
@@ -154,6 +164,22 @@ behavior, not a verified guarantee on a case-sensitive filesystem; treat that
 as an open, unenforced case, not as closed by `EnsurePathInCacheContext`/
 `IsSamePath` alone.
 
+**Gap:** both checks also rely on `Path.TrimEndingDirectorySeparator`, which
+does not strip the separator from a filesystem root — `TrimEndingDirectorySeparator("/")`
+returns `"/"` unchanged, confirmed directly. If `basePath` (or the legacy
+base path) is ever configured as a bare root such as `/`,
+`IsSameOrChildPath` compares an ordinary descendant path like `/tmp/x`
+against `"//"` (the root with its separator re-appended for the prefix
+check) rather than `"/"`, so the prefix match fails and a path that is in
+fact under the root is reported as **not** contained. This does not create a
+traversal exposure — the guard still fails closed, rejecting a legitimate
+path rather than admitting an illegitimate one — but it does mean
+`EnsurePathInCacheContext`/`Clear` would incorrectly refuse a legitimate,
+in-root operation whenever `basePath` is a filesystem root. This is a narrow
+edge case — no current caller configures `basePath` as a filesystem root —
+but it is unverified by any existing test and not stated as a constraint on
+`basePath` anywhere.
+
 **Gap:** `CoreCache`'s own read/write/statistics entry points (`TryGet`,
 `TryGetBytes`, `Set`, `SetBytes`, `GetFilePath`, `GetCacheInfo`) never call
 the guard themselves — only `Clear` and the external callers above do.
@@ -170,6 +196,18 @@ that already guards itself) is not caught by this mechanism at all. A future
 defensive check on `category`/`extension`/`appName` (the trust-boundary gap
 above) would close this without relying on every future caller remembering
 to call the guard itself.
+
+`Set`/`SetBytes` publish file content through a private `WriteAtomically`
+helper: it writes the new content to a sibling temp file named
+`{path}.{Guid.NewGuid():N}.tmp`, then calls `File.Move(tempPath, path,
+overwrite: true)` to publish it, then unconditionally attempts
+`File.Delete(tempPath)` in a `finally` block (a no-op after a successful
+move, since the temp path no longer exists). This is `CoreCache`'s own
+atomic single-file publication mechanism — a reader never observes a
+partially-written file — and is distinct from
+[`cache-concurrency.md`](cache-concurrency.md)'s package-*directory* staging
+protocol (stage into a temp directory, then `Directory.Move` the whole tree
+into place), which that document owns.
 
 ## Initialization lifecycle
 
@@ -193,22 +231,25 @@ every previously registered category under that new root.
 
 **Gap:** `_appName`/`_basePathOverride` are written only inside `Initialize`'s
 `lock (s_maintenanceLock)`, and every other method that also takes that lock
-— `RegisterVersionedCategory`, `Clear`, `WaitForMaintenance` (and therefore
-`CancelAndWaitForMaintenance`), and `RequestVersionedCategoryCleanupAsync` —
-is safely serialized against a concurrent `Initialize`; none of these can
-observe a partial field write. The unsynchronized race is narrower but wider
-than only the read/write path: the lock-free surface — `GetBasePath`,
-`GetDefaultBasePath`, `GetLegacyBasePath`, `GetCategoryPath`, `GetFilePath`,
-`TryGet`/`TryGetBytes`, `Set`/`SetBytes`, `GetCacheInfo`,
-`IsPathInCacheContext`, and (transitively, since it calls
+— including concurrent `Initialize` calls themselves, `RegisterVersionedCategory`,
+`Clear`, `WaitForMaintenance` (and therefore `CancelAndWaitForMaintenance`),
+and `RequestVersionedCategoryCleanupAsync` — is safely serialized against
+each other; none of these can observe a partial field write, and multiple
+concurrent `Initialize` calls are not by themselves a data race (whichever
+one takes the lock last determines the resulting root). The unsynchronized
+race is narrower but wider than only the read/write path: the lock-free
+surface — `GetBasePath`, `GetDefaultBasePath`, `GetLegacyBasePath`,
+`GetCategoryPath`, `GetFilePath`, `TryGet`/`TryGetBytes`, `Set`/`SetBytes`,
+`GetCacheInfo`, `IsPathInCacheContext`, and (transitively, since it calls
 `IsPathInCacheContext`) `EnsurePathInCacheContext` — reads
-`_appName`/`_basePathOverride` without the lock and without `volatile`. **At
-most one `Initialize` call may be outstanding, and no lock-free method may
-run concurrently with it.** Today's callers satisfy this by calling
-`Initialize` once at process startup before any other cache use, but the
-contract is not stated anywhere and not enforced by an assertion. A
-production build that calls `Initialize` a second time for any reason (for
-example, a hosted/long-lived process switching app identity) while a
+`_appName`/`_basePathOverride` without the lock and without `volatile`. **No
+lock-free method may run concurrently with any `Initialize` call** — this is
+the actual race boundary, not a restriction on how many `Initialize` calls
+may be outstanding. Today's callers satisfy this by calling `Initialize`
+once at process startup before any other cache use, but the contract is not
+stated anywhere and not enforced by an assertion. A production build that
+calls `Initialize` a second time for any reason (for example, a
+hosted/long-lived process switching app identity) while a
 concurrent `TryGet`/`Set`/`IsPathInCacheContext` is in flight has a data race
 on `_appName`/`_basePathOverride` — including the possibility that
 `IsPathInCacheContext` combines an active-root check against one
@@ -233,7 +274,14 @@ documented behavior above already states its own case.
 
 A versioned category family is identified by a `prefix` plus the current
 member's own integer suffix (for example prefix `pkg-index-v`, current
-`pkg-index-v8`). Retirement:
+`pkg-index-v8`). `RegisterVersionedCategory(prefix, current)` validates both
+arguments before scheduling any retirement: `prefix` and `current` must each
+be non-null and non-whitespace, and `current` must start with `prefix`
+case-insensitively and have the remainder parse as a non-negative integer
+via `int.TryParse(..., NumberStyles.None, ...)` (so no leading `+`/`-` sign,
+no thousands separator, and no leading/trailing whitespace in the suffix) —
+any violation throws `ArgumentException` synchronously from the call itself,
+before any background work is scheduled. Retirement:
 
 - deletes only sibling directories whose suffix parses as a non-negative
   integer strictly less than the current version;
@@ -279,11 +327,16 @@ error, an `IOException` from a file another process still has open, or a
 directory-enumeration error while measuring size — propagates to `Clear`'s
 caller rather than being swallowed. `Clear`'s `long` return value is not a
 confirmed bytes-freed count: it is the tree size *measured before deletion*,
-plus (for `Clear(null)` only) the consumed maintenance byte counter — if
-another process deletes some or all of the tree concurrently (the
-`DirectoryNotFoundException` case, or a race that removes only some files
-before `Clear` measures or deletes), the returned value can be higher or
-lower than what `Clear` itself actually removed. It also omits the
+plus (for `Clear(null)` only) the consumed maintenance byte counter. That
+measurement can diverge from what this `Clear` call actually removed in
+either direction, for different reasons: a concurrent deletion of some or
+all of the tree between the measurement and `Directory.Delete` (including
+the `DirectoryNotFoundException` case) can only make the returned value an
+*overcount*, since it reports bytes that this `Clear` no longer needed to
+remove; a concurrent `Set`/`SetBytes` that adds or grows a file in the same
+tree after the measurement but before `Directory.Delete` can make it an
+*undercount*, since those bytes are swept into the same recursive delete
+without ever being measured. It also omits the
 directory-deleted count even when `Clear(null)` consumes it from maintenance
 (see [Versioned category retirement](#versioned-category-retirement)) — a
 caller that needs the directory count must use `CancelAndWaitForMaintenance`
@@ -369,10 +422,14 @@ case-insensitively equals `"symbol-misses"`, but *rewrites* it as
 `$"{category}/{extension}"` — preserving the caller's original spelling and
 casing rather than canonicalizing it. `TryGet("symbol-misses", key,
 extension: "forbidden")` reports `symbol-misses/forbidden`, distinct from
-`symbol-misses/miss`, but a caller passing `"SYMBOL-MISSES"` would observe
-`SYMBOL-MISSES/forbidden`, not the lowercase form. Every other `category`
-passes through unchanged. This is an intentional, tested part of the
-observable telemetry contract, not an undocumented side effect.
+`symbol-misses/miss` — this extension-remapping behavior is covered by
+`HttpClientFactoryTests.CacheTelemetry_SymbolMissesIncludeExtensionInCategory`.
+A caller passing `"SYMBOL-MISSES"` would observe `SYMBOL-MISSES/forbidden`,
+not the lowercase form, per the `$"{category}/{extension}"` interpolation
+above — this casing-preservation consequence follows from reading the source
+and is not itself exercised by any existing test. Every other `category`
+passes through unchanged. This is an intentional part of the observable
+telemetry contract, not an undocumented side effect.
 
 ## `maxAge` freshness is a mechanism-owned rule, not a caller policy
 

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -202,9 +202,26 @@ enforce against.
 `EnsurePathInCacheContext`/`IsPathInCacheContext` are a public guard that
 confines a path to the cache root: a path is in context when it equals or is
 a descendant of the active base path (`GetBasePath()`) or the legacy
-pre-XDG path (`GetLegacyBasePath()`). `IsPathInCacheContext` fails closed —
-any exception while resolving the full path (malformed path, denied access)
-returns `false`, never `true`. `Clear` calls it internally before deleting;
+pre-XDG path (`GetLegacyBasePath()`). This is a purely lexical check —
+`IsPathInCacheContext` calls `Path.GetFullPath` and does string comparisons
+only; it never opens, enumerates, or otherwise accesses the candidate path
+on disk, so a lexically-contained path beneath a directory the process
+cannot actually read or write is still reported as in-context, and
+accessibility failures surface later, from whatever filesystem operation
+the caller performs next. `IsPathInCacheContext` fails closed for a
+different reason — an exception while resolving the full path itself
+(a malformed path, or one exceeding platform path-length limits) is caught
+and returns `false`, never `true`; so is a null, empty, or all-whitespace
+*candidate* path, rejected before any resolution is attempted. That last
+check has a consequence worth naming explicitly: an accepted, blank
+`basePath` override (see the trust-boundary section above) is a valid
+*root*, but `GetBasePath()`'s blank result is also *itself* rejected the
+moment it (or a path derived from it) is passed as the *candidate* to
+`IsPathInCacheContext` — so `Clear()` with a blank `basePath` override does
+not silently no-op or contain some unexpected path; it fails
+`EnsurePathInCacheContext`'s guard and throws, because the guard cannot
+distinguish "root not supplied" from "candidate not supplied" once both
+happen to be the same blank string. `Clear` calls it internally before deleting;
 other owners call it directly, but not exclusively before deletion. The
 following description of `NuGetCache`'s and `PlatformPackService`'s call
 sites is cited only as evidence for a `CoreCache`-owned claim — that this
@@ -285,10 +302,22 @@ narrow-but-reachable edge case, not a provably unreachable one.
 `TryGetBytes`, `Set`, `SetBytes`, `GetFilePath`, `GetCacheInfo`) never call
 the guard themselves — only `Clear` and the external callers above do.
 `GetCacheInfo(category)` in particular recursively measures and enumerates
-every file under `GetCategoryPath(category)` with no containment check and
-no exception handling of its own, so a category contract violation reaching
+every file under `GetCategoryPath(category)` with no containment check, and
+its own exception handling is mixed rather than absent: it returns an empty
+`CacheInfo(targetPath, 0, 0)` when its own `Directory.Exists(targetPath)`
+check reports `false` (ambiguous, as elsewhere, between "does not exist" and
+"error determining existence"); the size measurement it delegates to
+(`GetDirectorySize`) performs a *second*, independent `Directory.Exists`
+check with the same ambiguity and returns `0` rather than propagating; but
+the file-count enumeration, `Directory.GetFiles(targetPath, "*",
+SearchOption.AllDirectories)`, has no guard at all and propagates any
+enumeration failure that occurs after both existence checks have already
+passed. So a category contract violation reaching
 it is also an out-of-root enumeration read, not just a write/delete
-primitive. Because `category` is contract-restricted to literals (see
+primitive, and separately, a filesystem error partway through can surface as
+a zero/empty result at either existence check or as a propagated exception
+from the unguarded file count, depending on exactly where the failure
+occurs. Because `category` is contract-restricted to literals (see
 above), a conforming caller never needs the guard on the read/write/stats
 path today — but the guard's absence there means a
 `category`/`extension`/`appName` contract violation reaching `TryGet`/`Set`/
@@ -345,8 +374,25 @@ the case-sensitivity gap in
 [Path-context containment](#path-context-containment)); otherwise they reset,
 because the counters describe one cache root's history and a root change
 starts a new one. Both sides of that comparison are *recomputed live*, not
-the location actually recorded against by the earlier maintenance — but not
-at the *same instant*, either: the "old" root (`GetBasePath()` evaluated
+the location actually recorded against by the earlier maintenance — and
+that "recomputed" property has a sharper edge when `basePath` is a
+*relative* path (see the trust-boundary and containment-guard notes above
+on `basePath` not being guaranteed absolute): `IsSamePath` resolves each raw
+override string via `Path.GetFullPath` only at comparison time, against
+whatever the process's current directory is *then* — not the directory that
+was current while the earlier maintenance generation actually ran. If the
+same relative `basePath` string (for example `"cache"`) is passed to two
+`Initialize` calls, but the process's current directory differs between
+when the first generation's maintenance ran and when the second
+`Initialize` call runs `IsSamePath`, the two calls can resolve to two
+genuinely different absolute directories on disk while still comparing
+equal — carrying counters from one physical root's history into a
+different physical root's tally, not merely "carrying forward across a
+root change neither call intended" as in the ambient-environment scenario
+below, but across two locations that were never the same directory at any
+point in time. Separately, and regardless of whether `basePath` is relative
+or absolute, the "old" and "new" reads are not simultaneous either: the
+"old" root (`GetBasePath()` evaluated
 with the previous `appName`/`basePath`) is read first, before the
 cancellation and best-effort drain of in-flight maintenance tasks; the
 "new" root (`GetBasePath()` evaluated with the new values) is read only
@@ -484,7 +530,30 @@ exception is caught by their own blanket `try`/`catch` (see
 propagating, so `EnsurePathInCacheContext` throws its own refusal exception
 instead of the pre-initialization one; and `GetLegacyBasePath` reads `AppName`
 only on non-Windows platforms, so it throws there but returns `null` on
-Windows without touching `AppName` at all. There is no single
+Windows without touching `AppName` at all. The methods above are not the
+complete lock-free surface, though: `GetCategoryPath`, `GetFilePath`, and
+`GetCacheInfo` all reach `AppName` transitively through `GetBasePath` →
+`GetDefaultBasePath` and so throw the same pre-initialization exception —
+except that `GetBasePath` itself has a bypass the others do not: when
+`_basePathOverride` is non-null, `GetBasePath` returns it directly without
+ever calling `GetDefaultBasePath` or touching `AppName`, so a process that
+called `Initialize` with an explicit `basePath` override and then somehow
+reached these methods before `_appName` was set (not reachable through
+`Initialize` itself, which sets both fields together, but relevant to any
+future caller that manipulates the fields independently) would not throw
+from `GetBasePath` at all, only from whichever of `GetCategoryPath`/
+`GetFilePath`/`GetCacheInfo` still needs `category`/`key` hashing or
+enumeration — none of which touch `AppName` a second time once `GetBasePath`
+has already returned. `Clear` reaches the same exception while deriving its
+`targetPath` (after its own maintenance wait, which does not depend on
+`AppName` — see below). `CancelAndWaitForMaintenance` is the one public
+method that does *not* propagate this exception pre-initialization: it calls
+`WaitForMaintenance`, which calls `RequestVersionedCategoryCleanupAsync`,
+which checks `_appName is null` explicitly and returns a completed
+`default(CacheMaintenanceResult)` task rather than touching the throwing
+`AppName` property — so `CancelAndWaitForMaintenance(timeout)` called before
+`Initialize` returns a zeroed result instead of throwing, unlike every other
+lock-free method discussed here. There is no single
 "every lock-free method does X" pre-initialization rule; each method's
 documented behavior above already states its own case.
 
@@ -539,7 +608,24 @@ file, a permissions error partway through), the directory is left
 directory count, and no indication that the directory was touched at all;
 the next `Initialize`/registration cycle will reattempt it (the surviving
 directory still matches the retirement rule), but until then the on-disk
-state is neither the pre-cleanup directory nor a cleanly retired one.
+state is neither the pre-cleanup directory nor a cleanly retired one. That
+retry claim needs a precise qualifier, though: a repeated
+`RegisterVersionedCategory` call for the *same* prefix within the *same*
+maintenance generation does not itself trigger a retry —
+`ScheduleVersionedCategoryCleanup` keys each scheduled task by
+`(root, prefix, currentVersion)` and returns immediately, without scheduling
+anything, when that key is already present in `s_maintenanceTasks`
+(regardless of whether the previously-scheduled task's *own* cleanup
+attempt succeeded, partially failed, or fully failed — the task itself
+still completed, since `CleanupVersionedCategory`'s blanket `catch` prevents
+it from ever faulting). The key is only removed — and a fresh attempt
+scheduled — by a subsequent `Initialize` call (which replaces
+`s_maintenanceTasks` with a new, empty dictionary) or by
+`StartNewMaintenanceGenerationIfCanceled` replacing a canceled generation; a
+changed root (via a different `basePath`/`appName`, or the ambient-input
+change discussed above) also produces a different key and so schedules a
+fresh attempt against that new root, but this is really "different key
+scheduled," not "same failed attempt retried."
 `Clear`'s own `Directory.Delete(targetPath, recursive: true)` (see
 [Clear and concurrent writers](#clear-and-concurrent-writers)) has the
 equivalent exposure in the opposite direction: it catches only
@@ -588,9 +674,25 @@ enforce and today's callers satisfy only by using prefixes that do not
 overlap in practice.
 
 `CancelAndWaitForMaintenance`/`Clear` are the only **public** ways a caller
-observes completed maintenance (the internal `RequestVersionedCategoryCleanupAsync`
-is a third, assembly-internal path that test code uses directly to await the
-real aggregate task). `CancelAndWaitForMaintenance(timeout)` can return
+observes completed maintenance. The internal `RequestVersionedCategoryCleanupAsync`
+is a third, assembly-internal path that test code uses directly to await
+maintenance — but calling what it returns "the real aggregate task"
+overstates what it actually returns: the
+task it returns is only an aggregate of whatever was in `s_maintenanceTasks`
+*at the moment that call constructed it* (`AwaitMaintenanceAsync([..
+s_maintenanceTasks.Values], ...)` is a one-time array snapshot, not a live
+view), memoized in `s_maintenanceTask` so repeated calls return the same
+task instance. A later `RegisterVersionedCategory` call, after this method
+has released `s_maintenanceLock` and returned, can schedule a new cleanup
+task and reset `s_maintenanceTask` to `null` — but that clears the memoized
+field for the *next* caller of `RequestVersionedCategoryCleanupAsync`; it
+does not, and cannot, add the new task into the array a previously returned
+task already captured. Whoever is still awaiting that earlier task
+therefore never learns about maintenance scheduled after they obtained it.
+The public `WaitForMaintenance` path does not have this exposure: it holds
+`s_maintenanceLock` for its entire wait, so no `RegisterVersionedCategory`
+call can interleave and schedule additional work while it is in progress.
+`CancelAndWaitForMaintenance(timeout)` can return
 *partial* progress rather than confirmation that maintenance fully drained:
 `WaitForMaintenance` waits for the timeout given, then — if the task has not
 completed — cancels it and waits only another 25ms before returning whatever
@@ -722,7 +824,20 @@ the writer's still-open temporary file) that is not the narrow
 already-deleted case `Clear` catches, and so propagates to `Clear`'s caller.
 A caller relying on "the value I just set survives" immediately after a
 concurrent `Clear`, or relying on `Clear` never throwing because reads and
-writes elsewhere are best-effort, has no contract to rely on. No caller
+writes elsewhere are best-effort, has no contract to rely on. There is a
+fourth outcome the three above do not cover, and it is the one that leaves
+`Clear` looking most misleadingly successful: a `Set`/`SetBytes` call whose
+`Directory.CreateDirectory` and `WriteAtomically`/file-move both complete
+*after* `Clear`'s `Directory.Delete` call has already finished (still inside
+`Clear`'s `lock (s_maintenanceLock)`, since that lock never excludes
+`Set`/`SetBytes`, which take no lock at all) recreates part of the tree
+`Clear` just removed, and does so without raising any exception on either
+side. `Clear` still returns its pre-deletion measurement successfully in
+this case; nothing about that successful, non-throwing return means the
+cache root was empty at the moment `Clear` returned, or even that it is
+still empty by the time the caller next inspects it — `Clear`'s success is
+not a quiescence barrier and does not guarantee an empty cache at return,
+only that the deletion `Clear` itself performed did not fail. No caller
 within a single process clears a category while concurrently writing to it
 today, but two separate `dotnet-inspect` invocations racing this way is
 already possible; closing this gap (a future caller, in-process or

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -72,9 +72,11 @@ differently, but the difference is enforced for only one of them:
   key built from untrusted content — a package id, a URL, source text — can
   never produce a path outside the two-level hash bucket. The filesystem path
   is not `key`'s only sink, though: every telemetry event that *is* produced
-  (not every operation reaches telemetry — a read that fails before its own
-  telemetry call, or a write that fails before publication, produces no
-  event at all; see
+  (not every operation reaches telemetry — a non-`maxAge` read whose file
+  read fails before its own hit-telemetry call produces no event at all,
+  though the `maxAge` overloads normally still emit a miss event from that
+  same failure; a write that fails before publication likewise produces no
+  event; see
   [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)
   below) carries
   the original, unhashed `key` to `CacheTelemetry.Record` — that is a second,
@@ -96,8 +98,10 @@ differently, but the difference is enforced for only one of them:
   the filesystem path — every telemetry event that *is* produced (the same
   caveat as `key`'s above) carries it (via
   `GetTelemetryCategory`, below) to `CacheTelemetry.Record` — but unlike
-  `key`, nothing contains or redacts it there; it is recorded exactly as
-  received.
+  `key`, nothing contains or redacts it there; it is normally recorded
+  exactly as received, except that `GetTelemetryCategory` itself rewrites a
+  case-insensitive `symbol-misses` match to `{category}/{extension}` before
+  it reaches `CacheTelemetry.Record` (see the remapping described below).
 - **`extension`** is concatenated verbatim after the hash suffix. Most call
   sites pass a literal (`"json"`, `"forbidden"`, `"miss"`, `"md"`, `"tsv"`),
   but `SymbolPackageDownloader.Storage.cs` passes a local variable selected
@@ -399,7 +403,12 @@ overwrite: true)` to publish it, then unconditionally attempts
 `File.Delete(tempPath)` in a `finally` block (a no-op after a successful
 move, since the temp path no longer exists). This is `CoreCache`'s own
 atomic single-file publication mechanism — a reader never observes a
-partially-written file — and is distinct from
+partially-written file, on a local filesystem with normal atomic
+rename/replace semantics (NTFS, APFS, ext4, or similar); a cache root
+redirected to a network, FUSE, or other unusual filesystem is limited by
+that filesystem's own rename and cache-coherency guarantees, as
+[`cache-concurrency.md`](cache-concurrency.md) notes for its own directory
+staging protocol — and is distinct from
 [`cache-concurrency.md`](cache-concurrency.md)'s package-*directory* staging
 protocol (stage into a temp directory, then `Directory.Move` the whole tree
 into place), which that document owns.
@@ -1034,7 +1043,12 @@ overload observed it:
   only the hit counter is incremented, not both.)
 - **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
   `catch`, so a throwing subscriber is swallowed the same way any other write
-  failure is.
+  failure is — but not with the same outcome: the telemetry call happens
+  only after `WriteAtomically` has already published the new content via
+  `File.Move`, so a throwing subscriber here is swallowed *after* the write
+  has committed, and the method returns normally with the new content
+  already stored (there is no rollback of a successful publish because a
+  later telemetry call failed).
 
 This mechanism does not isolate telemetry from the operation it is
 recording; "fire-and-forget" describes the caller's intent, not an enforced

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -33,8 +33,15 @@ docs-only change.
   changes every subsequent path, containment, and clear decision without any
   `Initialize` call at all (see the trust-boundary and initialization-lifecycle
   sections below for the concrete consequences);
-- a collision-resistant, filesystem-safe path for a caller-chosen key within
-  a category;
+- a collision-resistant, filesystem-safe path for a caller-chosen
+  well-formed key within a category — `GetFilePath` hashes
+  `Encoding.UTF8.GetBytes(key)` using the standard replacement-fallback
+  `Encoding.UTF8` instance, so a *malformed* UTF-16 key (for example, one
+  containing a lone surrogate) is not rejected but is silently
+  replacement-normalized before hashing; two distinct malformed keys that
+  normalize to the same UTF-8 bytes collide. Containment still holds (the
+  guarantee stays inside the hash bucket), but collision resistance is a
+  claim about well-formed Unicode input, not every .NET string;
 - read, write, and background-maintenance operations whose *filesystem-access*
   failures are swallowed and observed only as a miss or as maintenance making
   no progress. This is not a blanket best-effort guarantee, and it is not
@@ -85,11 +92,19 @@ differently, but the difference is enforced for only one of them:
   every platform's default base path (`GetDefaultBasePath`'s
   `Path.Combine(..., AppName)` on each branch); `Initialize` only rejects a
   null or all-whitespace value. The current production caller passes one
-  fixed literal at process startup.
+  fixed literal at process startup. `appName` also, independently of any
+  `basePath` override, controls a *second* root `IsPathInCacheContext`
+  anchors to: on non-Windows platforms `GetLegacyBasePath` builds
+  `{LocalApplicationData}/{AppName}` and `IsPathInCacheContext` accepts a
+  descendant of that legacy root unconditionally — even when an explicit
+  `basePath` override is active — so `appName` is not merely a default-path
+  input; it is a live containment anchor of its own.
 - **`basePath`** (`Initialize`'s second, optional parameter) is returned
   verbatim by `GetBasePath()` with no validation at all — not even the
-  null/whitespace check `appName` gets — and becomes the trusted root that
-  `IsPathInCacheContext` anchors every containment decision to. Unlike
+  null/whitespace check `appName` gets — and becomes the *active-root* anchor
+  `IsPathInCacheContext` checks a candidate path against; it is not the sole
+  anchor, though — the legacy root derived from `appName` above is checked
+  too, unconditionally. Unlike
   `category`/`extension`/`appName`, this is **not** a fixed-literal value in
   production today: `dotnet-inspect`'s CLI entry point
   (`src/dotnet-inspect/Program.cs`) resolves it with explicit precedence —
@@ -107,12 +122,21 @@ differently, but the difference is enforced for only one of them:
   `category` or `extension` — and it is exercised in production, not merely
   hypothetical. `basePath` is not the only environment-controlled root
   input, either: when no override is supplied at all,
-  `GetDefaultBasePath`'s Linux branch reads `XDG_CACHE_HOME` directly and
-  uses it verbatim as the parent of `appName`, with the same absence of
-  validation. It is a narrower concession than an explicit `basePath`
-  override (since `appName` is still appended beneath it), but it is a
-  second, always-live environment-controlled root selector on Linux, not a
-  hypothetical one.
+  `GetDefaultBasePath`'s Linux branch reads `XDG_CACHE_HOME` directly and,
+  when it is non-empty (`!string.IsNullOrEmpty`, so a whitespace-only value
+  still counts as set), uses it verbatim as the parent of `appName` with no
+  further validation — this is not quite "the same absence of validation" as
+  `basePath`, though: an explicit `basePath` override is accepted whenever it
+  is non-null, including an empty string, while a `null` or empty
+  `XDG_CACHE_HOME` is treated as unset and falls back to `~/.cache`; only a
+  non-empty value receives XDG's verbatim, unvalidated treatment. It is a
+  narrower concession than an explicit `basePath` override (since `appName`
+  is still appended beneath it), but it is a second, always-live
+  environment-controlled root selector on Linux, not a hypothetical one.
+  Neither environment-controlled root is the sole anchor `IsPathInCacheContext`
+  checks against, either — see the `appName` bullet above and
+  [Path-context containment](#path-context-containment) for the
+  independently-anchored legacy root.
 
 The contract is: **`category`, `extension`, and `appName` are caller-owned
 values that every current producer restricts to a fixed literal or a
@@ -177,7 +201,21 @@ other owners call it directly, but not exclusively before deletion —
 operation begins (`Directory.CreateDirectory`, copying staged contents in);
 that same single guard call also covers the staging path's later, separate
 best-effort cleanup delete in a `finally` block once publication succeeds or
-fails, since the guarded local variable is reused rather than re-derived.
+fails, since the guarded local variable is reused rather than re-derived —
+this coverage is point-in-time, though, not a re-verified guarantee at
+delete time: `IsPathInCacheContext` resolves the guarded string with
+`Path.GetFullPath` internally but returns only a `bool`, not the resolved
+absolute path, so the *original*, possibly-relative string is what the
+later delete actually uses. `GetBasePath()`/`basePath` are not guaranteed
+absolute — production accepts `DOTNET_INSPECT_CACHE_DIR` verbatim with no
+rootedness check (see the trust-boundary section above) — so if a relative
+root or staging path is in play and the process's current directory changes
+between the guard call and the later delete, the same string can resolve to
+a different location than the one actually checked. No current caller
+changes the working directory during a commit/cleanup cycle, but the guard
+does not itself close this window; it assumes a stable current directory
+and an absolute (or effectively unchanging) resolved path across the reused
+call.
 Only `PlatformPackService`'s separate `destDir` guard (inside its
 content-copy helper, before overwriting an existing destination
 subdirectory) and `PackageCacheService`'s legacy-cache guard are dedicated
@@ -257,6 +295,22 @@ partially-written file — and is distinct from
 protocol (stage into a temp directory, then `Directory.Move` the whole tree
 into place), which that document owns.
 
+Publication is atomic per file, but `CoreCache` provides no serialization
+*between* operations on the same category/key: `TryGet`/`TryGetBytes`/`Set`/
+`SetBytes` take no lock of any kind (`s_maintenanceLock` guards only the
+maintenance-related methods listed above). Two concurrent `Set` calls for
+the same path each write their own temp file and each call
+`File.Move(..., overwrite: true)`; whichever move lands last wins, and it is
+not necessarily the call that was invoked last — only the call whose move
+completes last. A concurrent reader can therefore observe either publisher's
+complete content, never a mix of the two (each move is a single atomic
+rename), but a `maxAge` read is not itself one atomic observation: the
+existence/freshness check (`FileInfo.Exists`/`LastWriteTimeUtc`) and the
+subsequent content read are two separate filesystem operations, so a
+concurrent `Set` between them can mean the freshness decision was made
+against one generation of the file while the bytes actually returned came
+from a different, newer one.
+
 ## Initialization lifecycle
 
 `Initialize(appName, basePath)` is not an idempotent no-op past the first
@@ -268,15 +322,24 @@ path resolves to the same location as the old one (`IsSamePath` — subject to
 the case-sensitivity gap in
 [Path-context containment](#path-context-containment)); otherwise they reset,
 because the counters describe one cache root's history and a root change
-starts a new one. Both sides of that comparison are *recomputed live* at the
-moment of the second `Initialize` call, not the location actually recorded
-against by the earlier maintenance: the "old" root is `GetBasePath()`
-evaluated with the previous `appName`/`basePath` but the *current* process
-environment, and the "new" root is `GetBasePath()` evaluated with the new
-values and that same current environment. If `appName` is unchanged across
+starts a new one. Both sides of that comparison are *recomputed live*, not
+the location actually recorded against by the earlier maintenance — but not
+at the *same instant*, either: the "old" root (`GetBasePath()` evaluated
+with the previous `appName`/`basePath`) is read first, before the
+cancellation and best-effort drain of in-flight maintenance tasks; the
+"new" root (`GetBasePath()` evaluated with the new values) is read only
+afterward, once `_appName`/`_basePathOverride` have already been updated.
+The description below treats both reads as observing one shared snapshot of
+"the current process environment" — that holds only when no ambient input
+`GetDefaultBasePath` reads (for example `XDG_CACHE_HOME`) changes *during*
+the drain window between the two reads; if one does, the "old" and "new"
+sides can genuinely disagree about the environment even with `appName`
+unchanged, independent of the environment-change scenario discussed next.
+If `appName` is unchanged across
 the two calls, and no explicit `basePath` override was ever given, and
 `XDG_CACHE_HOME` (or another ambient input `GetDefaultBasePath` reads)
-changes between the first and second `Initialize` call, both sides of the
+changes between the first and second `Initialize` call (and stays stable
+across the drain window in between), both sides of the
 comparison observe the *same* changed environment and so still compare equal
 — counters can carry forward across an actual root change that neither
 `Initialize` call's caller intended, and conversely cannot be relied on to
@@ -316,9 +379,16 @@ throws, the already-consumed counters are lost with no return value to
 carry them.
 
 `RegisterVersionedCategory` may be called before or after `Initialize`, and
-repeated registration of the same prefix is idempotent only when `current`
-is unchanged; a second registration with a different `current` for a
-known prefix throws. Registered categories are never forgotten across a later
+repeated registration of the same prefix is idempotent when `current`
+is unchanged, comparing both `prefix` (the registry's dictionary key) and
+`current` case-insensitively (`StringComparer.OrdinalIgnoreCase` and
+`string.Equals(..., StringComparison.OrdinalIgnoreCase)` respectively) — so
+a repeat registration that differs from the first only in casing is treated
+as the same registration, not a conflicting one; a second registration
+whose `current` differs in any other way (a different suffix, or a
+different leading-zero spelling that parses to the same integer but is not
+an exact case-insensitive string match) for a known prefix throws. Registered
+categories are never forgotten across a later
 `Initialize` call — re-initializing to a different root replays cleanup for
 every previously registered category under that new root.
 
@@ -403,15 +473,58 @@ later consumes into its return value (see
 undercount real reclaimed space for a reason distinct from the concurrent-write
 undercounting already described there.
 
+**Gap:** `CleanupVersionedCategory`'s own deletion step is not transactional
+either — `Directory.Delete(directory, recursive: true)` and the subsequent
+`progress.RecordDeletion(size)` are both wrapped in one blanket `catch` that
+swallows any exception silently ("Cache cleanup is best-effort and retried
+on the next initialization"). If the recursive delete removes some files
+before encountering one it cannot remove (a concurrent writer holding the
+file, a permissions error partway through), the directory is left
+*partially* deleted and `RecordDeletion` never runs — no bytes, no
+directory count, and no indication that the directory was touched at all;
+the next `Initialize`/registration cycle will reattempt it (the surviving
+directory still matches the retirement rule), but until then the on-disk
+state is neither the pre-cleanup directory nor a cleanly retired one.
+`Clear`'s own `Directory.Delete(targetPath, recursive: true)` (see
+[Clear and concurrent writers](#clear-and-concurrent-writers)) has the
+equivalent exposure in the opposite direction: it catches only
+`DirectoryNotFoundException` (and only when the directory no longer
+exists), so any other exception from a partially-completed recursive delete
+propagates out of `Clear` to the caller — a caller that catches and ignores
+that exception, or does not catch it at all, cannot tell from the exception
+alone whether the target survived untouched or was partially removed.
+
+**Gap:** the two counters `CacheMaintenanceProgress` tracks —
+`_bytesFreed` and `_directoriesDeleted` — are each individually
+thread-safe (`Interlocked.Add`/`Increment`/`Exchange`/`Read`), but the pair
+is not updated or read atomically together. `RecordDeletion` performs two
+separate `Interlocked` operations (bytes, then count), and both
+`Snapshot()`/`TakeSnapshot()` likewise read or reset the two fields with two
+separate `Interlocked` calls. Background cleanup (`CleanupVersionedCategory`)
+calls `RecordDeletion` without holding `s_maintenanceLock`, while
+`WaitForMaintenance` reads the pair via `Snapshot()`/`TakeSnapshot()` while
+holding that lock — the lock does not prevent a concurrent, lock-free
+`RecordDeletion` call from executing between the two `Interlocked`
+operations inside `Snapshot()`/`TakeSnapshot()`. A caller can therefore
+observe a `CacheMaintenanceResult` where one field reflects a deletion that
+just completed and the other does not yet (or, symmetrically, where
+`TakeSnapshot()`'s reset of one field races a deletion recorded between the
+two exchanges) — the returned `(BytesFreed, DirectoriesDeleted)` pair is not
+guaranteed to describe one consistent point in time.
+
 **Gap:** the retirement rule above is scoped to one registered family (one
 `prefix`) at a time; nothing prevents two *different* registered prefixes
 from overlapping, and a directory that is the current member of one family
 can parse as an obsolete member of another. For example, registering
 `("foo-v", "foo-v20")` and `("foo-v2", "foo-v21")` both succeed —
-`s_versionedCategories` keys by the literal prefix string, so `"foo-v"` and
-`"foo-v2"` are distinct entries — but the second family's cleanup sees
-directory `foo-v20`, matches its `"foo-v2"` prefix, parses suffix `0`, and
-deletes it as obsolete (`0 < 21`), even though `foo-v20` is the *current*,
+`s_versionedCategories` keys the registry case-insensitively
+(`StringComparer.OrdinalIgnoreCase`), but `"foo-v"` and `"foo-v2"` still
+compare as distinct entries — but the second family's cleanup sees
+directory `foo-v20`, matches its `"foo-v2"` prefix, parses the remainder
+after the 6-character prefix (`"0"`) as suffix `0`, and deletes it as
+obsolete (`0 < 1`, since `"foo-v21"`'s own suffix after that same
+6-character prefix is `"1"`, making the second family's current version 1,
+not 21) — even though `foo-v20` is the *current*,
 still-referenced directory for the first family. `prefix`/`current` are
 therefore not just validated strings but caller-controlled deletion
 selectors whose safety depends on every registered family's prefix language
@@ -567,6 +680,19 @@ overload observed it:
   subscriber (or another) also throws on the miss observation, the exception
   propagates out of the method — unlike the non-`maxAge` overloads, a
   throwing hit subscriber does not reliably degrade to a silent `null` here.
+  This path also double-counts the `InfoTracker` counters, independent of
+  whether the *hit* telemetry subscriber itself is what throws:
+  `InfoTracker.RecordCacheHit()` runs, unconditionally, *before*
+  `CacheTelemetry.Record(..., Hit)` inside the same `try`; if that
+  `CacheTelemetry.Record` call throws for any reason (a hit subscriber, or
+  the `Activity.Current?.AddEvent` call itself), the already-incremented hit
+  counter is not rolled back, and control falls through to the shared
+  miss-path code below, which unconditionally calls
+  `InfoTracker.RecordCacheMiss()` too — so one logical read increments both
+  the hit and the miss counter. (If the miss-telemetry call *also* throws,
+  `RecordCacheMiss()` — which runs immediately after it, unguarded — never
+  executes, and the exception propagates as described above; in that case
+  only the hit counter is incremented, not both.)
 - **`Set`/`SetBytes`:** the telemetry call is inside the method's own blanket
   `catch`, so a throwing subscriber is swallowed the same way any other write
   failure is — the activity event (if any) and any subscribers up to and

--- a/docs/design/corecache-mechanism.md
+++ b/docs/design/corecache-mechanism.md
@@ -43,9 +43,19 @@ docs-only change.
   guarantee stays inside the hash bucket), but collision resistance is a
   claim about well-formed Unicode input, not every .NET string;
 - read, write, and background-maintenance operations whose *filesystem-access*
-  failures are swallowed. A read failure is observed as a miss (a `null`
-  result), and a maintenance failure is observed as no progress recorded for
-  that directory — but a write failure has no comparable observable outcome
+  failures are swallowed. A read failure is normally observed as a miss (a
+  `null` result) — though a `maxAge` read's own miss-telemetry call can
+  still propagate an exception after the swallowed filesystem failure,
+  since that telemetry call runs unguarded (see the maxAge miss-telemetry
+  note under
+  [Telemetry](#telemetry-is-fire-and-forget-but-not-exception-isolated)) —
+  and a maintenance measurement failure is normally observed as no progress
+  recorded for that directory, though a directory that fails to measure but
+  still deletes successfully is counted as one retired directory with zero
+  bytes rather than no progress at all (see the measurement-failure Gap
+  under
+  [Versioned category retirement](#versioned-category-retirement)) —
+  but a write failure has no comparable observable outcome
   at all: `Set`/`SetBytes` simply return, silently discarding the failure,
   and a subsequent read can still be a hit if an existing entry from a prior
   successful write is still in place (a failed write does not delete or
@@ -383,9 +393,14 @@ its own exception handling is mixed rather than absent: it returns an empty
 check reports `false` (ambiguous, as elsewhere, between "does not exist" and
 "error determining existence"); the size measurement it delegates to
 (`GetDirectorySize`) performs a *second*, independent `Directory.Exists`
-check with the same ambiguity and returns `0` rather than propagating; but
+check with the same ambiguity and returns `0` only for that second check —
+but once that second check passes, `GetDirectorySize`'s own recursive
+`EnumerateFiles(...).Sum(f => f.Length)` has no guard at all, so it can
+itself propagate an enumeration or length-read failure before file counting
+is ever reached; and
 the file-count enumeration, `Directory.GetFiles(targetPath, "*",
-SearchOption.AllDirectories)`, has no guard at all and propagates any
+SearchOption.AllDirectories)`, likewise has no guard at all and propagates
+any
 enumeration failure that occurs after both existence checks have already
 passed. So a category contract violation reaching
 it is also an out-of-root enumeration read, not just a write/delete
@@ -743,10 +758,19 @@ it from ever faulting). The key is only removed — and a fresh attempt
 scheduled — by a subsequent `Initialize` call (which replaces
 `s_maintenanceTasks` with a new, empty dictionary) or by
 `StartNewMaintenanceGenerationIfCanceled` replacing a canceled generation; a
-changed root (via a different `basePath`/`appName`, or the ambient-input
-change discussed above) also produces a different key and so schedules a
+changed `GetBasePath()` *string* (via a different `basePath`/`appName`)
+also produces a different key and so schedules a
 fresh attempt against that new root, but this is really "different key
-scheduled," not "same failed attempt retried."
+scheduled," not "same failed attempt retried." That key-based
+invalidation is itself sensitive to the relative-root exposure discussed
+above, though: `VersionedCacheCleanupKey` stores whatever unresolved string
+`GetBasePath()` returns, not a resolved absolute path, so changing only the
+*resolution* of an unchanged relative `basePath` (for example, a
+process-wide current-directory change) changes the physical root on disk
+without changing the key string — the existing task stays memoized under
+the old key, and the new physical root is never scheduled for cleanup at
+all, contrary to what "a changed root ... schedules a fresh attempt" would
+otherwise suggest.
 `Clear`'s own `Directory.Delete(targetPath, recursive: true)` (see
 [Clear and concurrent writers](#clear-and-concurrent-writers)) has the
 equivalent exposure in the opposite direction: it catches only

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1044,6 +1044,9 @@ restarts affected work before presentation.
 
 `CoreCache` is shared infrastructure for category roots, path-safe hashed keys,
 maintenance, and cache telemetry. It is a mechanism, not a semantic authority.
+The mechanism's own contract — the category/key/extension trust boundary,
+path-context containment, initialization lifecycle, and versioned category
+retirement — is owned by the [CoreCache mechanism](design/corecache-mechanism.md).
 
 The cache owner for each result must still define:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -79,10 +79,11 @@ substrates, and inspection producers that will extend that space.
   defined by [nuspec structural compatibility](design/nuspec-structural-compatibility.md);
   Queries owns manifest identity, dependency validation, and resource policy.
 - `src/DotnetInspector.Core/` is the reference-free tool runtime kernel beneath
-  Packages, Services, and the CLI: cache roots and eviction (`CoreCache`,
-  `AsyncCache`, see the [CoreCache mechanism](design/corecache-mechanism.md)),
-  the single `HttpClientFactory` seam with offline and network-policy
-  enforcement, network telemetry, and hardened XML/JSON readers.
+  Packages, Services, and the CLI: cache roots and eviction
+  (`CoreCache`, see the [CoreCache mechanism](design/corecache-mechanism.md);
+  `AsyncCache` is a separate in-memory single-flight coalescer), the single
+  `HttpClientFactory` seam with offline and network-policy enforcement,
+  network telemetry, and hardened XML/JSON readers.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
 - `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
 - `prototypes/annotated-source-viewer/` is the dependency-free browser consumer

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -80,8 +80,9 @@ substrates, and inspection producers that will extend that space.
   Queries owns manifest identity, dependency validation, and resource policy.
 - `src/DotnetInspector.Core/` is the reference-free tool runtime kernel beneath
   Packages, Services, and the CLI: cache roots and eviction (`CoreCache`,
-  `AsyncCache`), the single `HttpClientFactory` seam with offline and
-  network-policy enforcement, network telemetry, and hardened XML/JSON readers.
+  `AsyncCache`, see the [CoreCache mechanism](design/corecache-mechanism.md)),
+  the single `HttpClientFactory` seam with offline and network-policy
+  enforcement, network telemetry, and hardened XML/JSON readers.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
 - `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
 - `prototypes/annotated-source-viewer/` is the dependency-free browser consumer


### PR DESCRIPTION
## Claim

`CoreCache` (`DotnetInspector.Core`) is one of the oldest components in the
repo and sits on the untrusted-data path, but had no owning design doc. This
adds `docs/design/corecache-mechanism.md` as its focused owner: the
category/key/extension trust boundary, path-context containment,
initialization lifecycle, and versioned category retirement. It is scoped to
the mechanism only — it does not redefine the semantic-key/caller contract
already owned by `docs/inspection-space.md#CoreCache`, or the package-content
publication protocol owned by `docs/design/cache-concurrency.md`.

## Evidence

The retro-spec was written directly against `CoreCache.cs` and its current
callers (grepped every `CoreCache.TryGet`/`Set`/`GetCategoryPath` call site to
confirm `category`/`extension` are always literals today). It surfaces four
gaps in the existing implementation, each recorded as a **Gap** with
recommended follow-up rather than fixed here:

- `category`/`extension` are caller-owned-literal by convention only; nothing
  enforces it, so a future caller deriving either from untrusted content would
  gain a silent path-traversal read/write primitive (`key` is the only
  parameter this mechanism actually defends, via SHA-256 hashing).
- `EnsurePathInCacheContext` guards only the `Clear` path, not writes.
- `Initialize` is effectively single-writer, but `_appName`/`_basePathOverride`
  are read without synchronization from every other method — a data race if
  `Initialize` is ever called concurrently with cache use.
- `Clear` does not coordinate with concurrent `Set`/`SetBytes`; a racing write
  can be silently dropped with no delivery guarantee.

Whether the concurrency gaps warrant a TLA+ model was evaluated per
`docs/design-scope.md`: the `Initialize`/path-containment gaps are simple
invariants (fixable with a lock/assertion, no real state space); the
versioned-category maintenance generation/cancellation/drain lifecycle is a
plausible candidate if/when that gap is fixed, deferred to that follow-up.

## Compatibility / non-action boundary

Docs-only: no product code, test, or build changes. Does not fix any of the
four gaps — those are named as follow-up work.

## Validation

`npx markdownlint-cli` clean on every changed file:
`docs/design/corecache-mechanism.md`, `docs/README.md`, `docs/overview.md`,
`docs/inspection-space.md`, `docs/design/cache-concurrency.md`.