### PR TITLE
Make NuGetFetch quiescence test deterministic

### DIFF
--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -1263,13 +1263,23 @@ public sealed class PluginProtocolTests : IDisposable
             TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseInterruption = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var writeCompletes = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var quiescenceAwaiting = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var resourcesDisposing = new TaskCompletionSource<bool>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        using var hooksEnabled = new ManualResetEventSlim();
         var hooks = new PluginConnection.PluginConnectionTestHooks
         {
-            RequestWriteStarted = () => writeStarted.TrySetResult(),
+            RequestWriteOverride = () => hooksEnabled.IsSet ? writeCompletes.Task : null,
+            RequestWriteStarted = () =>
+            {
+                if (hooksEnabled.IsSet)
+                {
+                    writeStarted.TrySetResult();
+                }
+            },
             RequestWriteInterrupted = () =>
             {
                 writeInterrupted.TrySetResult();
@@ -1295,8 +1305,9 @@ public sealed class PluginProtocolTests : IDisposable
                 TestContext.Current.CancellationToken,
                 hooks));
         using var cancellation = new CancellationTokenSource();
+        hooksEnabled.Set();
         Task<GetAuthenticationCredentialsResponse?> request = connection.GetCredentialsAsync(
-            CreateLargeFeedUri(),
+            new Uri("https://feed.example/v3/index.json"),
             isRetry: false,
             isNonInteractive: true,
             canShowDialog: false,
@@ -1321,6 +1332,7 @@ public sealed class PluginProtocolTests : IDisposable
         }
         finally
         {
+            writeCompletes.TrySetResult();
             releaseInterruption.TrySetResult();
         }
 


### PR DESCRIPTION
Fixes #5153.

The interrupted-request quiescence gate now controls the target credential
write directly instead of assuming a 4 MiB pipe write remains blocked long
enough to cancel. This preserves the product contract under test without
changing `PluginConnection`.

## Demo

Before this change, the test's `writeStarted` signal could be satisfied by the
startup `SetLogLevel` request:

```text
StartAsync
  SetLogLevel write -> RequestWriteStarted
StartAsync returns
credential request begins
test cancels (credential write may not have started)
```

That ordering reproduced twice on shared Ubuntu CI, where the test timed out
waiting for `RequestWriteInterrupted`.

After this change, hooks remain disabled until `StartAsync` completes. The
target request then uses a controlled incomplete write:

```text
StartAsync completes
enable target hooks
credential write override starts
test cancels -> RequestWriteInterrupted
DisposeAsync reaches quiescence wait
test proves resources are not disposing
release write -> request quiesces -> resources dispose
```

The neighboring startup and plugin protocol remain real; only the write whose
lifetime the test measures is controlled.

## Validation

- `ConnectionResourcesWaitForInterruptedRequestsToQuiesce`: 100/100 focused
  Release runs passed.
- `NuGetFetch.Tests`: 799 total, 790 passed, 9 live-feed tests skipped.

## Compatibility

Test-only change. Product behavior and public APIs are unchanged.
