### PR TITLE
Check weekly that pinned CDN digests still match what jsDelivr serves

### DIFF
--- a/.github/workflows/inspect-web-sri.yml
+++ b/.github/workflows/inspect-web-sri.yml
@@ -1,0 +1,111 @@
+name: Inspect Web SRI freshness
+
+# `require-sri` in .htmlvalidate.json checks that the third-party subresources in
+# index.html carry a digest. Whether that digest still describes what the CDN serves is a
+# fact about the network, not about the source tree, so no linter and no offline test can
+# answer it -- and it can change without any commit to this repository.
+#
+# This runs on a schedule rather than as a pull-request gate on purpose. It needs to reach
+# jsDelivr, and jsDelivr being unreachable is not a defect in somebody's pull request.
+# Wiring it into `ci-required` would convert an external outage into a merge block, which
+# is a flake rather than a protection.
+on:
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+# Scoped by event rather than shared. With one group across both events, a manual run
+# cancels an in-flight weekly run -- and a cancelled job satisfies neither `failure()` nor
+# a failed conclusion, so its reporter never runs, while the manual run that replaced it is
+# excluded from reporting by design. Drift would go unreported because somebody looked.
+concurrency:
+  group: inspect-web-sri-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Verify pinned subresource digests
+    runs-on: ubuntu-26.04
+    outputs:
+      outcome: ${{ steps.check.outputs.outcome }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: prototypes/inspect-web/package-lock.json
+
+      # The checker reads index.html with html-validate's parser, so it needs the
+      # project's installed dependencies.
+      - name: Install dependencies
+        working-directory: prototypes/inspect-web
+        run: npm ci
+
+      - name: Check pinned subresource digests
+        id: check
+        working-directory: prototypes/inspect-web
+        shell: bash
+        run: |
+          set -uo pipefail
+          # `|| code=$?` rather than a bare call: GitHub runs `shell: bash` with `-e`, so
+          # a bare nonzero exit would abort this step before the code could be recorded and
+          # the reporter would lose the distinction it needs.
+          code=0
+          node scripts/check-sri-freshness.ts || code=$?
+          # Exit 1 means a pin is wrong and re-pinning is the fix. Exit 2 means the check
+          # could not reach a conclusion -- an unreachable CDN, say -- which is not a pin
+          # problem and must not be reported as one. Both still fail the job.
+          case "$code" in
+            0) echo "outcome=ok" >> "$GITHUB_OUTPUT" ;;
+            1) echo "outcome=drift" >> "$GITHUB_OUTPUT" ;;
+            *) echo "outcome=infrastructure" >> "$GITHUB_OUTPUT" ;;
+          esac
+          exit "$code"
+
+  report:
+    name: Report drift
+    needs: check
+    if: ${{ github.event_name == 'schedule' && failure() }}
+    runs-on: ubuntu-26.04
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ needs.check.outputs.outcome }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The title distinguishes the two failures, because they need different people to
+          # do different things. Reporting an outage as a digest mismatch sends somebody to
+          # look for drift that is not there. `outcome` is empty when the job failed before
+          # the check ran at all, which is an infrastructure failure by definition.
+          if [ "${OUTCOME:-}" = "drift" ]; then
+            title="Pinned inspect-web subresource digests no longer match the CDN"
+            detail=$'The run log names each URL and shows the pinned and served digests.\n\nSubresource Integrity means the browser refuses a resource whose bytes do not match, so the visible effect is a subresource that silently stops loading -- on this site, syntax highlighting. Re-pin the digests in `prototypes/inspect-web/index.html`, or pin a different version deliberately.'
+          else
+            title="Inspect Web SRI freshness check could not complete"
+            detail=$'The check did not reach a verdict on the pinned digests -- an unreachable CDN, a failed install, or a broken checkout. This is not evidence that a pin is stale, and re-pinning is not the fix. Read the run log to see which step failed.\n\nIf this persists across several weekly runs it is protecting nothing, which is worth fixing in itself.'
+          fi
+
+          num=$(gh issue list --repo "${{ github.repository }}" \
+            --state open --search "$title in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"$title\")) | .[0].number // empty")
+          if [ -n "$num" ]; then
+            gh issue comment --repo "${{ github.repository }}" "$num" \
+              --body "The scheduled check failed again: $RUN_URL"
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$title" \
+              --body "$detail"$'\n\nRun: '"$RUN_URL"$'\n\nReproduce locally with `npm ci && node scripts/check-sri-freshness.ts` in `prototypes/inspect-web`. This issue was opened automatically and will not auto-close.'
+          fi

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -871,9 +871,10 @@ CSS is not linted. Adopting Stylelint is tracked separately.
 
 ### Protections the linters cannot provide
 
-Everything above reads source text at build time. One property matters here that
-no amount of reading source text can establish: what a browser is allowed to do
-with the page once it ships.
+Everything above reads source text at build time. Two properties matter here that
+no amount of reading source text can establish.
+
+The first is what a browser is allowed to do with the page once it ships.
 
 `staticwebapp.config.json` sets four response headers globally —
 `X-Content-Type-Options: nosniff`, which stops content-type guessing on the JSON,
@@ -900,12 +901,39 @@ under `/api/*`, which carry whatever headers the function sets for itself. The
 MSDL proxy is such a function, so these four headers do not cover its responses.
 Giving the proxy its own headers is tracked in #5119.
 
-Two neighbouring protections are tracked separately rather than bundled here.
-`require-sri` enforces that a cross-origin subresource *carries* a digest, but
-whether that digest still describes what the CDN serves is a network fact no
-linter can reach; checking it is its own change. A Content-Security-Policy is
-also still outstanding, because the generated `<script type="importmap">` needs
-a per-build hash before `script-src` can be strict.
+The second property is whether the third-party digests in `index.html` still
+describe what the CDN serves. `require-sri` enforces that a cross-origin
+subresource *carries* a digest, and that is the whole of what a linter can see;
+whether the digest is still current lives on the network and changes without any
+commit here. `scripts/check-sri-freshness.ts` re-fetches each pinned URL and
+compares hashes, reading the pins out of the document so they cannot drift from
+what the site actually loads.
+
+Be precise about what that buys, because it is not a security control. SRI is
+the security control and the browser enforces it: a stale pin means the browser
+*refuses* the bytes, so nothing unexpected runs. What goes wrong is that the
+subresource silently disappears — on this site, syntax highlighting stops
+working — with nothing to say why. This is a maintenance signal, and it is
+scheduled weekly rather than gating pull requests, because reaching jsDelivr is
+required and an outage there is not a defect in somebody's change.
+
+It reads the document with html-validate's own parser — the same parser that
+lints the file — rather than with a pattern, so the two cannot disagree about
+what the markup contains. It resolves URLs the way a browser does and follows
+the SRI metadata grammar, so valid markup does not produce false drift. It also
+separates the two ways it can fail: a stale pin is fixed by re-pinning, an
+unreachable CDN is not a pin problem at all, and filing the second under the
+first sends somebody looking for drift that is not there.
+
+The check that matters most is the cheapest one. Finding *no* pinned
+subresources exits as inconclusive rather than as success, because this script
+exists to check them and finding none means the markup shape changed underneath
+it. Without that, every later refactor of `index.html` would quietly turn the
+weekly run into a green light for nothing.
+
+A Content-Security-Policy is still outstanding, because the generated
+`<script type="importmap">` needs a per-build hash before `script-src` can be
+strict.
 
 Knip checks authored source, every TypeScript and JavaScript test, and
 build/verification scripts for unused files, exports, and dependencies.

--- a/prototypes/inspect-web/scripts/check-sri-freshness.ts
+++ b/prototypes/inspect-web/scripts/check-sri-freshness.ts
@@ -1,0 +1,251 @@
+// Re-fetches every third-party subresource pinned in index.html and checks that the bytes
+// still hash to the `integrity` value committed beside them.
+//
+// `require-sri` in .htmlvalidate.json enforces that a cross-origin subresource *carries* a
+// digest. That is a source-text property and it is the whole of what a linter can see. It
+// says nothing about whether the digest still describes what the CDN serves today, because
+// that fact lives on the network and changes without any commit to this repository.
+//
+// What this closes is narrow, and it is not a security control. SRI is the security
+// control and the browser enforces it: a stale pin means the browser *refuses* the bytes
+// rather than running unexpected ones. The failure is that the site quietly loses the
+// subresource -- on this site, syntax highlighting stops working -- with nothing to say
+// why. The same check would also surface a CDN serving different bytes under a pinned
+// immutable URL, which is worth an issue even though SRI already blocked it.
+//
+// The document is read with html-validate's own parser rather than with a pattern, so the
+// checker and the linter cannot disagree about what the markup contains.
+
+import { createHash } from "node:crypto";
+import { HtmlValidate, Parser, type HtmlElement } from "html-validate";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const documentPath = path.join(projectRoot, "index.html");
+
+// Relative URLs have to resolve against something to decide whether they are cross-origin.
+// The scheme and host here stand for "wherever this site is served from"; only the
+// same-origin/cross-origin distinction is read off the result, never the host itself.
+const siteOrigin = "https://site.invalid/";
+
+// Exit codes are distinguished so the scheduled workflow can say which kind of failure
+// happened. A stale pin is actionable by re-pinning; an unreachable CDN is not, and
+// reporting one as the other sends somebody to look for a digest mismatch that is not
+// there.
+const EXIT_PIN_PROBLEM = 1;
+const EXIT_INFRASTRUCTURE = 2;
+
+// Which elements Subresource Integrity actually applies to. These mirror html-validate's
+// `require-sri` rule so the two agree about what needs a digest: SRI is defined for
+// `script[src]` and for `link` with one of these `rel` values, where `preload` also needs
+// an `as` naming a subresource kind SRI covers.
+const sriLinkRel = new Set(["stylesheet", "preload", "modulepreload"]);
+const sriPreloadAs = new Set(["style", "script"]);
+
+// Algorithms SRI defines, strongest first. A browser uses the strongest algorithm present
+// in the attribute and ignores the rest, so this order decides which digests are
+// authoritative when an attribute lists more than one.
+const algorithmStrength = ["sha512", "sha384", "sha256"];
+
+interface Pin {
+  readonly url: string;
+  readonly element: string;
+  readonly integrity: string;
+}
+
+// The parser preserves the source spelling of a tag name, so `<SCRIPT>` arrives as
+// `"SCRIPT"`. Not normalizing would drop an uppercase subresource while still reporting
+// success. Attribute lookup is already case-insensitive.
+function tagNameOf(element: HtmlElement): string {
+  return element.tagName.toLowerCase();
+}
+
+function isSriEligible(element: HtmlElement): boolean {
+  if (tagNameOf(element) === "script") {
+    return true;
+  }
+  const rel = element.getAttributeValue("rel");
+  if (rel === null || !sriLinkRel.has(rel.toLowerCase())) {
+    return false;
+  }
+  if (rel.toLowerCase() !== "preload") {
+    return true;
+  }
+  const as = element.getAttributeValue("as");
+  return as !== null && sriPreloadAs.has(as.toLowerCase());
+}
+
+// `<noscript>` and `<template>` content is inert: it is not fetched on load, so checking
+// it would report drift for bytes the browser never requests.
+function isInertContext(element: HtmlElement): boolean {
+  return element.closest("noscript") !== null || element.closest("template") !== null;
+}
+
+async function readPins(): Promise<readonly Pin[]> {
+  const htmlValidate = new HtmlValidate();
+  const config = await htmlValidate.getConfigFor(documentPath);
+  const parser = new Parser(config);
+  const data = await readFile(documentPath, "utf8");
+  const dom = parser.parseHtml({ data, filename: documentPath, line: 1, column: 1, offset: 0 });
+
+  const pins: Pin[] = [];
+  for (const element of dom.querySelectorAll("script, link")) {
+    if (isInertContext(element) || !isSriEligible(element)) {
+      continue;
+    }
+    const value =
+      tagNameOf(element) === "script"
+        ? element.getAttributeValue("src")
+        : element.getAttributeValue("href");
+    if (value === null || value === "") {
+      continue;
+    }
+
+    // Resolved the way a browser resolves it, rather than by inspecting the spelling:
+    // `https:\\host/path` and `//host/path` are both cross-origin fetches.
+    let resolved: URL;
+    try {
+      resolved = new URL(value, siteOrigin);
+    } catch {
+      continue;
+    }
+    if (resolved.origin === new URL(siteOrigin).origin) {
+      continue;
+    }
+
+    pins.push({
+      url: resolved.href,
+      element: tagNameOf(element),
+      integrity: element.getAttributeValue("integrity") ?? "",
+    });
+  }
+  return pins;
+}
+
+interface Metadata {
+  readonly algorithm: string;
+  readonly digests: readonly string[];
+}
+
+// The `integrity` attribute is a whitespace-separated set of `<algorithm>-<base64>` items,
+// each optionally carrying `?options`. Algorithm names are ASCII case-insensitive. A
+// browser selects the strongest algorithm it supports and accepts the resource if any
+// digest for that algorithm matches, so anything weaker present alongside it is ignored
+// rather than being a second requirement.
+function parseIntegrity(integrity: string): Metadata | { readonly error: string } {
+  const tokens = integrity.split(/[\t\n\f\r ]+/u).filter((token) => token !== "");
+  if (tokens.length === 0) {
+    return { error: "integrity attribute is empty" };
+  }
+
+  const byAlgorithm = new Map<string, string[]>();
+  for (const token of tokens) {
+    const separator = token.indexOf("-");
+    if (separator === -1) {
+      return { error: `integrity metadata '${token}' is not '<algorithm>-<base64>'` };
+    }
+    const algorithm = token.slice(0, separator).toLowerCase();
+    if (!algorithmStrength.includes(algorithm)) {
+      // Unknown algorithms are ignored by browsers rather than rejected, so that a future
+      // algorithm can be listed alongside a current one. Ignoring it here keeps this from
+      // failing on a document a browser is perfectly happy with.
+      continue;
+    }
+    // `?options` is reserved by the spec and is not part of the digest.
+    const digest = token.slice(separator + 1).split("?")[0] ?? "";
+    const existing = byAlgorithm.get(algorithm);
+    if (existing === undefined) {
+      byAlgorithm.set(algorithm, [digest]);
+    } else {
+      existing.push(digest);
+    }
+  }
+
+  for (const algorithm of algorithmStrength) {
+    const digests = byAlgorithm.get(algorithm);
+    if (digests !== undefined) {
+      return { algorithm, digests };
+    }
+  }
+  return { error: `no integrity metadata names an algorithm SRI defines (${integrity})` };
+}
+
+let pinProblem = false;
+let infrastructureProblem = false;
+
+function report(status: string, url: string, ...detail: readonly string[]): void {
+  console.log(`${status.padEnd(8)} ${url}`);
+  for (const line of detail) {
+    console.log(`         ${line}`);
+  }
+}
+
+let pins: readonly Pin[];
+try {
+  pins = await readPins();
+} catch (error) {
+  console.error(`could not read ${documentPath}: ${String(error)}`);
+  process.exit(EXIT_INFRASTRUCTURE);
+}
+
+if (pins.length === 0) {
+  console.error(`no third-party subresources found in ${documentPath}`);
+  console.error("this script exists to check them, so finding none means the markup shape changed");
+  process.exit(EXIT_INFRASTRUCTURE);
+}
+
+for (const pin of pins) {
+  if (pin.integrity === "") {
+    report("MISSING", pin.url, `loaded from another origin by <${pin.element}> with no integrity attribute`);
+    pinProblem = true;
+    continue;
+  }
+
+  const metadata = parseIntegrity(pin.integrity);
+  if ("error" in metadata) {
+    report("INVALID", pin.url, metadata.error);
+    pinProblem = true;
+    continue;
+  }
+
+  // Hashed from the response bytes rather than from decoded text, so a resource ending
+  // in a newline is not misread.
+  let actual: string;
+  try {
+    const response = await fetch(pin.url, { redirect: "follow" });
+    if (!response.ok) {
+      report("FETCH", pin.url, `server responded ${String(response.status)} ${response.statusText}`);
+      infrastructureProblem = true;
+      continue;
+    }
+    actual = createHash(metadata.algorithm)
+      .update(Buffer.from(await response.arrayBuffer()))
+      .digest("base64");
+  } catch (error) {
+    report("FETCH", pin.url, "could not be retrieved", String(error));
+    infrastructureProblem = true;
+    continue;
+  }
+
+  if (metadata.digests.includes(actual)) {
+    report("OK", pin.url);
+  } else {
+    report(
+      "DRIFT",
+      pin.url,
+      ...metadata.digests.map((digest) => `pinned ${metadata.algorithm}-${digest}`),
+      `served ${metadata.algorithm}-${actual}`,
+    );
+    pinProblem = true;
+  }
+}
+
+// A pin problem outranks an outage: if both happened, the actionable one is the digest.
+if (pinProblem) {
+  process.exit(EXIT_PIN_PROBLEM);
+}
+if (infrastructureProblem) {
+  process.exit(EXIT_INFRASTRUCTURE);
+}


### PR DESCRIPTION
Checks weekly that the third-party digests pinned in `index.html` still describe
what jsDelivr serves.

**Slice 2 of 2** in the split of #5111. Parent: #5111 (security response
headers). Targets `feature/web-security-headers` because both slices edit the
same README section. Nothing here depends on the headers for correctness — the
stack exists only to avoid a textual conflict.

## Demo

Today, all three pins are current:

```console
$ node scripts/check-sri-freshness.ts; echo "exit=$?"
OK       https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js
OK       https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-clike.min.js
OK       https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-csharp.min.js
exit=0
```

Corrupt one digest and it names the resource, the pin, and what was actually
served — which is exactly what re-pinning needs:

```console
$ node scripts/check-sri-freshness.ts; echo "exit=$?"
DRIFT    https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js
         pinned sha384-AAAA
         served sha384-zLRFO4dwowZvh8kzutOb5AWhH7f39HeJp+N7PtHF1SQtTBnifRx0AtmvTYs3F4YV
OK       https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-clike.min.js
exit=1
```

**What to notice is the neighbouring scenario**, because it is the one that
decides whether this is worth having. Delete the `<script>` tags entirely — the
shape any future refactor of `index.html` could produce — and the check does not
pass:

```console
$ node scripts/check-sri-freshness.ts; echo "exit=$?"
no third-party subresources found in .../index.html
this script exists to check them, so finding none means the markup shape changed
exit=2
```

A checker that finds nothing and reports success is worse than no checker, since
it converts an unnoticed gap into a green light. That case is the cheapest line
in the file and the one most worth reading.

## What this is, and what it is not

**It is not a security control, and the PR it came from was wrong to imply
otherwise.** SRI *is* the security control and the browser enforces it: a stale
pin means the browser **refuses** the bytes, so nothing unexpected executes. The
failure this closes is that the subresource silently disappears — on this site,
syntax highlighting stops working — with nothing to say why. That is a
maintenance signal, and it should be judged as one.

It is scheduled weekly rather than wired into `ci-required`, because reaching
jsDelivr is required and an outage there is not a defect in somebody's pull
request. Making it a merge gate would convert a third-party outage into a merge
block.

It separates its two failures because they need different people to do different
things: a stale pin (exit 1) is fixed by re-pinning; an unreachable CDN (exit 2)
is not a pin problem at all, and reporting it as one sends somebody hunting for
drift that is not there.

## Why a parser and not a pattern

This is the one design choice worth defending, because it is the difference
between the two slices' review histories.

The first version matched tags and attributes with regular expressions. In a
single review round it was defeated five ways: `data-integrity` shadowed
`integrity` (`\b` treats `-` as a word boundary), a `<!--` inside a quoted value
opened a comment that swallowed a later real one, a quoted `>` ended the tag
early, a backslash-form URL read as same-origin, and a `<noscript>` resource the
browser never requests was fetched anyway. **Four of those failed silently** —
resource dropped, exit 0.

The round before that had already fixed this same mistake once, by adding more
pattern. That is the enumeration failure that made #4976 unlandable, reappearing
in my own work. Patching five more spellings earns a sixth, so the approach was
replaced rather than extended: the document is read with **html-validate's own
parser**, the same one that lints the file, so the checker and the linter cannot
disagree about what the markup contains. URLs resolve through WHATWG `URL`, the
way a browser resolves them.

Three of those five findings (protocol-relative URLs, backslash URLs,
`<noscript>`) are shapes ordinary markup produces. The other two require a
contributor writing deliberately adversarial markup into their own repo — an
actor AGENTS.md excludes from the threat model. The structural fix is justified
by the first three; the other two came along for free.

## Validation

- `npm run lint`, `npm run typecheck`, `markdownlint` clean; toolchain 40/40.
- Live check against jsDelivr: 3/3 OK.
- Mutations verified end to end: backslash-form URL still checked (exit 0),
  zero pins inconclusive (exit 2), uppercase `SHA384` accepted (exit 0), stale
  digest detected (exit 1).
- The script and workflow are **byte-identical in code** to the version that
  passed two review rounds on #5111; only comments narrating that review history
  were trimmed. Verified by diffing both files with comment lines removed.

## Findings carried forward from #5111

Rounds 1 and 2 produced 17 findings; 13 of them were about this code and are
already fixed here. The full assignment table is in
[#5111's split comment](https://github.com/richlander/dotnet-inspect/pull/5111#issuecomment-5465765919).
