### PR TITLE
Run NuGet plugin protocol tests on Windows

### DIFF
--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -522,9 +522,11 @@ Two tiers, in `src/NuGetFetch.Tests`:
     origin scoping for ordinary hosts, organization scoping and GUID-alias reuse for Azure
     Artifacts, redirect isolation from credential scope and returned content, 403 opt-in, and that
     an existing credential is not overwritten.
-  - `PluginProtocolTests` runs a **real plugin process** — a shell script that genuinely speaks
-    the line protocol — so framing, the symmetric handshake, process death, selected shutdown
-    behavior, and caller-cancellation classification are exercised end to end rather than mocked.
+  - `PluginProtocolTests` runs a **real plugin process** — a cross-platform managed fixture that
+    genuinely speaks the line protocol — so framing, the symmetric handshake, process death,
+    selected shutdown behavior, and caller-cancellation classification are exercised end to end
+    rather than mocked. The suite runs on Windows and Unix; only executable-bit discovery coverage
+    remains Unix-specific.
     Concurrent request correlation, `Progress`-driven timeout extension, and pipe-loss admission
     remain unverified at the implementation boundary.
 - **Live**, tagged `[Trait("Network", "Live")]` and skipped unless a feed and token are supplied.

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -90,6 +90,7 @@
     <Project Path="src/InertText.Tests/InertText.Tests.csproj" />
     <Project Path="src/InertText/InertText.csproj" />
     <Project Path="src/mdi/mdi.csproj" />
+    <Project Path="src/NuGetFetch.PluginFixture/NuGetFetch.PluginFixture.csproj" />
     <Project Path="src/NuGetFetch.Tests/NuGetFetch.Tests.csproj" />
     <Project Path="src/NuGetFetch/NuGetFetch.csproj" />
     <Project Path="src/runfaster.Tests/runfaster.Tests.csproj" />

--- a/src/NuGetFetch.PluginFixture/NuGetFetch.PluginFixture.csproj
+++ b/src/NuGetFetch.PluginFixture/NuGetFetch.PluginFixture.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/NuGetFetch.PluginFixture/PluginFixtureConfiguration.cs
+++ b/src/NuGetFetch.PluginFixture/PluginFixtureConfiguration.cs
@@ -1,0 +1,40 @@
+namespace NuGetFetch.PluginFixture;
+
+internal sealed record PluginFixtureConfiguration
+{
+    public string RecordPath { get; init; } = "";
+    public string Username { get; init; } = "";
+    public string Password { get; init; } = "";
+    public string Claims { get; init; } = "Authentication";
+    public string ResponseCode { get; init; } = "Success";
+    public string? AuthenticationType { get; init; }
+    public string? PreambleMessage { get; init; }
+    public string InboundHandshakePayload { get; init; } =
+        """{"ProtocolVersion":"2.0.0","MinimumProtocolVersion":"1.0.0"}""";
+    public string OutboundHandshakePayload { get; init; } =
+        """{"ResponseCode":"Success","ProtocolVersion":"2.0.0"}""";
+    public string? InboundLogRequestId { get; init; }
+    public string? InboundLogPayload { get; init; }
+    public bool WriteGarbageAndWait { get; init; }
+    public PluginCredentialBehavior CredentialBehavior { get; init; }
+    public PluginAfterSetLogLevelBehavior AfterSetLogLevelBehavior { get; init; }
+}
+
+internal enum PluginCredentialBehavior
+{
+    Respond,
+    CloseOutput,
+    Exit,
+    ExitOnFirstRequest,
+}
+
+internal enum PluginAfterSetLogLevelBehavior
+{
+    Continue,
+    EmitLog,
+    CloseOutput,
+    WaitForCloseMarkerThenCloseOutput,
+    Stall,
+    WaitForLogMarkerThenEmitLogAndStall,
+    RespondBeforeCredentialLineCompletes,
+}

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -382,7 +382,7 @@ internal static class Program
     private static int CloseMatchingUnixDescriptors(bool isMacOS)
     {
         const int maxDescriptor = 1024;
-        if (FStat(isMacOS, 1, out UnixStat outputStat) != 0)
+        if (SystemNativeFStat(1, out FileStatus outputStatus) != 0)
         {
             return Marshal.GetLastPInvokeError();
         }
@@ -390,9 +390,9 @@ internal static class Program
         List<int> matches = [];
         for (int descriptor = 1; descriptor < maxDescriptor; descriptor++)
         {
-            if (FStat(isMacOS, descriptor, out UnixStat candidateStat) == 0
-                && outputStat.Device == candidateStat.Device
-                && outputStat.Inode == candidateStat.Inode)
+            if (SystemNativeFStat(descriptor, out FileStatus candidateStatus) == 0
+                && outputStatus.Device == candidateStatus.Device
+                && outputStatus.Inode == candidateStatus.Inode)
             {
                 matches.Add(descriptor);
             }
@@ -411,14 +411,6 @@ internal static class Program
 
         return 0;
     }
-
-    private static int FStat(
-        bool isMacOS,
-        int descriptor,
-        out UnixStat stat) =>
-        isMacOS
-            ? FStatMacOS(descriptor, out stat)
-            : FStatUnix(descriptor, out stat);
 
     private static async Task DrainInputAsync(
         StreamReader input,
@@ -458,15 +450,27 @@ internal static class Program
         Exit,
     }
 
-    // Linux and Darwin stat layouts both place the device at 0 and inode at 8.
-    [StructLayout(LayoutKind.Explicit, Size = 512)]
-    private struct UnixStat
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileStatus
     {
-        [FieldOffset(0)]
-        internal uint Device;
-
-        [FieldOffset(8)]
-        internal ulong Inode;
+        internal int Flags;
+        internal int Mode;
+        internal uint UserId;
+        internal uint GroupId;
+        internal long Size;
+        internal long AccessTime;
+        internal long AccessTimeNanoseconds;
+        internal long ModificationTime;
+        internal long ModificationTimeNanoseconds;
+        internal long ChangeTime;
+        internal long ChangeTimeNanoseconds;
+        internal long BirthTime;
+        internal long BirthTimeNanoseconds;
+        internal long Device;
+        internal long RawDevice;
+        internal long Inode;
+        internal uint UserFlags;
+        internal int HardLinkCount;
     }
 
     [DllImport("kernel32.dll", SetLastError = true)]
@@ -479,16 +483,14 @@ internal static class Program
     [DllImport("libc", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseUnix(int fileDescriptor);
 
-    [DllImport("libc", EntryPoint = "fstat", SetLastError = true)]
-    private static extern int FStatUnix(
-        int fileDescriptor,
-        out UnixStat stat);
-
     [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseMacOS(int fileDescriptor);
 
-    [DllImport("libSystem.B.dylib", EntryPoint = "fstat", SetLastError = true)]
-    private static extern int FStatMacOS(
-        int fileDescriptor,
-        out UnixStat stat);
+    [DllImport(
+        "libSystem.Native",
+        EntryPoint = "SystemNative_FStat",
+        SetLastError = true)]
+    private static extern int SystemNativeFStat(
+        nint fileDescriptor,
+        out FileStatus status);
 }

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -1,28 +1,79 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Win32.SafeHandles;
 
 namespace NuGetFetch.PluginFixture;
 
 internal static class Program
 {
+    private const int OutputClosedExitCode = 42;
     private static readonly UTF8Encoding Utf8NoBom = new(false);
 
     private static async Task<int> Main(string[] args)
     {
-        if (args is not ["-Plugin"])
+        if (args is ["-Plugin"])
         {
-            return 2;
+            return await RunSupervisorAsync();
         }
 
+        if (args is ["--worker", var configurationPath])
+        {
+            return await RunWorkerAsync(configurationPath);
+        }
+
+        return 2;
+    }
+
+    private static async Task<int> RunSupervisorAsync()
+    {
         string assemblyPath = typeof(Program).Assembly.Location;
         string configurationPath = Path.ChangeExtension(assemblyPath, ".json");
-        PluginFixtureConfiguration configuration =
-            JsonSerializer.Deserialize<PluginFixtureConfiguration>(
-                await File.ReadAllTextAsync(configurationPath))
+        string hostPath = Environment.ProcessPath
             ?? throw new InvalidOperationException(
-                $"Could not read plugin fixture configuration '{configurationPath}'.");
+                "Could not determine the plugin fixture host path.");
+        var startInfo = new ProcessStartInfo(hostPath)
+        {
+            UseShellExecute = false,
+        };
+        startInfo.ArgumentList.Add(assemblyPath);
+        startInfo.ArgumentList.Add("--worker");
+        startInfo.ArgumentList.Add(configurationPath);
+
+        using Process worker = Process.Start(startInfo)
+            ?? throw new InvalidOperationException(
+                "Could not start the plugin fixture worker.");
+        // The worker can end the output stream while this launched process stays alive.
+        CloseStandardOutput();
+        await worker.WaitForExitAsync();
+        if (worker.ExitCode != OutputClosedExitCode)
+        {
+            return worker.ExitCode;
+        }
+
+        PluginFixtureConfiguration configuration =
+            await ReadConfigurationAsync(configurationPath);
+        using var recordStream = new FileStream(
+            configuration.RecordPath,
+            FileMode.Append,
+            FileAccess.Write,
+            FileShare.ReadWrite);
+        using var record = new StreamWriter(recordStream, Utf8NoBom)
+        {
+            AutoFlush = true,
+        };
+        using var input = new StreamReader(
+            Console.OpenStandardInput(),
+            Utf8NoBom,
+            detectEncodingFromByteOrderMarks: false);
+        await DrainInputAsync(input, record);
+        return 0;
+    }
+
+    private static async Task<int> RunWorkerAsync(string configurationPath)
+    {
+        PluginFixtureConfiguration configuration =
+            await ReadConfigurationAsync(configurationPath);
 
         using var recordStream = new FileStream(
             configuration.RecordPath,
@@ -37,106 +88,104 @@ internal static class Program
             Console.OpenStandardInput(),
             Utf8NoBom,
             detectEncodingFromByteOrderMarks: false);
-        StreamWriter? output = new(OpenOwnedStandardOutput(), Utf8NoBom)
+        using var output = new StreamWriter(
+            Console.OpenStandardOutput(),
+            Utf8NoBom)
         {
             AutoFlush = true,
         };
 
-        try
+        if (configuration.WriteGarbageAndWait)
         {
-            if (configuration.WriteGarbageAndWait)
-            {
-                await output.WriteLineAsync("not json at all");
-                await Task.Delay(TimeSpan.FromSeconds(2));
-                return 0;
-            }
-
-            if (configuration.PreambleMessage is not null)
-            {
-                await output.WriteLineAsync(configuration.PreambleMessage);
-            }
-
-            await EmitMessageAsync(
-                output,
-                "fake-handshake",
-                "Request",
-                "Handshake",
-                configuration.InboundHandshakePayload);
-
-            while (await input.ReadLineAsync() is { } line)
-            {
-                await record.WriteLineAsync(line);
-
-                using JsonDocument message = JsonDocument.Parse(line);
-                JsonElement root = message.RootElement;
-                if (root.GetProperty("Type").GetString() != "Request")
-                {
-                    continue;
-                }
-
-                string requestId = root.GetProperty("RequestId").GetString()!;
-                string method = root.GetProperty("Method").GetString()!;
-                switch (method)
-                {
-                    case "Handshake":
-                        await EmitMessageAsync(
-                            output,
-                            requestId,
-                            "Response",
-                            method,
-                            configuration.OutboundHandshakePayload);
-                        break;
-                    case "MonitorNuGetProcessExit":
-                    case "Initialize":
-                    case "SetLogLevel":
-                        await EmitSuccessAsync(output, requestId, method);
-                        if (method == "SetLogLevel"
-                            && await ApplyAfterSetLogLevelBehaviorAsync(
-                                configuration,
-                                input,
-                                output))
-                        {
-                            output = null;
-                            await DrainInputAsync(input, record);
-                            return 0;
-                        }
-                        break;
-                    case "GetOperationClaims":
-                        await EmitObjectAsync(
-                            output,
-                            requestId,
-                            method,
-                            new { Claims = new[] { configuration.Claims } });
-                        break;
-                    case "GetAuthenticationCredentials":
-                        CredentialActionResult result =
-                            await ApplyCredentialBehaviorAsync(
-                                configuration,
-                                output,
-                                requestId);
-                        if (result == CredentialActionResult.OutputClosed)
-                        {
-                            output = null;
-                            await DrainInputAsync(input, record);
-                            return 0;
-                        }
-                        if (result == CredentialActionResult.Exit)
-                        {
-                            return 0;
-                        }
-                        break;
-                    case "Close":
-                        return 0;
-                }
-            }
-
+            await output.WriteLineAsync("not json at all");
+            await Task.Delay(TimeSpan.FromSeconds(2));
             return 0;
         }
-        finally
+
+        if (configuration.PreambleMessage is not null)
         {
-            output?.Dispose();
+            await output.WriteLineAsync(configuration.PreambleMessage);
         }
+
+        await EmitMessageAsync(
+            output,
+            "fake-handshake",
+            "Request",
+            "Handshake",
+            configuration.InboundHandshakePayload);
+
+        while (await input.ReadLineAsync() is { } line)
+        {
+            await record.WriteLineAsync(line);
+
+            using JsonDocument message = JsonDocument.Parse(line);
+            JsonElement root = message.RootElement;
+            if (root.GetProperty("Type").GetString() != "Request")
+            {
+                continue;
+            }
+
+            string requestId = root.GetProperty("RequestId").GetString()!;
+            string method = root.GetProperty("Method").GetString()!;
+            switch (method)
+            {
+                case "Handshake":
+                    await EmitMessageAsync(
+                        output,
+                        requestId,
+                        "Response",
+                        method,
+                        configuration.OutboundHandshakePayload);
+                    break;
+                case "MonitorNuGetProcessExit":
+                case "Initialize":
+                case "SetLogLevel":
+                    await EmitSuccessAsync(output, requestId, method);
+                    if (method == "SetLogLevel"
+                        && await ApplyAfterSetLogLevelBehaviorAsync(
+                            configuration,
+                            input,
+                            output))
+                    {
+                        return OutputClosedExitCode;
+                    }
+                    break;
+                case "GetOperationClaims":
+                    await EmitObjectAsync(
+                        output,
+                        requestId,
+                        method,
+                        new { Claims = new[] { configuration.Claims } });
+                    break;
+                case "GetAuthenticationCredentials":
+                    CredentialActionResult result =
+                        await ApplyCredentialBehaviorAsync(
+                            configuration,
+                            output,
+                            requestId);
+                    if (result == CredentialActionResult.OutputClosed)
+                    {
+                        return OutputClosedExitCode;
+                    }
+                    if (result == CredentialActionResult.Exit)
+                    {
+                        return 0;
+                    }
+                    break;
+                case "Close":
+                    return 0;
+            }
+        }
+
+        return 0;
     }
+
+    private static async Task<PluginFixtureConfiguration> ReadConfigurationAsync(
+        string configurationPath) =>
+        JsonSerializer.Deserialize<PluginFixtureConfiguration>(
+            await File.ReadAllTextAsync(configurationPath))
+        ?? throw new InvalidOperationException(
+            $"Could not read plugin fixture configuration '{configurationPath}'.");
 
     private static async Task<bool> ApplyAfterSetLogLevelBehaviorAsync(
         PluginFixtureConfiguration configuration,
@@ -151,11 +200,9 @@ internal static class Program
                 await EmitLogAsync(configuration, output);
                 return false;
             case PluginAfterSetLogLevelBehavior.CloseOutput:
-                await CloseOutputAsync(output);
                 return true;
             case PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput:
                 await WaitForMarkerAsync(configuration.RecordPath + ".close");
-                await CloseOutputAsync(output);
                 return true;
             case PluginAfterSetLogLevelBehavior.Stall:
                 await Task.Delay(TimeSpan.FromSeconds(30));
@@ -191,7 +238,6 @@ internal static class Program
                 await EmitCredentialResponseAsync(configuration, output, requestId);
                 return CredentialActionResult.Continue;
             case PluginCredentialBehavior.CloseOutput:
-                await CloseOutputAsync(output);
                 return CredentialActionResult.OutputClosed;
             case PluginCredentialBehavior.Exit:
                 return CredentialActionResult.Exit;
@@ -308,20 +354,33 @@ internal static class Program
         }
     }
 
-    private static async Task CloseOutputAsync(StreamWriter output)
+    private static void CloseStandardOutput()
     {
-        await output.FlushAsync();
-        output.Dispose();
-    }
+        int error;
+        if (OperatingSystem.IsWindows())
+        {
+            error = CloseHandle(GetStdHandle(-11))
+                ? 0
+                : Marshal.GetLastPInvokeError();
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            error = CloseMacOS(1) == 0
+                ? 0
+                : Marshal.GetLastPInvokeError();
+        }
+        else
+        {
+            error = CloseUnix(1) == 0
+                ? 0
+                : Marshal.GetLastPInvokeError();
+        }
 
-    private static FileStream OpenOwnedStandardOutput()
-    {
-        nint handle = OperatingSystem.IsWindows()
-            ? GetStdHandle(-11)
-            : 1;
-        return new FileStream(
-            new SafeFileHandle(handle, ownsHandle: true),
-            FileAccess.Write);
+        if (error != 0)
+        {
+            throw new IOException(
+                $"Could not close the plugin fixture output pipe (error {error}).");
+        }
     }
 
     private static async Task DrainInputAsync(
@@ -362,6 +421,16 @@ internal static class Program
         Exit,
     }
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
     private static extern nint GetStdHandle(int standardHandle);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseUnix(int fileDescriptor);
+
+    [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseMacOS(int fileDescriptor);
 }

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -1,0 +1,386 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace NuGetFetch.PluginFixture;
+
+internal static class Program
+{
+    private static readonly UTF8Encoding Utf8NoBom = new(false);
+
+    private static async Task<int> Main(string[] args)
+    {
+        if (args is not ["-Plugin"])
+        {
+            return 2;
+        }
+
+        string assemblyPath = typeof(Program).Assembly.Location;
+        string configurationPath = Path.ChangeExtension(assemblyPath, ".json");
+        PluginFixtureConfiguration configuration =
+            JsonSerializer.Deserialize<PluginFixtureConfiguration>(
+                await File.ReadAllTextAsync(configurationPath))
+            ?? throw new InvalidOperationException(
+                $"Could not read plugin fixture configuration '{configurationPath}'.");
+
+        using var recordStream = new FileStream(
+            configuration.RecordPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.ReadWrite);
+        using var record = new StreamWriter(recordStream, Utf8NoBom)
+        {
+            AutoFlush = true,
+        };
+        using var input = new StreamReader(
+            Console.OpenStandardInput(),
+            Utf8NoBom,
+            detectEncodingFromByteOrderMarks: false);
+        StreamWriter? output = new(Console.OpenStandardOutput(), Utf8NoBom)
+        {
+            AutoFlush = true,
+        };
+
+        try
+        {
+            if (configuration.WriteGarbageAndWait)
+            {
+                await output.WriteLineAsync("not json at all");
+                await Task.Delay(TimeSpan.FromSeconds(2));
+                return 0;
+            }
+
+            if (configuration.PreambleMessage is not null)
+            {
+                await output.WriteLineAsync(configuration.PreambleMessage);
+            }
+
+            await EmitMessageAsync(
+                output,
+                "fake-handshake",
+                "Request",
+                "Handshake",
+                configuration.InboundHandshakePayload);
+
+            while (await input.ReadLineAsync() is { } line)
+            {
+                await record.WriteLineAsync(line);
+
+                using JsonDocument message = JsonDocument.Parse(line);
+                JsonElement root = message.RootElement;
+                if (root.GetProperty("Type").GetString() != "Request")
+                {
+                    continue;
+                }
+
+                string requestId = root.GetProperty("RequestId").GetString()!;
+                string method = root.GetProperty("Method").GetString()!;
+                switch (method)
+                {
+                    case "Handshake":
+                        await EmitMessageAsync(
+                            output,
+                            requestId,
+                            "Response",
+                            method,
+                            configuration.OutboundHandshakePayload);
+                        break;
+                    case "MonitorNuGetProcessExit":
+                    case "Initialize":
+                    case "SetLogLevel":
+                        await EmitSuccessAsync(output, requestId, method);
+                        if (method == "SetLogLevel"
+                            && await ApplyAfterSetLogLevelBehaviorAsync(
+                                configuration,
+                                input,
+                                output))
+                        {
+                            output = null;
+                            await DrainInputAsync(input, record);
+                            return 0;
+                        }
+                        break;
+                    case "GetOperationClaims":
+                        await EmitObjectAsync(
+                            output,
+                            requestId,
+                            method,
+                            new { Claims = new[] { configuration.Claims } });
+                        break;
+                    case "GetAuthenticationCredentials":
+                        CredentialActionResult result =
+                            await ApplyCredentialBehaviorAsync(
+                                configuration,
+                                output,
+                                requestId);
+                        if (result == CredentialActionResult.OutputClosed)
+                        {
+                            output = null;
+                            await DrainInputAsync(input, record);
+                            return 0;
+                        }
+                        if (result == CredentialActionResult.Exit)
+                        {
+                            return 0;
+                        }
+                        break;
+                    case "Close":
+                        return 0;
+                }
+            }
+
+            return 0;
+        }
+        finally
+        {
+            output?.Dispose();
+        }
+    }
+
+    private static async Task<bool> ApplyAfterSetLogLevelBehaviorAsync(
+        PluginFixtureConfiguration configuration,
+        StreamReader input,
+        StreamWriter output)
+    {
+        switch (configuration.AfterSetLogLevelBehavior)
+        {
+            case PluginAfterSetLogLevelBehavior.Continue:
+                return false;
+            case PluginAfterSetLogLevelBehavior.EmitLog:
+                await EmitLogAsync(configuration, output);
+                return false;
+            case PluginAfterSetLogLevelBehavior.CloseOutput:
+                await CloseOutputAsync(output);
+                return true;
+            case PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput:
+                await WaitForMarkerAsync(configuration.RecordPath + ".close");
+                await CloseOutputAsync(output);
+                return true;
+            case PluginAfterSetLogLevelBehavior.Stall:
+                await Task.Delay(TimeSpan.FromSeconds(30));
+                return false;
+            case PluginAfterSetLogLevelBehavior.WaitForLogMarkerThenEmitLogAndStall:
+                await WaitForMarkerAsync(configuration.RecordPath + ".log");
+                await EmitLogAsync(configuration, output);
+                await Task.Delay(TimeSpan.FromSeconds(30));
+                return false;
+            case PluginAfterSetLogLevelBehavior.RespondBeforeCredentialLineCompletes:
+                char[] prefixBuffer = new char[256];
+                int count = await input.ReadBlockAsync(prefixBuffer);
+                string prefix = new(prefixBuffer, 0, count);
+                string requestId = ReadPartialStringProperty(prefix, "RequestId");
+                await EmitCredentialResponseAsync(configuration, output, requestId);
+                await Task.Delay(TimeSpan.FromSeconds(30));
+                return false;
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown post-initialization behavior " +
+                    $"'{configuration.AfterSetLogLevelBehavior}'.");
+        }
+    }
+
+    private static async Task<CredentialActionResult> ApplyCredentialBehaviorAsync(
+        PluginFixtureConfiguration configuration,
+        StreamWriter output,
+        string requestId)
+    {
+        switch (configuration.CredentialBehavior)
+        {
+            case PluginCredentialBehavior.Respond:
+                await EmitCredentialResponseAsync(configuration, output, requestId);
+                return CredentialActionResult.Continue;
+            case PluginCredentialBehavior.CloseOutput:
+                await CloseOutputAsync(output);
+                return CredentialActionResult.OutputClosed;
+            case PluginCredentialBehavior.Exit:
+                return CredentialActionResult.Exit;
+            case PluginCredentialBehavior.ExitOnFirstRequest:
+                string startsPath = configuration.RecordPath + ".starts";
+                int starts = File.Exists(startsPath)
+                    ? int.Parse(await File.ReadAllTextAsync(startsPath))
+                    : 0;
+                starts++;
+                await File.WriteAllTextAsync(startsPath, starts.ToString());
+                if (starts == 1)
+                {
+                    return CredentialActionResult.Exit;
+                }
+
+                await EmitCredentialResponseAsync(configuration, output, requestId);
+                return CredentialActionResult.Continue;
+            default:
+                throw new InvalidOperationException(
+                    $"Unknown credential behavior '{configuration.CredentialBehavior}'.");
+        }
+    }
+
+    private static async Task EmitCredentialResponseAsync(
+        PluginFixtureConfiguration configuration,
+        StreamWriter output,
+        string requestId)
+    {
+        if (configuration.ResponseCode != "Success")
+        {
+            await EmitObjectAsync(
+                output,
+                requestId,
+                "GetAuthenticationCredentials",
+                new { configuration.ResponseCode });
+            return;
+        }
+
+        string[]? authenticationTypes = configuration.AuthenticationType is null
+            ? null
+            : [configuration.AuthenticationType];
+        await EmitObjectAsync(
+            output,
+            requestId,
+            "GetAuthenticationCredentials",
+            new
+            {
+                configuration.Username,
+                configuration.Password,
+                AuthenticationTypes = authenticationTypes,
+                ResponseCode = "Success",
+            });
+    }
+
+    private static Task EmitSuccessAsync(
+        StreamWriter output,
+        string requestId,
+        string method) =>
+        EmitObjectAsync(output, requestId, method, new { ResponseCode = "Success" });
+
+    private static Task EmitObjectAsync<T>(
+        StreamWriter output,
+        string requestId,
+        string method,
+        T payload) =>
+        output.WriteLineAsync(JsonSerializer.Serialize(new
+        {
+            RequestId = requestId,
+            Type = "Response",
+            Method = method,
+            Payload = payload,
+        }));
+
+    private static async Task EmitMessageAsync(
+        StreamWriter output,
+        string requestId,
+        string type,
+        string method,
+        string payload)
+    {
+        using JsonDocument payloadDocument = JsonDocument.Parse(payload);
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("RequestId", requestId);
+            writer.WriteString("Type", type);
+            writer.WriteString("Method", method);
+            writer.WritePropertyName("Payload");
+            payloadDocument.RootElement.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+
+        await output.WriteLineAsync(Utf8NoBom.GetString(buffer.ToArray()));
+    }
+
+    private static Task EmitLogAsync(
+        PluginFixtureConfiguration configuration,
+        StreamWriter output) =>
+        EmitMessageAsync(
+            output,
+            configuration.InboundLogRequestId
+                ?? throw new InvalidOperationException("Inbound log request ID was not set."),
+            "Request",
+            "Log",
+            configuration.InboundLogPayload
+                ?? throw new InvalidOperationException("Inbound log payload was not set."));
+
+    private static async Task WaitForMarkerAsync(string path)
+    {
+        while (!File.Exists(path))
+        {
+            await Task.Delay(10);
+        }
+    }
+
+    private static async Task CloseOutputAsync(StreamWriter output)
+    {
+        await output.FlushAsync();
+
+        int error;
+        if (OperatingSystem.IsWindows())
+        {
+            nint handle = GetStdHandle(-11);
+            error = CloseHandle(handle) ? 0 : Marshal.GetLastPInvokeError();
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            error = CloseMacOS(1) == 0 ? 0 : Marshal.GetLastPInvokeError();
+        }
+        else
+        {
+            error = CloseUnix(1) == 0 ? 0 : Marshal.GetLastPInvokeError();
+        }
+
+        if (error != 0)
+        {
+            throw new IOException(
+                $"Could not close the plugin fixture output pipe (error {error}).");
+        }
+    }
+
+    private static async Task DrainInputAsync(
+        StreamReader input,
+        StreamWriter record)
+    {
+        while (await input.ReadLineAsync() is { } line)
+        {
+            await record.WriteLineAsync(line);
+        }
+    }
+
+    private static string ReadPartialStringProperty(string json, string property)
+    {
+        string prefix = $"\"{property}\":\"";
+        int start = json.IndexOf(prefix, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            throw new InvalidOperationException(
+                $"The partial request did not contain '{property}'.");
+        }
+
+        start += prefix.Length;
+        int end = json.IndexOf('"', start);
+        if (end < 0)
+        {
+            throw new InvalidOperationException(
+                $"The partial request did not contain a complete '{property}'.");
+        }
+
+        return json[start..end];
+    }
+
+    private enum CredentialActionResult
+    {
+        Continue,
+        OutputClosed,
+        Exit,
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(nint handle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern nint GetStdHandle(int standardHandle);
+
+    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseUnix(int fileDescriptor);
+
+    [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
+    private static extern int CloseMacOS(int fileDescriptor);
+}

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -31,13 +31,6 @@ internal static class Program
         string configurationPath = Path.ChangeExtension(assemblyPath, ".json");
         PluginFixtureConfiguration configuration =
             await ReadConfigurationAsync(configurationPath);
-        bool traceOutputClosure =
-            OperatingSystem.IsLinux()
-            && (configuration.CredentialBehavior == PluginCredentialBehavior.CloseOutput
-                || configuration.AfterSetLogLevelBehavior
-                    is PluginAfterSetLogLevelBehavior.CloseOutput
-                    or PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput);
-        TraceOutputDescriptors(traceOutputClosure, "before worker");
         string hostPath = Environment.ProcessPath
             ?? throw new InvalidOperationException(
                 "Could not determine the plugin fixture host path.");
@@ -54,11 +47,7 @@ internal static class Program
                 "Could not start the plugin fixture worker.");
         // The worker can end the output stream while this launched process stays alive.
         CloseStandardOutput();
-        TraceOutputDescriptors(traceOutputClosure, "after supervisor close");
         await worker.WaitForExitAsync();
-        TraceOutputDescriptors(
-            traceOutputClosure,
-            $"after worker exit {worker.ExitCode}");
         if (worker.ExitCode != OutputClosedExitCode)
         {
             return worker.ExitCode;
@@ -79,27 +68,6 @@ internal static class Program
             detectEncodingFromByteOrderMarks: false);
         await DrainInputAsync(input, record);
         return 0;
-    }
-
-    private static void TraceOutputDescriptors(bool enabled, string stage)
-    {
-        if (!enabled)
-        {
-            return;
-        }
-
-        string[] descriptors = Directory.GetFiles("/proc/self/fd")
-            .Select(path =>
-            {
-                FileSystemInfo? target = File.ResolveLinkTarget(
-                    path,
-                    returnFinalTarget: false);
-                return $"{Path.GetFileName(path)}={target?.FullName ?? "?"}";
-            })
-            .ToArray();
-        WriteDiagnostic(
-            $"fixture supervisor {Environment.ProcessId} {stage}: " +
-            string.Join(", ", descriptors));
     }
 
     private static async Task<int> RunWorkerAsync(string configurationPath)
@@ -179,8 +147,6 @@ internal static class Program
                             input,
                             output))
                     {
-                        WriteDiagnostic(
-                            $"fixture worker {Environment.ProcessId} closing output");
                         return OutputClosedExitCode;
                     }
                     break;
@@ -199,8 +165,6 @@ internal static class Program
                             requestId);
                     if (result == CredentialActionResult.OutputClosed)
                     {
-                        WriteDiagnostic(
-                            $"fixture worker {Environment.ProcessId} closing output");
                         return OutputClosedExitCode;
                     }
                     if (result == CredentialActionResult.Exit)
@@ -401,15 +365,11 @@ internal static class Program
         }
         else if (OperatingSystem.IsMacOS())
         {
-            error = CloseMacOS(1) == 0
-                ? 0
-                : Marshal.GetLastPInvokeError();
+            error = CloseMatchingUnixDescriptors(isMacOS: true);
         }
         else
         {
-            error = CloseUnix(1) == 0
-                ? 0
-                : Marshal.GetLastPInvokeError();
+            error = CloseMatchingUnixDescriptors(isMacOS: false);
         }
 
         if (error != 0)
@@ -419,6 +379,47 @@ internal static class Program
         }
     }
 
+    private static int CloseMatchingUnixDescriptors(bool isMacOS)
+    {
+        const int maxDescriptor = 1024;
+        if (FStat(isMacOS, 1, out UnixStat outputStat) != 0)
+        {
+            return Marshal.GetLastPInvokeError();
+        }
+
+        List<int> matches = [];
+        for (int descriptor = 1; descriptor < maxDescriptor; descriptor++)
+        {
+            if (FStat(isMacOS, descriptor, out UnixStat candidateStat) == 0
+                && outputStat.Device == candidateStat.Device
+                && outputStat.Inode == candidateStat.Inode)
+            {
+                matches.Add(descriptor);
+            }
+        }
+
+        foreach (int descriptor in matches)
+        {
+            int result = isMacOS
+                ? CloseMacOS(descriptor)
+                : CloseUnix(descriptor);
+            if (result != 0)
+            {
+                return Marshal.GetLastPInvokeError();
+            }
+        }
+
+        return 0;
+    }
+
+    private static int FStat(
+        bool isMacOS,
+        int descriptor,
+        out UnixStat stat) =>
+        isMacOS
+            ? FStatMacOS(descriptor, out stat)
+            : FStatUnix(descriptor, out stat);
+
     private static async Task DrainInputAsync(
         StreamReader input,
         StreamWriter record)
@@ -427,17 +428,6 @@ internal static class Program
         {
             await record.WriteLineAsync(line);
         }
-    }
-
-    private static void WriteDiagnostic(string message)
-    {
-        if (!OperatingSystem.IsLinux())
-        {
-            return;
-        }
-
-        byte[] bytes = Utf8NoBom.GetBytes(message + Environment.NewLine);
-        _ = WriteUnix(2, bytes, (nuint)bytes.Length);
     }
 
     private static string ReadPartialStringProperty(string json, string property)
@@ -468,6 +458,17 @@ internal static class Program
         Exit,
     }
 
+    // Linux and Darwin stat layouts both place the device at 0 and inode at 8.
+    [StructLayout(LayoutKind.Explicit, Size = 512)]
+    private struct UnixStat
+    {
+        [FieldOffset(0)]
+        internal uint Device;
+
+        [FieldOffset(8)]
+        internal ulong Inode;
+    }
+
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool CloseHandle(nint handle);
@@ -478,12 +479,16 @@ internal static class Program
     [DllImport("libc", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseUnix(int fileDescriptor);
 
-    [DllImport("libc", EntryPoint = "write")]
-    private static extern nint WriteUnix(
+    [DllImport("libc", EntryPoint = "fstat", SetLastError = true)]
+    private static extern int FStatUnix(
         int fileDescriptor,
-        byte[] buffer,
-        nuint count);
+        out UnixStat stat);
 
     [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseMacOS(int fileDescriptor);
+
+    [DllImport("libSystem.B.dylib", EntryPoint = "fstat", SetLastError = true)]
+    private static extern int FStatMacOS(
+        int fileDescriptor,
+        out UnixStat stat);
 }

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Win32.SafeHandles;
 
 namespace NuGetFetch.PluginFixture;
 
@@ -36,7 +37,7 @@ internal static class Program
             Console.OpenStandardInput(),
             Utf8NoBom,
             detectEncodingFromByteOrderMarks: false);
-        StreamWriter? output = new(Console.OpenStandardOutput(), Utf8NoBom)
+        StreamWriter? output = new(OpenOwnedStandardOutput(), Utf8NoBom)
         {
             AutoFlush = true,
         };
@@ -310,27 +311,17 @@ internal static class Program
     private static async Task CloseOutputAsync(StreamWriter output)
     {
         await output.FlushAsync();
+        output.Dispose();
+    }
 
-        int error;
-        if (OperatingSystem.IsWindows())
-        {
-            nint handle = GetStdHandle(-11);
-            error = CloseHandle(handle) ? 0 : Marshal.GetLastPInvokeError();
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            error = CloseMacOS(1) == 0 ? 0 : Marshal.GetLastPInvokeError();
-        }
-        else
-        {
-            error = CloseUnix(1) == 0 ? 0 : Marshal.GetLastPInvokeError();
-        }
-
-        if (error != 0)
-        {
-            throw new IOException(
-                $"Could not close the plugin fixture output pipe (error {error}).");
-        }
+    private static FileStream OpenOwnedStandardOutput()
+    {
+        nint handle = OperatingSystem.IsWindows()
+            ? GetStdHandle(-11)
+            : 1;
+        return new FileStream(
+            new SafeFileHandle(handle, ownsHandle: true),
+            FileAccess.Write);
     }
 
     private static async Task DrainInputAsync(
@@ -371,16 +362,6 @@ internal static class Program
         Exit,
     }
 
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CloseHandle(nint handle);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [DllImport("kernel32.dll")]
     private static extern nint GetStdHandle(int standardHandle);
-
-    [DllImport("libc", EntryPoint = "close", SetLastError = true)]
-    private static extern int CloseUnix(int fileDescriptor);
-
-    [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
-    private static extern int CloseMacOS(int fileDescriptor);
 }

--- a/src/NuGetFetch.PluginFixture/Program.cs
+++ b/src/NuGetFetch.PluginFixture/Program.cs
@@ -29,6 +29,15 @@ internal static class Program
     {
         string assemblyPath = typeof(Program).Assembly.Location;
         string configurationPath = Path.ChangeExtension(assemblyPath, ".json");
+        PluginFixtureConfiguration configuration =
+            await ReadConfigurationAsync(configurationPath);
+        bool traceOutputClosure =
+            OperatingSystem.IsLinux()
+            && (configuration.CredentialBehavior == PluginCredentialBehavior.CloseOutput
+                || configuration.AfterSetLogLevelBehavior
+                    is PluginAfterSetLogLevelBehavior.CloseOutput
+                    or PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput);
+        TraceOutputDescriptors(traceOutputClosure, "before worker");
         string hostPath = Environment.ProcessPath
             ?? throw new InvalidOperationException(
                 "Could not determine the plugin fixture host path.");
@@ -45,14 +54,16 @@ internal static class Program
                 "Could not start the plugin fixture worker.");
         // The worker can end the output stream while this launched process stays alive.
         CloseStandardOutput();
+        TraceOutputDescriptors(traceOutputClosure, "after supervisor close");
         await worker.WaitForExitAsync();
+        TraceOutputDescriptors(
+            traceOutputClosure,
+            $"after worker exit {worker.ExitCode}");
         if (worker.ExitCode != OutputClosedExitCode)
         {
             return worker.ExitCode;
         }
 
-        PluginFixtureConfiguration configuration =
-            await ReadConfigurationAsync(configurationPath);
         using var recordStream = new FileStream(
             configuration.RecordPath,
             FileMode.Append,
@@ -68,6 +79,27 @@ internal static class Program
             detectEncodingFromByteOrderMarks: false);
         await DrainInputAsync(input, record);
         return 0;
+    }
+
+    private static void TraceOutputDescriptors(bool enabled, string stage)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+
+        string[] descriptors = Directory.GetFiles("/proc/self/fd")
+            .Select(path =>
+            {
+                FileSystemInfo? target = File.ResolveLinkTarget(
+                    path,
+                    returnFinalTarget: false);
+                return $"{Path.GetFileName(path)}={target?.FullName ?? "?"}";
+            })
+            .ToArray();
+        WriteDiagnostic(
+            $"fixture supervisor {Environment.ProcessId} {stage}: " +
+            string.Join(", ", descriptors));
     }
 
     private static async Task<int> RunWorkerAsync(string configurationPath)
@@ -147,6 +179,8 @@ internal static class Program
                             input,
                             output))
                     {
+                        WriteDiagnostic(
+                            $"fixture worker {Environment.ProcessId} closing output");
                         return OutputClosedExitCode;
                     }
                     break;
@@ -165,6 +199,8 @@ internal static class Program
                             requestId);
                     if (result == CredentialActionResult.OutputClosed)
                     {
+                        WriteDiagnostic(
+                            $"fixture worker {Environment.ProcessId} closing output");
                         return OutputClosedExitCode;
                     }
                     if (result == CredentialActionResult.Exit)
@@ -393,6 +429,17 @@ internal static class Program
         }
     }
 
+    private static void WriteDiagnostic(string message)
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            return;
+        }
+
+        byte[] bytes = Utf8NoBom.GetBytes(message + Environment.NewLine);
+        _ = WriteUnix(2, bytes, (nuint)bytes.Length);
+    }
+
     private static string ReadPartialStringProperty(string json, string property)
     {
         string prefix = $"\"{property}\":\"";
@@ -430,6 +477,12 @@ internal static class Program
 
     [DllImport("libc", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseUnix(int fileDescriptor);
+
+    [DllImport("libc", EntryPoint = "write")]
+    private static extern nint WriteUnix(
+        int fileDescriptor,
+        byte[] buffer,
+        nuint count);
 
     [DllImport("libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
     private static extern int CloseMacOS(int fileDescriptor);

--- a/src/NuGetFetch.Tests/NuGetFetch.Tests.csproj
+++ b/src/NuGetFetch.Tests/NuGetFetch.Tests.csproj
@@ -21,6 +21,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\NuGetFetch.PluginFixture\PluginFixtureConfiguration.cs" Link="PluginFixtureConfiguration.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NuGetFetch.PluginFixture\NuGetFetch.PluginFixture.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\NuGetFetch\NuGetFetch.csproj" />
   </ItemGroup>
 

--- a/src/NuGetFetch.Tests/PluginProtocolTests.cs
+++ b/src/NuGetFetch.Tests/PluginProtocolTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using NuGetFetch;
+using NuGetFetch.PluginFixture;
 using NuGetFetch.Plugins;
 
 namespace NuGetFetch.Tests;
@@ -10,10 +11,10 @@ namespace NuGetFetch.Tests;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The fake is a shell script rather than a mock object, so these tests cover the parts most
-/// likely to be wrong in a hand-written protocol client: process launch and argument shape,
-/// newline-delimited JSON framing, the symmetric handshake, and the exact property names and
-/// enum spellings. A mock would have agreed with whatever we wrote.
+/// The fake is a managed child process rather than a mock object, so these tests cover the parts
+/// most likely to be wrong in a hand-written protocol client: process launch and argument shape,
+/// newline-delimited JSON framing, the symmetric handshake, and the exact property names and enum
+/// spellings. A mock would have agreed with whatever we wrote.
 /// </para>
 /// <para>
 /// The contract is defined by NuGet/NuGet.Client, src/NuGet.Core/NuGet.Protocol/Plugins/.
@@ -457,7 +458,11 @@ public sealed class PluginProtocolTests : IDisposable
     [Fact]
     public async Task APluginThatWritesGarbageIsSkipped()
     {
-        FakePlugin plugin = CreateRawPlugin("garbage", "printf 'not json at all\\n'\nsleep 2\n");
+        FakePlugin plugin = CreatePlugin(
+            "garbage",
+            username: "unused",
+            password: "unused",
+            writeGarbageAndWait: true);
 
         await using var provider = new PluginCredentialProvider(null, [plugin.Executable]);
         PackageSourceCredential? credential = await provider.GetCredentialsAsync(
@@ -479,7 +484,8 @@ public sealed class PluginProtocolTests : IDisposable
             "mistyped",
             username: "u",
             password: "p",
-            preamble: """emit '{"RequestId":123,"Type":"Response","Method":"GetAuthenticationCredentials"}'""");
+            preambleMessage:
+                """{"RequestId":123,"Type":"Response","Method":"GetAuthenticationCredentials"}""");
 
         await using var provider = new PluginCredentialProvider(null, [plugin.Executable]);
         PackageSourceCredential? credential = await provider.GetCredentialsAsync(
@@ -615,8 +621,9 @@ public sealed class PluginProtocolTests : IDisposable
             $"malformed-inbound-log-{name}",
             username: "u",
             password: "p",
-            afterSetLogLevel:
-                $"emit '{{\"RequestId\":\"malformed-log\",\"Type\":\"Request\",\"Method\":\"Log\",\"Payload\":{payload}}}'");
+            inboundLogRequestId: "malformed-log",
+            inboundLogPayload: payload,
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.EmitLog);
 
         await using var provider = new PluginCredentialProvider(null, [plugin.Executable]);
         PackageSourceCredential? credential = await provider.GetCredentialsAsync(
@@ -641,8 +648,10 @@ public sealed class PluginProtocolTests : IDisposable
             "valid-inbound-log",
             username: "u",
             password: "p",
-            afterSetLogLevel:
-                """emit '{"RequestId":"valid-log","Type":"Request","Method":"Log","Payload":{"LogLevel":"Information","Message":"hello"}}'""");
+            inboundLogRequestId: "valid-log",
+            inboundLogPayload:
+                """{"LogLevel":"Information","Message":"hello"}""",
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.EmitLog);
 
         await using var provider = new PluginCredentialProvider(log.Add, [plugin.Executable]);
         PackageSourceCredential? credential = await provider.GetCredentialsAsync(
@@ -695,7 +704,7 @@ public sealed class PluginProtocolTests : IDisposable
             "closed-admission",
             username: "u",
             password: "p",
-            afterSetLogLevel: "exec 1>&-",
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.CloseOutput,
             exitOnCredentialRequest: true);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
@@ -817,8 +826,8 @@ public sealed class PluginProtocolTests : IDisposable
             "admission-during-terminal-snapshot",
             username: "u",
             password: "p",
-            afterSetLogLevel:
-                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""",
+            afterSetLogLevelBehavior:
+                PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput,
             exitOnCredentialRequest: true);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
@@ -886,7 +895,7 @@ public sealed class PluginProtocolTests : IDisposable
             "canceled-after-receiver-loss",
             username: "u",
             password: "p",
-            afterSetLogLevel: "exec 1>&-");
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.CloseOutput);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -952,8 +961,8 @@ public sealed class PluginProtocolTests : IDisposable
             "canceled-while-waiting-for-closed-admission",
             username: "u",
             password: "p",
-            afterSetLogLevel:
-                """while [ ! -f "$RECORD.close" ]; do sleep 0.01; done; exec 1>&-""",
+            afterSetLogLevelBehavior:
+                PluginAfterSetLogLevelBehavior.WaitForCloseMarkerThenCloseOutput,
             exitOnCredentialRequest: true);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
@@ -1015,7 +1024,7 @@ public sealed class PluginProtocolTests : IDisposable
             "stalled-writer-timeout",
             username: "u",
             password: "p",
-            afterSetLogLevel: "sleep 30");
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.Stall);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -1081,7 +1090,7 @@ public sealed class PluginProtocolTests : IDisposable
             "stalled-writer-cancellation",
             username: "u",
             password: "p",
-            afterSetLogLevel: "sleep 30");
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.Stall);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -1137,7 +1146,8 @@ public sealed class PluginProtocolTests : IDisposable
             "response-before-complete-write",
             username: "right",
             password: "token",
-            respondBeforeCredentialLineCompletes: true);
+            afterSetLogLevelBehavior:
+                PluginAfterSetLogLevelBehavior.RespondBeforeCredentialLineCompletes);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -1297,7 +1307,7 @@ public sealed class PluginProtocolTests : IDisposable
             "quiesce-before-dispose",
             username: "u",
             password: "p",
-            afterSetLogLevel: "sleep 30");
+            afterSetLogLevelBehavior: PluginAfterSetLogLevelBehavior.Stall);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -1380,12 +1390,11 @@ public sealed class PluginProtocolTests : IDisposable
             "quiesce-inbound-response",
             username: "u",
             password: "p",
-            afterSetLogLevel:
-                """
-                while [ ! -f "$RECORD.log" ]; do sleep 0.01; done
-                emit '{"RequestId":"quiesce-log","Type":"Request","Method":"Log","Payload":{"LogLevel":"Information","Message":"hello"}}'
-                sleep 30
-                """);
+            inboundLogRequestId: "quiesce-log",
+            inboundLogPayload:
+                """{"LogLevel":"Information","Message":"hello"}""",
+            afterSetLogLevelBehavior:
+                PluginAfterSetLogLevelBehavior.WaitForLogMarkerThenEmitLogAndStall);
         PluginConnection connection = Assert.IsType<PluginConnection>(
             await PluginConnection.StartAsync(
                 plugin.Executable,
@@ -1532,140 +1541,78 @@ public sealed class PluginProtocolTests : IDisposable
         string claims = "Authentication",
         string responseCode = "Success",
         string? authenticationTypes = null,
-        string? preamble = null,
+        string? preambleMessage = null,
         string? inboundHandshakePayload = null,
         string? outboundHandshakePayload = null,
-        string? afterSetLogLevel = null,
-        bool respondBeforeCredentialLineCompletes = false,
+        string? inboundLogRequestId = null,
+        string? inboundLogPayload = null,
+        bool writeGarbageAndWait = false,
+        PluginAfterSetLogLevelBehavior afterSetLogLevelBehavior =
+            PluginAfterSetLogLevelBehavior.Continue,
         bool closeOutputOnCredentialRequest = false,
         bool exitOnFirstCredentialRequest = false,
         bool exitOnCredentialRequest = false)
     {
-        // Values are embedded in a double-quoted bash string, so every JSON quote needs a
-        // backslash in the emitted script.
-        static string Quoted(string value) => "\\\"" + value + "\\\"";
-
-        string types = authenticationTypes is null ? "null" : "[" + Quoted(authenticationTypes) + "]";
-
-        string credentialPayload = responseCode == "Success"
-            ? "{" + Quoted("Username") + ":" + Quoted(username)
-                + "," + Quoted("Password") + ":" + Quoted(password)
-                + "," + Quoted("AuthenticationTypes") + ":" + types
-                + "," + Quoted("ResponseCode") + ":" + Quoted("Success") + "}"
-            : "{" + Quoted("ResponseCode") + ":" + Quoted(responseCode) + "}";
-        string credentialResponse = """
-            emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetAuthenticationCredentials\",\"Payload\":__CREDENTIAL__}"
-            """;
-        string credentialAction = closeOutputOnCredentialRequest
-            ? "exec 1>&-"
-            : exitOnFirstCredentialRequest
-                ? """
-                  starts_file="$RECORD.starts"
-                  starts=0
-                  [ -f "$starts_file" ] && starts=$(cat "$starts_file")
-                  starts=$((starts + 1))
-                  printf '%s' "$starts" > "$starts_file"
-                  if [ "$starts" -eq 1 ]; then
-                    exit 0
-                  fi
-                  __CREDENTIAL_RESPONSE__
-                  """
-            : exitOnCredentialRequest
-                ? "exit 0"
-                : credentialResponse;
-        string afterSetLogLevelAction = respondBeforeCredentialLineCompletes
-            ? """
-              IFS= read -r -n 256 prefix
-              id=$(field "$prefix" RequestId)
-              __CREDENTIAL_RESPONSE__
-              sleep 30
-              exit 0
-              """
-                .Replace("__CREDENTIAL_RESPONSE__", credentialResponse)
-                .Replace("__CREDENTIAL__", credentialPayload)
-            : afterSetLogLevel ?? string.Empty;
-
-        // A non-interpolated raw string with tokens: the script is dense with braces, and
-        // interpolation holes would be indistinguishable from JSON.
-        string body = """
-            __PREAMBLE__
-            # Open with our own handshake, as a real plugin does. The host must answer it.
-            emit '{"RequestId":"fake-handshake","Type":"Request","Method":"Handshake","Payload":__INBOUND_HANDSHAKE__}'
-
-            while IFS= read -r line; do
-              printf '%s\n' "$line" >> "$RECORD"
-              type=$(field "$line" Type)
-              [ "$type" = "Request" ] || continue
-              id=$(field "$line" RequestId)
-              method=$(field "$line" Method)
-              case "$method" in
-                Handshake)
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"Handshake\",\"Payload\":__OUTBOUND_HANDSHAKE__}" ;;
-                MonitorNuGetProcessExit|Initialize)
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"$method\",\"Payload\":{\"ResponseCode\":\"Success\"}}" ;;
-                SetLogLevel)
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"$method\",\"Payload\":{\"ResponseCode\":\"Success\"}}"
-                  __AFTER_SET_LOG_LEVEL__ ;;
-                GetOperationClaims)
-                  emit "{\"RequestId\":\"$id\",\"Type\":\"Response\",\"Method\":\"GetOperationClaims\",\"Payload\":{\"Claims\":[__CLAIMS__]}}" ;;
-                GetAuthenticationCredentials)
-                  __AUTH_ACTION__ ;;
-                Close)
-                  exit 0 ;;
-              esac
-            done
-            """
-            .Replace("__CLAIMS__", Quoted(claims))
-            .Replace("__AUTH_ACTION__", credentialAction)
-            .Replace("__CREDENTIAL_RESPONSE__", credentialResponse)
-            .Replace("__CREDENTIAL__", credentialPayload)
-            .Replace(
-                "__INBOUND_HANDSHAKE__",
-                inboundHandshakePayload
-                    ?? """{"ProtocolVersion":"2.0.0","MinimumProtocolVersion":"1.0.0"}""")
-            .Replace(
-                "__OUTBOUND_HANDSHAKE__",
-                (outboundHandshakePayload
-                    ?? """{"ResponseCode":"Success","ProtocolVersion":"2.0.0"}""")
-                    .Replace("\"", "\\\"", StringComparison.Ordinal))
-            .Replace("__AFTER_SET_LOG_LEVEL__", afterSetLogLevelAction)
-            .Replace("__PREAMBLE__", preamble ?? string.Empty);
-
-        return CreateRawPlugin(name, body);
-    }
-
-    private FakePlugin CreateRawPlugin(string name, string body)
-    {
-        Assert.SkipWhen(OperatingSystem.IsWindows(), "The fake plugin is a shell script; CI for this suite is Linux.");
-
         string directory = Path.Combine(_root, name);
         Directory.CreateDirectory(directory);
         string record = Path.Combine(directory, "received.ndjson");
-        string script = Path.Combine(directory, $"nuget-plugin-{name}");
-
-        string contents = $$"""
-            #!/usr/bin/env bash
-            set -u
-            RECORD="{{record}}"
-            : > "$RECORD"
-
-            emit() { printf '%s\n' "$1"; }
-
-            field() { printf '%s' "$1" | sed -n "s/.*\"$2\":\"\([^\"]*\)\".*/\1/p"; }
-
-            {{body}}
-            """;
-
-        File.WriteAllText(script, contents);
-
-        if (!OperatingSystem.IsWindows())
+        var configuration = new PluginFixtureConfiguration
         {
-            File.SetUnixFileMode(
-                script,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            RecordPath = record,
+            Username = username,
+            Password = password,
+            Claims = claims,
+            ResponseCode = responseCode,
+            AuthenticationType = authenticationTypes,
+            PreambleMessage = preambleMessage,
+            InboundHandshakePayload = inboundHandshakePayload
+                ?? """{"ProtocolVersion":"2.0.0","MinimumProtocolVersion":"1.0.0"}""",
+            OutboundHandshakePayload = outboundHandshakePayload
+                ?? """{"ResponseCode":"Success","ProtocolVersion":"2.0.0"}""",
+            InboundLogRequestId = inboundLogRequestId,
+            InboundLogPayload = inboundLogPayload,
+            WriteGarbageAndWait = writeGarbageAndWait,
+            CredentialBehavior = closeOutputOnCredentialRequest
+                ? PluginCredentialBehavior.CloseOutput
+                : exitOnFirstCredentialRequest
+                    ? PluginCredentialBehavior.ExitOnFirstRequest
+                    : exitOnCredentialRequest
+                        ? PluginCredentialBehavior.Exit
+                        : PluginCredentialBehavior.Respond,
+            AfterSetLogLevelBehavior = afterSetLogLevelBehavior,
+        };
+
+        string sourceBase = Path.Combine(
+            FindPluginFixtureDirectory(),
+            "NuGetFetch.PluginFixture");
+        string targetBase = Path.Combine(directory, $"nuget-plugin-{name}");
+        foreach (string suffix in new[] { ".dll", ".deps.json", ".runtimeconfig.json" })
+        {
+            string source = sourceBase + suffix;
+            Assert.True(File.Exists(source), $"Expected plugin fixture file '{source}'.");
+            File.Copy(source, targetBase + suffix);
         }
 
-        return new FakePlugin(new PluginExecutable(script, RequiresDotnetHost: false), record);
+        File.WriteAllText(
+            targetBase + ".json",
+            JsonSerializer.Serialize(configuration));
+
+        return new FakePlugin(
+            new PluginExecutable(targetBase + ".dll", RequiresDotnetHost: true),
+            record);
+    }
+
+    private static string FindPluginFixtureDirectory()
+    {
+        string testOutput = Path.TrimEndingDirectorySeparator(
+            AppContext.BaseDirectory);
+        string configuration = Path.GetFileName(testOutput);
+        string projectOutput = Directory.GetParent(testOutput)!.FullName;
+        string binDirectory = Directory.GetParent(projectOutput)!.FullName;
+        return Path.Combine(
+            binDirectory,
+            "NuGetFetch.PluginFixture",
+            configuration);
     }
 
     private sealed record FakePlugin(PluginExecutable Executable, string RecordPath)


### PR DESCRIPTION
Runs the real NuGet credential-plugin protocol harness on Windows and Unix by replacing its generated Bash plugin with a managed child-process fixture. Product plugin behavior is unchanged.

Closes #4949.

## Demo

Before this change, `PluginProtocolTests` skipped on Windows when fixture creation reached its Bash-only guard.

```powershell
dotnet run --project src\NuGetFetch.Tests -c Release -p:DefaultTargetFramework=net10.0 -- -class NuGetFetch.Tests.PluginProtocolTests
```

```text
NuGetFetch.Tests  Total: 47, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

The managed fixture performs the same real stdin/stdout exchange, including symmetric handshakes, malformed messages, process exits, live-process pipe closure, stalls, restarts, inbound requests, and partial writes. The neighboring Windows-only distinction remains intact: executable-bit discovery is still the sole offline suite skip.

## Validation

```text
NuGetFetch.Tests  Total: 772, Errors: 0, Failed: 0, Skipped: 1, Not Run: 0
```

- `dotnet run --project src\NuGetFetch.Tests -c Release -p:DefaultTargetFramework=net10.0 -- -trait- "Network=Live"`
- `markdownlint docs/design/nuget-authentication.md`
- `dotnet format src\NuGetFetch.Tests\NuGetFetch.Tests.csproj --no-restore --verify-no-changes --include ...`

The target-framework override was needed only because this Windows host has a centrally installed .NET 10 preview SDK while repository development targets .NET 11 preview. CI will exercise the normal repository target.

## Scope

- **Owner:** NuGet credential-plugin protocol test harness
- **Owning document:** `docs/design/nuget-authentication.md#tests`
- **Non-claims:** no product protocol changes, no real feed/provider dependency, and no attempt to make Unix executable-bit semantics apply to Windows
