### PR TITLE
Point the il-tools PATH gate at the doc that owns the guidance

### DIFF
--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -613,24 +613,30 @@ public class IlToolsActivationTests
     /// snippet, so the gate rejects any runnable snippet that invokes the
     /// producer directly -- `PATH="$(eng/restore-iltools.sh):$PATH"` never
     /// mentions `export` and would otherwise sail through.
+    ///
+    /// The guidance moved out of AGENTS.md when that file was slimmed to its
+    /// line cap, so this reads the document that owns test-tool activation
+    /// today. Pointing it at a file that no longer carries the guidance turns
+    /// the gate into a failure that says nothing about PATH assembly.
     /// </summary>
     [Fact]
-    public void AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript()
+    public void DevEnvironmentDoc_DelegatesIlToolsPathAssemblyToTheScript()
     {
-        var agents = File.ReadAllText(Path.Combine(RepoRoot, "AGENTS.md"));
+        var doc = File.ReadAllText(
+            Path.Combine(RepoRoot, "docs", "dev-environment.md"));
 
-        Assert.Contains("source eng/activate-iltools.sh", agents);
+        Assert.Contains("source eng/activate-iltools.sh", doc);
 
-        foreach (var block in FencedBashBlocks(agents).Where(b => b.Contains("iltools")))
+        foreach (var block in FencedBashBlocks(doc).Where(b => b.Contains("iltools")))
         {
             Assert.False(
                 block.Contains("restore-iltools.sh"),
-                $"AGENTS.md tells the reader to run the producer directly instead of sourcing\n" +
+                $"docs/dev-environment.md tells the reader to run the producer directly instead of sourcing\n" +
                 $"eng/activate-iltools.sh, which puts the PATH assembly back outside the gate:\n{block}");
 
             Assert.False(
                 block.Contains("PATH="),
-                $"AGENTS.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
+                $"docs/dev-environment.md assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
         }
     }
 


### PR DESCRIPTION
## Demo

`main` is red. The failure is not in product code:

```text
[FAIL] IlToolsActivationTests.AgentsMarkdown_DelegatesIlToolsPathAssemblyToTheScript
  Assert.Contains() Failure: Sub-string not found
  String:  "# Agent instructions"...
  Not found: "source eng/activate-iltools.sh"
```

The gate asserted that `AGENTS.md` tells the reader to source
`eng/activate-iltools.sh`. #5079 (`f0a23e9e0`, "Slim AGENTS.md to fit the
600-line cap") moved test-tool activation into `docs/dev-environment.md`, where
it still reads:

```console
$ grep -n 'activate-iltools' docs/dev-environment.md
54:source eng/activate-iltools.sh --mdv
```

`AGENTS.md` now delegates explicitly: "Activate `ilasm`/`ildasm`/`mdv` before
relying on a clean run; see `docs/dev-environment.md#test-tooling-activation`."

So the guidance is intact — only its owner moved. This repoints the gate at
that owner.

What to notice: the gate's property is unchanged. It still requires the
document to tell the reader to *source the wrapper*, and still rejects any
`iltools` snippet that runs the producer directly or assembles `PATH` by hand.
Only the file it reads changed, and the test name changed with it. Reading a
file that no longer carries the guidance turns the gate into a failure that
says nothing about PATH assembly — a false negative dressed as enforcement.

## Why this is trivial-tier

One test file. No product code, no new behavior, no contract change. The
assertion set is identical; only the path it is evaluated against moved, to
track a documentation reorganization that already landed. Filed separately from
the change it unblocks so that the fix to `main` is not gated behind an
unrelated review.

## Validation

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/IlToolsActivationTests/*"
  Total: 37, Errors: 0, Failed: 0, Skipped: 0
```

Before this change the same selector reported `Total: 37, Failed: 1`, matching
the CI failure exactly.

Cause: #5079. Unblocks #5027 and any other PR branched from current `main`.
