### PR TITLE
Document worktree-local .NET 11 SDK setup

### DIFF
--- a/.github/instructions/dotnet-sdk.instructions.md
+++ b/.github/instructions/dotnet-sdk.instructions.md
@@ -4,26 +4,30 @@ applyTo: "**"
 
 # .NET SDK setup
 
-Before running a .NET build or test command, inspect the available and selected
-SDK:
+Before running any `dotnet` command other than these preflight commands, inspect
+the available and selected SDK:
 
 ```text
 dotnet --list-sdks
 dotnet --version
 ```
 
-The current repository SDK is .NET 11 Preview 7,
+The [repository development SDK](../../README.md#repository-development-sdk) is
+the current .NET 11 preview. As of Preview 7, that resolves to
 `11.0.100-preview.7.26381.103`. Use the installed SDK when that exact version
-appears in `dotnet --list-sdks` and `dotnet --version` selects it. Do not replace
-or modify a centrally installed `dotnet`.
+appears in `dotnet --list-sdks` and `dotnet --version` selects it. If `dotnet`
+is unavailable, treat the SDK as absent. Do not replace or modify a centrally
+installed `dotnet`.
 
 If the required SDK is absent or is not selected, install it with `dotnetup`
 under the current worktree's ignored `artifacts/` directory. On Windows
 PowerShell:
 
 ```powershell
+$ErrorActionPreference = "Stop"
+$requiredSdk = "11.0.100-preview.7.26381.103"
 $dotnetupRoot = Join-Path $PWD "artifacts\dotnetup"
-$dotnetRoot = Join-Path $PWD "artifacts\dotnet"
+$dotnetRoot = Join-Path $PWD "artifacts\dotnet\$requiredSdk"
 $dotnetupData = Join-Path $PWD "artifacts\dotnetup-data"
 $bootstrap = Join-Path $PWD "artifacts\get-dotnetup.ps1"
 
@@ -34,19 +38,31 @@ Invoke-WebRequest `
 & $bootstrap -InstallDir $dotnetupRoot
 
 $env:DOTNET_DOTNETUP_DATA_DIR = $dotnetupData
-& "$dotnetupRoot\dotnetup.exe" sdk install 11.0.100-preview.7.26381.103 `
+& "$dotnetupRoot\dotnetup.exe" sdk install $requiredSdk `
     --install-path $dotnetRoot `
     --untracked `
     --set-default-install false `
     --interactive false
-& "$dotnetRoot\dotnet.exe" --version
+if ($LASTEXITCODE -ne 0) {
+    throw "dotnetup failed with exit code $LASTEXITCODE"
+}
+
+$env:DOTNET_ROOT = $dotnetRoot
+$selectedSdk = (& "$dotnetRoot\dotnet.exe" --version | Select-Object -Last 1).Trim()
+if ($LASTEXITCODE -ne 0 -or $selectedSdk -ne $requiredSdk) {
+    throw "Expected .NET SDK $requiredSdk; selected $selectedSdk"
+}
+$selectedSdk
 ```
 
 On macOS or Linux:
 
 ```bash
+set -euo pipefail
+
+required_sdk="11.0.100-preview.7.26381.103"
 dotnetup_root="$PWD/artifacts/dotnetup"
-dotnet_root="$PWD/artifacts/dotnet"
+dotnet_root="$PWD/artifacts/dotnet/$required_sdk"
 dotnetup_data="$PWD/artifacts/dotnetup-data"
 bootstrap="$PWD/artifacts/get-dotnetup.sh"
 
@@ -57,19 +73,33 @@ curl -fsSL --retry 3 \
 bash "$bootstrap" --install-dir "$dotnetup_root"
 
 DOTNET_DOTNETUP_DATA_DIR="$dotnetup_data" \
-  "$dotnetup_root/dotnetup" sdk install 11.0.100-preview.7.26381.103 \
+  "$dotnetup_root/dotnetup" sdk install "$required_sdk" \
     --install-path "$dotnet_root" \
     --untracked \
     --set-default-install false \
     --interactive false
-"$dotnet_root/dotnet" --version
+
+export DOTNET_ROOT="$dotnet_root"
+selected_sdk=$("$dotnet_root/dotnet" --version | tail -n 1)
+if [[ "$selected_sdk" != "$required_sdk" ]]; then
+  echo "Expected .NET SDK $required_sdk; selected $selected_sdk" >&2
+  exit 1
+fi
+printf '%s\n' "$selected_sdk"
 ```
 
-After a local install, invoke the worktree-local executable explicitly for all
-repository commands. For example:
+After a local install, keep process-scoped `DOTNET_ROOT` set to the local root
+in every shell and invoke the worktree-local executable explicitly for all
+repository commands. For example, in PowerShell:
 
-```text
-artifacts/dotnet/dotnet build dotnet-inspect.slnx -c Release
+```powershell
+& "$env:DOTNET_ROOT\dotnet.exe" build dotnet-inspect.slnx -c Release
+```
+
+Or in Bash:
+
+```bash
+"$DOTNET_ROOT/dotnet" build dotnet-inspect.slnx -c Release
 ```
 
 Do not add it to the user or system `PATH`.

--- a/.github/instructions/dotnet-sdk.instructions.md
+++ b/.github/instructions/dotnet-sdk.instructions.md
@@ -1,0 +1,75 @@
+---
+applyTo: "**"
+---
+
+# .NET SDK setup
+
+Before running a .NET build or test command, inspect the available and selected
+SDK:
+
+```text
+dotnet --list-sdks
+dotnet --version
+```
+
+The current repository SDK is .NET 11 Preview 7,
+`11.0.100-preview.7.26381.103`. Use the installed SDK when that exact version
+appears in `dotnet --list-sdks` and `dotnet --version` selects it. Do not replace
+or modify a centrally installed `dotnet`.
+
+If the required SDK is absent or is not selected, install it with `dotnetup`
+under the current worktree's ignored `artifacts/` directory. On Windows
+PowerShell:
+
+```powershell
+$dotnetupRoot = Join-Path $PWD "artifacts\dotnetup"
+$dotnetRoot = Join-Path $PWD "artifacts\dotnet"
+$dotnetupData = Join-Path $PWD "artifacts\dotnetup-data"
+$bootstrap = Join-Path $PWD "artifacts\get-dotnetup.ps1"
+
+New-Item -ItemType Directory -Force (Split-Path $bootstrap) | Out-Null
+Invoke-WebRequest `
+    https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.ps1 `
+    -OutFile $bootstrap
+& $bootstrap -InstallDir $dotnetupRoot
+
+$env:DOTNET_DOTNETUP_DATA_DIR = $dotnetupData
+& "$dotnetupRoot\dotnetup.exe" sdk install 11.0.100-preview.7.26381.103 `
+    --install-path $dotnetRoot `
+    --untracked `
+    --set-default-install false `
+    --interactive false
+& "$dotnetRoot\dotnet.exe" --version
+```
+
+On macOS or Linux:
+
+```bash
+dotnetup_root="$PWD/artifacts/dotnetup"
+dotnet_root="$PWD/artifacts/dotnet"
+dotnetup_data="$PWD/artifacts/dotnetup-data"
+bootstrap="$PWD/artifacts/get-dotnetup.sh"
+
+mkdir -p "$PWD/artifacts"
+curl -fsSL --retry 3 \
+  https://aka.ms/dotnet/dotnetup/daily/get-dotnetup.sh \
+  -o "$bootstrap"
+bash "$bootstrap" --install-dir "$dotnetup_root"
+
+DOTNET_DOTNETUP_DATA_DIR="$dotnetup_data" \
+  "$dotnetup_root/dotnetup" sdk install 11.0.100-preview.7.26381.103 \
+    --install-path "$dotnet_root" \
+    --untracked \
+    --set-default-install false \
+    --interactive false
+"$dotnet_root/dotnet" --version
+```
+
+After a local install, invoke the worktree-local executable explicitly for all
+repository commands. For example:
+
+```text
+artifacts/dotnet/dotnet build dotnet-inspect.slnx -c Release
+```
+
+Do not add it to the user or system `PATH`.


### PR DESCRIPTION
## Summary

Adds repository-wide agent guidance for checking the selected .NET SDK and
using .NET 11 Preview 7 (`11.0.100-preview.7.26381.103`).

When the SDK is missing or not selected, agents install both `dotnetup` and the
SDK under the worktree's ignored `artifacts/` directory. The guidance provides
PowerShell and Bash commands and keeps central installations and `PATH`
unchanged.

## Demo

An agent starts without the required SDK:

```text
$ dotnet --version
10.0.400-preview.0.26356.102
```

The new guidance directs it to install the pinned SDK locally and verify the
result:

```text
$ artifacts/dotnet/11.0.100-preview.7.26381.103/dotnet --version
11.0.100-preview.7.26381.103
```

The same worktree-local executable and process-scoped `DOTNET_ROOT` are then
used for repository commands:

```text
$ "$DOTNET_ROOT/dotnet" build dotnet-inspect.slnx -c Release
```

## Validation

- `npx markdownlint-cli --dot .github/instructions/dotnet-sdk.instructions.md`
- Installed `11.0.100-preview.7.26381.103` with the documented `dotnetup sdk
  install` options and verified the local `dotnet --version` output.
