### PR TITLE
Define lease-draining InspectionWorkspace close

### DIFF
--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -441,6 +441,14 @@ that owner authorizes terminal release. Both forms close new group access
 before releasing resources, and actual release remains subject to the existing
 `AssemblyContextGroup` callback and owned-resource quiescence contract.
 
+The adjacent owner may authorize coordinated release before workspace close,
+such as when an explicit package-role session closes first. That transition
+atomically removes the registration from active workspace use, prevents new
+lease or query admission through it, and retains its historical registration
+and terminal completion for the eventual workspace report. A later workspace
+close observes the same completion; it neither reactivates nor releases the
+group again.
+
 Close awaits every admission that was in flight when closure began, every
 late-result cleanup path, and every group release completion. One failed group
 does not prevent another release from being requested or observed. The final
@@ -453,26 +461,40 @@ available only after all entries are terminal and is the same immutable
 instance returned by every close call.
 
 Workspace construction selects its lifetime mode before any group admission.
-The existing public construction path creates a direct-compatibility workspace:
-it accepts only synchronous direct group creation and retains the current
-`IDisposable` contract. A retained or shared host uses an explicit asynchronous
-construction path. That workspace may admit direct and coordinated groups and
-targets `IAsyncDisposable`; it cannot later become synchronously disposable
-merely because its current registry happens to contain only direct groups.
+The existing public construction path creates a synchronous-compatibility
+workspace. It continues to accept the current synchronous direct and
+package-role construction APIs. A coordinated registration in that mode must
+provide a synchronous request-release adapter over the same owner-issued
+completion retained by the package-role session; workspace disposal requests
+that path exactly once and never independently disposes the group.
+
+The synchronous compatibility path preserves the existing `IDisposable`
+boundary, not the target complete-report contract. `Dispose()` closes new
+workspace access and requests every direct or coordinated release before
+returning, but it does not block for quiescent completion or return the eventual
+report. Deferred release continues only through the already-owned group
+callback and release-completion state machine; the adapter starts no task or
+background work. Expected synchronous request failures retain the current
+throwing compatibility behavior. New retained or shared hosts instead use an
+explicit asynchronous construction path whose close is awaitable and reports
+every terminal result.
 
 `DisposeAsync` awaits the same close completion and exposes its report through
 the workspace rather than throwing expected cleanup failures that could replace
 a primary exception from an `await using` body. Callers that need to branch on
 cleanup use `CloseAsync` and inspect its returned report.
 
-Lifetime-mode enforcement is fail-before-mutation. A direct-compatibility
-workspace rejects coordinated registration or an asynchronous construction
-admission before either begins. Calling synchronous `Dispose()` on an
-asynchronous workspace throws `InvalidOperationException` before changing
-workspace state and directs the caller to asynchronous close. The validity of
-`Dispose()` therefore never depends on a race with later registration.
-Synchronous disposal never blocks a thread on a task, starts fire-and-forget
-cleanup, or leaves a half-closed workspace after rejecting the path.
+Lifetime-mode enforcement is fail-before-mutation. A
+synchronous-compatibility workspace rejects construction that requires an
+awaited admission or lacks a synchronous request-release adapter before that
+construction begins. Calling synchronous `Dispose()` on an asynchronous
+workspace throws `InvalidOperationException` before changing workspace state
+and directs the caller to asynchronous close. The validity of `Dispose()`
+therefore never depends on a race with later registration. Synchronous
+disposal never blocks a thread on a task, starts fire-and-forget cleanup, or
+leaves a half-closed workspace after rejecting the path. Its accepted
+compatibility path records a durable release request before returning; it does
+not launch an unobserved task or transfer progress to a background thread.
 
 The state transitions are short synchronous updates under the workspace gate.
 No gate is held across user or owner callbacks, group release, or an `await`.
@@ -508,12 +530,25 @@ The target is unverified until Release gates prove:
   direct and coordinated paths converge on one terminal authority without
   independent workspace disposal of a coordinated group;
 - `WorkspaceClose_ExistingCoordinatedLeaseRemainsUsableUntilOwnerRelease`
-  proves close does not release a coordinated group under an existing lease;
+  proves a lease holder can start and finish group work after workspace close
+  begins and that release remains unavailable until the lease returns;
+- `WorkspaceClose_OwnerFirstReleaseDeactivatesRegistrationAndRetainsReport`
+  proves explicit adjacent-owner close can remove a coordinated group from
+  active workspace use before workspace close while preserving its historical
+  registration and terminal result;
+- `WorkspaceClose_NoGroupFailureSettlesAdmissionWithoutCleanupEntry` proves
+  failed or canceled construction after admission cannot strand close and does
+  not invent a group cleanup record;
 - `WorkspaceClose_AwaitsAllGroupCompletionsAndReportsEveryFailure` proves
   callback/group quiescence, attempt-all cleanup, stable ordering, and complete
   typed failure retention;
-- `WorkspaceDispose_RejectsAsyncOwnedGroupsWithoutChangingState` proves the
-  construction-time lifetime-mode boundary is fail-before-mutation; and
+- `WorkspaceClose_ConcurrentCallersShareCompletionAndReportInstance` proves
+  repeated and concurrent close calls join one completion and receive the same
+  immutable report object;
+- `WorkspaceDispose_CompatibilityUsesSharedReleaseAuthority` proves the
+  synchronous package-role adapter requests the same owner-issued completion,
+  never independently disposes the group, and preserves fail-before-mutation
+  rejection for asynchronous-only construction; and
 - `WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking` proves
   the supported single-threaded host path reaches terminal close without a
   blocking wait or background-thread requirement.

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -454,11 +454,13 @@ late-result cleanup path, and every group release completion. One failed group
 does not prevent another release from being requested or observed. The final
 report retains one workspace registration identity and exact terminal release
 result for every group that reached workspace ownership, in registration
-order. A coordinated entry retains the adjacent owner's typed cleanup result;
-the workspace does not flatten it into exception text or a second cleanup
-taxonomy. Expected cleanup failures are data in the report. The report becomes
-available only after all entries are terminal and is the same immutable
-instance returned by every close call.
+order. That historical domain is immutable: owner-first release cannot remove
+an entry, while failed or canceled construction that produced no group never
+enters the domain and cannot acquire cleanup data. A coordinated entry retains
+the adjacent owner's typed cleanup result; the workspace does not flatten it
+into exception text or a second cleanup taxonomy. Expected cleanup failures are
+data in the report. The report becomes available only after all entries are
+terminal and is the same immutable instance returned by every close call.
 
 Workspace construction selects its lifetime mode before any group admission.
 The existing public construction path creates a synchronous-compatibility

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -387,6 +387,137 @@ all-group cleanup after an owned-resource failure, and
 `InspectionWorkspaceTests.CallbackFailure_IsPreservedWhenDeferredDisposalAlsoFails`
 gates preservation of an in-flight callback failure when deferred cleanup also
 fails.
+
+#### Workspace close and group release authority
+
+`InspectionWorkspace` owns whether new assembly-context group construction may
+begin, whether a completed group may enter the workspace registry, and when
+workspace close is complete. It does not follow from that ownership that the
+workspace directly disposes every group. A group has exactly one terminal
+release completion, selected before construction begins:
+
+| Registration kind | Terminal release authority | Workspace close behavior |
+| --- | --- | --- |
+| Direct | Workspace-owned release completion | Request release and await the group's quiescent terminal result |
+| Coordinated | Adjacent owner-issued release completion | Close workspace participation and await that same completion; never call `AssemblyContextGroup.Dispose()` independently |
+
+The coordinated form is the handoff used by package-role completion. The
+package-role owner supplies its keyed release-completion cell and owns the
+cleanup record it produces. Exact-request admission owns its request leases,
+cache closure, and the decision that authorizes package-role release. The
+workspace consumes only a narrow participation handle: it can close workspace
+admission, route a late group into cleanup, and await the owner-issued terminal
+completion. It does not inspect lease counts, reconstruct package-role group
+ids, or reinterpret the cleanup result.
+
+Group construction begins by atomically registering one opaque
+`WorkspaceGroupAdmission` while the workspace is open. The admission records
+the release kind and exact release completion before any potentially awaited
+construction work. It is single-use and belongs to one workspace. Completion
+has two outcomes:
+
+- while the workspace remains open, the exact constructed group and release
+  completion publish as one registry entry; or
+- after close begins, the group never publishes or becomes available to a new
+  query. It transfers directly into the recorded release path, and workspace
+  close awaits that cleanup.
+
+Failure or cancellation before a group exists completes the admission without
+inventing a group cleanup result. Its primary outcome remains owned by the
+constructing operation. If a group was returned, however, cleanup is a
+workspace obligation even when the operation ignored cancellation. A caller
+cannot abandon the admission ticket and leave an unregistered group outside
+both the registry and cleanup.
+
+Workspace close is one monotonic `Open` -> `Closing` -> `Closed` transition.
+The first `CloseAsync` call closes new admission under the workspace gate,
+captures every published registration and in-flight admission, and creates one
+shared completion. Later close calls return the same eventual
+`InspectionWorkspaceCloseReport`; close accepts no cancellation token after it
+starts. Direct registrations request their workspace-owned release.
+Coordinated registrations receive the workspace-close signal through their
+owner-issued participation handle and retain existing lease-holder access until
+that owner authorizes terminal release. Both forms close new group access
+before releasing resources, and actual release remains subject to the existing
+`AssemblyContextGroup` callback and owned-resource quiescence contract.
+
+Close awaits every admission that was in flight when closure began, every
+late-result cleanup path, and every group release completion. One failed group
+does not prevent another release from being requested or observed. The final
+report retains one workspace registration identity and exact terminal release
+result for every group that reached workspace ownership, in registration
+order. A coordinated entry retains the adjacent owner's typed cleanup result;
+the workspace does not flatten it into exception text or a second cleanup
+taxonomy. Expected cleanup failures are data in the report. The report becomes
+available only after all entries are terminal and is the same immutable
+instance returned by every close call.
+
+`InspectionWorkspace` targets `IAsyncDisposable`. `DisposeAsync` awaits the
+same close completion and exposes its report through the workspace rather than
+throwing expected cleanup failures that could replace a primary exception from
+an `await using` body. Callers that need to branch on cleanup use `CloseAsync`
+and inspect its returned report.
+
+The synchronous `IDisposable` surface remains a compatibility path only for a
+workspace containing direct registrations and no in-flight admission whose
+cleanup requires awaited progress. It atomically closes admission and preserves
+the current immediate direct-release and failure behavior. If coordinated
+state or an in-flight admission is present, `Dispose()` throws
+`InvalidOperationException` before changing workspace state and directs the
+caller to asynchronous close. It never blocks a thread on a task, starts
+fire-and-forget cleanup, or leaves a half-closed workspace after rejecting the
+synchronous path.
+
+The state transitions are short synchronous updates under the workspace gate.
+No gate is held across user or owner callbacks, group release, or an `await`.
+Progress resumes through ordinary task continuations and requires neither
+`Task.Run` nor a background thread, preserving the single-threaded
+Browser/Wasm execution target.
+
+[`InspectionWorkspaceClose.tla`](models/inspection-workspace-close/InspectionWorkspaceClose.tla)
+models this workspace-level interaction. It covers direct and coordinated
+release ownership, close racing construction, lease-draining authorization,
+group quiescence, complete failure reporting, and eventual asynchronous close.
+It treats package admission and `AssemblyContextGroup` release as adjacent
+abstract completions; their internal contracts remain owned by
+`docs/design/inspection-layers.md` and
+[`AssemblyContextGroupLifecycle.tla`](models/assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla).
+The model checks the target design, not current implementation conformance.
+
+The current implementation is narrower. `InspectionWorkspace` is synchronous
+`IDisposable`, stores raw groups in one list, and directly disposes every
+registered group. `PackageAssemblyContextRoles` independently disposes the
+same role groups. Group creation checks workspace state before and after
+construction, but a group completed after disposal is immediately disposed and
+cannot join an awaited cleanup result. There is no admission ticket, shared
+release completion, asynchronous workspace report, or coordinated-release
+exclusion. The existing group-internal callback quiescence remains valid; this
+gap is the workspace-level composition above it.
+
+The target is unverified until Release gates prove:
+
+- `WorkspaceClose_RejectsAdmissionAndRoutesLateGroupToRelease` closes admission
+  atomically and prevents a construction result from publishing after close;
+- `WorkspaceClose_DirectAndCoordinatedGroupsReleaseExactlyOnce` proves that
+  direct and coordinated paths converge on one terminal authority without
+  independent workspace disposal of a coordinated group;
+- `WorkspaceClose_ExistingCoordinatedLeaseRemainsUsableUntilOwnerRelease`
+  proves close does not release a coordinated group under an existing lease;
+- `WorkspaceClose_AwaitsAllGroupCompletionsAndReportsEveryFailure` proves
+  callback/group quiescence, attempt-all cleanup, stable ordering, and complete
+  typed failure retention;
+- `WorkspaceDispose_RejectsAsyncOwnedGroupsWithoutChangingState` proves the
+  synchronous compatibility boundary is fail-before-mutation; and
+- `WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking` proves
+  the supported single-threaded host path reaches terminal close without a
+  blocking wait or background-thread requirement.
+
+This contract does not define package admission keys, cache policy, package
+selection, role planning, participant projection, package cleanup-record shape,
+artifact acquisition lifetime, query-specific participant release policy, or
+the implementation of
+[#4960](https://github.com/richlander/dotnet-inspect/issues/4960).
+
 `WorkspaceContextLoader` now realizes package, platform, and embedded
 coordinates without requiring a filesystem. A platform coordinate maps the
 `runtime` or `aspnetcore` family to its product-owned implementation-pack

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -452,21 +452,27 @@ taxonomy. Expected cleanup failures are data in the report. The report becomes
 available only after all entries are terminal and is the same immutable
 instance returned by every close call.
 
-`InspectionWorkspace` targets `IAsyncDisposable`. `DisposeAsync` awaits the
-same close completion and exposes its report through the workspace rather than
-throwing expected cleanup failures that could replace a primary exception from
-an `await using` body. Callers that need to branch on cleanup use `CloseAsync`
-and inspect its returned report.
+Workspace construction selects its lifetime mode before any group admission.
+The existing public construction path creates a direct-compatibility workspace:
+it accepts only synchronous direct group creation and retains the current
+`IDisposable` contract. A retained or shared host uses an explicit asynchronous
+construction path. That workspace may admit direct and coordinated groups and
+targets `IAsyncDisposable`; it cannot later become synchronously disposable
+merely because its current registry happens to contain only direct groups.
 
-The synchronous `IDisposable` surface remains a compatibility path only for a
-workspace containing direct registrations and no in-flight admission whose
-cleanup requires awaited progress. It atomically closes admission and preserves
-the current immediate direct-release and failure behavior. If coordinated
-state or an in-flight admission is present, `Dispose()` throws
-`InvalidOperationException` before changing workspace state and directs the
-caller to asynchronous close. It never blocks a thread on a task, starts
-fire-and-forget cleanup, or leaves a half-closed workspace after rejecting the
-synchronous path.
+`DisposeAsync` awaits the same close completion and exposes its report through
+the workspace rather than throwing expected cleanup failures that could replace
+a primary exception from an `await using` body. Callers that need to branch on
+cleanup use `CloseAsync` and inspect its returned report.
+
+Lifetime-mode enforcement is fail-before-mutation. A direct-compatibility
+workspace rejects coordinated registration or an asynchronous construction
+admission before either begins. Calling synchronous `Dispose()` on an
+asynchronous workspace throws `InvalidOperationException` before changing
+workspace state and directs the caller to asynchronous close. The validity of
+`Dispose()` therefore never depends on a race with later registration.
+Synchronous disposal never blocks a thread on a task, starts fire-and-forget
+cleanup, or leaves a half-closed workspace after rejecting the path.
 
 The state transitions are short synchronous updates under the workspace gate.
 No gate is held across user or owner callbacks, group release, or an `await`.
@@ -507,7 +513,7 @@ The target is unverified until Release gates prove:
   callback/group quiescence, attempt-all cleanup, stable ordering, and complete
   typed failure retention;
 - `WorkspaceDispose_RejectsAsyncOwnedGroupsWithoutChangingState` proves the
-  synchronous compatibility boundary is fail-before-mutation; and
+  construction-time lifetime-mode boundary is fail-before-mutation; and
 - `WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking` proves
   the supported single-threaded host path reaches terminal close without a
   blocking wait or background-thread requirement.

--- a/docs/models/inspection-workspace-close/.gitignore
+++ b/docs/models/inspection-workspace-close/.gitignore
@@ -1,0 +1,2 @@
+states/
+*_TTrace_*

--- a/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = TRUE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoBuildAdmissionAfterClose
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoBuildAdmissionAfterClose

--- a/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenAdmissionAfterClose.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = TRUE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   NoBuildAdmissionAfterClose

--- a/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
+++ b/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = TRUE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   CleanupFailuresRemainVisible

--- a/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
+++ b/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = TRUE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  CleanupFailuresRemainVisible
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
+++ b/docs/models/inspection-workspace-close/BrokenCleanupOmission.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = TRUE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   CleanupFailuresRemainVisible

--- a/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = TRUE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   ReleaseBeginsAtMostOnce

--- a/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = TRUE
+
+INVARIANTS
+  ReleaseBeginsAtMostOnce
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenDoubleRelease.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = TRUE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   ReleaseBeginsAtMostOnce

--- a/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
+++ b/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   WorkspaceCloseWaitsForQuiescence

--- a/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
+++ b/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = TRUE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  WorkspaceCloseWaitsForQuiescence
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
+++ b/docs/models/inspection-workspace-close/BrokenEarlyWorkspaceCompletion.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = TRUE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   WorkspaceCloseWaitsForQuiescence

--- a/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = TRUE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   LateCompletionRoutesToCleanup

--- a/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   LateCompletionRoutesToCleanup

--- a/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLatePublication.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = TRUE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  LateCompletionRoutesToCleanup
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = TRUE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoLeaseAdmissionAfterClose
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = TRUE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   NoLeaseAdmissionAfterClose

--- a/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
+++ b/docs/models/inspection-workspace-close/BrokenLeaseAfterClose.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoLeaseAdmissionAfterClose

--- a/docs/models/inspection-workspace-close/BrokenNoGroupCleanupEntry.cfg
+++ b/docs/models/inspection-workspace-close/BrokenNoGroupCleanupEntry.cfg
@@ -1,8 +1,8 @@
 SPECIFICATION Spec
 
 CONSTANTS
-  Groups = {direct, coordinated}
-  CoordinatedGroups = {coordinated}
+  Groups = {direct}
+  CoordinatedGroups = {}
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
@@ -16,9 +16,9 @@ CONSTANTS
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
   AllowOwnerFirstHistoryLoss = FALSE
-  AllowNoGroupCleanupEntry = FALSE
+  AllowNoGroupCleanupEntry = TRUE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  NoCleanupWithoutRegisteredGroup
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenOwnerFirstHistoryLoss.cfg
+++ b/docs/models/inspection-workspace-close/BrokenOwnerFirstHistoryLoss.cfg
@@ -1,7 +1,7 @@
 SPECIFICATION Spec
 
 CONSTANTS
-  Groups = {direct, coordinated}
+  Groups = {coordinated}
   CoordinatedGroups = {coordinated}
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
@@ -15,10 +15,10 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
-  AllowOwnerFirstHistoryLoss = FALSE
+  AllowOwnerFirstHistoryLoss = TRUE
   AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  RegistrationHistoryMatchesBuildOutcome
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   ReleaseWaitsForGroupQuiescence

--- a/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = TRUE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  ReleaseWaitsForGroupQuiescence
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseBeforeQuiescence.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = TRUE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   ReleaseWaitsForGroupQuiescence

--- a/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = TRUE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  CoordinatedReleaseWaitsForLeases
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   CoordinatedReleaseWaitsForLeases

--- a/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
+++ b/docs/models/inspection-workspace-close/BrokenReleaseWithLease.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = TRUE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   CoordinatedReleaseWaitsForLeases

--- a/docs/models/inspection-workspace-close/BrokenStrandedNoGroupCompletion.cfg
+++ b/docs/models/inspection-workspace-close/BrokenStrandedNoGroupCompletion.cfg
@@ -1,8 +1,8 @@
 SPECIFICATION Spec
 
 CONSTANTS
-  Groups = {direct, coordinated}
-  CoordinatedGroups = {coordinated}
+  Groups = {direct}
+  CoordinatedGroups = {}
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
@@ -14,9 +14,9 @@ CONSTANTS
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
-  AllowStrandedNoGroupCompletion = FALSE
+  AllowStrandedNoGroupCompletion = TRUE
 
-INVARIANTS
-  NoCleanupFailureObserved
+PROPERTIES
+  EveryStartedBuildFinishes
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenStrandedNoGroupCompletion.cfg
+++ b/docs/models/inspection-workspace-close/BrokenStrandedNoGroupCompletion.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = TRUE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 PROPERTIES
   EveryStartedBuildFinishes

--- a/docs/models/inspection-workspace-close/BrokenWrongAuthority.cfg
+++ b/docs/models/inspection-workspace-close/BrokenWrongAuthority.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = TRUE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  ReleaseUsesSingleOwner
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/BrokenWrongCoordinatedAuthority.cfg
+++ b/docs/models/inspection-workspace-close/BrokenWrongCoordinatedAuthority.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   ReleaseUsesSingleOwner

--- a/docs/models/inspection-workspace-close/BrokenWrongCoordinatedAuthority.cfg
+++ b/docs/models/inspection-workspace-close/BrokenWrongCoordinatedAuthority.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = TRUE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = TRUE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   ReleaseUsesSingleOwner

--- a/docs/models/inspection-workspace-close/BrokenWrongDirectAuthority.cfg
+++ b/docs/models/inspection-workspace-close/BrokenWrongDirectAuthority.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   ReleaseUsesSingleOwner

--- a/docs/models/inspection-workspace-close/BrokenWrongDirectAuthority.cfg
+++ b/docs/models/inspection-workspace-close/BrokenWrongDirectAuthority.cfg
@@ -6,7 +6,7 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = TRUE
   AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
@@ -17,6 +17,6 @@ CONSTANTS
   AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  ReleaseUsesSingleOwner
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
+++ b/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
@@ -291,7 +291,7 @@ RequestDirectRelease(g) ==
         coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
-RequestCoordinatedRelease(g) ==
+OwnerRequestsCoordinatedRelease(g) ==
     /\ g \in CoordinatedGroups
     /\ workspaceState = "Closing"
     /\ groupState[g] \in {"Published", "ReleaseOnly"}
@@ -408,7 +408,7 @@ Next ==
     \/ \E g \in Groups : EndGroupWork(g)
     \/ CloseWorkspace
     \/ \E g \in Groups : RequestDirectRelease(g)
-    \/ \E g \in Groups : RequestCoordinatedRelease(g)
+    \/ \E g \in Groups : OwnerRequestsCoordinatedRelease(g)
     \/ \E g \in Groups : CompleteAnyRelease(g)
     \/ \E g \in Groups : RecordReport(g)
     \/ FinalizeWorkspace
@@ -419,7 +419,7 @@ Fairness ==
     /\ \A g \in Groups : WF_vars(ReturnLease(g))
     /\ \A g \in Groups : WF_vars(EndGroupWork(g))
     /\ \A g \in Groups : WF_vars(RequestDirectRelease(g))
-    /\ \A g \in Groups : WF_vars(RequestCoordinatedRelease(g))
+    /\ \A g \in Groups : WF_vars(OwnerRequestsCoordinatedRelease(g))
     /\ \A g \in Groups : WF_vars(CompleteAnyRelease(g))
     /\ \A g \in Groups : WF_vars(RecordReport(g))
     /\ WF_vars(FinalizeWorkspace)

--- a/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
+++ b/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
@@ -1,0 +1,480 @@
+--------------------- MODULE InspectionWorkspaceClose ---------------------
+(***************************************************************************)
+(* Models the TARGET workspace-level close contract in                     *)
+(* docs/inspection-space.md, "Workspace close and group release authority". *)
+(*                                                                         *)
+(* The model owns workspace admission, publication versus late-result      *)
+(* routing, direct versus coordinated release authority, and asynchronous  *)
+(* close completion. It abstracts the package-role lease owner and the     *)
+(* AssemblyContextGroup callback/resource protocol as adjacent components. *)
+(* Coordinated lease return is therefore an external authorization event,  *)
+(* while groupBusy represents the group owner's internal quiescence.        *)
+(*                                                                         *)
+(* THIS MODEL DOES NOT CLAIM CURRENT PRODUCT BEHAVIOR. The current          *)
+(* InspectionWorkspace synchronously disposes raw registered groups and    *)
+(* cannot await coordinated release or route a late construction result    *)
+(* into one shared cleanup completion.                                     *)
+(***************************************************************************)
+EXTENDS FiniteSets, Naturals, TLC
+
+CONSTANTS
+    Groups,
+    CoordinatedGroups,
+    MaxLeases,
+    AllowAdmissionAfterClose,
+    AllowLeaseAfterClose,
+    AllowWrongReleaseAuthority,
+    AllowReleaseWithActiveLease,
+    AllowReleaseBeforeGroupQuiescence,
+    AllowLatePublication,
+    AllowEarlyWorkspaceCompletion,
+    AllowCleanupOmission,
+    AllowDoubleRelease
+
+ASSUME
+    /\ Groups # {}
+    /\ IsFiniteSet(Groups)
+    /\ CoordinatedGroups \subseteq Groups
+    /\ MaxLeases \in Nat \ {0}
+    /\ AllowAdmissionAfterClose \in BOOLEAN
+    /\ AllowLeaseAfterClose \in BOOLEAN
+    /\ AllowWrongReleaseAuthority \in BOOLEAN
+    /\ AllowReleaseWithActiveLease \in BOOLEAN
+    /\ AllowReleaseBeforeGroupQuiescence \in BOOLEAN
+    /\ AllowLatePublication \in BOOLEAN
+    /\ AllowEarlyWorkspaceCompletion \in BOOLEAN
+    /\ AllowCleanupOmission \in BOOLEAN
+    /\ AllowDoubleRelease \in BOOLEAN
+
+DirectGroups == Groups \ CoordinatedGroups
+
+WorkspaceStates == {"Open", "Closing", "Closed"}
+BuildStates == {"NotStarted", "InFlight", "Finished"}
+GroupStates ==
+    {"Absent", "Published", "ReleaseOnly", "ReleaseRequested", "Released"}
+ReleaseOwners == {"None", "Workspace", "Completion"}
+CleanupOutcomes == {"None", "Succeeded", "Failed"}
+ReportEntries == {"None", "Succeeded", "Failed"}
+
+VARIABLES
+    workspaceState,
+    buildState,
+    groupState,
+    leaseCount,
+    groupBusy,
+    releaseOwner,
+    releaseStarts,
+    cleanupOutcome,
+    reportEntry,
+    lateGroup,
+    disposedWithLease,
+    buildAdmissionWitness,
+    leaseAdmissionWitness,
+    authorityWitness,
+    leaseDrainWitness,
+    lateRoutingWitness,
+    groupQuiescenceWitness,
+    workspaceCompletionWitness,
+    cleanupVisibilityWitness,
+    directReleaseObserved,
+    coordinatedDrainObserved,
+    lateCleanupObserved,
+    cleanupFailureObserved
+
+vars == <<
+    workspaceState, buildState, groupState, leaseCount, groupBusy,
+    releaseOwner, releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+    disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+    authorityWitness, leaseDrainWitness, lateRoutingWitness,
+    groupQuiescenceWitness, workspaceCompletionWitness,
+    cleanupVisibilityWitness, directReleaseObserved,
+    coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+    >>
+
+KnownGroups ==
+    {g \in Groups : buildState[g] = "Finished"
+        /\ groupState[g] # "Absent"}
+
+ExpectedReleaseOwner(g) ==
+    IF g \in CoordinatedGroups THEN "Completion" ELSE "Workspace"
+
+TerminalGroups ==
+    \A g \in KnownGroups : groupState[g] = "Released"
+
+CompleteReport ==
+    \A g \in KnownGroups :
+        /\ reportEntry[g] # "None"
+        /\ reportEntry[g] = cleanupOutcome[g]
+
+TypeOK ==
+    /\ workspaceState \in WorkspaceStates
+    /\ buildState \in [Groups -> BuildStates]
+    /\ groupState \in [Groups -> GroupStates]
+    /\ leaseCount \in [Groups -> 0..MaxLeases]
+    /\ groupBusy \in [Groups -> BOOLEAN]
+    /\ releaseOwner \in [Groups -> ReleaseOwners]
+    /\ releaseStarts \in [Groups -> Nat]
+    /\ cleanupOutcome \in [Groups -> CleanupOutcomes]
+    /\ reportEntry \in [Groups -> ReportEntries]
+    /\ lateGroup \in [Groups -> BOOLEAN]
+    /\ disposedWithLease \in [Groups -> BOOLEAN]
+    /\ buildAdmissionWitness \in BOOLEAN
+    /\ leaseAdmissionWitness \in BOOLEAN
+    /\ authorityWitness \in BOOLEAN
+    /\ leaseDrainWitness \in BOOLEAN
+    /\ lateRoutingWitness \in BOOLEAN
+    /\ groupQuiescenceWitness \in BOOLEAN
+    /\ workspaceCompletionWitness \in BOOLEAN
+    /\ cleanupVisibilityWitness \in BOOLEAN
+    /\ directReleaseObserved \in BOOLEAN
+    /\ coordinatedDrainObserved \in BOOLEAN
+    /\ lateCleanupObserved \in BOOLEAN
+    /\ cleanupFailureObserved \in BOOLEAN
+
+Init ==
+    /\ workspaceState = "Open"
+    /\ buildState = [g \in Groups |-> "NotStarted"]
+    /\ groupState = [g \in Groups |-> "Absent"]
+    /\ leaseCount = [g \in Groups |-> 0]
+    /\ groupBusy = [g \in Groups |-> FALSE]
+    /\ releaseOwner = [g \in Groups |-> "None"]
+    /\ releaseStarts = [g \in Groups |-> 0]
+    /\ cleanupOutcome = [g \in Groups |-> "None"]
+    /\ reportEntry = [g \in Groups |-> "None"]
+    /\ lateGroup = [g \in Groups |-> FALSE]
+    /\ disposedWithLease = [g \in Groups |-> FALSE]
+    /\ buildAdmissionWitness = TRUE
+    /\ leaseAdmissionWitness = TRUE
+    /\ authorityWitness = TRUE
+    /\ leaseDrainWitness = TRUE
+    /\ lateRoutingWitness = TRUE
+    /\ groupQuiescenceWitness = TRUE
+    /\ workspaceCompletionWitness = TRUE
+    /\ cleanupVisibilityWitness = TRUE
+    /\ directReleaseObserved = FALSE
+    /\ coordinatedDrainObserved = FALSE
+    /\ lateCleanupObserved = FALSE
+    /\ cleanupFailureObserved = FALSE
+
+StartBuild(g) ==
+    /\ buildState[g] = "NotStarted"
+    /\ \/ workspaceState = "Open"
+       \/ AllowAdmissionAfterClose
+    /\ buildState' = [buildState EXCEPT ![g] = "InFlight"]
+    /\ buildAdmissionWitness' =
+        (buildAdmissionWitness /\ workspaceState = "Open")
+    /\ UNCHANGED <<
+        workspaceState, groupState, leaseCount, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, leaseAdmissionWitness, authorityWitness,
+        leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
+        cleanupFailureObserved
+        >>
+
+CompleteBuild(g) ==
+    /\ buildState[g] = "InFlight"
+    /\ LET nextState ==
+            IF workspaceState = "Open" \/ AllowLatePublication
+            THEN "Published"
+            ELSE "ReleaseOnly"
+       IN
+        /\ buildState' = [buildState EXCEPT ![g] = "Finished"]
+        /\ groupState' = [groupState EXCEPT ![g] = nextState]
+        /\ lateGroup' =
+            [lateGroup EXCEPT ![g] = workspaceState # "Open"]
+        /\ lateRoutingWitness' =
+            (lateRoutingWitness
+             /\ (workspaceState = "Open" \/ nextState = "ReleaseOnly"))
+    /\ UNCHANGED <<
+        workspaceState, leaseCount, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, disposedWithLease,
+        buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
+        leaseDrainWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
+        cleanupFailureObserved
+        >>
+
+AcquireLease(g) ==
+    /\ g \in CoordinatedGroups
+    /\ groupState[g] = "Published"
+    /\ leaseCount[g] < MaxLeases
+    /\ \/ workspaceState = "Open"
+       \/ AllowLeaseAfterClose
+    /\ leaseCount' = [leaseCount EXCEPT ![g] = @ + 1]
+    /\ leaseAdmissionWitness' =
+        (leaseAdmissionWitness /\ workspaceState = "Open")
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, authorityWitness,
+        leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
+        cleanupFailureObserved
+        >>
+
+ReturnLease(g) ==
+    /\ g \in CoordinatedGroups
+    /\ leaseCount[g] > 0
+    /\ leaseCount' = [leaseCount EXCEPT ![g] = @ - 1]
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+BeginGroupWork(g) ==
+    /\ groupState[g] = "Published"
+    /\ workspaceState = "Open"
+    /\ ~groupBusy[g]
+    /\ groupBusy' = [groupBusy EXCEPT ![g] = TRUE]
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, leaseCount, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+EndGroupWork(g) ==
+    /\ groupBusy[g]
+    /\ groupBusy' = [groupBusy EXCEPT ![g] = FALSE]
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, leaseCount, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+CloseWorkspace ==
+    /\ workspaceState = "Open"
+    /\ workspaceState' = "Closing"
+    /\ disposedWithLease' =
+        [g \in Groups |-> leaseCount[g] > 0]
+    /\ UNCHANGED <<
+        buildState, groupState, leaseCount, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
+        leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
+        cleanupFailureObserved
+        >>
+
+RequestDirectRelease(g) ==
+    /\ g \in DirectGroups
+    /\ workspaceState = "Closing"
+    /\ groupState[g] \in {"Published", "ReleaseOnly"}
+    /\ groupState' = [groupState EXCEPT ![g] = "ReleaseRequested"]
+    /\ releaseOwner' = [releaseOwner EXCEPT ![g] = "Workspace"]
+    /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
+    /\ authorityWitness' =
+        (authorityWitness /\ ExpectedReleaseOwner(g) = "Workspace")
+    /\ UNCHANGED <<
+        workspaceState, buildState, leaseCount, groupBusy, cleanupOutcome,
+        reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
+        leaseAdmissionWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+RequestCoordinatedRelease(g) ==
+    /\ g \in CoordinatedGroups
+    /\ workspaceState = "Closing"
+    /\ groupState[g] \in {"Published", "ReleaseOnly"}
+    /\ \/ leaseCount[g] = 0
+       \/ AllowReleaseWithActiveLease
+    /\ LET owner ==
+            IF AllowWrongReleaseAuthority
+            THEN "Workspace"
+            ELSE "Completion"
+       IN
+        /\ groupState' =
+            [groupState EXCEPT ![g] = "ReleaseRequested"]
+        /\ releaseOwner' = [releaseOwner EXCEPT ![g] = owner]
+        /\ authorityWitness' =
+            (authorityWitness /\ owner = ExpectedReleaseOwner(g))
+    /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
+    /\ leaseDrainWitness' =
+        (leaseDrainWitness /\ leaseCount[g] = 0)
+    /\ coordinatedDrainObserved' =
+        (coordinatedDrainObserved
+         \/ (disposedWithLease[g] /\ leaseCount[g] = 0))
+    /\ UNCHANGED <<
+        workspaceState, buildState, leaseCount, groupBusy, cleanupOutcome,
+        reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
+        leaseAdmissionWitness, lateRoutingWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+CompleteRelease(g, outcome) ==
+    /\ outcome \in {"Succeeded", "Failed"}
+    /\ groupState[g] = "ReleaseRequested"
+    /\ \/ ~groupBusy[g]
+       \/ AllowReleaseBeforeGroupQuiescence
+    /\ groupState' = [groupState EXCEPT ![g] = "Released"]
+    /\ cleanupOutcome' = [cleanupOutcome EXCEPT ![g] = outcome]
+    /\ groupQuiescenceWitness' =
+        (groupQuiescenceWitness /\ ~groupBusy[g])
+    /\ directReleaseObserved' =
+        (directReleaseObserved \/ g \in DirectGroups)
+    /\ lateCleanupObserved' =
+        (lateCleanupObserved \/ lateGroup[g])
+    /\ cleanupFailureObserved' =
+        (cleanupFailureObserved \/ outcome = "Failed")
+    /\ UNCHANGED <<
+        workspaceState, buildState, leaseCount, groupBusy, releaseOwner,
+        releaseStarts, reportEntry, lateGroup, disposedWithLease,
+        buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
+        leaseDrainWitness, lateRoutingWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, coordinatedDrainObserved
+        >>
+
+CompleteAnyRelease(g) ==
+    \/ CompleteRelease(g, "Succeeded")
+    \/ CompleteRelease(g, "Failed")
+
+RecordReport(g) ==
+    /\ groupState[g] = "Released"
+    /\ cleanupOutcome[g] # "None"
+    /\ reportEntry[g] = "None"
+    /\ reportEntry' =
+        [reportEntry EXCEPT ![g] = cleanupOutcome[g]]
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, leaseCount, groupBusy,
+        releaseOwner, releaseStarts, cleanupOutcome, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+FinalizeWorkspace ==
+    /\ workspaceState = "Closing"
+    /\ \A g \in Groups : buildState[g] # "InFlight"
+    /\ \/ AllowEarlyWorkspaceCompletion
+       \/ /\ TerminalGroups
+          /\ \/ CompleteReport
+             \/ AllowCleanupOmission
+    /\ workspaceState' = "Closed"
+    /\ workspaceCompletionWitness' =
+        (workspaceCompletionWitness /\ TerminalGroups)
+    /\ cleanupVisibilityWitness' =
+        (cleanupVisibilityWitness /\ CompleteReport)
+    /\ UNCHANGED <<
+        buildState, groupState, leaseCount, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+RepeatRelease(g) ==
+    /\ AllowDoubleRelease
+    /\ groupState[g] = "Released"
+    /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
+    /\ UNCHANGED <<
+        workspaceState, buildState, groupState, leaseCount, groupBusy,
+        releaseOwner, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+Next ==
+    \/ \E g \in Groups : StartBuild(g)
+    \/ \E g \in Groups : CompleteBuild(g)
+    \/ \E g \in Groups : AcquireLease(g)
+    \/ \E g \in Groups : ReturnLease(g)
+    \/ \E g \in Groups : BeginGroupWork(g)
+    \/ \E g \in Groups : EndGroupWork(g)
+    \/ CloseWorkspace
+    \/ \E g \in Groups : RequestDirectRelease(g)
+    \/ \E g \in Groups : RequestCoordinatedRelease(g)
+    \/ \E g \in Groups : CompleteAnyRelease(g)
+    \/ \E g \in Groups : RecordReport(g)
+    \/ FinalizeWorkspace
+    \/ \E g \in Groups : RepeatRelease(g)
+
+Fairness ==
+    /\ \A g \in Groups : WF_vars(CompleteBuild(g))
+    /\ \A g \in Groups : WF_vars(ReturnLease(g))
+    /\ \A g \in Groups : WF_vars(EndGroupWork(g))
+    /\ \A g \in Groups : WF_vars(RequestDirectRelease(g))
+    /\ \A g \in Groups : WF_vars(RequestCoordinatedRelease(g))
+    /\ \A g \in Groups : WF_vars(CompleteAnyRelease(g))
+    /\ \A g \in Groups : WF_vars(RecordReport(g))
+    /\ WF_vars(FinalizeWorkspace)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************)
+(* Safety properties. Witnesses preserve each action's required pre-state   *)
+(* so a mutation cannot make its own weakened guard vacuously authoritative.*)
+(***************************************************************************)
+NoBuildAdmissionAfterClose == buildAdmissionWitness
+NoLeaseAdmissionAfterClose == leaseAdmissionWitness
+ReleaseUsesSingleOwner == authorityWitness
+CoordinatedReleaseWaitsForLeases == leaseDrainWitness
+LateCompletionRoutesToCleanup == lateRoutingWitness
+ReleaseWaitsForGroupQuiescence == groupQuiescenceWitness
+WorkspaceCloseWaitsForQuiescence == workspaceCompletionWitness
+CleanupFailuresRemainVisible == cleanupVisibilityWitness
+
+ReleaseBeginsAtMostOnce ==
+    \A g \in Groups : releaseStarts[g] <= 1
+
+ExistingLeasesRemainUsable ==
+    \A g \in CoordinatedGroups :
+        leaseCount[g] > 0 => groupState[g] # "Released"
+
+ClosedWorkspaceIsDrained ==
+    workspaceState = "Closed"
+        => /\ \A g \in Groups : buildState[g] # "InFlight"
+           /\ TerminalGroups
+           /\ CompleteReport
+
+(***************************************************************************)
+(* Liveness properties. The model does not require StartBuild or            *)
+(* CloseWorkspace to occur; once those operations start, weak fairness      *)
+(* requires their owner-visible completion.                                 *)
+(***************************************************************************)
+EveryStartedBuildFinishes ==
+    \A g \in Groups :
+        buildState[g] = "InFlight" ~> buildState[g] = "Finished"
+
+EveryRequestedReleaseCompletes ==
+    \A g \in Groups :
+        groupState[g] = "ReleaseRequested" ~> groupState[g] = "Released"
+
+ClosingWorkspaceEventuallyCloses ==
+    workspaceState = "Closing" ~> workspaceState = "Closed"
+
+(***************************************************************************)
+(* Reachability probes. Configurations negate these observations so TLC     *)
+(* emits a trace when the intended path is reachable.                       *)
+(***************************************************************************)
+NoDirectReleaseObserved == ~directReleaseObserved
+NoCoordinatedDrainObserved == ~coordinatedDrainObserved
+NoLateCleanupObserved == ~lateCleanupObserved
+NoCleanupFailureObserved == ~cleanupFailureObserved
+
+=============================================================================

--- a/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
+++ b/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
@@ -23,13 +23,15 @@ CONSTANTS
     MaxLeases,
     AllowAdmissionAfterClose,
     AllowLeaseAfterClose,
-    AllowWrongReleaseAuthority,
+    AllowWrongDirectReleaseAuthority,
+    AllowWrongCoordinatedReleaseAuthority,
     AllowReleaseWithActiveLease,
     AllowReleaseBeforeGroupQuiescence,
     AllowLatePublication,
     AllowEarlyWorkspaceCompletion,
     AllowCleanupOmission,
-    AllowDoubleRelease
+    AllowDoubleRelease,
+    AllowStrandedNoGroupCompletion
 
 ASSUME
     /\ Groups # {}
@@ -38,18 +40,21 @@ ASSUME
     /\ MaxLeases \in Nat \ {0}
     /\ AllowAdmissionAfterClose \in BOOLEAN
     /\ AllowLeaseAfterClose \in BOOLEAN
-    /\ AllowWrongReleaseAuthority \in BOOLEAN
+    /\ AllowWrongDirectReleaseAuthority \in BOOLEAN
+    /\ AllowWrongCoordinatedReleaseAuthority \in BOOLEAN
     /\ AllowReleaseWithActiveLease \in BOOLEAN
     /\ AllowReleaseBeforeGroupQuiescence \in BOOLEAN
     /\ AllowLatePublication \in BOOLEAN
     /\ AllowEarlyWorkspaceCompletion \in BOOLEAN
     /\ AllowCleanupOmission \in BOOLEAN
     /\ AllowDoubleRelease \in BOOLEAN
+    /\ AllowStrandedNoGroupCompletion \in BOOLEAN
 
 DirectGroups == Groups \ CoordinatedGroups
 
 WorkspaceStates == {"Open", "Closing", "Closed"}
 BuildStates == {"NotStarted", "InFlight", "Finished"}
+BuildOutcomes == {"None", "Group", "Failed", "Canceled"}
 GroupStates ==
     {"Absent", "Published", "ReleaseOnly", "ReleaseRequested", "Released"}
 ReleaseOwners == {"None", "Workspace", "Completion"}
@@ -59,6 +64,7 @@ ReportEntries == {"None", "Succeeded", "Failed"}
 VARIABLES
     workspaceState,
     buildState,
+    buildOutcome,
     groupState,
     leaseCount,
     groupBusy,
@@ -78,17 +84,22 @@ VARIABLES
     cleanupVisibilityWitness,
     directReleaseObserved,
     coordinatedDrainObserved,
+    ownerFirstReleaseObserved,
+    postCloseLeaseWorkObserved,
+    noGroupCompletionObserved,
     lateCleanupObserved,
     cleanupFailureObserved
 
 vars == <<
-    workspaceState, buildState, groupState, leaseCount, groupBusy,
+    workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
     releaseOwner, releaseStarts, cleanupOutcome, reportEntry, lateGroup,
     disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
     authorityWitness, leaseDrainWitness, lateRoutingWitness,
     groupQuiescenceWitness, workspaceCompletionWitness,
     cleanupVisibilityWitness, directReleaseObserved,
-    coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+    coordinatedDrainObserved, ownerFirstReleaseObserved,
+    postCloseLeaseWorkObserved, noGroupCompletionObserved,
+    lateCleanupObserved, cleanupFailureObserved
     >>
 
 KnownGroups ==
@@ -109,6 +120,7 @@ CompleteReport ==
 TypeOK ==
     /\ workspaceState \in WorkspaceStates
     /\ buildState \in [Groups -> BuildStates]
+    /\ buildOutcome \in [Groups -> BuildOutcomes]
     /\ groupState \in [Groups -> GroupStates]
     /\ leaseCount \in [Groups -> 0..MaxLeases]
     /\ groupBusy \in [Groups -> BOOLEAN]
@@ -128,12 +140,16 @@ TypeOK ==
     /\ cleanupVisibilityWitness \in BOOLEAN
     /\ directReleaseObserved \in BOOLEAN
     /\ coordinatedDrainObserved \in BOOLEAN
+    /\ ownerFirstReleaseObserved \in BOOLEAN
+    /\ postCloseLeaseWorkObserved \in BOOLEAN
+    /\ noGroupCompletionObserved \in BOOLEAN
     /\ lateCleanupObserved \in BOOLEAN
     /\ cleanupFailureObserved \in BOOLEAN
 
 Init ==
     /\ workspaceState = "Open"
     /\ buildState = [g \in Groups |-> "NotStarted"]
+    /\ buildOutcome = [g \in Groups |-> "None"]
     /\ groupState = [g \in Groups |-> "Absent"]
     /\ leaseCount = [g \in Groups |-> 0]
     /\ groupBusy = [g \in Groups |-> FALSE]
@@ -153,6 +169,9 @@ Init ==
     /\ cleanupVisibilityWitness = TRUE
     /\ directReleaseObserved = FALSE
     /\ coordinatedDrainObserved = FALSE
+    /\ ownerFirstReleaseObserved = FALSE
+    /\ postCloseLeaseWorkObserved = FALSE
+    /\ noGroupCompletionObserved = FALSE
     /\ lateCleanupObserved = FALSE
     /\ cleanupFailureObserved = FALSE
 
@@ -164,23 +183,26 @@ StartBuild(g) ==
     /\ buildAdmissionWitness' =
         (buildAdmissionWitness /\ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, groupState, leaseCount, groupBusy, releaseOwner,
+        workspaceState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
-        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
-        cleanupFailureObserved
+        directReleaseObserved, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
 CompleteBuild(g) ==
     /\ buildState[g] = "InFlight"
+    /\ buildOutcome[g] = "None"
     /\ LET nextState ==
             IF workspaceState = "Open" \/ AllowLatePublication
             THEN "Published"
             ELSE "ReleaseOnly"
        IN
         /\ buildState' = [buildState EXCEPT ![g] = "Finished"]
+        /\ buildOutcome' = [buildOutcome EXCEPT ![g] = "Group"]
         /\ groupState' = [groupState EXCEPT ![g] = nextState]
         /\ lateGroup' =
             [lateGroup EXCEPT ![g] = workspaceState # "Open"]
@@ -193,7 +215,33 @@ CompleteBuild(g) ==
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
-        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
+        directReleaseObserved, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
+        >>
+
+CompleteBuildWithoutGroup(g, outcome) ==
+    /\ outcome \in {"Failed", "Canceled"}
+    /\ buildState[g] = "InFlight"
+    /\ buildOutcome[g] = "None"
+    /\ buildState' =
+        [buildState EXCEPT
+            ![g] = IF AllowStrandedNoGroupCompletion
+                    THEN "InFlight"
+                    ELSE "Finished"]
+    /\ buildOutcome' = [buildOutcome EXCEPT ![g] = outcome]
+    /\ noGroupCompletionObserved' =
+        (noGroupCompletionObserved
+         \/ (workspaceState # "Open" /\ ~AllowStrandedNoGroupCompletion))
+    /\ UNCHANGED <<
+        workspaceState, groupState, leaseCount, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
+        authorityWitness, leaseDrainWitness, lateRoutingWitness,
+        groupQuiescenceWitness, workspaceCompletionWitness,
+        cleanupVisibilityWitness, directReleaseObserved,
+        coordinatedDrainObserved, ownerFirstReleaseObserved,
+        postCloseLeaseWorkObserved, lateCleanupObserved,
         cleanupFailureObserved
         >>
 
@@ -207,13 +255,14 @@ AcquireLease(g) ==
     /\ leaseAdmissionWitness' =
         (leaseAdmissionWitness /\ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, groupBusy, releaseOwner,
+        workspaceState, buildState, buildOutcome, groupState, groupBusy, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
-        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
-        cleanupFailureObserved
+        directReleaseObserved, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
 ReturnLease(g) ==
@@ -221,41 +270,52 @@ ReturnLease(g) ==
     /\ leaseCount[g] > 0
     /\ leaseCount' = [leaseCount EXCEPT ![g] = @ - 1]
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, groupBusy, releaseOwner,
+        workspaceState, buildState, buildOutcome, groupState, groupBusy, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
 BeginGroupWork(g) ==
     /\ groupState[g] = "Published"
-    /\ workspaceState = "Open"
+    /\ \/ workspaceState = "Open"
+       \/ /\ workspaceState = "Closing"
+          /\ g \in CoordinatedGroups
+          /\ leaseCount[g] > 0
     /\ ~groupBusy[g]
     /\ groupBusy' = [groupBusy EXCEPT ![g] = TRUE]
+    /\ postCloseLeaseWorkObserved' =
+        (postCloseLeaseWorkObserved \/ workspaceState = "Closing")
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, leaseCount, releaseOwner,
+        workspaceState, buildState, buildOutcome, groupState, leaseCount, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved,
+        ownerFirstReleaseObserved, noGroupCompletionObserved,
+        lateCleanupObserved, cleanupFailureObserved
         >>
 
 EndGroupWork(g) ==
     /\ groupBusy[g]
     /\ groupBusy' = [groupBusy EXCEPT ![g] = FALSE]
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, leaseCount, releaseOwner,
+        workspaceState, buildState, buildOutcome, groupState, leaseCount, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
 CloseWorkspace ==
@@ -264,41 +324,50 @@ CloseWorkspace ==
     /\ disposedWithLease' =
         [g \in Groups |-> leaseCount[g] > 0]
     /\ UNCHANGED <<
-        buildState, groupState, leaseCount, groupBusy, releaseOwner,
+        buildState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
-        directReleaseObserved, coordinatedDrainObserved, lateCleanupObserved,
-        cleanupFailureObserved
+        directReleaseObserved, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved, cleanupFailureObserved
         >>
 
 RequestDirectRelease(g) ==
     /\ g \in DirectGroups
     /\ workspaceState = "Closing"
     /\ groupState[g] \in {"Published", "ReleaseOnly"}
-    /\ groupState' = [groupState EXCEPT ![g] = "ReleaseRequested"]
-    /\ releaseOwner' = [releaseOwner EXCEPT ![g] = "Workspace"]
+    /\ LET owner ==
+            IF AllowWrongDirectReleaseAuthority
+            THEN "Completion"
+            ELSE "Workspace"
+       IN
+        /\ groupState' =
+            [groupState EXCEPT ![g] = "ReleaseRequested"]
+        /\ releaseOwner' = [releaseOwner EXCEPT ![g] = owner]
+        /\ authorityWitness' =
+            (authorityWitness /\ owner = ExpectedReleaseOwner(g))
     /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
-    /\ authorityWitness' =
-        (authorityWitness /\ ExpectedReleaseOwner(g) = "Workspace")
     /\ UNCHANGED <<
-        workspaceState, buildState, leaseCount, groupBusy, cleanupOutcome,
+        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, cleanupOutcome,
         reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
         leaseAdmissionWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved, ownerFirstReleaseObserved,
+        postCloseLeaseWorkObserved, noGroupCompletionObserved,
+        lateCleanupObserved, cleanupFailureObserved
         >>
 
 OwnerRequestsCoordinatedRelease(g) ==
     /\ g \in CoordinatedGroups
-    /\ workspaceState = "Closing"
+    /\ workspaceState \in {"Open", "Closing"}
     /\ groupState[g] \in {"Published", "ReleaseOnly"}
     /\ \/ leaseCount[g] = 0
        \/ AllowReleaseWithActiveLease
     /\ LET owner ==
-            IF AllowWrongReleaseAuthority
+            IF AllowWrongCoordinatedReleaseAuthority
             THEN "Workspace"
             ELSE "Completion"
        IN
@@ -313,12 +382,16 @@ OwnerRequestsCoordinatedRelease(g) ==
     /\ coordinatedDrainObserved' =
         (coordinatedDrainObserved
          \/ (disposedWithLease[g] /\ leaseCount[g] = 0))
+    /\ ownerFirstReleaseObserved' =
+        (ownerFirstReleaseObserved \/ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, buildState, leaseCount, groupBusy, cleanupOutcome,
+        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, cleanupOutcome,
         reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
         leaseAdmissionWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
-        directReleaseObserved, lateCleanupObserved, cleanupFailureObserved
+        directReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved,
+        cleanupFailureObserved
         >>
 
 CompleteRelease(g, outcome) ==
@@ -337,11 +410,13 @@ CompleteRelease(g, outcome) ==
     /\ cleanupFailureObserved' =
         (cleanupFailureObserved \/ outcome = "Failed")
     /\ UNCHANGED <<
-        workspaceState, buildState, leaseCount, groupBusy, releaseOwner,
+        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, releaseOwner,
         releaseStarts, reportEntry, lateGroup, disposedWithLease,
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, workspaceCompletionWitness,
-        cleanupVisibilityWitness, coordinatedDrainObserved
+        cleanupVisibilityWitness, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved
         >>
 
 CompleteAnyRelease(g) ==
@@ -355,13 +430,15 @@ RecordReport(g) ==
     /\ reportEntry' =
         [reportEntry EXCEPT ![g] = cleanupOutcome[g]]
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, leaseCount, groupBusy,
+        workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
         releaseOwner, releaseStarts, cleanupOutcome, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved, ownerFirstReleaseObserved,
+        postCloseLeaseWorkObserved, noGroupCompletionObserved,
+        lateCleanupObserved, cleanupFailureObserved
         >>
 
 FinalizeWorkspace ==
@@ -377,12 +454,14 @@ FinalizeWorkspace ==
     /\ cleanupVisibilityWitness' =
         (cleanupVisibilityWitness /\ CompleteReport)
     /\ UNCHANGED <<
-        buildState, groupState, leaseCount, groupBusy, releaseOwner,
+        buildState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
         releaseStarts, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved, ownerFirstReleaseObserved,
+        postCloseLeaseWorkObserved, noGroupCompletionObserved,
+        lateCleanupObserved, cleanupFailureObserved
         >>
 
 RepeatRelease(g) ==
@@ -390,18 +469,23 @@ RepeatRelease(g) ==
     /\ groupState[g] = "Released"
     /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
     /\ UNCHANGED <<
-        workspaceState, buildState, groupState, leaseCount, groupBusy,
+        workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
         releaseOwner, cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
-        coordinatedDrainObserved, lateCleanupObserved, cleanupFailureObserved
+        coordinatedDrainObserved, ownerFirstReleaseObserved,
+        postCloseLeaseWorkObserved, noGroupCompletionObserved,
+        lateCleanupObserved, cleanupFailureObserved
         >>
 
 Next ==
     \/ \E g \in Groups : StartBuild(g)
     \/ \E g \in Groups : CompleteBuild(g)
+    \/ \E g \in Groups :
+        \E outcome \in {"Failed", "Canceled"} :
+            CompleteBuildWithoutGroup(g, outcome)
     \/ \E g \in Groups : AcquireLease(g)
     \/ \E g \in Groups : ReturnLease(g)
     \/ \E g \in Groups : BeginGroupWork(g)
@@ -416,6 +500,9 @@ Next ==
 
 Fairness ==
     /\ \A g \in Groups : WF_vars(CompleteBuild(g))
+    /\ \A g \in Groups :
+        \A outcome \in {"Failed", "Canceled"} :
+            WF_vars(CompleteBuildWithoutGroup(g, outcome))
     /\ \A g \in Groups : WF_vars(ReturnLease(g))
     /\ \A g \in Groups : WF_vars(EndGroupWork(g))
     /\ \A g \in Groups : WF_vars(RequestDirectRelease(g))
@@ -442,7 +529,7 @@ CleanupFailuresRemainVisible == cleanupVisibilityWitness
 ReleaseBeginsAtMostOnce ==
     \A g \in Groups : releaseStarts[g] <= 1
 
-ExistingLeasesRemainUsable ==
+ActiveLeasesPreventRelease ==
     \A g \in CoordinatedGroups :
         leaseCount[g] > 0 => groupState[g] # "Released"
 
@@ -474,6 +561,9 @@ ClosingWorkspaceEventuallyCloses ==
 (***************************************************************************)
 NoDirectReleaseObserved == ~directReleaseObserved
 NoCoordinatedDrainObserved == ~coordinatedDrainObserved
+NoOwnerFirstReleaseObserved == ~ownerFirstReleaseObserved
+NoPostCloseLeaseWorkObserved == ~postCloseLeaseWorkObserved
+NoNoGroupCompletionObserved == ~noGroupCompletionObserved
 NoLateCleanupObserved == ~lateCleanupObserved
 NoCleanupFailureObserved == ~cleanupFailureObserved
 

--- a/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
+++ b/docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla
@@ -31,7 +31,9 @@ CONSTANTS
     AllowEarlyWorkspaceCompletion,
     AllowCleanupOmission,
     AllowDoubleRelease,
-    AllowStrandedNoGroupCompletion
+    AllowStrandedNoGroupCompletion,
+    AllowOwnerFirstHistoryLoss,
+    AllowNoGroupCleanupEntry
 
 ASSUME
     /\ Groups # {}
@@ -49,6 +51,8 @@ ASSUME
     /\ AllowCleanupOmission \in BOOLEAN
     /\ AllowDoubleRelease \in BOOLEAN
     /\ AllowStrandedNoGroupCompletion \in BOOLEAN
+    /\ AllowOwnerFirstHistoryLoss \in BOOLEAN
+    /\ AllowNoGroupCleanupEntry \in BOOLEAN
 
 DirectGroups == Groups \ CoordinatedGroups
 
@@ -65,8 +69,10 @@ VARIABLES
     workspaceState,
     buildState,
     buildOutcome,
+    registeredGroup,
     groupState,
     leaseCount,
+    ownerReleaseRequested,
     groupBusy,
     releaseOwner,
     releaseStarts,
@@ -91,8 +97,9 @@ VARIABLES
     cleanupFailureObserved
 
 vars == <<
-    workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
-    releaseOwner, releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+    workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+    leaseCount, ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+    cleanupOutcome, reportEntry, lateGroup,
     disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
     authorityWitness, leaseDrainWitness, lateRoutingWitness,
     groupQuiescenceWitness, workspaceCompletionWitness,
@@ -103,8 +110,7 @@ vars == <<
     >>
 
 KnownGroups ==
-    {g \in Groups : buildState[g] = "Finished"
-        /\ groupState[g] # "Absent"}
+    {g \in Groups : registeredGroup[g]}
 
 ExpectedReleaseOwner(g) ==
     IF g \in CoordinatedGroups THEN "Completion" ELSE "Workspace"
@@ -113,16 +119,21 @@ TerminalGroups ==
     \A g \in KnownGroups : groupState[g] = "Released"
 
 CompleteReport ==
-    \A g \in KnownGroups :
-        /\ reportEntry[g] # "None"
-        /\ reportEntry[g] = cleanupOutcome[g]
+    \A g \in Groups :
+        IF registeredGroup[g]
+        THEN /\ reportEntry[g] # "None"
+             /\ reportEntry[g] = cleanupOutcome[g]
+        ELSE /\ reportEntry[g] = "None"
+             /\ cleanupOutcome[g] = "None"
 
 TypeOK ==
     /\ workspaceState \in WorkspaceStates
     /\ buildState \in [Groups -> BuildStates]
     /\ buildOutcome \in [Groups -> BuildOutcomes]
+    /\ registeredGroup \in [Groups -> BOOLEAN]
     /\ groupState \in [Groups -> GroupStates]
     /\ leaseCount \in [Groups -> 0..MaxLeases]
+    /\ ownerReleaseRequested \in [Groups -> BOOLEAN]
     /\ groupBusy \in [Groups -> BOOLEAN]
     /\ releaseOwner \in [Groups -> ReleaseOwners]
     /\ releaseStarts \in [Groups -> Nat]
@@ -150,8 +161,10 @@ Init ==
     /\ workspaceState = "Open"
     /\ buildState = [g \in Groups |-> "NotStarted"]
     /\ buildOutcome = [g \in Groups |-> "None"]
+    /\ registeredGroup = [g \in Groups |-> FALSE]
     /\ groupState = [g \in Groups |-> "Absent"]
     /\ leaseCount = [g \in Groups |-> 0]
+    /\ ownerReleaseRequested = [g \in Groups |-> FALSE]
     /\ groupBusy = [g \in Groups |-> FALSE]
     /\ releaseOwner = [g \in Groups |-> "None"]
     /\ releaseStarts = [g \in Groups |-> 0]
@@ -183,8 +196,9 @@ StartBuild(g) ==
     /\ buildAdmissionWitness' =
         (buildAdmissionWitness /\ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildOutcome, registeredGroup, groupState, leaseCount,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
@@ -203,6 +217,7 @@ CompleteBuild(g) ==
        IN
         /\ buildState' = [buildState EXCEPT ![g] = "Finished"]
         /\ buildOutcome' = [buildOutcome EXCEPT ![g] = "Group"]
+        /\ registeredGroup' = [registeredGroup EXCEPT ![g] = TRUE]
         /\ groupState' = [groupState EXCEPT ![g] = nextState]
         /\ lateGroup' =
             [lateGroup EXCEPT ![g] = workspaceState # "Open"]
@@ -210,8 +225,9 @@ CompleteBuild(g) ==
             (lateRoutingWitness
              /\ (workspaceState = "Open" \/ nextState = "ReleaseOnly"))
     /\ UNCHANGED <<
-        workspaceState, leaseCount, groupBusy, releaseOwner, releaseStarts,
-        cleanupOutcome, reportEntry, disposedWithLease,
+        workspaceState, leaseCount, ownerReleaseRequested, groupBusy,
+        releaseOwner, releaseStarts, cleanupOutcome, reportEntry,
+        disposedWithLease,
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
@@ -230,12 +246,19 @@ CompleteBuildWithoutGroup(g, outcome) ==
                     THEN "InFlight"
                     ELSE "Finished"]
     /\ buildOutcome' = [buildOutcome EXCEPT ![g] = outcome]
+    /\ cleanupOutcome' =
+        [cleanupOutcome EXCEPT
+            ![g] = IF AllowNoGroupCleanupEntry THEN "Failed" ELSE @]
+    /\ reportEntry' =
+        [reportEntry EXCEPT
+            ![g] = IF AllowNoGroupCleanupEntry THEN "Failed" ELSE @]
     /\ noGroupCompletionObserved' =
         (noGroupCompletionObserved
          \/ (workspaceState # "Open" /\ ~AllowStrandedNoGroupCompletion))
     /\ UNCHANGED <<
-        workspaceState, groupState, leaseCount, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, registeredGroup, groupState, leaseCount,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -248,6 +271,7 @@ CompleteBuildWithoutGroup(g, outcome) ==
 AcquireLease(g) ==
     /\ g \in CoordinatedGroups
     /\ groupState[g] = "Published"
+    /\ ~ownerReleaseRequested[g]
     /\ leaseCount[g] < MaxLeases
     /\ \/ workspaceState = "Open"
        \/ AllowLeaseAfterClose
@@ -255,8 +279,9 @@ AcquireLease(g) ==
     /\ leaseAdmissionWitness' =
         (leaseAdmissionWitness /\ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
@@ -270,8 +295,9 @@ ReturnLease(g) ==
     /\ leaseCount[g] > 0
     /\ leaseCount' = [leaseCount EXCEPT ![g] = @ - 1]
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -283,17 +309,18 @@ ReturnLease(g) ==
 
 BeginGroupWork(g) ==
     /\ groupState[g] = "Published"
-    /\ \/ workspaceState = "Open"
-       \/ /\ workspaceState = "Closing"
-          /\ g \in CoordinatedGroups
+    /\ \/ /\ workspaceState = "Open"
+          /\ ~ownerReleaseRequested[g]
+       \/ /\ g \in CoordinatedGroups
           /\ leaseCount[g] > 0
     /\ ~groupBusy[g]
     /\ groupBusy' = [groupBusy EXCEPT ![g] = TRUE]
     /\ postCloseLeaseWorkObserved' =
         (postCloseLeaseWorkObserved \/ workspaceState = "Closing")
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, leaseCount, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        leaseCount, ownerReleaseRequested, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -307,8 +334,9 @@ EndGroupWork(g) ==
     /\ groupBusy[g]
     /\ groupBusy' = [groupBusy EXCEPT ![g] = FALSE]
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, leaseCount, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        leaseCount, ownerReleaseRequested, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -324,8 +352,9 @@ CloseWorkspace ==
     /\ disposedWithLease' =
         [g \in Groups |-> leaseCount[g] > 0]
     /\ UNCHANGED <<
-        buildState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        buildState, buildOutcome, registeredGroup, groupState, leaseCount,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
@@ -350,8 +379,9 @@ RequestDirectRelease(g) ==
             (authorityWitness /\ owner = ExpectedReleaseOwner(g))
     /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, cleanupOutcome,
-        reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
+        workspaceState, buildState, buildOutcome, registeredGroup, leaseCount,
+        ownerReleaseRequested, groupBusy, cleanupOutcome, reportEntry,
+        lateGroup, disposedWithLease, buildAdmissionWitness,
         leaseAdmissionWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, directReleaseObserved,
@@ -360,9 +390,32 @@ RequestDirectRelease(g) ==
         lateCleanupObserved, cleanupFailureObserved
         >>
 
-OwnerRequestsCoordinatedRelease(g) ==
+RequestOwnerRelease(g) ==
+    \* External owner input is intentionally not fair: owner-first close is
+    \* optional, while workspace-triggered processing below must make progress.
     /\ g \in CoordinatedGroups
     /\ workspaceState \in {"Open", "Closing"}
+    /\ groupState[g] = "Published"
+    /\ ~ownerReleaseRequested[g]
+    /\ ownerReleaseRequested' =
+        [ownerReleaseRequested EXCEPT ![g] = TRUE]
+    /\ UNCHANGED <<
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        leaseCount, groupBusy, releaseOwner, releaseStarts, cleanupOutcome,
+        reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
+        leaseAdmissionWitness, authorityWitness, leaseDrainWitness,
+        lateRoutingWitness, groupQuiescenceWitness,
+        workspaceCompletionWitness, cleanupVisibilityWitness,
+        directReleaseObserved, coordinatedDrainObserved,
+        ownerFirstReleaseObserved, postCloseLeaseWorkObserved,
+        noGroupCompletionObserved, lateCleanupObserved,
+        cleanupFailureObserved
+        >>
+
+ProcessCoordinatedRelease(g) ==
+    /\ g \in CoordinatedGroups
+    /\ \/ workspaceState = "Closing"
+       \/ ownerReleaseRequested[g]
     /\ groupState[g] \in {"Published", "ReleaseOnly"}
     /\ \/ leaseCount[g] = 0
        \/ AllowReleaseWithActiveLease
@@ -373,6 +426,12 @@ OwnerRequestsCoordinatedRelease(g) ==
        IN
         /\ groupState' =
             [groupState EXCEPT ![g] = "ReleaseRequested"]
+        /\ registeredGroup' =
+            [registeredGroup EXCEPT
+                ![g] = IF AllowOwnerFirstHistoryLoss
+                        /\ workspaceState = "Open"
+                        THEN FALSE
+                        ELSE @]
         /\ releaseOwner' = [releaseOwner EXCEPT ![g] = owner]
         /\ authorityWitness' =
             (authorityWitness /\ owner = ExpectedReleaseOwner(g))
@@ -385,8 +444,9 @@ OwnerRequestsCoordinatedRelease(g) ==
     /\ ownerFirstReleaseObserved' =
         (ownerFirstReleaseObserved \/ workspaceState = "Open")
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, cleanupOutcome,
-        reportEntry, lateGroup, disposedWithLease, buildAdmissionWitness,
+        workspaceState, buildState, buildOutcome, leaseCount,
+        ownerReleaseRequested, groupBusy, cleanupOutcome, reportEntry,
+        lateGroup, disposedWithLease, buildAdmissionWitness,
         leaseAdmissionWitness, lateRoutingWitness, groupQuiescenceWitness,
         workspaceCompletionWitness, cleanupVisibilityWitness,
         directReleaseObserved, postCloseLeaseWorkObserved,
@@ -410,8 +470,9 @@ CompleteRelease(g, outcome) ==
     /\ cleanupFailureObserved' =
         (cleanupFailureObserved \/ outcome = "Failed")
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, leaseCount, groupBusy, releaseOwner,
-        releaseStarts, reportEntry, lateGroup, disposedWithLease,
+        workspaceState, buildState, buildOutcome, registeredGroup, leaseCount,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        reportEntry, lateGroup, disposedWithLease,
         buildAdmissionWitness, leaseAdmissionWitness, authorityWitness,
         leaseDrainWitness, lateRoutingWitness, workspaceCompletionWitness,
         cleanupVisibilityWitness, coordinatedDrainObserved,
@@ -430,8 +491,9 @@ RecordReport(g) ==
     /\ reportEntry' =
         [reportEntry EXCEPT ![g] = cleanupOutcome[g]]
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
-        releaseOwner, releaseStarts, cleanupOutcome, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        leaseCount, ownerReleaseRequested, groupBusy, releaseOwner,
+        releaseStarts, cleanupOutcome, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -454,8 +516,9 @@ FinalizeWorkspace ==
     /\ cleanupVisibilityWitness' =
         (cleanupVisibilityWitness /\ CompleteReport)
     /\ UNCHANGED <<
-        buildState, buildOutcome, groupState, leaseCount, groupBusy, releaseOwner,
-        releaseStarts, cleanupOutcome, reportEntry, lateGroup,
+        buildState, buildOutcome, registeredGroup, groupState, leaseCount,
+        ownerReleaseRequested, groupBusy, releaseOwner, releaseStarts,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, directReleaseObserved,
@@ -469,8 +532,9 @@ RepeatRelease(g) ==
     /\ groupState[g] = "Released"
     /\ releaseStarts' = [releaseStarts EXCEPT ![g] = @ + 1]
     /\ UNCHANGED <<
-        workspaceState, buildState, buildOutcome, groupState, leaseCount, groupBusy,
-        releaseOwner, cleanupOutcome, reportEntry, lateGroup,
+        workspaceState, buildState, buildOutcome, registeredGroup, groupState,
+        leaseCount, ownerReleaseRequested, groupBusy, releaseOwner,
+        cleanupOutcome, reportEntry, lateGroup,
         disposedWithLease, buildAdmissionWitness, leaseAdmissionWitness,
         authorityWitness, leaseDrainWitness, lateRoutingWitness,
         groupQuiescenceWitness, workspaceCompletionWitness,
@@ -492,7 +556,8 @@ Next ==
     \/ \E g \in Groups : EndGroupWork(g)
     \/ CloseWorkspace
     \/ \E g \in Groups : RequestDirectRelease(g)
-    \/ \E g \in Groups : OwnerRequestsCoordinatedRelease(g)
+    \/ \E g \in Groups : RequestOwnerRelease(g)
+    \/ \E g \in Groups : ProcessCoordinatedRelease(g)
     \/ \E g \in Groups : CompleteAnyRelease(g)
     \/ \E g \in Groups : RecordReport(g)
     \/ FinalizeWorkspace
@@ -506,7 +571,7 @@ Fairness ==
     /\ \A g \in Groups : WF_vars(ReturnLease(g))
     /\ \A g \in Groups : WF_vars(EndGroupWork(g))
     /\ \A g \in Groups : WF_vars(RequestDirectRelease(g))
-    /\ \A g \in Groups : WF_vars(OwnerRequestsCoordinatedRelease(g))
+    /\ \A g \in Groups : WF_vars(ProcessCoordinatedRelease(g))
     /\ \A g \in Groups : WF_vars(CompleteAnyRelease(g))
     /\ \A g \in Groups : WF_vars(RecordReport(g))
     /\ WF_vars(FinalizeWorkspace)
@@ -532,6 +597,16 @@ ReleaseBeginsAtMostOnce ==
 ActiveLeasesPreventRelease ==
     \A g \in CoordinatedGroups :
         leaseCount[g] > 0 => groupState[g] # "Released"
+
+RegistrationHistoryMatchesBuildOutcome ==
+    \A g \in Groups :
+        registeredGroup[g] = (buildOutcome[g] = "Group")
+
+NoCleanupWithoutRegisteredGroup ==
+    \A g \in Groups :
+        ~registeredGroup[g]
+            => /\ cleanupOutcome[g] = "None"
+               /\ reportEntry[g] = "None"
 
 ClosedWorkspaceIsDrained ==
     workspaceState = "Closed"

--- a/docs/models/inspection-workspace-close/Liveness.cfg
+++ b/docs/models/inspection-workspace-close/Liveness.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 PROPERTIES
   EveryStartedBuildFinishes

--- a/docs/models/inspection-workspace-close/Liveness.cfg
+++ b/docs/models/inspection-workspace-close/Liveness.cfg
@@ -1,0 +1,22 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 2
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+PROPERTIES
+  EveryStartedBuildFinishes
+  EveryRequestedReleaseCompletes
+  ClosingWorkspaceEventuallyCloses
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/Liveness.cfg
+++ b/docs/models/inspection-workspace-close/Liveness.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 2
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 PROPERTIES
   EveryStartedBuildFinishes

--- a/docs/models/inspection-workspace-close/README.md
+++ b/docs/models/inspection-workspace-close/README.md
@@ -19,7 +19,10 @@ The modeled interactions are:
 - construction admission before workspace close;
 - completion that either publishes while open or enters cleanup-only routing
   after close;
+- failed or canceled construction that settles admission without a group;
 - coordinated lease acquisition and return;
+- lease-backed group work that begins after workspace close;
+- adjacent-owner release before workspace close;
 - workspace close while construction, leases, or group work remain active;
 - one release authority per direct or coordinated group;
 - release after external leases and group work quiesce;
@@ -38,8 +41,10 @@ The model does not cover:
 - `AssemblyContextGroup` image opening, resource ordering, or callback-local
   snapshots beyond the abstract busy state;
 - exception payloads, report serialization, or implementation conformance; or
-- the construction-time synchronous compatibility adapter, which has no
-  concurrent release protocol of its own; or
+- the construction-time synchronous compatibility adapter, whose request-only
+  disposal surface has no awaited close report;
+- close-caller or report object identity, which is assigned to the named
+  implementation gate in the owning design;
 - thread scheduling. The design separately requires awaited progress without
   a blocking wait or background-thread dependency.
 
@@ -56,7 +61,7 @@ The model does not cover:
 | `WorkspaceCloseWaitsForQuiescence` | Terminal workspace close observes every known group released. |
 | `CleanupFailuresRemainVisible` | Terminal workspace close has a complete report matching every group cleanup outcome. |
 | `ReleaseBeginsAtMostOnce` | Each group starts terminal release at most once. |
-| `ExistingLeasesRemainUsable` | A coordinated group is not released while an existing lease remains active. |
+| `ActiveLeasesPreventRelease` | A coordinated group is not released while an existing lease remains active. |
 | `ClosedWorkspaceIsDrained` | A closed workspace has no in-flight construction and has complete terminal group reports. |
 | `EveryStartedBuildFinishes` | Under weak fairness, every admitted construction reaches its owner-visible completion. |
 | `EveryRequestedReleaseCompletes` | Under weak fairness, every release request reaches a terminal group outcome. |
@@ -76,17 +81,22 @@ mutated guard.
 | `Liveness.cfg` | Checks construction, release, and workspace-close progress under weak fairness. |
 | `ReachabilityDirectRelease.cfg` | Demonstrates workspace-owned direct release. |
 | `ReachabilityCoordinatedDrain.cfg` | Demonstrates close waiting for an existing coordinated lease before release. |
+| `ReachabilityOwnerFirstRelease.cfg` | Demonstrates adjacent-owner release while the workspace remains open. |
+| `ReachabilityPostCloseLeaseWork.cfg` | Demonstrates an existing lease starting work after workspace close. |
+| `ReachabilityNoGroupCompletion.cfg` | Demonstrates a failed or canceled late construction settling without a group. |
 | `ReachabilityLateCleanup.cfg` | Demonstrates a construction completed after close reaching cleanup without publication. |
 | `ReachabilityCleanupFailure.cfg` | Demonstrates cleanup failure remaining a terminal report outcome. |
 | `BrokenAdmissionAfterClose.cfg` | Allows construction admission after close; TLC must violate `NoBuildAdmissionAfterClose`. |
 | `BrokenLeaseAfterClose.cfg` | Allows a new coordinated lease after close; TLC must violate `NoLeaseAdmissionAfterClose`. |
-| `BrokenWrongAuthority.cfg` | Lets the workspace claim coordinated release; TLC must violate `ReleaseUsesSingleOwner`. |
+| `BrokenWrongDirectAuthority.cfg` | Lets the completion claim direct release; TLC must violate `ReleaseUsesSingleOwner`. |
+| `BrokenWrongCoordinatedAuthority.cfg` | Lets the workspace claim coordinated release; TLC must violate `ReleaseUsesSingleOwner`. |
 | `BrokenReleaseWithLease.cfg` | Requests coordinated release with an active lease; TLC must violate `CoordinatedReleaseWaitsForLeases`. |
 | `BrokenReleaseBeforeQuiescence.cfg` | Completes group release while group work remains active; TLC must violate `ReleaseWaitsForGroupQuiescence`. |
 | `BrokenLatePublication.cfg` | Publishes a construction result after close; TLC must violate `LateCompletionRoutesToCleanup`. |
 | `BrokenEarlyWorkspaceCompletion.cfg` | Completes workspace close before group release; TLC must violate `WorkspaceCloseWaitsForQuiescence`. |
 | `BrokenCleanupOmission.cfg` | Completes workspace close without every group report; TLC must violate `CleanupFailuresRemainVisible`. |
 | `BrokenDoubleRelease.cfg` | Starts terminal release more than once; TLC must violate `ReleaseBeginsAtMostOnce`. |
+| `BrokenStrandedNoGroupCompletion.cfg` | Selects failed construction without settling admission; TLC must violate `EveryStartedBuildFinishes`. |
 
 ## Running TLC
 
@@ -99,11 +109,14 @@ java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
 java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
   -cleanup -config Liveness.cfg InspectionWorkspaceClose.tla
 for config in ReachabilityDirectRelease ReachabilityCoordinatedDrain \
-  ReachabilityLateCleanup ReachabilityCleanupFailure \
-  BrokenAdmissionAfterClose BrokenLeaseAfterClose BrokenWrongAuthority \
-  BrokenReleaseWithLease BrokenReleaseBeforeQuiescence \
-  BrokenLatePublication BrokenEarlyWorkspaceCompletion \
-  BrokenCleanupOmission BrokenDoubleRelease; do
+  ReachabilityOwnerFirstRelease ReachabilityPostCloseLeaseWork \
+  ReachabilityNoGroupCompletion ReachabilityLateCleanup \
+  ReachabilityCleanupFailure BrokenAdmissionAfterClose \
+  BrokenLeaseAfterClose BrokenWrongDirectAuthority \
+  BrokenWrongCoordinatedAuthority BrokenReleaseWithLease \
+  BrokenReleaseBeforeQuiescence BrokenLatePublication \
+  BrokenEarlyWorkspaceCompletion BrokenCleanupOmission \
+  BrokenDoubleRelease BrokenStrandedNoGroupCompletion; do
   java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
     -cleanup -noGenerateSpecTE -config "$config.cfg" \
     InspectionWorkspaceClose.tla
@@ -127,26 +140,32 @@ checked `tla2tools.jar` has SHA-256
 
 | Configuration | Result | Generated states | Distinct states | Maximum depth |
 | --- | --- | ---: | ---: | ---: |
-| `Safety.cfg` | No error | 1,004 | 515 | 15 |
-| `Liveness.cfg` | No error | 1,004 | 515 | 15 |
-| `ReachabilityDirectRelease.cfg` | Direct release reached | 73 | 53 | 6 |
-| `ReachabilityCoordinatedDrain.cfg` | Coordinated post-lease drain reached | 139 | 98 | 7 |
-| `ReachabilityLateCleanup.cfg` | Late-result cleanup reached | 75 | 55 | 6 |
-| `ReachabilityCleanupFailure.cfg` | Failed cleanup report reached | 74 | 54 | 6 |
-| `BrokenAdmissionAfterClose.cfg` | `NoBuildAdmissionAfterClose` violated | 15 | 10 | 3 |
-| `BrokenLeaseAfterClose.cfg` | `NoLeaseAdmissionAfterClose` violated | 49 | 35 | 5 |
-| `BrokenWrongAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 46 | 35 | 5 |
-| `BrokenReleaseWithLease.cfg` | `CoordinatedReleaseWaitsForLeases` violated | 86 | 59 | 6 |
-| `BrokenReleaseBeforeQuiescence.cfg` | `ReleaseWaitsForGroupQuiescence` violated | 149 | 93 | 7 |
-| `BrokenLatePublication.cfg` | `LateCompletionRoutesToCleanup` violated | 18 | 16 | 4 |
-| `BrokenEarlyWorkspaceCompletion.cfg` | `WorkspaceCloseWaitsForQuiescence` violated | 38 | 31 | 5 |
-| `BrokenCleanupOmission.cfg` | `CleanupFailuresRemainVisible` violated | 135 | 94 | 7 |
-| `BrokenDoubleRelease.cfg` | `ReleaseBeginsAtMostOnce` violated | 134 | 94 | 7 |
+| `Safety.cfg` | No error | 2,330 | 1,215 | 17 |
+| `Liveness.cfg` | No error | 2,330 | 1,215 | 17 |
+| `ReachabilityDirectRelease.cfg` | Direct release reached | 194 | 136 | 6 |
+| `ReachabilityCoordinatedDrain.cfg` | Coordinated post-lease drain reached | 363 | 247 | 7 |
+| `ReachabilityOwnerFirstRelease.cfg` | Owner-first release reached | 37 | 32 | 4 |
+| `ReachabilityPostCloseLeaseWork.cfg` | Post-close lease work reached | 203 | 142 | 6 |
+| `ReachabilityNoGroupCompletion.cfg` | No-group completion reached | 31 | 27 | 4 |
+| `ReachabilityLateCleanup.cfg` | Late-result cleanup reached | 196 | 138 | 6 |
+| `ReachabilityCleanupFailure.cfg` | Failed cleanup report reached | 101 | 77 | 5 |
+| `BrokenAdmissionAfterClose.cfg` | `NoBuildAdmissionAfterClose` violated | 19 | 14 | 3 |
+| `BrokenLeaseAfterClose.cfg` | `NoLeaseAdmissionAfterClose` violated | 100 | 74 | 5 |
+| `BrokenWrongDirectAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 82 | 64 | 5 |
+| `BrokenWrongCoordinatedAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 37 | 32 | 4 |
+| `BrokenReleaseWithLease.cfg` | `CoordinatedReleaseWaitsForLeases` violated | 94 | 72 | 5 |
+| `BrokenReleaseBeforeQuiescence.cfg` | `ReleaseWaitsForGroupQuiescence` violated | 217 | 145 | 6 |
+| `BrokenLatePublication.cfg` | `LateCompletionRoutesToCleanup` violated | 30 | 26 | 4 |
+| `BrokenEarlyWorkspaceCompletion.cfg` | `WorkspaceCloseWaitsForQuiescence` violated | 84 | 65 | 5 |
+| `BrokenCleanupOmission.cfg` | `CleanupFailuresRemainVisible` violated | 375 | 243 | 7 |
+| `BrokenDoubleRelease.cfg` | `ReleaseBeginsAtMostOnce` violated | 216 | 150 | 6 |
+| `BrokenStrandedNoGroupCompletion.cfg` | `EveryStartedBuildFinishes` violated | 34 | 29 | 8 |
 
 The normal configurations explored their complete bounded state graphs. Each
 reachability configuration stopped when its intended direct, coordinated,
-late-result, or failure path became observable. Every mutation stopped at the
-property named in the table: admission or lease creation crossed close, the
-wrong owner claimed release, release preceded external or group quiescence, a
-late group published, the workspace closed early, a cleanup result disappeared,
-or release began twice.
+owner-first, post-close lease-work, no-group, late-result, or failure path
+became observable. Every mutation stopped at the property named in the table:
+admission or lease creation crossed close, either release kind used the wrong
+owner, release preceded external or group quiescence, a late group published,
+the workspace closed early, a cleanup result disappeared, release began twice,
+or a failed construction stranded its admission.

--- a/docs/models/inspection-workspace-close/README.md
+++ b/docs/models/inspection-workspace-close/README.md
@@ -1,0 +1,150 @@
+# Inspection workspace close model
+
+`InspectionWorkspaceClose.tla` models the target
+`InspectionWorkspace` admission, group-release ownership, and asynchronous
+close protocol described by
+[`../../inspection-space.md`](../../inspection-space.md#workspace-close-and-group-release-authority).
+
+## Scope
+
+The model contains a bounded set of direct and coordinated group constructions.
+A direct group uses a workspace-owned release completion. A coordinated group
+uses an adjacent owner-issued completion and may have active external leases.
+Each group also has one abstract busy bit representing the callback and
+owned-resource quiescence protocol checked in more detail by
+[`AssemblyContextGroupLifecycle.tla`](../assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla).
+
+The modeled interactions are:
+
+- construction admission before workspace close;
+- completion that either publishes while open or enters cleanup-only routing
+  after close;
+- coordinated lease acquisition and return;
+- workspace close while construction, leases, or group work remain active;
+- one release authority per direct or coordinated group;
+- release after external leases and group work quiesce;
+- successful or failed cleanup recorded in the workspace report; and
+- terminal close only after every admitted construction and group release is
+  complete.
+
+## Non-claims
+
+The model does not cover:
+
+- package-realization keys, cache retention, capacity, or eviction;
+- package selection, role topology, participant projection, or cleanup-record
+  internals;
+- artifact acquisition identity or content lifetime;
+- `AssemblyContextGroup` image opening, resource ordering, or callback-local
+  snapshots beyond the abstract busy state;
+- exception payloads, report serialization, or implementation conformance; or
+- thread scheduling. The design separately requires awaited progress without
+  a blocking wait or background-thread dependency.
+
+## Checked properties
+
+| Property | Claim |
+| --- | --- |
+| `NoBuildAdmissionAfterClose` | A group construction starts only while the workspace is open. |
+| `NoLeaseAdmissionAfterClose` | Coordinated lease admission stops when workspace close begins. |
+| `ReleaseUsesSingleOwner` | Direct groups release through the workspace completion and coordinated groups through their owner-issued completion. |
+| `CoordinatedReleaseWaitsForLeases` | Coordinated release is not requested before existing leases return. |
+| `LateCompletionRoutesToCleanup` | A construction completed after close never publishes into the workspace. |
+| `ReleaseWaitsForGroupQuiescence` | Actual group release waits for already-admitted group work to finish. |
+| `WorkspaceCloseWaitsForQuiescence` | Terminal workspace close observes every known group released. |
+| `CleanupFailuresRemainVisible` | Terminal workspace close has a complete report matching every group cleanup outcome. |
+| `ReleaseBeginsAtMostOnce` | Each group starts terminal release at most once. |
+| `ExistingLeasesRemainUsable` | A coordinated group is not released while an existing lease remains active. |
+| `ClosedWorkspaceIsDrained` | A closed workspace has no in-flight construction and has complete terminal group reports. |
+| `EveryStartedBuildFinishes` | Under weak fairness, every admitted construction reaches its owner-visible completion. |
+| `EveryRequestedReleaseCompletes` | Under weak fairness, every release request reaches a terminal group outcome. |
+| `ClosingWorkspaceEventuallyCloses` | Under weak fairness, a closing workspace eventually reaches terminal close. |
+
+Admission, authority, lease-drain, late-routing, group-quiescence,
+workspace-completion, and report-completeness claims use monotonic witnesses
+that record the required action pre-state. Mutation configurations weaken the
+corresponding transition and falsify the witness rather than merely restating a
+mutated guard.
+
+## Configurations
+
+| Configuration | Purpose |
+| --- | --- |
+| `Safety.cfg` | Checks all safety properties with one direct group, one coordinated group, and up to two leases. |
+| `Liveness.cfg` | Checks construction, release, and workspace-close progress under weak fairness. |
+| `ReachabilityDirectRelease.cfg` | Demonstrates workspace-owned direct release. |
+| `ReachabilityCoordinatedDrain.cfg` | Demonstrates close waiting for an existing coordinated lease before release. |
+| `ReachabilityLateCleanup.cfg` | Demonstrates a construction completed after close reaching cleanup without publication. |
+| `ReachabilityCleanupFailure.cfg` | Demonstrates cleanup failure remaining a terminal report outcome. |
+| `BrokenAdmissionAfterClose.cfg` | Allows construction admission after close; TLC must violate `NoBuildAdmissionAfterClose`. |
+| `BrokenLeaseAfterClose.cfg` | Allows a new coordinated lease after close; TLC must violate `NoLeaseAdmissionAfterClose`. |
+| `BrokenWrongAuthority.cfg` | Lets the workspace claim coordinated release; TLC must violate `ReleaseUsesSingleOwner`. |
+| `BrokenReleaseWithLease.cfg` | Requests coordinated release with an active lease; TLC must violate `CoordinatedReleaseWaitsForLeases`. |
+| `BrokenReleaseBeforeQuiescence.cfg` | Completes group release while group work remains active; TLC must violate `ReleaseWaitsForGroupQuiescence`. |
+| `BrokenLatePublication.cfg` | Publishes a construction result after close; TLC must violate `LateCompletionRoutesToCleanup`. |
+| `BrokenEarlyWorkspaceCompletion.cfg` | Completes workspace close before group release; TLC must violate `WorkspaceCloseWaitsForQuiescence`. |
+| `BrokenCleanupOmission.cfg` | Completes workspace close without every group report; TLC must violate `CleanupFailuresRemainVisible`. |
+| `BrokenDoubleRelease.cfg` | Starts terminal release more than once; TLC must violate `ReleaseBeginsAtMostOnce`. |
+
+## Running TLC
+
+Use the repository-pinned `v1.8.0` `tla2tools.jar`:
+
+```bash
+cd docs/models/inspection-workspace-close
+java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+  -cleanup -config Safety.cfg InspectionWorkspaceClose.tla
+java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+  -cleanup -config Liveness.cfg InspectionWorkspaceClose.tla
+for config in ReachabilityDirectRelease ReachabilityCoordinatedDrain \
+  ReachabilityLateCleanup ReachabilityCleanupFailure \
+  BrokenAdmissionAfterClose BrokenLeaseAfterClose BrokenWrongAuthority \
+  BrokenReleaseWithLease BrokenReleaseBeforeQuiescence \
+  BrokenLatePublication BrokenEarlyWorkspaceCompletion \
+  BrokenCleanupOmission BrokenDoubleRelease; do
+  java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
+    -cleanup -noGenerateSpecTE -config "$config.cfg" \
+    InspectionWorkspaceClose.tla
+done
+```
+
+Run these commands sequentially. Concurrent TLC processes in one directory
+share the default `states/` checkpoint path unless each receives a distinct
+`-metadir`.
+
+The normal configurations must complete without errors. Reachability and
+broken configurations must stop at their intended counterexamples. A successful
+mutation run means its probe no longer exercises the intended rule.
+
+## TLC evidence
+
+Checked on macOS with Homebrew OpenJDK `25.0.4.1` and the repository-pinned
+TLA+ `v1.8.0` prerelease (`TLC2 2026.08.21.155922`, rev `9787e65`). The
+checked `tla2tools.jar` has SHA-256
+`eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a`.
+
+| Configuration | Result | Generated states | Distinct states | Maximum depth |
+| --- | --- | ---: | ---: | ---: |
+| `Safety.cfg` | No error | 1,004 | 515 | 15 |
+| `Liveness.cfg` | No error | 1,004 | 515 | 15 |
+| `ReachabilityDirectRelease.cfg` | Direct release reached | 73 | 53 | 6 |
+| `ReachabilityCoordinatedDrain.cfg` | Coordinated post-lease drain reached | 139 | 98 | 7 |
+| `ReachabilityLateCleanup.cfg` | Late-result cleanup reached | 75 | 55 | 6 |
+| `ReachabilityCleanupFailure.cfg` | Failed cleanup report reached | 74 | 54 | 6 |
+| `BrokenAdmissionAfterClose.cfg` | `NoBuildAdmissionAfterClose` violated | 15 | 10 | 3 |
+| `BrokenLeaseAfterClose.cfg` | `NoLeaseAdmissionAfterClose` violated | 49 | 35 | 5 |
+| `BrokenWrongAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 46 | 35 | 5 |
+| `BrokenReleaseWithLease.cfg` | `CoordinatedReleaseWaitsForLeases` violated | 86 | 59 | 6 |
+| `BrokenReleaseBeforeQuiescence.cfg` | `ReleaseWaitsForGroupQuiescence` violated | 149 | 93 | 7 |
+| `BrokenLatePublication.cfg` | `LateCompletionRoutesToCleanup` violated | 18 | 16 | 4 |
+| `BrokenEarlyWorkspaceCompletion.cfg` | `WorkspaceCloseWaitsForQuiescence` violated | 38 | 31 | 5 |
+| `BrokenCleanupOmission.cfg` | `CleanupFailuresRemainVisible` violated | 135 | 94 | 7 |
+| `BrokenDoubleRelease.cfg` | `ReleaseBeginsAtMostOnce` violated | 134 | 94 | 7 |
+
+The normal configurations explored their complete bounded state graphs. Each
+reachability configuration stopped when its intended direct, coordinated,
+late-result, or failure path became observable. Every mutation stopped at the
+property named in the table: admission or lease creation crossed close, the
+wrong owner claimed release, release preceded external or group quiescence, a
+late group published, the workspace closed early, a cleanup result disappeared,
+or release began twice.

--- a/docs/models/inspection-workspace-close/README.md
+++ b/docs/models/inspection-workspace-close/README.md
@@ -22,7 +22,7 @@ The modeled interactions are:
 - failed or canceled construction that settles admission without a group;
 - coordinated lease acquisition and return;
 - lease-backed group work that begins after workspace close;
-- adjacent-owner release before workspace close;
+- explicit adjacent-owner release before workspace close;
 - workspace close while construction, leases, or group work remain active;
 - one release authority per direct or coordinated group;
 - release after external leases and group work quiesce;
@@ -62,6 +62,8 @@ The model does not cover:
 | `CleanupFailuresRemainVisible` | Terminal workspace close has a complete report matching every group cleanup outcome. |
 | `ReleaseBeginsAtMostOnce` | Each group starts terminal release at most once. |
 | `ActiveLeasesPreventRelease` | A coordinated group is not released while an existing lease remains active. |
+| `RegistrationHistoryMatchesBuildOutcome` | Every group-producing admission remains in the immutable report domain. |
+| `NoCleanupWithoutRegisteredGroup` | Failed, canceled, or unstarted no-group slots never gain cleanup data. |
 | `ClosedWorkspaceIsDrained` | A closed workspace has no in-flight construction and has complete terminal group reports. |
 | `EveryStartedBuildFinishes` | Under weak fairness, every admitted construction reaches its owner-visible completion. |
 | `EveryRequestedReleaseCompletes` | Under weak fairness, every release request reaches a terminal group outcome. |
@@ -97,6 +99,8 @@ mutated guard.
 | `BrokenCleanupOmission.cfg` | Completes workspace close without every group report; TLC must violate `CleanupFailuresRemainVisible`. |
 | `BrokenDoubleRelease.cfg` | Starts terminal release more than once; TLC must violate `ReleaseBeginsAtMostOnce`. |
 | `BrokenStrandedNoGroupCompletion.cfg` | Selects failed construction without settling admission; TLC must violate `EveryStartedBuildFinishes`. |
+| `BrokenOwnerFirstHistoryLoss.cfg` | Drops an owner-first group from report history; TLC must violate `RegistrationHistoryMatchesBuildOutcome`. |
+| `BrokenNoGroupCleanupEntry.cfg` | Invents cleanup data for a no-group outcome; TLC must violate `NoCleanupWithoutRegisteredGroup`. |
 
 ## Running TLC
 
@@ -116,7 +120,8 @@ for config in ReachabilityDirectRelease ReachabilityCoordinatedDrain \
   BrokenWrongCoordinatedAuthority BrokenReleaseWithLease \
   BrokenReleaseBeforeQuiescence BrokenLatePublication \
   BrokenEarlyWorkspaceCompletion BrokenCleanupOmission \
-  BrokenDoubleRelease BrokenStrandedNoGroupCompletion; do
+  BrokenDoubleRelease BrokenStrandedNoGroupCompletion \
+  BrokenOwnerFirstHistoryLoss BrokenNoGroupCleanupEntry; do
   java -XX:+UseParallelGC -cp /path/to/tla2tools.jar tlc2.TLC \
     -cleanup -noGenerateSpecTE -config "$config.cfg" \
     InspectionWorkspaceClose.tla
@@ -140,26 +145,28 @@ checked `tla2tools.jar` has SHA-256
 
 | Configuration | Result | Generated states | Distinct states | Maximum depth |
 | --- | --- | ---: | ---: | ---: |
-| `Safety.cfg` | No error | 2,330 | 1,215 | 17 |
-| `Liveness.cfg` | No error | 2,330 | 1,215 | 17 |
-| `ReachabilityDirectRelease.cfg` | Direct release reached | 194 | 136 | 6 |
-| `ReachabilityCoordinatedDrain.cfg` | Coordinated post-lease drain reached | 363 | 247 | 7 |
-| `ReachabilityOwnerFirstRelease.cfg` | Owner-first release reached | 37 | 32 | 4 |
-| `ReachabilityPostCloseLeaseWork.cfg` | Post-close lease work reached | 203 | 142 | 6 |
+| `Safety.cfg` | No error | 4,270 | 1,945 | 18 |
+| `Liveness.cfg` | No error | 4,270 | 1,945 | 18 |
+| `ReachabilityDirectRelease.cfg` | Direct release reached | 198 | 136 | 6 |
+| `ReachabilityCoordinatedDrain.cfg` | Coordinated post-lease drain reached | 394 | 255 | 7 |
+| `ReachabilityOwnerFirstRelease.cfg` | Owner-first release reached | 103 | 77 | 5 |
+| `ReachabilityPostCloseLeaseWork.cfg` | Post-close lease work reached | 208 | 143 | 6 |
 | `ReachabilityNoGroupCompletion.cfg` | No-group completion reached | 31 | 27 | 4 |
-| `ReachabilityLateCleanup.cfg` | Late-result cleanup reached | 196 | 138 | 6 |
-| `ReachabilityCleanupFailure.cfg` | Failed cleanup report reached | 101 | 77 | 5 |
+| `ReachabilityLateCleanup.cfg` | Late-result cleanup reached | 200 | 138 | 6 |
+| `ReachabilityCleanupFailure.cfg` | Failed cleanup report reached | 199 | 137 | 6 |
 | `BrokenAdmissionAfterClose.cfg` | `NoBuildAdmissionAfterClose` violated | 19 | 14 | 3 |
-| `BrokenLeaseAfterClose.cfg` | `NoLeaseAdmissionAfterClose` violated | 100 | 74 | 5 |
+| `BrokenLeaseAfterClose.cfg` | `NoLeaseAdmissionAfterClose` violated | 102 | 75 | 5 |
 | `BrokenWrongDirectAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 82 | 64 | 5 |
-| `BrokenWrongCoordinatedAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 37 | 32 | 4 |
-| `BrokenReleaseWithLease.cfg` | `CoordinatedReleaseWaitsForLeases` violated | 94 | 72 | 5 |
-| `BrokenReleaseBeforeQuiescence.cfg` | `ReleaseWaitsForGroupQuiescence` violated | 217 | 145 | 6 |
+| `BrokenWrongCoordinatedAuthority.cfg` | `ReleaseUsesSingleOwner` violated | 100 | 76 | 5 |
+| `BrokenReleaseWithLease.cfg` | `CoordinatedReleaseWaitsForLeases` violated | 216 | 145 | 6 |
+| `BrokenReleaseBeforeQuiescence.cfg` | `ReleaseWaitsForGroupQuiescence` violated | 402 | 248 | 7 |
 | `BrokenLatePublication.cfg` | `LateCompletionRoutesToCleanup` violated | 30 | 26 | 4 |
 | `BrokenEarlyWorkspaceCompletion.cfg` | `WorkspaceCloseWaitsForQuiescence` violated | 84 | 65 | 5 |
-| `BrokenCleanupOmission.cfg` | `CleanupFailuresRemainVisible` violated | 375 | 243 | 7 |
-| `BrokenDoubleRelease.cfg` | `ReleaseBeginsAtMostOnce` violated | 216 | 150 | 6 |
+| `BrokenCleanupOmission.cfg` | `CleanupFailuresRemainVisible` violated | 400 | 249 | 7 |
+| `BrokenDoubleRelease.cfg` | `ReleaseBeginsAtMostOnce` violated | 383 | 249 | 7 |
 | `BrokenStrandedNoGroupCompletion.cfg` | `EveryStartedBuildFinishes` violated | 34 | 29 | 8 |
+| `BrokenOwnerFirstHistoryLoss.cfg` | `RegistrationHistoryMatchesBuildOutcome` violated | 30 | 25 | 5 |
+| `BrokenNoGroupCleanupEntry.cfg` | `NoCleanupWithoutRegisteredGroup` violated | 5 | 5 | 3 |
 
 The normal configurations explored their complete bounded state graphs. Each
 reachability configuration stopped when its intended direct, coordinated,
@@ -168,4 +175,6 @@ became observable. Every mutation stopped at the property named in the table:
 admission or lease creation crossed close, either release kind used the wrong
 owner, release preceded external or group quiescence, a late group published,
 the workspace closed early, a cleanup result disappeared, release began twice,
-or a failed construction stranded its admission.
+or a failed construction stranded its admission. The final two mutations prove
+that owner-first release cannot erase report history and no-group completion
+cannot invent cleanup data.

--- a/docs/models/inspection-workspace-close/README.md
+++ b/docs/models/inspection-workspace-close/README.md
@@ -38,6 +38,8 @@ The model does not cover:
 - `AssemblyContextGroup` image opening, resource ordering, or callback-local
   snapshots beyond the abstract busy state;
 - exception payloads, report serialization, or implementation conformance; or
+- the construction-time synchronous compatibility adapter, which has no
+  concurrent release protocol of its own; or
 - thread scheduling. The design separately requires awaited progress without
   a blocking wait or background-thread dependency.
 

--- a/docs/models/inspection-workspace-close/ReachabilityCleanupFailure.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityCleanupFailure.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoCleanupFailureObserved
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoCoordinatedDrainObserved
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   NoCoordinatedDrainObserved

--- a/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityCoordinatedDrain.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoCoordinatedDrainObserved

--- a/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   NoDirectReleaseObserved

--- a/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoDirectReleaseObserved

--- a/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityDirectRelease.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoDirectReleaseObserved
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
@@ -1,0 +1,20 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 1
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  NoLateCleanupObserved
+
+CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoLateCleanupObserved

--- a/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityLateCleanup.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 1
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   NoLateCleanupObserved

--- a/docs/models/inspection-workspace-close/ReachabilityNoGroupCompletion.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityNoGroupCompletion.cfg
@@ -17,6 +17,6 @@ CONSTANTS
   AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  NoNoGroupCompletionObserved
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityNoGroupCompletion.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityNoGroupCompletion.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoNoGroupCompletionObserved

--- a/docs/models/inspection-workspace-close/ReachabilityOwnerFirstRelease.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityOwnerFirstRelease.cfg
@@ -17,6 +17,6 @@ CONSTANTS
   AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  NoOwnerFirstReleaseObserved
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/ReachabilityOwnerFirstRelease.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityOwnerFirstRelease.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoOwnerFirstReleaseObserved

--- a/docs/models/inspection-workspace-close/ReachabilityPostCloseLeaseWork.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityPostCloseLeaseWork.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   NoPostCloseLeaseWorkObserved

--- a/docs/models/inspection-workspace-close/ReachabilityPostCloseLeaseWork.cfg
+++ b/docs/models/inspection-workspace-close/ReachabilityPostCloseLeaseWork.cfg
@@ -17,6 +17,6 @@ CONSTANTS
   AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
-  NoCleanupFailureObserved
+  NoPostCloseLeaseWorkObserved
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/Safety.cfg
+++ b/docs/models/inspection-workspace-close/Safety.cfg
@@ -6,13 +6,15 @@ CONSTANTS
   MaxLeases = 2
   AllowAdmissionAfterClose = FALSE
   AllowLeaseAfterClose = FALSE
-  AllowWrongReleaseAuthority = FALSE
+  AllowWrongDirectReleaseAuthority = FALSE
+  AllowWrongCoordinatedReleaseAuthority = FALSE
   AllowReleaseWithActiveLease = FALSE
   AllowReleaseBeforeGroupQuiescence = FALSE
   AllowLatePublication = FALSE
   AllowEarlyWorkspaceCompletion = FALSE
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
+  AllowStrandedNoGroupCompletion = FALSE
 
 INVARIANTS
   TypeOK
@@ -25,7 +27,7 @@ INVARIANTS
   WorkspaceCloseWaitsForQuiescence
   CleanupFailuresRemainVisible
   ReleaseBeginsAtMostOnce
-  ExistingLeasesRemainUsable
+  ActiveLeasesPreventRelease
   ClosedWorkspaceIsDrained
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/Safety.cfg
+++ b/docs/models/inspection-workspace-close/Safety.cfg
@@ -15,6 +15,8 @@ CONSTANTS
   AllowCleanupOmission = FALSE
   AllowDoubleRelease = FALSE
   AllowStrandedNoGroupCompletion = FALSE
+  AllowOwnerFirstHistoryLoss = FALSE
+  AllowNoGroupCleanupEntry = FALSE
 
 INVARIANTS
   TypeOK
@@ -28,6 +30,8 @@ INVARIANTS
   CleanupFailuresRemainVisible
   ReleaseBeginsAtMostOnce
   ActiveLeasesPreventRelease
+  RegistrationHistoryMatchesBuildOutcome
+  NoCleanupWithoutRegisteredGroup
   ClosedWorkspaceIsDrained
 
 CHECK_DEADLOCK FALSE

--- a/docs/models/inspection-workspace-close/Safety.cfg
+++ b/docs/models/inspection-workspace-close/Safety.cfg
@@ -1,0 +1,31 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Groups = {direct, coordinated}
+  CoordinatedGroups = {coordinated}
+  MaxLeases = 2
+  AllowAdmissionAfterClose = FALSE
+  AllowLeaseAfterClose = FALSE
+  AllowWrongReleaseAuthority = FALSE
+  AllowReleaseWithActiveLease = FALSE
+  AllowReleaseBeforeGroupQuiescence = FALSE
+  AllowLatePublication = FALSE
+  AllowEarlyWorkspaceCompletion = FALSE
+  AllowCleanupOmission = FALSE
+  AllowDoubleRelease = FALSE
+
+INVARIANTS
+  TypeOK
+  NoBuildAdmissionAfterClose
+  NoLeaseAdmissionAfterClose
+  ReleaseUsesSingleOwner
+  CoordinatedReleaseWaitsForLeases
+  LateCompletionRoutesToCleanup
+  ReleaseWaitsForGroupQuiescence
+  WorkspaceCloseWaitsForQuiescence
+  CleanupFailuresRemainVisible
+  ReleaseBeginsAtMostOnce
+  ExistingLeasesRemainUsable
+  ClosedWorkspaceIsDrained
+
+CHECK_DEADLOCK FALSE


### PR DESCRIPTION
## Summary

Defines one release authority and an asynchronous, lease-draining close
boundary for `InspectionWorkspace`.

The workspace now has a target contract for atomically closing group
construction, routing late results into cleanup, distinguishing directly owned
from completion-owned groups, and reporting every terminal release outcome
without blocking Browser/Wasm. This resolves the workspace-lifetime
prerequisite needed by package-role completion and exact-request admission
without redefining either adjacent owner.

Closes #5156.

## Demo

The design makes the intended ownership visible for two neighboring cases:

```text
direct group
  workspace open -> group published
  workspace close -> workspace release completion
  callback quiesces -> resources release -> close report

coordinated package-role group
  workspace open -> group published under owner-issued completion
  demand A holds a lease
  workspace close -> new admission closes; demand A remains usable
  demand A returns -> package-role owner authorizes release
  group quiesces -> shared completion -> workspace close report
```

A construction that finishes after close follows neither publication path:

```text
group construction in flight
  workspace close
  construction returns group
  -> cleanup-only routing
  -> never visible to a new query
  -> close waits for its terminal release result
```

What to notice: the workspace owns admission and terminal observation, but a
coordinated group is released only through the completion that already owns
its lease and cleanup policy.

## Design

- Names `docs/inspection-space.md`'s workspace lifetime as the sole normative
  owner.
- Introduces an opaque, single-use workspace group admission recorded before
  potentially awaited construction.
- Selects direct or coordinated release authority before construction starts.
- Makes close one idempotent `Open -> Closing -> Closed` transition returning
  the same immutable report.
- Keeps package-role lease counts, cleanup records, cache policy, and release
  authorization with their adjacent owners.
- Routes late construction success into the recorded cleanup path rather than
  publishing or abandoning the group.
- Settles failed or canceled construction without inventing a group report
  entry.
- Supports adjacent-owner release before workspace close while retaining the
  terminal result for the eventual workspace report.
- Keeps existing coordinated leases usable for group work after workspace
  close begins.
- Requires attempt-all cleanup and complete typed failure retention.
- Selects lifetime mode at workspace construction: the existing compatibility
  path requests direct and package-role release through their one shared
  authority, while retained/shared workspaces require asynchronous close and
  reject synchronous disposal before mutation.
- Requires awaited progress without `Task.Run`, a blocking wait, or a
  background-thread dependency.

## Model

`docs/models/inspection-workspace-close/InspectionWorkspaceClose.tla` models
one direct and one coordinated group, construction racing close, external
leases, abstract group quiescence, release ownership, cleanup reporting, and
terminal workspace close.

Safety and liveness both explore the complete bounded graph:

```text
4,270 generated states
1,945 distinct states
maximum depth 18
no error
```

Seven reachability configurations demonstrate direct release, coordinated
post-lease drain, owner-first release, post-close lease work, no-group
construction completion, late-result cleanup, and failed cleanup reporting.
Thirteen mutation configurations independently fail admission closure, lease
closure, both release-authority paths, lease-drain ordering, group quiescence,
late publication, workspace completion, cleanup visibility, exactly-once
release, no-group admission settlement, owner-first report history, and exact
no-group report exclusion.

## Validation

- TLA+ SANY parse succeeded with pinned `v1.8.0`.
- `Safety.cfg`: complete graph, no error.
- `Liveness.cfg`: complete graph, no error.
- 7/7 reachability configurations produced their intended traces.
- 13/13 mutation configurations violated their intended properties.
- `npx markdownlint-cli docs/inspection-space.md
  docs/models/inspection-workspace-close/README.md`
- `git diff --check`

## Compatibility and non-claims

This is a design and model PR; product behavior and public APIs do not change.
It does not define package admission keys, cache policy, package selection,
role planning, participant projection, package cleanup-record shape, artifact
acquisition lifetime, query-specific participant release policy, or the
implementation of #4960.
