### PR TITLE
Design shared local-path admission

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -526,15 +526,15 @@ no `.` or `..` segment; otherwise it is rejected as invalid. Any other
 non-empty path that cannot be normalized is also rejected rather than escaping
 as a platform exception.
 
-All local coordinates follow symbolic links and name-surrogate reparse points
-to their final target. The same policy preserves existing explicit-file
+All local coordinates follow symbolic links and supported link-like reparse
+points to their final target. The same policy preserves existing explicit-file
 behavior and supports symlinked build outputs without making directory
 acquisition a second policy domain. A dangling link is unavailable. A link
-whose final target has the wrong kind is rejected. A name-surrogate reparse
-point whose final target cannot be classified by the supported link API is
-rejected rather than opened as an unknown entry. Non-name-surrogate reparse
-points are ordinary filesystem entries whose own expected kind is classified;
-the `ReparsePoint` attribute alone does not reject them.
+whose final target has the wrong kind is rejected. A reparse entry whose tag
+denotes an unsupported link, a non-regular entry, or an unknown meaning is
+rejected rather than opened. Recognized non-link data-bearing reparse entries
+retain their own expected kind; the `ReparsePoint` attribute alone does not
+reject them.
 
 The canonical requested path remains the coordinate after link resolution. The
 adapter does not publish a physical target path or require the target to remain
@@ -553,7 +553,7 @@ deferred, but consumers cannot replace them with exception-message matching:
 | The path is missing, a link is dangling, or the entry disappears before the file open | `Unavailable` |
 | The path cannot be normalized | `Rejected` with an invalid-path reason |
 | The final target has the wrong expected kind | `Rejected` with a kind-mismatch reason |
-| The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unclassifiable name-surrogate reparse point | `Rejected` with a non-regular or unsupported-entry reason |
+| The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unsupported, special, ambiguous, or unknown reparse entry | `Rejected` with a non-regular or unsupported-entry reason |
 | Metadata inspection, native classification, or the file open fails for a reason other than absence | `Failed` with an admission-failed reason |
 | The current host has no supported classifier | `Failed` with a classification-unsupported reason |
 | Cancellation is observed | `OperationCanceledException` |
@@ -562,8 +562,15 @@ The shared result carries a typed reason and canonical path, not a
 source-neutral artifact outcome. The explicit-file and directory operations
 project it into their existing `LocalArtifactDiagnostic` surface. Equivalent
 reasons must retain the same result arm and meaning across coordinates;
-coordinate-specific context may refine the diagnostic code and summary. The
-existing explicit-file missing projection remains `local.file.missing`.
+coordinate-specific context may refine the diagnostic code and summary.
+Explicit-file projection preserves `local.file.missing`,
+`local.file.read-failed`, and `local.file.size-limit`: classification or open
+failures continue to use `Failed` with `local.file.read-failed`. Invalid paths
+use `Rejected` with `local.file.invalid-path`; an existing target that is a
+directory, non-regular entry, or unsupported reparse entry uses `Rejected` with
+`local.file.unsupported-entry`. The latter deliberately changes the current
+directory-target behavior from `Failed`/`local.file.read-failed` because the
+present path is now proven not to satisfy the explicit regular-file coordinate.
 Failures after a regular file is admitted, including bounded snapshot-copy
 failures, remain read failures owned by the consuming acquisition rather than
 being relabeled as path admission.
@@ -581,13 +588,22 @@ device coordinates. Extended-length disk and UNC paths are not rejected merely
 for using the `\\?\` prefix after their segments satisfy the normalization rule
 above. Ordinary filesystem paths are inspected through managed attributes. For
 a final reparse point, a metadata handle opened without following the point
-queries its tag. A name-surrogate tag denotes a link-like entry: supported
-symbolic-link and mount-point forms are resolved and their final target
-attributes inspected, while an unsupported name-surrogate tag is rejected. A
-non-name-surrogate tag, including an ordinary cloud placeholder, retains its
-own file or directory attributes and proceeds to normal expected-kind and
-post-open checks. This step must prove a file or directory target before a
-file-content open.
+queries its tag. Classification is tag-semantic rather than based only on the
+name-surrogate bit:
+
+- symbolic-link and mount-point tags are supported links, so their final target
+  is resolved and classified;
+- tags that can denote a special file or an unsupported link are rejected,
+  including AF_UNIX, WSL FIFO/character/block entries, and the entire NFS tag
+  unless a later design adds bounded subtype parsing;
+- audited non-link data-bearing tags, including cloud-placeholder,
+  deduplication, and projection forms, retain their own file or directory
+  attributes and proceed to expected-kind and post-open checks; and
+- unknown tags are rejected rather than assumed to be data-bearing.
+
+The tag policy is one enumerated classifier whose coverage gate fails when an
+implemented known-tag constant lacks a disposition. This step must prove a file
+or directory target before a file-content open.
 
 Regular-file admission then opens the canonical requested path exactly once and
 returns that owned read-only stream or handle to the consuming acquisition.
@@ -632,8 +648,9 @@ The implementation is complete when focused gates prove:
 
 - canonicalization, including extended-path segment rejection, expected-kind
   mismatches, final-target link following, dangling links, name-surrogate
-  rejection, non-name-surrogate treatment, and hard-link non-deduplication have
-  the same semantics for every consuming local coordinate;
+  handling, special and unknown reparse rejection, audited data-bearing
+  reparse treatment, and hard-link non-deduplication have the same semantics
+  for every consuming local coordinate;
 - stable FIFOs, sockets, devices, and their link aliases are rejected before a
   blocking content open, while an empty regular file remains admissible;
 - a regular-file consumer receives the once-opened, post-classified handle and
@@ -641,8 +658,9 @@ The implementation is complete when focused gates prove:
 - unavailable, rejected, failed, and cancellation results remain distinct; and
 - the normalized `Stat` and `FStat` classifier compiles and runs under both
   NativeAOT and Browser/Wasm, while Windows gates cover disk files,
-  directories, traversable links, reserved device names, and named-pipe
-  coordinates.
+  directories, traversable links, reserved device names, named-pipe
+  coordinates, allowed data-bearing reparse tags, every supported special-tag
+  family, and an unknown tag.
 
 These properties are represented by
 `LocalPathAdmission_ExpectedKindsAndLinksAreShared`,
@@ -710,16 +728,21 @@ Acquisition follows this order:
 4. Derive one direct-child relative name per observed entry and sort by that
    name with `StringComparer.Ordinal`. Filesystem enumeration order is never
    publication order.
-5. Ignore ordinary directories before filename selection, apply the extension
-   allow list and exclusions, and reject the batch if `MaxSelectedFiles` is
-   exceeded.
-6. In sorted order, admit each selected entry as a regular file through the
-   shared contract, then copy it into an adapter-private snapshot while
-   enforcing `MaxFileBytes` and the remaining `MaxTotalBytes`.
+5. Use enumeration attributes only to discard an entry already proven to be a
+   non-reparse directory. Apply the extension allow list and exclusions to the
+   remaining observed names, producing lexical candidates without deciding
+   their final target kind.
+6. In sorted order, classify each candidate through the shared contract. Ignore
+   a candidate whose final target is a directory. For each regular-file target,
+   increment the selected-file count, reject the batch if `MaxSelectedFiles` is
+   exceeded, then continue shared admission through its verified open handle
+   and consume that handle into an adapter-private snapshot while enforcing
+   `MaxFileBytes` and the remaining `MaxTotalBytes`. Any other classification
+   result rejects or fails the batch with its typed reason.
 7. Register the complete batch in one contribution scope only after every
-   selected snapshot succeeds. Any enumeration, selected-entry, limit,
-   registration, or outcome-construction failure publishes no contribution
-   from the batch.
+   selected snapshot succeeds. Any enumeration, candidate admission,
+   selected-entry, limit, registration, or outcome-construction failure
+   publishes no contribution from the batch.
 
 Copying stops before retaining a byte that would exceed either bound. The bound
 that would be exceeded first determines the rejection; when the same byte would
@@ -733,6 +756,9 @@ workspace acquisition retains its existing empty-batch failure; #5010 owns the
 supplemental path that can compose this result.
 
 Root and selected-entry admission outcomes remain those of the shared contract.
+A lexical candidate whose final target is a directory is a classification
+result used for filtering, not a selected coordinate, and emits no path
+outcome. Every other candidate classification failure remains visible.
 Directory-specific enumeration and snapshot-copy diagnostics use the canonical
 root and, when applicable, the observed relative name:
 
@@ -761,14 +787,16 @@ and bytes do not establish media or semantic kind.
 
 The adapter establishes an immutable batch of the bytes it actually copied,
 not a transactional filesystem snapshot. A file created after enumeration is
-outside that acquisition. Any selected-entry failure rejects the whole batch
-rather than shortening it. Shared admission owns the residual local-path race
-and classification guarantees; mutation after copying cannot change the
-retained snapshot.
+outside that acquisition. Any candidate classification, admission, or selected
+entry failure rejects the whole batch rather than shortening it. Shared
+admission owns the residual local-path race and classification guarantees;
+mutation after copying cannot change the retained snapshot.
 
 The implementation is complete when focused gates prove:
 
 - bounded top-level selection is deterministic and source-neutral;
+- plain and linked directory targets are ignored through the shared
+  final-target classification, while links to regular files remain selectable;
 - empty selection registers nothing, while enumeration failure remains failed
   rather than becoming empty success, and neither it nor entry admission,
   per-file and aggregate overflow with their defined precedence, read failure,
@@ -1243,8 +1271,14 @@ The migration is intentionally incremental:
    adapters land only with their own typed coordinates, capabilities, limits,
    and provenance gates.
 
-Each slice must preserve current visible diagnostics and selection semantics.
-The migration does not justify a success-shaped fallback or an unbounded eager
+Each slice must preserve current visible diagnostics and selection semantics
+unless its owning design names an intentional change. Shared local-path
+admission deliberately changes an explicit-file coordinate that resolves to a
+directory or another non-regular entry from
+`Failed`/`local.file.read-failed` to
+`Rejected`/`local.file.unsupported-entry`; its missing, size-limit, and genuine
+classification, open, or read failures retain their current projections. The
+migration does not justify a success-shaped fallback or an unbounded eager
 materialization.
 
 ## Required gates

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -506,25 +506,38 @@ owner-mediated on-demand digest remains unverified.
 `DotnetInspector.Artifacts.Local` owns one package-free admission contract for
 every path coordinate it consumes. The contract is internal to the local
 adapter; it does not add filesystem policy to source-neutral artifact
-contracts. Its input is a non-empty path and one required kind:
+contracts. It has two stages over one classifier:
+
+1. Classification accepts a non-empty requested path and returns a canonical
+   path plus the observed final kind, `RegularFile` or `Directory`, or a typed
+   path outcome.
+2. Admission adds one required kind and rejects a classified target that does
+   not match it. Regular-file admission then opens and verifies the content
+   handle; directory admission returns the canonical path.
+
+Direct coordinates always admit one required kind:
 
 - `RegularFile` for an explicit-file coordinate or a selected directory entry;
   or
 - `Directory` for a bounded-directory root.
 
-There is no "any filesystem entry" kind. Admission proves that the coordinate
-currently resolves to the kind the consuming operation requires.
+There is no "any filesystem entry" admission. Classification exposes only the
+two admissible observed kinds; non-regular or unclassifiable entries remain
+typed outcomes. Bounded-directory candidate filtering is the only consumer that
+uses an observed kind before choosing whether the candidate becomes an admitted
+coordinate.
 
-The adapter converts the input once with `Path.GetFullPath`. The result is the
-canonical requested path used by diagnostics and provenance. For ordinary
-paths, this lexical normalization makes the coordinate absolute and removes
-relative path segments, but it does not resolve links, normalize case, or mint
-physical file identity. Windows treats extended `\\?\` paths as already
-normalized and leaves their segments unchanged. An extended disk or UNC
-coordinate is therefore admitted only when it is fully qualified and contains
-no `.` or `..` segment; otherwise it is rejected as invalid. Any other
-non-empty path that cannot be normalized is also rejected rather than escaping
-as a platform exception.
+The classifier retains the original non-empty requested path and converts it
+once with `Path.GetFullPath`. Successful normalization adds the canonical path
+used by provenance and ordinary diagnostics. For ordinary paths, this lexical
+normalization makes the coordinate absolute and removes relative path segments,
+but it does not resolve links, normalize case, or mint physical file identity.
+Windows treats extended `\\?\` paths as already normalized and leaves their
+segments unchanged. An extended disk or UNC coordinate is therefore admitted
+only when it is fully qualified and contains no `.` or `..` segment; otherwise
+it is rejected as invalid. Any other non-empty path that cannot be normalized
+is also rejected rather than escaping as a platform exception. Invalid-path
+results carry the requested path and no canonical path.
 
 All local coordinates follow symbolic links and supported link-like reparse
 points to their final target. The same policy preserves existing explicit-file
@@ -545,35 +558,44 @@ boundary: the caller selected the local location, and local actors are outside
 the hostile-input model. Hard links are ordinary regular files and are not
 collapsed.
 
-Admission has these semantic results. Exact implementation type names are
-deferred, but consumers cannot replace them with exception-message matching:
+Classification and admission have these semantic results. Exact implementation
+type names are deferred, but consumers cannot replace them with
+exception-message matching:
 
 | Condition | Result |
 | --- | --- |
+| The final target is a regular file or directory | Internal classified result carrying the observed kind |
 | The path is missing, a link is dangling, or the entry disappears before the file open | `Unavailable` |
-| The path cannot be normalized | `Rejected` with an invalid-path reason |
+| The path cannot be normalized | `Rejected` with an invalid-path reason and no canonical path |
 | The final target has the wrong expected kind | `Rejected` with a kind-mismatch reason |
 | The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unsupported, special, ambiguous, or unknown reparse entry | `Rejected` with a non-regular or unsupported-entry reason |
 | Metadata inspection, native classification, or the file open fails for a reason other than absence | `Failed` with an admission-failed reason |
 | The current host has no supported classifier | `Failed` with a classification-unsupported reason |
 | Cancellation is observed | `OperationCanceledException` |
 
-The shared result carries a typed reason and canonical path, not a
-source-neutral artifact outcome. The explicit-file and directory operations
-project it into their existing `LocalArtifactDiagnostic` surface. Equivalent
-reasons must retain the same result arm and meaning across coordinates;
+The shared result carries a typed reason, requested path, and optional canonical
+path, not a source-neutral artifact outcome. The explicit-file and directory
+operations project it into their existing `LocalArtifactDiagnostic` surface.
+The target diagnostic adds a requested path and nullable canonical path;
+existing `FullPath` remains a compatibility display projection of
+`CanonicalPath ?? RequestedPath`. Provenance is produced only after successful
+normalization and always uses the canonical path. Equivalent admission reasons
+must retain the same result arm and meaning across direct coordinates;
 coordinate-specific context may refine the diagnostic code and summary.
 Explicit-file projection preserves `local.file.missing`,
-`local.file.read-failed`, and `local.file.size-limit`: classification or open
-failures continue to use `Failed` with `local.file.read-failed`. Invalid paths
-use `Rejected` with `local.file.invalid-path`; an existing target that is a
-directory, non-regular entry, or unsupported reparse entry uses `Rejected` with
-`local.file.unsupported-entry`. The latter deliberately changes the current
-directory-target behavior from `Failed`/`local.file.read-failed` because the
-present path is now proven not to satisfy the explicit regular-file coordinate.
-Failures after a regular file is admitted, including bounded snapshot-copy
-failures, remain read failures owned by the consuming acquisition rather than
-being relabeled as path admission.
+`local.file.read-failed`, and `local.file.size-limit`: path-specific metadata,
+open, and read failures continue to use `Failed` with
+`local.file.read-failed`. Invalid paths use `Rejected` with
+`local.file.invalid-path`; an existing target that is a directory, non-regular
+entry, or unsupported reparse entry uses `Rejected` with
+`local.file.unsupported-entry`. Unexpected absence of a required platform
+classifier uses `Failed` with `local.file.classification-unsupported`, not the
+generic read-failure code. The unsupported-entry projection deliberately
+changes the current directory-target behavior from
+`Failed`/`local.file.read-failed` because the present path is now proven not to
+satisfy the explicit regular-file coordinate. Failures after a regular file is
+admitted, including bounded snapshot-copy failures, remain read failures owned
+by the consuming acquisition rather than being relabeled as path admission.
 
 Admission occurs before any operation known to block on a stable non-regular
 entry. Managed attributes are insufficient on Unix: a FIFO, a character device,
@@ -644,13 +666,24 @@ supported target is intentionally excluded. A missing native library or entry
 point is a visible classification-unsupported failure, never permission to
 open an unclassified path.
 
+This does not inherit the CLI-only physical-identity exception in
+[`schema-query.md`](schema-query.md#effective-filtering). That provider's
+contract needs stable device/inode identity and intentionally restricts the
+hosts on which it deduplicates physical files. Local-path admission consumes
+only the normalized mode field and does not mint physical identity. The
+portable gate must run the actual `Stat` and `FStat` imports under 32-bit
+Browser/Wasm as well as NativeAOT. If that gate fails on a supported target, the
+platform design reopens; returning classification-unsupported is an operational
+failure mode, not approval to ship an unsupported-platform degradation.
+
 The implementation is complete when focused gates prove:
 
 - canonicalization, including extended-path segment rejection, expected-kind
-  mismatches, final-target link following, dangling links, name-surrogate
-  handling, special and unknown reparse rejection, audited data-bearing
-  reparse treatment, and hard-link non-deduplication have the same semantics
-  for every consuming local coordinate;
+  mismatches, requested-path retention when canonicalization fails,
+  final-target link following, dangling links, name-surrogate handling, special
+  and unknown reparse rejection, audited data-bearing reparse treatment, and
+  hard-link non-deduplication have the same semantics for every consuming local
+  coordinate;
 - stable FIFOs, sockets, devices, and their link aliases are rejected before a
   blocking content open, while an empty regular file remains admissible;
 - a regular-file consumer receives the once-opened, post-classified handle and
@@ -733,12 +766,13 @@ Acquisition follows this order:
    remaining observed names, producing lexical candidates without deciding
    their final target kind.
 6. In sorted order, classify each candidate through the shared contract. Ignore
-   a candidate whose final target is a directory. For each regular-file target,
-   increment the selected-file count, reject the batch if `MaxSelectedFiles` is
-   exceeded, then continue shared admission through its verified open handle
-   and consume that handle into an adapter-private snapshot while enforcing
-   `MaxFileBytes` and the remaining `MaxTotalBytes`. Any other classification
-   result rejects or fails the batch with its typed reason.
+   a classified directory. For each classified regular file, increment the
+   selected-file count, reject the batch if `MaxSelectedFiles` is exceeded,
+   then continue shared admission through its verified open handle and consume
+   that handle into an adapter-private snapshot while enforcing
+   `MaxFileBytes` and the remaining `MaxTotalBytes`. Any `Unavailable`,
+   `Rejected`, or `Failed` classification or admission result aborts the atomic
+   batch without publishing and preserves that exact outcome arm.
 7. Register the complete batch in one contribution scope only after every
    selected snapshot succeeds. Any enumeration, candidate admission,
    selected-entry, limit, registration, or outcome-construction failure
@@ -756,9 +790,22 @@ workspace acquisition retains its existing empty-batch failure; #5010 owns the
 supplemental path that can compose this result.
 
 Root and selected-entry admission outcomes remain those of the shared contract.
-A lexical candidate whose final target is a directory is a classification
-result used for filtering, not a selected coordinate, and emits no path
-outcome. Every other candidate classification failure remains visible.
+A lexical candidate classified as a directory is used for filtering, not
+admitted as a selected coordinate, and emits no path outcome. Every other
+candidate classification or admission outcome remains visible. Directory path
+diagnostics retain the requested root, its canonical path when available, and
+the observed relative candidate name when applicable:
+
+| Condition | Outcome | Diagnostic code |
+| --- | --- | --- |
+| Root is missing or a root link is dangling | `Unavailable` | `local.directory.root-missing` |
+| Root path is invalid | `Rejected` | `local.directory.root-invalid-path` |
+| Root has the wrong kind or unsupported entry kind | `Rejected` | `local.directory.root-unsupported` |
+| Root classification fails | `Failed` | `local.directory.root-admission-failed` |
+| Candidate is missing, dangling, or disappears | `Unavailable` | `local.directory.entry-missing` |
+| Candidate is non-regular or unsupported | `Rejected` | `local.directory.entry-unsupported` |
+| Candidate classification or open fails | `Failed` | `local.directory.entry-admission-failed` |
+
 Directory-specific enumeration and snapshot-copy diagnostics use the canonical
 root and, when applicable, the observed relative name:
 
@@ -788,9 +835,10 @@ and bytes do not establish media or semantic kind.
 The adapter establishes an immutable batch of the bytes it actually copied,
 not a transactional filesystem snapshot. A file created after enumeration is
 outside that acquisition. Any candidate classification, admission, or selected
-entry failure rejects the whole batch rather than shortening it. Shared
-admission owns the residual local-path race and classification guarantees;
-mutation after copying cannot change the retained snapshot.
+entry failure aborts the whole batch with its defined outcome rather than
+shortening it. Shared admission owns the residual local-path race and
+classification guarantees; mutation after copying cannot change the retained
+snapshot.
 
 The implementation is complete when focused gates prove:
 
@@ -1277,9 +1325,11 @@ admission deliberately changes an explicit-file coordinate that resolves to a
 directory or another non-regular entry from
 `Failed`/`local.file.read-failed` to
 `Rejected`/`local.file.unsupported-entry`; its missing, size-limit, and genuine
-classification, open, or read failures retain their current projections. The
-migration does not justify a success-shaped fallback or an unbounded eager
-materialization.
+path-specific metadata, open, or read failures retain their current
+projections. `local.file.classification-unsupported` identifies an unexpected
+platform-classifier deployment failure rather than disguising it as a read
+failure. The migration does not justify a success-shaped fallback or an
+unbounded eager materialization.
 
 ## Required gates
 

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -608,10 +608,16 @@ and block or character devices without opening the entry.
 Windows admission first rejects device and pipe namespaces and reserved DOS
 device coordinates. Extended-length disk and UNC paths are not rejected merely
 for using the `\\?\` prefix after their segments satisfy the normalization rule
-above. Ordinary filesystem paths are inspected through managed attributes. For
-a final reparse point, a metadata handle opened without following the point
-queries its tag. Classification is tag-semantic rather than based only on the
-name-surrogate bit:
+above. An ordinary drive root such as `C:\` is a supported `Directory`
+coordinate; bounded-directory limits still govern its top-level enumeration.
+An ordinary regular file directly beneath that root, such as `C:\foo.dll`, is a
+supported `RegularFile` coordinate. Neither form is a device coordinate.
+`C:` without the trailing separator is instead drive-relative input and follows
+the ordinary `Path.GetFullPath` normalization rule before classification.
+Ordinary filesystem paths are inspected through managed attributes. For a final
+reparse point, a metadata handle opened without following the point queries its
+tag. Classification is tag-semantic rather than based only on the name-surrogate
+bit:
 
 - symbolic-link and mount-point tags are supported links, so their final target
   is resolved and classified;
@@ -691,9 +697,10 @@ The implementation is complete when focused gates prove:
 - unavailable, rejected, failed, and cancellation results remain distinct; and
 - the normalized `Stat` and `FStat` classifier compiles and runs under both
   NativeAOT and Browser/Wasm, while Windows gates cover disk files,
-  directories, traversable links, reserved device names, named-pipe
-  coordinates, allowed data-bearing reparse tags, every supported special-tag
-  family, and an unknown tag.
+  drive-root directories, regular files directly beneath a drive root,
+  traversable links, reserved device names, named-pipe coordinates, allowed
+  data-bearing reparse tags, every supported special-tag family, and an unknown
+  tag.
 
 These properties are represented by
 `LocalPathAdmission_ExpectedKindsAndLinksAreShared`,

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -501,13 +501,151 @@ snapshot.
 The ordinary retained snapshot does not compute a digest eagerly. The target
 owner-mediated on-demand digest remains unverified.
 
-Shared local-path admission is tracked by
-[#5096](https://github.com/richlander/dotnet-inspect/issues/5096). It owns
-expected entry kind, path normalization, link and reparse-point policy,
-non-regular entries, supported-host behavior, and pre-open classification for
-both explicit-file and directory coordinates. The directory contract below
-consumes admitted directory roots and regular-file entries; it does not
-define a second path classifier.
+#### Shared local-path admission
+
+`DotnetInspector.Artifacts.Local` owns one package-free admission contract for
+every path coordinate it consumes. The contract is internal to the local
+adapter; it does not add filesystem policy to source-neutral artifact
+contracts. Its input is a non-empty path and one required kind:
+
+- `RegularFile` for an explicit-file coordinate or a selected directory entry;
+  or
+- `Directory` for a bounded-directory root.
+
+There is no "any filesystem entry" kind. Admission proves that the coordinate
+currently resolves to the kind the consuming operation requires.
+
+The adapter converts the input once with `Path.GetFullPath`. The result is the
+canonical requested path used by diagnostics and provenance. This is lexical
+normalization: it makes the coordinate absolute and removes relative path
+segments, but it does not resolve links, normalize case, or mint physical file
+identity. A non-empty path that cannot be normalized is rejected rather than
+escaping as a platform exception.
+
+All local coordinates follow symbolic links and traversable reparse points to
+their final target. The same policy preserves existing explicit-file behavior
+and supports symlinked build outputs without making directory acquisition a
+second policy domain. A dangling link is unavailable. A link whose final target
+has the wrong kind is rejected. A reparse point whose final target cannot be
+classified by the supported link API is rejected rather than opened as an
+unknown entry.
+
+The canonical requested path remains the coordinate after link resolution. The
+adapter does not publish a physical target path or require the target to remain
+beneath the lexical parent. Consequently, a top-level directory entry that is a
+link may resolve outside the requested root and still contribute the regular
+file named by that entry. This is coordinate behavior, not a containment
+boundary: the caller selected the local location, and local actors are outside
+the hostile-input model. Hard links are ordinary regular files and are not
+collapsed.
+
+Admission has these semantic results. Exact implementation type names are
+deferred, but consumers cannot replace them with exception-message matching:
+
+| Condition | Result |
+| --- | --- |
+| The path is missing, a link is dangling, or the entry disappears before the file open | `Unavailable` |
+| The path cannot be normalized | `Rejected` with an invalid-path reason |
+| The final target has the wrong expected kind | `Rejected` with a kind-mismatch reason |
+| The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unclassifiable reparse point | `Rejected` with a non-regular or unsupported-entry reason |
+| Metadata inspection, native classification, or the file open fails for a reason other than absence | `Failed` with an admission-failed reason |
+| The current host has no supported classifier | `Failed` with a classification-unsupported reason |
+| Cancellation is observed | `OperationCanceledException` |
+
+The shared result carries a typed reason and canonical path, not a
+source-neutral artifact outcome. The explicit-file and directory operations
+project it into their existing `LocalArtifactDiagnostic` surface. Equivalent
+reasons must retain the same result arm and meaning across coordinates;
+coordinate-specific context may refine the diagnostic code and summary. The
+existing explicit-file missing projection remains `local.file.missing`.
+Failures after a regular file is admitted, including bounded snapshot-copy
+failures, remain read failures owned by the consuming acquisition rather than
+being relabeled as path admission.
+
+Admission occurs before any operation known to block on a stable non-regular
+entry. Managed attributes are insufficient on Unix: a FIFO, a character device,
+and an empty regular file can all appear as normal zero-length files. Supported
+non-Windows hosts therefore classify the final target with the .NET runtime's
+normalized `SystemNative_Stat` ABI. `stat` follows links and exposes the stable
+mode mask needed to distinguish directories, regular files, FIFOs, sockets,
+and block or character devices without opening the entry.
+
+Windows admission first rejects device and pipe namespaces and reserved DOS
+device coordinates. Extended-length paths to disk files are not rejected merely
+for using the `\\?\` prefix. Ordinary filesystem paths are inspected through
+managed attributes. A final symbolic link or traversable reparse point is
+resolved and its target attributes are inspected; an unsupported reparse kind
+is rejected. This step must prove a file or directory target before a
+file-content open.
+
+Regular-file admission then opens the canonical requested path exactly once and
+returns that owned read-only stream or handle to the consuming acquisition.
+Before returning it, the adapter classifies the handle again:
+
+- non-Windows hosts use `SystemNative_FStat` and require regular-file mode; and
+- Windows requires `GetFileType` to report `FILE_TYPE_DISK` and handle-based
+  attributes not to report a directory.
+
+A post-open kind mismatch is rejected and the handle is disposed. The explicit
+file and future directory-entry copy therefore consume the same verified open
+generation; neither reopens the path after admission. Size limits, last-write
+observation, copying, provenance construction, and contribution registration
+remain with the consuming acquisition.
+
+Directory-root admission performs the same normalization, link policy, and
+pre-open expected-kind classification, then returns the canonical requested
+path for enumeration. It does not promise handle-relative or transactional
+enumeration. If the root changes after classification, ordinary enumeration
+failure remains visible through the directory contract below.
+
+This contract prevents a stable non-regular entry from predictably reaching a
+blocking content open. It does not make path classification and open atomic. A
+local process can replace a regular file with a FIFO after classification and
+before open, or replace a directory before enumeration. Defending against that
+same-machine mutation would require a native nonblocking or handle-relative
+filesystem protocol and is outside the local-actor threat model. Once file
+admission returns an open regular-file handle, later link retargeting or path
+replacement cannot change the generation that is copied; immutable retained
+snapshot lifetime remains owned by
+[#4816](https://github.com/richlander/dotnet-inspect/issues/4816).
+
+The implementation remains package-free, source-generated-interop compatible,
+and NativeAOT-friendly. `LibraryImport` of the runtime-normalized `Stat` and
+`FStat` entry points works on ordinary Unix hosts and Browser/Wasm; Windows uses
+managed file APIs plus source-generated `kernel32` interop. No currently
+supported target is intentionally excluded. A missing native library or entry
+point is a visible classification-unsupported failure, never permission to
+open an unclassified path.
+
+The implementation is complete when focused gates prove:
+
+- canonicalization, expected-kind mismatches, final-target link following,
+  dangling links, unsupported reparse points, and hard-link non-deduplication
+  have the same semantics for every consuming local coordinate;
+- stable FIFOs, sockets, devices, and their link aliases are rejected before a
+  blocking content open, while an empty regular file remains admissible;
+- a regular-file consumer receives the once-opened, post-classified handle and
+  cannot reopen the coordinate;
+- unavailable, rejected, failed, and cancellation results remain distinct; and
+- the normalized `Stat` and `FStat` classifier compiles and runs under both
+  NativeAOT and Browser/Wasm, while Windows gates cover disk files,
+  directories, traversable links, reserved device names, and named-pipe
+  coordinates.
+
+These properties are represented by
+`LocalPathAdmission_ExpectedKindsAndLinksAreShared`,
+`LocalPathAdmission_StableNonRegularEntriesRejectBeforeOpen`,
+`LocalPathAdmission_ConsumerReceivesTheVerifiedOpenGeneration`,
+`LocalPathAdmission_OutcomesAndCancellationRemainDistinct`, and
+`LocalPathAdmission_PlatformClassifiersRemainPortable`. They are unverified
+until those gates exist. The bounded-directory implementation must exercise
+the same contract through its public root and selected-entry outcomes rather
+than adding another classifier.
+
+Admission is sequential and adds no publication, interleaving, or concurrent
+ownership state. A new TLA+ model would duplicate the existing artifact-session
+model without checking a new state machine. Native classification and
+cross-platform executable canaries are the evidence this contract needs.
 
 #### Bounded directory coordinate
 
@@ -551,7 +689,8 @@ a later contract.
 Acquisition follows this order:
 
 1. Validate and copy options before filesystem work.
-2. Admit the requested root as a directory through #5096. Preserve its visible
+2. Admit the requested root as a directory through the
+   [shared contract](#shared-local-path-admission). Preserve its visible
    unavailable, rejected, failed, and cancellation outcomes.
 3. Enumerate top-level entries incrementally. Count every observed entry before
    classifying it and stop with a typed rejection as soon as
@@ -562,9 +701,9 @@ Acquisition follows this order:
 5. Ignore ordinary directories before filename selection, apply the extension
    allow list and exclusions, and reject the batch if `MaxSelectedFiles` is
    exceeded.
-6. In sorted order, admit each selected entry as a regular file through #5096,
-   then copy it into an adapter-private snapshot while enforcing
-   `MaxFileBytes` and the remaining `MaxTotalBytes`.
+6. In sorted order, admit each selected entry as a regular file through the
+   shared contract, then copy it into an adapter-private snapshot while
+   enforcing `MaxFileBytes` and the remaining `MaxTotalBytes`.
 7. Register the complete batch in one contribution scope only after every
    selected snapshot succeeds. Any enumeration, selected-entry, limit,
    registration, or outcome-construction failure publishes no contribution
@@ -581,7 +720,7 @@ to an optional source coordinate, not a shortened successful batch. Required
 workspace acquisition retains its existing empty-batch failure; #5010 owns the
 supplemental path that can compose this result.
 
-Root and selected-entry admission outcomes remain those of #5096.
+Root and selected-entry admission outcomes remain those of the shared contract.
 Directory-specific enumeration and snapshot-copy diagnostics use the canonical
 root and, when applicable, the observed relative name:
 
@@ -611,9 +750,9 @@ and bytes do not establish media or semantic kind.
 The adapter establishes an immutable batch of the bytes it actually copied,
 not a transactional filesystem snapshot. A file created after enumeration is
 outside that acquisition. Any selected-entry failure rejects the whole batch
-rather than shortening it. #5096 owns the residual local-path race and
-classification guarantees; mutation after copying cannot change the retained
-snapshot.
+rather than shortening it. Shared admission owns the residual local-path race
+and classification guarantees; mutation after copying cannot change the
+retained snapshot.
 
 The implementation is complete when focused gates prove:
 
@@ -653,12 +792,13 @@ duplicate that owner without checking a new interaction. Parallel directory
 copying, directory-level single-flight, or independent partial publication
 would reopen that decision and require a focused interaction model.
 
-After #5096 defines shared local-path admission, one local-adapter PR adds this
-API, options, provenance, directory-specific diagnostics, and outcome-level
-gates without changing `AssemblySetResolver`, CLI defaults, assembly
-projection, workspace admission, or binding policy. Adoption follows #5010 and
-may choose which directories a scenario authorizes; it may not weaken adapter
-bounds or reinterpret directory provenance as caller designation.
+After shared local-path admission is implemented, one local-adapter PR adds
+this API, options, provenance, directory-specific diagnostics, and
+outcome-level gates without changing `AssemblySetResolver`, CLI defaults,
+assembly projection, workspace admission, or binding policy. Adoption follows
+[#5010](https://github.com/richlander/dotnet-inspect/issues/5010) and may choose
+which directories a scenario authorizes; it may not weaken adapter bounds or
+reinterpret directory provenance as caller designation.
 
 This adapter is the proof that the abstraction is independently useful. The
 package-free fixture composes:
@@ -1221,8 +1361,9 @@ remaining cancellation. The three named `LocalDirectoryAcquisition_*` gates
 remain unverified. Together they require bounded deterministic top-level
 selection, source-neutral exclusions, atomic empty and failure outcomes,
 directory provenance, immutable batch snapshots, and cancellation
-preservation. Shared local-path admission remains with #5096 rather than these
-directory gates.
+preservation. Shared local-path admission remains with the
+[local adapter](#shared-local-path-admission) rather than these directory
+gates.
 `LocalOnlyHost_InspectsCallerSuppliedLocalAssembly`
 deletes its temporary source after publication, then passes an
 `ArtifactContentReference`'s guarded published snapshot opener to Metadata, so

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -612,8 +612,6 @@ above. An ordinary drive root such as `C:\` is a supported `Directory`
 coordinate; bounded-directory limits still govern its top-level enumeration.
 An ordinary regular file directly beneath that root, such as `C:\foo.dll`, is a
 supported `RegularFile` coordinate. Neither form is a device coordinate.
-`C:` without the trailing separator is instead drive-relative input and follows
-the ordinary `Path.GetFullPath` normalization rule before classification.
 Ordinary filesystem paths are inspected through managed attributes. For a final
 reparse point, a metadata handle opened without following the point queries its
 tag. Classification is tag-semantic rather than based only on the name-surrogate

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -516,19 +516,25 @@ There is no "any filesystem entry" kind. Admission proves that the coordinate
 currently resolves to the kind the consuming operation requires.
 
 The adapter converts the input once with `Path.GetFullPath`. The result is the
-canonical requested path used by diagnostics and provenance. This is lexical
-normalization: it makes the coordinate absolute and removes relative path
-segments, but it does not resolve links, normalize case, or mint physical file
-identity. A non-empty path that cannot be normalized is rejected rather than
-escaping as a platform exception.
+canonical requested path used by diagnostics and provenance. For ordinary
+paths, this lexical normalization makes the coordinate absolute and removes
+relative path segments, but it does not resolve links, normalize case, or mint
+physical file identity. Windows treats extended `\\?\` paths as already
+normalized and leaves their segments unchanged. An extended disk or UNC
+coordinate is therefore admitted only when it is fully qualified and contains
+no `.` or `..` segment; otherwise it is rejected as invalid. Any other
+non-empty path that cannot be normalized is also rejected rather than escaping
+as a platform exception.
 
-All local coordinates follow symbolic links and traversable reparse points to
-their final target. The same policy preserves existing explicit-file behavior
-and supports symlinked build outputs without making directory acquisition a
-second policy domain. A dangling link is unavailable. A link whose final target
-has the wrong kind is rejected. A reparse point whose final target cannot be
-classified by the supported link API is rejected rather than opened as an
-unknown entry.
+All local coordinates follow symbolic links and name-surrogate reparse points
+to their final target. The same policy preserves existing explicit-file
+behavior and supports symlinked build outputs without making directory
+acquisition a second policy domain. A dangling link is unavailable. A link
+whose final target has the wrong kind is rejected. A name-surrogate reparse
+point whose final target cannot be classified by the supported link API is
+rejected rather than opened as an unknown entry. Non-name-surrogate reparse
+points are ordinary filesystem entries whose own expected kind is classified;
+the `ReparsePoint` attribute alone does not reject them.
 
 The canonical requested path remains the coordinate after link resolution. The
 adapter does not publish a physical target path or require the target to remain
@@ -547,7 +553,7 @@ deferred, but consumers cannot replace them with exception-message matching:
 | The path is missing, a link is dangling, or the entry disappears before the file open | `Unavailable` |
 | The path cannot be normalized | `Rejected` with an invalid-path reason |
 | The final target has the wrong expected kind | `Rejected` with a kind-mismatch reason |
-| The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unclassifiable reparse point | `Rejected` with a non-regular or unsupported-entry reason |
+| The final target is a FIFO, socket, block device, character device, Windows device or pipe coordinate, or an unclassifiable name-surrogate reparse point | `Rejected` with a non-regular or unsupported-entry reason |
 | Metadata inspection, native classification, or the file open fails for a reason other than absence | `Failed` with an admission-failed reason |
 | The current host has no supported classifier | `Failed` with a classification-unsupported reason |
 | Cancellation is observed | `OperationCanceledException` |
@@ -571,11 +577,16 @@ mode mask needed to distinguish directories, regular files, FIFOs, sockets,
 and block or character devices without opening the entry.
 
 Windows admission first rejects device and pipe namespaces and reserved DOS
-device coordinates. Extended-length paths to disk files are not rejected merely
-for using the `\\?\` prefix. Ordinary filesystem paths are inspected through
-managed attributes. A final symbolic link or traversable reparse point is
-resolved and its target attributes are inspected; an unsupported reparse kind
-is rejected. This step must prove a file or directory target before a
+device coordinates. Extended-length disk and UNC paths are not rejected merely
+for using the `\\?\` prefix after their segments satisfy the normalization rule
+above. Ordinary filesystem paths are inspected through managed attributes. For
+a final reparse point, a metadata handle opened without following the point
+queries its tag. A name-surrogate tag denotes a link-like entry: supported
+symbolic-link and mount-point forms are resolved and their final target
+attributes inspected, while an unsupported name-surrogate tag is rejected. A
+non-name-surrogate tag, including an ordinary cloud placeholder, retains its
+own file or directory attributes and proceeds to normal expected-kind and
+post-open checks. This step must prove a file or directory target before a
 file-content open.
 
 Regular-file admission then opens the canonical requested path exactly once and
@@ -619,9 +630,10 @@ open an unclassified path.
 
 The implementation is complete when focused gates prove:
 
-- canonicalization, expected-kind mismatches, final-target link following,
-  dangling links, unsupported reparse points, and hard-link non-deduplication
-  have the same semantics for every consuming local coordinate;
+- canonicalization, including extended-path segment rejection, expected-kind
+  mismatches, final-target link following, dangling links, name-surrogate
+  rejection, non-name-surrogate treatment, and hard-link non-deduplication have
+  the same semantics for every consuming local coordinate;
 - stable FIFOs, sockets, devices, and their link aliases are rejected before a
   blocking content open, while an empty regular file remains admissible;
 - a regular-file consumer receives the once-opened, post-classified handle and
@@ -1286,6 +1298,11 @@ The target is complete only when tests equivalent to these exist:
 - `ArtifactOpen_RejectsContentSubstitutionAfterAdmission`
 - `ArtifactContentReference_BindsIdentityRegistrationRoleAndContent`
 - `LocalArtifactSnapshot_MutationCannotChangeInspectionBytes`
+- `LocalPathAdmission_ExpectedKindsAndLinksAreShared`
+- `LocalPathAdmission_StableNonRegularEntriesRejectBeforeOpen`
+- `LocalPathAdmission_ConsumerReceivesTheVerifiedOpenGeneration`
+- `LocalPathAdmission_OutcomesAndCancellationRemainDistinct`
+- `LocalPathAdmission_PlatformClassifiersRemainPortable`
 - `LocalDirectoryAcquisition_BoundedDeterministicSelection`
 - `LocalDirectoryAcquisition_EmptyOrFailedBatchPublishesNothing`
 - `LocalDirectoryAcquisition_ProvenanceSnapshotAndCancellationArePreserved`


### PR DESCRIPTION
## Outcome

Defines one package-free local-path admission contract in
`DotnetInspector.Artifacts.Local` for explicit files, bounded-directory roots,
and selected directory entries.

The contract:

- separates observed-kind classification from required-kind admission;
- requires either a regular file or directory target for every direct
  coordinate;
- keeps `Path.GetFullPath` as the lexical coordinate and provenance path;
- follows symbolic links and supported link-like reparse points consistently;
- rejects stable FIFOs, sockets, devices, Windows pipe/device coordinates, and
  special, ambiguous, unsupported, or unknown reparse kinds before a content
  open while allowing audited data-bearing reparse forms;
- returns the once-opened, post-classified regular-file handle to the consumer;
- preserves distinct unavailable, rejected, failed, and cancellation outcomes;
- retains the requested path when invalid input cannot produce a canonical
  path;
- names the classification/open race that remains outside the local-actor
  threat model; and
- retains package-free NativeAOT and Browser/Wasm compatibility.

Existing explicit-file link following and `local.file.missing` behavior are
preserved. Snapshot lifetime remains owned by #4816; directory enumeration and
batch behavior remain owned by PR #5000; supplemental workspace admission
remains owned by #5010.

## Mockup

```text
AcquireFile("/build/app.dll", RegularFile)
  -> canonical coordinate /build/app.dll
  -> pre-classified regular file
  -> once-opened and handle-verified
  -> copied by explicit-file acquisition

AcquireDirectory("/build", Directory)
  -> canonical coordinate /build
  -> pre-classified directory
  -> enumerated by the bounded-directory contract

AcquireDirectory("C:\\", Directory)
  -> supported drive-root coordinate
  -> top-level enumeration remains bounded

AcquireFile("C:\\foo.dll", RegularFile)
  -> supported file directly beneath the drive root
  -> once-opened and handle-verified

/build/fifo.dll
  -> Rejected(non-regular) before content open

/build/app-link.dll -> /store/app.dll
  -> final target classified as regular
  -> admitted under lexical coordinate /build/app-link.dll

/build/directory-link.dll -> /store/components/
  -> final target classified as directory
  -> ignored before it becomes a selected file

/build/vanished.dll
  -> Unavailable(local.directory.entry-missing)
  -> whole directory batch publishes nothing
```

## Evidence

- Managed filesystem attributes were probed against a regular file, directory,
  file and directory links, FIFO, link to FIFO, dangling link, and `/dev/null`;
  FIFO and character-device entries are indistinguishable from empty regular
  files through those attributes alone.
- A package-free `LibraryImport` canary for normalized
  `SystemNative_Stat`/`SystemNative_FStat` compiled and ran under both
  `linux-x64` NativeAOT and WebAssembly/Node with the repository-selected SDK.
- The design names persistent outcome-level and platform gates required before
  implementation is complete.
- No TLA+ model is added: admission is sequential and introduces no new
  publication, interleaving, or ownership state machine.

## Validation

```text
npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md
git diff --check
```

Closes #5096.
