### PR TITLE
Remove lexical documentation gates

### DIFF
--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -607,40 +607,6 @@ public class IlToolsActivationTests
         Assert.Equal(["/orig1"], result.PathEntries);
     }
 
-    /// <summary>
-    /// Keeps the documentation pointing at the tested artifact. The defect
-    /// class these tests close was a hand-written PATH incantation in a doc
-    /// snippet, so the gate rejects any runnable snippet that invokes the
-    /// producer directly -- `PATH="$(eng/restore-iltools.sh):$PATH"` never
-    /// mentions `export` and would otherwise sail through.
-    /// </summary>
-    [Fact]
-    public void DevelopmentDocumentation_DelegatesIlToolsPathAssemblyToTheScript()
-    {
-        var agents = File.ReadAllText(Path.Combine(RepoRoot, "AGENTS.md"));
-        var developmentEnvironment = File.ReadAllText(
-            Path.Combine(RepoRoot, "docs", "dev-environment.md"));
-
-        Assert.Contains(
-            "docs/dev-environment.md#test-tooling-activation",
-            agents);
-        Assert.Contains(
-            "source eng/activate-iltools.sh",
-            developmentEnvironment);
-
-        foreach (var block in FencedBashBlocks($"{agents}\n{developmentEnvironment}").Where(b => b.Contains("iltools")))
-        {
-            Assert.False(
-                block.Contains("restore-iltools.sh"),
-                $"Contributor guidance tells the reader to run the producer directly instead of sourcing\n" +
-                $"eng/activate-iltools.sh, which puts the PATH assembly back outside the gate:\n{block}");
-
-            Assert.False(
-                block.Contains("PATH="),
-                $"Contributor guidance assembles PATH by hand instead of sourcing eng/activate-iltools.sh:\n{block}");
-        }
-    }
-
     [Fact]
     public void SlowWorkflows_FailAfterOracleRestoreFailure()
     {
@@ -1123,23 +1089,6 @@ public class IlToolsActivationTests
         Assert.Contains(
             "[ \"$resolved_sha\" != \"$expected_sha\" ]",
             evidenceScript);
-    }
-
-    static IEnumerable<string> FencedBashBlocks(string markdown)
-    {
-        var lines = markdown.Split('\n');
-        for (int i = 0; i < lines.Length; i++)
-        {
-            if (lines[i].TrimEnd() is not "```bash" && lines[i].TrimEnd() is not "```sh")
-                continue;
-
-            int end = i + 1;
-            while (end < lines.Length && lines[end].TrimEnd() != "```")
-                end++;
-
-            yield return string.Join('\n', lines[(i + 1)..Math.Min(end, lines.Length)]);
-            i = end;
-        }
     }
 
     // --- harness ---

--- a/src/dotnet-inspect.Tests/SkillCommandTests.cs
+++ b/src/dotnet-inspect.Tests/SkillCommandTests.cs
@@ -66,49 +66,6 @@ public class SkillCommandTests
     }
 
     [Fact]
-    public void PdbSourceGuidance_StatesBothAcquisitionPaths()
-    {
-        string root = FindRepositoryRoot();
-        string[] guidancePaths =
-        [
-            "README.md",
-            "skills/sourcelink/SKILL.md",
-            "skills/compatibility/SKILL.md",
-            "docs/decompiler-quality.md",
-            "docs/templates/decompiler-pr.md",
-            "docs/workflows/getting-started/verbosity-and-tips.md",
-            "docs/workflows/core/member-lookup-docs-code.md"
-        ];
-        string[] forbiddenImplications =
-        [
-            "SourceLink-backed source",
-            "SourceLink-backed C#",
-            "PDB-mapped SourceLink text",
-            "when SourceLink can resolve",
-            "when SourceLink cannot supply",
-            "PDB Source` (SourceLink",
-            "PDB Source (SourceLink"
-        ];
-
-        foreach (string relativePath in guidancePaths)
-        {
-            string guidance = string.Join(
-                " ",
-                File.ReadAllLines(Path.Combine(root, relativePath)).Select(line => line.Trim()));
-
-            Assert.True(
-                guidance.Contains("locally or through SourceLink", StringComparison.Ordinal),
-                $"{relativePath} must state that PDB Source can be acquired locally or through SourceLink.");
-            foreach (string implication in forbiddenImplications)
-            {
-                Assert.False(
-                    guidance.Contains(implication, StringComparison.OrdinalIgnoreCase),
-                    $"{relativePath} still implies that PDB Source requires SourceLink: {implication}");
-            }
-        }
-    }
-
-    [Fact]
     public async Task ExecuteList_UsesFrontmatterDescriptions()
     {
         var (_, output, _) = await ConsoleCapture.RunAsync(


### PR DESCRIPTION
## Demo

Before, changing contributor prose could fail the product test executable:
#5099 and #5101 record the concrete failure after test-tool guidance moved from
`AGENTS.md` to its owning development-environment document. The same suite also
required one exact PDB-source sentence in seven user-facing documents.

After, the owning test classes exercise product and script behavior without
reading those documents:

```text
dotnet run --project src/dotnet-inspect.Tests -c Release -- \
  -class DotnetInspector.Tests.IlToolsActivationTests \
  -class DotnetInspector.Tests.SkillCommandTests

Total: 59, Errors: 0, Failed: 0, Skipped: 0
```

What to notice: documentation wording and placement can now evolve through
documentation review and Markdown/link validation, while the activation script
and shipped skill behavior remain covered. No product behavior or documentation
content changes in this PR.

## Summary

- Remove the test that required exact iltools command and anchor text in
  contributor documentation.
- Remove the test that required one exact PDB-source phrase across seven
  documents.
- Remove the now-unused fenced-Bash Markdown parser.

`docs/evidence-and-validation.md` owns the claim: evidence should match the
property asserted. Behavioral tests remain the evidence for script and skill
behavior; trusted repository prose is no longer a product-test contract.

This is the first focused cleanup batch from #5112. Metadata architecture,
console-test hygiene, command-layering enforcement, and CI change routing remain
separate owners.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -class
  'DotnetInspector.Tests.IlToolsActivationTests' -class
  'DotnetInspector.Tests.SkillCommandTests' -xml <results>` — 59 passed.
- Post-fix base integration was non-interacting: `5b6b0a429` changed only
  Queries and NuGet plugin files.
