### PR TITLE
Stage cross-cutting designs subsystem-by-subsystem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,12 +243,12 @@ over-broad-design recovery procedure live in
   Do not start or broaden into one without the user's explicit request or
   approval; a large issue, cross-cutting motivation, or reviewer suggestion is
   not approval.
-- If review keeps discovering new component-internal contracts the design
-  doesn't close, stop and apply the
-  [scope-violation recovery transition](#recovery-transitions): keep the locked
-  candidate unchanged, name the combined components, and ask the user to
-  choose among splitting into focused successors, abandoning, or approving a
-  recorded broad exception.
+- If review keeps discovering new component-internal contracts, stop and apply
+  the [scope-violation recovery transition](#recovery-transitions).
+- Lock a focused design as its own document before implementing broadly, then
+  apply it through scoped, subsystem-by-subsystem efforts rather than one PR
+  sweeping every affected component; see
+  [Stage implementation after locking the design](docs/design-scope.md#stage-implementation-after-locking-the-design).
 
 ## Repository-wide engineering constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,9 +245,9 @@ over-broad-design recovery procedure live in
   not approval.
 - If review keeps discovering new component-internal contracts, stop and apply
   the [scope-violation recovery transition](#recovery-transitions).
-- Lock a focused design as its own document before implementing broadly, then
-  apply it through scoped, subsystem-by-subsystem efforts rather than one PR
-  sweeping every affected component; see
+- Lock a new cross-cutting pattern as its own focused design document — defining
+  only the pattern's contract, not other owners' internals — then have each
+  owner adopt it one at a time rather than one PR sweeping every owner; see
   [Stage implementation after locking the design](docs/design-scope.md#stage-implementation-after-locking-the-design).
 
 ## Repository-wide engineering constraints

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -54,6 +54,36 @@ approval. Before requesting approval, present the component map, explain why
 focused designs cannot close independently, and name the intended claims and
 non-claims.
 
+## Stage implementation after locking the design
+
+A cross-cutting design (a new pattern, containment model, or convention meant
+to apply repo-wide) is itself a focused effort: it gets its own owning
+document, informed by a survey of the components it will eventually touch, and
+it is locked and reviewed before broad implementation starts. Do not fold the
+design and every affected component's migration into one PR. A design that
+tries to convert all components in a single shot produces a PR that cannot
+close: reviewers keep finding subsystem-specific issues the design didn't
+anticipate, rounds never converge, and the true, high-value defects get lost
+in the noise of unrelated subsystem detail.
+
+Once the design document is locked, apply it through scoped implementation
+efforts, one subsystem (or a small, coherent group of subsystems) at a time.
+Each implementation PR names the design it applies, the one subsystem it
+converts, and any subsystem-specific adaptation the design didn't already
+cover. The first subsystem's conversion may land together with the design in
+one PR when that pairing is the cheapest way to prove the design works; every
+other subsystem stages as its own follow-on effort or stack slice. Track
+remaining subsystems as filed issues or a stack rather than reopening the
+locked design to add them.
+
+This mirrors [What makes a design broad](#what-makes-a-design-broad): a design
+that normatively converts multiple independently owned components in one
+effort is a broad design and needs the same explicit approval. Staging
+subsystem-by-subsystem is what keeps both the design and each conversion
+closable, and closable work is what actually finds the critical issues —
+an unclosable, boil-the-ocean PR finds nothing because it never gets read
+closely enough to matter.
+
 ## Keep specifications readable; model interactions
 
 Design specifications own detailed requirements, component boundaries, and

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -60,27 +60,32 @@ A new cross-cutting pattern, containment model, or convention gets its own
 focused design document under [One owner per focused
 design](#one-owner-per-focused-design): informed by a survey of the components
 that will eventually adopt it, the document defines the pattern's own
-contract — its type, construction, validation, and invariants — and is locked
-and reviewed before adoption starts. It must not also redefine how any
-existing owner's internals change to adopt the pattern; specifying every
-adopting owner's migration in the same document is the multiple-owners case
-that [What makes a design broad](#what-makes-a-design-broad) already gates,
-and needs that same explicit approval.
+contract — its type, construction, validation, and invariants. It must not
+also redefine how any existing owner's internals change to adopt the pattern;
+specifying every adopting owner's migration in the same document is the
+multiple-owners case that [What makes a design broad](#what-makes-a-design-broad)
+already gates, and needs that same explicit approval.
 
-Once the pattern document is locked, each existing owner adopts it as its own
-focused effort. An adoption PR names the pattern document, names the one owner
-adopting it, and states that owner's adoption-specific decisions; do not fold
-one owner's adoption into another's PR, and do not adopt the pattern across
-every owner in a single PR. The first owner's adoption may land together with
-the pattern document in one PR when that pairing is the cheapest way to prove
-the pattern works end to end; every other owner's adoption stages as its own
-follow-on effort or stack slice, tracked as filed issues rather than reopening
-the locked pattern document to add them.
+Beyond that document, each existing owner adopts the pattern as its own
+focused effort, one owner at a time: an adoption PR names the pattern
+document, names the one owner adopting it, and states that owner's
+adoption-specific decisions. Do not fold one owner's adoption into another
+owner's PR, and do not adopt the pattern across every owner in a single PR.
+
+One bounded exception: the pattern document may lock together with exactly
+one owner's adoption in a single PR, proving the pattern works end to end
+before any other owner adopts it. Treat this the same way as the other named
+exceptions in this document — one additional cohesive claim riding with the
+focused effort, not a license to combine further owners. After that PR locks,
+every other owner's adoption stages as its own follow-on effort or stack
+slice, tracked as filed issues rather than reopening the pattern document or
+the first adoption to add them.
 
 Folding every owner's adoption into the pattern document, or into one
-implementation PR, is what makes this kind of work unclosable: reviewers keep
-finding owner-specific issues the pattern document didn't anticipate, rounds
-never converge, and the critical issues get lost in the noise of unrelated
+implementation PR beyond the bounded first-adopter exception, is what makes
+this kind of work unclosable: reviewers keep finding owner-specific issues the
+pattern document didn't anticipate, rounds never converge, and the critical
+issues get lost in the noise of unrelated
 owner detail. Staging the pattern first, then one owner at a time, is what
 keeps both closable.
 

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -56,33 +56,33 @@ non-claims.
 
 ## Stage implementation after locking the design
 
-A cross-cutting design (a new pattern, containment model, or convention meant
-to apply repo-wide) is itself a focused effort: it gets its own owning
-document, informed by a survey of the components it will eventually touch, and
-it is locked and reviewed before broad implementation starts. Do not fold the
-design and every affected component's migration into one PR. A design that
-tries to convert all components in a single shot produces a PR that cannot
-close: reviewers keep finding subsystem-specific issues the design didn't
-anticipate, rounds never converge, and the true, high-value defects get lost
-in the noise of unrelated subsystem detail.
+A new cross-cutting pattern, containment model, or convention gets its own
+focused design document under [One owner per focused
+design](#one-owner-per-focused-design): informed by a survey of the components
+that will eventually adopt it, the document defines the pattern's own
+contract — its type, construction, validation, and invariants — and is locked
+and reviewed before adoption starts. It must not also redefine how any
+existing owner's internals change to adopt the pattern; specifying every
+adopting owner's migration in the same document is the multiple-owners case
+that [What makes a design broad](#what-makes-a-design-broad) already gates,
+and needs that same explicit approval.
 
-Once the design document is locked, apply it through scoped implementation
-efforts, one subsystem (or a small, coherent group of subsystems) at a time.
-Each implementation PR names the design it applies, the one subsystem it
-converts, and any subsystem-specific adaptation the design didn't already
-cover. The first subsystem's conversion may land together with the design in
-one PR when that pairing is the cheapest way to prove the design works; every
-other subsystem stages as its own follow-on effort or stack slice. Track
-remaining subsystems as filed issues or a stack rather than reopening the
-locked design to add them.
+Once the pattern document is locked, each existing owner adopts it as its own
+focused effort. An adoption PR names the pattern document, names the one owner
+adopting it, and states that owner's adoption-specific decisions; do not fold
+one owner's adoption into another's PR, and do not adopt the pattern across
+every owner in a single PR. The first owner's adoption may land together with
+the pattern document in one PR when that pairing is the cheapest way to prove
+the pattern works end to end; every other owner's adoption stages as its own
+follow-on effort or stack slice, tracked as filed issues rather than reopening
+the locked pattern document to add them.
 
-This mirrors [What makes a design broad](#what-makes-a-design-broad): a design
-that normatively converts multiple independently owned components in one
-effort is a broad design and needs the same explicit approval. Staging
-subsystem-by-subsystem is what keeps both the design and each conversion
-closable, and closable work is what actually finds the critical issues —
-an unclosable, boil-the-ocean PR finds nothing because it never gets read
-closely enough to matter.
+Folding every owner's adoption into the pattern document, or into one
+implementation PR, is what makes this kind of work unclosable: reviewers keep
+finding owner-specific issues the pattern document didn't anticipate, rounds
+never converge, and the critical issues get lost in the noise of unrelated
+owner detail. Staging the pattern first, then one owner at a time, is what
+keeps both closable.
 
 ## Keep specifications readable; model interactions
 


### PR DESCRIPTION
## Claim

Codify guidance already implicit in the broad-design gate: a cross-cutting
design must lock as its own isolated document (informed by a survey of the
components it will touch) before implementation, and implementation must then
apply the design in scoped, subsystem-by-subsystem efforts rather than one
shot across every affected component.

## Motivation

Several PRs over the last few days were superseded because a design tried to
convert every affected component in one PR. Sweeping designs/implementations
don't close: reviewers keep surfacing subsystem-specific issues the design
didn't anticipate, rounds never converge, and real critical issues get lost in
the noise. Staging design-first, then subsystem-by-subsystem, keeps each
effort closable and focused enough to find the issues that matter.

## Change

- `AGENTS.md` — Design scope and composition: tightened the existing
  recovery bullet and added a bullet pointing to the new staging rule.
- `docs/design-scope.md` — new section "Stage implementation after locking the
  design": lock the design first, then apply per-subsystem, optionally pairing
  the design with its first subsystem's conversion, staging the rest.

## Demo (docs-only mockup)

Before: a "adopt InertString repo-wide" design PR also converts Metadata,
Analysis, CSharpText, and CLI call sites in the same PR — reviewers find a
different subsystem-specific gap each round; it never closes.

After: the design PR locks `docs/design/inert-string-adoption.md` alone (or
paired with one subsystem's conversion as proof. Each other subsystem lands
as its own follow-on PR/stack slice naming the design and the one subsystem it
converts.

## Validation

-  — clean.
-      600 AGENTS.md — 600 (at cap, unchanged; growth offset by tightening the
  existing recovery bullet).

## Non-action boundary

No behavior, code, or other doc content changed.
EOF
)