### PR TITLE
Apply item windows before projection

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14121,11 +14121,11 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_SourceFiles_UrlsRejectsRowsMode()
+    public async Task Type_SourceFiles_UrlsRejectsAbsoluteRowsMode()
     {
         var (exit, output, error) = await RunAppAsync(
             "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
-            "-S", "Source Files", "--urls", "--rows", "1", "--raw", "--tips", "q");
+            "-S", "Source Files", "--urls", "--rows", "1..1", "--raw", "--tips", "q");
 
         Assert.Equal(1, exit);
         Assert.Empty(output);

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -14100,6 +14100,27 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Library_SourceFiles_Urls_ItemLimitSelectsOneUrl()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library",
+            "System.Text.Json",
+            "-S",
+            "Source Files",
+            "--urls",
+            "-n",
+            "1",
+            "--json-array",
+            "--tips",
+            "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        Assert.Equal(1, document.RootElement.GetArrayLength());
+    }
+
+    [Fact]
     public async Task Type_SourceFiles_UrlsRejectsRowsMode()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -31552,10 +31573,55 @@ public partial class CommandExecutionTests
                     Assert.Single(artifact.Split('\n', StringSplitOptions.RemoveEmptyEntries)));
             }
         }
+
         finally
         {
             Directory.Delete(projectTempDir, recursive: true);
             Directory.Delete(packageTempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ProjectAgentsIndex_FileOutputAppliesRenderedLineWindow()
+    {
+        const string agents = """
+            ---
+            name: line-window
+            ---
+            agents body
+            """;
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage(
+                "Test.Project.LineWindow",
+                "1.0.0",
+                "README.md",
+                "readme",
+                agents,
+                [CompliantProjectSkill("skills/window/SKILL.md", "skill body")]));
+
+        try
+        {
+            var outputPath = Path.Combine(tempDir, "agents.jsonl");
+            var (exit, stdout, error) = await RunProjectFixtureAsync(
+                projectPath,
+                "--agents-index",
+                "--jsonl",
+                "-n",
+                "1",
+                "--lines",
+                "--out",
+                outputPath);
+
+            Assert.Equal(0, exit);
+            Assert.Empty(stdout);
+            Assert.Empty(error);
+            Assert.Single(
+                File.ReadAllText(outputPath)
+                    .Split('\n', StringSplitOptions.RemoveEmptyEntries));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
         }
     }
 

--- a/src/dotnet-inspect.Tests/InspectionGraphCommandTests.cs
+++ b/src/dotnet-inspect.Tests/InspectionGraphCommandTests.cs
@@ -328,19 +328,23 @@ public sealed class InspectionGraphCommandTests
         InspectionGraphDocument document = GraphWithTwoEdges();
 
         Execution markdown = await ExecuteAsync(
-            ["--rows", "1"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
         Execution table = await ExecuteAsync(
-            ["--table", "--rows", "1"],
+            ["--table"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
         Execution json = await ExecuteAsync(
-            ["--json", "--rows", "1"],
+            ["--json"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
         Execution jsonLines = await ExecuteAsync(
-            ["--jsonl", "--rows", "1"],
+            ["--jsonl"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
         Execution count = await ExecuteAsync(
-            ["--count", "--rows", "1"],
+            ["--count"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
 
         Assert.All(
@@ -614,7 +618,8 @@ public sealed class InspectionGraphCommandTests
         InspectionGraphDocument document = GraphWithDuplicateLabels();
 
         Execution json = await ExecuteAsync(
-            ["--json", "--rows", "1"],
+            ["--json"],
+            rows: RowWindow.Head(1),
             injectedDocument: document);
 
         Assert.Equal(0, json.ExitCode);

--- a/src/dotnet-inspect.Tests/MetadataLensTests.cs
+++ b/src/dotnet-inspect.Tests/MetadataLensTests.cs
@@ -103,7 +103,7 @@ public partial class CommandExecutionTests
     public async Task MetadataLens_ExactName_RendersOnlyThatTable()
     {
         var (exit, output, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Metadata: TypeRef", "--rows", "5", "--tips", "q");
+            "library", TestAssemblyPath, "-S", "Metadata: TypeRef", "-n", "5", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Metadata: TypeRef", output, StringComparison.Ordinal);
@@ -365,7 +365,7 @@ public partial class CommandExecutionTests
     public async Task MetadataLens_Tabular_RowsAreSelfIdentifying()
     {
         var (exit, output, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Metadata: TypeRef", "--tsv", "--rows", "3", "--tips", "q");
+            "library", TestAssemblyPath, "-S", "Metadata: TypeRef", "--tsv", "-n", "3", "--tips", "q");
 
         Assert.Equal(0, exit);
         var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
@@ -481,7 +481,7 @@ public partial class CommandExecutionTests
 
         var (exit, output, _) = await RunAppAsync(
             "library", TestAssemblyPath, "-S", "Metadata: TypeRef",
-            "--columns", "Name", "--rows", "2", "--tsv", "--tips", "q");
+            "--columns", "Name", "-n", "2", "--tsv", "--tips", "q");
 
         Assert.Equal(0, exit);
         var rows = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
@@ -832,7 +832,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, _) = await RunAppAsync(
             "library", TestAssemblyPath, "-S", MetadataSectionNames.ForHeap(HeapKind.String),
-            "--rows", "5", "--tips", "q");
+            "-n", "5", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Metadata: #Strings", output, StringComparison.Ordinal);
@@ -969,7 +969,7 @@ public partial class CommandExecutionTests
     public async Task MetadataLens_HexTableSelection_RendersTheCanonicalSection()
     {
         var (exit, output, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "--rows", "3", "--tips", "q");
+            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "-n", "3", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("## " + MetadataSectionNames.ForTable(System.Reflection.Metadata.Ecma335.TableIndex.TypeDef), output, StringComparison.Ordinal);
@@ -995,9 +995,9 @@ public partial class CommandExecutionTests
     public async Task MetadataLens_HexTableSpellings_AreTheNameSelector(string hex)
     {
         var (hexExit, hexOutput, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", hex, "--rows", "5", "--tips", "q");
+            "library", TestAssemblyPath, "-S", hex, "-n", "5", "--tips", "q");
         var (nameExit, nameOutput, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Metadata: TypeDef", "--rows", "5", "--tips", "q");
+            "library", TestAssemblyPath, "-S", "Metadata: TypeDef", "-n", "5", "--tips", "q");
 
         Assert.Equal(0, hexExit);
         Assert.Equal(nameExit, hexExit);
@@ -1025,12 +1025,12 @@ public partial class CommandExecutionTests
     public async Task MetadataLens_BothTableSpellings_SelectOneSection()
     {
         var (aloneExit, aloneOutput, _) = await RunAppAsync(
-            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "--rows", "3", "--tips", "q");
+            "library", TestAssemblyPath, "-S", "Metadata: 0x02", "-n", "3", "--tips", "q");
         Assert.Equal(0, aloneExit);
 
         var (exit, output, _) = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Metadata: 0x02", "-S", "Metadata: TypeDef", "--rows", "3", "--tips", "q");
+            "-S", "Metadata: 0x02", "-S", "Metadata: TypeDef", "-n", "3", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Equal(1, output.Split('\n').Count(l => l.StartsWith("## ", StringComparison.Ordinal)));

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -69,7 +69,6 @@ public class OutputFormatterTests
             var path = Path.Combine(tempDirectory.FullName, "output.txt");
             OutputDestination.Write(
                 path,
-                rowWindow: null,
                 writer => writer.Write("first\r\nsecond\rthird\n"));
             Assert.Equal("first\nsecond\nthird\n", File.ReadAllText(path));
 
@@ -83,6 +82,43 @@ public class OutputFormatterTests
         {
             tempDirectory.Delete(recursive: true);
         }
+    }
+
+    [Theory]
+    [InlineData("first\rsecond\rthird", 2, false, "first\rsecond\r")]
+    [InlineData("first\nsecond\nthird", 2, false, "first\nsecond\n")]
+    [InlineData("first\r\nsecond\r\nthird", 2, false, "first\r\nsecond\r\n")]
+    [InlineData("first\rsecond\nthird\r\nfourth", 2, true, "third\r\nfourth")]
+    public void StructuredLineWindowsRecognizeCrLfAndCrLfPairs(
+        string content,
+        int count,
+        bool tail,
+        string expected)
+    {
+        var actual = tail
+            ? TextLineWindow.Tail(content, count)
+            : TextLineWindow.Head(content, count);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ReferenceTreeItemWindowRetainsRequiredAncestors()
+    {
+        List<AssemblyReferenceNode> references =
+        [
+            new() { Name = "RootA", Depth = 0 },
+            new() { Name = "ChildA", Depth = 1 },
+            new() { Name = "GrandchildA", Depth = 2 },
+            new() { Name = "RootB", Depth = 0 },
+            new() { Name = "ChildB", Depth = 1 },
+        ];
+
+        var selected = OutputFormatter.SelectReferenceTreeNodes(
+            references,
+            RowWindow.Tail(1));
+
+        Assert.Equal(["RootB", "ChildB"], selected.Select(node => node.Name));
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -906,10 +906,10 @@ public class ApiCommand
                 $"{optionName} cannot be combined with --count or --print.");
             return false;
         }
-        if (options.Rows is not null)
+        if (options.Rows is { Kind: RowWindowKind.Range })
         {
             CommandError.Write(
-                $"--rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
+                $"--rows cannot be combined with {optionName}; use -n N to limit projected items or --row N|first|last to select a projected row.");
             return false;
         }
 
@@ -2796,7 +2796,7 @@ public class ApiCommand
         }
 
         return ShapeProjectionOutput.Write(
-            rows,
+            RowWindow.Apply(options.Rows, rows),
             new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 

--- a/src/dotnet-inspect/Commands/FindCommand.cs
+++ b/src/dotnet-inspect/Commands/FindCommand.cs
@@ -112,7 +112,7 @@ public class FindCommand
                 else
                 {
                     JsonOutputHelper.Write(
-                        results,
+                        RowWindow.Apply(options.Rows, results).ToList(),
                         TypeFindResultJsonContext.Default.ListTypeFindResult,
                         TypeFindResultCompactJsonContext.Default.ListTypeFindResult,
                         options.CompactJson);
@@ -363,7 +363,7 @@ public class FindCommand
             else
             {
                 JsonOutputHelper.Write(
-                    results,
+                    RowWindow.Apply(options.Rows, results).ToList(),
                     MemberFindResultJsonContext.Default.ListMemberFindResult,
                     MemberFindResultCompactJsonContext.Default.ListMemberFindResult,
                     options.CompactJson);
@@ -437,12 +437,13 @@ public class FindCommand
                 options.Columns, options.Fields,
                 (writer, formatter, writerOptions) =>
                     MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-                options.Rows);
+                options.Rows, options.HumanRowWindowNote);
         }
         else
         {
             OutputFormatter.WriteWindowedMarkdown(Console.Out, options.Rows,
-                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts),
+                humanRowWindowNote: options.HumanRowWindowNote);
         }
     }
 
@@ -474,12 +475,13 @@ public class FindCommand
                 options.Columns, options.Fields,
                 (writer, formatter, writerOptions) =>
                     MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-                options.Rows);
+                options.Rows, options.HumanRowWindowNote);
         }
         else
         {
             OutputFormatter.WriteWindowedMarkdown(Console.Out, options.Rows,
-                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts),
+                humanRowWindowNote: options.HumanRowWindowNote);
         }
     }
 

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -340,7 +340,7 @@ public class LibraryCommand
                 || options.Paths
                 || options.Columns is { Length: > 0 }
                 || options.Fields is { Length: > 0 }
-                || options.Rows is not null
+                || options.Rows is { Kind: RowWindowKind.Range }
                 || options.JsonOutput
                 || options.PlainText
                 || options.TabularExplicitlySet)
@@ -425,9 +425,9 @@ public class LibraryCommand
                 CommandError.Write($"{optionName} cannot be combined with --count or --print.");
                 return 1;
             }
-            if (options.Rows is not null)
+            if (options.Rows is { Kind: RowWindowKind.Range })
             {
-                CommandError.Write($"--rows cannot be combined with {optionName}; use -n N to limit projected output lines or --row N|first|last to select a projected row.");
+                CommandError.Write($"--rows cannot be combined with {optionName}; use -n N to limit projected items or --row N|first|last to select a projected row.");
                 return 1;
             }
         }
@@ -1884,7 +1884,7 @@ public class LibraryCommand
             return 1;
 
         return ShapeProjectionOutput.Write(
-            rows,
+            RowWindow.Apply(options.Rows, rows),
             new ShapeProjectionOptions(kind, options.ProjectionRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1121,14 +1121,9 @@ public class PackageCommand
                         options.Fields ?? options.Columns,
                         output,
                         diagnosticCandidates!);
-                if (!string.IsNullOrEmpty(options.OutputPath))
-                {
-                    File.WriteAllText(options.OutputPath, output);
-                }
-                else
-                {
-                    Console.WriteLine(output);
-                }
+                OutputDestination.Write(
+                    options.OutputPath,
+                    writer => writer.WriteLine(output));
             }
 
             return PackageIntegrityExitCode(result);
@@ -4447,7 +4442,6 @@ public class PackageCommand
                 JsonContext.Default.LibraryInspectionArray);
             OutputDestination.Write(
                 libraryOptions.OutputPath,
-                libraryOptions.Rows,
                 writer => writer.WriteLine(json));
             return completionExitCode;
         }
@@ -4514,7 +4508,6 @@ public class PackageCommand
             CommandError.WriteNote("matched sections have no data across all libraries.");
             OutputDestination.Write(
                 libraryOptions.OutputPath,
-                libraryOptions.Rows,
                 static _ => { });
             return completionExitCode;
         }
@@ -4536,7 +4529,6 @@ public class PackageCommand
         var markdown = RenderAllLibrariesMarkdown(packageName, version, inspections, sections, libraryOptions, pipeline);
         OutputDestination.Write(
             libraryOptions.OutputPath,
-            libraryOptions.Rows,
             writer => OutputFormatter.WriteLfLine(writer, markdown));
         return completionExitCode;
     }
@@ -4891,12 +4883,11 @@ public class PackageCommand
             CommandError.WriteNote("matched section has no row data across all libraries.");
             OutputDestination.Write(
                 options.OutputPath,
-                options.Rows,
                 static _ => { });
             return true;
         }
 
-        OutputDestination.Write(options.OutputPath, options.Rows, output =>
+        OutputDestination.Write(options.OutputPath, output =>
         {
             OutputFormatter.WriteTable(output, !options.NoHeader, (writer, formatter) =>
             {
@@ -5666,7 +5657,6 @@ public class PackageCommand
             };
             OutputDestination.Write(
                 options.OutputPath,
-                options.Rows,
                 writer => MarkoutSerializer.Serialize(
                     emptyView,
                     writer,
@@ -5711,7 +5701,6 @@ public class PackageCommand
 
         OutputDestination.Write(
             options.OutputPath,
-            options.Rows,
             writer => MarkoutSerializer.Serialize(
                 view,
                 writer,

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -245,9 +245,11 @@ public class ProjectCommand
 
     private static int WriteAgentsIndex(IReadOnlyList<ProjectPackageReference> dependencies, ProjectOptions options)
     {
-        var rows = dependencies
-            .Select(CreateAgentsIndexRow)
-            .ToList();
+        var rows = RowWindow.Apply(
+            options.Rows,
+            dependencies
+                .Select(CreateAgentsIndexRow)
+                .ToList());
 
         var output = options.JsonOutput
             ? JsonSerializer.Serialize(rows.ToArray(), ProjectCommandJsonContext.Default.ProjectAgentsIndexRowArray)
@@ -384,7 +386,12 @@ public class ProjectCommand
                     ? RenderSkillTable(visibleRows, options)
                     : RenderSkillMarkdown(visibleRows);
 
-        WriteOutput(output, options.OutputPath);
+        bool suppressNote = options.JsonOutput || options.Jsonl || options.Tsv || rows.Count == 0;
+        WriteOutput(
+            suppressNote
+                ? output
+                : OutputFormatter.AddHumanRowWindowNote(output, options.HumanRowWindowNote),
+            options.OutputPath);
         return 0;
     }
 
@@ -756,12 +763,9 @@ public class ProjectCommand
     }
 
     private static void WriteOutput(string output, string? outputPath)
-    {
-        if (!string.IsNullOrWhiteSpace(outputPath))
-            File.WriteAllText(outputPath, output);
-        else
-            Console.Write(output);
-    }
+        => OutputDestination.Write(
+            outputPath,
+            writer => writer.Write(output));
 
     /// <summary>
     /// Escapes a table cell for Markdown. This handles the pipe and the line

--- a/src/dotnet-inspect/Commands/VocabularyCommand.cs
+++ b/src/dotnet-inspect/Commands/VocabularyCommand.cs
@@ -167,7 +167,8 @@ public static class VocabularyCommand
                     WriteTable(markout, section);
                     markout.Flush();
                 },
-                options.Rows);
+                options.Rows,
+                options.HumanRowWindowNote);
             return 0;
         }
 
@@ -175,14 +176,17 @@ public static class VocabularyCommand
             projectedColumns,
             fields: null,
             options.Rows);
+        var buffer = new StringWriter { NewLine = "\n" };
         var markdown = new MarkoutWriter(
-            Console.Out,
+            buffer,
             options.PlainText
                 ? new PlainTextFormatter()
                 : new MarkdownFormatter(),
             markdownOptions);
         WriteSections(markdown, renderedSections, includeDocumentHeading: true);
         markdown.Flush();
+        Console.Out.Write(
+            OutputFormatter.AddHumanRowWindowNote(buffer.ToString(), options.HumanRowWindowNote));
         return 0;
     }
 

--- a/src/dotnet-inspect/Output/CountOutput.cs
+++ b/src/dotnet-inspect/Output/CountOutput.cs
@@ -109,7 +109,6 @@ public static class CountOutput
         var text = result.TrimEnd('\r', '\n') + '\n';
         OutputDestination.Write(
             outputPath,
-            rows,
             writer => writer.Write(text));
     }
 

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -87,7 +87,7 @@ public static class DiffOutputFormatter
         };
     }
 
-    public static DiffDetailedChangesView BuildDetailedChangesView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
+    public static DiffDetailedChangesView BuildDetailedChangesView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion, RowWindow? rows = null)
     {
         int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
         foreach (var td in typeDiffs)
@@ -97,10 +97,11 @@ public static class DiffOutputFormatter
             totalPotentiallyBreaking += td.PotentiallyBreakingCount;
         }
 
-        var rows = typeDiffs
+        var allRows = typeDiffs
             .OrderBy(td => td.TypeFullName, StringComparer.Ordinal)
             .SelectMany(td => td.Changes.Select(change => BuildDetailedRow(td.TypeFullName, change)))
             .ToList();
+        var windowedRows = RowWindow.Apply(rows, allRows);
 
         return new DiffDetailedChangesView(
             DiffViewText.Field($"API Diff: {name}"),
@@ -110,7 +111,7 @@ public static class DiffOutputFormatter
                 totalAdditive,
                 totalPotentiallyBreaking)))
         {
-            Rows = rows.Count > 0 ? rows : null
+            Rows = windowedRows.Count > 0 ? [.. windowedRows] : null
         };
     }
 
@@ -292,7 +293,8 @@ public static class DiffOutputFormatter
         string name,
         IReadOnlyList<FindingTransitionRow> rows,
         string fromVersion,
-        string toVersion)
+        string toVersion,
+        RowWindow? window = null)
         => new(
             DiffViewText.Field($"Finding Transitions: {name}"),
             DiffViewText.Field($"{fromVersion} -> {toVersion}"))
@@ -300,7 +302,7 @@ public static class DiffOutputFormatter
             Status = rows.Count == 0
                 ? new Callout(CalloutSeverity.Note, "No selected Finding exists at either endpoint.")
                 : new Callout(CalloutSeverity.Note, $"{rows.Count} selected Finding transition{(rows.Count == 1 ? "" : "s")}."),
-            Rows = rows.Count > 0 ? rows.ToList() : null
+            Rows = WindowRows(rows.Count > 0 ? rows.ToList() : null, window)
         };
 
     public static string RenderFindingTransitionsView(FindingTransitionsView view, MarkoutWriterOptions? options = null)
@@ -314,20 +316,23 @@ public static class DiffOutputFormatter
         string name,
         IReadOnlyList<TypeDiff> typeDiffs,
         string fromVersion,
-        string toVersion) =>
+        string toVersion,
+        RowWindow? rows = null) =>
         BuildFullView(
             name,
             typeDiffs,
             [],
             fromVersion,
-            toVersion);
+            toVersion,
+            rows);
 
     static DiffFullView BuildFullView(
         string name,
         IReadOnlyList<TypeDiff> typeDiffs,
         IReadOnlyList<ApiDiffInspectionFailure> inspectionFailures,
         string fromVersion,
-        string toVersion)
+        string toVersion,
+        RowWindow? rows = null)
     {
         var view = new DiffFullView(
             DiffViewText.Field($"API Diff: {name}"),
@@ -359,9 +364,13 @@ public static class DiffOutputFormatter
         view.SummaryText = DiffViewText.Field(
             $"**Summary:** {FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking)} across {typeDiffs.Count} types");
 
-        view.BreakingChanges = BuildChangeRows(ChangeClassification.Breaking, typeDiffs);
-        view.PotentiallyBreakingChanges = BuildChangeRows(ChangeClassification.PotentiallyBreaking, typeDiffs);
-        view.AdditiveChanges = BuildChangeRows(ChangeClassification.Additive, typeDiffs);
+        // -n/-N windows each classification group independently, matching the multi-section
+        // precedent elsewhere (e.g. `type -S "Constructors,Methods" -n 1`): the underlying
+        // Markout GroupBy-sectioned properties don't honor RowWindow, so the flat change list
+        // is windowed here, before grouping, rather than relying on the writer to do it.
+        view.BreakingChanges = WindowChangeRows(BuildChangeRows(ChangeClassification.Breaking, typeDiffs), rows);
+        view.PotentiallyBreakingChanges = WindowChangeRows(BuildChangeRows(ChangeClassification.PotentiallyBreaking, typeDiffs), rows);
+        view.AdditiveChanges = WindowChangeRows(BuildChangeRows(ChangeClassification.Additive, typeDiffs), rows);
         if (inspectionFailures.Count > 0)
         {
             view.Status = new Callout(
@@ -372,9 +381,9 @@ public static class DiffOutputFormatter
         return view;
     }
 
-    public static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion, MarkoutWriterOptions? options = null)
+    public static string RenderFullMarkdown(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion, MarkoutWriterOptions? options = null, RowWindow? rows = null)
     {
-        var view = BuildFullView(name, typeDiffs, fromVersion, toVersion);
+        var view = BuildFullView(name, typeDiffs, fromVersion, toVersion, rows);
         var writer = new MarkoutWriter(new MarkdownFormatter(), options);
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
@@ -386,14 +395,16 @@ public static class DiffOutputFormatter
         IReadOnlyList<ApiDiffInspectionFailure> inspectionFailures,
         string fromVersion,
         string toVersion,
-        MarkoutWriterOptions? options = null)
+        MarkoutWriterOptions? options = null,
+        RowWindow? rows = null)
     {
         var view = BuildFullView(
             name,
             typeDiffs,
             inspectionFailures,
             fromVersion,
-            toVersion);
+            toVersion,
+            rows);
         var writer =
             new MarkoutWriter(
                 new MarkdownFormatter(),
@@ -438,7 +449,8 @@ public static class DiffOutputFormatter
         string summary,
         string fromVersion,
         string toVersion,
-        bool decorateMember = true)
+        bool decorateMember = true,
+        RowWindow? window = null)
         => new(
             DiffViewText.Field($"Analysis Diff: {name}"),
             DiffViewText.Field($"{fromVersion} -> {toVersion}"),
@@ -447,11 +459,13 @@ public static class DiffOutputFormatter
             Status = rows.Count == 0
                 ? new Callout(CalloutSeverity.Note, summary)
                 : new Callout(CalloutSeverity.Note, "Analysis signal changes are body-level evidence, not public API compatibility changes."),
-            Rows = rows.Count > 0
-                ? rows.Select(row => decorateMember
-                    ? row with { MemberText = MarkoutInline.CodeText(row.MemberText) }
-                    : row).ToList()
-                : null
+            Rows = WindowRows(
+                rows.Count > 0
+                    ? rows.Select(row => decorateMember
+                        ? row with { MemberText = MarkoutInline.CodeText(row.MemberText) }
+                        : row).ToList()
+                    : null,
+                window)
         };
 
     /// <summary>
@@ -474,7 +488,8 @@ public static class DiffOutputFormatter
         string name,
         ImplementationDiffResult diff,
         string fromVersion,
-        string toVersion)
+        string toVersion,
+        RowWindow? window = null)
     {
         List<ImplementationDiffRow> rows = [];
         foreach (var member in diff.Members)
@@ -557,7 +572,7 @@ public static class DiffOutputFormatter
                     hasSourceLane
                         ? "C# is decompiled evidence; PDB Source is checksum-verified PDB-mapped evidence; IL is shipped body evidence. These peer lanes do not replace one another and are not public API compatibility."
                         : "C# and IL implementation evidence is body-level evidence, not public API compatibility."),
-            Rows = rows.Count > 0 ? rows : null
+            Rows = WindowRows(rows.Count > 0 ? rows : null, window)
         };
     }
 
@@ -598,6 +613,23 @@ public static class DiffOutputFormatter
         if (additive > 0) parts.Add($"{additive} additive");
         if (potentiallyBreaking > 0) parts.Add($"{potentiallyBreaking} potentially breaking");
         return parts.Count > 0 ? string.Join(", ", parts) : "no changes";
+    }
+
+    private static List<DiffChangeRow>? WindowChangeRows(List<DiffChangeRow>? rows, RowWindow? window)
+        => WindowRows(rows, window);
+
+    /// <summary>
+    /// Applies a declared-item window to a document-view row list, matching
+    /// <see cref="BuildDetailedChangesView"/>'s pattern of windowing at construction time so
+    /// that document-JSON serialization (which bypasses the Markout writer's own windowing)
+    /// still honors <c>-n</c>/<c>--top</c>.
+    /// </summary>
+    private static List<T>? WindowRows<T>(List<T>? rows, RowWindow? window)
+    {
+        if (rows is null)
+            return null;
+        var windowed = RowWindow.Apply(window, rows);
+        return windowed.Count > 0 ? [.. windowed] : null;
     }
 
     private static List<DiffChangeRow>? BuildChangeRows(ChangeClassification classification, IReadOnlyList<TypeDiff> typeDiffs)

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -108,7 +108,12 @@ public static class DiscoverOutput
         }
         else if (markdown)
         {
-            context.Serialize(view, Console.Out, new MarkdownFormatter());
+            var writer = new StringWriter { NewLine = "\n" };
+            context.Serialize(view, writer, new MarkdownFormatter());
+            var rendered = writer.ToString();
+            if (rows.Count > 0)
+                rendered = OutputFormatter.AddHumanRowWindowNote(rendered, projection?.HumanRowWindowNote);
+            OutputFormatter.WriteLfLine(Console.Out, rendered.TrimEnd('\n'));
         }
         else if (plainText)
         {
@@ -121,7 +126,8 @@ public static class DiscoverOutput
                     view,
                     writer,
                     formatter,
-                    OutputFormatter.CreateTableWriterOptions(tsv, jsonl)));
+                    OutputFormatter.CreateTableWriterOptions(tsv, jsonl)),
+                humanRowWindowNote: tsv || jsonl ? null : projection?.HumanRowWindowNote);
         }
 
         return 0;

--- a/src/dotnet-inspect/Output/OutputDestination.cs
+++ b/src/dotnet-inspect/Output/OutputDestination.cs
@@ -8,7 +8,6 @@ internal static class OutputDestination
 {
     public static void Write(
         string? outputPath,
-        RowWindow? rowWindow,
         Action<TextWriter> write)
     {
         if (string.IsNullOrEmpty(outputPath))
@@ -35,8 +34,7 @@ internal static class OutputDestination
 
         TailLineLimitingTextWriter? tailWriter = null;
         bool hasLineWindow = false;
-        if (rowWindow is null
-            && CommandLineBuilder.HeadLines is int headLines)
+        if (CommandLineBuilder.HeadLines is int headLines)
         {
             destination = new LineLimitingTextWriter(
                 destination,
@@ -44,8 +42,7 @@ internal static class OutputDestination
             hasLineWindow = true;
         }
 
-        if (rowWindow is null
-            && CommandLineBuilder.TailLines is int tailLines)
+        if (CommandLineBuilder.TailLines is int tailLines)
         {
             tailWriter = new TailLineLimitingTextWriter(
                 destination,

--- a/src/dotnet-inspect/Output/OutputFormatter.cs
+++ b/src/dotnet-inspect/Output/OutputFormatter.cs
@@ -4,6 +4,7 @@ using DotnetInspector.Views;
 using System.Text.Json;
 using DotnetInspector.Options;
 using DotnetInspector.Sections;
+using ILInspector.Metadata;
 using Markout;
 using Markout.Formatting;
 
@@ -27,7 +28,12 @@ public static class OutputFormatter
         return sw.ToString();
     }
 
-    public static void WriteTable(TextWriter output, bool showHeader, Action<TextWriter, IMarkoutFormatter> serialize, RowWindow? maxRows = null)
+    public static void WriteTable(
+        TextWriter output,
+        bool showHeader,
+        Action<TextWriter, IMarkoutFormatter> serialize,
+        RowWindow? maxRows = null,
+        string? humanRowWindowNote = null)
     {
         // Row-limiting operates on the rendered text, so the capped path must materialize
         // the table first. Without a cap, serialize straight to the destination writer and
@@ -37,13 +43,22 @@ public static class OutputFormatter
         // so a single buffered Write(string) is not interchangeable with row-by-row writes
         // (it changes which trailing content survives the limit). Keep the buffered path for
         // those wrappers to preserve byte-identical output; their output is already small.
-        if (maxRows is null or { IsUnlimited: true } && output is not (LineLimitingTextWriter or TailLineLimitingTextWriter))
+        //
+        // A note is also buffered: whether the window actually applied to any data is only
+        // known after rendering, and an empty result must not gain a "first N"/"top N" note
+        // with nothing beneath it.
+        if (humanRowWindowNote is null
+            && maxRows is null or { IsUnlimited: true }
+            && output is not (LineLimitingTextWriter or TailLineLimitingTextWriter))
         {
             serialize(output, new TableFormatter(showHeader));
             return;
         }
 
-        output.Write(LimitRenderedTableRows(RenderTable(showHeader, serialize), maxRows, showHeader));
+        var rendered = LimitRenderedTableRows(RenderTable(showHeader, serialize), maxRows, showHeader);
+        if (!string.IsNullOrWhiteSpace(rendered))
+            WriteHumanRowWindowNote(output, humanRowWindowNote);
+        output.Write(rendered);
     }
 
     /// <summary>
@@ -135,8 +150,14 @@ public static class OutputFormatter
         string[]? columns,
         string[]? fields,
         Action<TextWriter, IMarkoutFormatter, MarkoutWriterOptions> serialize,
-        RowWindow? maxRows = null) =>
-        output.Write(RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize, maxRows));
+        RowWindow? maxRows = null,
+        string? humanRowWindowNote = null)
+    {
+        var rendered = RenderProjectedTable(showHeader, tsv, jsonl, columns, fields, serialize, maxRows);
+        if (!string.IsNullOrWhiteSpace(rendered))
+            WriteHumanRowWindowNote(output, tsv || jsonl ? null : humanRowWindowNote);
+        output.Write(rendered);
+    }
 
     /// <summary>
     /// Renders a view as the lowered JSON view: the same section and projection decisions the
@@ -213,8 +234,11 @@ public static class OutputFormatter
         RowWindow? rows,
         Func<MarkoutWriterOptions, string> serialize,
         string[]? columns = null,
-        string[]? fields = null) =>
-        output.WriteLine(serialize(CreateWindowedOptions(rows, columns, fields)).TrimEnd());
+        string[]? fields = null,
+        string? humanRowWindowNote = null) =>
+        output.WriteLine(AddHumanRowWindowNote(
+            serialize(CreateWindowedOptions(rows, columns, fields)).TrimEnd(),
+            humanRowWindowNote));
 
     /// <summary>
     /// Creates writer options carrying a <c>--rows</c> window and optional projection, for callers
@@ -248,6 +272,39 @@ public static class OutputFormatter
     {
         output.Write(payload);
         output.Write('\n');
+    }
+
+    internal static string AddHumanRowWindowNote(string rendered, string? humanRowWindowNote)
+    {
+        if (string.IsNullOrWhiteSpace(humanRowWindowNote) || string.IsNullOrWhiteSpace(rendered))
+            return rendered;
+
+        const string SectionHeadingPrefix = "\n## ";
+        var normalized = rendered.ReplaceLineEndings("\n").TrimEnd();
+        int headingStart = normalized.StartsWith("## ", StringComparison.Ordinal)
+            ? 0
+            : normalized.IndexOf(SectionHeadingPrefix, StringComparison.Ordinal);
+        if (headingStart < 0)
+            return $"{humanRowWindowNote}\n\n{normalized}";
+
+        if (headingStart > 0)
+            headingStart += 1;
+
+        int headingEnd = normalized.IndexOf('\n', headingStart);
+        if (headingEnd < 0)
+            return $"{normalized}\n\n{humanRowWindowNote}";
+
+        string before = normalized[..headingEnd];
+        string after = normalized[(headingEnd + 1)..].TrimStart('\n');
+        return after.Length == 0
+            ? $"{before}\n\n{humanRowWindowNote}"
+            : $"{before}\n\n{humanRowWindowNote}\n\n{after}";
+    }
+
+    internal static void WriteHumanRowWindowNote(TextWriter output, string? humanRowWindowNote)
+    {
+        if (!string.IsNullOrWhiteSpace(humanRowWindowNote))
+            WriteLfLine(output, humanRowWindowNote);
     }
 
     /// <summary>
@@ -294,7 +351,7 @@ public static class OutputFormatter
     }
 
     public static void WriteStringList(IEnumerable<string> values, string displayName, string stableName,
-        bool tsv, bool jsonl, TextWriter output)
+        bool tsv, bool jsonl, TextWriter output, string? humanRowWindowNote = null)
     {
         var rows = values.Select(value => new[] { value }).ToArray();
         WriteTable(output, showHeader: false, (writer, formatter) =>
@@ -305,7 +362,7 @@ public static class OutputFormatter
             else
                 markoutWriter.WriteList(rows.Select(row => row[0]).ToArray());
             markoutWriter.Flush();
-        });
+        }, humanRowWindowNote: tsv || jsonl ? null : humanRowWindowNote);
     }
 
     /// <summary>
@@ -379,8 +436,12 @@ public static class OutputFormatter
                 projection, ordered, options.Format, options.NoHeader);
         }
 
-        return MarkoutSerializer.Serialize(
+        var markdown = MarkoutSerializer.Serialize(
             view, InspectionContext.Default, writerOptions).TrimEnd();
+        return options.Verbosity != Verbosity.Quiet
+               && writerOptions.IncludeSections is { Count: 1 }
+            ? AddHumanRowWindowNote(markdown, options.HumanRowWindowNote)
+            : markdown;
     }
 
     internal static CountProjection CapturePackageCountProjection(
@@ -423,7 +484,10 @@ public static class OutputFormatter
         var view = new InspectionResultView(result);
         WriteTable(Console.Out, showHeader,
             (writer, formatter) => MarkoutSerializer.Serialize(view, writer, formatter, InspectionContext.Default, writerOpts),
-            options.Rows);
+            options.Rows,
+            options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                ? options.HumanRowWindowNote
+                : null);
     }
 
     /// <summary>
@@ -486,8 +550,7 @@ public static class OutputFormatter
         {
             OutputDestination.Write(
                 options.OutputPath,
-                options.Rows,
-                output => WriteReferenceTree(inspection, output));
+                output => WriteReferenceTree(inspection, options.Rows, output));
             return;
         }
 
@@ -499,13 +562,18 @@ public static class OutputFormatter
 
         if (options.Format == OutputFormat.PlainText)
         {
-            WriteLfLine(Console.Out, SerializeLibraryPlainText(
-                auditView, inspection, writerOpts, options.Rows));
+            var plain = SerializeLibraryPlainText(
+                auditView, inspection, writerOpts, options.Rows);
+            if (options.Verbosity != Verbosity.Quiet && writerOpts.IncludeSections is { Count: 1 })
+                plain = AddHumanRowWindowNote(plain, options.HumanRowWindowNote);
+            WriteLfLine(Console.Out, plain);
         }
         else if (options.VerbosityEnabled)
         {
             var markdown = SerializeLibraryMarkdown(
                 auditView, inspection, writerOpts, pipeline, options.Rows);
+            if (options.Verbosity != Verbosity.Quiet && writerOpts.IncludeSections is { Count: 1 })
+                markdown = AddHumanRowWindowNote(markdown, options.HumanRowWindowNote);
             WriteLfLine(Console.Out, markdown);
         }
         else if (writerOpts.IncludeSections is { Count: > 1 } && !options.TabularExplicitlySet)
@@ -513,6 +581,8 @@ public static class OutputFormatter
             // Auto-promote to markdown when multiple sections and tabular output wasn't explicitly requested
             var markdown = SerializeLibraryMarkdown(
                 auditView, inspection, writerOpts, pipeline, options.Rows);
+            if (options.Verbosity != Verbosity.Quiet && writerOpts.IncludeSections is { Count: 1 })
+                markdown = AddHumanRowWindowNote(markdown, options.HumanRowWindowNote);
             WriteLfLine(Console.Out, markdown);
         }
         else
@@ -561,15 +631,48 @@ public static class OutputFormatter
 
     private static void WriteReferenceTree(
         LibraryInspection inspection,
+        RowWindow? rows,
         TextWriter output)
     {
         var references = inspection.AssemblyInfo?.TransitiveReferences ?? [];
-        var tree = LibraryInspectionView.BuildNestedReferenceTree(references);
+        var tree = LibraryInspectionView.BuildNestedReferenceTree(
+            SelectReferenceTreeNodes(references, rows));
         var writer = MarkoutWriter.Create(output, new MarkdownFormatter());
         writer.WriteHeading(1, LibraryViewText.Contain(inspection.FileName) ?? string.Empty);
         writer.WriteHeading(2, SectionNames.References);
         writer.WriteTree([.. tree]);
         writer.Flush();
+    }
+
+    internal static List<AssemblyReferenceNode> SelectReferenceTreeNodes(
+        List<AssemblyReferenceNode> references,
+        RowWindow? rows)
+    {
+        if (rows is null || references.Count == 0)
+            return references;
+
+        var selectedIndexes = RowWindow.Apply(
+            rows,
+            Enumerable.Range(0, references.Count).ToArray());
+        HashSet<int> included = [.. selectedIndexes];
+        foreach (var selectedIndex in selectedIndexes)
+        {
+            var parentDepth = references[selectedIndex].Depth;
+            for (var index = selectedIndex - 1;
+                 index >= 0 && parentDepth > 0;
+                 index--)
+            {
+                if (references[index].Depth >= parentDepth)
+                    continue;
+
+                included.Add(index);
+                parentDepth = references[index].Depth;
+            }
+        }
+
+        return references
+            .Where((_, index) => included.Contains(index))
+            .ToList();
     }
 
     /// <summary>
@@ -665,13 +768,19 @@ public static class OutputFormatter
                 new MarkoutWriterOptions { Projection = writerOpts.Projection }, options.Tsv, options.Jsonl);
             WriteTable(Console.Out, !options.NoHeader,
                 (writer, formatter) => MarkoutSerializer.Serialize(groupView, writer, formatter, InspectionContext.Default, groupOpts),
-                options.Rows);
+                options.Rows,
+                options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                    ? options.HumanRowWindowNote
+                    : null);
         }
         else
         {
             WriteTable(Console.Out, !options.NoHeader,
                 (writer, formatter) => MarkoutSerializer.Serialize(auditView, writer, formatter, InspectionContext.Default, writerOpts),
-                options.Rows);
+                options.Rows,
+                options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                    ? options.HumanRowWindowNote
+                    : null);
         }
     }
 

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DotnetInspector;
 using DotnetInspector.Models;
 using InertText;
 
@@ -133,8 +134,10 @@ public static class PrintProjectionOutput
             selectedRow.Label,
             selectedRow.Path,
             selectedRow.Url,
-            payload.SelectedContent?.ToString()
-                ?? payload.Content)
+            ClipStructuredContent(
+                payload.SelectedContent?.ToString()
+                    ?? payload.Content,
+                options))
         {
             SelectedContent = payload.SelectedContent
         };
@@ -190,6 +193,26 @@ public static class PrintProjectionOutput
         else
             Console.Write(output);
     }
+
+    private static string ClipStructuredContent(string content, PrintProjectionOptions options)
+    {
+        if (!options.JsonOutput && !options.Jsonl && !options.JsonArray)
+            return content;
+
+        if (CommandLineBuilder.HeadLines is int headLines)
+            return ClipHeadLines(content, headLines);
+
+        if (CommandLineBuilder.TailLines is int tailLines)
+            return ClipTailLines(content, tailLines);
+
+        return content;
+    }
+
+    private static string ClipHeadLines(string content, int maxLines)
+        => TextLineWindow.Head(content, maxLines);
+
+    private static string ClipTailLines(string content, int maxLines)
+        => TextLineWindow.Tail(content, maxLines);
 }
 
 [JsonSourceGenerationOptions(

--- a/src/dotnet-inspect/Output/TextLineWindow.cs
+++ b/src/dotnet-inspect/Output/TextLineWindow.cs
@@ -1,0 +1,57 @@
+namespace DotnetInspector.Output;
+
+internal static class TextLineWindow
+{
+    public static string Head(string content, int count)
+    {
+        if (count < 1 || content.Length == 0)
+            return string.Empty;
+
+        var lines = GetLines(content);
+        return count >= lines.Count
+            ? content
+            : content[..lines[count - 1].End];
+    }
+
+    public static string Tail(string content, int count)
+    {
+        if (count < 1 || content.Length == 0)
+            return string.Empty;
+
+        var lines = GetLines(content);
+        return count >= lines.Count
+            ? content
+            : content[lines[^count].Start..];
+    }
+
+    private static List<(int Start, int End)> GetLines(string content)
+    {
+        List<(int Start, int End)> lines = [];
+        var start = 0;
+        for (var i = 0; i < content.Length;)
+        {
+            if (content[i] is not ('\r' or '\n'))
+            {
+                i++;
+                continue;
+            }
+
+            var end = i + 1;
+            if (content[i] == '\r'
+                && end < content.Length
+                && content[end] == '\n')
+            {
+                end++;
+            }
+
+            lines.Add((start, end));
+            start = end;
+            i = end;
+        }
+
+        if (start < content.Length)
+            lines.Add((start, content.Length));
+
+        return lines;
+    }
+}


### PR DESCRIPTION
## Summary

Successor 2 of 3 replacing superseded PR #4750 for #4677. This PR targets
`limit-core-grammar-utilities` (PR #5144) and contains only projection, graph,
and rendered-output destination adoption.

- Applies relative item windows before `--value`, `--urls`, and `--paths`
  projection while keeping absolute ranges rejected at unsupported seams.
- Selects logical reference edges in tree mode and retains required ancestors
  as context.
- Routes ordinary Project and Package file output through the line-aware
  `OutputDestination`.
- Adds structured CR, LF, and CRLF line scanning, treating CRLF as one
  boundary.
- Keeps semantic item selection before projection and rendered-line clipping
  after rendering.

## Demo

```console
$ dotnet-inspect library System.Text.Json \
    -S "SourceLink: Files" --urls -n 1 --json
["https://.../one-selected-source-file.cs"]
```

The projection emits one selected logical row; before this slice validation
accepted the window but the projection still received every row.

## Stack

1. PR #5144: core grammar and utility adoption.
2. **This PR:** projection, graph, and line-aware destination adoption.
3. `limit-typed-json`: typed document JSON adoption.

Remaining #4677 slices retain ownership of absolute range/count composition,
retired selector spellings, package search/versions, print-mode acquisition and
destination auditing, and final repository-wide documentation/skill sync.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- Focused projection, output destination, reference-tree, graph, metadata-lens,
  and body-shape regressions
- Direct SourceLink URL projection and reference-tree demos

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
