### PR TITLE
Clarify agent PR, review, and design scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,13 @@ documentation.
   ask the user when it is unclear whether a new design is needed. Finding
   defects in a design is always cheaper than finding them in code.
 - **Requested work hot-starts through PR and review.** Agents may branch,
-  commit, push, open a PR, and dispatch round 1 without separate approval.
-  Replacement rounds inside the current six-round block also dispatch
+  commit, push, and open its PR without separate approval. Once eligible, round
+  1 and every replacement inside the current six-round block dispatch
   automatically; only a new block (rounds 7, 13, 19, ...) requires approval.
   Merge remains separately authorized.
-- **Markdown-only PRs hot-start immediately.** When every changed file is
-  `*.md`, `markdownlint` is the only pre-review and per-round gate. Open the PR
-  and dispatch review without asking or waiting for `ci-required`.
+- **Markdown-only PRs hot-start immediately at non-boundary rounds.** When every
+  changed file is `*.md`, `markdownlint` is the pre-review and per-round gate.
+  Open the PR and dispatch review without asking or waiting for `ci-required`.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -133,9 +133,9 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 
 ### Standing adjustments
 
-- **Review in parallel with CI:** requires the user's approval for that PR. A CI
-  failure requiring an author change still supersedes the attempt, and all
-  findings carry forward.
+- **Review non-Markdown changes in parallel with CI:** requires the user's
+  approval for that PR. A CI failure requiring an author change still
+  supersedes the attempt, and all findings carry forward.
 - **Auto-merge on the final push:** once every required review is review-clean,
   or the intended final head/base carries an approved exact-head
   trivial-interaction waiver, the user may authorize auto-merge for that exact
@@ -395,11 +395,11 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    CI and GitHub's live mergeability immediately before every merge attempt,
    even when `review-clean` is present.
 6. **A round closes only when reconciled and its applicable gates are green.**
-   A known-red current-head `ci-required` still blocks; unavailable or pending
-   status follows
+   For a non-Markdown-only PR, known-red `ci-required` blocks; pending status follows
    [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
-   A Markdown-only PR's per-round gate is pre-commit `markdownlint`; do not wait
-   for `ci-required` before review. Author changes restart the *same* round.
+   At non-boundary rounds, a Markdown-only PR's gate is pre-commit
+   `markdownlint`; do not wait for CI before review. A gate failure requiring an
+   author change restarts the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
@@ -553,10 +553,10 @@ Put it under `## Demo` above validation in the PR body.
 - Use REST endpoints via `gh api`, not `gh pr edit`, for PR/issue metadata
   changes; see [GitHub API operations](docs/github-api-operations.md) for the
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
-- For non-Markdown-only PRs, treat CI as confirmation: run the focused gate;
-  run eligible local suites, CI, and review concurrently. Query GitHub status
-  only when the round cadence requires it, using response headers instead of
-  quota probes, and follow
+- For non-Markdown-only PRs, run the focused gate, push promptly, and start
+  eligible local suites and CI concurrently. Reviewer dispatch waits for green
+  `ci-required` unless the user approved parallel review. Query GitHub status
+  only when the round cadence requires it; follow
   [GitHub status queries](docs/github-status-queries.md)'s bounded waiting
   instead of polling. If an hour passes without an authored change while an
   independent gate hasn't started, fix the sequencing or record the blocker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,14 +16,14 @@ documentation.
 
 ### How work runs on this repo
 
-- **Design first.** Work must be covered by a design or reasonably extend one;
-  ask the user when it is unclear whether a new design is needed. Finding
-  defects in a design is always cheaper than finding them in code.
-- **Requested work hot-starts through PR and review.** Agents may branch,
-  commit, push, and open its PR without separate approval. Once eligible, round
-  1 and every replacement inside the current six-round block dispatch
-  automatically; only a new block (rounds 7, 13, 19, ...) requires approval.
-  Merge remains separately authorized.
+- **Design first and state the basis.** Before starting new work, visibly name
+  one normative owner and exact owned claim, then supporting designs and models
+  by role. If ownership is unclear or multiple, apply the design-scope rules or
+  ask the user; finding design defects is cheaper than finding them in code.
+- **Requested work hot-starts through PR and review.** Agents may branch, commit,
+  push, and open its PR without separate approval. Once eligible, round 1 and
+  replacements inside the current six-round block dispatch automatically; only
+  a new block requires approval. Merge remains separately authorized.
 - **Markdown-only PRs hot-start immediately at non-boundary rounds.** When every
   changed file is `*.md`, `markdownlint` is the pre-review and per-round gate.
   Open the PR and dispatch review without asking or waiting for `ci-required`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,10 +517,11 @@ replacement within an authorized block dispatches without asking, setting
 `HELP`, or waiting for user input. Approval is required only before rounds 7,
 13, 19, and so on; each approval authorizes at most six more rounds.
 
-At a block boundary, conflict recovery may push immediately, but reviewer
-dispatch waits for approval. Before asking, acquire fresh green current-head
-`ci-required` and definite positive mergeability under the 60-minute status
-budget; if it expires, publish its report and stop without asking.
+At a block boundary, conflict recovery may push immediately unless an immutable
+split decision hold is active; reviewer dispatch waits for approval. Before
+asking, acquire fresh green current-head `ci-required` and definite positive
+mergeability under the 60-minute status budget; if it expires, publish its
+report and stop without asking.
 
 Round 12 and every later six-round boundary presume splitting into focused
 successors unless a strong, user-approved reason keeps the PR intact. Full

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,14 @@ documentation.
 - **Design first.** Work must be covered by a design or reasonably extend one;
   ask the user when it is unclear whether a new design is needed. Finding
   defects in a design is always cheaper than finding them in code.
-- **Markdown-only PRs do not wait on CI before review.** When every changed
-  file is `*.md`, `markdownlint` is the only pre-review and per-round gate.
-  Dispatch review without checking or waiting for `ci-required`.
+- **Requested work hot-starts through PR and review.** Agents may branch,
+  commit, push, open a PR, and dispatch round 1 without separate approval.
+  Replacement rounds inside the current six-round block also dispatch
+  automatically; only a new block (rounds 7, 13, 19, ...) requires approval.
+  Merge remains separately authorized.
+- **Markdown-only PRs hot-start immediately.** When every changed file is
+  `*.md`, `markdownlint` is the only pre-review and per-round gate. Open the PR
+  and dispatch review without asking or waiting for `ci-required`.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -507,25 +512,19 @@ follow-up work unless the operator explicitly approves it.
 
 ### Stop after six rounds
 
-Rounds 1-6 are the initial authorized block. Within an authorized block, a
-fix-producing round that requires replacement review continues automatically:
-report `Recommendation: continue` and begin the next candidate cycle without
-asking for approval, setting `HELP`, or waiting for user input.
+Review blocks hot-start. Rounds 1-6 begin automatically, and every fix-producing
+replacement within an authorized block dispatches without asking, setting
+`HELP`, or waiting for user input. Approval is required only before rounds 7,
+13, 19, and so on; each approval authorizes at most six more rounds.
 
-Approval is required only before rounds 7, 13, 19, and so on. Each approval
-allows at most six more rounds; stop sooner when review converges. At a block
-boundary, conflict recovery may resolve and push immediately, but reviewers
-still wait for approval unless an immutable split decision hold is active — a
-boundary push resets the status prerequisite, so checks from the previous head
-do not satisfy it. Before offering `approve next rounds`, acquire fresh green
-current-head `ci-required` and definite positive mergeability under the
-60-minute status budget; if it expires, publish the status budget report and
-stop observation without opening an approval prompt.
+At a block boundary, conflict recovery may push immediately, but reviewer
+dispatch waits for approval. Before asking, acquire fresh green current-head
+`ci-required` and definite positive mergeability under the 60-minute status
+budget; if it expires, publish its report and stop without asking.
 
-Round 12, and every six-round boundary after it, carries a presumption to
-split remaining work into focused successors rather than continue, unless a
-strong, user-approved reason keeps the PR intact. Checkpoint questions, the
-split exception, and execution mechanics:
+Round 12 and every later six-round boundary presume splitting into focused
+successors unless a strong, user-approved reason keeps the PR intact. Full
+checkpoint and split mechanics:
 [Block boundaries and splitting](docs/round-orchestration.md#block-boundaries-and-splitting).
 
 ## Lead with the demo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ documentation.
 - **Design first.** Work must be covered by a design or reasonably extend one;
   ask the user when it is unclear whether a new design is needed. Finding
   defects in a design is always cheaper than finding them in code.
-  Docs-only PRs move faster than code PRs: a code PR must wait on CI before
-  review, to avoid spending agent time reviewing a broken build, but a
-  docs-only PR only needs `markdownlint` and does not wait on CI at all.
+- **Markdown-only PRs do not wait on CI.** When every changed file is `*.md`,
+  `markdownlint` is the only pre-review and per-round gate. Dispatch review
+  without checking or waiting for `ci-required`.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -45,8 +45,8 @@ documentation.
   executes code, which narrows the threat model. We don't defend against
   local or intra-repo actors. `InertString` and `HardenedJson` are the model:
   construction-time containment threaded through the object model (see
-  [Security work follows the actual trust
-  boundary](#security-work-follows-the-actual-trust-boundary)).
+  [Keep design and adversarial review within
+  scope](#keep-design-and-adversarial-review-within-scope)).
 
 > A change spanning Markout and this repo is rare and uses a separate
 > co-development loop: read
@@ -267,19 +267,19 @@ over-broad-design recovery procedure live in
   "whitelist"/"blacklist" (match casing and word form, e.g. `allowList`,
   "deny-listed").
 
-### Security work follows the actual trust boundary
+### Keep design and adversarial review within scope
 
-Our primary scenario is downloading and processing untrusted internet data; the
-tool never executes inspected code. Local actors, contributors, and agents are
-not part of the threat model — that is a code-review or repository-hygiene
-concern, not product hardening. The full trust-boundary table, existing
-controls, and structural-containment guidance (`HardenedJson`,
-`InertText.InertString`) live in
+Do not add design requirements or adversarial-review findings for symlinks or
+reparse points; other users or agents acting on the same machine; or files
+mutating during inspection unless an owning design explicitly opts in.
+nuget.org content is immutable; local files may change freely between
+operations rather than provide stable snapshots. The primary threat is
+untrusted internet data; the tool never executes inspected code. Additional
+trust-boundary and containment guidance:
 [`docs/design/untrusted-data-threat-model.md`](docs/design/untrusted-data-threat-model.md#trust-boundaries).
-When a credible external-input threat exists, define it in the focused owning
-design first: name the actor, input path, boundary, containment invariant, and
-enforcement gate. Prefer a constrained type whose construction establishes the
-invariant over string conventions or scattered checks.
+For a credible external-input threat, first define its actor, input path,
+boundary, containment invariant, and enforcement gate in the owning design.
+Prefer construction-time containment (`HardenedJson`, `InertText.InertString`).
 
 ### Platform compatibility
 
@@ -392,8 +392,8 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    A known-red current-head `ci-required` still blocks; unavailable or pending
    status follows
    [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
-   A documentation-only PR's per-round gate is pre-commit `markdownlint`. A
-   failure requiring an author change restarts the *same* round.
+   A Markdown-only PR never waits for `ci-required`; its per-round gate is
+   pre-commit `markdownlint`. An author-change failure restarts the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
@@ -549,12 +549,11 @@ Put it under `## Demo` above validation in the PR body.
 ## PR and CI discipline
 
 - Keep concurrent agents modest and avoid unnecessary churn in central files.
-  Label a documentation-only PR (no product code, test, or build changes)
-  `documentation` when opening it.
+  Label a Markdown-only PR (every changed file is `*.md`) `documentation`.
 - Use REST endpoints via `gh api`, not `gh pr edit`, for PR/issue metadata
   changes; see [GitHub API operations](docs/github-api-operations.md) for the
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
-- Treat CI as confirmation: run the focused local gate, then push promptly;
+- For non-Markdown-only PRs, treat CI as confirmation: run the focused gate;
   run eligible local suites, CI, and review concurrently. Query GitHub status
   only when the round cadence requires it, using response headers instead of
   quota probes, and follow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ documentation.
 - **Design first.** Work must be covered by a design or reasonably extend one;
   ask the user when it is unclear whether a new design is needed. Finding
   defects in a design is always cheaper than finding them in code.
-- **Markdown-only PRs do not wait on CI.** When every changed file is `*.md`,
-  `markdownlint` is the only pre-review and per-round gate. Dispatch review
-  without checking or waiting for `ci-required`.
+- **Markdown-only PRs do not wait on CI before review.** When every changed
+  file is `*.md`, `markdownlint` is the only pre-review and per-round gate.
+  Dispatch review without checking or waiting for `ci-required`.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -269,9 +269,10 @@ over-broad-design recovery procedure live in
 
 ### Keep design and adversarial review within scope
 
-Do not add design requirements or adversarial-review findings for symlinks or
-reparse points; other users or agents acting on the same machine; or files
-mutating during inspection unless an owning design explicitly opts in.
+Unless an owning design explicitly opts in, do not add design requirements or
+adversarial-review findings for symlinks/reparse points, same-machine users or
+agents, or files mutating during inspection. Existing explicit controls remain
+governed by their owning designs.
 nuget.org content is immutable; local files may change freely between
 operations rather than provide stable snapshots. The primary threat is
 untrusted internet data; the tool never executes inspected code. Additional
@@ -392,8 +393,8 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    A known-red current-head `ci-required` still blocks; unavailable or pending
    status follows
    [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
-   A Markdown-only PR never waits for `ci-required`; its per-round gate is
-   pre-commit `markdownlint`. An author-change failure restarts the *same* round.
+   A Markdown-only PR's per-round gate is pre-commit `markdownlint`; do not wait
+   for `ci-required` before review. Author changes restart the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,9 +133,9 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 
 ### Standing adjustments
 
-- **Review non-Markdown changes in parallel with CI:** requires the user's
-  approval for that PR. A CI failure requiring an author change still
-  supersedes the attempt, and all findings carry forward.
+- **Review ordinary non-Markdown changes in parallel with CI:** requires user
+  approval; conflict recovery is the explicit exception. A CI failure requiring
+  an author change still supersedes the attempt, and all findings carry forward.
 - **Auto-merge on the final push:** once every required review is review-clean,
   or the intended final head/base carries an approved exact-head
   trivial-interaction waiver, the user may authorize auto-merge for that exact
@@ -556,8 +556,8 @@ Put it under `## Demo` above validation in the PR body.
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
   eligible local suites and CI concurrently. Reviewer dispatch waits for green
-  `ci-required` unless the user approved parallel review. Query GitHub status
-  only when the round cadence requires it; follow
+  `ci-required` unless parallel review is approved or conflict recovery applies.
+  Query GitHub status only when the round cadence requires it; follow
   [GitHub status queries](docs/github-status-queries.md)'s bounded waiting
   instead of polling. If an hour passes without an authored change while an
   independent gate hasn't started, fix the sequencing or record the blocker.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -86,10 +86,11 @@ Recovery transitions, applied without waiting for CI:
   unchanged head; repeat only with concrete transient evidence, otherwise treat
   it as an author change.
 
-A final-gate `ci-required` regression discovered after a Markdown-only
-round closes does not reopen that round: retry the unchanged head only with
-concrete transient evidence, otherwise remove `review-clean` and form a
-candidate at the next round number. Never close with a required check red. A
+A final-gate `ci-required` failure observed during or after a non-boundary
+Markdown-only round does not interrupt or reopen that round. Finish its review
+path; afterward, retry the unchanged head only with concrete transient evidence,
+otherwise remove `review-clean` and form a candidate at the next round number.
+Never close with a required check red. A
 superseded attempt spends no round and gets no completion report; let its
 reviewers finish or acknowledge cancellation, and carry every returned finding
 forward.
@@ -373,6 +374,9 @@ a blocker, and it clears only when every listed predicate clears.
   author or review round is needed, but `ci-required` remains pending or
   missing, use `Waiting: check:ci-required` and `Recommendation: wait`. Use
   `Waiting: check:ci-required,merge` when live mergeability is also unresolved.
+  A completed failure finishes the current round, then follows the final-gate
+  transition above; use `Recommendation: continue` only when the next round is
+  inside the authorized block.
   An intermediate or fix-producing round reports `continue` without waiting for
   CI only when the next round remains inside the current authorized block and
   the status cadence permits it. At a six-round boundary, fresh green

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -44,15 +44,16 @@ locked candidate.
 | --- | --- | --- |
 | First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, applicable CI rule below | Mergeability; eligible pending CI |
 | Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
-| Conflict-recovery attempt | Resolution head pushed, round number authorized, applicable CI rule below | Post-push local gates, mergeability; eligible pending CI |
+| Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, one status attempt, applicable CI rule below, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
 A non-Markdown candidate requires green current-head `ci-required` before
-reviewer dispatch unless the user authorized parallel review. A Markdown-only
-candidate (every changed file is `*.md`) substitutes pre-commit `markdownlint`
-at non-boundary rounds. Only those two exceptions make pending CI eligible;
-`ci-required` remains mandatory at six-round boundaries and final merge.
+reviewer dispatch unless the user authorized parallel review or conflict
+recovery applies. A Markdown-only candidate (every changed file is `*.md`)
+substitutes pre-commit `markdownlint` at non-boundary rounds. Only these
+exceptions make pending CI eligible; `ci-required` remains mandatory at
+six-round boundaries and final merge.
 
 ### Review-clean, and recovery
 
@@ -135,32 +136,37 @@ unrelated members such as `review`. In the table, **status members** means
 | PR is closed or draft | Leave the status wait, publish the human action or stopped state, and end. |
 | Head changed | Leave the status wait; route the returned head through candidate formation without inheriting fixed-head evidence. |
 | REST `mergeable: false` or GraphQL `mergeable: CONFLICTING` | Leave the status wait; apply conflict recovery before considering CI. |
-| `ci-required` completed without `success` | Leave the status wait; classify the result and apply the applicable recovery transition. |
+| `ci-required` completed without `success` while required for the current round or goal | Leave the status wait; classify the result and apply the applicable recovery transition. |
+| `ci-required` completed without `success` while not required for the current round or goal | Record the final-readiness failure and continue the current review path. |
 | GraphQL `mergeStateStatus: BLOCKED`, `goal=merge` | Leave the status wait, publish `blocked=<pr-number> rec=wait`, and end. |
 | Green `ci-required` and positive mergeability at the expected head | Leave the status wait and continue when no other predicate remains. |
 | CI or mergeability is pending or missing | Preserve the unresolved status members and apply the round cadence below. |
 | Rate-limited or transient query failure | Record the concrete failure and retry-not-before time, preserve the unresolved status members, and apply the round cadence below. |
 | Terminal query failure | Leave the status wait with `rec=stop`, surface the failure, and end. |
 
-Read the table top-down. Conflict recovery outranks CI, terminal non-green CI
-outranks the remaining merge states, and a documented GraphQL block prevents a
-merge goal. Carry-forward remains a separate pre-merge obligation driven by the
-fetched base tip, not by undocumented REST `mergeable_state` values.
+Read the table top-down. Conflict recovery outranks CI, terminal non-green
+required CI outranks the remaining merge states, and a documented GraphQL block
+prevents a merge goal. Carry-forward remains a separate pre-merge obligation
+driven by the fetched base tip, not by undocumented REST `mergeable_state`
+values.
 
 ### Bounded status waiting
 
 *This section defines repository policy, not GitHub timing guarantees.*
 
-Every round attempts one current-head snapshot. When CI is eligible to remain
-pending, a pending, rate-limited, or transient result is recorded and the next
-round continues. A known conflict, ineligible non-green `ci-required`, or
-terminal query failure still takes its transition.
+Every round attempts one current-head snapshot. When CI is a reviewer-dispatch
+prerequisite, pending, missing, rate-limited, or transient status enters the
+60-minute budget below; expiry publishes the status report and stops without
+dispatch. When CI may remain pending, record that status and continue the
+current review path. A known conflict, required CI completed without success,
+or terminal query failure still takes its transition.
 
-Every third round spends up to a 60-minute status budget before it may advance;
-a merge or readiness goal may use the same bound. Every sixth round uses that
-budget, but fresh green current-head `ci-required` and positive mergeability
-remain prerequisites for the next-block approval prompt. Measure the budget
-from the first scheduled wait and publish `status-deadline=<UTC>`.
+A reviewer-dispatch CI prerequisite spends up to a 60-minute status budget
+before dispatch. Every third round, and any merge or readiness goal, may use the
+same bound. Every sixth round uses that budget, but fresh green current-head
+`ci-required` and positive mergeability remain prerequisites for the next-block
+approval prompt. Measure the budget from the first scheduled wait and publish
+`status-deadline=<UTC>`.
 
 Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -25,9 +25,12 @@ it or a recovery transition supersedes it. Both integrations (steps 1 and 4)
 happen before the push — base movement after the push does not reopen the
 locked candidate.
 
-Before step 1 for new work, visibly state `Design basis:` followed by every
-owning design document and the specific claim the work extends. Do not begin
-without naming that basis; return to design or ask the user when it is unclear.
+Before step 1 for new work, visibly state `Design basis:`. Name exactly one
+normative owner with its exact document section and owned claim, then identify
+supporting models, adjacent contracts, consumed constraints, and consumer
+boundaries by role rather than presenting them as co-owners. Apply the
+[design-scope rules](design-scope.md) before starting if ownership is unclear
+or the work appears to need multiple normative owners.
 
 1. Integrate the effective base.
 2. Make the initial or review-driven change.
@@ -90,7 +93,7 @@ A final-gate `ci-required` failure observed during or after a non-boundary
 Markdown-only round does not interrupt or reopen that round. Finish its review
 path; afterward, retry the unchanged head only with concrete transient evidence,
 otherwise remove `review-clean` and form a candidate at the next round number.
-Never close with a required check red. A
+Never close a round or goal while one of its applicable required checks is red. A
 superseded attempt spends no round and gets no completion report; let its
 reviewers finish or acknowledge cancellation, and carry every returned finding
 forward.
@@ -332,7 +335,8 @@ prompt:
 ```text
 Round <n> is complete for PR <number>.
 - Review models <model-a> and <model-b> were used for adversarial review.
-- Design basis: <owning design paths and the claims this work extends>.
+- Design basis: normative owner <path#section> — <owned claim>; supporting
+  <path and role for each model, adjacent contract, constraint, or consumer>.
 - Review feedback is: [converging, diverging, neutral, clean].
 - Round start: <datetime>.
 - Round end: <datetime>.
@@ -351,9 +355,9 @@ Use `Fix description` to state the concrete review-driven changes.
 Classification must match the reviewer outcomes:
 
 - If every required reviewer returned no findings and the locked head remained
-  unchanged, use `clean`. The report's `Design basis` must restate the owning
-  designs as part of that clean completion. Do not use `converging` as a generic
-  positive label.
+  unchanged, use `clean`. The report's `Design basis` must restate the normative
+  owner and supporting-role map, confirming that review did not reveal ownership
+  drift. Do not use `converging` as a generic positive label.
 - If any reviewer returned a finding, use `converging`, `diverging`, or
   `neutral`, even when every finding was dismissed and the head stayed
   unchanged. Explain dismissals in the public reconciliation.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -25,6 +25,10 @@ it or a recovery transition supersedes it. Both integrations (steps 1 and 4)
 happen before the push — base movement after the push does not reopen the
 locked candidate.
 
+Before step 1 for new work, visibly state `Design basis:` followed by every
+owning design document and the specific claim the work extends. Do not begin
+without naming that basis; return to design or ask the user when it is unclear.
+
 1. Integrate the effective base.
 2. Make the initial or review-driven change.
 3. Run the focused gate.
@@ -327,6 +331,7 @@ prompt:
 ```text
 Round <n> is complete for PR <number>.
 - Review models <model-a> and <model-b> were used for adversarial review.
+- Design basis: <owning design paths and the claims this work extends>.
 - Review feedback is: [converging, diverging, neutral, clean].
 - Round start: <datetime>.
 - Round end: <datetime>.
@@ -345,7 +350,9 @@ Use `Fix description` to state the concrete review-driven changes.
 Classification must match the reviewer outcomes:
 
 - If every required reviewer returned no findings and the locked head remained
-  unchanged, use `clean`. Do not use `converging` as a generic positive label.
+  unchanged, use `clean`. The report's `Design basis` must restate the owning
+  designs as part of that clean completion. Do not use `converging` as a generic
+  positive label.
 - If any reviewer returned a finding, use `converging`, `diverging`, or
   `neutral`, even when every finding was dismissed and the head stayed
   unchanged. Explain dismissals in the public reconciliation.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -48,10 +48,10 @@ locked candidate.
 | Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict or non-green `ci-required` | Pending or unavailable CI and mergeability, subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
-A documentation-only candidate substitutes pre-commit `markdownlint` for green
-`ci-required` at non-boundary rounds; `ci-required` is still mandatory at every
-six-round boundary and for final merge readiness. The user may authorize review
-in parallel with CI for other changes.
+A Markdown-only candidate (every changed file is `*.md`) substitutes pre-commit
+`markdownlint` for green `ci-required` at non-boundary rounds; `ci-required`
+remains mandatory at every six-round boundary and for final merge readiness.
+The user may authorize review in parallel with CI for other changes.
 
 ### Review-clean, and recovery
 
@@ -80,7 +80,7 @@ Recovery transitions, applied without waiting for CI:
   unchanged head; repeat only with concrete transient evidence, otherwise treat
   it as an author change.
 
-A final-gate `ci-required` regression discovered after a documentation-only
+A final-gate `ci-required` regression discovered after a Markdown-only
 round closes does not reopen that round: retry the unchanged head only with
 concrete transient evidence, otherwise remove `review-clean` and form a
 candidate at the next round number. Never close with a required check red. A
@@ -355,7 +355,7 @@ a blocker, and it clears only when every listed predicate clears.
 - `wait` requires a non-empty `Blocked` or `Waiting` field. A retained
   `schedule` means the agent will check automatically; without one, the wait is
   passive and resumes only when a later user or workflow turn re-enters it.
-- When a completed documentation-only round is review-clean and no further
+- When a completed Markdown-only round is review-clean and no further
   author or review round is needed, but `ci-required` remains pending or
   missing, use `Waiting: check:ci-required` and `Recommendation: wait`. Use
   `Waiting: check:ci-required,merge` when live mergeability is also unresolved.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -42,16 +42,17 @@ locked candidate.
 
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
-| First attempt at round 1 | Pushed settled head, recorded effective base, focused gate | CI and mergeability |
-| Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict or non-green `ci-required` | Pending or unavailable CI and mergeability, subject to [Bounded status waiting](#bounded-status-waiting) |
-| Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
-| Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict or non-green `ci-required` | Pending or unavailable CI and mergeability, subject to [Bounded status waiting](#bounded-status-waiting) |
+| First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, applicable CI rule below | Mergeability; eligible pending CI |
+| Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
+| Conflict-recovery attempt | Resolution head pushed, round number authorized, applicable CI rule below | Post-push local gates, mergeability; eligible pending CI |
+| Failed-gate restart | Required fix pushed, one status attempt, applicable CI rule below, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
-A Markdown-only candidate (every changed file is `*.md`) substitutes pre-commit
-`markdownlint` for green `ci-required` at non-boundary rounds; `ci-required`
-remains mandatory at every six-round boundary and for final merge readiness.
-The user may authorize review in parallel with CI for other changes.
+A non-Markdown candidate requires green current-head `ci-required` before
+reviewer dispatch unless the user authorized parallel review. A Markdown-only
+candidate (every changed file is `*.md`) substitutes pre-commit `markdownlint`
+at non-boundary rounds. Only those two exceptions make pending CI eligible;
+`ci-required` remains mandatory at six-round boundaries and final merge.
 
 ### Review-clean, and recovery
 
@@ -150,10 +151,10 @@ fetched base tip, not by undocumented REST `mergeable_state` values.
 
 *This section defines repository policy, not GitHub timing guarantees.*
 
-Every round attempts one current-head snapshot. At an ordinary round, a
-pending, rate-limited, or transient result is recorded and the next round
-continues. A known conflict, non-green `ci-required`, or terminal query failure
-still takes its transition.
+Every round attempts one current-head snapshot. When CI is eligible to remain
+pending, a pending, rate-limited, or transient result is recorded and the next
+round continues. A known conflict, ineligible non-green `ci-required`, or
+terminal query failure still takes its transition.
 
 Every third round spends up to a 60-minute status budget before it may advance;
 a merge or readiness goal may use the same bound. Every sixth round uses that


### PR DESCRIPTION
Clarifies repository-wide authorization, review sequencing, design-basis reporting, and adversarial-review scope.

## Demo

Before this change, agents could ask whether to open an already-requested PR or dispatch its first review round. They could begin implementation without naming the governing design ownership and supporting constraints, and a clean round report did not restate that basis. Agents could also propose defenses for symlinks or reparse points, same-machine actors, and in-operation file mutation, while the Markdown-only CI exception was easy to miss.

After this change, AGENTS.md states directly:

```text
Design first and state the basis.
Requested work hot-starts through PR and review.
Markdown-only PRs hot-start immediately at non-boundary rounds.
```

Before any new work—including trivial changes—agents name one normative owner and exact owned claim, then identify supporting designs and models by role. The detailed round guidance expands those roles to supporting models, adjacent contracts, consumed constraints, and consumer boundaries; a clean round report restates the map and confirms no ownership drift.

Agents may branch, commit, push, and open the requested PR without separate approval. Once eligible, round 1 and replacement rounds within the current six-round block start automatically; only a new block requires approval. Merge authorization remains separate. Non-Markdown changes retain their normal CI prerequisite unless the user authorizes parallel review.

The design boundary is also explicit:

```text
Unless an owning design explicitly opts in, do not add design requirements or
adversarial-review findings for symlinks/reparse points, same-machine users or
agents, or files mutating during inspection.
```

## Compatibility

Documentation-only; no product code or runtime behavior changes.

## Validation

- `npx markdownlint-cli AGENTS.md docs/round-orchestration.md`
- `AGENTS.md` remains at its 600-line cap.