### PR TITLE
Reject clamped package counts

### DIFF
--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -146,10 +146,11 @@ between 1 and..."). `-S` and `--where` are also not yet wired (there is
 currently exactly one section, `Packages`, so `-S` selection is moot until the
 facet layer adds more to select between).
 
-While that legacy spelling remains, numeric `-t` is a package-result clamp and
-is mutually exclusive with `--count`. A bounded prefix and an unwindowed count
-are different requests; accepting both would make the scalar neither the
-selected package count nor an exhaustive corpus count.
+While that legacy spelling remains, numeric `-t` clamps the package candidates
+the source is asked to return and is mutually exclusive with `--count`.
+Accepting both would present a count over an intentionally shortened
+acquisition as though no package clamp applied. This package-source rule does
+not define how `--count` composes with L2 row windows.
 
 **Interaction concern for the next CLI slice:** the Sections migration and the
 `-t`→`-n` flag rename were assumed to be one atomic step; in practice they

--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -146,6 +146,11 @@ between 1 and..."). `-S` and `--where` are also not yet wired (there is
 currently exactly one section, `Packages`, so `-S` selection is moot until the
 facet layer adds more to select between).
 
+While that legacy spelling remains, numeric `-t` is a package-result clamp and
+is mutually exclusive with `--count`. A bounded prefix and an unwindowed count
+are different requests; accepting both would make the scalar neither the
+selected package count nor an exhaustive corpus count.
+
 **Interaction concern for the next CLI slice:** the Sections migration and the
 `-t`→`-n` flag rename were assumed to be one atomic step; in practice they
 decoupled, and the migration landed first. The CLI facet wiring in

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -1138,6 +1138,31 @@ public class FindCommandIntegrationTests
     }
 
     [Theory]
+    [InlineData("-t")]
+    [InlineData("--type")]
+    public void PackageProfileCountWithPackageLimit_FailsBeforeNetwork(
+        string option)
+    {
+        var (exit, output, error) = RunCli(
+            [
+                "find",
+                "--package-prefix",
+                "Microsoft",
+                option,
+                "2",
+                "--count",
+                "--offline",
+            ]);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            "--count cannot be combined with -t for a package-prefix search",
+            error);
+        Assert.DoesNotContain("Attempted:", error);
+    }
+
+    [Theory]
     [InlineData("not-a-number")]
     [InlineData("2147483648")]
     public void PackageProfileInvalidRawLimit_FailsBeforeNetwork(

--- a/src/dotnet-inspect.Tests/FindCommandTests.cs
+++ b/src/dotnet-inspect.Tests/FindCommandTests.cs
@@ -1163,6 +1163,35 @@ public class FindCommandIntegrationTests
     }
 
     [Theory]
+    [InlineData("-t", "-D")]
+    [InlineData("-t", "--discover")]
+    [InlineData("--type", "-D")]
+    [InlineData("--type", "--discover")]
+    public void PackageProfileDiscoveryRejectsCountWithPackageLimit(
+        string limitOption,
+        string discoverOption)
+    {
+        var (exit, output, error) = RunCli(
+            [
+                "find",
+                "--package-prefix",
+                "Microsoft",
+                limitOption,
+                "2",
+                "--count",
+                discoverOption,
+                "--offline",
+            ]);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(
+            "--count cannot be combined with -t for a package-prefix search",
+            error);
+        Assert.DoesNotContain("Attempted:", error);
+    }
+
+    [Theory]
     [InlineData("not-a-number")]
     [InlineData("2147483648")]
     public void PackageProfileInvalidRawLimit_FailsBeforeNetwork(

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -21,6 +21,15 @@ public class FindCommand
         FindOptions options,
         CancellationToken cancellationToken = default)
     {
+        if (options.IsPackageProfile
+            && options.Count
+            && options.Limit is not null)
+        {
+            CommandError.Write(
+                "--count cannot be combined with -t for a package-prefix search.");
+            return 1;
+        }
+
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
 
@@ -183,13 +192,6 @@ public class FindCommand
         {
             CommandError.Write(
                 $"-t must be between 1 and {PackageProfileQuery.MaximumPackageLimit} for a package-prefix profile (got {maximumPackages}).");
-            return 1;
-        }
-
-        if (options.Count && options.Limit is not null)
-        {
-            CommandError.Write(
-                "--count cannot be combined with -t for a package-prefix search.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -186,6 +186,13 @@ public class FindCommand
             return 1;
         }
 
+        if (options.Count && options.Limit is not null)
+        {
+            CommandError.Write(
+                "--count cannot be combined with -t for a package-prefix search.");
+            return 1;
+        }
+
         using IPackageSourceClient source =
             PackageSourceClientFactory.CreateGallery(
                 DotnetInspector.Core.HttpClientFactory


### PR DESCRIPTION
## Summary

- reject `find --package-prefix PREFIX -t N --count` during command preflight
- keep both `-t` and its `--type` alias from turning a bounded package set into
  a success-shaped scalar count
- perform the rejection before package-source creation, network acquisition,
  or stdout publication

Closes #5064

## Demo

Before:

```console
$ dotnet-inspect find --package-prefix Microsoft -t 2 --count
21
Warning: Package discovery reached the requested package limit.
```

The scalar counted flattened package/dependency rows plus a terminal status
row. It was neither the two-package clamp nor an exhaustive package count.

After:

```console
$ dotnet run --no-build --project src/dotnet-inspect -c Release -- find --package-prefix Microsoft -t 2 --count --offline
Error: --count cannot be combined with -t for a package-prefix search.
```

The command exits nonzero, writes no stdout, and fails before the offline
network guard can observe an acquisition attempt.

## Stack

- Slice 2, targeting `compiled-inspection-lenses`
- Parent: PR #5008
- Residual: generic count/window composition is tracked by #5173; package-prefix
  clamp completion, exact-count behavior, terminology, multi-input package
  evidence, and native query syntax remain separate work

## Validation

- focused
  `PackageProfileCountWithPackageLimit_FailsBeforeNetwork` and
  `PackageProfileDiscoveryRejectsCountWithPackageLimit` Release tests:
  6 passed
- `npx markdownlint-cli docs/design/package-query-cli.md`
- `git diff --check`
- source-built rejection demo above

## Non-action boundary

This PR does not change what `-t` alone returns, define an exhaustive package
count, rename `PackageProfile*` internals, replace `-t` with item-mode `-n`, or
add package evidence/query capabilities.
