### PR TITLE
Keep design guidance focused on contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,12 +232,12 @@ Full mechanics, the composition-document rules, TLA+ modeling guidance, and the
 over-broad-design recovery procedure live in
 [`docs/design-scope.md`](docs/design-scope.md). The binding rules:
 
-- Default every design effort to exactly one architectural owner with a named
-  owning document. A focused design may reference an adjacent owner's types but
-  must not redefine that owner's construction, validation, identity, lifetime,
-  or failure semantics. One bounded exception allows a single-claim transfer of
-  one cohesive responsibility between two owners; any other cross-owner change
-  needs two focused efforts connected by a thin composition map.
+- Default every design effort to one named architectural owner. A focused design
+  may reference adjacent owner-issued types but must not redefine another
+  owner's contract; beyond the single-claim transfer exception, cross-owner
+  normative changes need focused efforts joined by a thin composition map.
+- State boundaries and contracts as simply as possible. Never translate
+  implementation into prose or prescribe it; code implements the contract.
 - A **broad design** normatively specifies multiple independently owned
   components (outside that one exception) or sweeps an end-to-end lifecycle.
   Do not start or broaden into one without the user's explicit request or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,8 +236,8 @@ over-broad-design recovery procedure live in
   may reference adjacent owner-issued types but must not redefine another
   owner's contract; beyond the single-claim transfer exception, cross-owner
   normative changes need focused efforts joined by a thin composition map.
-- State boundaries and contracts as simply as possible. Never translate
-  implementation into prose or prescribe it; code implements the contract.
+- State boundaries and contracts as simply as possible. Never translate current
+  or planned implementation into prose; code implements the contract.
 - A **broad design** normatively specifies multiple independently owned
   components (outside that one exception) or sweeps an end-to-end lifecycle.
   Do not start or broaden into one without the user's explicit request or

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -93,10 +93,10 @@ keeps both closable.
 
 Design documents state the smallest contract needed to guide implementation and
 review: the owner's boundary, observable obligations, invariants, failure
-semantics, and non-claims. They do not narrate current fields, methods, branches,
-or execution steps, and they prescribe an implementation only when that choice
-is itself part of the contract. Code implements the contract; do not duplicate
-it in words.
+semantics, and non-claims. They do not narrate current or planned fields,
+methods, branches, or execution steps. State architectural constraints as
+contract boundaries, not as prose implementation plans. Code implements the
+contract; do not duplicate it in words.
 
 When correctness depends on significant stateful, concurrent, distributed, or
 scheduling interactions, use a small TLA+ model that states the relevant safety

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -91,12 +91,16 @@ keeps both closable.
 
 ## Keep specifications readable; model interactions
 
-Design specifications own detailed requirements, component boundaries, and
-policies. Keep them readable as prose and typed contracts; do not turn them
-into unconventional EBNF-like descriptions of operational behavior. When a
-feature's correctness depends on significant stateful, concurrent, distributed,
-or scheduling interactions, use a small TLA+ model that states the relevant
-safety and liveness properties, and model-check it before implementation. (See
+Design documents state the smallest contract needed to guide implementation and
+review: the owner's boundary, observable obligations, invariants, failure
+semantics, and non-claims. They do not narrate current fields, methods, branches,
+or execution steps, and they prescribe an implementation only when that choice
+is itself part of the contract. Code implements the contract; do not duplicate
+it in words.
+
+When correctness depends on significant stateful, concurrent, distributed, or
+scheduling interactions, use a small TLA+ model that states the relevant safety
+and liveness properties, and model-check it before implementation. (See
 [`docs/runbooks/tla-plus-setup.md`](runbooks/tla-plus-setup.md) for installing
 and pinning the TLA+ tools and Java, and
 [`docs/tla-plus-methodology.md`](tla-plus-methodology.md) for modeling


### PR DESCRIPTION
## Claim

Design guidance now requires the smallest useful statement of boundaries and
contracts, and explicitly rejects translating implementation into prose.
`docs/design-scope.md` applies the rule to fields, methods, branches, and
execution steps: code implements the contract instead of being duplicated in
words.

## Demo

Before, a retro-spec could grow into a 1,197-line narration of `CoreCache` and
spend 18 review rounds correcting prose against individual code paths, as in
#5103.

After, the same design task stops at the owner boundary, observable obligations,
invariants, failure semantics, and non-claims. A finding about the exact order
or effect of internal `Directory.Exists` checks belongs in code and tests, not
in a prose copy of the implementation.

The same rule applies to a neighboring subsystem such as the decompiler: define
what a stage accepts, guarantees, and refuses without prescribing its internal
methods or control flow.

## Compatibility / non-action boundary

Guidance-only. This does not change product behavior or reduce the evidence
required to prove that code satisfies a contract.

## Validation

- `npx markdownlint-cli AGENTS.md docs/design-scope.md`
- `wc -l AGENTS.md` -> `600`
