### PR TITLE
Define admission-scoped artifact-to-assembly projection

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -221,6 +221,219 @@ PDB artifact acquisition, symbol stores, and SourceLink policy are separate
 contracts; only validation of the assembly PE opened by an existing
 descriptor-based PDB entry point belongs here.
 
+#### Admission-scoped artifact projection
+
+Issue [#5143](https://github.com/richlander/dotnet-inspect/issues/5143)
+defines the target replacement for using
+`ResolvedAssemblyReference.CreateFromArtifactIfManaged` while a workspace is
+constructing an assembly context. This is an assembly-inspection-query
+contract. Artifact acquisition still owns admission and query authorization,
+retained bytes, source provenance, and publication. Metadata still owns PE
+classification, assembly identity, and MVID decoding.
+
+The target operation has two distinct phases:
+
+1. During admission, the artifact owner validates the current admission
+   authority and invokes the assembly projector with the exact acquisition
+   registration and callback-scoped immutable bytes. The projector classifies
+   those bytes and returns content-free assembly facts.
+2. During a later query, the artifact owner validates the current query
+   authority and lends the retained immutable bytes for one operation. The
+   assembly consumer validates those bytes against the published facts before
+   inspection. Validation never rebinds or replaces the published facts.
+
+The artifact owner performs lease and generation checks before invoking either
+callback. The assembly projector does not receive an admission or query lease,
+does not retain the callback input, and does not mint artifact authority. This
+is the immediate typed boundary the assembly query consumes:
+
+```csharp
+public abstract record ArtifactAssemblyProjectionOutcome
+{
+    public sealed record Projected(
+        ArtifactAssemblyProjection Value)
+        : ArtifactAssemblyProjectionOutcome;
+
+    public sealed record NotAssembly(
+        ArtifactNonAssemblyKind Kind)
+        : ArtifactAssemblyProjectionOutcome;
+
+    public sealed record Rejected(
+        ArtifactAssemblyProjectionFailure Failure)
+        : ArtifactAssemblyProjectionOutcome;
+}
+
+public sealed record ArtifactAssemblyProjection(
+    ArtifactGenerationIdentity Generation,
+    ArtifactAcquisitionRegistration ArtifactRegistration,
+    AssemblyAcquisitionRegistration AssemblyRegistration,
+    AssemblyReferenceIdentity Identity,
+    Guid ModuleVersionId);
+
+public enum ArtifactNonAssemblyKind
+{
+    NativeImage,
+    ManagedModule,
+}
+
+public enum ArtifactAssemblyProjectionFailureKind
+{
+    AdmissionUnauthorized,
+    MalformedMetadata,
+    EmptyModuleVersionId,
+    ArtifactRegistrationMismatch,
+    GenerationMismatch,
+    AssemblyIdentityMismatch,
+    ModuleVersionIdMismatch,
+}
+```
+
+These declarations describe the value shape and typed outcomes; they do not
+assign the artifact owner's callback API or authorization implementation to
+Metadata. The implementation may use a closed hierarchy instead of records or
+enums, but it must preserve the distinctions above.
+
+`ArtifactAssemblyProjection` is immutable, content-free, and bound to one
+in-process artifact generation. It is not a durable or serializable identity.
+`Generation` must be the same owner-issued object exposed by
+`ArtifactRegistration.Generation`.
+`AssemblyRegistration.ArtifactRegistration` must be the exact
+`ArtifactRegistration` object, and `AssemblyRegistration.ModuleVersionId` must
+already equal the non-empty `ModuleVersionId` when the outcome is returned.
+The assembly registration is therefore bound once during admission. Later
+query validation compares identity and MVID; it does not call a bind operation
+or mutate the projection.
+
+The successful output exposes none of the following, directly or through a
+nested public value:
+
+- a filesystem path;
+- `Stream`, `Func<Stream>`, or another content opener;
+- immutable or mutable content bytes;
+- `ArtifactContentReference` or retained-content handle;
+- `ArtifactAdmissionLease` or `ArtifactQueryLease`; or
+- an operation that can reacquire, reopen, or reconstruct any of those values.
+
+The exact artifact registration is required even though it indirectly carries
+source-specific provenance. It is correspondence evidence minted by the
+artifact owner, not a source interpretation performed by Metadata. Consumers
+may retain the registration and generation to join owner-issued workspace
+facts, but only the artifact owner can turn current authorization into another
+content callback.
+
+##### Admission classification
+
+The admission callback must observe one immutable byte sequence. Metadata
+classifies it without loading the inspected assembly:
+
+| Input | Outcome | Participant consequence |
+| --- | --- | --- |
+| Managed assembly with a non-empty MVID | `Projected` | The context realizer may use the returned facts when forming its atomic publication. |
+| Native PE image with no managed metadata | `NotAssembly(NativeImage)` | No assembly registration or participant is manufactured. |
+| Managed netmodule | `NotAssembly(ManagedModule)` | No assembly registration or participant is manufactured. |
+| Malformed PE or metadata | `Rejected(MalformedMetadata)` | Required context admission fails visibly. |
+| Managed assembly with an empty MVID | `Rejected(EmptyModuleVersionId)` | Required context admission fails visibly. |
+| Foreign, revoked, disposed, or ended admission authority | `Rejected(AdmissionUnauthorized)` | The callback is not invoked and no assembly facts are minted. |
+
+`NotAssembly` is a positive classification, not successful assembly
+projection. Whether a non-assembly artifact is allowed to remain in a broader
+artifact catalog belongs to that catalog's owner. It cannot enter an
+`AssemblyContextGroup` through this contract.
+
+The projector receives the exact artifact registration selected by the
+artifact owner. It does not accept a caller-reconstructed registration,
+generation, identity, or MVID. The context realizer owns the frozen map from
+selected artifact registrations to successful projections and the atomic
+decision to publish a complete group; this component neither assigns workspace
+roles nor constructs the group.
+
+##### Query-time revalidation
+
+The later query path starts from a published
+`ArtifactAssemblyProjection`. Under current query authorization, the artifact
+owner locates the exact retained artifact registration and lends its immutable
+bytes for one operation. Before any producer observes assembly evidence, the
+assembly query validates all of:
+
+1. the content callback belongs to the projection's artifact generation;
+2. its artifact registration is the exact registered artifact;
+3. the retained image is still a managed assembly;
+4. its assembly identity equals the projected identity; and
+5. its non-empty MVID equals the projected MVID.
+
+A generation, registration, identity, or MVID mismatch is a typed rejection.
+Native, module, malformed, and empty-MVID replacements retain their distinct
+classification where that distinction is available. None is retried through a
+path, source adapter, descriptor opener, or new acquisition. The query returns
+the visible failure under its existing result contract and does not inspect or
+publish evidence from the mismatched bytes.
+
+The artifact owner remains responsible for rejecting a missing, foreign,
+revoked, disposed, or ended query authorization before lending content. The
+assembly query consumes that guarantee and performs the content-derived checks;
+it does not infer authorization from equal registrations or generations.
+
+##### Relationship to compatibility descriptors
+
+`ResolvedAssemblyReference` remains a compatibility descriptor for current
+path- and stream-based consumers. Implementing this design must not put an
+admission callback, query callback, retained-content handle, or lease into that
+descriptor. A query may adapt currently authorized bytes to an internal
+`AssemblyImage` or `AssemblyInspectionSession` for the duration of one
+operation, but the adapter cannot escape the artifact callback or recreate a
+parameterless opener.
+
+General removal of `ResolvedAssemblyReference.Path` and
+`ResolvedAssemblyReference.OpenRead` waits for their existing consumers to
+migrate. This slice adds the content-free route required by context
+publication; it does not silently change compatibility behavior.
+
+##### Interaction model
+
+The
+[admission assembly projection model](models/admission-assembly-projection/README.md)
+checks the bounded interaction among current admission authority, projection,
+publication, authority expiry, and later query revalidation. It verifies that
+successful projection requires current admission authority, published facts
+retain the exact registration but no content authority, and query validation
+requires current query authority plus exact generation, registration,
+identity, and MVID agreement. Mutation configurations independently show that
+stale admission, leaked authority, dropped registration, relaxed identity,
+MVID or generation checks, and revoked-query access violate those properties.
+The model does not establish implementation conformance.
+
+##### Required gates
+
+Implementation is complete only when Release tests equivalent to these exist:
+
+- `AdmissionProjection_BindsExactArtifactAndAssemblyRegistrationsIdentityAndMvid`
+- `AdmissionProjection_RejectsForeignRevokedDisposedOrEndedAuthority`
+- `AdmissionProjection_PublicSurfaceCarriesNoContentOrLeaseCapability`
+- `AdmissionProjection_ClassifiesNativeModuleMalformedAndEmptyMvid`
+- `QueryValidation_AcceptsExactRetainedImageWithoutRebinding`
+- `QueryValidation_RejectsRegistrationGenerationIdentityAndMvidMismatch`
+- `AdmissionProjection_ExactArtifactRegistrationIsNonVacuous`
+
+The first gate uses the existing artifact-backed fixture from #4954/#4957 and
+requires the same artifact registration, assembly identity, and non-empty MVID.
+The public-surface gate recursively inspects nested public types for paths,
+content, openers, content references, and leases. The non-vacuity gate removes
+the exact artifact registration from an otherwise valid projection and must
+fail before publication.
+
+##### Non-goals
+
+This contract does not:
+
+- acquire artifacts or define local-path and installed-platform membership;
+- assign workspace roles or construct and publish an
+  `AssemblyContextGroup`;
+- define binding precedence, member or call-target correspondence, CLI
+  sections, or rendering;
+- acquire PDBs or source;
+- make assembly projection portable across processes; or
+- remove compatibility descriptor APIs before their consumers migrate.
+
 ```csharp
 public abstract record AssemblyResolutionProvenance
 {

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -234,9 +234,11 @@ classification, assembly identity, and MVID decoding.
 The target operation has two distinct phases:
 
 1. During admission, the artifact owner validates the current admission
-   authority and invokes the assembly projector with the exact acquisition
-   registration and callback-scoped immutable bytes. The projector classifies
-   those bytes and returns content-free assembly facts.
+   authority, derives an owner-attested view from the exact selected
+   acquisition registration, and invokes the assembly projector with only that
+   view and callback-scoped immutable bytes. The full acquisition registration
+   does not cross the boundary. The projector classifies those bytes and
+   returns content-free assembly facts.
 2. During a later query, the artifact owner validates the current query
    authority and lends the retained immutable bytes for one operation. The
    assembly consumer validates those bytes against the published facts before
@@ -318,6 +320,7 @@ public sealed record ArtifactAssemblyProjectionFailure(
 public enum ArtifactAssemblyProjectionFailureKind
 {
     AdmissionUnauthorized,
+    UnsupportedWindowsMetadata,
     MalformedMetadata,
     EmptyModuleVersionId,
 }
@@ -342,6 +345,7 @@ public enum ArtifactAssemblyQueryFailureKind
     QueryUnauthorized,
     GenerationMismatch,
     ArtifactIdentityMismatch,
+    UnsupportedWindowsMetadata,
     MalformedMetadata,
     EmptyModuleVersionId,
     AssemblyIdentityMismatch,
@@ -395,13 +399,18 @@ content callback.
 ##### Admission classification
 
 The admission callback must observe one immutable byte sequence. Metadata
-classifies it without loading the inspected assembly:
+first applies the MetadataPrimitives-owned
+`MetadataImageFormatClassifier`. Unsupported Windows Metadata is rejected
+before constructing a `MetadataReader` or performing other managed metadata
+work. Supported input is then classified without loading the inspected
+assembly:
 
 | Input | Outcome | Participant consequence |
 | --- | --- | --- |
 | Managed assembly with a non-empty MVID | `Projected` | The context realizer may use the returned facts when forming its atomic publication. |
 | Native PE image with no managed metadata | `NotAssembly(NativeImage)` | No assembly registration or participant is manufactured. |
 | Managed netmodule | `NotAssembly(ManagedModule)` | No assembly registration or participant is manufactured. |
+| Windows Metadata (`WindowsMetadata` or `ManagedWindowsMetadata`) | `Rejected(UnsupportedWindowsMetadata)` | Required context admission fails visibly before managed metadata work. |
 | Malformed PE or metadata | `Rejected(MalformedMetadata)` | Required context admission fails visibly. |
 | Managed assembly with an empty MVID | `Rejected(EmptyModuleVersionId)` | Required context admission fails visibly. |
 | Foreign, revoked, disposed, or ended admission authority | `Rejected(AdmissionUnauthorized)` | The callback is not invoked and no assembly facts are minted. |
@@ -431,9 +440,12 @@ validates all of:
 
 1. the view's generation is the projection registration's exact generation;
 2. its artifact identity is the projection registration's exact artifact;
-3. the retained image is still a managed assembly;
-4. its assembly identity equals the projected identity; and
-5. its non-empty MVID equals the projection registration's MVID.
+3. `MetadataImageFormatClassifier` still classifies the retained image as
+   supported ECMA-335 before any `MetadataReader` construction or managed
+   metadata work;
+4. the retained image is still a managed assembly;
+5. its assembly identity equals the projected identity; and
+6. its non-empty MVID equals the projection registration's MVID.
 
 Because an `ArtifactIdentity` is scoped to its owner-issued generation, exact
 artifact identity already entails generation equality. The explicit generation
@@ -442,9 +454,10 @@ comparison runs first to classify a foreign-generation owner view as
 
 A generation, artifact identity, assembly identity, or MVID mismatch is a
 typed `Rejected` outcome. Native and module replacements produce the query
-outcome's typed `NotAssembly` arm; malformed and empty-MVID replacements use
-their dedicated query failure kinds. None is retried through a path, source
-adapter, descriptor opener, or new acquisition.
+outcome's typed `NotAssembly` arm; unsupported Windows Metadata, malformed
+metadata, and empty-MVID replacements use their dedicated query failure kinds.
+None is retried through a path, source adapter, descriptor opener, or new
+acquisition.
 
 The `Validated<TResult>` value is produced inside the query view's callback.
 The assembly query opens an internal `AssemblyImage` or
@@ -458,6 +471,13 @@ outer query operation maps that rejection to `QueryUnauthorized`. The assembly
 query consumes the owner-attested generation and artifact identity and performs
 the content-derived checks; it does not infer owner state from PE bytes,
 ordinal equality, or display values.
+
+The interaction model treats current admission and query authority as external
+inputs. It proves that projection or validation cannot proceed after
+revocation, but it does not model the artifact owner's outer
+`AdmissionUnauthorized` or `QueryUnauthorized` result mapping. The named
+Release gates below own those exact mappings and prove that the callback and
+producer are not invoked.
 
 ##### Relationship to compatibility descriptors
 
@@ -489,20 +509,25 @@ provenance, and query validation requires current query authority plus exact
 generation, artifact identity, assembly identity, and MVID agreement. Mutation
 configurations independently show that stale admission, leaked authority,
 dropped artifact identity, relaxed artifact, assembly-identity, MVID, or
-revoked-query checks violate those properties; the positive model separately
-requires a foreign-generation view to produce `GenerationMismatch`. The model
-does not establish implementation conformance.
+revoked-query checks violate those properties. Separate mutations show that
+unsupported Windows Metadata cannot project or validate as supported
+ECMA-335. The positive model separately requires a foreign-generation view to
+produce `GenerationMismatch`. The model does not establish implementation
+conformance or the outer authorization-result mapping.
 
 ##### Required gates
 
 Implementation is complete only when Release tests equivalent to these exist:
 
 - `AdmissionProjection_BindsExactArtifactIdentityAssemblyRegistrationIdentityAndMvid`
-- `AdmissionProjection_RejectsForeignRevokedDisposedOrEndedAuthority`
+- `AdmissionProjection_MapsUnauthorizedAuthorityWithoutInvokingCallback`
 - `AdmissionProjection_PublicSurfaceCarriesNoProvenanceContentOrLeaseCapability`
+- `AdmissionProjection_RejectsUnsupportedWindowsMetadataBeforeMetadataWork`
 - `AdmissionProjection_ClassifiesNativeModuleMalformedAndEmptyMvid`
+- `QueryValidation_MapsUnauthorizedAuthorityWithoutInvokingCallback`
 - `QueryValidation_ConsumesOwnerAttestedArtifactIdentityAndGeneration`
 - `QueryValidation_AcceptsExactRetainedImageInsideCallbackWithoutRebinding`
+- `QueryValidation_RejectsUnsupportedWindowsMetadataBeforeMetadataWork`
 - `QueryValidation_ClassifiesNativeModuleMalformedAndEmptyMvid`
 - `QueryValidation_RejectsArtifactGenerationAssemblyIdentityAndMvidMismatch`
 - `AdmissionProjection_ExactArtifactIdentityIsNonVacuous`
@@ -515,7 +540,13 @@ The public-surface gate recursively inspects nested public types for paths,
 source provenance, content, openers, content references, and leases. The
 non-vacuity gate substitutes a different owner-issued artifact identity from
 the same generation in an otherwise valid query view and must fail before
-producer execution.
+producer execution. The two authorization-mapping gates cover every listed
+missing, foreign, revoked, disposed, and ended state, require the exact typed
+failure, and prove that no callback or producer runs. The two unsupported-input
+gates use both Windows Metadata kinds and require the
+MetadataPrimitives-owned classifier to reject before `MetadataReader`
+construction or other managed metadata work; `MDP017` continues to own the
+classifier's format detection and bounded-work guarantees.
 
 ##### Non-goals
 

--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -248,6 +248,40 @@ does not retain the callback input, and does not mint artifact authority. This
 is the immediate typed boundary the assembly query consumes:
 
 ```csharp
+public readonly ref struct ArtifactAssemblyAdmissionView
+{
+    internal ArtifactAssemblyAdmissionView(
+        ArtifactGenerationIdentity generation,
+        ArtifactIdentity artifact,
+        ReadOnlySpan<byte> content)
+    {
+        Generation = generation;
+        Artifact = artifact;
+        Content = content;
+    }
+
+    public ArtifactGenerationIdentity Generation { get; }
+    public ArtifactIdentity Artifact { get; }
+    public ReadOnlySpan<byte> Content { get; }
+}
+
+public readonly ref struct ArtifactAssemblyQueryView
+{
+    internal ArtifactAssemblyQueryView(
+        ArtifactGenerationIdentity generation,
+        ArtifactIdentity artifact,
+        ReadOnlySpan<byte> content)
+    {
+        Generation = generation;
+        Artifact = artifact;
+        Content = content;
+    }
+
+    public ArtifactGenerationIdentity Generation { get; }
+    public ArtifactIdentity Artifact { get; }
+    public ReadOnlySpan<byte> Content { get; }
+}
+
 public abstract record ArtifactAssemblyProjectionOutcome
 {
     public sealed record Projected(
@@ -264,10 +298,12 @@ public abstract record ArtifactAssemblyProjectionOutcome
 }
 
 public sealed record ArtifactAssemblyProjection(
+    AssemblyProjectionRegistration Registration,
+    AssemblyReferenceIdentity Identity);
+
+public sealed record AssemblyProjectionRegistration(
     ArtifactGenerationIdentity Generation,
-    ArtifactAcquisitionRegistration ArtifactRegistration,
-    AssemblyAcquisitionRegistration AssemblyRegistration,
-    AssemblyReferenceIdentity Identity,
+    ArtifactIdentity Artifact,
     Guid ModuleVersionId);
 
 public enum ArtifactNonAssemblyKind
@@ -276,13 +312,38 @@ public enum ArtifactNonAssemblyKind
     ManagedModule,
 }
 
+public sealed record ArtifactAssemblyProjectionFailure(
+    ArtifactAssemblyProjectionFailureKind Kind);
+
 public enum ArtifactAssemblyProjectionFailureKind
 {
     AdmissionUnauthorized,
     MalformedMetadata,
     EmptyModuleVersionId,
-    ArtifactRegistrationMismatch,
+}
+
+public abstract record ArtifactAssemblyQueryOutcome<TResult>
+{
+    public sealed record Validated(TResult Value)
+        : ArtifactAssemblyQueryOutcome<TResult>;
+
+    public sealed record NotAssembly(ArtifactNonAssemblyKind Kind)
+        : ArtifactAssemblyQueryOutcome<TResult>;
+
+    public sealed record Rejected(ArtifactAssemblyQueryFailure Failure)
+        : ArtifactAssemblyQueryOutcome<TResult>;
+}
+
+public sealed record ArtifactAssemblyQueryFailure(
+    ArtifactAssemblyQueryFailureKind Kind);
+
+public enum ArtifactAssemblyQueryFailureKind
+{
+    QueryUnauthorized,
     GenerationMismatch,
+    ArtifactIdentityMismatch,
+    MalformedMetadata,
+    EmptyModuleVersionId,
     AssemblyIdentityMismatch,
     ModuleVersionIdMismatch,
 }
@@ -291,18 +352,27 @@ public enum ArtifactAssemblyProjectionFailureKind
 These declarations describe the value shape and typed outcomes; they do not
 assign the artifact owner's callback API or authorization implementation to
 Metadata. The implementation may use a closed hierarchy instead of records or
-enums, but it must preserve the distinctions above.
+enums, but it must preserve the distinctions above. The two `ref struct` views
+illustrate the required phase distinction and non-retention boundary; the
+artifact owner owns their construction and may expose an equivalent scoped
+callback shape.
 
 `ArtifactAssemblyProjection` is immutable, content-free, and bound to one
 in-process artifact generation. It is not a durable or serializable identity.
-`Generation` must be the same owner-issued object exposed by
-`ArtifactRegistration.Generation`.
-`AssemblyRegistration.ArtifactRegistration` must be the exact
-`ArtifactRegistration` object, and `AssemblyRegistration.ModuleVersionId` must
-already equal the non-empty `ModuleVersionId` when the outcome is returned.
-The assembly registration is therefore bound once during admission. Later
-query validation compares identity and MVID; it does not call a bind operation
-or mutate the projection.
+`Registration.Generation` must be the same owner-issued object exposed by
+`Registration.Artifact.Generation`. `Registration.Artifact` must be the exact
+`ArtifactIdentity` from the selected
+`ArtifactAcquisitionRegistration.Artifact`, compared by reference identity.
+The artifact owner retains the complete acquisition registration and its
+provenance; neither crosses this boundary.
+
+`AssemblyProjectionRegistration` is the content-free assembly registration for
+this path. Its non-empty MVID is bound when the admission outcome is returned.
+The existing `AssemblyAcquisitionRegistration`, including its public
+`ArtifactRegistration` compatibility property and mutable internal bind
+operation, does not appear inside the projection. Later query validation
+compares identity and MVID; it does not mutate or replace the projection
+registration.
 
 The successful output exposes none of the following, directly or through a
 nested public value:
@@ -311,14 +381,15 @@ nested public value:
 - `Stream`, `Func<Stream>`, or another content opener;
 - immutable or mutable content bytes;
 - `ArtifactContentReference` or retained-content handle;
+- `ArtifactAcquisitionRegistration` or source provenance;
 - `ArtifactAdmissionLease` or `ArtifactQueryLease`; or
 - an operation that can reacquire, reopen, or reconstruct any of those values.
 
-The exact artifact registration is required even though it indirectly carries
-source-specific provenance. It is correspondence evidence minted by the
-artifact owner, not a source interpretation performed by Metadata. Consumers
-may retain the registration and generation to join owner-issued workspace
-facts, but only the artifact owner can turn current authorization into another
+The exact artifact identity is correspondence evidence minted with the full
+artifact acquisition registration, not a source interpretation performed by
+Metadata. Consumers may retain that opaque identity and generation to join
+owner-issued workspace facts, but only the artifact owner retains the mapping
+to acquisition provenance or can turn current authorization into another
 content callback.
 
 ##### Admission classification
@@ -340,48 +411,66 @@ projection. Whether a non-assembly artifact is allowed to remain in a broader
 artifact catalog belongs to that catalog's owner. It cannot enter an
 `AssemblyContextGroup` through this contract.
 
-The projector receives the exact artifact registration selected by the
-artifact owner. It does not accept a caller-reconstructed registration,
-generation, identity, or MVID. The context realizer owns the frozen map from
-selected artifact registrations to successful projections and the atomic
-decision to publish a complete group; this component neither assigns workspace
-roles nor constructs the group.
+The projector receives an artifact-owner-attested admission view. The
+`Artifact` value is the exact identity carried by the selected acquisition
+registration; it is not caller-reconstructed from ordinal, generation, path,
+provenance, or display data. The context realizer owns the frozen map from
+selected artifact identities to successful projections and the atomic decision
+to publish a complete group; this component neither assigns workspace roles
+nor constructs the group.
 
 ##### Query-time revalidation
 
 The later query path starts from a published
 `ArtifactAssemblyProjection`. Under current query authorization, the artifact
-owner locates the exact retained artifact registration and lends its immutable
-bytes for one operation. Before any producer observes assembly evidence, the
-assembly query validates all of:
+owner locates the exact retained acquisition registration and supplies an
+owner-attested `ArtifactAssemblyQueryView` for one operation. Registration and
+generation are not decoded from PE bytes: they come from this scoped owner
+view. Before any producer observes assembly evidence, the assembly query
+validates all of:
 
-1. the content callback belongs to the projection's artifact generation;
-2. its artifact registration is the exact registered artifact;
+1. the view's generation is the projection registration's exact generation;
+2. its artifact identity is the projection registration's exact artifact;
 3. the retained image is still a managed assembly;
 4. its assembly identity equals the projected identity; and
-5. its non-empty MVID equals the projected MVID.
+5. its non-empty MVID equals the projection registration's MVID.
 
-A generation, registration, identity, or MVID mismatch is a typed rejection.
-Native, module, malformed, and empty-MVID replacements retain their distinct
-classification where that distinction is available. None is retried through a
-path, source adapter, descriptor opener, or new acquisition. The query returns
-the visible failure under its existing result contract and does not inspect or
-publish evidence from the mismatched bytes.
+Because an `ArtifactIdentity` is scoped to its owner-issued generation, exact
+artifact identity already entails generation equality. The explicit generation
+comparison runs first to classify a foreign-generation owner view as
+`GenerationMismatch`; it is not a second way to authenticate the artifact.
+
+A generation, artifact identity, assembly identity, or MVID mismatch is a
+typed `Rejected` outcome. Native and module replacements produce the query
+outcome's typed `NotAssembly` arm; malformed and empty-MVID replacements use
+their dedicated query failure kinds. None is retried through a path, source
+adapter, descriptor opener, or new acquisition.
+
+The `Validated<TResult>` value is produced inside the query view's callback.
+The assembly query opens an internal `AssemblyImage` or
+`AssemblyInspectionSession`, invokes the selected producer, and disposes all
+image-local state before returning `TResult` to the artifact owner. A validated
+marker cannot escape first and authorize a later unguarded open.
 
 The artifact owner remains responsible for rejecting a missing, foreign,
 revoked, disposed, or ended query authorization before lending content. The
-assembly query consumes that guarantee and performs the content-derived checks;
-it does not infer authorization from equal registrations or generations.
+outer query operation maps that rejection to `QueryUnauthorized`. The assembly
+query consumes the owner-attested generation and artifact identity and performs
+the content-derived checks; it does not infer owner state from PE bytes,
+ordinal equality, or display values.
 
 ##### Relationship to compatibility descriptors
 
 `ResolvedAssemblyReference` remains a compatibility descriptor for current
 path- and stream-based consumers. Implementing this design must not put an
 admission callback, query callback, retained-content handle, or lease into that
-descriptor. A query may adapt currently authorized bytes to an internal
-`AssemblyImage` or `AssemblyInspectionSession` for the duration of one
-operation, but the adapter cannot escape the artifact callback or recreate a
-parameterless opener.
+descriptor. The existing artifact-backed
+`AssemblyAcquisitionRegistration.ArtifactRegistration` property also remains a
+compatibility path and is intentionally absent from
+`AssemblyProjectionRegistration`. A query may adapt currently authorized bytes
+to an internal `AssemblyImage` or `AssemblyInspectionSession` for the duration
+of one operation, but the adapter cannot escape the artifact callback or
+recreate a parameterless opener.
 
 General removal of `ResolvedAssemblyReference.Path` and
 `ResolvedAssemblyReference.OpenRead` waits for their existing consumers to
@@ -395,31 +484,38 @@ The
 checks the bounded interaction among current admission authority, projection,
 publication, authority expiry, and later query revalidation. It verifies that
 successful projection requires current admission authority, published facts
-retain the exact registration but no content authority, and query validation
-requires current query authority plus exact generation, registration,
-identity, and MVID agreement. Mutation configurations independently show that
-stale admission, leaked authority, dropped registration, relaxed identity,
-MVID or generation checks, and revoked-query access violate those properties.
-The model does not establish implementation conformance.
+retain the exact opaque artifact identity but no content authority or
+provenance, and query validation requires current query authority plus exact
+generation, artifact identity, assembly identity, and MVID agreement. Mutation
+configurations independently show that stale admission, leaked authority,
+dropped artifact identity, relaxed artifact, assembly-identity, MVID, or
+revoked-query checks violate those properties; the positive model separately
+requires a foreign-generation view to produce `GenerationMismatch`. The model
+does not establish implementation conformance.
 
 ##### Required gates
 
 Implementation is complete only when Release tests equivalent to these exist:
 
-- `AdmissionProjection_BindsExactArtifactAndAssemblyRegistrationsIdentityAndMvid`
+- `AdmissionProjection_BindsExactArtifactIdentityAssemblyRegistrationIdentityAndMvid`
 - `AdmissionProjection_RejectsForeignRevokedDisposedOrEndedAuthority`
-- `AdmissionProjection_PublicSurfaceCarriesNoContentOrLeaseCapability`
+- `AdmissionProjection_PublicSurfaceCarriesNoProvenanceContentOrLeaseCapability`
 - `AdmissionProjection_ClassifiesNativeModuleMalformedAndEmptyMvid`
-- `QueryValidation_AcceptsExactRetainedImageWithoutRebinding`
-- `QueryValidation_RejectsRegistrationGenerationIdentityAndMvidMismatch`
-- `AdmissionProjection_ExactArtifactRegistrationIsNonVacuous`
+- `QueryValidation_ConsumesOwnerAttestedArtifactIdentityAndGeneration`
+- `QueryValidation_AcceptsExactRetainedImageInsideCallbackWithoutRebinding`
+- `QueryValidation_ClassifiesNativeModuleMalformedAndEmptyMvid`
+- `QueryValidation_RejectsArtifactGenerationAssemblyIdentityAndMvidMismatch`
+- `AdmissionProjection_ExactArtifactIdentityIsNonVacuous`
 
 The first gate uses the existing artifact-backed fixture from #4954/#4957 and
-requires the same artifact registration, assembly identity, and non-empty MVID.
+requires the same `ArtifactAcquisitionRegistration.Artifact` object, assembly
+identity, and non-empty MVID while proving the full acquisition registration
+remains artifact-owner-private.
 The public-surface gate recursively inspects nested public types for paths,
-content, openers, content references, and leases. The non-vacuity gate removes
-the exact artifact registration from an otherwise valid projection and must
-fail before publication.
+source provenance, content, openers, content references, and leases. The
+non-vacuity gate substitutes a different owner-issued artifact identity from
+the same generation in an otherwise valid query view and must fail before
+producer execution.
 
 ##### Non-goals
 

--- a/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
+++ b/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
@@ -1,0 +1,418 @@
+------------------- MODULE AdmissionAssemblyProjection -------------------
+(***************************************************************************)
+(* Target admission-scoped artifact-to-assembly projection for             *)
+(* docs/design/assembly-inspection-query.md.                                *)
+(*                                                                         *)
+(* The artifact owner validates admission or query authority and lends one  *)
+(* immutable image for a callback. The assembly-query owner classifies the  *)
+(* admission image into content-free facts and later validates query bytes  *)
+(* against those frozen facts. It never retains a path, opener, stream,     *)
+(* content reference, lease, or bytes.                                      *)
+(*                                                                         *)
+(* Images A-D are managed assemblies. B keeps A's identity but changes the  *)
+(* MVID; C keeps A's MVID but changes identity; D keeps both but belongs to  *)
+(* another artifact generation and registration. The remaining images      *)
+(* exercise native, netmodule, malformed, and empty-MVID classification.    *)
+(*                                                                         *)
+(* Mutation constants independently weaken the authority, output, or        *)
+(* validation rules. Witness variables latch the pre-state condition at the *)
+(* action that depends on it, so a mutation cannot make its own property    *)
+(* vacuously true by changing later state.                                  *)
+(***************************************************************************)
+EXTENDS FiniteSets, TLC
+
+CONSTANTS
+    AllowStaleAdmission,
+    LeakContentAuthority,
+    DropArtifactRegistration,
+    AcceptIdentityMismatch,
+    AcceptMvidMismatch,
+    AcceptGenerationMismatch,
+    AllowRevokedQuery
+
+ASSUME
+    /\ AllowStaleAdmission \in BOOLEAN
+    /\ LeakContentAuthority \in BOOLEAN
+    /\ DropArtifactRegistration \in BOOLEAN
+    /\ AcceptIdentityMismatch \in BOOLEAN
+    /\ AcceptMvidMismatch \in BOOLEAN
+    /\ AcceptGenerationMismatch \in BOOLEAN
+    /\ AllowRevokedQuery \in BOOLEAN
+
+NoImage == "NoImage"
+NoValue == "NoValue"
+
+ManagedAssemblies == {"A", "B", "C", "D"}
+Images ==
+    ManagedAssemblies
+        \union {"Native", "Module", "Malformed", "EmptyMvid"}
+
+ImageKind(image) ==
+    CASE image \in ManagedAssemblies -> "Assembly"
+      [] image = "Native" -> "Native"
+      [] image = "Module" -> "Module"
+      [] image = "Malformed" -> "Malformed"
+      [] image = "EmptyMvid" -> "EmptyMvid"
+
+ImageIdentity(image) ==
+    CASE image \in {"A", "B", "D", "EmptyMvid"} -> "Identity1"
+      [] image = "C" -> "Identity2"
+      [] OTHER -> NoValue
+
+ImageMvid(image) ==
+    CASE image \in {"A", "C", "D"} -> "Mvid1"
+      [] image = "B" -> "Mvid2"
+      [] OTHER -> NoValue
+
+ImageGeneration(image) ==
+    IF image = "D" THEN "Generation2" ELSE "Generation1"
+
+ImageRegistration(image) ==
+    IF image = "D" THEN "ArtifactRegistration2"
+    ELSE "ArtifactRegistration1"
+
+VARIABLES
+    admissionAuthority,
+    projectionState,
+    projectionReason,
+    projectionImage,
+    projectionGeneration,
+    projectionRegistration,
+    projectionIdentity,
+    projectionMvid,
+    projectionCarriesAuthority,
+    published,
+    queryAuthority,
+    queryState,
+    queryImage,
+    admissionAuthorityWitness,
+    contentFreeWitness,
+    exactRegistrationWitness,
+    publicationWitness,
+    queryAuthorityWitness,
+    queryMatchWitness,
+    matchingRoundTripReached,
+    mismatchRejectionReached
+
+vars == <<
+    admissionAuthority,
+    projectionState,
+    projectionReason,
+    projectionImage,
+    projectionGeneration,
+    projectionRegistration,
+    projectionIdentity,
+    projectionMvid,
+    projectionCarriesAuthority,
+    published,
+    queryAuthority,
+    queryState,
+    queryImage,
+    admissionAuthorityWitness,
+    contentFreeWitness,
+    exactRegistrationWitness,
+    publicationWitness,
+    queryAuthorityWitness,
+    queryMatchWitness,
+    matchingRoundTripReached,
+    mismatchRejectionReached
+    >>
+
+ProjectionStates == {"None", "Projected", "NotAssembly", "Rejected"}
+ProjectionReasons ==
+    {"None", "NativeImage", "ManagedModule", "MalformedMetadata",
+     "EmptyModuleVersionId"}
+QueryStates == {"None", "Validated", "Rejected"}
+
+ExactQueryMatch(image) ==
+    /\ image \in ManagedAssemblies
+    /\ ImageGeneration(image) = projectionGeneration
+    /\ ImageRegistration(image) = projectionRegistration
+    /\ ImageIdentity(image) = projectionIdentity
+    /\ ImageMvid(image) = projectionMvid
+
+AcceptedQueryMatch(image) ==
+    /\ image \in ManagedAssemblies
+    /\ (AcceptGenerationMismatch
+        \/ ImageGeneration(image) = projectionGeneration)
+    /\ (AcceptGenerationMismatch
+        \/ ImageRegistration(image) = projectionRegistration)
+    /\ (AcceptIdentityMismatch
+        \/ ImageIdentity(image) = projectionIdentity)
+    /\ (AcceptMvidMismatch
+        \/ ImageMvid(image) = projectionMvid)
+
+TypeOK ==
+    /\ admissionAuthority \in {"Current", "Revoked", "Ended"}
+    /\ projectionState \in ProjectionStates
+    /\ projectionReason \in ProjectionReasons
+    /\ projectionImage \in Images \union {NoImage}
+    /\ projectionGeneration
+        \in {"Generation1", "Generation2", NoValue}
+    /\ projectionRegistration
+        \in {"ArtifactRegistration1", "ArtifactRegistration2", NoValue}
+    /\ projectionIdentity \in {"Identity1", "Identity2", NoValue}
+    /\ projectionMvid \in {"Mvid1", "Mvid2", NoValue}
+    /\ projectionCarriesAuthority \in BOOLEAN
+    /\ published \in BOOLEAN
+    /\ queryAuthority \in {"None", "Current", "Revoked"}
+    /\ queryState \in QueryStates
+    /\ queryImage \in Images \union {NoImage}
+    /\ admissionAuthorityWitness \in BOOLEAN
+    /\ contentFreeWitness \in BOOLEAN
+    /\ exactRegistrationWitness \in BOOLEAN
+    /\ publicationWitness \in BOOLEAN
+    /\ queryAuthorityWitness \in BOOLEAN
+    /\ queryMatchWitness \in BOOLEAN
+    /\ matchingRoundTripReached \in BOOLEAN
+    /\ mismatchRejectionReached \in BOOLEAN
+
+Init ==
+    /\ admissionAuthority = "Current"
+    /\ projectionState = "None"
+    /\ projectionReason = "None"
+    /\ projectionImage = NoImage
+    /\ projectionGeneration = NoValue
+    /\ projectionRegistration = NoValue
+    /\ projectionIdentity = NoValue
+    /\ projectionMvid = NoValue
+    /\ projectionCarriesAuthority = FALSE
+    /\ published = FALSE
+    /\ queryAuthority = "None"
+    /\ queryState = "None"
+    /\ queryImage = NoImage
+    /\ admissionAuthorityWitness = TRUE
+    /\ contentFreeWitness = TRUE
+    /\ exactRegistrationWitness = TRUE
+    /\ publicationWitness = TRUE
+    /\ queryAuthorityWitness = TRUE
+    /\ queryMatchWitness = TRUE
+    /\ matchingRoundTripReached = FALSE
+    /\ mismatchRejectionReached = FALSE
+
+RevokeAdmission ==
+    /\ admissionAuthority = "Current"
+    /\ admissionAuthority' = "Revoked"
+    /\ UNCHANGED <<
+        projectionState, projectionReason, projectionImage,
+        projectionGeneration,
+        projectionRegistration, projectionIdentity, projectionMvid,
+        projectionCarriesAuthority, published, queryAuthority, queryState,
+        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, publicationWitness,
+        queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+EndGeneration ==
+    /\ admissionAuthority # "Ended"
+    /\ admissionAuthority' = "Ended"
+    /\ queryAuthority' =
+        IF queryAuthority = "Current" THEN "Revoked" ELSE queryAuthority
+    /\ UNCHANGED <<
+        projectionState, projectionReason, projectionImage,
+        projectionGeneration,
+        projectionRegistration, projectionIdentity, projectionMvid,
+        projectionCarriesAuthority, published, queryState, queryImage,
+        admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, publicationWitness,
+        queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+Project(image) ==
+    /\ image \in Images
+    /\ image # "D"
+    /\ projectionState = "None"
+    /\ IF AllowStaleAdmission
+        THEN admissionAuthority \in {"Current", "Revoked", "Ended"}
+        ELSE admissionAuthority = "Current"
+    /\ projectionImage' = image
+    /\ admissionAuthorityWitness' =
+        (admissionAuthorityWitness /\ admissionAuthority = "Current")
+    /\ CASE ImageKind(image) = "Assembly" ->
+            /\ projectionState' = "Projected"
+            /\ projectionReason' = "None"
+            /\ projectionGeneration' = ImageGeneration(image)
+            /\ projectionRegistration' =
+                IF DropArtifactRegistration
+                    THEN NoValue
+                    ELSE ImageRegistration(image)
+            /\ projectionIdentity' = ImageIdentity(image)
+            /\ projectionMvid' = ImageMvid(image)
+            /\ projectionCarriesAuthority' = LeakContentAuthority
+            /\ contentFreeWitness' =
+                (contentFreeWitness /\ ~LeakContentAuthority)
+            /\ exactRegistrationWitness' =
+                (exactRegistrationWitness
+                    /\ ~DropArtifactRegistration)
+        [] ImageKind(image) \in {"Native", "Module"} ->
+            /\ projectionState' = "NotAssembly"
+            /\ projectionReason' =
+                IF image = "Native"
+                    THEN "NativeImage"
+                    ELSE "ManagedModule"
+            /\ projectionGeneration' = NoValue
+            /\ projectionRegistration' = NoValue
+            /\ projectionIdentity' = NoValue
+            /\ projectionMvid' = NoValue
+            /\ projectionCarriesAuthority' = FALSE
+            /\ contentFreeWitness' = contentFreeWitness
+            /\ exactRegistrationWitness' = exactRegistrationWitness
+        [] OTHER ->
+            /\ projectionState' = "Rejected"
+            /\ projectionReason' =
+                IF image = "Malformed"
+                    THEN "MalformedMetadata"
+                    ELSE "EmptyModuleVersionId"
+            /\ projectionGeneration' = NoValue
+            /\ projectionRegistration' = NoValue
+            /\ projectionIdentity' = NoValue
+            /\ projectionMvid' = NoValue
+            /\ projectionCarriesAuthority' = FALSE
+            /\ contentFreeWitness' = contentFreeWitness
+            /\ exactRegistrationWitness' = exactRegistrationWitness
+    /\ UNCHANGED <<
+        admissionAuthority, published, queryAuthority, queryState, queryImage,
+        publicationWitness, queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+Publish ==
+    /\ admissionAuthority = "Current"
+    /\ projectionState = "Projected"
+    /\ ~published
+    /\ published' = TRUE
+    /\ admissionAuthority' = "Revoked"
+    /\ publicationWitness' =
+        (publicationWitness
+            /\ projectionRegistration # NoValue
+            /\ projectionRegistration
+                = ImageRegistration(projectionImage)
+            /\ projectionGeneration
+                = ImageGeneration(projectionImage)
+            /\ projectionIdentity = ImageIdentity(projectionImage)
+            /\ projectionMvid = ImageMvid(projectionImage))
+    /\ UNCHANGED <<
+        projectionState, projectionReason, projectionImage,
+        projectionGeneration,
+        projectionRegistration, projectionIdentity, projectionMvid,
+        projectionCarriesAuthority, queryAuthority, queryState, queryImage,
+        admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+AuthorizeQuery ==
+    /\ published
+    /\ admissionAuthority = "Revoked"
+    /\ queryAuthority = "None"
+    /\ queryAuthority' = "Current"
+    /\ UNCHANGED <<
+        admissionAuthority, projectionState, projectionReason,
+        projectionImage,
+        projectionGeneration, projectionRegistration, projectionIdentity,
+        projectionMvid, projectionCarriesAuthority, published, queryState,
+        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, publicationWitness,
+        queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+RevokeQuery ==
+    /\ queryAuthority = "Current"
+    /\ queryAuthority' = "Revoked"
+    /\ UNCHANGED <<
+        admissionAuthority, projectionState, projectionReason,
+        projectionImage,
+        projectionGeneration, projectionRegistration, projectionIdentity,
+        projectionMvid, projectionCarriesAuthority, published, queryState,
+        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, publicationWitness,
+        queryAuthorityWitness, queryMatchWitness,
+        matchingRoundTripReached, mismatchRejectionReached
+        >>
+
+ValidateQuery(image) ==
+    LET accepted == AcceptedQueryMatch(image)
+        exact == ExactQueryMatch(image)
+    IN
+    /\ image \in Images
+    /\ published
+    /\ queryState = "None"
+    /\ IF AllowRevokedQuery
+        THEN queryAuthority \in {"Current", "Revoked"}
+        ELSE queryAuthority = "Current"
+    /\ queryImage' = image
+    /\ queryState' = IF accepted THEN "Validated" ELSE "Rejected"
+    /\ queryAuthorityWitness' =
+        (queryAuthorityWitness /\ queryAuthority = "Current")
+    /\ queryMatchWitness' =
+        (queryMatchWitness /\ (~accepted \/ exact))
+    /\ matchingRoundTripReached' =
+        (matchingRoundTripReached \/ (accepted /\ exact))
+    /\ mismatchRejectionReached' =
+        (mismatchRejectionReached \/ (~accepted /\ ~exact))
+    /\ UNCHANGED <<
+        admissionAuthority, projectionState, projectionReason,
+        projectionImage,
+        projectionGeneration, projectionRegistration, projectionIdentity,
+        projectionMvid, projectionCarriesAuthority, published,
+        queryAuthority, admissionAuthorityWitness, contentFreeWitness,
+        exactRegistrationWitness, publicationWitness
+        >>
+
+Next ==
+    \/ RevokeAdmission
+    \/ EndGeneration
+    \/ \E image \in Images : Project(image)
+    \/ Publish
+    \/ AuthorizeQuery
+    \/ RevokeQuery
+    \/ \E image \in Images : ValidateQuery(image)
+
+Spec == Init /\ [][Next]_vars
+
+ProjectionRequiresCurrentAdmission == admissionAuthorityWitness
+ProjectedFactsCarryNoAuthority == contentFreeWitness
+ProjectedRegistrationIsExact == exactRegistrationWitness
+PublicationCarriesExactFacts == publicationWitness
+QueryValidationRequiresCurrentAuthority == queryAuthorityWitness
+ValidatedImageMatchesProjection == queryMatchWitness
+
+OnlyManagedAssembliesProject ==
+    projectionState = "Projected"
+        => projectionImage \in ManagedAssemblies
+
+NonAssembliesHaveNoAssemblyFacts ==
+    projectionState \in {"NotAssembly", "Rejected"}
+        => /\ projectionGeneration = NoValue
+           /\ projectionRegistration = NoValue
+           /\ projectionIdentity = NoValue
+           /\ projectionMvid = NoValue
+           /\ ~projectionCarriesAuthority
+
+NonAssemblyAndRejectionKindsAreTyped ==
+    /\ (projectionImage = "Native"
+        => /\ projectionState = "NotAssembly"
+           /\ projectionReason = "NativeImage")
+    /\ (projectionImage = "Module"
+        => /\ projectionState = "NotAssembly"
+           /\ projectionReason = "ManagedModule")
+    /\ (projectionImage = "Malformed"
+        => /\ projectionState = "Rejected"
+           /\ projectionReason = "MalformedMetadata")
+    /\ (projectionImage = "EmptyMvid"
+        => /\ projectionState = "Rejected"
+           /\ projectionReason = "EmptyModuleVersionId")
+
+PublishedProjectionIsContentFree ==
+    published => ~projectionCarriesAuthority
+
+QueryStartsAfterPublication ==
+    queryState # "None" => published
+
+MatchingQueryRoundTripIsUnreachable == ~matchingRoundTripReached
+MismatchRejectionIsUnreachable == ~mismatchRejectionReached
+
+=============================================================================

--- a/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
+++ b/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
@@ -9,9 +9,10 @@
 (* against those frozen facts. It never retains a path, opener, stream,     *)
 (* content reference, lease, or bytes.                                      *)
 (*                                                                         *)
-(* Images A-D are managed assemblies. B keeps A's identity but changes the  *)
+(* Images A-E are managed assemblies. B keeps A's identity but changes the  *)
 (* MVID; C keeps A's MVID but changes identity; D keeps both but belongs to  *)
-(* another artifact generation and registration. The remaining images      *)
+(* a different artifact generation and identity; E keeps both and the       *)
+(* generation but reports a different artifact identity. The remaining      *)
 (* exercise native, netmodule, malformed, and empty-MVID classification.    *)
 (*                                                                         *)
 (* Mutation constants independently weaken the authority, output, or        *)
@@ -25,24 +26,24 @@ CONSTANTS
     AllowStaleAdmission,
     LeakContentAuthority,
     DropArtifactRegistration,
+    AcceptRegistrationMismatch,
     AcceptIdentityMismatch,
     AcceptMvidMismatch,
-    AcceptGenerationMismatch,
     AllowRevokedQuery
 
 ASSUME
     /\ AllowStaleAdmission \in BOOLEAN
     /\ LeakContentAuthority \in BOOLEAN
     /\ DropArtifactRegistration \in BOOLEAN
+    /\ AcceptRegistrationMismatch \in BOOLEAN
     /\ AcceptIdentityMismatch \in BOOLEAN
     /\ AcceptMvidMismatch \in BOOLEAN
-    /\ AcceptGenerationMismatch \in BOOLEAN
     /\ AllowRevokedQuery \in BOOLEAN
 
 NoImage == "NoImage"
 NoValue == "NoValue"
 
-ManagedAssemblies == {"A", "B", "C", "D"}
+ManagedAssemblies == {"A", "B", "C", "D", "E"}
 Images ==
     ManagedAssemblies
         \union {"Native", "Module", "Malformed", "EmptyMvid"}
@@ -55,12 +56,12 @@ ImageKind(image) ==
       [] image = "EmptyMvid" -> "EmptyMvid"
 
 ImageIdentity(image) ==
-    CASE image \in {"A", "B", "D", "EmptyMvid"} -> "Identity1"
+    CASE image \in {"A", "B", "D", "E", "EmptyMvid"} -> "Identity1"
       [] image = "C" -> "Identity2"
       [] OTHER -> NoValue
 
 ImageMvid(image) ==
-    CASE image \in {"A", "C", "D"} -> "Mvid1"
+    CASE image \in {"A", "C", "D", "E"} -> "Mvid1"
       [] image = "B" -> "Mvid2"
       [] OTHER -> NoValue
 
@@ -68,8 +69,9 @@ ImageGeneration(image) ==
     IF image = "D" THEN "Generation2" ELSE "Generation1"
 
 ImageRegistration(image) ==
-    IF image = "D" THEN "ArtifactRegistration2"
-    ELSE "ArtifactRegistration1"
+    CASE image = "D" -> "ArtifactRegistration3"
+      [] image = "E" -> "ArtifactRegistration2"
+      [] OTHER -> "ArtifactRegistration1"
 
 VARIABLES
     admissionAuthority,
@@ -84,6 +86,7 @@ VARIABLES
     published,
     queryAuthority,
     queryState,
+    queryReason,
     queryImage,
     admissionAuthorityWitness,
     contentFreeWitness,
@@ -107,6 +110,7 @@ vars == <<
     published,
     queryAuthority,
     queryState,
+    queryReason,
     queryImage,
     admissionAuthorityWitness,
     contentFreeWitness,
@@ -122,7 +126,12 @@ ProjectionStates == {"None", "Projected", "NotAssembly", "Rejected"}
 ProjectionReasons ==
     {"None", "NativeImage", "ManagedModule", "MalformedMetadata",
      "EmptyModuleVersionId"}
-QueryStates == {"None", "Validated", "Rejected"}
+QueryStates == {"None", "Validated", "NotAssembly", "Rejected"}
+QueryReasons ==
+    {"None", "NativeImage", "ManagedModule", "MalformedMetadata",
+     "EmptyModuleVersionId", "GenerationMismatch",
+     "ArtifactIdentityMismatch", "AssemblyIdentityMismatch",
+     "ModuleVersionIdMismatch"}
 
 ExactQueryMatch(image) ==
     /\ image \in ManagedAssemblies
@@ -133,9 +142,8 @@ ExactQueryMatch(image) ==
 
 AcceptedQueryMatch(image) ==
     /\ image \in ManagedAssemblies
-    /\ (AcceptGenerationMismatch
-        \/ ImageGeneration(image) = projectionGeneration)
-    /\ (AcceptGenerationMismatch
+    /\ ImageGeneration(image) = projectionGeneration
+    /\ (AcceptRegistrationMismatch
         \/ ImageRegistration(image) = projectionRegistration)
     /\ (AcceptIdentityMismatch
         \/ ImageIdentity(image) = projectionIdentity)
@@ -150,13 +158,15 @@ TypeOK ==
     /\ projectionGeneration
         \in {"Generation1", "Generation2", NoValue}
     /\ projectionRegistration
-        \in {"ArtifactRegistration1", "ArtifactRegistration2", NoValue}
+        \in {"ArtifactRegistration1", "ArtifactRegistration2",
+            "ArtifactRegistration3", NoValue}
     /\ projectionIdentity \in {"Identity1", "Identity2", NoValue}
     /\ projectionMvid \in {"Mvid1", "Mvid2", NoValue}
     /\ projectionCarriesAuthority \in BOOLEAN
     /\ published \in BOOLEAN
     /\ queryAuthority \in {"None", "Current", "Revoked"}
     /\ queryState \in QueryStates
+    /\ queryReason \in QueryReasons
     /\ queryImage \in Images \union {NoImage}
     /\ admissionAuthorityWitness \in BOOLEAN
     /\ contentFreeWitness \in BOOLEAN
@@ -180,6 +190,7 @@ Init ==
     /\ published = FALSE
     /\ queryAuthority = "None"
     /\ queryState = "None"
+    /\ queryReason = "None"
     /\ queryImage = NoImage
     /\ admissionAuthorityWitness = TRUE
     /\ contentFreeWitness = TRUE
@@ -198,7 +209,7 @@ RevokeAdmission ==
         projectionGeneration,
         projectionRegistration, projectionIdentity, projectionMvid,
         projectionCarriesAuthority, published, queryAuthority, queryState,
-        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        queryReason, queryImage, admissionAuthorityWitness, contentFreeWitness,
         exactRegistrationWitness, publicationWitness,
         queryAuthorityWitness, queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
@@ -213,8 +224,8 @@ EndGeneration ==
         projectionState, projectionReason, projectionImage,
         projectionGeneration,
         projectionRegistration, projectionIdentity, projectionMvid,
-        projectionCarriesAuthority, published, queryState, queryImage,
-        admissionAuthorityWitness, contentFreeWitness,
+        projectionCarriesAuthority, published, queryState, queryReason,
+        queryImage, admissionAuthorityWitness, contentFreeWitness,
         exactRegistrationWitness, publicationWitness,
         queryAuthorityWitness, queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
@@ -222,7 +233,7 @@ EndGeneration ==
 
 Project(image) ==
     /\ image \in Images
-    /\ image # "D"
+    /\ image \notin {"B", "C", "D", "E"}
     /\ projectionState = "None"
     /\ IF AllowStaleAdmission
         THEN admissionAuthority \in {"Current", "Revoked", "Ended"}
@@ -273,8 +284,9 @@ Project(image) ==
             /\ contentFreeWitness' = contentFreeWitness
             /\ exactRegistrationWitness' = exactRegistrationWitness
     /\ UNCHANGED <<
-        admissionAuthority, published, queryAuthority, queryState, queryImage,
-        publicationWitness, queryAuthorityWitness, queryMatchWitness,
+        admissionAuthority, published, queryAuthority, queryState, queryReason,
+        queryImage, publicationWitness, queryAuthorityWitness,
+        queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
         >>
 
@@ -297,8 +309,8 @@ Publish ==
         projectionState, projectionReason, projectionImage,
         projectionGeneration,
         projectionRegistration, projectionIdentity, projectionMvid,
-        projectionCarriesAuthority, queryAuthority, queryState, queryImage,
-        admissionAuthorityWitness, contentFreeWitness,
+        projectionCarriesAuthority, queryAuthority, queryState, queryReason,
+        queryImage, admissionAuthorityWitness, contentFreeWitness,
         exactRegistrationWitness, queryAuthorityWitness, queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
         >>
@@ -313,7 +325,7 @@ AuthorizeQuery ==
         projectionImage,
         projectionGeneration, projectionRegistration, projectionIdentity,
         projectionMvid, projectionCarriesAuthority, published, queryState,
-        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        queryReason, queryImage, admissionAuthorityWitness, contentFreeWitness,
         exactRegistrationWitness, publicationWitness,
         queryAuthorityWitness, queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
@@ -327,15 +339,36 @@ RevokeQuery ==
         projectionImage,
         projectionGeneration, projectionRegistration, projectionIdentity,
         projectionMvid, projectionCarriesAuthority, published, queryState,
-        queryImage, admissionAuthorityWitness, contentFreeWitness,
+        queryReason, queryImage, admissionAuthorityWitness, contentFreeWitness,
         exactRegistrationWitness, publicationWitness,
         queryAuthorityWitness, queryMatchWitness,
         matchingRoundTripReached, mismatchRejectionReached
         >>
 
 ValidateQuery(image) ==
-    LET accepted == AcceptedQueryMatch(image)
+    LET kind == ImageKind(image)
+        accepted == AcceptedQueryMatch(image)
         exact == ExactQueryMatch(image)
+        outcome ==
+            IF kind \in {"Native", "Module"}
+                THEN "NotAssembly"
+            ELSE IF accepted
+                THEN "Validated"
+                ELSE "Rejected"
+        reason ==
+            CASE kind = "Native" -> "NativeImage"
+              [] kind = "Module" -> "ManagedModule"
+              [] kind = "Malformed" -> "MalformedMetadata"
+              [] kind = "EmptyMvid" -> "EmptyModuleVersionId"
+              [] ImageGeneration(image) # projectionGeneration ->
+                    "GenerationMismatch"
+              [] ImageRegistration(image) # projectionRegistration ->
+                    "ArtifactIdentityMismatch"
+              [] ImageIdentity(image) # projectionIdentity ->
+                    "AssemblyIdentityMismatch"
+              [] ImageMvid(image) # projectionMvid ->
+                    "ModuleVersionIdMismatch"
+              [] OTHER -> "None"
     IN
     /\ image \in Images
     /\ published
@@ -344,7 +377,8 @@ ValidateQuery(image) ==
         THEN queryAuthority \in {"Current", "Revoked"}
         ELSE queryAuthority = "Current"
     /\ queryImage' = image
-    /\ queryState' = IF accepted THEN "Validated" ELSE "Rejected"
+    /\ queryState' = outcome
+    /\ queryReason' = reason
     /\ queryAuthorityWitness' =
         (queryAuthorityWitness /\ queryAuthority = "Current")
     /\ queryMatchWitness' =
@@ -352,7 +386,8 @@ ValidateQuery(image) ==
     /\ matchingRoundTripReached' =
         (matchingRoundTripReached \/ (accepted /\ exact))
     /\ mismatchRejectionReached' =
-        (mismatchRejectionReached \/ (~accepted /\ ~exact))
+        (mismatchRejectionReached
+            \/ (outcome \in {"NotAssembly", "Rejected"} /\ ~exact))
     /\ UNCHANGED <<
         admissionAuthority, projectionState, projectionReason,
         projectionImage,
@@ -411,6 +446,31 @@ PublishedProjectionIsContentFree ==
 
 QueryStartsAfterPublication ==
     queryState # "None" => published
+
+QueryOutcomesAreTyped ==
+    /\ (queryState = "None" => queryReason = "None")
+    /\ (queryState = "Validated" => queryReason = "None")
+    /\ (queryState = "NotAssembly"
+        => queryReason \in {"NativeImage", "ManagedModule"})
+    /\ (queryState = "Rejected"
+        => queryReason
+            \in {"MalformedMetadata", "EmptyModuleVersionId",
+                "GenerationMismatch", "ArtifactIdentityMismatch",
+                "AssemblyIdentityMismatch", "ModuleVersionIdMismatch"})
+
+QueryMismatchReasonsAreExact ==
+    /\ (queryImage = "B"
+        => /\ queryState = "Rejected"
+           /\ queryReason = "ModuleVersionIdMismatch")
+    /\ (queryImage = "C"
+        => /\ queryState = "Rejected"
+           /\ queryReason = "AssemblyIdentityMismatch")
+    /\ (queryImage = "D"
+        => /\ queryState = "Rejected"
+           /\ queryReason = "GenerationMismatch")
+    /\ (queryImage = "E"
+        => /\ queryState = "Rejected"
+           /\ queryReason = "ArtifactIdentityMismatch")
 
 MatchingQueryRoundTripIsUnreachable == ~matchingRoundTripReached
 MismatchRejectionIsUnreachable == ~mismatchRejectionReached

--- a/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
+++ b/docs/design/models/admission-assembly-projection/AdmissionAssemblyProjection.tla
@@ -13,7 +13,8 @@
 (* MVID; C keeps A's MVID but changes identity; D keeps both but belongs to  *)
 (* a different artifact generation and identity; E keeps both and the       *)
 (* generation but reports a different artifact identity. The remaining      *)
-(* exercise native, netmodule, malformed, and empty-MVID classification.    *)
+(* exercise native, netmodule, unsupported Windows Metadata, malformed, and *)
+(* empty-MVID classification.                                               *)
 (*                                                                         *)
 (* Mutation constants independently weaken the authority, output, or        *)
 (* validation rules. Witness variables latch the pre-state condition at the *)
@@ -29,7 +30,9 @@ CONSTANTS
     AcceptRegistrationMismatch,
     AcceptIdentityMismatch,
     AcceptMvidMismatch,
-    AllowRevokedQuery
+    AllowRevokedQuery,
+    MisclassifyUnsupportedAdmission,
+    MisclassifyUnsupportedQuery
 
 ASSUME
     /\ AllowStaleAdmission \in BOOLEAN
@@ -39,6 +42,8 @@ ASSUME
     /\ AcceptIdentityMismatch \in BOOLEAN
     /\ AcceptMvidMismatch \in BOOLEAN
     /\ AllowRevokedQuery \in BOOLEAN
+    /\ MisclassifyUnsupportedAdmission \in BOOLEAN
+    /\ MisclassifyUnsupportedQuery \in BOOLEAN
 
 NoImage == "NoImage"
 NoValue == "NoValue"
@@ -46,22 +51,24 @@ NoValue == "NoValue"
 ManagedAssemblies == {"A", "B", "C", "D", "E"}
 Images ==
     ManagedAssemblies
-        \union {"Native", "Module", "Malformed", "EmptyMvid"}
+        \union {"Native", "Module", "WindowsMetadata", "Malformed", "EmptyMvid"}
 
 ImageKind(image) ==
     CASE image \in ManagedAssemblies -> "Assembly"
       [] image = "Native" -> "Native"
       [] image = "Module" -> "Module"
+      [] image = "WindowsMetadata" -> "Unsupported"
       [] image = "Malformed" -> "Malformed"
       [] image = "EmptyMvid" -> "EmptyMvid"
 
 ImageIdentity(image) ==
-    CASE image \in {"A", "B", "D", "E", "EmptyMvid"} -> "Identity1"
+    CASE image \in {"A", "B", "D", "E", "WindowsMetadata", "EmptyMvid"}
+        -> "Identity1"
       [] image = "C" -> "Identity2"
       [] OTHER -> NoValue
 
 ImageMvid(image) ==
-    CASE image \in {"A", "C", "D", "E"} -> "Mvid1"
+    CASE image \in {"A", "C", "D", "E", "WindowsMetadata"} -> "Mvid1"
       [] image = "B" -> "Mvid2"
       [] OTHER -> NoValue
 
@@ -124,12 +131,12 @@ vars == <<
 
 ProjectionStates == {"None", "Projected", "NotAssembly", "Rejected"}
 ProjectionReasons ==
-    {"None", "NativeImage", "ManagedModule", "MalformedMetadata",
-     "EmptyModuleVersionId"}
+    {"None", "NativeImage", "ManagedModule", "UnsupportedWindowsMetadata",
+     "MalformedMetadata", "EmptyModuleVersionId"}
 QueryStates == {"None", "Validated", "NotAssembly", "Rejected"}
 QueryReasons ==
-    {"None", "NativeImage", "ManagedModule", "MalformedMetadata",
-     "EmptyModuleVersionId", "GenerationMismatch",
+    {"None", "NativeImage", "ManagedModule", "UnsupportedWindowsMetadata",
+     "MalformedMetadata", "EmptyModuleVersionId", "GenerationMismatch",
      "ArtifactIdentityMismatch", "AssemblyIdentityMismatch",
      "ModuleVersionIdMismatch"}
 
@@ -141,7 +148,8 @@ ExactQueryMatch(image) ==
     /\ ImageMvid(image) = projectionMvid
 
 AcceptedQueryMatch(image) ==
-    /\ image \in ManagedAssemblies
+    /\ (image \in ManagedAssemblies
+        \/ (MisclassifyUnsupportedQuery /\ image = "WindowsMetadata"))
     /\ ImageGeneration(image) = projectionGeneration
     /\ (AcceptRegistrationMismatch
         \/ ImageRegistration(image) = projectionRegistration)
@@ -241,7 +249,9 @@ Project(image) ==
     /\ projectionImage' = image
     /\ admissionAuthorityWitness' =
         (admissionAuthorityWitness /\ admissionAuthority = "Current")
-    /\ CASE ImageKind(image) = "Assembly" ->
+    /\ CASE ImageKind(image) = "Assembly"
+            \/ (MisclassifyUnsupportedAdmission
+                /\ image = "WindowsMetadata") ->
             /\ projectionState' = "Projected"
             /\ projectionReason' = "None"
             /\ projectionGeneration' = ImageGeneration(image)
@@ -263,6 +273,16 @@ Project(image) ==
                 IF image = "Native"
                     THEN "NativeImage"
                     ELSE "ManagedModule"
+            /\ projectionGeneration' = NoValue
+            /\ projectionRegistration' = NoValue
+            /\ projectionIdentity' = NoValue
+            /\ projectionMvid' = NoValue
+            /\ projectionCarriesAuthority' = FALSE
+            /\ contentFreeWitness' = contentFreeWitness
+            /\ exactRegistrationWitness' = exactRegistrationWitness
+        [] ImageKind(image) = "Unsupported" ->
+            /\ projectionState' = "Rejected"
+            /\ projectionReason' = "UnsupportedWindowsMetadata"
             /\ projectionGeneration' = NoValue
             /\ projectionRegistration' = NoValue
             /\ projectionIdentity' = NoValue
@@ -350,7 +370,9 @@ ValidateQuery(image) ==
         accepted == AcceptedQueryMatch(image)
         exact == ExactQueryMatch(image)
         outcome ==
-            IF kind \in {"Native", "Module"}
+            IF kind = "Unsupported" /\ ~MisclassifyUnsupportedQuery
+                THEN "Rejected"
+            ELSE IF kind \in {"Native", "Module"}
                 THEN "NotAssembly"
             ELSE IF accepted
                 THEN "Validated"
@@ -358,6 +380,8 @@ ValidateQuery(image) ==
         reason ==
             CASE kind = "Native" -> "NativeImage"
               [] kind = "Module" -> "ManagedModule"
+              [] kind = "Unsupported" /\ ~MisclassifyUnsupportedQuery ->
+                    "UnsupportedWindowsMetadata"
               [] kind = "Malformed" -> "MalformedMetadata"
               [] kind = "EmptyMvid" -> "EmptyModuleVersionId"
               [] ImageGeneration(image) # projectionGeneration ->
@@ -415,7 +439,7 @@ PublicationCarriesExactFacts == publicationWitness
 QueryValidationRequiresCurrentAuthority == queryAuthorityWitness
 ValidatedImageMatchesProjection == queryMatchWitness
 
-OnlyManagedAssembliesProject ==
+OnlySupportedAssembliesProject ==
     projectionState = "Projected"
         => projectionImage \in ManagedAssemblies
 
@@ -434,6 +458,9 @@ NonAssemblyAndRejectionKindsAreTyped ==
     /\ (projectionImage = "Module"
         => /\ projectionState = "NotAssembly"
            /\ projectionReason = "ManagedModule")
+    /\ (projectionImage = "WindowsMetadata"
+        => /\ projectionState = "Rejected"
+           /\ projectionReason = "UnsupportedWindowsMetadata")
     /\ (projectionImage = "Malformed"
         => /\ projectionState = "Rejected"
            /\ projectionReason = "MalformedMetadata")
@@ -454,7 +481,8 @@ QueryOutcomesAreTyped ==
         => queryReason \in {"NativeImage", "ManagedModule"})
     /\ (queryState = "Rejected"
         => queryReason
-            \in {"MalformedMetadata", "EmptyModuleVersionId",
+            \in {"UnsupportedWindowsMetadata", "MalformedMetadata",
+                "EmptyModuleVersionId",
                 "GenerationMismatch", "ArtifactIdentityMismatch",
                 "AssemblyIdentityMismatch", "ModuleVersionIdMismatch"})
 
@@ -471,6 +499,11 @@ QueryMismatchReasonsAreExact ==
     /\ (queryImage = "E"
         => /\ queryState = "Rejected"
            /\ queryReason = "ArtifactIdentityMismatch")
+
+UnsupportedQueryIsRejected ==
+    queryImage = "WindowsMetadata"
+        => /\ queryState = "Rejected"
+           /\ queryReason = "UnsupportedWindowsMetadata"
 
 MatchingQueryRoundTripIsUnreachable == ~matchingRoundTripReached
 MismatchRejectionIsUnreachable == ~mismatchRejectionReached

--- a/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = TRUE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT ProjectedRegistrationIsExact

--- a/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT ProjectedRegistrationIsExact

--- a/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenDroppedRegistration.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = TRUE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ProjectedRegistrationIsExact

--- a/docs/design/models/admission-assembly-projection/BrokenGenerationValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenGenerationValidation.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = TRUE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = TRUE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = TRUE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenIdentityValidation.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = TRUE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenLeakedAuthority.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenLeakedAuthority.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = TRUE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT ProjectedFactsCarryNoAuthority

--- a/docs/design/models/admission-assembly-projection/BrokenLeakedAuthority.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenLeakedAuthority.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = TRUE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ProjectedFactsCarryNoAuthority

--- a/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = TRUE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = TRUE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenMvidValidation.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = TRUE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenRegistrationValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenRegistrationValidation.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenRegistrationValidation.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenRegistrationValidation.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = TRUE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = TRUE
     AllowRevokedQuery = FALSE
 
 INVARIANT ValidatedImageMatchesProjection

--- a/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = TRUE
+
+INVARIANT QueryValidationRequiresCurrentAuthority

--- a/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = TRUE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT QueryValidationRequiresCurrentAuthority

--- a/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenRevokedQuery.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = TRUE
 
 INVARIANT QueryValidationRequiresCurrentAuthority

--- a/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = TRUE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT ProjectionRequiresCurrentAdmission

--- a/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT ProjectionRequiresCurrentAdmission

--- a/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenStaleAdmission.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = TRUE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT ProjectionRequiresCurrentAdmission

--- a/docs/design/models/admission-assembly-projection/BrokenUnsupportedAdmission.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenUnsupportedAdmission.cfg
@@ -3,13 +3,13 @@ CHECK_DEADLOCK FALSE
 
 CONSTANTS
     AllowStaleAdmission = FALSE
-    LeakContentAuthority = TRUE
+    LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
     AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
-    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedAdmission = TRUE
     MisclassifyUnsupportedQuery = FALSE
 
-INVARIANT ProjectedFactsCarryNoAuthority
+INVARIANT OnlySupportedAssembliesProject

--- a/docs/design/models/admission-assembly-projection/BrokenUnsupportedQuery.cfg
+++ b/docs/design/models/admission-assembly-projection/BrokenUnsupportedQuery.cfg
@@ -3,13 +3,13 @@ CHECK_DEADLOCK FALSE
 
 CONSTANTS
     AllowStaleAdmission = FALSE
-    LeakContentAuthority = TRUE
+    LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
     AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
     MisclassifyUnsupportedAdmission = FALSE
-    MisclassifyUnsupportedQuery = FALSE
+    MisclassifyUnsupportedQuery = TRUE
 
-INVARIANT ProjectedFactsCarryNoAuthority
+INVARIANT UnsupportedQueryIsRejected

--- a/docs/design/models/admission-assembly-projection/README.md
+++ b/docs/design/models/admission-assembly-projection/README.md
@@ -22,20 +22,21 @@ assembly images separate the matching dimensions:
 - `E` has `A`'s generation, assembly identity, and MVID but a different
   artifact identity.
 
-Native, managed-module, malformed, and empty-MVID images exercise the
-typed query and admission non-participant outcomes. In the model,
-`projectionRegistration` is the opaque, provenance-free `ArtifactIdentity`
-minted with the owner-private acquisition registration; it is not the current
-public `ArtifactAcquisitionRegistration` value.
+Native, managed-module, unsupported Windows Metadata, malformed, and
+empty-MVID images exercise the typed query and admission non-participant
+outcomes. In the model, `projectionRegistration` is the opaque,
+provenance-free `ArtifactIdentity` minted with the owner-private acquisition
+registration; it is not the current public
+`ArtifactAcquisitionRegistration` value.
 
 The model checks:
 
 - projection requires current admission authority;
 - projected facts retain the exact opaque artifact identity;
 - projected and published facts carry no content authority;
-- only managed assemblies with non-empty MVIDs project;
-- native and module classifications and malformed or empty-MVID rejections
-  carry no assembly facts;
+- only supported ECMA-335 managed assemblies with non-empty MVIDs project;
+- native and module classifications and unsupported Windows Metadata,
+  malformed, or empty-MVID rejections carry no assembly facts;
 - publication uses the exact projected artifact identity, generation, assembly
   identity, and MVID;
 - query validation begins only after publication and requires current query
@@ -63,6 +64,8 @@ quiescence, and group disposal are independently modeled by
 | `BrokenIdentityValidation.cfg` | Accepting a different assembly identity violates `ValidatedImageMatchesProjection`. |
 | `BrokenMvidValidation.cfg` | Accepting a replacement MVID violates `ValidatedImageMatchesProjection`. |
 | `BrokenRevokedQuery.cfg` | Validation under revoked query authority violates `QueryValidationRequiresCurrentAuthority`. |
+| `BrokenUnsupportedAdmission.cfg` | Projecting unsupported Windows Metadata violates `OnlySupportedAssembliesProject`. |
+| `BrokenUnsupportedQuery.cfg` | Validating unsupported Windows Metadata violates `UnsupportedQueryIsRejected`. |
 
 ## Running TLC
 
@@ -79,7 +82,8 @@ for config in ReachabilityMatching ReachabilityMismatch; do
 done
 for config in BrokenStaleAdmission BrokenLeakedAuthority \
   BrokenDroppedRegistration BrokenRegistrationValidation \
-  BrokenIdentityValidation BrokenMvidValidation BrokenRevokedQuery; do
+  BrokenIdentityValidation BrokenMvidValidation BrokenRevokedQuery \
+  BrokenUnsupportedAdmission BrokenUnsupportedQuery; do
   java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
     -cleanup -noGenerateSpecTE -config "$config.cfg" \
     AdmissionAssemblyProjection.tla
@@ -98,16 +102,18 @@ prerelease (`TLC2 2026.08.21.155922`, rev `9787e65`). The checked
 
 | Configuration | Result | Generated states | Distinct states | Maximum depth |
 | --- | --- | ---: | ---: | ---: |
-| `Safety.cfg` | No error | 66 | 50 | 6 |
-| `ReachabilityMatching.cfg` | `MatchingQueryRoundTripIsUnreachable` violated | 30 | 24 | 5 |
-| `ReachabilityMismatch.cfg` | `MismatchRejectionIsUnreachable` violated | 31 | 25 | 5 |
-| `BrokenStaleAdmission.cfg` | `ProjectionRequiresCurrentAdmission` violated | 10 | 9 | 3 |
+| `Safety.cfg` | No error | 74 | 56 | 6 |
+| `ReachabilityMatching.cfg` | `MatchingQueryRoundTripIsUnreachable` violated | 34 | 27 | 5 |
+| `ReachabilityMismatch.cfg` | `MismatchRejectionIsUnreachable` violated | 35 | 28 | 5 |
+| `BrokenStaleAdmission.cfg` | `ProjectionRequiresCurrentAdmission` violated | 11 | 10 | 3 |
 | `BrokenLeakedAuthority.cfg` | `ProjectedFactsCarryNoAuthority` violated | 4 | 4 | 2 |
 | `BrokenDroppedRegistration.cfg` | `ProjectedRegistrationIsExact` violated | 4 | 4 | 2 |
-| `BrokenRegistrationValidation.cfg` | `ValidatedImageMatchesProjection` violated | 34 | 28 | 5 |
-| `BrokenIdentityValidation.cfg` | `ValidatedImageMatchesProjection` violated | 32 | 26 | 5 |
-| `BrokenMvidValidation.cfg` | `ValidatedImageMatchesProjection` violated | 31 | 25 | 5 |
-| `BrokenRevokedQuery.cfg` | `QueryValidationRequiresCurrentAuthority` violated | 39 | 33 | 6 |
+| `BrokenRegistrationValidation.cfg` | `ValidatedImageMatchesProjection` violated | 38 | 31 | 5 |
+| `BrokenIdentityValidation.cfg` | `ValidatedImageMatchesProjection` violated | 36 | 29 | 5 |
+| `BrokenMvidValidation.cfg` | `ValidatedImageMatchesProjection` violated | 35 | 28 | 5 |
+| `BrokenRevokedQuery.cfg` | `QueryValidationRequiresCurrentAuthority` violated | 44 | 37 | 6 |
+| `BrokenUnsupportedAdmission.cfg` | `OnlySupportedAssembliesProject` violated | 7 | 7 | 2 |
+| `BrokenUnsupportedQuery.cfg` | `UnsupportedQueryIsRejected` violated | 41 | 34 | 5 |
 
 The positive configuration explored its complete bounded state graph. Each
 probe or mutation stopped at its first expected counterexample. The shortest
@@ -118,12 +124,19 @@ reach publication and then accept the corresponding replacement view. The
 positive safety configuration separately requires the foreign-generation view
 to produce `GenerationMismatch`. The revoked query mutation publishes exact
 facts, obtains and revokes query authority, and then validates under that stale
-authority.
+authority. The unsupported-admission mutation projects marker-bearing Windows
+Metadata, while the unsupported-query mutation publishes `A` and accepts the
+otherwise matching unsupported image instead of returning its dedicated
+rejection.
 
 ## Assumptions and non-claims
 
 - The artifact owner's authority validation and immutable callback bytes are
   inputs to this model; their internal implementation is not modeled.
+- The artifact owner's mapping from failed authority validation to the outer
+  `AdmissionUnauthorized` or `QueryUnauthorized` result is not modeled. The
+  design assigns those exact mappings and callback/producer non-invocation to
+  named Release gates.
 - One symbolic content-authority bit stands for every forbidden path, stream,
   opener, content reference, lease, and retained byte route.
 - The model does not cover artifact acquisition, workspace roles, group

--- a/docs/design/models/admission-assembly-projection/README.md
+++ b/docs/design/models/admission-assembly-projection/README.md
@@ -6,37 +6,43 @@ contract.
 
 The artifact owner validates one admission or query authority and lends one
 immutable image for a callback. The assembly-query owner classifies an
-admission image into content-free registration facts and later validates
+admission image into content-free correspondence facts and later validates
 query-authorized retained bytes against those frozen facts.
 
 ## Scope
 
-The model contains one artifact projection and one later query. Four managed
+The model contains one artifact projection and one later query. Five managed
 assembly images separate the matching dimensions:
 
 - `A` is the projected image;
 - `B` has `A`'s identity and generation but a different MVID;
 - `C` has `A`'s MVID and generation but a different assembly identity; and
-- `D` has `A`'s identity and MVID but a different artifact generation and
-  registration.
+- `D` has `A`'s assembly identity and MVID but belongs to a different artifact
+  generation and artifact identity; and
+- `E` has `A`'s generation, assembly identity, and MVID but a different
+  artifact identity.
 
 Native, managed-module, malformed, and empty-MVID images exercise the
-non-participant outcomes.
+typed query and admission non-participant outcomes. In the model,
+`projectionRegistration` is the opaque, provenance-free `ArtifactIdentity`
+minted with the owner-private acquisition registration; it is not the current
+public `ArtifactAcquisitionRegistration` value.
 
 The model checks:
 
 - projection requires current admission authority;
-- projected facts retain the exact artifact registration;
+- projected facts retain the exact opaque artifact identity;
 - projected and published facts carry no content authority;
 - only managed assemblies with non-empty MVIDs project;
 - native and module classifications and malformed or empty-MVID rejections
   carry no assembly facts;
-- publication uses the exact projected registration, generation, identity,
-  and MVID;
+- publication uses the exact projected artifact identity, generation, assembly
+  identity, and MVID;
 - query validation begins only after publication and requires current query
   authority; and
-- successful query validation requires exact registration, generation,
-  identity, and MVID agreement.
+- successful query validation requires exact artifact identity, generation,
+  assembly identity, and MVID agreement, with typed non-assembly and rejection
+  reasons.
 
 The model has no liveness claim. Artifact admission, content-access
 quiescence, and group disposal are independently modeled by
@@ -52,10 +58,10 @@ quiescence, and group disposal are independently modeled by
 | `ReachabilityMismatch.cfg` | The probe invariant fails, proving mismatch rejection is reachable. |
 | `BrokenStaleAdmission.cfg` | Projection after admission revocation violates `ProjectionRequiresCurrentAdmission`. |
 | `BrokenLeakedAuthority.cfg` | A projection retaining content authority violates `ProjectedFactsCarryNoAuthority`. |
-| `BrokenDroppedRegistration.cfg` | Omitting the exact artifact registration violates `ProjectedRegistrationIsExact`. |
+| `BrokenDroppedRegistration.cfg` | Omitting the exact opaque artifact identity violates `ProjectedRegistrationIsExact`. |
+| `BrokenRegistrationValidation.cfg` | Accepting a different artifact identity in the same generation violates `ValidatedImageMatchesProjection`. |
 | `BrokenIdentityValidation.cfg` | Accepting a different assembly identity violates `ValidatedImageMatchesProjection`. |
 | `BrokenMvidValidation.cfg` | Accepting a replacement MVID violates `ValidatedImageMatchesProjection`. |
-| `BrokenGenerationValidation.cfg` | Accepting a foreign generation and registration violates `ValidatedImageMatchesProjection`. |
 | `BrokenRevokedQuery.cfg` | Validation under revoked query authority violates `QueryValidationRequiresCurrentAuthority`. |
 
 ## Running TLC
@@ -72,8 +78,8 @@ for config in ReachabilityMatching ReachabilityMismatch; do
     AdmissionAssemblyProjection.tla
 done
 for config in BrokenStaleAdmission BrokenLeakedAuthority \
-  BrokenDroppedRegistration BrokenIdentityValidation BrokenMvidValidation \
-  BrokenGenerationValidation BrokenRevokedQuery; do
+  BrokenDroppedRegistration BrokenRegistrationValidation \
+  BrokenIdentityValidation BrokenMvidValidation BrokenRevokedQuery; do
   java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
     -cleanup -noGenerateSpecTE -config "$config.cfg" \
     AdmissionAssemblyProjection.tla
@@ -92,25 +98,27 @@ prerelease (`TLC2 2026.08.21.155922`, rev `9787e65`). The checked
 
 | Configuration | Result | Generated states | Distinct states | Maximum depth |
 | --- | --- | ---: | ---: | ---: |
-| `Safety.cfg` | No error | 146 | 111 | 6 |
-| `ReachabilityMatching.cfg` | `MatchingQueryRoundTripIsUnreachable` violated | 44 | 36 | 5 |
-| `ReachabilityMismatch.cfg` | `MismatchRejectionIsUnreachable` violated | 45 | 37 | 5 |
-| `BrokenStaleAdmission.cfg` | `ProjectionRequiresCurrentAdmission` violated | 12 | 11 | 3 |
+| `Safety.cfg` | No error | 66 | 50 | 6 |
+| `ReachabilityMatching.cfg` | `MatchingQueryRoundTripIsUnreachable` violated | 30 | 24 | 5 |
+| `ReachabilityMismatch.cfg` | `MismatchRejectionIsUnreachable` violated | 31 | 25 | 5 |
+| `BrokenStaleAdmission.cfg` | `ProjectionRequiresCurrentAdmission` violated | 10 | 9 | 3 |
 | `BrokenLeakedAuthority.cfg` | `ProjectedFactsCarryNoAuthority` violated | 4 | 4 | 2 |
 | `BrokenDroppedRegistration.cfg` | `ProjectedRegistrationIsExact` violated | 4 | 4 | 2 |
-| `BrokenIdentityValidation.cfg` | `ValidatedImageMatchesProjection` violated | 46 | 38 | 5 |
-| `BrokenMvidValidation.cfg` | `ValidatedImageMatchesProjection` violated | 45 | 37 | 5 |
-| `BrokenGenerationValidation.cfg` | `ValidatedImageMatchesProjection` violated | 47 | 39 | 5 |
-| `BrokenRevokedQuery.cfg` | `QueryValidationRequiresCurrentAuthority` violated | 72 | 64 | 6 |
+| `BrokenRegistrationValidation.cfg` | `ValidatedImageMatchesProjection` violated | 34 | 28 | 5 |
+| `BrokenIdentityValidation.cfg` | `ValidatedImageMatchesProjection` violated | 32 | 26 | 5 |
+| `BrokenMvidValidation.cfg` | `ValidatedImageMatchesProjection` violated | 31 | 25 | 5 |
+| `BrokenRevokedQuery.cfg` | `QueryValidationRequiresCurrentAuthority` violated | 39 | 33 | 6 |
 
 The positive configuration explored its complete bounded state graph. Each
 probe or mutation stopped at its first expected counterexample. The shortest
-capability and registration counterexamples are two transitions: a valid
+capability and artifact-identity counterexamples are two transitions: a valid
 managed assembly projects while retaining authority or omitting its exact
-artifact registration. Identity, MVID, and generation mutations reach
-publication and then accept the corresponding replacement image. The revoked
-query mutation publishes exact facts, obtains and revokes query authority, and
-then validates under that stale authority.
+opaque correspondence value. Artifact, assembly-identity, and MVID mutations
+reach publication and then accept the corresponding replacement view. The
+positive safety configuration separately requires the foreign-generation view
+to produce `GenerationMismatch`. The revoked query mutation publishes exact
+facts, obtains and revokes query authority, and then validates under that stale
+authority.
 
 ## Assumptions and non-claims
 

--- a/docs/design/models/admission-assembly-projection/README.md
+++ b/docs/design/models/admission-assembly-projection/README.md
@@ -1,0 +1,125 @@
+# Admission assembly projection model
+
+`AdmissionAssemblyProjection.tla` models the target interaction defined by the
+[admission-scoped artifact projection](../../assembly-inspection-query.md#admission-scoped-artifact-projection)
+contract.
+
+The artifact owner validates one admission or query authority and lends one
+immutable image for a callback. The assembly-query owner classifies an
+admission image into content-free registration facts and later validates
+query-authorized retained bytes against those frozen facts.
+
+## Scope
+
+The model contains one artifact projection and one later query. Four managed
+assembly images separate the matching dimensions:
+
+- `A` is the projected image;
+- `B` has `A`'s identity and generation but a different MVID;
+- `C` has `A`'s MVID and generation but a different assembly identity; and
+- `D` has `A`'s identity and MVID but a different artifact generation and
+  registration.
+
+Native, managed-module, malformed, and empty-MVID images exercise the
+non-participant outcomes.
+
+The model checks:
+
+- projection requires current admission authority;
+- projected facts retain the exact artifact registration;
+- projected and published facts carry no content authority;
+- only managed assemblies with non-empty MVIDs project;
+- native and module classifications and malformed or empty-MVID rejections
+  carry no assembly facts;
+- publication uses the exact projected registration, generation, identity,
+  and MVID;
+- query validation begins only after publication and requires current query
+  authority; and
+- successful query validation requires exact registration, generation,
+  identity, and MVID agreement.
+
+The model has no liveness claim. Artifact admission, content-access
+quiescence, and group disposal are independently modeled by
+`ArtifactSessionAdmission`, `ArtifactGenerationAccess`, and
+`AssemblyContextGroupLifecycle`. This model does not redefine those owners.
+
+## Configurations
+
+| Configuration | Expected result |
+| --- | --- |
+| `Safety.cfg` | Every safety invariant passes. |
+| `ReachabilityMatching.cfg` | The probe invariant fails, proving matching validation is reachable. |
+| `ReachabilityMismatch.cfg` | The probe invariant fails, proving mismatch rejection is reachable. |
+| `BrokenStaleAdmission.cfg` | Projection after admission revocation violates `ProjectionRequiresCurrentAdmission`. |
+| `BrokenLeakedAuthority.cfg` | A projection retaining content authority violates `ProjectedFactsCarryNoAuthority`. |
+| `BrokenDroppedRegistration.cfg` | Omitting the exact artifact registration violates `ProjectedRegistrationIsExact`. |
+| `BrokenIdentityValidation.cfg` | Accepting a different assembly identity violates `ValidatedImageMatchesProjection`. |
+| `BrokenMvidValidation.cfg` | Accepting a replacement MVID violates `ValidatedImageMatchesProjection`. |
+| `BrokenGenerationValidation.cfg` | Accepting a foreign generation and registration violates `ValidatedImageMatchesProjection`. |
+| `BrokenRevokedQuery.cfg` | Validation under revoked query authority violates `QueryValidationRequiresCurrentAuthority`. |
+
+## Running TLC
+
+Use the repository-pinned TLA+ v1.8.0 tools:
+
+```bash
+cd docs/design/models/admission-assembly-projection
+java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+  -cleanup -config Safety.cfg AdmissionAssemblyProjection.tla
+for config in ReachabilityMatching ReachabilityMismatch; do
+  java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+    -cleanup -noGenerateSpecTE -config "$config.cfg" \
+    AdmissionAssemblyProjection.tla
+done
+for config in BrokenStaleAdmission BrokenLeakedAuthority \
+  BrokenDroppedRegistration BrokenIdentityValidation BrokenMvidValidation \
+  BrokenGenerationValidation BrokenRevokedQuery; do
+  java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+    -cleanup -noGenerateSpecTE -config "$config.cfg" \
+    AdmissionAssemblyProjection.tla
+done
+```
+
+Run configurations sequentially because TLC otherwise shares its default
+checkpoint directory.
+
+## Checked results
+
+Checked on Linux with OpenJDK `21.0.12` and the repository-pinned TLA+ v1.8.0
+prerelease (`TLC2 2026.08.21.155922`, rev `9787e65`). The checked
+`tla2tools.jar` has SHA-256
+`eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a`.
+
+| Configuration | Result | Generated states | Distinct states | Maximum depth |
+| --- | --- | ---: | ---: | ---: |
+| `Safety.cfg` | No error | 146 | 111 | 6 |
+| `ReachabilityMatching.cfg` | `MatchingQueryRoundTripIsUnreachable` violated | 44 | 36 | 5 |
+| `ReachabilityMismatch.cfg` | `MismatchRejectionIsUnreachable` violated | 45 | 37 | 5 |
+| `BrokenStaleAdmission.cfg` | `ProjectionRequiresCurrentAdmission` violated | 12 | 11 | 3 |
+| `BrokenLeakedAuthority.cfg` | `ProjectedFactsCarryNoAuthority` violated | 4 | 4 | 2 |
+| `BrokenDroppedRegistration.cfg` | `ProjectedRegistrationIsExact` violated | 4 | 4 | 2 |
+| `BrokenIdentityValidation.cfg` | `ValidatedImageMatchesProjection` violated | 46 | 38 | 5 |
+| `BrokenMvidValidation.cfg` | `ValidatedImageMatchesProjection` violated | 45 | 37 | 5 |
+| `BrokenGenerationValidation.cfg` | `ValidatedImageMatchesProjection` violated | 47 | 39 | 5 |
+| `BrokenRevokedQuery.cfg` | `QueryValidationRequiresCurrentAuthority` violated | 72 | 64 | 6 |
+
+The positive configuration explored its complete bounded state graph. Each
+probe or mutation stopped at its first expected counterexample. The shortest
+capability and registration counterexamples are two transitions: a valid
+managed assembly projects while retaining authority or omitting its exact
+artifact registration. Identity, MVID, and generation mutations reach
+publication and then accept the corresponding replacement image. The revoked
+query mutation publishes exact facts, obtains and revokes query authority, and
+then validates under that stale authority.
+
+## Assumptions and non-claims
+
+- The artifact owner's authority validation and immutable callback bytes are
+  inputs to this model; their internal implementation is not modeled.
+- One symbolic content-authority bit stands for every forbidden path, stream,
+  opener, content reference, lease, and retained byte route.
+- The model does not cover artifact acquisition, workspace roles, group
+  construction, binding policy, member correspondence, PDB or source
+  acquisition, or CLI presentation.
+- The model establishes properties of the bounded abstract protocol, not
+  implementation conformance.

--- a/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT MatchingQueryRoundTripIsUnreachable

--- a/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT MatchingQueryRoundTripIsUnreachable

--- a/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMatching.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT MatchingQueryRoundTripIsUnreachable

--- a/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANT MismatchRejectionIsUnreachable

--- a/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
@@ -9,5 +9,7 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANT MismatchRejectionIsUnreachable

--- a/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
+++ b/docs/design/models/admission-assembly-projection/ReachabilityMismatch.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANT MismatchRejectionIsUnreachable

--- a/docs/design/models/admission-assembly-projection/Safety.cfg
+++ b/docs/design/models/admission-assembly-projection/Safety.cfg
@@ -9,6 +9,8 @@ CONSTANTS
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
     AllowRevokedQuery = FALSE
+    MisclassifyUnsupportedAdmission = FALSE
+    MisclassifyUnsupportedQuery = FALSE
 
 INVARIANTS
     TypeOK
@@ -18,10 +20,11 @@ INVARIANTS
     PublicationCarriesExactFacts
     QueryValidationRequiresCurrentAuthority
     ValidatedImageMatchesProjection
-    OnlyManagedAssembliesProject
+    OnlySupportedAssembliesProject
     NonAssembliesHaveNoAssemblyFacts
     NonAssemblyAndRejectionKindsAreTyped
     PublishedProjectionIsContentFree
     QueryStartsAfterPublication
     QueryOutcomesAreTyped
     QueryMismatchReasonsAreExact
+    UnsupportedQueryIsRejected

--- a/docs/design/models/admission-assembly-projection/Safety.cfg
+++ b/docs/design/models/admission-assembly-projection/Safety.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    AllowStaleAdmission = FALSE
+    LeakContentAuthority = FALSE
+    DropArtifactRegistration = FALSE
+    AcceptIdentityMismatch = FALSE
+    AcceptMvidMismatch = FALSE
+    AcceptGenerationMismatch = FALSE
+    AllowRevokedQuery = FALSE
+
+INVARIANTS
+    TypeOK
+    ProjectionRequiresCurrentAdmission
+    ProjectedFactsCarryNoAuthority
+    ProjectedRegistrationIsExact
+    PublicationCarriesExactFacts
+    QueryValidationRequiresCurrentAuthority
+    ValidatedImageMatchesProjection
+    OnlyManagedAssembliesProject
+    NonAssembliesHaveNoAssemblyFacts
+    NonAssemblyAndRejectionKindsAreTyped
+    PublishedProjectionIsContentFree
+    QueryStartsAfterPublication

--- a/docs/design/models/admission-assembly-projection/Safety.cfg
+++ b/docs/design/models/admission-assembly-projection/Safety.cfg
@@ -5,9 +5,9 @@ CONSTANTS
     AllowStaleAdmission = FALSE
     LeakContentAuthority = FALSE
     DropArtifactRegistration = FALSE
+    AcceptRegistrationMismatch = FALSE
     AcceptIdentityMismatch = FALSE
     AcceptMvidMismatch = FALSE
-    AcceptGenerationMismatch = FALSE
     AllowRevokedQuery = FALSE
 
 INVARIANTS
@@ -23,3 +23,5 @@ INVARIANTS
     NonAssemblyAndRejectionKindsAreTyped
     PublishedProjectionIsContentFree
     QueryStartsAfterPublication
+    QueryOutcomesAreTyped
+    QueryMismatchReasonsAreExact


### PR DESCRIPTION
## Summary

Define the assembly-query-owned boundary that projects one
admission-authorized artifact into immutable, content-free assembly facts, then
revalidates later query-authorized bytes without retaining or recreating an
artifact capability.

- Add typed projected, not-assembly, and rejected outcomes.
- Preserve the MetadataPrimitives-owned unsupported-Windows-Metadata boundary
  before managed metadata work.
- Bind the exact opaque artifact identity, content-free assembly registration,
  generation, assembly identity, and non-empty MVID during admission while the
  full acquisition registration remains artifact-owner-private.
- Keep paths, source provenance, streams, openers, bytes, content references,
  and leases out of the published projection.
- Require later query validation to match exact artifact identity, generation,
  assembly identity, and MVID without rebinding the projection.
- Preserve artifact/workspace ownership of authorization, retained content,
  roles, and publication.
- Add a bounded TLA+ model with independent reachability and mutation
  configurations.

## Demo

The target handoff is now explicit:

```text
admission-authorized retained bytes
  -> Metadata classifies one immutable callback view
  -> ArtifactAssemblyProjection
       opaque artifact identity + generation
       content-free assembly registration
       assembly identity
       non-empty MVID
       no path, opener, stream, bytes, content reference, or lease
  -> atomic context publication by the workspace owner

later owner-attested query view
  -> exact artifact + generation + assembly identity + MVID validation
  -> inspect for this operation
```

A native image or managed netmodule produces a typed non-assembly result.
Malformed metadata, empty MVID, stale authority, and every later correspondence
mismatch fail visibly without manufacturing an assembly participant or falling
back to a path.

## Design basis

Normative owner:
`docs/design/assembly-inspection-query.md` — artifact-to-assembly projection,
assembly identity, MVID binding, and query-time content validation.

Supporting contracts:

- `docs/design/artifact-acquisition-and-workspaces.md` owns admission/query
  authorization, retained immutable bytes, roles, and publication.
- `docs/inspection-space.md` owns retained assembly-context access and
  correspondence.
- Existing artifact-generation and assembly-context lifecycle models retain
  their independent admission, quiescence, and disposal scopes.

## TLA+ evidence

`AdmissionAssemblyProjection.tla` explores admission authority, projection,
publication, authority expiry, and later query validation.

- `Safety.cfg`: 74 generated states, 56 distinct, depth 6, no errors.
- Two reachability probes demonstrate matching validation and mismatch
  rejection.
- Nine mutations demonstrate stale-admission, leaked-authority,
  dropped-artifact, artifact-identity, assembly-identity, MVID, revoked-query,
  and unsupported-Windows-Metadata admission/query failures. The positive model
  separately requires a foreign-generation view to produce
  `GenerationMismatch`.

The model was checked with repository-pinned TLA+ v1.8.0,
TLC2 `2026.08.21.155922` rev `9787e65`.

## Scope

This PR defines one focused owner contract. It does not acquire artifacts,
assign workspace roles, construct groups, define binding precedence or member
correspondence, change CLI output, or remove compatibility descriptor APIs.
Implementation gates remain future work.

## Validation

- `npx markdownlint-cli docs/design/assembly-inspection-query.md docs/design/models/admission-assembly-projection/README.md`
- `git diff --check`
- TLC `Safety.cfg`
- TLC reachability and mutation configurations

Closes #5143.
