### PR TITLE
Implement asynchronous InspectionWorkspace close

### DIFF
--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -481,10 +481,13 @@ throwing compatibility behavior. New retained or shared hosts instead use an
 explicit asynchronous construction path whose close is awaitable and reports
 every terminal result.
 
-`DisposeAsync` awaits the same close completion and exposes its report through
-the workspace rather than throwing expected cleanup failures that could replace
-a primary exception from an `await using` body. Callers that need to branch on
-cleanup use `CloseAsync` and inspect its returned report.
+On an asynchronous workspace, `DisposeAsync` awaits the same close completion
+and exposes its report through the workspace rather than throwing expected
+cleanup failures that could replace a primary exception from an `await using`
+body. On a synchronous-compatibility workspace, `DisposeAsync` performs the
+same release request as `Dispose()` so generic asynchronous disposal remains
+compatible. Callers that need to branch on cleanup use `CloseAsync` and inspect
+its returned report.
 
 Lifetime-mode enforcement is fail-before-mutation. A
 synchronous-compatibility workspace rejects construction that requires an
@@ -514,46 +517,48 @@ abstract completions; their internal contracts remain owned by
 [`AssemblyContextGroupLifecycle.tla`](models/assembly-context-group-lifecycle/AssemblyContextGroupLifecycle.tla).
 The model checks the target design, not current implementation conformance.
 
-The current implementation is narrower. `InspectionWorkspace` is synchronous
-`IDisposable`, stores raw groups in one list, and directly disposes every
-registered group. `PackageAssemblyContextRoles` independently disposes the
-same role groups. Group creation checks workspace state before and after
-construction, but a group completed after disposal is immediately disposed and
-cannot join an awaited cleanup result. There is no admission ticket, shared
-release completion, asynchronous workspace report, or coordinated-release
-exclusion. The existing group-internal callback quiescence remains valid; this
-gap is the workspace-level composition above it.
+The direct-group foundation is implemented. The parameterless constructor
+retains synchronous compatibility. `CreateAsynchronous()` selects the awaited
+lifetime before admission, `CloseAsync()` returns one shared
+`Task<InspectionWorkspaceCloseReport>`, `DisposeAsync()` awaits that task, and
+`CloseReport` exposes the same immutable report after completion. Each direct
+group has one release completion. An asynchronous workspace captures cleanup
+failure as `InspectionWorkspaceGroupCloseResult.Failure`; synchronous
+compatibility continues to throw the same cleanup failure while requesting the
+same group-owned release.
 
-The target is unverified until Release gates prove:
+The direct implementation is enforced by these Release gates:
 
 - `WorkspaceClose_RejectsAdmissionAndRoutesLateGroupToRelease` closes admission
-  atomically and prevents a construction result from publishing after close;
-- `WorkspaceClose_DirectAndCoordinatedGroupsReleaseExactlyOnce` proves that
-  direct and coordinated paths converge on one terminal authority without
-  independent workspace disposal of a coordinated group;
-- `WorkspaceClose_ExistingCoordinatedLeaseRemainsUsableUntilOwnerRelease`
-  proves a lease holder can start and finish group work after workspace close
-  begins and that release remains unavailable until the lease returns;
-- `WorkspaceClose_OwnerFirstReleaseDeactivatesRegistrationAndRetainsReport`
-  proves explicit adjacent-owner close can remove a coordinated group from
-  active workspace use before workspace close while preserving its historical
-  registration and terminal result;
-- `WorkspaceClose_NoGroupFailureSettlesAdmissionWithoutCleanupEntry` proves
-  failed or canceled construction after admission cannot strand close and does
-  not invent a group cleanup record;
+  atomically, prevents a late construction result from publishing, and retains
+  its cleanup result;
+- `WorkspaceClose_NoGroupFailureSettlesAdmissionWithoutCleanupEntry` proves a
+  construction failure after admission cannot strand close or invent a group
+  cleanup record;
 - `WorkspaceClose_AwaitsAllGroupCompletionsAndReportsEveryFailure` proves
   callback/group quiescence, attempt-all cleanup, stable ordering, and complete
-  typed failure retention;
+  failure retention;
 - `WorkspaceClose_ConcurrentCallersShareCompletionAndReportInstance` proves
-  repeated and concurrent close calls join one completion and receive the same
+  repeated and concurrent close calls join one task and receive the same
   immutable report object;
-- `WorkspaceDispose_CompatibilityUsesSharedReleaseAuthority` proves the
-  synchronous package-role adapter requests the same owner-issued completion,
-  never independently disposes the group, and preserves fail-before-mutation
-  rejection for asynchronous-only construction; and
+- `WorkspaceDispose_CompatibilityUsesSharedReleaseAuthority` proves
+  asynchronous `Dispose()` rejection is fail-before-mutation and synchronous
+  compatibility retains its throwing behavior through the group-owned release
+  completion; and
 - `WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking` proves
-  the supported single-threaded host path reaches terminal close without a
-  blocking wait or background-thread requirement.
+  close rejects new work immediately, preserves an already-admitted callback,
+  and reaches terminal close through awaited progress without a blocking wait
+  or background-thread requirement.
+
+Coordinated package-role adoption remains unverified. The current
+`PackageAssemblyContextRoles` path independently disposes its role groups and
+does not yet supply the owner-issued participation and completion contracts
+required above. These remaining Release gates belong to that adjacent
+composition:
+
+- `WorkspaceClose_DirectAndCoordinatedGroupsReleaseExactlyOnce`;
+- `WorkspaceClose_ExistingCoordinatedLeaseRemainsUsableUntilOwnerRelease`; and
+- `WorkspaceClose_OwnerFirstReleaseDeactivatesRegistrationAndRetainsReport`.
 
 This contract does not define package admission keys, cache policy, package
 selection, role planning, participant projection, package cleanup-record shape,

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -882,17 +882,18 @@ public sealed class InspectionWorkspaceTests
     public async Task WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking()
     {
         TestAssembly source = TestAssembly.Create();
-        InspectionWorkspace workspace =
-            InspectionWorkspace.CreateAsynchronous();
         var creationContext =
             new NonPumpingSynchronizationContext();
         SynchronizationContext? previousContext =
             SynchronizationContext.Current;
+        InspectionWorkspace workspace;
         AssemblyContextGroup group;
         try
         {
             SynchronizationContext.SetSynchronizationContext(
                 creationContext);
+            workspace =
+                InspectionWorkspace.CreateAsynchronous();
             group = workspace.CreateAssemblyContextGroup(
                 [source.Participant]);
         }
@@ -928,7 +929,10 @@ public sealed class InspectionWorkspaceTests
             AssemblyImageAccessResult<int>.Available>(
                 await operation);
         Assert.Equal(0, creationContext.PostCount);
-        InspectionWorkspaceCloseReport report = await close;
+        InspectionWorkspaceCloseReport report =
+            await close.WaitAsync(
+                TimeSpan.FromSeconds(10),
+                TestContext.Current.CancellationToken);
 
         Assert.Equal(42, available.Value);
         Assert.True(Assert.Single(report.Groups).Succeeded);

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -624,6 +624,317 @@ public sealed class InspectionWorkspaceTests
     }
 
     [Fact]
+    public async Task WorkspaceClose_RejectsAdmissionAndRoutesLateGroupToRelease()
+    {
+        TestAssembly source = TestAssembly.Create();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        using var enumerationEntered = new ManualResetEventSlim();
+        using var enumerationResume = new ManualResetEventSlim();
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+
+        IEnumerable<AssemblyContextParticipant> Participants()
+        {
+            enumerationEntered.Set();
+            enumerationResume.Wait(cancellationToken);
+            yield return source.Participant;
+        }
+
+        Task<AssemblyContextGroup> construction = StartConcurrent(
+            () => workspace.CreateAssemblyContextGroup(
+                Participants()));
+        Assert.True(
+            enumerationEntered.Wait(
+                TimeSpan.FromSeconds(10),
+                cancellationToken));
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        Assert.False(close.IsCompleted);
+        Assert.Throws<ObjectDisposedException>(
+            () => workspace.CreateAssemblyContextGroup(
+                [source.Participant]));
+
+        enumerationResume.Set();
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await construction);
+        InspectionWorkspaceCloseReport report = await close;
+
+        InspectionWorkspaceGroupCloseResult result =
+            Assert.Single(report.Groups);
+        Assert.Equal(0, result.RegistrationIndex);
+        Assert.True(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_NoGroupFailureSettlesAdmissionWithoutCleanupEntry()
+    {
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        using var enumerationEntered = new ManualResetEventSlim();
+        using var enumerationResume = new ManualResetEventSlim();
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+
+        IEnumerable<AssemblyContextParticipant> Participants()
+        {
+            enumerationEntered.Set();
+            enumerationResume.Wait(cancellationToken);
+            yield return ThrowConstructionFailure();
+        }
+
+        Task<AssemblyContextGroup> construction = StartConcurrent(
+            () => workspace.CreateAssemblyContextGroup(
+                Participants()));
+        Assert.True(
+            enumerationEntered.Wait(
+                TimeSpan.FromSeconds(10),
+                cancellationToken));
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        Assert.False(close.IsCompleted);
+        enumerationResume.Set();
+
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await construction);
+        InspectionWorkspaceCloseReport report = await close;
+
+        Assert.Equal(
+            "Synthetic construction failure.",
+            failure.Message);
+        Assert.Empty(report.Groups);
+
+        static AssemblyContextParticipant
+            ThrowConstructionFailure() =>
+            throw new InvalidOperationException(
+                "Synthetic construction failure.");
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_AwaitsAllGroupCompletionsAndReportsEveryFailure()
+    {
+        TestAssembly first = TestAssembly.Create();
+        TestAssembly second = TestAssembly.Create();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup firstGroup =
+            workspace.CreateAssemblyContextGroup(
+                [first.Participant]);
+        AssemblyContextGroup secondGroup =
+            workspace.CreateAssemblyContextGroup(
+                [second.Participant]);
+        firstGroup.RegisterOwnedResource(new ThrowingResource());
+        secondGroup.RegisterOwnedResource(new ThrowingResource());
+        var callbackEntered =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackResume =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<AssemblyImageAccessResult<int>> operation =
+            firstGroup.UseAndReleaseAssemblySessionAsync(
+                first.Assembly,
+                async (_, _) =>
+                {
+                    callbackEntered.SetResult();
+                    await callbackResume.Task;
+                    return 1;
+                });
+        await callbackEntered.Task;
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        Assert.False(close.IsCompleted);
+
+        callbackResume.SetResult();
+        Assert.IsType<AssemblyImageAccessResult<int>.Available>(
+            await operation);
+        InspectionWorkspaceCloseReport report = await close;
+
+        Assert.Equal(2, report.Groups.Length);
+        Assert.All(
+            report.Groups,
+            result =>
+            {
+                Assert.False(result.Succeeded);
+                AggregateException failure =
+                    Assert.IsType<AggregateException>(
+                        result.Failure);
+                Assert.Contains(
+                    failure.InnerExceptions,
+                    ex => ex is InvalidOperationException
+                        && ex.Message
+                            == "Synthetic owned-resource disposal failure.");
+            });
+        Assert.Equal(
+            [0, 1],
+            report.Groups
+                .Select(result => result.RegistrationIndex)
+                .ToArray());
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_ConcurrentCallersShareCompletionAndReportInstance()
+    {
+        TestAssembly firstSource = TestAssembly.Create();
+        TestAssembly secondSource = TestAssembly.Create();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup firstGroup =
+            workspace.CreateAssemblyContextGroup(
+                [firstSource.Participant]);
+        AssemblyContextGroup secondGroup =
+            workspace.CreateAssemblyContextGroup(
+                [secondSource.Participant]);
+        using var releaseEntered = new ManualResetEventSlim();
+        using var releaseResume = new ManualResetEventSlim();
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        firstGroup.RegisterOwnedResource(
+            new BlockingResource(
+                releaseEntered,
+                releaseResume,
+                cancellationToken));
+
+        Task<Task<InspectionWorkspaceCloseReport>> firstCall =
+            StartConcurrent(workspace.CloseAsync);
+        Assert.True(
+            releaseEntered.Wait(
+                TimeSpan.FromSeconds(10),
+                cancellationToken));
+        Task<InspectionWorkspaceCloseReport> second =
+            workspace.CloseAsync();
+        Assert.Throws<ObjectDisposedException>(
+            () => secondGroup.GetAssemblyImageSpan(
+                secondSource.Assembly));
+        Assert.False(second.IsCompleted);
+        releaseResume.Set();
+        Task<InspectionWorkspaceCloseReport> first =
+            await firstCall;
+        InspectionWorkspaceCloseReport firstReport = await first;
+        InspectionWorkspaceCloseReport secondReport = await second;
+        Task<InspectionWorkspaceCloseReport> third =
+            workspace.CloseAsync();
+
+        Assert.Same(first, second);
+        Assert.Same(first, third);
+        Assert.Same(firstReport, secondReport);
+        Assert.Same(firstReport, await third);
+        Assert.Same(firstReport, workspace.CloseReport);
+    }
+
+    [Fact]
+    public async Task WorkspaceDispose_CompatibilityUsesSharedReleaseAuthority()
+    {
+        TestAssembly source = TestAssembly.Create();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [source.Participant]);
+        group.RegisterOwnedResource(new ThrowingResource());
+
+        Assert.Throws<InvalidOperationException>(workspace.Dispose);
+        Assert.True(
+            group.GetAssemblyImageSpan(source.Assembly).IsAvailable);
+        group.Dispose();
+
+        InspectionWorkspaceCloseReport report =
+            await workspace.CloseAsync();
+
+        Assert.False(Assert.Single(report.Groups).Succeeded);
+
+        TestAssembly synchronousSource = TestAssembly.Create();
+        using var synchronousWorkspace = new InspectionWorkspace();
+        Assert.Throws<InvalidOperationException>(
+            () =>
+            {
+                _ = synchronousWorkspace.CloseAsync();
+            });
+        AssemblyContextGroup synchronousGroup =
+            synchronousWorkspace.CreateAssemblyContextGroup(
+                [synchronousSource.Participant]);
+        synchronousGroup.RegisterOwnedResource(
+            new ThrowingResource());
+        Assert.Throws<AggregateException>(
+            synchronousWorkspace.Dispose);
+
+        TestAssembly asyncCompatibilitySource =
+            TestAssembly.Create();
+        var asyncCompatibilityWorkspace =
+            new InspectionWorkspace();
+        AssemblyContextGroup asyncCompatibilityGroup =
+            asyncCompatibilityWorkspace.CreateAssemblyContextGroup(
+                [asyncCompatibilitySource.Participant]);
+
+        await asyncCompatibilityWorkspace.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(
+            () => asyncCompatibilityGroup.GetAssemblyImageSpan(
+                asyncCompatibilitySource.Assembly));
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_BrowserWasmUsesAwaitedProgressWithoutThreadBlocking()
+    {
+        TestAssembly source = TestAssembly.Create();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        var creationContext =
+            new NonPumpingSynchronizationContext();
+        SynchronizationContext? previousContext =
+            SynchronizationContext.Current;
+        AssemblyContextGroup group;
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext(
+                creationContext);
+            group = workspace.CreateAssemblyContextGroup(
+                [source.Participant]);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(
+                previousContext);
+        }
+        var callbackEntered =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackResume =
+            new TaskCompletionSource<int>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<AssemblyImageAccessResult<int>> operation =
+            group.UseAndReleaseAssemblySessionAsync(
+                source.Assembly,
+                async (_, _) =>
+                {
+                    callbackEntered.SetResult();
+                    return await callbackResume.Task;
+                });
+        await callbackEntered.Task;
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        Assert.False(close.IsCompleted);
+        Assert.Throws<ObjectDisposedException>(
+            () => group.GetAssemblyImageSpan(source.Assembly));
+
+        callbackResume.SetResult(42);
+        var available = Assert.IsType<
+            AssemblyImageAccessResult<int>.Available>(
+                await operation);
+        Assert.Equal(0, creationContext.PostCount);
+        InspectionWorkspaceCloseReport report = await close;
+
+        Assert.Equal(42, available.Value);
+        Assert.True(Assert.Single(report.Groups).Succeeded);
+    }
+
+    [Fact]
     public void ConcurrentDisposal_AfterAsyncCallbackEnds_PreservesOwnedResourceDisposalOrder()
     {
         TestAssembly source = TestAssembly.Create();
@@ -881,6 +1192,33 @@ public sealed class InspectionWorkspaceTests
         public void Dispose() =>
             throw new InvalidOperationException(
                 "Synthetic owned-resource disposal failure.");
+    }
+
+    sealed class BlockingResource(
+        ManualResetEventSlim entered,
+        ManualResetEventSlim resume,
+        CancellationToken cancellationToken)
+        : IDisposable
+    {
+        public void Dispose()
+        {
+            entered.Set();
+            resume.Wait(cancellationToken);
+        }
+    }
+
+    sealed class NonPumpingSynchronizationContext :
+        SynchronizationContext
+    {
+        int _postCount;
+
+        internal int PostCount =>
+            Volatile.Read(ref _postCount);
+
+        public override void Post(
+            SendOrPostCallback callback,
+            object? state) =>
+            Interlocked.Increment(ref _postCount);
     }
 
     sealed class RetainedImageAssertingResource(

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -153,22 +153,31 @@ public sealed class AssemblyContextGroup : IDisposable
     readonly HashSet<IDisposable> _ownedResources =
         new(ReferenceEqualityComparer.Instance);
     readonly Action<AssemblyContextGroup> _onDisposed;
+    readonly TaskCompletionSource<AssemblyContextGroupReleaseResult>
+        _releaseCompletion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    readonly bool _captureReleaseFailuresByDefault;
     readonly long _maxRetainedImageBytes;
     long _retainedImageBytes;
     int _activeCallbacks;
     bool _disposed;
+    bool _captureReleaseFailure;
+    bool _releaseRequested;
     bool _released;
 
     internal AssemblyContextGroup(
         IEnumerable<AssemblyContextParticipant> participants,
         AssemblyContextGroupOptions? options,
-        Action<AssemblyContextGroup> onDisposed)
+        Action<AssemblyContextGroup> onDisposed,
+        bool captureReleaseFailuresByDefault)
     {
         ArgumentNullException.ThrowIfNull(participants);
         ArgumentNullException.ThrowIfNull(onDisposed);
         options ??= new AssemblyContextGroupOptions();
         options.Validate();
         _onDisposed = onDisposed;
+        _captureReleaseFailuresByDefault =
+            captureReleaseFailuresByDefault;
         _maxRetainedImageBytes = options.MaxRetainedImageBytes;
 
         var builder =
@@ -614,13 +623,16 @@ public sealed class AssemblyContextGroup : IDisposable
         Exception? operationFailure)
     {
         bool release;
+        bool captureReleaseFailure;
         lock (participant.ImageLoadGate)
         {
             lock (_lifetimeGate)
             {
                 _activeCallbacks--;
                 release =
-                    _disposed && _activeCallbacks == 0 && !_released;
+                    _releaseRequested
+                    && _activeCallbacks == 0
+                    && !_released;
                 if (release)
                 {
                     _released = true;
@@ -629,10 +641,15 @@ public sealed class AssemblyContextGroup : IDisposable
                 {
                     _retainedImageBytes -= participant.Release();
                 }
+
+                captureReleaseFailure = _captureReleaseFailure;
             }
         }
 
-        CompleteCallbackRelease(release, operationFailure);
+        CompleteCallbackRelease(
+            release,
+            captureReleaseFailure,
+            operationFailure);
     }
 
     void ReleaseSnapshotCore(ParticipantState participant)
@@ -677,59 +694,114 @@ public sealed class AssemblyContextGroup : IDisposable
     void EndCallback(Exception? operationFailure)
     {
         bool release;
+        bool captureReleaseFailure;
         lock (_lifetimeGate)
         {
             _activeCallbacks--;
             release =
-                _disposed && _activeCallbacks == 0 && !_released;
+                _releaseRequested
+                && _activeCallbacks == 0
+                && !_released;
             if (release)
                 _released = true;
+            captureReleaseFailure = _captureReleaseFailure;
         }
 
-        CompleteCallbackRelease(release, operationFailure);
+        CompleteCallbackRelease(
+            release,
+            captureReleaseFailure,
+            operationFailure);
     }
 
     void CompleteCallbackRelease(
         bool release,
+        bool captureReleaseFailure,
         Exception? operationFailure)
     {
         if (!release)
             return;
 
-        try
-        {
-            ReleaseOwnedState();
-        }
-        catch (Exception releaseFailure)
-            when (operationFailure is not null)
+        Exception? releaseFailure = ReleaseOwnedState();
+        _releaseCompletion.TrySetResult(
+            new AssemblyContextGroupReleaseResult(releaseFailure));
+        if (releaseFailure is null || captureReleaseFailure)
+            return;
+
+        if (operationFailure is not null)
         {
             throw new AggregateException(
                 operationFailure,
                 releaseFailure);
         }
+
+        throw releaseFailure;
     }
 
     public void Dispose()
     {
-        bool release;
+        RequestRelease(captureFailure: false);
+    }
+
+    internal Task<AssemblyContextGroupReleaseResult> RequestReleaseAsync()
+    {
+        RequestRelease(captureFailure: true);
+        return _releaseCompletion.Task;
+    }
+
+    internal Task<AssemblyContextGroupReleaseResult> ReleaseCompletion =>
+        _releaseCompletion.Task;
+
+    internal void CloseAdmissionFromWorkspace(
+        bool captureFailure)
+    {
         lock (_lifetimeGate)
         {
-            if (_disposed)
+            _captureReleaseFailure |=
+                captureFailure
+                || _captureReleaseFailuresByDefault;
+            _disposed = true;
+        }
+    }
+
+    void RequestRelease(bool captureFailure)
+    {
+        bool release;
+        bool captureReleaseFailure;
+        bool notifyOwner;
+        lock (_lifetimeGate)
+        {
+            _captureReleaseFailure |=
+                captureFailure
+                || _captureReleaseFailuresByDefault;
+            captureReleaseFailure = _captureReleaseFailure;
+            if (_releaseRequested)
                 return;
 
+            notifyOwner = !_disposed;
             _disposed = true;
+            _releaseRequested = true;
             release = _activeCallbacks == 0 && !_released;
             if (release)
                 _released = true;
         }
 
-        _onDisposed(this);
+        if (notifyOwner)
+            _onDisposed(this);
 
         if (release)
-            ReleaseOwnedState();
+        {
+            Exception? releaseFailure = ReleaseOwnedState();
+            _releaseCompletion.TrySetResult(
+                new AssemblyContextGroupReleaseResult(releaseFailure));
+            if (releaseFailure is not null
+                && !captureReleaseFailure)
+            {
+                throw releaseFailure;
+            }
+        }
     }
 
-    void ReleaseOwnedState()
+    Exception? ReleaseOwnedState()
     {
         IDisposable[] resources;
         lock (_lifetimeGate)
@@ -757,8 +829,9 @@ public sealed class AssemblyContextGroup : IDisposable
             ReleaseSnapshotCore(participant);
         }
 
-        if (failures is not null)
-            throw new AggregateException(failures);
+        return failures is null
+            ? null
+            : new AggregateException(failures);
     }
 
     sealed class ParticipantState(
@@ -789,49 +862,184 @@ public sealed class AssemblyContextGroup : IDisposable
         CandidateOpenFailure? Failure);
 }
 
+sealed record AssemblyContextGroupReleaseResult(Exception? Failure);
+
+/// <summary>
+/// Terminal release result for one group admitted by an asynchronous workspace.
+/// </summary>
+public sealed class InspectionWorkspaceGroupCloseResult
+{
+    internal InspectionWorkspaceGroupCloseResult(
+        int registrationIndex,
+        Exception? failure)
+    {
+        RegistrationIndex = registrationIndex;
+        Failure = failure;
+    }
+
+    public int RegistrationIndex { get; }
+
+    public bool Succeeded => Failure is null;
+
+    public Exception? Failure { get; }
+}
+
+/// <summary>
+/// Immutable terminal report produced by an asynchronous workspace close.
+/// </summary>
+public sealed class InspectionWorkspaceCloseReport
+{
+    internal InspectionWorkspaceCloseReport(
+        ImmutableArray<InspectionWorkspaceGroupCloseResult> groups)
+    {
+        Groups = groups;
+    }
+
+    public ImmutableArray<InspectionWorkspaceGroupCloseResult> Groups
+    {
+        get;
+    }
+}
+
 /// <summary>
 /// Shared owner for one or more assembly context groups.
 /// </summary>
-public sealed partial class InspectionWorkspace : IDisposable
+public sealed partial class InspectionWorkspace :
+    IDisposable,
+    IAsyncDisposable
 {
     readonly object _gate = new();
     readonly List<AssemblyContextGroup> _groups = [];
-    bool _disposed;
+    readonly List<WorkspaceGroupAdmission> _admissions = [];
+    readonly InspectionWorkspaceLifetimeMode _lifetimeMode;
+    readonly TaskCompletionSource<
+        ImmutableArray<WorkspaceGroupAdmission>>? _closeStart;
+    readonly Task<InspectionWorkspaceCloseReport>? _closeTask;
+    InspectionWorkspaceCloseReport? _closeReport;
+    InspectionWorkspaceState _state;
+    int _nextRegistrationIndex;
+
+    public InspectionWorkspace()
+    {
+        _lifetimeMode = InspectionWorkspaceLifetimeMode.Synchronous;
+    }
+
+    InspectionWorkspace(
+        InspectionWorkspaceLifetimeMode lifetimeMode)
+    {
+        _lifetimeMode = lifetimeMode;
+        _closeStart = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        _closeTask = CloseCoreAsync(_closeStart.Task);
+    }
+
+    /// <summary>
+    /// Creates a workspace whose terminal lifetime is observed through
+    /// <see cref="CloseAsync"/>.
+    /// </summary>
+    public static InspectionWorkspace CreateAsynchronous() =>
+        new(InspectionWorkspaceLifetimeMode.Asynchronous);
+
+    /// <summary>
+    /// Gets the terminal report after asynchronous close completes.
+    /// </summary>
+    public InspectionWorkspaceCloseReport? CloseReport
+    {
+        get
+        {
+            lock (_gate)
+                return _closeReport;
+        }
+    }
 
     public AssemblyContextGroup CreateAssemblyContextGroup(
         IEnumerable<AssemblyContextParticipant> participants,
         AssemblyContextGroupOptions? options = null)
     {
-        lock (_gate)
-            ObjectDisposedException.ThrowIf(_disposed, this);
-
-        var group = new AssemblyContextGroup(
-            participants,
-            options,
-            RemoveGroup);
-
+        WorkspaceGroupAdmission? admission = null;
         lock (_gate)
         {
-            if (!_disposed)
+            ObjectDisposedException.ThrowIf(
+                _state != InspectionWorkspaceState.Open,
+                this);
+            if (_lifetimeMode
+                == InspectionWorkspaceLifetimeMode.Asynchronous)
             {
-                _groups.Add(group);
-                return group;
+                admission = new WorkspaceGroupAdmission(
+                    _nextRegistrationIndex++);
+                _admissions.Add(admission);
             }
         }
 
-        group.Dispose();
+        AssemblyContextGroup group;
+        try
+        {
+            group = new AssemblyContextGroup(
+                participants,
+                options,
+                RemoveGroup,
+                captureReleaseFailuresByDefault:
+                    _lifetimeMode
+                    == InspectionWorkspaceLifetimeMode.Asynchronous);
+        }
+        catch
+        {
+            admission?.Complete(registration: null);
+            throw;
+        }
+
+        WorkspaceGroupRegistration? registration =
+            admission is null
+                ? null
+                : new WorkspaceGroupRegistration(
+                    admission.RegistrationIndex,
+                    group);
+        bool published;
+        lock (_gate)
+        {
+            published = _state == InspectionWorkspaceState.Open;
+            if (published)
+            {
+                _groups.Add(group);
+                admission?.Complete(registration);
+            }
+        }
+
+        if (published)
+            return group;
+
+        admission?.Complete(registration);
+        if (_lifetimeMode
+            == InspectionWorkspaceLifetimeMode.Synchronous)
+        {
+            group.Dispose();
+        }
+
         throw new ObjectDisposedException(nameof(InspectionWorkspace));
     }
 
     public void Dispose()
     {
+        if (_lifetimeMode
+            == InspectionWorkspaceLifetimeMode.Asynchronous)
+        {
+            throw new InvalidOperationException(
+                "An asynchronous inspection workspace must be closed with CloseAsync or DisposeAsync.");
+        }
+
         List<AssemblyContextGroup> groups;
         lock (_gate)
         {
-            if (_disposed)
+            if (_state != InspectionWorkspaceState.Open)
                 return;
-            _disposed = true;
+            _state = InspectionWorkspaceState.Closing;
             groups = [.. _groups];
+            foreach (AssemblyContextGroup group in groups)
+            {
+                group.CloseAdmissionFromWorkspace(
+                    captureFailure: false);
+            }
+
             _groups.Clear();
         }
 
@@ -848,13 +1056,214 @@ public sealed partial class InspectionWorkspace : IDisposable
             }
         }
 
+        lock (_gate)
+            _state = InspectionWorkspaceState.Closed;
+
         if (failures is not null)
             throw new AggregateException(failures);
+    }
+
+    /// <summary>
+    /// Closes an asynchronous workspace and returns its shared terminal report.
+    /// </summary>
+    public Task<InspectionWorkspaceCloseReport> CloseAsync()
+    {
+        if (_lifetimeMode
+            != InspectionWorkspaceLifetimeMode.Asynchronous)
+        {
+            throw new InvalidOperationException(
+                "CloseAsync requires a workspace created by CreateAsynchronous.");
+        }
+
+        ImmutableArray<WorkspaceGroupAdmission> admissions = default;
+        bool startClose = false;
+        lock (_gate)
+        {
+            if (_state == InspectionWorkspaceState.Open)
+            {
+                _state = InspectionWorkspaceState.Closing;
+                admissions = [.. _admissions];
+                foreach (AssemblyContextGroup group in _groups)
+                {
+                    group.CloseAdmissionFromWorkspace(
+                        captureFailure: true);
+                }
+
+                _groups.Clear();
+                startClose = true;
+            }
+        }
+
+        if (startClose)
+        {
+            foreach (WorkspaceGroupAdmission admission in admissions)
+            {
+                admission.TryRequestRelease();
+            }
+
+            _closeStart!.SetResult(admissions);
+        }
+
+        return _closeTask!;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (_lifetimeMode
+            == InspectionWorkspaceLifetimeMode.Asynchronous)
+        {
+            return new ValueTask(CloseAsync());
+        }
+
+        Dispose();
+        return ValueTask.CompletedTask;
     }
 
     void RemoveGroup(AssemblyContextGroup group)
     {
         lock (_gate)
             _groups.Remove(group);
+    }
+
+    async Task<InspectionWorkspaceCloseReport> CloseCoreAsync(
+        Task<ImmutableArray<WorkspaceGroupAdmission>> start)
+    {
+        ImmutableArray<WorkspaceGroupAdmission> admissions =
+            await start.ConfigureAwait(false);
+        var completionTasks =
+            new Task<InspectionWorkspaceGroupCloseResult?>[
+                admissions.Length];
+        for (int index = 0; index < admissions.Length; index++)
+        {
+            completionTasks[index] =
+                admissions[index].RequestReleaseAndGetResultAsync();
+        }
+
+        InspectionWorkspaceGroupCloseResult?[] completed =
+            await Task.WhenAll(completionTasks).ConfigureAwait(false);
+        var reportGroups =
+            ImmutableArray.CreateBuilder<
+                InspectionWorkspaceGroupCloseResult>();
+        foreach (InspectionWorkspaceGroupCloseResult? result in completed)
+        {
+            if (result is not null)
+                reportGroups.Add(result);
+        }
+
+        var report = new InspectionWorkspaceCloseReport(
+            reportGroups.ToImmutable());
+        lock (_gate)
+        {
+            _closeReport = report;
+            _state = InspectionWorkspaceState.Closed;
+        }
+        return report;
+    }
+
+    sealed class WorkspaceGroupAdmission(int registrationIndex)
+    {
+        readonly object _gate = new();
+        readonly TaskCompletionSource _constructionCompletion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource<
+            InspectionWorkspaceGroupCloseResult?> _terminalCompletion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+        WorkspaceGroupRegistration? _registration;
+
+        internal int RegistrationIndex { get; } = registrationIndex;
+
+        internal void TryRequestRelease()
+        {
+            WorkspaceGroupRegistration? registration;
+            lock (_gate)
+                registration = _registration;
+
+            if (registration is not null)
+                _ = registration.Group.RequestReleaseAsync();
+        }
+
+        internal async Task<InspectionWorkspaceGroupCloseResult?>
+            RequestReleaseAndGetResultAsync()
+        {
+            await _constructionCompletion.Task.ConfigureAwait(false);
+            TryRequestRelease();
+            return await _terminalCompletion.Task.ConfigureAwait(false);
+        }
+
+        internal void Complete(
+            WorkspaceGroupRegistration? registration)
+        {
+            if (registration is null)
+            {
+                _terminalCompletion.SetResult(result: null);
+                _constructionCompletion.SetResult();
+                return;
+            }
+
+            lock (_gate)
+                _registration = registration;
+
+            ObserveRelease(registration);
+
+            _constructionCompletion.SetResult();
+        }
+
+        void ObserveRelease(
+            WorkspaceGroupRegistration registration)
+        {
+            Task<AssemblyContextGroupReleaseResult> completion =
+                registration.Group.ReleaseCompletion;
+            var awaiter =
+                completion.ConfigureAwait(false).GetAwaiter();
+            if (awaiter.IsCompleted)
+            {
+                CompleteRelease(
+                    registration,
+                    awaiter.GetResult());
+                return;
+            }
+
+            awaiter.OnCompleted(
+                () => CompleteRelease(
+                    registration,
+                    awaiter.GetResult()));
+        }
+
+        void CompleteRelease(
+            WorkspaceGroupRegistration registration,
+            AssemblyContextGroupReleaseResult release)
+        {
+            var result = new InspectionWorkspaceGroupCloseResult(
+                registration.RegistrationIndex,
+                release.Failure);
+            lock (_gate)
+            {
+                if (ReferenceEquals(
+                        _registration,
+                        registration))
+                {
+                    _registration = null;
+                }
+            }
+
+            _terminalCompletion.SetResult(result);
+        }
+    }
+
+    sealed record WorkspaceGroupRegistration(
+        int RegistrationIndex,
+        AssemblyContextGroup Group);
+
+    enum InspectionWorkspaceLifetimeMode
+    {
+        Synchronous,
+        Asynchronous
+    }
+
+    enum InspectionWorkspaceState
+    {
+        Open,
+        Closing,
+        Closed
     }
 }


### PR DESCRIPTION
Implements the direct-group `InspectionWorkspace` close foundation defined by
the merged workspace-close design. Group construction now has atomic admission,
asynchronous workspaces close through one shared completion, and expected
cleanup failures remain visible in an immutable ordered report.

## Demo

```csharp
InspectionWorkspace workspace =
    InspectionWorkspace.CreateAsynchronous();
AssemblyContextGroup group =
    workspace.CreateAssemblyContextGroup(participants);

Task<InspectionWorkspaceCloseReport> close = workspace.CloseAsync();
InspectionWorkspaceCloseReport report = await close;
```

What to notice:

- `CloseAsync()` rejects new group and callback admission before it returns.
- callbacks admitted before close retain their local view and drain normally;
- late construction is routed into the same release completion instead of
  escaping workspace ownership;
- repeated and concurrent close calls return the same task and report object;
  and
- cleanup failure is report data for asynchronous workspaces, while the
  parameterless synchronous compatibility path retains its throwing behavior.

The neighboring no-group path is also covered: construction failure after
admission settles close without inventing a cleanup row.

## Implementation

- Splits group admission closure from quiescent resource release so close can
  reject new callbacks promptly without revoking active callbacks.
- Adds a single-use workspace admission ledger and compacts released entries to
  terminal report data rather than retaining group graphs.
- Adds `CreateAsynchronous()`, `CloseAsync()`, `DisposeAsync()`, `CloseReport`,
  and immutable per-registration close results.
- Keeps the existing parameterless `IDisposable` behavior and makes generic
  asynchronous disposal compatible with that synchronous mode.
- Uses context-free task continuations and no blocking task waits, `Task.Run`,
  or background-thread dependency.

Coordinated package-role adoption remains in #5185 and depends on the typed
contracts owned by #5122 and #5118.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  (785 passed)
- focused workspace close and compatibility gates (8 passed)
- `npx markdownlint-cli docs/inspection-space.md`

Closes #5184.
