### PR TITLE
Restore ordinary round status cadence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,9 @@ documentation.
   push, and open its PR without separate approval. Once eligible, round 1 and
   replacements inside the current six-round block dispatch automatically; only
   a new block requires approval. Merge remains separately authorized.
-- **Review normally runs alongside CI.** Every round attempts one current-head
-  status snapshot; ordinary rounds continue when status is unavailable, every
-  third may wait up to 60 minutes, and every sixth requires green CI and
-  mergeability before approval. Markdown-only rounds never wait for CI.
+- **Review normally runs alongside CI.** Normally each round tries status;
+  ordinary rounds continue if unavailable, every third may wait 60 minutes, and
+  every sixth needs green CI/mergeability. Markdown-only review never waits.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -380,8 +379,9 @@ the replacement head. These are the binding invariants; the rest of this
 section and [round orchestration](docs/round-orchestration.md) explain them.
 
 1. **One frozen head per round.** The lock begins at the push and ends only
-   when the round closes (reconciled *and* green) or recovery supersedes the
-   attempt. Do not edit a locked head; fixes belong to the next cycle.
+   when the round closes (reconciled, local gates green, and status cadence
+   satisfied) or recovery supersedes the attempt. Do not edit a locked head;
+   fixes belong to the next cycle.
 2. **A candidate includes its effective base.** Integrate twice before pushing
    — once before fixing, once after — because the fix window is long enough for
    `main` to move.
@@ -392,14 +392,14 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
 5. **Never claim merge readiness from label state alone.** Confirm current-head
    CI and GitHub's live mergeability immediately before every merge attempt,
    even when `review-clean` is present.
-6. **A round closes only when reconciled and its applicable gates are green.**
-   Every round attempts current-head status. Known-red `ci-required` blocks;
-   pending, missing, rate-limited, or transient status does not block an
-   ordinary round. Every third round follows
+6. **A round closes only when reconciled, its applicable local gates are green,
+   and its status cadence is satisfied.** Absent a standing adjustment, every
+   round tries current-head status. Required CI failure blocks; unresolved
+   status does not block ordinary closure. Every third round follows
    [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
    At non-boundary rounds, a Markdown-only PR's gate is pre-commit
-   `markdownlint`; do not wait for CI before review. A gate failure requiring an
-   author change restarts the *same* round.
+   `markdownlint`; its final CI gate follows the detailed transition. A gate
+   failure requiring an author change restarts the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
    Auto-merge armed at the user's direction is that authorization; see
@@ -413,7 +413,7 @@ definition live in
 essentials: integrate the effective base, make the change, run the focused
 gate, integrate again, push to lock the head, satisfy the eligibility row,
 dispatch reviewers, reconcile publicly, and close only when reconciliation and
-the applicable gates are green.
+the applicable local gates and status cadence are satisfied.
 
 ### Recovery transitions
 
@@ -555,9 +555,9 @@ Put it under `## Demo` above validation in the PR body.
   changes; see [GitHub API operations](docs/github-api-operations.md) for the
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
-  eligible local suites and CI concurrently. Attempt one status snapshot before
-  reviewer dispatch; pending or unavailable status does not block an ordinary
-  round, while every third round uses the bounded wait. Follow
+  eligible local suites and CI concurrently. Follow the round's status cadence:
+  pending or unavailable status does not block an ordinary round, while every
+  third round uses the bounded wait. Follow
   [GitHub status queries](docs/github-status-queries.md) instead of polling. If
   an hour passes without an authored change while an independent gate hasn't
   started, fix the sequencing or record the blocker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,10 @@ documentation.
   push, and open its PR without separate approval. Once eligible, round 1 and
   replacements inside the current six-round block dispatch automatically; only
   a new block requires approval. Merge remains separately authorized.
-- **Markdown-only PRs hot-start immediately at non-boundary rounds.** When every
-  changed file is `*.md`, `markdownlint` is the pre-review and per-round gate.
-  Open the PR and dispatch review without asking or waiting for `ci-required`.
+- **Review normally runs alongside CI.** Every round attempts one current-head
+  status snapshot; ordinary rounds continue when status is unavailable, every
+  third may wait up to 60 minutes, and every sixth requires green CI and
+  mergeability before approval. Markdown-only rounds never wait for CI.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -133,9 +134,6 @@ make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
 
 ### Standing adjustments
 
-- **Review ordinary non-Markdown changes in parallel with CI:** requires user
-  approval; conflict recovery is the explicit exception. A CI failure requiring
-  an author change still supersedes the attempt, and all findings carry forward.
 - **Auto-merge on the final push:** once every required review is review-clean,
   or the intended final head/base carries an approved exact-head
   trivial-interaction waiver, the user may authorize auto-merge for that exact
@@ -395,7 +393,9 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    CI and GitHub's live mergeability immediately before every merge attempt,
    even when `review-clean` is present.
 6. **A round closes only when reconciled and its applicable gates are green.**
-   For a non-Markdown-only PR, known-red `ci-required` blocks; pending status follows
+   Every round attempts current-head status. Known-red `ci-required` blocks;
+   pending, missing, rate-limited, or transient status does not block an
+   ordinary round. Every third round follows
    [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
    At non-boundary rounds, a Markdown-only PR's gate is pre-commit
    `markdownlint`; do not wait for CI before review. A gate failure requiring an
@@ -555,12 +555,12 @@ Put it under `## Demo` above validation in the PR body.
   changes; see [GitHub API operations](docs/github-api-operations.md) for the
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
-  eligible local suites and CI concurrently. Reviewer dispatch waits for green
-  `ci-required` unless parallel review is approved or conflict recovery applies.
-  Query GitHub status only when the round cadence requires it; follow
-  [GitHub status queries](docs/github-status-queries.md)'s bounded waiting
-  instead of polling. If an hour passes without an authored change while an
-  independent gate hasn't started, fix the sequencing or record the blocker.
+  eligible local suites and CI concurrently. Attempt one status snapshot before
+  reviewer dispatch; pending or unavailable status does not block an ordinary
+  round, while every third round uses the bounded wait. Follow
+  [GitHub status queries](docs/github-status-queries.md) instead of polling. If
+  an hour passes without an authored change while an independent gate hasn't
+  started, fix the sequencing or record the blocker.
 - `ci-required` is this repository's aggregate merge gate
   (`.github/workflows/ci.yml`): it passes only when the aggregate itself
   concludes `success`, and a missing aggregate is not green. Never require a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ documentation.
   a new block requires approval. Merge remains separately authorized.
 - **Review normally runs alongside CI.** Each round normally tries status; ordinary
   non-Markdown rounds continue if unavailable, every third may wait 60 minutes,
-  and every sixth needs green CI/mergeability. Recovery and Markdown review never wait.
+  and every sixth boundary needs green CI/mergeability. Conflict recovery and Markdown never wait.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -395,7 +395,7 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
 6. **A round closes only when reconciled, its applicable local gates are green,
    and its status cadence is satisfied.** Absent a standing adjustment, every
    round tries current-head status. Required CI failure blocks; unresolved
-   status does not block ordinary closure. Every third ordinary non-Markdown round
+   status does not block closure when cadence permits dispatch. Every third ordinary non-Markdown round
    follows [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
    At non-boundary rounds, a Markdown-only PR's gate is pre-commit
    `markdownlint`; its final CI gate follows the detailed transition. A gate
@@ -557,7 +557,7 @@ Put it under `## Demo` above validation in the PR body.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
   eligible local suites and CI concurrently. Follow the round's status cadence:
   pending or unavailable status does not block an ordinary round, while every
-  third ordinary attempt uses the bounded wait; conflict recovery does not. Follow
+  third normal attempt uses the bounded wait; conflict recovery does not. Follow
   [GitHub status queries](docs/github-status-queries.md) instead of polling. If
   an hour passes without an authored change while an independent gate hasn't
   started, fix the sequencing or record the blocker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ documentation.
   push, and open its PR without separate approval. Once eligible, round 1 and
   replacements inside the current six-round block dispatch automatically; only
   a new block requires approval. Merge remains separately authorized.
-- **Review normally runs alongside CI.** Each round normally tries status; ordinary
-  non-Markdown rounds continue if unavailable, every third round may wait 60 minutes,
-  and every sixth boundary needs green CI/mergeability. Conflict recovery and Markdown never wait.
+- **Review normally runs alongside CI.** Ordinary non-Markdown rounds continue for
+  pending, missing, rate-limited, or transient status; terminal failures stop, and every
+  third round may wait 60 minutes. Conflict recovery and Markdown never wait; sixth boundaries need green CI/mergeability.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -397,8 +397,8 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    round tries current-head status. Required CI failure blocks; unresolved
    status does not block closure when cadence permits dispatch. A normal-cadence attempt in every third round
    follows [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
-   At non-boundary rounds, a Markdown-only PR's gate is pre-commit
-   `markdownlint`; its final CI gate follows the detailed transition. A gate
+   Every Markdown-only round's gate is pre-commit `markdownlint`; its final CI
+   gate follows the detailed transition. A gate
    failure requiring an author change restarts the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
@@ -556,9 +556,9 @@ Put it under `## Demo` above validation in the PR body.
   exact commands and the `-F`/`-f` distinction that matters for PR bodies.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
   eligible local suites and CI concurrently. Follow the round's status cadence:
-  pending or unavailable status does not block an ordinary round, while every
-  normal attempt in a third round uses the bounded wait; conflict recovery does not. Follow
-  [GitHub status queries](docs/github-status-queries.md) instead of polling. If
+  pending, missing, rate-limited, or transient status does not block an ordinary
+  round; terminal query failures stop. Every normal attempt in a third round
+  uses the bounded wait; conflict recovery does not. Follow [GitHub status queries](docs/github-status-queries.md) instead of polling. If
   an hour passes without an authored change while an independent gate hasn't
   started, fix the sequencing or record the blocker.
 - `ci-required` is this repository's aggregate merge gate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ documentation.
   push, and open its PR without separate approval. Once eligible, round 1 and
   replacements inside the current six-round block dispatch automatically; only
   a new block requires approval. Merge remains separately authorized.
-- **Review normally runs alongside CI.** Normally each round tries status;
-  ordinary rounds continue if unavailable, every third may wait 60 minutes, and
-  every sixth needs green CI/mergeability. Markdown-only review never waits.
+- **Review normally runs alongside CI.** Each round normally tries status; ordinary
+  non-Markdown rounds continue if unavailable, every third may wait 60 minutes,
+  and every sixth needs green CI/mergeability. Recovery and Markdown review never wait.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
   spec developed with close user input are examples of high-value levers.
@@ -395,8 +395,8 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
 6. **A round closes only when reconciled, its applicable local gates are green,
    and its status cadence is satisfied.** Absent a standing adjustment, every
    round tries current-head status. Required CI failure blocks; unresolved
-   status does not block ordinary closure. Every third round follows
-   [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
+   status does not block ordinary closure. Every third ordinary non-Markdown round
+   follows [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
    At non-boundary rounds, a Markdown-only PR's gate is pre-commit
    `markdownlint`; its final CI gate follows the detailed transition. A gate
    failure requiring an author change restarts the *same* round.
@@ -557,7 +557,7 @@ Put it under `## Demo` above validation in the PR body.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
   eligible local suites and CI concurrently. Follow the round's status cadence:
   pending or unavailable status does not block an ordinary round, while every
-  third round uses the bounded wait. Follow
+  third ordinary attempt uses the bounded wait; conflict recovery does not. Follow
   [GitHub status queries](docs/github-status-queries.md) instead of polling. If
   an hour passes without an authored change while an independent gate hasn't
   started, fix the sequencing or record the blocker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ documentation.
   replacements inside the current six-round block dispatch automatically; only
   a new block requires approval. Merge remains separately authorized.
 - **Review normally runs alongside CI.** Each round normally tries status; ordinary
-  non-Markdown rounds continue if unavailable, every third may wait 60 minutes,
+  non-Markdown rounds continue if unavailable, every third round may wait 60 minutes,
   and every sixth boundary needs green CI/mergeability. Conflict recovery and Markdown never wait.
 - **Complicated features need extraordinary evidence and pre-work** before
   code is written: corpus evidence, an established oracle, a TLA+ model, or a
@@ -395,7 +395,7 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
 6. **A round closes only when reconciled, its applicable local gates are green,
    and its status cadence is satisfied.** Absent a standing adjustment, every
    round tries current-head status. Required CI failure blocks; unresolved
-   status does not block closure when cadence permits dispatch. Every third ordinary non-Markdown round
+   status does not block closure when cadence permits dispatch. A normal-cadence attempt in every third round
    follows [Bounded status waiting](docs/round-orchestration.md#bounded-status-waiting).
    At non-boundary rounds, a Markdown-only PR's gate is pre-commit
    `markdownlint`; its final CI gate follows the detailed transition. A gate
@@ -557,7 +557,7 @@ Put it under `## Demo` above validation in the PR body.
 - For non-Markdown-only PRs, run the focused gate, push promptly, and start
   eligible local suites and CI concurrently. Follow the round's status cadence:
   pending or unavailable status does not block an ordinary round, while every
-  third normal attempt uses the bounded wait; conflict recovery does not. Follow
+  normal attempt in a third round uses the bounded wait; conflict recovery does not. Follow
   [GitHub status queries](docs/github-status-queries.md) instead of polling. If
   an hour passes without an authored change while an independent gate hasn't
   started, fix the sequencing or record the blocker.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -55,12 +55,13 @@ or the work appears to need multiple normative owners.
 | Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
-At rounds not divisible by three, one status attempt is enough: pending,
-missing, rate-limited, or transient status may remain pending and reviewer
-dispatch continues. This is the normal cadence, not a user-authorized parallel
-review exception. Every third round instead applies the bounded wait before
-dispatch. A Markdown-only candidate (every changed file is `*.md`) substitutes
-pre-commit `markdownlint` and never waits for CI before review. Fresh green
+For ordinary non-Markdown attempts at rounds not divisible by three, one status
+attempt is enough: pending, missing, rate-limited, or transient status may
+remain pending and reviewer dispatch continues. This is the normal cadence, not
+a user-authorized parallel review exception. Every third ordinary non-Markdown
+attempt instead applies the bounded wait before dispatch. Conflict-recovery and
+Markdown-only attempts dispatch after their required local gate and status
+attempt without waiting on unresolved CI or mergeability. Fresh green
 current-head `ci-required` and positive mergeability remain mandatory at
 six-round boundaries and final merge.
 
@@ -165,16 +166,18 @@ values.
 *This section defines repository policy, not GitHub timing guarantees.*
 
 Absent a standing adjustment in `AGENTS.md`, every round attempts one
-current-head snapshot. At rounds not divisible by three, pending, missing,
-rate-limited, or transient status does not block reviewer dispatch or round
-closure: record it and continue. Every third round, and any merge or readiness
-goal, instead enters a status budget of up to 60 minutes; expiry publishes the
-status report and stops without dispatch or goal completion. Every sixth round
-uses that budget, but fresh green current-head `ci-required` and positive
-mergeability remain prerequisites for the next-block approval prompt. A known
-conflict, required CI completed without success, or terminal query failure
-still takes its transition. Measure the budget from the first scheduled wait
-and publish `status-deadline=<UTC>`.
+current-head snapshot. For ordinary non-Markdown attempts at rounds not
+divisible by three, pending, missing, rate-limited, or transient status does not
+block reviewer dispatch or round closure: record it and continue. Every third
+ordinary non-Markdown attempt, and any merge or readiness goal, instead enters a
+status budget of up to 60 minutes; expiry publishes the status report and stops
+without dispatch or goal completion. Conflict-recovery and Markdown-only
+attempts never enter that wait; after one snapshot, unresolved status does not
+block their reviewer dispatch. Every sixth round uses the budget, but fresh
+green current-head `ci-required` and positive mergeability remain prerequisites
+for the next-block approval prompt. A known conflict, required CI completed
+without success, or terminal query failure still takes its transition. Measure
+the budget from the first scheduled wait and publish `status-deadline=<UTC>`.
 
 Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -65,8 +65,9 @@ wait before dispatch. Conflict recovery may dispatch after its status attempt
 while post-push local gates remain pending, but closes only after they pass.
 Markdown-only attempts dispatch and may close after `markdownlint` and their
 status attempt without waiting on unresolved CI or mergeability. Fresh green
-current-head `ci-required` and positive mergeability remain mandatory at
-six-round boundaries and final merge.
+current-head `ci-required` and positive mergeability remain mandatory for the
+separate next-block approval goal after every sixth completed round and for
+final merge.
 
 ### Review-clean, and recovery
 
@@ -221,7 +222,7 @@ Status not observed for PR <number> at round <n> after <mm> minutes.
 - This is not a CI result. No failing check was observed. GitHub documents
   hosted-job execution limits up to 6 hours and self-hosted queue limits up to
   24 hours, so this repository's 60-minute budget can expire first.
-- Effect: <next round not started | boundary approval withheld>.
+- Effect: <reviewer dispatch withheld for round n | boundary approval withheld>.
 - Next: <what a later user or workflow turn should re-check>.
 Recommendation: stop (status budget exhausted); nothing is closed or abandoned.
 ```

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -49,17 +49,19 @@ or the work appears to need multiple normative owners.
 
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
-| First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, applicable CI rule below | Mergeability; eligible pending CI |
-| Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
+| First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, one status attempt, and no observed conflict | CI and mergeability |
+| Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
-| Failed-gate restart | Required fix pushed, one status attempt, applicable CI rule below, and no observed conflict | Mergeability; eligible pending CI subject to [Bounded status waiting](#bounded-status-waiting) |
+| Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
-A non-Markdown candidate requires green current-head `ci-required` before
-reviewer dispatch unless the user authorized parallel review or conflict
-recovery applies. A Markdown-only candidate (every changed file is `*.md`)
-substitutes pre-commit `markdownlint` at non-boundary rounds. Only these
-exceptions make pending CI eligible; `ci-required` remains mandatory at
+At rounds not divisible by three, one status attempt is enough: pending,
+missing, rate-limited, or transient status may remain pending and reviewer
+dispatch continues. This is the normal cadence, not a user-authorized parallel
+review exception. Every third round instead applies the bounded wait before
+dispatch. A Markdown-only candidate (every changed file is `*.md`) substitutes
+pre-commit `markdownlint` and never waits for CI before review. Fresh green
+current-head `ci-required` and positive mergeability remain mandatory at
 six-round boundaries and final merge.
 
 ### Review-clean, and recovery
@@ -162,19 +164,16 @@ values.
 
 *This section defines repository policy, not GitHub timing guarantees.*
 
-Every round attempts one current-head snapshot. When CI is a reviewer-dispatch
-prerequisite, pending, missing, rate-limited, or transient status enters the
-60-minute budget below; expiry publishes the status report and stops without
-dispatch. When CI may remain pending, record that status and continue the
-current review path. A known conflict, required CI completed without success,
-or terminal query failure still takes its transition.
-
-A reviewer-dispatch CI prerequisite spends up to a 60-minute status budget
-before dispatch. Every third round, and any merge or readiness goal, may use the
-same bound. Every sixth round uses that budget, but fresh green current-head
-`ci-required` and positive mergeability remain prerequisites for the next-block
-approval prompt. Measure the budget from the first scheduled wait and publish
-`status-deadline=<UTC>`.
+Every round attempts one current-head snapshot. At rounds not divisible by
+three, pending, missing, rate-limited, or transient status does not block
+reviewer dispatch: record it and continue the current review path. Every third
+round, and any merge or readiness goal, instead enters a status budget of up to
+60 minutes; expiry publishes the status report and stops without dispatch or
+goal completion. Every sixth round uses that budget, but fresh green
+current-head `ci-required` and positive mergeability remain prerequisites for
+the next-block approval prompt. A known conflict, required CI completed without
+success, or terminal query failure still takes its transition. Measure the
+budget from the first scheduled wait and publish `status-deadline=<UTC>`.
 
 Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -55,15 +55,16 @@ or the work appears to need multiple normative owners.
 | Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
-For ordinary non-Markdown attempts at rounds not divisible by three, one status
-attempt is enough: pending, missing, rate-limited, or transient status may
-remain pending and reviewer dispatch continues. This is the normal cadence, not
-a user-authorized parallel review exception. Every third ordinary non-Markdown
-attempt instead applies the bounded wait before dispatch. Conflict-recovery and
-Markdown-only attempts dispatch after their required local gate and status
-attempt without waiting on unresolved CI or mergeability. Fresh green
-current-head `ci-required` and positive mergeability remain mandatory at
-six-round boundaries and final merge.
+For status cadence, a **normal-cadence attempt** is a first attempt, ordinary
+subsequent attempt, or failed-gate restart for a non-Markdown PR. At rounds not
+divisible by three, one status attempt is enough: pending, missing, rate-limited,
+or transient status may remain pending and reviewer dispatch continues. This is
+the normal cadence, not a user-authorized parallel review exception. Every third
+normal-cadence attempt instead applies the bounded wait before dispatch.
+Conflict-recovery and Markdown-only attempts dispatch and may close after their
+required local gate and status attempt without waiting on unresolved CI or
+mergeability. Fresh green current-head `ci-required` and positive mergeability
+remain mandatory at six-round boundaries and final merge.
 
 ### Review-clean, and recovery
 
@@ -166,18 +167,21 @@ values.
 *This section defines repository policy, not GitHub timing guarantees.*
 
 Absent a standing adjustment in `AGENTS.md`, every round attempts one
-current-head snapshot. For ordinary non-Markdown attempts at rounds not
-divisible by three, pending, missing, rate-limited, or transient status does not
-block reviewer dispatch or round closure: record it and continue. Every third
-ordinary non-Markdown attempt, and any merge or readiness goal, instead enters a
-status budget of up to 60 minutes; expiry publishes the status report and stops
-without dispatch or goal completion. Conflict-recovery and Markdown-only
-attempts never enter that wait; after one snapshot, unresolved status does not
-block their reviewer dispatch. Every sixth round uses the budget, but fresh
-green current-head `ci-required` and positive mergeability remain prerequisites
-for the next-block approval prompt. A known conflict, required CI completed
-without success, or terminal query failure still takes its transition. Measure
-the budget from the first scheduled wait and publish `status-deadline=<UTC>`.
+current-head snapshot. For a normal-cadence attempt at a round not divisible by
+three, pending, missing, rate-limited, or transient status does not block
+reviewer dispatch or round closure: record it and continue. Every third
+normal-cadence attempt instead enters a status budget of up to 60 minutes;
+expiry publishes the status report and stops without dispatch. Conflict-recovery
+and Markdown-only attempts never enter that reviewer-dispatch wait; after one
+snapshot, unresolved status blocks neither dispatch nor closure.
+
+Any merge or readiness goal uses the same status budget and stops without goal
+completion if it expires. After every sixth completed round, the separate
+next-block approval goal uses that budget and requires fresh green current-head
+`ci-required` and positive mergeability before the prompt. A known conflict,
+required CI completed without success, or terminal query failure still takes
+its transition. Measure the budget from the first scheduled wait and publish
+`status-deadline=<UTC>`.
 
 Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -50,7 +50,7 @@ or the work appears to need multiple normative owners.
 | Attempt | Required before reviewer dispatch | May remain pending |
 | --- | --- | --- |
 | First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, one status attempt, and no observed conflict | CI and mergeability |
-| Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
+| Ordinary subsequent round | First-attempt requirements | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Conflict-recovery attempt | Resolution head pushed, one status attempt, round number authorized, and no observed conflict | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
@@ -59,12 +59,14 @@ For status cadence, a **normal-cadence attempt** is a first attempt, ordinary
 subsequent attempt, or failed-gate restart for a non-Markdown PR. At rounds not
 divisible by three, one status attempt is enough: pending, missing, rate-limited,
 or transient status may remain pending and reviewer dispatch continues. This is
-the normal cadence, not a user-authorized parallel review exception. Every third
-normal-cadence attempt instead applies the bounded wait before dispatch.
-Conflict-recovery and Markdown-only attempts dispatch and may close after their
-required local gate and status attempt without waiting on unresolved CI or
-mergeability. Fresh green current-head `ci-required` and positive mergeability
-remain mandatory at six-round boundaries and final merge.
+the normal cadence, not a user-authorized parallel review exception. A
+normal-cadence attempt in a round divisible by three instead applies the bounded
+wait before dispatch. Conflict recovery may dispatch after its status attempt
+while post-push local gates remain pending, but closes only after they pass.
+Markdown-only attempts dispatch and may close after `markdownlint` and their
+status attempt without waiting on unresolved CI or mergeability. Fresh green
+current-head `ci-required` and positive mergeability remain mandatory at
+six-round boundaries and final merge.
 
 ### Review-clean, and recovery
 
@@ -169,11 +171,12 @@ values.
 Absent a standing adjustment in `AGENTS.md`, every round attempts one
 current-head snapshot. For a normal-cadence attempt at a round not divisible by
 three, pending, missing, rate-limited, or transient status does not block
-reviewer dispatch or round closure: record it and continue. Every third
-normal-cadence attempt instead enters a status budget of up to 60 minutes;
-expiry publishes the status report and stops without dispatch. Conflict-recovery
-and Markdown-only attempts never enter that reviewer-dispatch wait; after one
-snapshot, unresolved status blocks neither dispatch nor closure.
+reviewer dispatch or round closure: record it and continue. A normal-cadence
+attempt in a round divisible by three instead enters a status budget of up to 60
+minutes; expiry publishes the status report and stops without dispatch.
+Conflict-recovery and Markdown-only attempts never enter that reviewer-dispatch
+wait; after one snapshot, unresolved status blocks neither dispatch nor
+closure.
 
 Any merge or readiness goal uses the same status budget and stops without goal
 completion if it expires. After every sixth completed round, the separate

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -51,7 +51,7 @@ or the work appears to need multiple normative owners.
 | --- | --- | --- |
 | First attempt at round 1 | Pushed settled head, recorded effective base, focused gate, one status attempt, and no observed conflict | CI and mergeability |
 | Ordinary subsequent round | First-attempt requirements, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
-| Conflict-recovery attempt | Resolution head pushed, round number authorized | Post-push local gates, CI, mergeability |
+| Conflict-recovery attempt | Resolution head pushed, one status attempt, round number authorized, and no observed conflict | Post-push local gates, CI, mergeability |
 | Failed-gate restart | Required fix pushed, one status attempt, and no observed conflict | CI and mergeability subject to [Bounded status waiting](#bounded-status-waiting) |
 | Six-round boundary approval | Fresh green current-head `ci-required` and definite positive mergeability | Nothing |
 
@@ -164,16 +164,17 @@ values.
 
 *This section defines repository policy, not GitHub timing guarantees.*
 
-Every round attempts one current-head snapshot. At rounds not divisible by
-three, pending, missing, rate-limited, or transient status does not block
-reviewer dispatch: record it and continue the current review path. Every third
-round, and any merge or readiness goal, instead enters a status budget of up to
-60 minutes; expiry publishes the status report and stops without dispatch or
-goal completion. Every sixth round uses that budget, but fresh green
-current-head `ci-required` and positive mergeability remain prerequisites for
-the next-block approval prompt. A known conflict, required CI completed without
-success, or terminal query failure still takes its transition. Measure the
-budget from the first scheduled wait and publish `status-deadline=<UTC>`.
+Absent a standing adjustment in `AGENTS.md`, every round attempts one
+current-head snapshot. At rounds not divisible by three, pending, missing,
+rate-limited, or transient status does not block reviewer dispatch or round
+closure: record it and continue. Every third round, and any merge or readiness
+goal, instead enters a status budget of up to 60 minutes; expiry publishes the
+status report and stops without dispatch or goal completion. Every sixth round
+uses that budget, but fresh green current-head `ci-required` and positive
+mergeability remain prerequisites for the next-block approval prompt. A known
+conflict, required CI completed without success, or terminal query failure
+still takes its transition. Measure the budget from the first scheduled wait
+and publish `status-deadline=<UTC>`.
 
 Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -96,14 +96,15 @@ Recovery transitions, applied without waiting for CI:
   unchanged head; repeat only with concrete transient evidence, otherwise treat
   it as an author change.
 
-A final-gate `ci-required` failure observed during or after a non-boundary
-Markdown-only round does not interrupt or reopen that round. Finish its review
-path; afterward, retry the unchanged head only with concrete transient evidence,
-otherwise remove `review-clean` and form a candidate at the next round number.
-Never close a round or goal while one of its applicable required checks is red. A
-superseded attempt spends no round and gets no completion report; let its
-reviewers finish or acknowledge cancellation, and carry every returned finding
-forward.
+A final-gate `ci-required` failure observed during or after a Markdown-only round
+does not interrupt or reopen that round. Finish its review path; afterward,
+retry the unchanged head only with concrete transient evidence, otherwise
+remove `review-clean` and form a candidate at the next round number. After every
+sixth completed round, the failure instead prevents the separate next-block
+approval goal from completing. Never close a round or goal while one of its
+applicable required checks is red. A superseded attempt spends no round and
+gets no completion report; let its reviewers finish or acknowledge
+cancellation, and carry every returned finding forward.
 
 ### Merge preflight
 
@@ -222,7 +223,8 @@ Status not observed for PR <number> at round <n> after <mm> minutes.
 - This is not a CI result. No failing check was observed. GitHub documents
   hosted-job execution limits up to 6 hours and self-hosted queue limits up to
   24 hours, so this repository's 60-minute budget can expire first.
-- Effect: <reviewer dispatch withheld for round n | boundary approval withheld>.
+- Effect: <reviewer dispatch withheld for round n | boundary approval withheld
+  | merge withheld | readiness not established>.
 - Next: <what a later user or workflow turn should re-check>.
 Recommendation: stop (status budget exhausted); nothing is closed or abandoned.
 ```


### PR DESCRIPTION
## Summary

Restore the status-acquisition asymmetry introduced by #4822 and later
overridden by #5105:

- ordinary rounds attempt one accurate current-head snapshot, then dispatch
  review when CI or mergeability remains pending or unavailable;
- every third round may spend up to 60 minutes on scheduled acquisition; and
- every sixth-round approval boundary and every merge goal still require fresh
  green `ci-required` and positive mergeability.

Known-red CI, conflicts, terminal query failures, fixed-head evidence, and final
merge readiness retain their existing transitions.

## Design basis

Normative owner:
[`docs/round-orchestration.md`](docs/round-orchestration.md) `Candidate
lifecycle` and `Bounded status waiting`, which own reviewer-dispatch eligibility
and status cadence.

`AGENTS.md` carries the binding cross-cutting summary. GitHub request mechanics
remain owned by `docs/github-status-queries.md` and are unchanged.

## Demo

The decision table now produces these outcomes:

| Situation | Before | After |
| --- | --- | --- |
| Round 1, status pending | Chain scheduled waits before review | Record the snapshot and dispatch review |
| Round 3, status pending | Chain scheduled waits before review | Keep the bounded wait, capped at 60 minutes |
| Round 6 boundary | Require green CI and mergeability | Unchanged |
| Merge/readiness goal | Require green CI and mergeability | Unchanged |

This preserves the useful bounded acquisition behavior while removing ordinary
round-1 scheduling churn.

## Evidence

The post-#4822 assessment found 65 scheduling operations across five sessions:
30 creates, 27 stops, six lists, and two wakeups. Ordinary round-1 work on
#5138 and #5166 repeatedly chained status schedules after #5105 restored green
CI as a reviewer-dispatch prerequisite.

The bounded model behaved as intended for round-3 work on #4753 and #5030 and
for the authorized merge goal on #5177. This change therefore corrects only the
ordinary-round prerequisite rather than removing bounded status acquisition.

## Validation

```text
$ wc -l AGENTS.md
600 AGENTS.md

$ npx markdownlint-cli AGENTS.md docs/round-orchestration.md
(no output)
```
