### PR TITLE
Issue image-derived module identity with every LibraryBodyIndex

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -563,6 +563,30 @@ ownership, its contract forbids retention after the call, and it avoids a produc
 remains the public
 body-local Metadata capability, and high-level Metadata facets own drill projection. These paths
 remove target reopens without exposing the raw reader to the CLI.
+
+Every image-backed `LibraryBodyIndex` publishes one immutable
+`LibraryBodyModuleIdentity` derived from the same `MetadataReader` before
+feature selection or method filtering. It retains the exact assembly-definition
+identity and non-empty MVID; a standalone managed module has no assembly
+identity. The caller-supplied `Path` remains a display/acquisition input and
+method rows remain body evidence, so neither can substitute for module
+identity. `CatalogCallGraphScope` validates and keys participants with the
+issued identity even when an index has no declared methods. The internal
+`FromEvidence` test seam is not image-backed: non-empty synthetic method
+evidence is validated against its synthetic identity, and an empty synthetic
+index must receive identity explicitly rather than acquiring a success-shaped
+default. `ModuleIdentity_IsImageDerivedAcrossFeaturesAndScopes`,
+`ModuleIdentity_MethodlessPrefetchedImageRetainsExactIdentity`,
+`ModuleIdentity_DistinguishesAssemblyAndModuleGeneration`,
+`ModuleIdentity_StandaloneModuleHasNoAssemblyIdentity`,
+`ModuleIdentity_RejectsEmptyModuleVersionIdentifier`, and
+`EmptyIndexCatalogBindingUsesIssuedModuleIdentity` gate the image-backed and
+catalog properties.
+`SyntheticModuleIdentity_EmptyEvidenceRequiresExplicitIdentity`,
+`SyntheticModuleIdentity_ValidatesMethodsAgainstExplicitIdentity`, and
+`SyntheticModuleIdentity_NonEmptyEvidenceDerivesFixtureIdentity` gate the
+synthetic seam.
+
 The broader model still has a prerequisite. `MetadataSource` owns a separate reader, and
 `ResolvedAssemblyReference` carries only an `OpenRead` opener. Completing the session across
 member/decompiler and descriptor-based paths requires a **low-level PE-owner primitive** opened

--- a/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
@@ -11,6 +11,49 @@ namespace ILInspector.Analysis.Tests;
 public class CatalogCallGraphScopeTests
 {
     [Fact]
+    public void EmptyIndexCatalogBindingUsesIssuedModuleIdentity()
+    {
+        string path =
+            typeof(CatalogCallGraphScopeTests).Assembly.Location;
+        LibraryBodyIndex index = LibraryBodyIndex.Open(
+            path,
+            LibraryBodyAnalysisFeatures.None);
+        ResolvedAssemblyReference assembly = Descriptor(index);
+        var policy = new AssemblyDependencyResolver(
+            new AssemblyDependencyResolutionOptions(path));
+
+        Assert.Empty(index.DeclaredMethods);
+        using (var scope = new CatalogCallGraphScope(
+            policy,
+            [new(index, assembly)]))
+        {
+            CallTreeNode root = scope.BuildCallerTree(
+                index,
+                0x06000001);
+
+            Assert.Equal(
+                index.ModuleIdentity.ModuleVersionId,
+                root.GraphEvidence?.Storage.ModuleVersionId);
+        }
+
+        ResolvedAssemblyReference wrongAssembly =
+            ResolvedAssemblyReference.Create(
+                assembly.Identity with
+                {
+                    Version = new Version(99, 0, 0, 0),
+                },
+                path,
+                () => File.OpenRead(path),
+                AssemblyResolutionProvenance.Local(
+                    "mismatched catalog module identity"));
+
+        Assert.Throws<ArgumentException>(
+            () => new CatalogCallGraphScope(
+                policy,
+                [new(index, wrongAssembly)]));
+    }
+
+    [Fact]
     public void BothDirectionsAndProjectionReuseOneFrozenGraph()
     {
         LibraryBodyIndex analysis = LibraryBodyIndex.Open(

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -168,7 +168,7 @@ public class LibraryBodyIndexTests
                     LibraryBodyAnalysisFeatures.None));
 
         Assert.Contains(
-            "empty module version identifier",
+            "non-empty MVID",
             error.Message,
             StringComparison.Ordinal);
     }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -22,6 +22,222 @@ namespace ILInspector.Analysis.Tests;
 public class LibraryBodyIndexTests
 {
     [Fact]
+    public void
+        ModuleIdentity_IsImageDerivedAcrossFeaturesAndScopes()
+    {
+        string sourcePath =
+            typeof(LibraryBodyIndexTests).Assembly.Location;
+        ImmutableArray<byte> image =
+            [.. File.ReadAllBytes(sourcePath)];
+        using var peReader = new PEReader(image);
+        MetadataReader reader = peReader.GetMetadataReader();
+        var expected = new LibraryBodyModuleIdentity(
+            AssemblyReferenceIdentity.FromAssemblyDefinition(reader),
+            reader.GetGuid(reader.GetModuleDefinition().Mvid));
+
+        LibraryBodyIndex ordinary =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "ordinary-label.dll",
+                image,
+                LibraryBodyAnalysisFeatures.MethodEvidence);
+        LibraryBodyIndex capabilityLimited =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "capability-label.dll",
+                image,
+                LibraryBodyAnalysisFeatures.None);
+        LibraryBodyIndex filtered =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "filtered-label.dll",
+                image,
+                LibraryBodyAnalysisFeatures.MethodEvidence,
+                bodyScope:
+                    new HashSet<int> { 0x0600FFFF });
+
+        Assert.NotEmpty(ordinary.DeclaredMethods);
+        Assert.NotEmpty(ordinary.DirectCalls);
+        Assert.Equal(
+            LibraryBodyAnalysisFeatures.None,
+            capabilityLimited.Features);
+        Assert.Equal(
+            LibraryBodyAnalysisFeatures.MethodEvidence,
+            filtered.Features);
+        Assert.Empty(filtered.DirectCalls);
+        Assert.Equal(expected, ordinary.ModuleIdentity);
+        Assert.Equal(expected, capabilityLimited.ModuleIdentity);
+        Assert.Equal(expected, filtered.ModuleIdentity);
+    }
+
+    [Fact]
+    public void
+        ModuleIdentity_MethodlessPrefetchedImageRetainsExactIdentity()
+    {
+        Guid moduleVersionId = Guid.NewGuid();
+        ImmutableArray<byte> image =
+            [.. EmitAssembly(
+                "MethodlessIdentity",
+                static _ => { },
+                moduleVersionId)];
+
+        LibraryBodyIndex index =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "not-the-assembly-name.dll",
+                image,
+                LibraryBodyAnalysisFeatures.MethodEvidence);
+
+        Assert.Empty(index.DeclaredMethods);
+        Assert.Equal(
+            new AssemblyReferenceIdentity(
+                "MethodlessIdentity",
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            index.ModuleIdentity.AssemblyIdentity);
+        Assert.Equal(
+            moduleVersionId,
+            index.ModuleIdentity.ModuleVersionId);
+    }
+
+    [Fact]
+    public void ModuleIdentity_DistinguishesAssemblyAndModuleGeneration()
+    {
+        Guid firstModuleVersionId = Guid.NewGuid();
+        LibraryBodyModuleIdentity first =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "first.dll",
+                [.. EmitAssembly(
+                    "FirstIdentity",
+                    static _ => { },
+                    firstModuleVersionId)],
+                LibraryBodyAnalysisFeatures.None)
+            .ModuleIdentity;
+        LibraryBodyModuleIdentity differentAssembly =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "second.dll",
+                [.. EmitAssembly(
+                    "SecondIdentity",
+                    static _ => { },
+                    firstModuleVersionId)],
+                LibraryBodyAnalysisFeatures.None)
+            .ModuleIdentity;
+        LibraryBodyModuleIdentity differentGeneration =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "third.dll",
+                [.. EmitAssembly(
+                    "FirstIdentity",
+                    static _ => { },
+                    Guid.NewGuid())],
+                LibraryBodyAnalysisFeatures.None)
+            .ModuleIdentity;
+
+        Assert.NotEqual(first, differentAssembly);
+        Assert.NotEqual(first, differentGeneration);
+    }
+
+    [Fact]
+    public void ModuleIdentity_StandaloneModuleHasNoAssemblyIdentity()
+    {
+        Guid moduleVersionId = Guid.NewGuid();
+        LibraryBodyIndex index =
+            LibraryBodyIndex.OpenFromPrefetchedImage(
+                "standalone-label.netmodule",
+                [.. EmitStandaloneModule(
+                    "StandaloneIdentity.netmodule",
+                    moduleVersionId)],
+                LibraryBodyAnalysisFeatures.None);
+
+        Assert.Null(index.ModuleIdentity.AssemblyIdentity);
+        Assert.Equal(
+            moduleVersionId,
+            index.ModuleIdentity.ModuleVersionId);
+    }
+
+    [Fact]
+    public void ModuleIdentity_RejectsEmptyModuleVersionIdentifier()
+    {
+        ImmutableArray<byte> image =
+            [.. EmitAssembly(
+                "EmptyModuleVersionId",
+                static _ => { },
+                Guid.Empty)];
+
+        BadImageFormatException error =
+            Assert.Throws<BadImageFormatException>(
+                () => LibraryBodyIndex.OpenFromPrefetchedImage(
+                    "empty-mvid.dll",
+                    image,
+                    LibraryBodyAnalysisFeatures.None));
+
+        Assert.Contains(
+            "empty module version identifier",
+            error.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void
+        SyntheticModuleIdentity_EmptyEvidenceRequiresExplicitIdentity()
+    {
+        Assert.Throws<ArgumentException>(
+            () => LibraryBodyIndex.FromEvidence([], []));
+
+        var identity = new LibraryBodyModuleIdentity(
+            new AssemblyReferenceIdentity(
+                "EmptySynthetic",
+                Version: null,
+                Culture: null,
+                PublicKeyToken: null),
+            Guid.Empty);
+        LibraryBodyIndex index = LibraryBodyIndex.FromEvidence(
+            [],
+            [],
+            moduleIdentity: identity);
+
+        Assert.Same(identity, index.ModuleIdentity);
+    }
+
+    [Fact]
+    public void
+        SyntheticModuleIdentity_ValidatesMethodsAgainstExplicitIdentity()
+    {
+        Guid moduleVersionId = Guid.NewGuid();
+        MethodIdentity method = SyntheticMethod(
+            "ActualAssembly",
+            moduleVersionId);
+        var identity = new LibraryBodyModuleIdentity(
+            new AssemblyReferenceIdentity(
+                "DifferentAssembly",
+                Version: null,
+                Culture: null,
+                PublicKeyToken: null),
+            moduleVersionId);
+
+        ArgumentException error = Assert.Throws<ArgumentException>(
+            () => LibraryBodyIndex.FromEvidence(
+                [method],
+                [],
+                moduleIdentity: identity));
+
+        Assert.Equal("methods", error.ParamName);
+    }
+
+    [Fact]
+    public void
+        SyntheticModuleIdentity_NonEmptyEvidenceDerivesFixtureIdentity()
+    {
+        Guid moduleVersionId = Guid.NewGuid();
+        LibraryBodyIndex index = LibraryBodyIndex.FromEvidence(
+            [SyntheticMethod("SyntheticAssembly", moduleVersionId)],
+            []);
+
+        Assert.Equal(
+            "SyntheticAssembly",
+            index.ModuleIdentity.AssemblyIdentity?.Name);
+        Assert.Equal(
+            moduleVersionId,
+            index.ModuleIdentity.ModuleVersionId);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_FindSyncCallsWithAsyncSiblings()
     {
         string path = typeof(OptimizationOpportunityFixtures)
@@ -8480,13 +8696,16 @@ public class LibraryBodyIndexTests
     }
 
     /// <summary>Emits a minimal unsigned assembly whose only content is what <paramref name="addContent"/> adds.</summary>
-    static byte[] EmitAssembly(string name, Action<MetadataBuilder> addContent)
+    static byte[] EmitAssembly(
+        string name,
+        Action<MetadataBuilder> addContent,
+        Guid? moduleVersionId = null)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
             generation: 0,
             metadata.GetOrAddString(name + ".dll"),
-            metadata.GetOrAddGuid(Guid.NewGuid()),
+            metadata.GetOrAddGuid(moduleVersionId ?? Guid.NewGuid()),
             default,
             default);
         metadata.AddAssembly(
@@ -8517,6 +8736,50 @@ public class LibraryBodyIndexTests
         pe.Serialize(image);
         return image.ToArray();
     }
+
+    static byte[] EmitStandaloneModule(
+        string name,
+        Guid moduleVersionId)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            metadata.GetOrAddString(name),
+            metadata.GetOrAddGuid(moduleVersionId),
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static MethodIdentity SyntheticMethod(
+        string assemblyName,
+        Guid moduleVersionId) =>
+        new(
+            assemblyName,
+            moduleVersionId,
+            TypeRef.Definition(
+                assemblyName,
+                "Fixtures",
+                "SyntheticType"),
+            "SyntheticMethod",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            0x06000001,
+            IsStatic: true);
 
     static byte[] EmitAssemblyIdentity(
         string name,

--- a/src/ILInspector.Analysis/CatalogCallGraphScope.cs
+++ b/src/ILInspector.Analysis/CatalogCallGraphScope.cs
@@ -126,9 +126,11 @@ public sealed class CatalogCallGraphScope : IDisposable
         {
             ArgumentNullException.ThrowIfNull(participant);
             ValidateParticipant(participant);
+            LibraryBodyModuleIdentity moduleIdentity =
+                participant.Index.ModuleIdentity;
             var artifact = (
-                participant.Assembly.Identity,
-                ModuleVersionId(participant.Index));
+                moduleIdentity.AssemblyIdentity!,
+                moduleIdentity.ModuleVersionId);
             if (artifacts.TryGetValue(
                     artifact,
                     out CatalogCallGraphParticipant? canonical))
@@ -302,23 +304,21 @@ public sealed class CatalogCallGraphScope : IDisposable
     static void ValidateParticipant(
         CatalogCallGraphParticipant participant)
     {
-        MethodIdentity? method =
-            participant.Index.DeclaredMethods.FirstOrDefault();
-        if (method is not null
-            && !string.Equals(
-                method.AssemblyName,
-                participant.Assembly.Identity.Name,
-                StringComparison.OrdinalIgnoreCase))
+        LibraryBodyModuleIdentity moduleIdentity =
+            participant.Index.ModuleIdentity;
+        if (moduleIdentity.AssemblyIdentity is not { } assemblyIdentity
+            || !assemblyIdentity.IsEquivalentTo(
+                participant.Assembly.Identity)
+            || participant.Assembly.Registration.ModuleVersionId
+                is { } registeredModuleVersionId
+            && registeredModuleVersionId
+                != moduleIdentity.ModuleVersionId)
         {
             throw new ArgumentException(
                 "The assembly descriptor does not describe the body index.",
                 nameof(participant));
         }
     }
-
-    static Guid ModuleVersionId(LibraryBodyIndex index) =>
-        index.DeclaredMethods.FirstOrDefault()?.ModuleVersionId
-            ?? Guid.Empty;
 
     sealed class ScopeGraph : IDisposable
     {
@@ -1128,8 +1128,7 @@ public sealed class CatalogCallGraphScope : IDisposable
                 $"method token 0x{rootMethodToken:X8}");
             var storage = GraphNodeStorageKey.Definition(
                 root.Assembly,
-                root.Index.DeclaredMethods.FirstOrDefault()
-                    ?.ModuleVersionId ?? Guid.Empty,
+                root.Index.ModuleIdentity.ModuleVersionId,
                 rootMethodToken);
             return (
                 member,

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -69,10 +69,12 @@ public sealed class LibraryBodyIndex
 {
     LibraryBodyIndex(
         string path,
+        LibraryBodyModuleIdentity moduleIdentity,
         LibraryBodyAnalysisResult analysis,
         LibraryBodyAnalysisFeatures features)
     {
         Path = path;
+        ModuleIdentity = moduleIdentity;
         DeclaredMethods = analysis.Methods.DeclaredMethods;
         Methods = analysis.Methods.Methods;
         DirectCalls = analysis.Methods.DirectCalls;
@@ -123,6 +125,11 @@ public sealed class LibraryBodyIndex
     }
 
     public string Path { get; }
+    /// <summary>
+    /// Exact image-derived identity for the module that produced this index.
+    /// This remains available when no body producer or method is selected.
+    /// </summary>
+    public LibraryBodyModuleIdentity ModuleIdentity { get; }
     /// <summary>
     /// Every decoded method identity, including abstract and extern members,
     /// when <see cref="LibraryBodyAnalysisFeatures.MethodEvidence"/> is enabled.
@@ -1082,9 +1089,14 @@ public sealed class LibraryBodyIndex
         ImmutableArray<MethodResultSink> resultSinks = default,
         ImmutableArray<FieldStoreFact> fieldStores = default,
         ImmutableArray<FieldLoadFact> fieldLoads = default,
-        ImmutableArray<MethodReturnFlow> returnFlows = default)
-        => new(
+        ImmutableArray<MethodReturnFlow> returnFlows = default,
+        LibraryBodyModuleIdentity? moduleIdentity = null)
+    {
+        moduleIdentity ??= SyntheticEvidenceIdentity(methods);
+        ValidateSyntheticEvidenceIdentity(moduleIdentity, methods);
+        return new(
             path: "",
+            moduleIdentity,
             analysis: new(
                 Methods: new(
                     DeclaredMethods: methods,
@@ -1135,6 +1147,7 @@ public sealed class LibraryBodyIndex
                 | (allocationOccurrences is null
                     ? LibraryBodyAnalysisFeatures.None
                     : LibraryBodyAnalysisFeatures.Allocations));
+    }
 
     public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
         bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
@@ -1307,6 +1320,8 @@ public sealed class LibraryBodyIndex
         if (!peReader.HasMetadata)
             throw new BadImageFormatException($"No managed metadata: {path}");
         var reader = peReader.GetMetadataReader();
+        LibraryBodyModuleIdentity moduleIdentity =
+            LibraryBodyModuleIdentity.FromImage(reader);
         IAssemblyReferenceResolver? analysisResolver =
             plan.Includes(
                 LibraryBodyAnalysisFeatures
@@ -1329,7 +1344,52 @@ public sealed class LibraryBodyIndex
                 : rootSnapshot);
         LibraryBodyAnalysisResult analysis =
             builder.Build(plan);
-        return new LibraryBodyIndex(path, analysis, plan.Features);
+        return new LibraryBodyIndex(
+            path,
+            moduleIdentity,
+            analysis,
+            plan.Features);
+    }
+
+    static void ValidateSyntheticEvidenceIdentity(
+        LibraryBodyModuleIdentity moduleIdentity,
+        ImmutableArray<MethodIdentity> methods)
+    {
+        foreach (MethodIdentity method in methods)
+        {
+            if (moduleIdentity.AssemblyIdentity is not { } assembly
+                || !StringComparer.OrdinalIgnoreCase.Equals(
+                    assembly.Name,
+                    method.AssemblyName)
+                || moduleIdentity.ModuleVersionId
+                    != method.ModuleVersionId)
+            {
+                throw new ArgumentException(
+                    "Synthetic method evidence does not match the supplied "
+                    + "module identity.",
+                    nameof(methods));
+            }
+        }
+    }
+
+    static LibraryBodyModuleIdentity SyntheticEvidenceIdentity(
+        ImmutableArray<MethodIdentity> methods)
+    {
+        if (methods.IsDefaultOrEmpty)
+        {
+            throw new ArgumentException(
+                "An empty synthetic index requires an explicit module identity.",
+                nameof(methods));
+        }
+
+        MethodIdentity first = methods[0];
+        return new LibraryBodyModuleIdentity(
+            new AssemblyReferenceIdentity(
+                first.AssemblyName,
+                Version: null,
+                Culture: null,
+                PublicKeyToken: null),
+            first.ModuleVersionId);
     }
 
     static bool UsesReferenceResolution(

--- a/src/ILInspector.Analysis/LibraryBodyModuleIdentity.cs
+++ b/src/ILInspector.Analysis/LibraryBodyModuleIdentity.cs
@@ -41,7 +41,8 @@ public sealed record LibraryBodyModuleIdentity
         if (moduleVersionId == Guid.Empty)
         {
             throw new BadImageFormatException(
-                "The analyzed module has an empty module version identifier.");
+                "The analyzed module must have a non-empty MVID "
+                + "(module version identifier).");
         }
 
         return new(

--- a/src/ILInspector.Analysis/LibraryBodyModuleIdentity.cs
+++ b/src/ILInspector.Analysis/LibraryBodyModuleIdentity.cs
@@ -1,0 +1,53 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Metadata identity for the physical module that produced one
+/// <see cref="LibraryBodyIndex"/>.
+/// </summary>
+/// <remarks>
+/// This is image-derived evidence, not a path, display label, artifact
+/// authenticity claim, or persistent cache key. <see cref="AssemblyIdentity"/>
+/// is null only for a standalone managed module.
+/// </remarks>
+public sealed record LibraryBodyModuleIdentity
+{
+    internal LibraryBodyModuleIdentity(
+        AssemblyReferenceIdentity? assemblyIdentity,
+        Guid moduleVersionId)
+    {
+        AssemblyIdentity = assemblyIdentity;
+        ModuleVersionId = moduleVersionId;
+    }
+
+    /// <summary>
+    /// Exact assembly-definition identity, or null for a standalone managed
+    /// module.
+    /// </summary>
+    public AssemblyReferenceIdentity? AssemblyIdentity { get; }
+
+    /// <summary>The module version identifier read from the same image.</summary>
+    public Guid ModuleVersionId { get; }
+
+    internal static LibraryBodyModuleIdentity FromImage(
+        MetadataReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        Guid moduleVersionId = reader.GetGuid(
+            reader.GetModuleDefinition().Mvid);
+        if (moduleVersionId == Guid.Empty)
+        {
+            throw new BadImageFormatException(
+                "The analyzed module has an empty module version identifier.");
+        }
+
+        return new(
+            reader.IsAssembly
+                ? AssemblyReferenceIdentity.FromAssemblyDefinition(reader)
+                : null,
+            moduleVersionId);
+    }
+}

--- a/src/ILInspector.Research.Tests/ResearchComparisonAdmissionTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchComparisonAdmissionTests.cs
@@ -1317,7 +1317,16 @@ public class ResearchComparisonAdmissionTests
         => new(PathlessAssembly(), new UnusedResolver(), BodyIndex());
 
     static LibraryBodyIndex BodyIndex()
-        => LibraryBodyIndex.FromEvidence([], []);
+        => LibraryBodyIndex.FromEvidence(
+            [],
+            [],
+            moduleIdentity: new(
+                new AssemblyReferenceIdentity(
+                    "SyntheticAdmission",
+                    Version: null,
+                    Culture: null,
+                    PublicKeyToken: null),
+                new Guid("f88df8d2-0474-4f48-811a-bf5cb2af203e")));
 
     static ResolvedAssemblyReference PathlessAssembly()
         => ResolvedAssemblyReference.Create(


### PR DESCRIPTION
## Summary

`ILInspector.Analysis` now issues immutable, image-derived assembly/module
identity with every `LibraryBodyIndex`.

- Derive exact assembly-definition identity and MVID from the same
  `MetadataReader` before feature selection or body filtering.
- Retain identity for capability-limited, methodless, and standalone-module
  indexes, while rejecting image-backed indexes with an empty MVID.
- Make Analysis-owned catalog binding and missing-root graph storage consume
  the issued identity instead of sampling method rows.
- Keep the internal synthetic-evidence seam explicit and validated.

This is the Analysis-owned prerequisite for #5049. It does not change CLI
output or define Research target admission/correspondence. Legacy Research and
CLI consumers discovered during the work are tracked separately by #5125 and
#5126.

## Demo

Two differently labeled, prefetched opens of the same built Analysis image use
no body producers and therefore expose no method rows:

```text
old methods: 0
new methods: 0
same module identity: True
assembly: AssemblyReferenceIdentity { Name = ILInspector.Analysis, Version = 1.0.0.0, Culture = , PublicKeyToken =  }
mvid: c7b95651-019a-41a5-9f85-208cef451b1b
```

The identity follows the image, not either caller-supplied label or a sampled
method.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-restore`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- Browser engine layering gates:
  `EveryBannedSymbolStillExists`,
  `BanListForbidsEverySessionAndImageDoor`
- `npx markdownlint-cli docs/design/assembly-inspection-query.md`
- `git diff --check`

Closes #5043
