### PR TITLE
Apply item windows to typed JSON

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionLimitSlice4677Tests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionLimitSlice4677Tests.cs
@@ -1,0 +1,771 @@
+using System.Text.Json;
+using DotnetInspector.Fixtures;
+using DotnetInspector.Output;
+
+namespace DotnetInspector.Tests;
+
+public partial class CommandExecutionTests
+{
+    [Fact]
+    public async Task ItemLimitsUseDeclaredRowsAcrossFormats()
+    {
+        string[] common =
+        [
+            "library",
+            TestAssemblyPath,
+            "-S",
+            "Performance: Boxing",
+            "--where",
+            "Member=BoxInt(int)",
+            "--columns",
+            "Member;Confidence",
+            "-n",
+            "1",
+            "--tips",
+            "q",
+        ];
+
+        var natural = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance: Boxing",
+            "--columns", "Member;Confidence",
+            "-n", "1",
+            "--jsonl",
+            "--tips", "q");
+        var markdown = await RunAppAsync(common);
+        var tsv = await RunAppAsync([.. common, "--tsv"]);
+        var jsonl = await RunAppAsync([.. common, "--jsonl"]);
+        var multiSection = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Library Info,Performance: Boxing",
+            "--where", "Member=BoxInt(int)",
+            "-n", "1",
+            "--tips", "q");
+
+        Assert.All(
+            new[] { natural, markdown, tsv, jsonl, multiSection },
+            result =>
+            {
+                Assert.Equal(0, result.Exit);
+                if (!string.IsNullOrEmpty(result.Error))
+                    AssertOnlyPerformanceAnalysisWarnings(result.Error);
+            });
+
+        var naturalRow = JsonDocument.Parse(Assert.Single(SplitOutputLines(natural.Output))).RootElement;
+        var markdownRow = FirstMarkdownTableRow(markdown.Output);
+        var tsvRow = Assert.Single(SplitOutputLines(tsv.Output).Skip(1));
+        var jsonlRow = JsonDocument.Parse(Assert.Single(SplitOutputLines(jsonl.Output))).RootElement;
+
+        string naturalMember = naturalRow.GetProperty("member").GetString()!;
+        string selectedMember = jsonlRow.GetProperty("member").GetString()!;
+        Assert.NotEqual(naturalMember, selectedMember);
+
+        Assert.Equal(selectedMember, markdownRow[0]);
+        Assert.Equal(jsonlRow.GetProperty("confidence").GetString(), markdownRow[1]);
+
+        string[] tsvCells = tsvRow.Split('\t');
+        Assert.Equal(selectedMember, tsvCells[0]);
+        Assert.Equal(jsonlRow.GetProperty("confidence").GetString(), tsvCells[1]);
+
+        Assert.Contains("## Library Info", multiSection.Output, StringComparison.Ordinal);
+        Assert.Contains("## Performance: Boxing", multiSection.Output, StringComparison.Ordinal);
+    }
+
+    // Plain document `--json` (not `--jsonl`) previously bypassed -n/-N entirely for
+    // `type`/`member`: WriteJsonTypeOutput serialized every filtered member regardless of
+    // options.Rows. Closes the coverage gap: ItemLimitsUseDeclaredRowsAcrossFormats above never
+    // exercised plain --json, only --jsonl/--tsv/markdown/multi-section.
+    [Fact]
+    public async Task DocumentJsonAppliesItemWindowForTypeMembers()
+    {
+        var unwindowed = await RunAppAsync(
+            "type", "DotnetInspector.Tests.CacheCommandTests",
+            "--library", TestAssemblyPath,
+            "-S", "Methods",
+            "--json",
+            "--tips", "q");
+        var windowed = await RunAppAsync(
+            "type", "DotnetInspector.Tests.CacheCommandTests",
+            "--library", TestAssemblyPath,
+            "-S", "Methods",
+            "-n", "1",
+            "--json",
+            "--tips", "q");
+        var markdown = await RunAppAsync(
+            "type", "DotnetInspector.Tests.CacheCommandTests",
+            "--library", TestAssemblyPath,
+            "-S", "Methods",
+            "-n", "1",
+            "--tips", "q");
+
+        Assert.Equal(0, unwindowed.Exit);
+        Assert.Equal(0, windowed.Exit);
+        Assert.Equal(0, markdown.Exit);
+
+        var unwindowedMembers = JsonDocument.Parse(unwindowed.Output).RootElement.GetProperty("members");
+        var windowedMembers = JsonDocument.Parse(windowed.Output).RootElement.GetProperty("members");
+
+        Assert.True(unwindowedMembers.GetArrayLength() > 1, "fixture needs 2+ methods to prove windowing");
+        Assert.Equal(1, windowedMembers.GetArrayLength());
+
+        string windowedName = windowedMembers[0].GetProperty("name").GetString()!;
+        string? markdownFirstMember = SplitOutputLines(markdown.Output)
+            .SkipWhile(line => !line.StartsWith("| ----", StringComparison.Ordinal))
+            .Skip(1)
+            .Select(line => line.Split('|', StringSplitOptions.TrimEntries)[1])
+            .FirstOrDefault();
+        Assert.Equal(markdownFirstMember, windowedName);
+    }
+
+    [Fact]
+    public async Task DocumentJsonAppliesItemWindowIndependentlyToTypeRowSets()
+    {
+        var windowed = await RunAppAsync(
+            "type", typeof(ItemWindowTypeFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "-S", "Interfaces,Methods",
+            "-n", "1",
+            "--json",
+            "--tips", "q");
+        var unsupported = await RunAppAsync(
+            "type", typeof(ItemWindowTypeFixture).FullName!,
+            "--library", TestAssemblyPath,
+            "-S", "Methods,Properties",
+            "-n", "1",
+            "--json",
+            "--tips", "q");
+
+        Assert.Equal(0, windowed.Exit);
+        Assert.Empty(windowed.Error);
+        using var document = JsonDocument.Parse(windowed.Output);
+        Assert.Equal(
+            1,
+            document.RootElement.GetProperty("interfaces").GetArrayLength());
+        Assert.Equal(
+            1,
+            document.RootElement.GetProperty("members").GetArrayLength());
+
+        Assert.Equal(1, unsupported.Exit);
+        Assert.Empty(unsupported.Output);
+        Assert.Contains(
+            "cannot apply an item window independently to multiple member sections",
+            unsupported.Error,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DocumentJsonAppliesItemWindowToFullApiSurfaceTypes()
+    {
+        var unwindowed = await RunAppAsync(
+            "type",
+            "--library", TestAssemblyPath,
+            "--json",
+            "--tips", "q");
+        var windowed = await RunAppAsync(
+            "type",
+            "--library", TestAssemblyPath,
+            "-n", "1",
+            "--json",
+            "--tips", "q");
+
+        Assert.Equal(0, unwindowed.Exit);
+        Assert.Equal(0, windowed.Exit);
+        Assert.Empty(unwindowed.Error);
+        Assert.Empty(windowed.Error);
+
+        using var unwindowedDocument = JsonDocument.Parse(unwindowed.Output);
+        using var windowedDocument = JsonDocument.Parse(windowed.Output);
+        var unwindowedRoot = unwindowedDocument.RootElement;
+        var windowedRoot = windowedDocument.RootElement;
+
+        Assert.True(
+            unwindowedRoot.GetProperty("types").GetArrayLength() > 1,
+            "fixture needs 2+ types to prove windowing");
+        Assert.Equal(1, windowedRoot.GetProperty("types").GetArrayLength());
+        Assert.Equal(
+            unwindowedRoot.GetProperty("name").GetString(),
+            windowedRoot.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task TopRequiresRankingOrder()
+    {
+        var sequence = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--top", "1",
+            "--tsv",
+            "--tips", "q");
+        var rankingDefault = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "--top", "1",
+            "--table",
+            "--tips", "q");
+        var rankingWildcard = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Lever*",
+            "--top", "1",
+            "--table",
+            "--tips", "q");
+        var explicitOrder = await RunAppAsync(
+            "library", "System.Text.Json",
+            "-S", "Performance: Boxing",
+            "--order-by", "RootReach desc",
+            "--top", "1",
+            "--json",
+            "--tips", "q");
+        var explicitOrderMarkdown = await RunAppAsync(
+            "library", "System.Text.Json",
+            "-S", "Performance: Boxing",
+            "--order-by", "RootReach desc",
+            "--top", "1",
+            "--markdown",
+            "--tips", "q");
+        var inapplicableOrder = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--order-by", "RootReach desc",
+            "--top", "1",
+            "--table",
+            "--tips", "q");
+        var inapplicableOrderOnly = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--order-by", "RootReach desc",
+            "--table",
+            "--tips", "q");
+        var legacyPerformanceAlias = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--top", "1",
+            "--json",
+            "--tips", "q");
+        var head = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "-n", "1",
+            "--table",
+            "--tips", "q");
+        var tail = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "-n", "1",
+            "--tail",
+            "--table",
+            "--tips", "q");
+        var tsv = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "--top", "1",
+            "--tsv",
+            "--tips", "q");
+        var jsonl = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "--top", "1",
+            "--jsonl",
+            "--tips", "q");
+
+        Assert.Equal(1, sequence.Exit);
+        Assert.Empty(sequence.Output);
+        Assert.Contains(
+            "Section 'References' does not support --top. Use -n N for a positional limit.",
+            sequence.Error,
+            StringComparison.Ordinal);
+
+        Assert.Equal(0, rankingDefault.Exit);
+        Assert.Contains(
+            "top 1 by Callers desc, RootReach desc, Fanout desc, LoopCalls desc",
+            rankingDefault.Output,
+            StringComparison.Ordinal);
+        Assert.Equal(0, rankingWildcard.Exit);
+        Assert.Contains(
+            "top 1 by Callers desc, RootReach desc, Fanout desc, LoopCalls desc",
+            rankingWildcard.Output,
+            StringComparison.Ordinal);
+        Assert.Equal(0, explicitOrder.Exit);
+        Assert.NotEmpty(PerformanceRows(explicitOrder.Output));
+        Assert.DoesNotContain("top 1 by", explicitOrder.Output, StringComparison.Ordinal);
+        Assert.Equal(0, explicitOrderMarkdown.Exit);
+        Assert.Contains("top 1 by RootReach desc", explicitOrderMarkdown.Output, StringComparison.Ordinal);
+        Assert.All(
+            new[] { inapplicableOrder, inapplicableOrderOnly },
+            result =>
+            {
+                Assert.Equal(1, result.Exit);
+                Assert.Empty(result.Output);
+                Assert.Contains(
+                    "Section 'References' has no ranking order, so --top/--order-by do not apply.",
+                    result.Error,
+                    StringComparison.Ordinal);
+            });
+        Assert.Equal(1, legacyPerformanceAlias.Exit);
+        Assert.Empty(legacyPerformanceAlias.Output);
+        Assert.Contains(
+            "Section 'Performance Triage' does not support --top.",
+            legacyPerformanceAlias.Error,
+            StringComparison.Ordinal);
+        Assert.Equal(0, head.Exit);
+        Assert.Contains("first 1", head.Output, StringComparison.Ordinal);
+        Assert.Equal(0, tail.Exit);
+        Assert.Contains("last 1", tail.Output, StringComparison.Ordinal);
+        Assert.Equal(0, tsv.Exit);
+        Assert.DoesNotContain("top 1 by", tsv.Output, StringComparison.Ordinal);
+        Assert.Equal(0, jsonl.Exit);
+        Assert.DoesNotContain("top 1 by", jsonl.Output, StringComparison.Ordinal);
+
+        var root = CommandLineBuilder.CreateRootCommand();
+        Assert.Contains(
+            root.Parse(["library", TestAssemblyPath, "-S", "Top Leverage", "--top", "0"]).Errors,
+            error => error.Message.Contains("--top must be a positive integer.", StringComparison.Ordinal));
+        Assert.Contains(
+            root.Parse(["library", TestAssemblyPath, "-S", "Top Leverage", "--top", "-1"]).Errors,
+            error => error.Message.Contains("--top must be a positive integer.", StringComparison.Ordinal)
+                     || error.Message.Contains("Cannot parse value", StringComparison.Ordinal));
+        Assert.Contains(
+            root.Parse(["library", TestAssemblyPath, "-S", "Top Leverage", "--top", "1", "--top", "2"]).Errors,
+            error => error.Message.Contains("Specify --top only once.", StringComparison.Ordinal));
+        Assert.Contains(
+            root.Parse(["library", TestAssemblyPath, "-S", "Top Leverage", "--top", "999999999999999999999"]).Errors,
+            error => error.Message.Contains("Cannot parse argument", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task EnvironmentJsonRejectsRenderedLineWindows()
+    {
+        string? originalFormat =
+            Environment.GetEnvironmentVariable("DOTNET_INSPECT_FORMAT");
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                "DOTNET_INSPECT_FORMAT",
+                "json");
+            var result = await RunAppAsync(
+                "library", TestAssemblyPath,
+                "-S", "References",
+                "-n", "2",
+                "--lines",
+                "--tips", "q");
+
+            Assert.Equal(1, result.Exit);
+            Assert.Empty(result.Output);
+            Assert.Contains(
+                "Document --json cannot be combined with --lines.",
+                result.Error,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                "DOTNET_INSPECT_FORMAT",
+                originalFormat);
+        }
+    }
+
+    [Fact]
+    public async Task BarePrintSuppressesEnvironmentJsonlBeforeLineWindowing()
+    {
+        string? originalFormat =
+            Environment.GetEnvironmentVariable("DOTNET_INSPECT_FORMAT");
+        var (packagePath, tempDirectory) = CreateLocalReadmePackage(
+            "Test.Bare.Print.Lines",
+            "README.md",
+            "readme",
+            null,
+            null,
+            ("skills/alpha/SKILL.md", "# Alpha skill\nsecond\nthird"));
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                "DOTNET_INSPECT_FORMAT",
+                "jsonl");
+            var result = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Package skill files",
+                "--print",
+                "--row", "1",
+                "--bare",
+                "-n", "1",
+                "--lines",
+                "--tips", "q");
+
+            Assert.Equal(0, result.Exit);
+            Assert.Empty(result.Error);
+            Assert.Equal("# Alpha skill\n", result.Output);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                "DOTNET_INSPECT_FORMAT",
+                originalFormat);
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SeparatedFalseBooleanDoesNotBecomeImplicitTarget()
+    {
+        var explicitCommand = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--json", "false",
+            "--tips", "q");
+        var implicitCommand = await RunAppAsync(
+            "--json", "false",
+            TestAssemblyPath,
+            "-S", "References",
+            "--tips", "q");
+
+        Assert.Equal(0, explicitCommand.Exit);
+        Assert.Equal(0, implicitCommand.Exit);
+        Assert.Empty(explicitCommand.Error);
+        Assert.Empty(implicitCommand.Error);
+        Assert.Equal(explicitCommand.Output, implicitCommand.Output);
+    }
+
+    [Fact]
+    public void FileOutputComposesAbsoluteRowsAndRenderedLines()
+    {
+        var tempDirectory =
+            Directory.CreateTempSubdirectory("item-line-output-");
+        try
+        {
+            string outputPath =
+                Path.Combine(tempDirectory.FullName, "rows.txt");
+            var root = CommandLineBuilder.CreateRootCommand();
+            DotnetInspector.CommandLine.ArgumentPreprocessor.PreprocessArgs(
+                ["library", TestAssemblyPath, "-n", "2", "--lines"],
+                root);
+
+            OutputDestination.Write(
+                outputPath,
+                writer =>
+                {
+                    foreach (string row in RowWindow.Apply(
+                                 RowWindow.Range(2, 3),
+                                 new[] { "first", "second", "third" }))
+                    {
+                        writer.WriteLine(row);
+                    }
+                });
+
+            Assert.Equal(
+                "second\nthird\n",
+                File.ReadAllText(outputPath));
+        }
+        finally
+        {
+            DotnetInspector.CommandLine.ArgumentPreprocessor.Reset();
+            tempDirectory.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task AggregateDocumentJsonRejectsUnsupportedItemWindows()
+    {
+        var (packagePath, tempDirectory) = CreateLocalLibPackage();
+        try
+        {
+            var multiple = await RunAppAsync(
+                "package",
+                packagePath,
+                packagePath,
+                "-n", "1",
+                "--json",
+                "--tips", "q");
+            var allLibraries = await RunAppAsync(
+                "package",
+                packagePath,
+                "--all-libraries",
+                "-n", "1",
+                "--json",
+                "--tips", "q");
+
+            Assert.All(
+                new[] { multiple, allLibraries },
+                result =>
+                {
+                    Assert.Equal(1, result.Exit);
+                    Assert.Empty(result.Output);
+                    Assert.Contains(
+                        "Document --json item windows are not yet supported",
+                        result.Error,
+                        StringComparison.Ordinal);
+                });
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task HumanRowWindowNotes_AreSuppressedForPrint()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.WindowNotes.Print",
+            "README.md",
+            "readme",
+            null,
+            null,
+            ("skills/alpha/SKILL.md", "# Alpha skill"),
+            ("skills/beta/SKILL.md", "# Beta skill"));
+        try
+        {
+            var markdown = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Package skill files",
+                "-n", "1",
+                "--tips", "q");
+            var printed = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Package skill files",
+                "--print",
+                "--row", "1",
+                "--bare",
+                "--tips", "q");
+
+            Assert.Equal(0, markdown.Exit);
+            Assert.Contains("first 1", markdown.Output, StringComparison.Ordinal);
+            Assert.Equal(0, printed.Exit);
+            Assert.Equal("# Alpha skill", printed.Output);
+            Assert.DoesNotContain("first 1", printed.Output, StringComparison.Ordinal);
+        }
+
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    public sealed class ItemWindowTypeFixture : IDisposable, ICloneable
+    {
+        public string Name { get; set; } = "";
+
+        public object Clone() => new ItemWindowTypeFixture { Name = Name };
+
+        public void Dispose()
+        {
+        }
+
+        public void First()
+        {
+        }
+
+        public void Second()
+        {
+        }
+    }
+
+    [Fact]
+    public async Task OrdinaryLineWindowsApplyAfterRendering()
+    {
+        var full = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--table",
+            "--rows", "1..3",
+            "--tips", "q");
+        var head = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--table",
+            "--rows", "1..3",
+            "-n", "2",
+            "--lines",
+            "--tips", "q");
+        var concatenated = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--table",
+            "--rows", "1..3",
+            "-n2",
+            "--lines",
+            "--tips", "q");
+        var tail = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--table",
+            "--rows", "1..3",
+            "-n", "1",
+            "--tail-lines",
+            "--tips", "q");
+        var rankedFull = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "--table",
+            "--top", "2",
+            "--tips", "q");
+        var rankedHead = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Top Leverage",
+            "--table",
+            "--top", "2",
+            "-n", "2",
+            "--lines",
+            "--tips", "q");
+
+        Assert.All(
+            new[] { full, head, concatenated, tail, rankedFull, rankedHead },
+            result =>
+            {
+                Assert.Equal(0, result.Exit);
+                Assert.Empty(result.Error);
+            });
+
+        Assert.Equal(TakeRenderedLines(full.Output, 2, tail: false), head.Output);
+        Assert.Equal(head.Output, concatenated.Output);
+        Assert.Equal(TakeRenderedLines(full.Output, 1, tail: true), tail.Output);
+        Assert.Equal(TakeRenderedLines(rankedFull.Output, 2, tail: false), rankedHead.Output);
+    }
+
+    [Fact]
+    public async Task NonPrintJsonRejectsLineWindows()
+    {
+        var rejected = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--json",
+            "-n", "2",
+            "--lines",
+            "--tips", "q");
+
+        Assert.Equal(1, rejected.Exit);
+        Assert.Empty(rejected.Output);
+        Assert.Contains(
+            "Document --json cannot be combined with --lines.",
+            rejected.Error,
+            StringComparison.Ordinal);
+
+        var falseJson = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--json=false",
+            "-n", "2",
+            "--lines",
+            "--tips", "q");
+        var plainLineWindow = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "-n", "2",
+            "--lines",
+            "--tips", "q");
+        Assert.Equal(0, falseJson.Exit);
+        Assert.Equal(0, plainLineWindow.Exit);
+        Assert.Equal(plainLineWindow.Output, falseJson.Output);
+        Assert.Empty(falseJson.Error);
+        Assert.Empty(plainLineWindow.Error);
+
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.PrintJsonLines",
+            "README.md",
+            "alpha\nbeta\ngamma\n");
+        try
+        {
+            var printed = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Package README file",
+                "--print",
+                "--json",
+                "-n", "2",
+                "--lines",
+                "--tips", "q");
+
+            Assert.Equal(0, printed.Exit);
+            Assert.Empty(printed.Error);
+            using var document = JsonDocument.Parse(printed.Output);
+            Assert.Equal(
+                "alpha\nbeta\n",
+                document.RootElement.GetProperty("content").GetString());
+
+            var falseJsonl = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Package README file",
+                "--print",
+                "--jsonl=false",
+                "-n", "2",
+                "--lines",
+                "--tips", "q");
+            Assert.Equal(0, falseJsonl.Exit);
+            Assert.Equal("alpha\nbeta\n", falseJsonl.Output);
+            Assert.Empty(falseJsonl.Error);
+
+            var unsupportedDocumentJson = await RunAppAsync(
+                "package", packagePath,
+                "-S", "Files",
+                "--json",
+                "-n", "1",
+                "--tips", "q");
+            Assert.Equal(1, unsupportedDocumentJson.Exit);
+            Assert.Empty(unsupportedDocumentJson.Output);
+            Assert.Contains(
+                "Use --jsonl for row-shaped JSON output.",
+                unsupportedDocumentJson.Error,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DirectOutputPathsApplyOrRejectItemWindows()
+    {
+        var libraryJson = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "References",
+            "--json",
+            "-n", "1",
+            "--tips", "q");
+        Assert.Equal(1, libraryJson.Exit);
+        Assert.Empty(libraryJson.Output);
+        Assert.Contains(
+            "Use --jsonl for row-shaped JSON output.",
+            libraryJson.Error,
+            StringComparison.Ordinal);
+
+        var nameOnly = await RunAppAsync(
+            "diff",
+            "--library",
+            $"{FixtureCatalog.DiffPair.OldAssemblyPath()}..{FixtureCatalog.DiffPair.NewAssemblyPath()}",
+            "--name-only",
+            "-n", "1",
+            "--tips", "q");
+        Assert.Equal(0, nameOnly.Exit);
+        Assert.Empty(nameOnly.Error);
+        Assert.Collection(
+            SplitOutputLines(nameOnly.Output),
+            line => Assert.Equal("first 1", line),
+            line => Assert.StartsWith(
+                "DiffFixtureSample.",
+                line,
+                StringComparison.Ordinal));
+    }
+
+    private static string[] FirstMarkdownTableRow(string output) =>
+        SplitOutputLines(output)
+            .Where(line => line.StartsWith("| `", StringComparison.Ordinal))
+            .Select(ParsePipeCells)
+            .First();
+
+    private static string[] ParsePipeCells(string line) =>
+        line
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(cell => System.Net.WebUtility.HtmlDecode(cell).Trim('`'))
+            .ToArray();
+
+    private static string TakeRenderedLines(string text, int count, bool tail)
+    {
+        string[] lines = text.ReplaceLineEndings("\n").Split('\n');
+        if (lines.Length > 0 && lines[^1].Length == 0)
+            lines = lines[..^1];
+
+        IEnumerable<string> selected = tail
+            ? lines.Skip(Math.Max(0, lines.Length - count))
+            : lines.Take(count);
+
+        return string.Join('\n', selected) + (selected.Any() ? "\n" : string.Empty);
+    }
+}

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1897,7 +1897,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance:*",
             "--where", "Finding=analysis.allocation",
             "--where", "Operation=box",
             "--top", "1",
@@ -1935,7 +1935,9 @@ public partial class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             [
                 .. sourceArgs,
-                "-S", "Performance Triage",
+                "-S", command == "library"
+                    ? "Performance:*"
+                    : "Performance Triage",
                 "--where", "CallerLoop=direct",
                 "--where", "CallerLoopDepth>=1",
                 "--order-by", "CallerLoopDepth desc",
@@ -2121,7 +2123,7 @@ public partial class CommandExecutionTests
         string assemblyPath = FixtureCatalog.AnalysisCallerLoop.AssemblyPath();
         var (exit, output, error) = await RunAppAsync(
             "library", assemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance:*",
             "--order-by", $"CallerLoopDepth {direction}",
             "--top", "1",
             "--json",
@@ -2138,7 +2140,7 @@ public partial class CommandExecutionTests
     {
         var baseline = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance:*",
             "--where", "Finding=analysis.allocation",
             "--top", "1",
             "--json",
@@ -2151,7 +2153,7 @@ public partial class CommandExecutionTests
 
         var filtered = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance:*",
             "--where", $"Token={unpaddedToken}",
             "--json",
             "--tips", "q");
@@ -2237,7 +2239,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-S", "Performance Triage",
+            "-S", "Performance:*",
             "--where", "Post Dominance=return-post-dominates",
             "--order-by", "PostDominance desc,RootReach desc",
             "--json",
@@ -2926,16 +2928,17 @@ public partial class CommandExecutionTests
         // headers previously inflated the count and stole a row slot).
         const int cap = 5;
         var (exit, output, error) = await RunAppAsync(
-            "library", "System.Text.Json", "-S", "Performance:*", "--table", "--rows", cap.ToString(),
+            "library", "System.Text.Json", "-S", "Performance:*", "--table", "-n", cap.ToString(),
             "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
         var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal($"first {cap}", lines[0]);
         var headerCount = lines.Count(l => l.StartsWith("Kind", StringComparison.Ordinal) && l.Contains("Member", StringComparison.Ordinal));
         Assert.Equal(1, headerCount);
-        // One header + cap data rows.
-        Assert.Equal(cap + 1, lines.Length);
+        // One note + one header + cap data rows.
+        Assert.Equal(cap + 2, lines.Length);
     }
 
     [Fact]
@@ -3010,7 +3013,7 @@ public partial class CommandExecutionTests
             "-n", "80");
 
         Assert.Equal(0, exit);
-        Assert.Empty(error);
+        Assert.Contains("Tips:", error, StringComparison.Ordinal);
         Assert.Contains("NestedDrillTarget", output);
         Assert.Contains(".ctor", output);
     }
@@ -4373,8 +4376,7 @@ public partial class CommandExecutionTests
             "--where",
             "Kind=InvocationExpression",
             "--table",
-            "--rows",
-            "1",
+            "-n", "1",
             "--tips",
             "q"
         ];
@@ -6356,7 +6358,7 @@ public partial class CommandExecutionTests
     public async Task Member_BareSimpleTypeMiss_UsesPlatformFindIfMiss()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "Regex", "-m", "Match", "-S", "Member Index", "--rows", "4", "--tips", "q");
+            "member", "Regex", "-m", "Match", "-S", "Member Index", "-n", "4", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("# System.Text.RegularExpressions.Regex", output);
@@ -6370,9 +6372,9 @@ public partial class CommandExecutionTests
         // A real command must wire ParseRows and honor the tail branch: the last-N
         // window selects a different endpoint than the first-N window.
         var head = await RunAppAsync(
-            "type", "System.String", "-S", "Member Index", "--rows", "2", "--tsv", "--tips", "q");
+            "type", "System.String", "-S", "Member Index", "-n", "2", "--tsv", "--tips", "q");
         var tail = await RunAppAsync(
-            "type", "System.String", "-S", "Member Index", "--rows", "2", "--tail", "--tsv", "--tips", "q");
+            "type", "System.String", "-S", "Member Index", "-n", "2", "--tail", "--tsv", "--tips", "q");
 
         Assert.Equal(0, head.Exit);
         Assert.Equal(0, tail.Exit);
@@ -6395,7 +6397,7 @@ public partial class CommandExecutionTests
         // token, and the arg-preprocessor token scan does not see it. Reading the
         // parse result rather than the raw tokens is what keeps the two equivalent.
         var (exit, output, error) = await RunAppAsync(
-            "type", "System.String", "-S", "Member Index", "--rows=2", "--tail", "--tsv", "--tips", "q");
+            "type", "System.String", "-S", "Member Index", "-n=2", "--tail", "--tsv", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -6408,7 +6410,7 @@ public partial class CommandExecutionTests
         // --head and --tail name opposite ends, so asking for both is a contradiction
         // rather than a narrower window. The =-syntax spelling must be caught too.
         var (exit, output, error) = await RunAppAsync(
-            "type", "System.String", "-S", "Member Index", "--rows=3", "--head", "--tail", "--tsv", "--tips", "q");
+            "type", "System.String", "-S", "Member Index", "-n=3", "--head", "--tail", "--tsv", "--tips", "q");
 
         Assert.Equal(1, exit);
         Assert.Empty(output);
@@ -6459,7 +6461,7 @@ public partial class CommandExecutionTests
         // first four rows and `2..4` takes three rows starting at the second, so the
         // two must not resolve to the same window.
         var count = await RunAppAsync(
-            "type", "System.String", "-S", "Member Index", "--rows", "4", "--tsv", "--tips", "q");
+            "type", "System.String", "-S", "Member Index", "-n", "4", "--tsv", "--tips", "q");
         var range = await RunAppAsync(
             "type", "System.String", "-S", "Member Index", "--rows", "2..4", "--tsv", "--tips", "q");
 
@@ -8791,7 +8793,7 @@ public partial class CommandExecutionTests
         string[][] modes =
         [
             ["--plaintext"],
-            ["--rows", "1"]
+            ["-n", "1"]
         ];
 
         foreach (var mode in modes)
@@ -9247,8 +9249,7 @@ public partial class CommandExecutionTests
             "-S",
             "Classes",
             "--plaintext",
-            "--rows",
-            "2",
+            "-n", "2",
             "--tips",
             "q");
 
@@ -9811,7 +9812,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "JsonSerializer", "--platform", "System.Text.Json",
-            "-m", "Serialize", "-S", "Source Locations", "--rows", "6", "--tips", "q");
+            "-m", "Serialize", "-S", "Source Locations", "-n", "6", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -11298,7 +11299,7 @@ public partial class CommandExecutionTests
         try
         {
             var (exit, output, error) = await RunPackageSearchFixtureAsync(
-                "package", "--rows", "1", "--out", outputPath,
+                "package", "--rows", "1..1", "--out", outputPath,
                 "search", "Fixture", "--count", "--take", "2");
 
             Assert.Equal(0, exit);
@@ -11359,7 +11360,7 @@ public partial class CommandExecutionTests
     public async Task ProjectedJsonRoutingAudit_PackageSearchInheritedDiscoveryFailsBeforeNetwork()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "-D", "--rows", "1",
+            "package", "-D", "--rows", "1..1",
             "search", "ThisQueryMustNotReachTheNetwork", "--count",
             "--source", "http://127.0.0.1:9/index.json");
 
@@ -11496,8 +11497,12 @@ public partial class CommandExecutionTests
     [Fact]
     public async Task ProjectedJsonRoutingAudit_PackageSearchMalformedLimitWithRowsIsContained()
     {
+        // --rows and -n are mutually exclusive (item-mode -n) as of the -n item-window
+        // redesign, so this no longer exercises "malformed -n alongside --rows" -- it
+        // exercises the still-relevant part of the original audit: a malformed -n value
+        // fails cleanly before the network, without crashing.
         var (exit, output, error) = await RunAppAsync(
-            "package", "--rows", "2",
+            "package",
             "search", "ThisQueryMustNotReachTheNetwork", "-n=abc",
             "--source", "http://127.0.0.1:9/index.json");
 
@@ -11574,10 +11579,10 @@ public partial class CommandExecutionTests
     }
 
     [Theory]
-    [InlineData("--rows", "2", "--head", "--tail",
+    [InlineData("--rows", "2..3", "--head", "--tail",
         "--head and --tail select opposite ends")]
-    [InlineData("--rows", "2", "-n", "3",
-        "already carries the count")]
+    [InlineData("--rows", "2..3", "-n", "3",
+        "cannot be combined with item-mode -n")]
     public async Task ProjectedJsonRoutingAudit_PackageSearchWindowConflictsFailBeforeNetwork(
         string firstOption,
         string firstValue,
@@ -11829,14 +11834,14 @@ public partial class CommandExecutionTests
             "-D", "Library Info", "--json", "--columns", "Name", "--tips", "q");
         var wildcard = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-D", "Library Info", "--json", "--columns", "Nam*", "--rows", "1", "--tips", "q");
+            "-D", "Library Info", "--json", "--columns", "Nam*", "--rows", "1..1", "--tips", "q");
         var allColumns = await RunAppAsync(
             "library", TestAssemblyPath,
-            "-D", "Library Info", "--json", "--columns", "*", "--rows", "1", "--tips", "q");
+            "-D", "Library Info", "--json", "--columns", "*", "--rows", "1..1", "--tips", "q");
         var overlapping = await RunAppAsync(
             "library", TestAssemblyPath,
             "-D", "Library Info", "--json",
-            "--fields", "Nam*", "--columns", "N*", "--rows", "1", "--tips", "q");
+            "--fields", "Nam*", "--columns", "N*", "--rows", "1..1", "--tips", "q");
         var invalid = await RunAppAsync(
             "library", TestAssemblyPath,
             "-D", "Library Info", "--json", "--columns", "NoSuchColumn", "--tips", "q");
@@ -12511,7 +12516,7 @@ public partial class CommandExecutionTests
     public async Task Discover_Count_StaticSchemaHonorsRowWindow(string command)
     {
         var (exit, output, error) = await RunAppAsync(
-            command, "--schema", "-D", "", "--count", "--rows", "1");
+            command, "--schema", "-D", "", "--count", "-n", "1");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -12578,11 +12583,11 @@ public partial class CommandExecutionTests
 
     [Theory]
     // Head, tail, an absolute range, an open range, and a window wider than the batch.
-    [InlineData(new[] { "--rows", "2" }, 2)]
-    [InlineData(new[] { "--rows", "2", "--tail" }, 2)]
+    [InlineData(new[] { "-n", "2" }, 2)]
+    [InlineData(new[] { "-n", "2", "--tail" }, 2)]
     [InlineData(new[] { "--rows", "2..3" }, 2)]
     [InlineData(new[] { "--rows", "3.." }, 1)]
-    [InlineData(new[] { "--rows", "9" }, 3)]
+    [InlineData(new[] { "-n", "9" }, 3)]
     public async Task IlOffsetsFile_Count_CountsTheWindowItRenders(string[] window, int expected)
     {
         // --rows narrows the rendered table, so it has to narrow --count identically.
@@ -12642,9 +12647,9 @@ public partial class CommandExecutionTests
         try
         {
             var (headExit, headOut, _) = await RunAppAsync(
-                "library", TestAssemblyPath, "--il-offsets", path, "--rows", "1", "--head", "--tips", "q");
+                "library", TestAssemblyPath, "--il-offsets", path, "-n", "1", "--head", "--tips", "q");
             var (tailExit, tailOut, _) = await RunAppAsync(
-                "library", TestAssemblyPath, "--il-offsets", path, "--rows", "1", "--tail", "--tips", "q");
+                "library", TestAssemblyPath, "--il-offsets", path, "-n", "1", "--tail", "--tips", "q");
 
             Assert.Equal(0, headExit);
             Assert.Equal(0, tailExit);
@@ -13368,10 +13373,17 @@ public partial class CommandExecutionTests
         // post-processor -- counting lines is only safe when one row is one line, which a
         // pretty-printed JSON document violates. Every window kind is covered because Markout,
         // not the caller, decides what head/range/start+count mean.
+        string[] windowArgs = window == "3" ? ["-n", "3"] : ["--rows", window];
         var (tsvExit, tsvOutput, _) = await RunAppAsync(
-            "find", "*", "--library", TestAssemblyPath, "--columns", "Type", "--tsv", "--rows", window);
+            [
+                "find", "*", "--library", TestAssemblyPath, "--columns", "Type", "--tsv",
+                .. windowArgs,
+            ]);
         var (jsonExit, jsonOutput, _) = await RunAppAsync(
-            "find", "*", "--library", TestAssemblyPath, "--columns", "Type", "--json", "--rows", window);
+            [
+                "find", "*", "--library", TestAssemblyPath, "--columns", "Type", "--json",
+                .. windowArgs,
+            ]);
 
         Assert.Equal(0, tsvExit);
         Assert.Equal(0, jsonExit);
@@ -13466,9 +13478,9 @@ public partial class CommandExecutionTests
         // The member search reaches the lowered view through a separate call site; a fix applied to
         // only one of the two would leave --rows silently dropped on the other.
         var (tsvExit, tsvOutput, _) = await RunAppAsync(
-            "find", "Dispose", "--members", "--library", TestAssemblyPath, "--columns", "Member", "--tsv", "--rows", "2");
+            "find", "Dispose", "--members", "--library", TestAssemblyPath, "--columns", "Member", "--tsv", "-n", "2");
         var (jsonExit, jsonOutput, _) = await RunAppAsync(
-            "find", "Dispose", "--members", "--library", TestAssemblyPath, "--columns", "Member", "--json", "--rows", "2");
+            "find", "Dispose", "--members", "--library", TestAssemblyPath, "--columns", "Member", "--json", "-n", "2");
 
         Assert.Equal(0, tsvExit);
         Assert.Equal(0, jsonExit);
@@ -13943,7 +13955,7 @@ public partial class CommandExecutionTests
             "--count", "-v", "q", "--tips", "q");
         var quietWindowed = await RunAppAsync(
             "extensions", "IEnumerable<T>", "--platform", "System.Linq",
-            "--count", "-v", "q", "--rows", "1", "--tips", "q");
+            "--count", "-v", "q", "-n", "1", "--tips", "q");
 
         Assert.Equal(0, normal.Exit);
         Assert.Equal(normal.Output, quiet.Output);
@@ -13956,16 +13968,16 @@ public partial class CommandExecutionTests
     {
         var find = await RunAppAsync(
             "find", "*", "--platform", "System.Private.CoreLib",
-            "--count", "--rows", "1", "--tips", "q");
+            "--count", "-n", "1", "--tips", "q");
         var members = await RunAppAsync(
             "find", ".ToString", "--platform", "System.Private.CoreLib",
-            "--count", "--rows", "1", "--tips", "q");
+            "--count", "-n", "1", "--tips", "q");
         var implements = await RunAppAsync(
             "implements", "IDisposable", "--platform", "System.Private.CoreLib",
-            "--count", "--rows", "1", "--tips", "q");
+            "--count", "-n", "1", "--tips", "q");
         var extensions = await RunAppAsync(
             "extensions", "IEnumerable<T>", "--platform", "System.Linq",
-            "--count", "--rows", "1", "--tips", "q");
+            "--count", "-n", "1", "--tips", "q");
         var invalid = await RunAppAsync(
             "find", "*", "--platform", "System.Private.CoreLib",
             "--count", "--columns", "NoSuchColumn", "--tips", "q");
@@ -13991,23 +14003,23 @@ public partial class CommandExecutionTests
         {
             var tfms = await RunAppAsync(
                 "package", packagePath, "--tfms",
-                "--count", "--rows", "1", "--tips", "q");
+                "--count", "-n", "1", "--tips", "q");
             var projectedTfms = await RunAppAsync(
                 "package", packagePath, "--tfms",
                 "--columns", "TFM",
-                "--count", "--rows", "1", "--tips", "q");
+                "--count", "-n", "1", "--tips", "q");
             var layout = await RunAppAsync(
                 "package", packagePath, "--layout",
-                "--count", "--rows", "1", "--tips", "q");
+                "--count", "-n", "1", "--tips", "q");
             var discovery = await RunAppAsync(
                 "library", TestAssemblyPath, "-D", "",
-                "--count", "--rows", "1", "--tips", "q");
+                "--count", "-n", "1", "--tips", "q");
             var renderedTfms = await RunAppAsync(
                 "package", packagePath, "--tfms",
-                "--jsonl", "--rows", "1", "--tips", "q");
+                "--jsonl", "-n", "1", "--tips", "q");
             var renderedDiscovery = await RunAppAsync(
                 "library", TestAssemblyPath, "-D", "",
-                "--jsonl", "--rows", "1", "--tips", "q");
+                "--jsonl", "-n", "1", "--tips", "q");
             var invalid = await RunAppAsync(
                 "package", packagePath, "--tfms",
                 "--columns", "NoSuchColumn",
@@ -14471,7 +14483,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "JsonConvert", "--package", "Newtonsoft.Json",
-            "-m", "SerializeObject", "-S", "Source Locations", "--rows", "6", "--tips", "q");
+            "-m", "SerializeObject", "-S", "Source Locations", "-n", "6", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -17123,7 +17135,7 @@ public partial class CommandExecutionTests
     public async Task Member_StringBareSelect_RendersLearnMemberOrder()
     {
         var (exit, output, error) = await RunAppAsync(
-            "member", "String", "--platform", "System.Private.CoreLib", "-S", "--tips", "q", "--rows", "3");
+            "member", "String", "--platform", "System.Private.CoreLib", "-S", "--tips", "q", "-n", "3");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -17154,7 +17166,7 @@ public partial class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             "member", "String", "--platform", "System.Private.CoreLib",
             "-S", "Operators,Explicit Interface Implementations,Extension Methods",
-            "--tips", "q", "--rows", "3");
+            "--tips", "q", "-n", "3");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -17171,7 +17183,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", "String", "--platform", "System.Private.CoreLib",
-            "-S", "Explicit Interface Implementations,Member Index", "--tips", "q", "--rows", "4");
+            "-S", "Explicit Interface Implementations,Member Index", "--tips", "q", "-n", "4");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -17206,7 +17218,7 @@ public partial class CommandExecutionTests
 
         (exit, output, error) = await RunAppAsync(
             "member", "String", "--platform", "System.Private.CoreLib",
-            "-S", "Extension Methods,Member Index", "--tips", "q", "--rows", "4");
+            "-S", "Extension Methods,Member Index", "--tips", "q", "-n", "4");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -17466,7 +17478,7 @@ public partial class CommandExecutionTests
     public async Task Extensions_JsonlAfterPackage_RendersJsonlAndDoesNotWarnAboutPackageFlag()
     {
         var (exit, output, error) = await RunAppAsync(
-            "extensions", "IEnumerable<T>", "--platform", "System.Linq", "--jsonl", "--rows", "2", "--tips", "q");
+            "extensions", "IEnumerable<T>", "--platform", "System.Linq", "--jsonl", "-n", "2", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -21260,7 +21272,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_SwitchesSection_DetectsFeatureSwitchDefinitions()
     {
         var (exit, output, error) = await RunAppAsync(
-            "library", "System.Text.Json", "-S", "Switches", "--rows", "20");
+            "library", "System.Text.Json", "-S", "Switches", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Switches", output);
@@ -21288,7 +21300,7 @@ public partial class CommandExecutionTests
         var (exit, all, _) = await RunAppAsync(
             "package", "System.Text.Json", "--all-libraries", "-S", "Switches");
         var (windowedExit, windowed, _) = await RunAppAsync(
-            "package", "System.Text.Json", "--all-libraries", "-S", "Switches", "--rows", "2");
+            "package", "System.Text.Json", "--all-libraries", "-S", "Switches", "-n", "2");
 
         Assert.Equal(0, exit);
         Assert.Equal(0, windowedExit);
@@ -21420,7 +21432,7 @@ public partial class CommandExecutionTests
             var (exit, output, error) = await RunAppAsync(
                 "package", packagePath, "--all-libraries", "-S", "Library Info");
             var (windowedExit, windowed, windowedError) = await RunAppAsync(
-                "package", packagePath, "--all-libraries", "-S", "Library Info", "--rows", "20");
+                "package", packagePath, "--all-libraries", "-S", "Library Info", "-n", "20");
 
             Assert.Equal(0, exit);
             Assert.Equal(0, windowedExit);
@@ -21504,7 +21516,7 @@ public partial class CommandExecutionTests
                     StringComparison.Ordinal));
 
         var (exit, output, error) = await RunAppAsync(
-            "library", assemblyPath, "-S", "Switches", "--rows", "20");
+            "library", assemblyPath, "-S", "Switches", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Equal(
@@ -21536,7 +21548,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationOpportunities_ForAwsS3_ShowsCloudClientSuggestions()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "AWSSDK.S3", "--library", "-S", "Integration: Opportunities", "--rows", "20");
+            "package", "AWSSDK.S3", "--library", "-S", "Integration: Opportunities", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Opportunities", output);
@@ -21550,7 +21562,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationOpportunities_ForCognito_ShowsAuthenticationSuggestion()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Amazon.Extensions.CognitoAuthentication", "--library", "-S", "Integration: Opportunities", "--rows", "20");
+            "package", "Amazon.Extensions.CognitoAuthentication", "--library", "-S", "Integration: Opportunities", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Opportunities", output);
@@ -21562,7 +21574,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationOpportunities_ForNpgsql_ShowsResourceSuggestions()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Npgsql", "--library", "-S", "Integration: Opportunities", "--rows", "20");
+            "package", "Npgsql", "--library", "-S", "Integration: Opportunities", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Opportunities", output);
@@ -21575,7 +21587,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationOpportunities_ForAzureAppConfiguration_ShowsConfigurationSuggestion()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Azure.Data.AppConfiguration", "--library", "-S", "Integration: Opportunities", "--rows", "20");
+            "package", "Azure.Data.AppConfiguration", "--library", "-S", "Integration: Opportunities", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Opportunities", output);
@@ -21591,8 +21603,7 @@ public partial class CommandExecutionTests
             typeof(Npgsql.NpgsqlConnection).Assembly.Location,
             "-S",
             "Integration: Opportunities",
-            "--rows",
-            "20");
+            "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Opportunities", output);
@@ -21628,7 +21639,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_ConfigurationIntegration_ForSystemsManager_ShowsConfigurationApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Amazon.Extensions.Configuration.SystemsManager", "--library", "-S", "Integration: Configuration", "--rows", "20");
+            "package", "Amazon.Extensions.Configuration.SystemsManager", "--library", "-S", "Integration: Configuration", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Configuration", output);
@@ -21643,7 +21654,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_ConfigurationIntegration_ForJson_ShowsConfigurationProviderShape()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Configuration.Json", "--library", "-S", "Integration: Configuration", "--rows", "20");
+            "package", "Microsoft.Extensions.Configuration.Json", "--library", "-S", "Integration: Configuration", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Configuration", output);
@@ -21658,7 +21669,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_ConfigurationIntegration_ForUserSecrets_ShowsConfigurationApi()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Configuration.UserSecrets", "--library", "-S", "Integration: Configuration", "--rows", "20");
+            "package", "Microsoft.Extensions.Configuration.UserSecrets", "--library", "-S", "Integration: Configuration", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Configuration", output);
@@ -21671,7 +21682,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_ConfigurationIntegration_ForBinder_ShowsBindingApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Configuration.Binder", "--library", "-S", "Integration: Configuration", "--rows", "20");
+            "package", "Microsoft.Extensions.Configuration.Binder", "--library", "-S", "Integration: Configuration", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Configuration", output);
@@ -21684,7 +21695,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_ConfigurationIntegration_ForOptionsConfiguration_ShowsOptionsBindingApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Options.ConfigurationExtensions", "--library", "-S", "Integration: Configuration", "--rows", "20");
+            "package", "Microsoft.Extensions.Options.ConfigurationExtensions", "--library", "-S", "Integration: Configuration", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Configuration", output);
@@ -21697,7 +21708,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_DependencyInjectionIntegration_ForScrutor_ShowsScanningAndDecorationApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Scrutor", "--library", "-S", "Integration: Dependency Injection", "--rows", "20");
+            "package", "Scrutor", "--library", "-S", "Integration: Dependency Injection", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Dependency Injection", output);
@@ -21711,7 +21722,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OptionsIntegration_ForValidationPackage_ShowsValidationApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "ReHackt.Extensions.Options.Validation", "--library", "-S", "Integration: Options", "--rows", "20");
+            "package", "ReHackt.Extensions.Options.Validation", "--library", "-S", "Integration: Options", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Options", output);
@@ -21724,7 +21735,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HealthChecksIntegration_ForAspNetCoreMiddleware_ShowsUseHealthChecks()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.Diagnostics.HealthChecks", "--library", "-S", "Integration: Health Checks", "--rows", "20");
+            "package", "Microsoft.AspNetCore.Diagnostics.HealthChecks", "--library", "-S", "Integration: Health Checks", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Health Checks", output);
@@ -21736,7 +21747,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HostingIntegration_ForHostedServiceRegistration_ShowsHostedServiceApi()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "App.Metrics.Extensions.Hosting", "--library", "-S", "Integration: Hosting", "--rows", "20");
+            "package", "App.Metrics.Extensions.Hosting", "--library", "-S", "Integration: Hosting", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Hosting", output);
@@ -21748,7 +21759,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenApiIntegration_ForAnnotations_ShowsAnnotationSupport()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Swashbuckle.AspNetCore.Annotations", "--library", "-S", "Integration: OpenAPI", "--rows", "20");
+            "package", "Swashbuckle.AspNetCore.Annotations", "--library", "-S", "Integration: OpenAPI", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenAPI", output);
@@ -21761,7 +21772,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenTelemetryIntegration_ForSerilogSink_ShowsOtlpLoggingApi()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Serilog.Sinks.OpenTelemetry", "--library", "-S", "Integration: OpenTelemetry", "--rows", "20");
+            "package", "Serilog.Sinks.OpenTelemetry", "--library", "-S", "Integration: OpenTelemetry", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenTelemetry", output);
@@ -21774,7 +21785,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationIntegration_ForOpenIddictValidation_ShowsValidationApi()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "OpenIddict.Validation.AspNetCore", "--library", "-S", "Integration: Authentication", "--rows", "20");
+            "package", "OpenIddict.Validation.AspNetCore", "--library", "-S", "Integration: Authentication", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -21787,7 +21798,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationIntegration_ForBlazorAuthorization_ShowsAuthenticationStateApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.Components.Authorization", "--library", "-S", "Integration: Authentication", "--rows", "20");
+            "package", "Microsoft.AspNetCore.Components.Authorization", "--library", "-S", "Integration: Authentication", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -21800,9 +21811,9 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationIntegration_ForGraphQlPackages_ShowsAuthorizationBuilderApis()
     {
         var (hotChocolateExit, hotChocolateOutput, hotChocolateError) = await RunAppAsync(
-            "package", "HotChocolate.Authorization", "--library", "-S", "Integration: Authentication", "--rows", "20");
+            "package", "HotChocolate.Authorization", "--library", "-S", "Integration: Authentication", "-n", "20");
         var (graphQlExit, graphQlOutput, graphQlError) = await RunAppAsync(
-            "package", "GraphQL.Authorization", "--library", "-S", "Integration: Authentication", "--rows", "20");
+            "package", "GraphQL.Authorization", "--library", "-S", "Integration: Authentication", "-n", "20");
 
         Assert.Equal(0, hotChocolateExit);
         Assert.Contains("## Integration: Authentication", hotChocolateOutput);
@@ -21861,7 +21872,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_SelectIntegrationsCategory_RendersIntegrationSections()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.AI", "--library", "-S", "@Integrations", "--rows", "6");
+            "package", "Microsoft.Extensions.AI", "--library", "-S", "@Integrations", "-n", "6");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -21878,7 +21889,7 @@ public partial class CommandExecutionTests
         // "Integrations" was a rollup section before the per-integration decomposition. It keeps
         // resolving as a category alias, exactly like the retired "Performance Triage" monolith.
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.AI", "--library", "-S", "Integrations", "--rows", "6");
+            "package", "Microsoft.Extensions.AI", "--library", "-S", "Integrations", "-n", "6");
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("not found", error);
@@ -21901,7 +21912,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AISection_DetectsAiCurrencyTypes()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.AI.Abstractions", "--library", "-S", "Integration: AI", "--rows", "80");
+            "package", "Microsoft.Extensions.AI.Abstractions", "--library", "-S", "Integration: AI", "-n", "80");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -21918,7 +21929,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AISection_ForAspireOpenAI_ShowsStarterApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.OpenAI", "--library", "-S", "Integration: AI", "--rows", "40");
+            "package", "Aspire.OpenAI", "--library", "-S", "Integration: AI", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -21936,7 +21947,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AISection_ForMicrosoftExtensionsAIOpenAI_ShowsAdapterApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.AI.OpenAI", "--library", "-S", "@Integrations", "--rows", "40");
+            "package", "Microsoft.Extensions.AI.OpenAI", "--library", "-S", "@Integrations", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -21957,7 +21968,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationsCategory_ForAspireOpenAI_ShowsStarterIntegrations()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.OpenAI", "--library", "-S", "@Integrations", "--rows", "40");
+            "package", "Aspire.OpenAI", "--library", "-S", "@Integrations", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: AI", output);
@@ -21974,7 +21985,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspireSection_ForAspireHostingRedis_ShowsResourceCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.Hosting.Redis", "--library", "-S", "Integration: Aspire", "--rows", "20");
+            "package", "Aspire.Hosting.Redis", "--library", "-S", "Integration: Aspire", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Aspire", output);
@@ -21989,7 +22000,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_IntegrationsCategory_ForAspireHostingRedis_RendersAspireSection()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.Hosting.Redis", "--library", "-S", "@Integrations", "--rows", "20");
+            "package", "Aspire.Hosting.Redis", "--library", "-S", "@Integrations", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Aspire", output);
@@ -22017,7 +22028,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenTelemetrySection_ForAspireKafka_ShowsTelemetryControls()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Aspire.Confluent.Kafka", "--library", "-S", "@Integrations", "--rows", "40");
+            "package", "Aspire.Confluent.Kafka", "--library", "-S", "@Integrations", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenTelemetry", output);
@@ -22049,7 +22060,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_LoggingSection_ForAwsLogger_ShowsProviderApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "AWS.Logger.AspNetCore", "--library", "-S", "@Integrations", "--rows", "20");
+            "package", "AWS.Logger.AspNetCore", "--library", "-S", "@Integrations", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Logging", output);
@@ -22065,7 +22076,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_LoggingSection_ForSerilog_ShowsProviderApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Serilog.Extensions.Logging", "--library", "-S", "Integration: Logging", "--rows", "20");
+            "package", "Serilog.Extensions.Logging", "--library", "-S", "Integration: Logging", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Logging", output);
@@ -22097,7 +22108,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_DependencyInjectionSection_ForAzureClients_ShowsServiceRegistrationApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Azure", "--library", "-S", "Integration: Dependency Injection", "--rows", "20");
+            "package", "Microsoft.Extensions.Azure", "--library", "-S", "Integration: Dependency Injection", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Dependency Injection", output);
@@ -22112,7 +22123,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HealthChecksSection_ForSqlServer_ShowsHealthCheckBuilderApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "AspNetCore.HealthChecks.SqlServer", "--library", "-S", "@Integrations", "--rows", "20");
+            "package", "AspNetCore.HealthChecks.SqlServer", "--library", "-S", "@Integrations", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("Dependency Injection", output);
@@ -22126,7 +22137,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationSection_ForJwtBearer_ShowsSchemeCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.Authentication.JwtBearer", "--library", "-S", "@Integrations", "--rows", "40");
+            "package", "Microsoft.AspNetCore.Authentication.JwtBearer", "--library", "-S", "@Integrations", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -22140,7 +22151,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationSection_ForAuthenticationCore_ShowsMiddlewareCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.Authentication", "--library", "-S", "Integration: Authentication", "--rows", "40");
+            "package", "Microsoft.AspNetCore.Authentication", "--library", "-S", "Integration: Authentication", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -22154,7 +22165,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationSection_ForAuthorization_ShowsAuthorizationCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.Authorization", "--library", "-S", "Integration: Authentication", "--rows", "40");
+            "package", "Microsoft.AspNetCore.Authorization", "--library", "-S", "Integration: Authentication", "-n", "40");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -22168,7 +22179,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AuthenticationSection_ForAwsCognitoIdentity_ShowsIdentityCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Amazon.AspNetCore.Identity.Cognito", "--library", "-S", "@Integrations", "--rows", "30");
+            "package", "Amazon.AspNetCore.Identity.Cognito", "--library", "-S", "@Integrations", "-n", "30");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Authentication", output);
@@ -22181,7 +22192,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenApiSection_ForSwashbuckle_ShowsOpenApiCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Swashbuckle.AspNetCore.Swagger", "--library", "-S", "@Integrations", "--rows", "30");
+            "package", "Swashbuckle.AspNetCore.Swagger", "--library", "-S", "@Integrations", "-n", "30");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenAPI", output);
@@ -22195,7 +22206,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenApiSection_ForMicrosoftOpenApi_ShowsServiceAndEndpointApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.AspNetCore.OpenApi", "--library", "-S", "Integration: OpenAPI", "--rows", "20");
+            "package", "Microsoft.AspNetCore.OpenApi", "--library", "-S", "Integration: OpenAPI", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenAPI", output);
@@ -22209,7 +22220,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspNetCoreSection_ForSerilog_ShowsMiddlewareCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Serilog.AspNetCore", "--library", "-S", "Integration: ASP.NET Core", "--rows", "20");
+            "package", "Serilog.AspNetCore", "--library", "-S", "Integration: ASP.NET Core", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: ASP.NET Core", output);
@@ -22223,7 +22234,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspNetCoreSection_ForHangfire_ShowsEndpointAndMiddlewareCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Hangfire.AspNetCore", "--library", "-S", "Integration: ASP.NET Core", "--rows", "20");
+            "package", "Hangfire.AspNetCore", "--library", "-S", "Integration: ASP.NET Core", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: ASP.NET Core", output);
@@ -22237,7 +22248,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspNetCoreSection_ForGrpc_ShowsEndpointCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Grpc.AspNetCore.Server", "--library", "-S", "@Integrations", "--rows", "30");
+            "package", "Grpc.AspNetCore.Server", "--library", "-S", "@Integrations", "-n", "30");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: ASP.NET Core", output);
@@ -22251,7 +22262,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspNetCoreSection_ForAzureDataProtectionBlobs_ShowsDataProtectionCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Azure.Extensions.AspNetCore.DataProtection.Blobs@1.5.3", "--all-libraries", "-S", "Integration: ASP.NET Core", "--rows", "20");
+            "package", "Azure.Extensions.AspNetCore.DataProtection.Blobs@1.5.3", "--all-libraries", "-S", "Integration: ASP.NET Core", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: ASP.NET Core", output);
@@ -22264,7 +22275,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_AspNetCoreSection_ForAzureDataProtectionKeys_ShowsDataProtectionCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Azure.Extensions.AspNetCore.DataProtection.Keys@1.6.3", "--all-libraries", "-S", "Integration: ASP.NET Core", "--rows", "20");
+            "package", "Azure.Extensions.AspNetCore.DataProtection.Keys@1.6.3", "--all-libraries", "-S", "Integration: ASP.NET Core", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: ASP.NET Core", output);
@@ -22277,7 +22288,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HostingSection_ForMassTransit_ShowsHostBuilderApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "MassTransit", "--library", "-S", "Integration: Hosting", "--rows", "20");
+            "package", "MassTransit", "--library", "-S", "Integration: Hosting", "-n", "20");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: Hosting", output);
@@ -22291,7 +22302,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_OpenTelemetrySection_ForAzureMonitorExporter_ShowsBuilderApis()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Azure.Monitor.OpenTelemetry.Exporter", "--library", "-S", "Integration: OpenTelemetry", "--rows", "30");
+            "package", "Azure.Monitor.OpenTelemetry.Exporter", "--library", "-S", "Integration: OpenTelemetry", "-n", "30");
 
         Assert.Equal(0, exit);
         Assert.Contains("## Integration: OpenTelemetry", output);
@@ -22306,7 +22317,7 @@ public partial class CommandExecutionTests
     public async Task LibraryCommand_HttpClientDiagnostics_ShowsUserFacingHttpClientCurrency()
     {
         var (exit, output, error) = await RunAppAsync(
-            "package", "Microsoft.Extensions.Http.Diagnostics", "--library", "-S", "@Integrations", "--rows", "30");
+            "package", "Microsoft.Extensions.Http.Diagnostics", "--library", "-S", "@Integrations", "-n", "30");
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("OpenTelemetry", output);
@@ -23439,7 +23450,7 @@ public partial class CommandExecutionTests
                 var noDependencies = await RunAppAsync(
                     "package", noDependenciesPath, "-S", "Dependencies", "--tree",
                     "--out", outputPath, "--tips", "q",
-                    "-n", "2", "--tail");
+                    "-n", "2", "--tail-lines");
 
                 Assert.Equal(0, noDependencies.Exit);
                 Assert.Empty(noDependencies.Output);
@@ -23470,8 +23481,8 @@ public partial class CommandExecutionTests
         {
             foreach (string[] lineWindow in new[]
                      {
-                         new[] { "-n", "2" },
-                         ["-n", "2", "--tail"],
+                         new[] { "-n", "2", "--lines" },
+                         ["-n", "2", "--tail-lines"],
                      })
             {
                 var baseline = await RunAppInDirectoryAsync(
@@ -23788,12 +23799,12 @@ public partial class CommandExecutionTests
                 tempDir,
                 "package", packagePath, "--library", "Test.Primary.dll",
                 "-S", "References", "--tree", "--markdown",
-                "-n", "2", "--tips", "q");
+                "-n", "2", "--lines", "--tips", "q");
             var windowedFile = await RunAppInDirectoryAsync(
                 tempDir,
                 "package", packagePath, "--library", "Test.Primary.dll",
                 "-S", "References", "--tree", "--markdown",
-                "-n", "2", "--out", outputPath, "--tips", "q");
+                "-n", "2", "--lines", "--out", outputPath, "--tips", "q");
 
             Assert.Equal(0, windowed.Exit);
             Assert.Equal(2, windowed.Output.Count(character => character == '\n'));
@@ -24162,7 +24173,7 @@ public partial class CommandExecutionTests
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "package", packagePath, "--all-libraries", "-S", "Library Info", "--rows", "20");
+                "package", packagePath, "--all-libraries", "-S", "Library Info", "-n", "20");
 
             Assert.Equal(0, exit);
             Assert.Contains("## Library Info (lib/net10.0/Latest.One.dll)", output);
@@ -24183,7 +24194,7 @@ public partial class CommandExecutionTests
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "package", packagePath, "--all-libraries", "--tfm", "all", "-S", "Library Info", "--rows", "12");
+                "package", packagePath, "--all-libraries", "--tfm", "all", "-S", "Library Info", "-n", "12");
 
             Assert.Equal(0, exit);
             Assert.Contains("## Library Info (lib/net8.0/Older.dll)", output);
@@ -24853,7 +24864,7 @@ public partial class CommandExecutionTests
         try
         {
             var (exit, output, error) = await RunAppAsync(
-                "package", packagePath, "--all-libraries", "-S", "@Integrations", "--rows", "40");
+                "package", packagePath, "--all-libraries", "-S", "@Integrations", "-n", "40");
 
             Assert.Equal(0, exit);
             Assert.Contains("## Integration: Configuration", output);
@@ -25370,8 +25381,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Integration: Opportunities",
-                "--rows",
-                "20");
+                "-n", "20");
 
             Assert.Equal(0, exit);
             Assert.Contains("## Integration: Opportunities", output);
@@ -25476,8 +25486,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--count",
                 "--tips",
                 "q");
@@ -25487,8 +25496,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tsv",
                 "--tips",
                 "q");
@@ -25498,8 +25506,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--jsonl",
                 "--tips",
                 "q");
@@ -25559,8 +25566,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tail",
                 "--tips",
                 "q");
@@ -25570,8 +25576,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tail",
                 "--tsv",
                 "--tips",
@@ -25582,8 +25587,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Library Info",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tail",
                 "--jsonl",
                 "--tips",
@@ -25644,8 +25648,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Integration: Configuration",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--count",
                 "--tips",
                 "q");
@@ -25655,8 +25658,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Integration: Configuration",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--tsv",
                 "--tips",
                 "q");
@@ -25690,8 +25692,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Switches",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--tips",
                 "q");
             var (tsvExit, tsvOutput, tsvError) = await RunAppAsync(
@@ -25700,8 +25701,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Switches",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--tsv",
                 "--tips",
                 "q");
@@ -25753,8 +25753,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Integration: Opportunities",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tips",
                 "q");
             var (tsvExit, tsvOutput, tsvError) = await RunAppAsync(
@@ -25763,8 +25762,7 @@ public partial class CommandExecutionTests
                 "--all-libraries",
                 "-S",
                 "Integration: Opportunities",
-                "--rows",
-                "2",
+                "-n", "2",
                 "--tsv",
                 "--tips",
                 "q");
@@ -26955,7 +26953,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, _) = await RunAppAsync(
             "member", "System.Text.Json.JsonSerializer", "--package", "System.Text.Json",
-            "-m", "Serialize", "--rows", "10", "--tips", "q");
+            "-m", "Serialize", "-n", "10", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Contains("Serialize<TValue>(TValue value", output);
@@ -26979,7 +26977,7 @@ public partial class CommandExecutionTests
     {
         var (exit, output, error) = await RunAppAsync(
             "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
-            "GenericChoice<T>", "--rows", "10", "--tips", "q");
+            "GenericChoice<T>", "-n", "10", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -27036,7 +27034,7 @@ public partial class CommandExecutionTests
         var (exit, output, error) = await RunAppAsync(
             "member", $"{typeof(MemberGenericSelectorFixture).FullName!}.GenericChoice<T>",
             "--library", TestAssemblyPath,
-            "--rows", "10", "--tips", "q");
+            "-n", "10", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
@@ -28224,7 +28222,7 @@ public partial class CommandExecutionTests
 
             var (windowedExit, windowedOutput, windowedError) = await RunAppAsync(
                 "package", packagePath, packagePath,
-                "-S", "Package Info", "--count", "--tsv", "--rows", "1");
+                "-S", "Package Info", "--count", "--tsv", "-n", "1");
             Assert.Equal(0, windowedExit);
             Assert.Empty(windowedError);
             Assert.Equal("1\n", windowedOutput.ReplaceLineEndings("\n"));
@@ -28322,11 +28320,11 @@ public partial class CommandExecutionTests
         {
             var formats = new (string Name, string[] Arguments)[]
             {
-                ("markdown", ["-S", "Library Info", "--rows", "2"]),
+                ("markdown", ["-S", "Library Info", "-n", "2"]),
                 ("json", ["--json"]),
-                ("table", ["-S", "Library Info", "--rows", "2", "--table"]),
-                ("tsv", ["-S", "Library Info", "--rows", "2", "--tsv"]),
-                ("jsonl", ["-S", "Library Info", "--rows", "2", "--jsonl"])
+                ("table", ["-S", "Library Info", "-n", "2", "--table"]),
+                ("tsv", ["-S", "Library Info", "-n", "2", "--tsv"]),
+                ("jsonl", ["-S", "Library Info", "-n", "2", "--jsonl"])
             };
 
             foreach (var (name, arguments) in formats)
@@ -28381,8 +28379,8 @@ public partial class CommandExecutionTests
         {
             foreach (string[] lineWindow in new[]
                      {
-                         new[] { "-n", "3" },
-                         ["-n", "3", "--tail"]
+                         new[] { "-n", "3", "--lines" },
+                         ["-n", "3", "--lines", "--tail"]
                      })
             {
                 string outputPath = Path.Combine(
@@ -28498,8 +28496,8 @@ public partial class CommandExecutionTests
         {
             foreach (string[] lineWindow in new[]
                      {
-                         new[] { "-n", "1" },
-                         ["-n", "1", "--tail"]
+                         new[] { "-n", "1", "--lines" },
+                         ["-n", "1", "--lines", "--tail"]
                      })
             {
                 string outputPath = Path.Combine(
@@ -30207,10 +30205,10 @@ public partial class CommandExecutionTests
                 "package", firstPackage, secondPackage, "--path", "MISSING.md", "--tsv", "--count");
             var (windowedCountExit, windowedCountOutput, _) = await RunAppAsync(
                 "package", firstPackage, secondPackage,
-                "--path", "MISSING.md", "--jsonl", "--count", "--rows", "1");
+                "--path", "MISSING.md", "--jsonl", "--count", "-n", "1");
             var (windowedRowsExit, windowedRowsOutput, _) = await RunAppAsync(
                 "package", firstPackage, secondPackage,
-                "--path", "MISSING.md", "--jsonl", "--rows", "1");
+                "--path", "MISSING.md", "--jsonl", "-n", "1");
 
             Assert.Equal(0, exit);
             Assert.Equal("2", output.Trim());
@@ -30490,6 +30488,13 @@ public partial class CommandExecutionTests
             using var emptyDocument = JsonDocument.Parse(lines.Single(line => line.Contains("Test.Project.NoAgents")));
             Assert.Equal("", emptyDocument.RootElement.GetProperty("name").GetString());
             Assert.Equal("", emptyDocument.RootElement.GetProperty("description").GetString());
+
+            var windowed = await RunProjectFixtureAsync(
+                projectPath, "--agents-index", "-n", "1", "--json");
+            Assert.Equal(0, windowed.Exit);
+            Assert.Empty(windowed.Error);
+            using var windowedDocument = JsonDocument.Parse(windowed.Output);
+            Assert.Equal(1, windowedDocument.RootElement.GetArrayLength());
         }
         finally
         {
@@ -31434,7 +31439,7 @@ public partial class CommandExecutionTests
             var (exit, output, error) = await RunProjectFixtureAsync(
                 projectPath, "-S", "Skills", "--count");
             var (windowedExit, windowedOutput, windowedError) = await RunProjectFixtureAsync(
-                projectPath, "-S", "Skills", "--count", "--rows", "1");
+                projectPath, "-S", "Skills", "--count", "-n", "1");
 
             Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
             Assert.Empty(error);
@@ -31831,8 +31836,7 @@ public partial class CommandExecutionTests
                 "Signature",
                 "--json",
                 "--count",
-                "--rows",
-                "1");
+                "-n", "1");
             var table = await RunAppAsync(
                 "package",
                 firstPackage,
@@ -32211,8 +32215,7 @@ public partial class CommandExecutionTests
                 "Package README file",
                 "--columns",
                 "Path",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--tail",
                 "--tsv");
             var tailWithoutHeader = await RunAppAsync(
@@ -32223,8 +32226,7 @@ public partial class CommandExecutionTests
                 "Package README file",
                 "--columns",
                 "Path",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--tail",
                 "--tsv",
                 "--no-header");
@@ -32279,16 +32281,14 @@ public partial class CommandExecutionTests
                 "-S",
                 "Package files",
                 "--jsonl",
-                "--rows",
-                "1");
+                "-n", "1");
             var count = await RunAppAsync(
                 "package",
                 package,
                 "-S",
                 "Package files",
                 "--jsonl",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--count");
             var projected = await RunAppAsync(
                 "package",
@@ -32298,8 +32298,7 @@ public partial class CommandExecutionTests
                 "--jsonl",
                 "--columns",
                 "Path",
-                "--rows",
-                "1");
+                "-n", "1");
 
             Assert.Equal(0, full.Exit);
             Assert.Equal(0, windowed.Exit);
@@ -32371,8 +32370,7 @@ public partial class CommandExecutionTests
                 "-S",
                 "Library Info",
                 "--jsonl",
-                "--rows",
-                "1");
+                "-n", "1");
             var count = await RunAppAsync(
                 "package",
                 package,
@@ -32380,8 +32378,7 @@ public partial class CommandExecutionTests
                 "-S",
                 "Library Info",
                 "--count",
-                "--rows",
-                "1");
+                "-n", "1");
 
             Assert.Equal(0, allRows.Exit);
             Assert.Equal(0, allCount.Exit);
@@ -32444,8 +32441,7 @@ public partial class CommandExecutionTests
                 "--path",
                 "@readme",
                 "--jsonl",
-                "--rows",
-                "1");
+                "-n", "1");
             var projected = await RunAppAsync(
                 "package",
                 firstPackage,
@@ -32755,8 +32751,7 @@ public partial class CommandExecutionTests
                 "--columns",
                 "Field",
                 "--tsv",
-                "--rows",
-                "1");
+                "-n", "1");
             var ordered = await RunAppAsync(
                 "package",
                 firstPackage,
@@ -33510,8 +33505,7 @@ public partial class CommandExecutionTests
                 "--path",
                 "docs/*.md",
                 "--content",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--bare",
                 "--tips",
                 "q");
@@ -33521,8 +33515,7 @@ public partial class CommandExecutionTests
                 "--path",
                 "docs/*.md",
                 "--content",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--bare",
                 "--out",
                 bareOutputPath,
@@ -33534,8 +33527,7 @@ public partial class CommandExecutionTests
                 "--path",
                 "docs/*.md",
                 "--content",
-                "--rows",
-                "1",
+                "-n", "1",
                 "--out",
                 exactOutputPath,
                 "--tips",

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -473,6 +473,62 @@ public class DiffCommandTests
             StringComparison.Ordinal);
     }
 
+    private static TypeDiff BreakingAndAdditiveTypeDiff(string typeFullName, string breakingMessage, string additiveMessage)
+        => new(
+            typeFullName,
+            [
+                new ApiChange(ChangeKind.MemberRemoved, ChangeClassification.Breaking, breakingMessage, null, null),
+                new ApiChange(ChangeKind.MemberAdded, ChangeClassification.Additive, additiveMessage, null, null),
+            ]);
+
+    [Fact]
+    public void RenderDiff_MarkdownWithRows_WindowsEachClassificationIndependently()
+    {
+        // Round 8 finding: the default (non-tabular) full-markdown path annotated its output
+        // with a "first N" note but rendered every change under every classification heading,
+        // because Markout's GroupBy-sectioned properties do not honor RowWindow. Each of
+        // Breaking/PotentiallyBreaking/Additive must window independently, at construction time.
+        var typeDiffs = new[]
+        {
+            BreakingAndAdditiveTypeDiff("Sample.Alpha", "Alpha breaking change", "Alpha additive change"),
+            BreakingAndAdditiveTypeDiff("Sample.Beta", "Beta breaking change", "Beta additive change"),
+        };
+        var diff = new ApiDiff { TypeDiffs = typeDiffs };
+
+        string markdown = DiffCommand.RenderDiff(
+            "Sample",
+            diff,
+            "1.0.0",
+            "2.0.0",
+            new DiffOptions { Rows = RowWindow.Head(1) });
+
+        Assert.Contains("Alpha breaking change", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Beta breaking change", markdown, StringComparison.Ordinal);
+        Assert.Contains("Alpha additive change", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("Beta additive change", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RenderDiff_EmptyFilteredResult_DoesNotLeakRowWindowNote()
+    {
+        // Round 8 finding: a type filter that matched no changed types still rendered the
+        // "first N" note even though the resulting document had zero changes to window.
+        var diff = new ApiDiff
+        {
+            TypeDiffs = [BreakingAndAdditiveTypeDiff("Sample.Alpha", "Alpha breaking change", "Alpha additive change")],
+        };
+
+        string markdown = DiffCommand.RenderDiff(
+            "Sample",
+            diff,
+            "1.0.0",
+            "2.0.0",
+            new DiffOptions { Rows = RowWindow.Head(1), TypeFilter = ["NoSuchType"] });
+
+        Assert.DoesNotContain("first 1", markdown, StringComparison.Ordinal);
+        Assert.Contains("No API changes detected.", markdown, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void FilterApiDiffByMemberTargets_PreservesInspectionFailures()
     {
@@ -2489,6 +2545,224 @@ public class DiffCommandTests
             row.GetProperty("member").GetString()!.Contains("List<object>", StringComparison.Ordinal));
         Assert.True(analysis.GetArrayLength() > 0);
         Assert.True(implementation.GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ChangesJsonWithRows_WindowsChanges()
+    {
+        // Round 8 finding: diff --json -S Changes -n N ignored the item window entirely,
+        // serializing every change while --tabular (same underlying flat list) windowed
+        // correctly.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (unwindowedExitCode, unwindowedOutput, unwindowedError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Changes"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+            }));
+        var (windowedExitCode, windowedOutput, windowedError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Changes"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+                Rows = RowWindow.Head(1),
+            }));
+
+        Assert.Equal(0, unwindowedExitCode);
+        Assert.Empty(unwindowedError);
+        Assert.Equal(0, windowedExitCode);
+        Assert.Empty(windowedError);
+
+        using var unwindowedDocument = System.Text.Json.JsonDocument.Parse(unwindowedOutput);
+        using var windowedDocument = System.Text.Json.JsonDocument.Parse(windowedOutput);
+        var unwindowedCount = unwindowedDocument.RootElement.GetProperty("changes").GetArrayLength();
+        var windowedCount = windowedDocument.RootElement.GetProperty("changes").GetArrayLength();
+
+        Assert.True(unwindowedCount > 1, "fixture must produce more than one change to prove windowing");
+        Assert.Equal(1, windowedCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AnalysisAndImplementationDiffJsonWithRows_WindowsBothSections()
+    {
+        // Round 9 finding: diff --json -S "Analysis Diff"/"Implementation Diff" -n N ignored
+        // the item window entirely (only Changes was fixed in Round 8), serializing every row
+        // while --table (same underlying view) windowed correctly.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (unwindowedExitCode, unwindowedOutput, unwindowedError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff", "Implementation Diff"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+            }));
+        var (windowedExitCode, windowedOutput, windowedError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff", "Implementation Diff"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+                Rows = RowWindow.Head(1),
+            }));
+
+        Assert.Equal(0, unwindowedExitCode);
+        Assert.Empty(unwindowedError);
+        Assert.Equal(0, windowedExitCode);
+        Assert.Empty(windowedError);
+
+        using var unwindowedDocument = System.Text.Json.JsonDocument.Parse(unwindowedOutput);
+        using var windowedDocument = System.Text.Json.JsonDocument.Parse(windowedOutput);
+        var unwindowedAnalysisCount = unwindowedDocument.RootElement.GetProperty("analysis_diff").GetArrayLength();
+        var unwindowedImplementationCount = unwindowedDocument.RootElement.GetProperty("implementation_diff").GetArrayLength();
+        var windowedAnalysisCount = windowedDocument.RootElement.GetProperty("analysis_diff").GetArrayLength();
+        var windowedImplementationCount = windowedDocument.RootElement.GetProperty("implementation_diff").GetArrayLength();
+
+        Assert.True(unwindowedAnalysisCount > 1, "fixture must produce more than one analysis-diff row to prove windowing");
+        Assert.True(unwindowedImplementationCount > 1, "fixture must produce more than one implementation-diff row to prove windowing");
+        Assert.Equal(1, windowedAnalysisCount);
+        Assert.Equal(1, windowedImplementationCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultiSectionMarkdownWithRangeRows_DoesNotDoubleWindow()
+    {
+        // Round 10 finding (Sol): the multi-section (non-JSON) document markdown path built
+        // Analysis/Implementation/FindingTransitions views with options.Rows applied at
+        // construction (Round 9's fix), then RenderDocumentView applied the same window a
+        // second time via the Markout writer. Head(N)/Tail(N) are idempotent under double
+        // application, but an absolute range like "rows 2..3" is not: re-applying it to the
+        // already-windowed (shorter) list silently drops rows. Fixed by only windowing at
+        // construction time when producing JSON (which bypasses the writer's own windowing
+        // entirely); non-JSON output now windows exactly once, via the writer.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        // First confirm the JSON path (single window, at construction) sees >= 2 analysis rows
+        // so that a 2-row range window is meaningful and not itself clipped by a small fixture.
+        var (jsonExitCode, jsonOutput, jsonError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff"],
+                JsonOutput = true,
+                TypeFilter = ["DiffSample"],
+            }));
+        Assert.Equal(0, jsonExitCode);
+        Assert.Empty(jsonError);
+        using var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonOutput);
+        var totalAnalysisRows = jsonDocument.RootElement.GetProperty("analysis_diff").GetArrayLength();
+        Assert.True(totalAnalysisRows >= 3, "fixture must produce at least 3 analysis-diff rows to prove a 2..3 range window is not double-applied");
+
+        var (markdownExitCode, markdownOutput, markdownError) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff", "Implementation Diff"],
+                TypeFilter = ["DiffSample"],
+                Rows = RowWindow.Range(2, 3),
+            }));
+
+        Assert.Equal(0, markdownExitCode);
+        Assert.Empty(markdownError);
+
+        var analysisTableStart = markdownOutput.IndexOf("## Analysis Diff", StringComparison.Ordinal);
+        var implementationTableStart = markdownOutput.IndexOf("## Implementation Diff", StringComparison.Ordinal);
+        Assert.True(analysisTableStart >= 0);
+        Assert.True(implementationTableStart > analysisTableStart);
+        var analysisSection = markdownOutput[analysisTableStart..implementationTableStart];
+
+        // A double-applied "rows 2..3" window on an already-2-row list would collapse to 0 or 1
+        // rows; confirm both rows in the range survive (row 2 and row 3 of the full list).
+        var analysisRowLines = analysisSection
+            .Split('\n')
+            .Where(line => line.StartsWith('|') && !line.Contains("---", StringComparison.Ordinal) && !line.Contains("Member", StringComparison.Ordinal))
+            .ToList();
+        Assert.Equal(2, analysisRowLines.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AnalysisDiffMarkdownEmptyWithRows_DoesNotLeakRowWindowNote()
+    {
+        // Round 9 finding: standalone `diff -S "Analysis Diff" -n N` leaked "first N" above
+        // "No analysis signal changes detected." when the type filter matched nothing.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Analysis Diff"],
+                TypeFilter = ["NoSuchType"],
+                Rows = RowWindow.Head(1),
+                HumanRowWindowNote = "first 1"
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.DoesNotContain("first 1", output, StringComparison.Ordinal);
+        Assert.Contains("No analysis signal changes detected.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ImplementationDiffMarkdownEmptyWithRows_DoesNotLeakRowWindowNote()
+    {
+        // Round 9 finding: standalone `diff -S "Implementation Diff" -n N` leaked "first N"
+        // above "No implementation differences detected." when the type filter matched
+        // nothing.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Implementation Diff"],
+                TypeFilter = ["NoSuchType"],
+                Rows = RowWindow.Head(1),
+                HumanRowWindowNote = "first 1"
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.DoesNotContain("first 1", output, StringComparison.Ordinal);
+        Assert.Contains("No implementation differences detected.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FindingTransitionsMarkdownEmptyWithRows_DoesNotLeakRowWindowNote()
+    {
+        // Round 9 finding: standalone `diff -S "Finding Transitions" -n N` leaked "first N"
+        // above "No selected Finding exists at either endpoint." when the type filter matched
+        // nothing.
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var (exitCode, output, error) = await ConsoleCapture.RunAsync(() =>
+            DiffCommand.ExecuteAsync(new DiffOptions
+            {
+                LibraryVersionRange = $"{v1}..{v2}",
+                Select = ["Finding Transitions"],
+                TypeFilter = ["NoSuchType"],
+                Finding = "api.type",
+                Rows = RowWindow.Head(1),
+                HumanRowWindowNote = "first 1"
+            }));
+
+        Assert.Equal(0, exitCode);
+        Assert.Empty(error);
+        Assert.DoesNotContain("first 1", output, StringComparison.Ordinal);
+        Assert.Contains("No selected Finding exists at either endpoint.", output, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Commands;
 using DotnetInspector.Inspectors;
@@ -207,6 +208,44 @@ public class ExtensionsCommandTests
 
         Assert.Same(MetadataFindings.ExtensionMemberDescriptor, failure.Error.Descriptor);
         Assert.Contains("Finding inspection failed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JsonWithRows_WindowsSortedOrderMatchingMarkdown()
+    {
+        // Round 8 finding: extensions --json windowed the raw/unsorted discovery-order list,
+        // while markdown/table sort by ReachablePath, ExtensionClass, MethodName first -- so
+        // -n N --json could return a different item set than -n N markdown/table for the same
+        // invocation. SampleExtensions declares ToUpperCase before Repeat, so raw discovery
+        // order differs from the sorted (alphabetical by method name) order.
+        var unwindowedOptions = new ExtensionsOptions
+        {
+            TargetType = typeof(string).FullName!,
+            Assemblies = [typeof(ExtensionsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            JsonOutput = true,
+        };
+        var windowedOptions = unwindowedOptions with { Rows = RowWindow.Head(1) };
+
+        var (unwindowedExitCode, unwindowedOutput, unwindowedError) =
+            await ConsoleCapture.RunAsync(() => ExtensionsCommand.ExecuteAsync(unwindowedOptions));
+        var (windowedExitCode, windowedOutput, windowedError) =
+            await ConsoleCapture.RunAsync(() => ExtensionsCommand.ExecuteAsync(windowedOptions));
+
+        Assert.Equal(0, unwindowedExitCode);
+        Assert.Empty(unwindowedError);
+        Assert.Equal(0, windowedExitCode);
+        Assert.Empty(windowedError);
+
+        using var unwindowedDocument = System.Text.Json.JsonDocument.Parse(unwindowedOutput);
+        using var windowedDocument = System.Text.Json.JsonDocument.Parse(windowedOutput);
+        var unwindowedRows = unwindowedDocument.RootElement.EnumerateArray().ToList();
+        var windowedRows = windowedDocument.RootElement.EnumerateArray().ToList();
+
+        Assert.True(unwindowedRows.Count > 1, "fixture must produce more than one row to prove windowing");
+        Assert.Equal("Repeat", unwindowedRows[0].GetProperty("method").GetString());
+        Assert.Single(windowedRows);
+        Assert.Equal("Repeat", windowedRows[0].GetProperty("method").GetString());
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ImplementsCommandTests.cs
@@ -1,5 +1,8 @@
+using System.Linq;
+using System.Text.Json;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
@@ -29,6 +32,42 @@ public sealed class ImplementsCommandTests
         Assert.Contains(
             "\"source\": \"dotnet-inspect.Tests.dll\"",
             output);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_JsonWithRows_WindowsSortedOrderMatchingMarkdown()
+    {
+        // Round 8 finding: implements --json windowed the raw/unsorted discovery-order list,
+        // while markdown/table sort by TypeName first -- so -n N --json could return a
+        // different item set than -n N markdown/table for the same invocation.
+        var unwindowedOptions = new ImplementsOptions
+        {
+            TargetType = typeof(IOrderedImplementationMarker).FullName!,
+            Assemblies = [typeof(ImplementsCommandTests).Assembly.Location],
+            IncludeAll = true,
+            JsonOutput = true,
+        };
+        var windowedOptions = unwindowedOptions with { Rows = RowWindow.Head(1) };
+
+        var (unwindowedExitCode, unwindowedOutput, unwindowedError) =
+            await ConsoleCapture.RunAsync(() => ImplementsCommand.ExecuteAsync(unwindowedOptions));
+        var (windowedExitCode, windowedOutput, windowedError) =
+            await ConsoleCapture.RunAsync(() => ImplementsCommand.ExecuteAsync(windowedOptions));
+
+        Assert.Equal(0, unwindowedExitCode);
+        Assert.Empty(unwindowedError);
+        Assert.Equal(0, windowedExitCode);
+        Assert.Empty(windowedError);
+
+        using var unwindowedDocument = JsonDocument.Parse(unwindowedOutput);
+        using var windowedDocument = JsonDocument.Parse(windowedOutput);
+        var unwindowedRows = unwindowedDocument.RootElement.EnumerateArray().ToList();
+        var windowedRows = windowedDocument.RootElement.EnumerateArray().ToList();
+
+        Assert.True(unwindowedRows.Count > 1, "fixture must produce more than one row to prove windowing");
+        Assert.Equal(typeof(AlphaOrderedImplementation).FullName!, unwindowedRows[0].GetProperty("type").GetString());
+        Assert.Single(windowedRows);
+        Assert.Equal(typeof(AlphaOrderedImplementation).FullName!, windowedRows[0].GetProperty("type").GetString());
     }
 
     [Fact]
@@ -67,3 +106,11 @@ public interface IWorkspaceImplementationMarker;
 
 public sealed class WorkspaceImplementation :
     IWorkspaceImplementationMarker;
+
+// Declared in reverse-alphabetical order so metadata discovery order (declaration order)
+// differs from the sorted-by-TypeName order implements --json must match.
+public interface IOrderedImplementationMarker;
+
+public sealed class ZetaOrderedImplementation : IOrderedImplementationMarker;
+
+public sealed class AlphaOrderedImplementation : IOrderedImplementationMarker;

--- a/src/dotnet-inspect.Tests/MatchCommandTests.cs
+++ b/src/dotnet-inspect.Tests/MatchCommandTests.cs
@@ -1,5 +1,7 @@
+using System.Text.Json;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Output;
 
 namespace DotnetInspector.Tests;
 
@@ -205,6 +207,37 @@ public sealed class MatchCommandTests
         Assert.Contains("\"match\": {", output);
         Assert.Contains("\"implementation\": {", output);
         Assert.Contains("\"disposition\": \"Completed\"", output);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteAsync_JsonWithRows_RejectsUnwindowableReceiptDocument(
+        bool includeImplementation)
+    {
+        // Correspondence receipts are derived from the complete block set, so neither the
+        // plain document nor the implementation envelope can truncate every declared row
+        // set independently without invalidating the receipt.
+        var options = new MatchOptions
+        {
+            LeftSelector = $"{typeof(MatchSampleA).FullName}.Greet",
+            RightSelector = $"{typeof(MatchSampleA).FullName}.GreetFormal",
+            AssemblyPath = typeof(MatchCommandTests).Assembly.Location,
+            IncludeAll = true,
+            IncludeImplementation = includeImplementation,
+            JsonOutput = true,
+        };
+        var windowed = options with { Rows = RowWindow.Head(1) };
+
+        var (windowedExitCode, windowedOutput, windowedError) =
+            await ConsoleCapture.RunAsync(() => MatchCommand.ExecuteAsync(windowed));
+
+        Assert.Equal(1, windowedExitCode);
+        Assert.Empty(windowedOutput);
+        Assert.Contains(
+            "Document --json item windows are not yet supported by 'match'.",
+            windowedError,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/TimelineCommandTests.cs
+++ b/src/dotnet-inspect.Tests/TimelineCommandTests.cs
@@ -120,6 +120,34 @@ public sealed class TimelineCommandTests
     }
 
     [Fact]
+    public async Task Write_MarkdownWithEmptyTransitions_DoesNotLeakRowWindowNote()
+    {
+        // Round 8 finding: the non-tabular multi-section markdown path unconditionally wrapped
+        // its rendered output with the human row-window note, even when the only selected
+        // section (Transitions) had zero rows to window.
+        var view = new TimelineDocumentView
+        {
+            Title = "Timeline",
+            Transitions = [],
+        };
+        var sections = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Transitions" };
+
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            TimelineCommand.Write(
+                view,
+                new TimelineOptions
+                {
+                    Rows = RowWindow.Head(1),
+                    HumanRowWindowNote = "first 1",
+                },
+                sections)));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        Assert.DoesNotContain("first 1", result.Output);
+    }
+
+    [Fact]
     public async Task ProjectedJsonRoutingAudit_UnadoptedTypedDocumentFailsClosed()
     {
         var view = new TimelineDocumentView
@@ -147,6 +175,49 @@ public sealed class TimelineCommandTests
         Assert.Equal(1, result.ExitCode);
         Assert.Empty(result.Output);
         Assert.Contains("requires lowered JSON", result.Error);
+    }
+
+    [Fact]
+    public async Task DocumentJsonAppliesItemWindowToEverySelectedRowSet()
+    {
+        var view = new TimelineDocumentView
+        {
+            Title = "Timeline",
+            Evaluations =
+            [
+                new("Sample@1.0.0", "1.0.0", "Present", 1, null),
+                new("Sample@1.0.1", "1.0.1", "Present", 1, null),
+            ],
+            Transitions =
+            [
+                new("1.0.0", "1.0.1", "1.0.0..1.0.1", "Added", "api.member", "Run", null),
+                new("1.0.1", "1.0.2", "1.0.1..1.0.2", "Changed", "api.member", "Run", null),
+            ],
+        };
+
+        var result = await ConsoleCapture.RunAsync(() => Task.FromResult(
+            TimelineCommand.Write(
+                view,
+                new TimelineOptions
+                {
+                    JsonOutput = true,
+                    Rows = RowWindow.Head(1),
+                },
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    "Evaluations",
+                    "Transitions",
+                })));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Empty(result.Error);
+        using var document = JsonDocument.Parse(result.Output);
+        Assert.Equal(
+            1,
+            document.RootElement.GetProperty("Evaluations").GetArrayLength());
+        Assert.Equal(
+            1,
+            document.RootElement.GetProperty("Transitions").GetArrayLength());
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -146,6 +146,7 @@ public static class InspectionCommandDefinitions
                 NoHeader = parseResult.GetValue(opts.NoHeaders),
                 Count = parseResult.GetValue(opts.Count),
                 Rows = opts.ParseRows(parseResult),
+                HumanRowWindowNote = opts.BuildHumanRowWindowNote(parseResult),
                 Select = opts.ParseSelect(parseResult),
                 SelectDefault = opts.ParseSelectDefault(parseResult),
                 Columns = opts.ParseColumns(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -143,6 +143,7 @@ public static class DiffOptionsParser
             Columns = opts.ParseColumns(parseResult),
             Fields = opts.ParseFields(parseResult),
             Rows = opts.ParseRows(parseResult),
+            HumanRowWindowNote = opts.BuildHumanRowWindowNote(parseResult),
         };
 
         var verbosity = opts.ParseVerbosity(parseResult);

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -103,6 +103,7 @@ public class ApiCommand
             ShapeOutput = options.ShapeOutput,
             ShapeExplicitlySet = options.ShapeExplicitlySet,
             Schema = options.Schema, Count = options.Count, Rows = options.Rows,
+            HumanRowWindowNote = options.HumanRowWindowNote,
             JsonArray = options.JsonArray,
             PerformanceTriage = options.PerformanceTriage,
             BodyKindQuery = options.BodyKindQuery,
@@ -1495,6 +1496,7 @@ public class ApiCommand
             // facility, so the combination is rejected rather than silently dropped.
             if (IsColumnProjectionRequested(options))
                 return RejectColumnProjectionUnderJson(suggestPayloadProjection: false);
+            api.Types = RowWindow.Apply(options.Rows, api.Types).ToList();
             Console.WriteLine(JsonSerializer.Serialize(api, ApiJsonContext.Default.ApiSurface));
             return successExitCode;
         }
@@ -1572,7 +1574,14 @@ public class ApiCommand
                 ProjectionDiagnostics.DiagnoseRendered(options.Fields ?? options.Columns, factRows);
                 if (!TryReportEmptyProjection(factRows, options))
                     return 1;
-                Console.Out.Write(OutputFormatter.LimitRenderedTableRows(factRows, options.Rows, !options.NoHeader));
+                var limitedFactRows = OutputFormatter.LimitRenderedTableRows(factRows, options.Rows, !options.NoHeader);
+                if (!string.IsNullOrWhiteSpace(limitedFactRows))
+                    OutputFormatter.WriteHumanRowWindowNote(
+                        Console.Out,
+                        options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                            ? options.HumanRowWindowNote
+                            : null);
+                Console.Out.Write(limitedFactRows);
                 return successExitCode;
             }
 
@@ -1584,7 +1593,14 @@ public class ApiCommand
             ProjectionDiagnostics.DiagnoseRendered(options.Fields ?? options.Columns, rendered);
             if (!TryReportEmptyProjection(rendered, options))
                 return 1;
-            Console.Out.Write(OutputFormatter.LimitRenderedTableRows(rendered, options.Rows, !options.NoHeader));
+            var limitedRendered = OutputFormatter.LimitRenderedTableRows(rendered, options.Rows, !options.NoHeader);
+            if (!string.IsNullOrWhiteSpace(limitedRendered))
+                OutputFormatter.WriteHumanRowWindowNote(
+                    Console.Out,
+                    options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                        ? options.HumanRowWindowNote
+                        : null);
+            Console.Out.Write(limitedRendered);
         }
         else
         {
@@ -1600,6 +1616,8 @@ public class ApiCommand
                 var plainText = plain.ToString();
                 if (!TryReportEmptyProjection(plainText, options))
                     return 1;
+                if (options.Verbosity != Verbosity.Quiet && writerOptions.IncludeSections is { Count: 1 })
+                    plainText = OutputFormatter.AddHumanRowWindowNote(plainText, options.HumanRowWindowNote);
                 Console.Out.Write(plainText);
             }
             else
@@ -1610,6 +1628,8 @@ public class ApiCommand
                 var markdown = markdownWriter.ToString().TrimEnd();
                 if (!TryReportEmptyProjection(markdown, options))
                     return 1;
+                if (options.Verbosity != Verbosity.Quiet && writerOptions.IncludeSections is { Count: 1 })
+                    markdown = OutputFormatter.AddHumanRowWindowNote(markdown, options.HumanRowWindowNote);
                 OutputFormatter.WriteLfLine(Console.Out, markdown);
             }
         }
@@ -2314,10 +2334,7 @@ public class ApiCommand
             // payload projection (--value/--print) does compose, and is handled above.
             if (IsColumnProjectionRequested(options))
                 return RejectColumnProjectionUnderJson(suggestPayloadProjection: true);
-            if (ProjectionAudit.RejectUnsupportedDocumentJsonRowWindow(
-                    options,
-                    options.JsonOutput,
-                    "type"))
+            if (RejectUnsupportedTypeJsonRowWindow(options))
                 return 1;
             WriteJsonTypeOutput(type, options);
             return 0;
@@ -2661,7 +2678,10 @@ public class ApiCommand
                             view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
                             explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, markoutWriter);
                         markoutWriter.Flush();
-                    }, options.Rows);
+                    }, options.Rows,
+                    options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                        ? options.HumanRowWindowNote
+                        : null);
             }
             else
             {
@@ -2670,7 +2690,10 @@ public class ApiCommand
                     options.Columns, options.Fields,
                     (writer, formatter, writerOptions) =>
                         MarkoutSerializer.Serialize(tableView, writer, formatter, ApiViewContext.Default, writerOptions),
-                    options.Rows);
+                    options.Rows,
+                    options.Verbosity != Verbosity.Quiet
+                        ? options.HumanRowWindowNote
+                        : null);
             }
         }
         else
@@ -2679,11 +2702,16 @@ public class ApiCommand
             writerOptions.RowWindow = RowWindow.ToMarkout(options.Rows);
             if (options.PlainText)
             {
-                var writer = new Markout.MarkoutWriter(sink, options.CreateFormatter(), writerOptions);
+                var plain = new StringWriter();
+                var writer = new Markout.MarkoutWriter(plain, options.CreateFormatter(), writerOptions);
                 ApiOutputFormatter.SerializeTypeDocument(
                     view, eventsView, methodGroupsView, methodsView, memberIndexView, operatorsView,
                     explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
                 writer.Flush();
+                var plainText = plain.ToString().TrimEnd();
+                if (options.Verbosity != Verbosity.Quiet && writerOptions.IncludeSections is { Count: 1 })
+                    plainText = OutputFormatter.AddHumanRowWindowNote(plainText, options.HumanRowWindowNote);
+                OutputFormatter.WriteLfLine(sink, plainText);
             }
             else
             {
@@ -2711,6 +2739,8 @@ public class ApiCommand
                     explicitInterfaceImplementationsView, extensionMethodsView, view.MemberCode, writer);
                 writer.Flush();
                 var markdown = sw.ToString().TrimEnd();
+                if (options.Verbosity != Verbosity.Quiet && writerOptions.IncludeSections is { Count: 1 })
+                    markdown = OutputFormatter.AddHumanRowWindowNote(markdown, options.HumanRowWindowNote);
                 OutputFormatter.WriteLfLine(sink, markdown);
             }
         }
@@ -3614,6 +3644,24 @@ public class ApiCommand
             };
         }
 
+        // -n/-N applies the declared item window to whatever member list document JSON is
+        // about to serialize. Sort first to match the markdown/table writer's row order
+        // (kind, then name, then signature) so "first/last/top N" picks the same members
+        // in JSON as in markdown, then window.
+        outputType.Members = RowWindow.Apply(
+            options.Rows,
+            outputType.Members
+                .OrderBy(m => ApiOutputFormatter.GetMemberSortOrder(m.Kind))
+                .ThenBy(m => m.Name, StringComparer.Ordinal)
+                .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
+                .ToList()).ToList();
+        outputType.Interfaces = RowWindow.Apply(
+            options.Rows,
+            outputType.Interfaces).ToList();
+        outputType.TypeParameters = RowWindow.Apply(
+            options.Rows,
+            outputType.TypeParameters).ToList();
+
         // Project the durable identity (Digest + Canonical Signature) onto each member so
         // JSON consumers get the same overload handle the Markdown Digest column exposes.
         // Computed against the resolved declaring type, matching the table's anchor.
@@ -3628,6 +3676,25 @@ public class ApiCommand
             Console.WriteLine(JsonSerializer.Serialize(outputType, ApiTypeCompactJsonContext.Default.ApiType));
         else
             Console.WriteLine(JsonSerializer.Serialize(outputType, ApiTypeJsonContext.Default.ApiType));
+    }
+
+    private static bool RejectUnsupportedTypeJsonRowWindow(
+        ApiOptions options)
+    {
+        if (options.Rows is null
+            || options.IncludeSections is not { Count: > 0 } sections)
+            return false;
+
+        int selectedMemberSections = MemberSectionPredicates.Keys.Count(
+            sections.Contains);
+        if (selectedMemberSections <= 1)
+            return false;
+
+        CommandError.Write(
+            "type cannot apply an item window independently to multiple member "
+            + "sections in typed document JSON. Use --jsonl for row-shaped "
+            + "output, or select one member section.");
+        return true;
     }
 
     private static bool IsAnnotatedSourceDocumentJson(ApiOptions options)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -240,7 +240,7 @@ public class DiffCommand
                             options.Columns, options.Fields,
                             (writer, formatter, writerOptions) =>
                                 MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                            options.Rows);
+                            options.Rows, options.HumanRowWindowNote);
                     }
                     else
                     {
@@ -263,7 +263,9 @@ public class DiffCommand
                                         inspectionFailures),
                                     OutputFormatter.CreateWindowedOptions(
                                         options.Rows));
-                        Console.WriteLine(output);
+                        Console.WriteLine(view.Rows is { Count: > 0 }
+                            ? OutputFormatter.AddHumanRowWindowNote(output, options.HumanRowWindowNote)
+                            : output);
                     }
                     if (inspectionFailures.Count > 0
                         && (options.Tabular
@@ -298,7 +300,7 @@ public class DiffCommand
                             options.Columns, options.Fields,
                             (writer, formatter, writerOptions) =>
                                 MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                            options.Rows);
+                            options.Rows, options.HumanRowWindowNote);
                     }
                     else
                     {
@@ -321,7 +323,9 @@ public class DiffCommand
                                         inspectionFailures),
                                     OutputFormatter.CreateWindowedOptions(
                                         options.Rows));
-                        Console.WriteLine(output);
+                        Console.WriteLine(view.Rows is { Count: > 0 }
+                            ? OutputFormatter.AddHumanRowWindowNote(output, options.HumanRowWindowNote)
+                            : output);
                     }
                     if (options.Tabular || options.NameOnly)
                     {
@@ -349,7 +353,7 @@ public class DiffCommand
                             options.Columns, options.Fields,
                             (writer, formatter, writerOptions) =>
                                 MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                            options.Rows);
+                            options.Rows, options.HumanRowWindowNote);
                     }
                     else
                     {
@@ -372,7 +376,9 @@ public class DiffCommand
                                         inspectionFailures),
                                     OutputFormatter.CreateWindowedOptions(
                                         options.Rows));
-                        Console.WriteLine(output);
+                        Console.WriteLine(view.Rows is { Count: > 0 }
+                            ? OutputFormatter.AddHumanRowWindowNote(output, options.HumanRowWindowNote)
+                            : output);
                     }
                     if (options.Tabular
                         || options.NameOnly)
@@ -399,7 +405,7 @@ public class DiffCommand
                             options.Columns, options.Fields,
                             (writer, formatter, writerOptions) =>
                                 MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                            options.Rows);
+                            options.Rows, options.HumanRowWindowNote);
                     }
                     else
                     {
@@ -408,7 +414,7 @@ public class DiffCommand
                             options.Columns, options.Fields,
                             (writer, formatter, writerOptions) =>
                                 MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                            options.Rows);
+                            options.Rows, options.HumanRowWindowNote);
                     }
 
                     WriteIncompleteComparisonDiagnostic(
@@ -416,8 +422,10 @@ public class DiffCommand
                 }
                 else
                 {
-                    var output = RenderDiff(inputs.Name, diff, inputs.FromVersion, inputs.ToVersion, options);
-                    Console.WriteLine(output);
+                    var output = RenderDiff(inputs.Name, diff, inputs.FromVersion, inputs.ToVersion, options, out var hasContent);
+                    Console.WriteLine(hasContent
+                        ? OutputFormatter.AddHumanRowWindowNote(output, options.HumanRowWindowNote)
+                        : output);
                     if (options.NameOnly)
                     {
                         WriteIncompleteComparisonDiagnostic(
@@ -870,6 +878,15 @@ public class DiffCommand
                     : DiffSections.Changes.Name
             };
 
+        // JSON serializes the view's Rows directly, bypassing the Markout writer's own
+        // render-time windowing (RenderDocumentView's CreateWindowedOptions), so the window
+        // must be applied here instead. For non-JSON (markdown) output, RenderDocumentView
+        // already applies options.Rows once via the writer; windowing here too would apply it
+        // *twice*, which is only safe for idempotent Head/Tail windows and corrupts an
+        // absolute --rows range (e.g. "2..3" re-interpreted against the already-windowed,
+        // shorter list). So only window at construction time when producing JSON.
+        RowWindow? windowForConstruction = options.JsonOutput ? options.Rows : null;
+
         ApiDiff? changesDiff = null;
         DiffDetailedChangesView? changesView = null;
         if (selected.Contains(DiffSections.Changes.Name))
@@ -883,7 +900,8 @@ public class DiffCommand
                 inputs.Name,
                 ApplyFilters(changesDiff, options),
                 inputs.FromVersion,
-                inputs.ToVersion);
+                inputs.ToVersion,
+                windowForConstruction);
         }
 
         AnalysisDiffView? analysisView = null;
@@ -898,7 +916,8 @@ public class DiffCommand
                 analysis.Summary,
                 inputs.FromVersion,
                 inputs.ToVersion,
-                decorateMember: false);
+                decorateMember: false,
+                window: windowForConstruction);
         }
 
         ImplementationDiffView? implementationView = null;
@@ -915,7 +934,8 @@ public class DiffCommand
                 inputs.Name,
                 implementation,
                 inputs.FromVersion,
-                inputs.ToVersion);
+                inputs.ToVersion,
+                windowForConstruction);
         }
 
         FindingTransitionsView? findingTransitionsView = null;
@@ -926,7 +946,8 @@ public class DiffCommand
                 inputs.Name,
                 rows,
                 inputs.FromVersion,
-                inputs.ToVersion);
+                inputs.ToVersion,
+                windowForConstruction);
         }
 
         var view = DiffOutputFormatter.BuildDocumentView(
@@ -945,8 +966,14 @@ public class DiffCommand
             return inspectionFailures.Count > 0;
         }
 
-        Console.WriteLine(DiffOutputFormatter.RenderDocumentView(
-            view, OutputFormatter.CreateWindowedOptions(options.Rows)));
+        bool hasContent = changesView?.Rows is { Count: > 0 }
+            || analysisView?.Rows is { Count: > 0 }
+            || implementationView?.Rows is { Count: > 0 }
+            || findingTransitionsView?.Rows is { Count: > 0 };
+        var rendered = DiffOutputFormatter.RenderDocumentView(view, OutputFormatter.CreateWindowedOptions(options.Rows));
+        Console.WriteLine(hasContent
+            ? OutputFormatter.AddHumanRowWindowNote(rendered, options.HumanRowWindowNote)
+            : rendered);
         return inspectionFailures.Count > 0;
     }
 
@@ -1478,27 +1505,35 @@ public class DiffCommand
     }
 
     internal static string RenderDiff(string name, ApiDiff diff, string fromVersion, string toVersion, DiffOptions options)
+        => RenderDiff(name, diff, fromVersion, toVersion, options, out _);
+
+    internal static string RenderDiff(string name, ApiDiff diff, string fromVersion, string toVersion, DiffOptions options, out bool hasContent)
     {
         var typeDiffs = ApplyFilters(diff, options);
 
         if (options.NameOnly)
         {
+            var visibleTypeDiffs = RowWindow.Apply(options.Rows, typeDiffs);
+            hasContent = visibleTypeDiffs.Count > 0;
             return OutputFormatter.RenderTable(showHeader: false, (writer, formatter) =>
             {
                 var nameWriter = new Markout.MarkoutWriter(writer, formatter, OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl));
-                DiffOutputFormatter.RenderNameOnly(nameWriter, typeDiffs);
+                DiffOutputFormatter.RenderNameOnly(nameWriter, visibleTypeDiffs);
                 nameWriter.Flush();
             });
         }
 
+        hasContent = typeDiffs.Any(td => td.Changes.Any());
         return DiffOutputFormatter.RenderFullMarkdown(
             name,
             typeDiffs,
             diff.InspectionFailures,
             fromVersion,
             toVersion,
-            OutputFormatter.CreateWindowedOptions(options.Rows));
+            OutputFormatter.CreateWindowedOptions(options.Rows),
+            options.Rows);
     }
+
 
     internal static ApiDiff BuildApiDiff(ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)
         => BuildApiDiff(
@@ -2507,6 +2542,7 @@ public record DiffOptions
     public string[]? Columns { get; init; }
     public string[]? Fields { get; init; }
     public RowWindow? Rows { get; init; }
+    public string? HumanRowWindowNote { get; init; }
     public NuGetSourceOptions? SourceOptions { get; init; }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -64,7 +64,7 @@ public class ExtensionsCommand
                 if (ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                     return 1;
 
-                WriteJsonOutput(results, options.CompactJson);
+                WriteJsonOutput(results, options.Rows, options.CompactJson);
             }
             else if (options.Tabular || options.Tsv || options.Jsonl || options.NoHeader)
             {
@@ -72,7 +72,7 @@ public class ExtensionsCommand
             }
             else
             {
-                WriteMarkoutOutput(targetType, results, options.Verbosity, options.Rows);
+                WriteMarkoutOutput(targetType, results, options.Verbosity, options.Rows, options.HumanRowWindowNote);
             }
 
             return 0;
@@ -367,9 +367,17 @@ public class ExtensionsCommand
         return results;
     }
 
-    private static void WriteJsonOutput(List<ExtensionMethodResult> results, bool compact)
+    private static void WriteJsonOutput(List<ExtensionMethodResult> results, RowWindow? rows, bool compact)
     {
-        var jsonResults = results.Select(ExtensionMethodJsonResult.From).ToList();
+        // Sort to match the markdown/table view's row order (ReachablePath, then
+        // ExtensionClass, then MethodName) before windowing, so -n/--top picks the same
+        // "first/last/top N" extension methods in JSON as in markdown/table.
+        var sorted = results
+            .OrderBy(r => r.ReachablePath ?? "")
+            .ThenBy(r => r.ExtensionClass)
+            .ThenBy(r => r.MethodName)
+            .ToList();
+        var jsonResults = RowWindow.Apply(rows, sorted).Select(ExtensionMethodJsonResult.From).ToList();
         JsonOutputHelper.Write(jsonResults, ExtensionsJsonContext.Default.ListExtensionMethodJsonResult,
             ExtensionsCompactJsonContext.Default.ListExtensionMethodJsonResult, compact);
     }
@@ -391,11 +399,15 @@ public class ExtensionsCommand
             options.Rows);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows)
+    private static void WriteMarkoutOutput(string targetType, List<ExtensionMethodResult> results, Verbosity verbosity, RowWindow? rows, string? humanRowWindowNote = null)
     {
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
+        // The "No extension methods found." document is non-whitespace even with zero
+        // results, so the AddHumanRowWindowNote emptiness guard can't catch it here.
+        // Gate on the actual result count instead.
         OutputFormatter.WriteWindowedMarkdown(Console.Out, rows,
-            opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
+            opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts),
+            humanRowWindowNote: results.Count == 0 ? null : humanRowWindowNote);
     }
 
     private static void WriteTableOutput(string targetType, List<ExtensionMethodResult> results, ExtensionsOptions options)
@@ -405,7 +417,7 @@ public class ExtensionsCommand
             options.Columns, options.Fields,
             (writer, formatter, writerOptions) =>
                 MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-            options.Rows);
+            options.Rows, options.HumanRowWindowNote);
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ImplementsCommand.cs
+++ b/src/dotnet-inspect/Commands/ImplementsCommand.cs
@@ -96,11 +96,11 @@ public class ImplementsCommand
                 if (ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                     return 1;
 
-                WriteJsonOutput(results, options.CompactJson);
+                WriteJsonOutput(results, options.Rows, options.CompactJson);
             }
             else
             {
-                WriteMarkoutOutput(targetType, results, options.Tabular, options.Tsv, options.Jsonl, options.NoHeader, options.Columns, options.Fields, options.Rows);
+                WriteMarkoutOutput(targetType, results, options.Tabular, options.Tsv, options.Jsonl, options.NoHeader, options.Columns, options.Fields, options.Rows, options.HumanRowWindowNote);
             }
 
             return 0;
@@ -153,9 +153,12 @@ public class ImplementsCommand
         }
     }
 
-    private static void WriteJsonOutput(List<ImplementerResult> results, bool compact)
+    private static void WriteJsonOutput(List<ImplementerResult> results, RowWindow? rows, bool compact)
     {
-        var jsonResults = results.Select(ImplementerJsonResult.From).ToList();
+        // Sort to match the markdown/table view's row order (TypeName) before windowing, so
+        // -n/--top picks the same "first/last/top N" implementers in JSON as in markdown/table.
+        var sorted = results.OrderBy(r => r.TypeName).ToList();
+        var jsonResults = RowWindow.Apply(rows, sorted).Select(ImplementerJsonResult.From).ToList();
         JsonOutputHelper.Write(jsonResults, ImplementsJsonContext.Default.ListImplementerJsonResult,
             ImplementsCompactJsonContext.Default.ListImplementerJsonResult, compact);
     }
@@ -175,7 +178,7 @@ public class ImplementsCommand
             options.Rows);
     }
 
-    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool tabular, bool tsv, bool jsonl, bool noHeader, string[]? columns, string[]? fields, RowWindow? rows)
+    private static void WriteMarkoutOutput(string targetType, List<ImplementerResult> results, bool tabular, bool tsv, bool jsonl, bool noHeader, string[]? columns, string[]? fields, RowWindow? rows, string? humanRowWindowNote = null)
     {
         var view = ImplementsOutputFormatter.BuildView(targetType, results);
 
@@ -190,12 +193,13 @@ public class ImplementsCommand
             OutputFormatter.WriteProjectedTable(Console.Out, !noHeader, tsv, jsonl, columns, fields,
                 (writer, formatter, writerOptions) =>
                     MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-                rows);
+                rows, humanRowWindowNote);
         }
         else
         {
             OutputFormatter.WriteWindowedMarkdown(Console.Out, rows,
-                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts));
+                opts => MarkoutSerializer.Serialize(view, SearchViewContext.Default, opts),
+                humanRowWindowNote: humanRowWindowNote);
         }
     }
 }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -710,9 +710,9 @@ public class LibraryCommand
                 ExtractResourcesIfRequested(resolvedPath!, options);
                 if (!IsPerformanceDocumentJsonWindowApplied(options)
                     && ProjectionAudit.RejectUnsupportedDocumentJsonRowWindow(
-                            options,
-                            options.JsonOutput,
-                            "library")
+                        options,
+                        options.JsonOutput,
+                        "library")
                     || ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                     return 1;
 
@@ -878,9 +878,9 @@ public class LibraryCommand
 
                 if (!IsPerformanceDocumentJsonWindowApplied(options)
                     && ProjectionAudit.RejectUnsupportedDocumentJsonRowWindow(
-                            options,
-                            options.JsonOutput,
-                            "library")
+                        options,
+                        options.JsonOutput,
+                        "library")
                     || ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                     return 1;
 
@@ -997,9 +997,9 @@ public class LibraryCommand
                 ExtractResourcesIfRequested(assemblyPath!, options);
                 if (!IsPerformanceDocumentJsonWindowApplied(options)
                     && ProjectionAudit.RejectUnsupportedDocumentJsonRowWindow(
-                            options,
-                            options.JsonOutput,
-                            "library")
+                        options,
+                        options.JsonOutput,
+                        "library")
                     || ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                     return 1;
 
@@ -1033,6 +1033,15 @@ public class LibraryCommand
             }
         }
     }
+
+    private static bool IsPerformanceDocumentJsonWindowApplied(
+        LibraryOptions options) =>
+        options.PerformanceTriage.Top.HasValue
+        && options.IncludeSections is { Count: > 0 } sections
+        && sections.All(section =>
+            PerformanceKinds.Sections.Contains(
+                section,
+                StringComparer.Ordinal));
 
     private static int IntegrityExitCode(params LibraryInspection[] inspections)
         => IntegrityExitCode(0, inspections);
@@ -1350,17 +1359,8 @@ public class LibraryCommand
                     row.Evidence
                 }).ToArray());
             markoutWriter.Flush();
-        }, options.Rows);
+        }, options.Rows, rows.Count > 0 ? options.HumanRowWindowNote : null);
     }
-
-    private static bool IsPerformanceDocumentJsonWindowApplied(
-        LibraryOptions options) =>
-        options.PerformanceTriage.Top.HasValue
-        && options.IncludeSections is { Count: > 0 } sections
-        && sections.All(section =>
-            PerformanceKinds.Sections.Contains(
-                section,
-                StringComparer.Ordinal));
 
     private static (LibraryOptions Options, string? Error) NormalizeILOffsetSelection(LibraryOptions options)
     {

--- a/src/dotnet-inspect/Commands/MatchCommand.cs
+++ b/src/dotnet-inspect/Commands/MatchCommand.cs
@@ -288,7 +288,7 @@ public static class MatchCommand
                 options.Columns, options.Fields,
                 (writer, formatter, writerOptions) =>
                     MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
-                options.Rows);
+                options.Rows, options.HumanRowWindowNote);
         }
         else
         {
@@ -303,7 +303,8 @@ public static class MatchCommand
                     }
 
                     return text;
-                });
+                },
+                humanRowWindowNote: options.HumanRowWindowNote);
         }
     }
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1099,6 +1099,12 @@ public class PackageCommand
                         options.Fields ?? options.Columns,
                         rendered,
                         diagnosticCandidates!);
+                    if (!string.IsNullOrWhiteSpace(rendered))
+                        OutputFormatter.WriteHumanRowWindowNote(
+                            Console.Out,
+                            options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                                ? options.HumanRowWindowNote
+                                : null);
                     Console.Out.Write(rendered);
                 }
                 else
@@ -1263,8 +1269,10 @@ public class PackageCommand
             if (ProjectionAudit.RejectUnsupportedDocumentJsonRowWindow(
                     options,
                     options.JsonOutput,
-                    "package")
-                || ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
+                    "package"))
+                return 1;
+
+            if (ProjectionAudit.RejectUnloweredJson(options, options.JsonOutput))
                 return 1;
 
             Console.WriteLine(JsonSerializer.Serialize(
@@ -3661,7 +3669,7 @@ public class PackageCommand
                 ["package", "version", "path", "size"],
                 windowedRows);
             markoutWriter.Flush();
-        });
+        }, humanRowWindowNote: options.Tsv || options.Jsonl ? null : options.HumanRowWindowNote);
     }
 
     private static void WritePackageFilesJsonl(
@@ -3968,11 +3976,17 @@ public class PackageCommand
             section,
             options.Fields,
             rows.Select(row => row[1]));
-        Console.Out.Write(
-            OutputFormatter.LimitRenderedTableRows(
-                rendered,
-                options.Rows,
-                !options.NoHeader));
+        var limited = OutputFormatter.LimitRenderedTableRows(
+            rendered,
+            options.Rows,
+            !options.NoHeader);
+        if (!string.IsNullOrWhiteSpace(limited))
+            OutputFormatter.WriteHumanRowWindowNote(
+                Console.Out,
+                options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                    ? options.HumanRowWindowNote
+                    : null);
+        Console.Out.Write(limited);
     }
 
     private static void DiagnoseMissingPackageFieldSectionFields(
@@ -4527,6 +4541,8 @@ public class PackageCommand
         }
 
         var markdown = RenderAllLibrariesMarkdown(packageName, version, inspections, sections, libraryOptions, pipeline);
+        if (sections.Count == 1)
+            markdown = OutputFormatter.AddHumanRowWindowNote(markdown, libraryOptions.HumanRowWindowNote);
         OutputDestination.Write(
             libraryOptions.OutputPath,
             writer => OutputFormatter.WriteLfLine(writer, markdown));
@@ -4751,6 +4767,7 @@ public class PackageCommand
             JsonArray = options.JsonArray,
             ProjectionRow = options.PrintRow,
             Rows = options.Rows,
+            HumanRowWindowNote = options.HumanRowWindowNote,
             SourceOptions = options.SourceOptions,
             NoHeader = options.NoHeader,
             UserVerbosityOverride = options.Verbosity
@@ -4903,7 +4920,9 @@ public class PackageCommand
                     table.StableHeaders,
                     table.Rows);
                 markoutWriter.Flush();
-            });
+            }, humanRowWindowNote: options.Verbosity != Verbosity.Quiet && !options.Tsv && !options.Jsonl
+                ? options.HumanRowWindowNote
+                : null);
         });
         return true;
     }
@@ -5600,7 +5619,14 @@ public class PackageCommand
                 ["TFM"]))
             return projectionExit;
 
-        OutputFormatter.WriteStringList(visibleTfms, "TFM", "Tfm", options.Tsv, options.Jsonl, Console.Out);
+        OutputFormatter.WriteStringList(
+            visibleTfms,
+            "TFM",
+            "Tfm",
+            options.Tsv,
+            options.Jsonl,
+            Console.Out,
+            visibleTfms.Count > 0 ? options.HumanRowWindowNote : null);
         return 0;
     }
 

--- a/src/dotnet-inspect/Commands/TimelineCommand.cs
+++ b/src/dotnet-inspect/Commands/TimelineCommand.cs
@@ -1363,7 +1363,7 @@ public static class TimelineCommand
                 return 1;
 
             Console.WriteLine(JsonSerializer.Serialize(
-                view,
+                ApplyRowWindow(view, options.Rows),
                 TimelineJsonContext.Default.TimelineDocumentView));
             return 0;
         }
@@ -1387,7 +1387,7 @@ public static class TimelineCommand
                             formatter,
                             TimelineViewContext.Default,
                             writerOptions),
-                    options.Rows);
+                    options.Rows, options.HumanRowWindowNote);
             }
             else
             {
@@ -1406,16 +1406,39 @@ public static class TimelineCommand
                             formatter,
                             TimelineViewContext.Default,
                             writerOptions),
-                    options.Rows);
+                    options.Rows, options.HumanRowWindowNote);
             }
             return 0;
         }
 
         var writer = new MarkoutWriter(new MarkdownFormatter(), OutputFormatter.CreateWindowedOptions(options.Rows));
         TimelineViewContext.Default.Serialize(view, writer);
-        Console.WriteLine(writer.ToString().TrimEnd());
+        var hasContent = (view.Evaluations?.Count > 0) || (view.Transitions?.Count > 0);
+        var rendered = writer.ToString().TrimEnd();
+        Console.WriteLine(hasContent
+            ? OutputFormatter.AddHumanRowWindowNote(rendered, options.HumanRowWindowNote)
+            : rendered);
         return 0;
     }
+
+    private static TimelineDocumentView ApplyRowWindow(
+        TimelineDocumentView view,
+        RowWindow? rows) =>
+        new()
+        {
+            Title = view.Title,
+            Range = view.Range,
+            Type = view.Type,
+            Member = view.Member,
+            Finding = view.Finding,
+            Recommendation = view.Recommendation,
+            Evaluations = view.Evaluations is null
+                ? null
+                : RowWindow.Apply(rows, view.Evaluations).ToList(),
+            Transitions = view.Transitions is null
+                ? null
+                : RowWindow.Apply(rows, view.Transitions).ToList(),
+        };
 
     internal sealed record TimelineEvaluation(
         PackageVersionAddress Address,
@@ -1450,6 +1473,7 @@ public sealed record TimelineOptions : IProjectionOptions
     public bool NoHeader { get; init; }
     public bool Count { get; init; }
     public RowWindow? Rows { get; init; }
+    public string? HumanRowWindowNote { get; init; }
     public string[]? Select { get; init; }
     public bool SelectDefault { get; init; }
     public string[]? Columns { get; init; }


### PR DESCRIPTION
## Summary

Successor 3 of 3 replacing superseded PR #4750 for #4677. This PR targets
`limit-projection-destinations` (PR #5145) and completes typed document JSON
item-window adoption for the current stack.

- Applies item windows independently to declared type JSON row sets.
- Bounds full API-surface JSON by its declared `types` rows while preserving
  scalar assembly identity.
- Applies typed JSON windows across diff, extensions, implements, timeline,
  package, library, and supported match output.
- Preserves the existing truthful Performance document path and fails closed
  for unsupported aggregate document shapes rather than emitting unbounded
  success-shaped output.
- Carries durable member identity into windowed type JSON.

## Demo

```console
$ dotnet-inspect type --library dotnet-inspect.Tests.dll \
    -n 1 --json --tips q | jq '{name, typeCount: (.types | length)}'
{
  "name": "dotnet-inspect.Tests",
  "typeCount": 1
}
```

Before this slice, the same command accepted `-n 1` but serialized all 274
fixture types.

## Stack

1. PR #5144: core grammar and utility adoption.
2. PR #5145: projection, graph, and line-aware destination adoption.
3. **This PR:** typed document JSON adoption.

Remaining #4677 slices retain ownership of absolute range/count composition,
retired selector spellings, package search/versions, print-mode acquisition and
destination auditing, and final repository-wide documentation/skill sync.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- `CommandExecutionLimitSlice4677Tests`
- Complete Timeline, Match, Diff, Extensions, and Implements command test
  classes
- Direct full API-surface JSON demo confirming one selected type

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
