### PR TITLE
Fix package projection destination edge cases

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -514,7 +514,10 @@ documents: skills are agent instructions, so every route, including
 through stdout, structured output, and `--out`. The raw scoped skill is
 classified before link normalization; concerning text becomes the standard
 placeholder, safe text retains its full presented spelling, and exact package
-bytes are not retained. A Markdown scope exports projected text.
+bytes are not retained. Skill destinations therefore accept rendered line
+windows; `PackageSkillDestinations_ApplyLineWindowsToSelectedText` gates safe
+text and the containment placeholder across stdout and file output. A Markdown
+scope exports projected text.
 Terminal-facing output never emits a live control or bidi scalar from package
 content. Multi-item
 `--print --out` and multi-file or multi-package `--content --out` are refused

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -29242,9 +29242,11 @@ public partial class CommandExecutionTests
             foreach (var testCase in cases)
             {
                 var outputPath = Path.Combine(tempDir, $"{testCase.Name}.txt");
-                var stdout = await RunAppAsync(
+                var stdout = await RunAppInDirectoryAsync(
+                    tempDir,
                     ["package", packagePath, .. testCase.Arguments, "--tips", "q"]);
-                var redirected = await RunAppAsync(
+                var redirected = await RunAppInDirectoryAsync(
+                    tempDir,
                     [
                         "package", packagePath, .. testCase.Arguments,
                         "--out", outputPath, "--tips", "q",

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -29200,6 +29200,127 @@ public partial class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PackageSkillDestinations_ApplyLineWindowsToSelectedText()
+    {
+        const string bidi = "\u202E";
+        const string safe = "safe-first\nsafe-second";
+        string placeholder = InertString.ContainmentRequiredPlaceholder.ToString();
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Projection.SkillWindows",
+            "README.md",
+            "readme",
+            null,
+            null,
+            ("skills/safe/SKILL.md", safe),
+            ("skills/contained/SKILL.md", $"contained{bidi}skill"));
+        try
+        {
+            (string Name, string[] Arguments, string Stdout, string File)[] cases =
+            [
+                (
+                    "print-safe",
+                    ["-S", "Package skill files", "--print", "--row", "2", "--bare", "-n1"],
+                    "safe-first\n",
+                    "safe-first\n"),
+                (
+                    "content-safe",
+                    ["--content", "--path", "skills/safe/SKILL.md", "--bare", "-n1"],
+                    "safe-first\n",
+                    "safe-first\n"),
+                (
+                    "print-contained",
+                    ["-S", "Package skill files", "--print", "--row", "1", "--bare", "-n1"],
+                    placeholder,
+                    placeholder),
+                (
+                    "content-contained",
+                    ["--content", "--path", "skills/contained/SKILL.md", "--bare", "-n1"],
+                    placeholder + "\n",
+                    placeholder),
+            ];
+
+            foreach (var testCase in cases)
+            {
+                var outputPath = Path.Combine(tempDir, $"{testCase.Name}.txt");
+                var stdout = await RunAppAsync(
+                    ["package", packagePath, .. testCase.Arguments, "--tips", "q"]);
+                var redirected = await RunAppAsync(
+                    [
+                        "package", packagePath, .. testCase.Arguments,
+                        "--out", outputPath, "--tips", "q",
+                    ]);
+
+                Assert.Equal(0, stdout.Exit);
+                Assert.Equal(0, redirected.Exit);
+                Assert.Empty(stdout.Error);
+                Assert.Empty(redirected.Error);
+                Assert.Empty(redirected.Output);
+                Assert.Equal(testCase.Stdout, stdout.Output);
+                Assert.Equal(testCase.File, File.ReadAllText(outputPath));
+                Assert.DoesNotContain(bidi, stdout.Output, StringComparison.Ordinal);
+                Assert.DoesNotContain(bidi, File.ReadAllText(outputPath), StringComparison.Ordinal);
+            }
+
+            var wildcardPath = Path.Combine(tempDir, "wildcard.md");
+            var wildcard = await RunAppAsync(
+                "package", packagePath,
+                "--content", "--path", "skills/safe/*.md", "--bare", "-n1",
+                "--out", wildcardPath, "--tips", "q");
+
+            Assert.Equal(1, wildcard.Exit);
+            Assert.Empty(wildcard.Output);
+            Assert.Contains(
+                "a rendered line limit cannot be combined with exact --out transfer",
+                wildcard.Error,
+                StringComparison.Ordinal);
+            Assert.False(File.Exists(wildcardPath));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task PackageOutputPath_RejectsExplicitEmptyValuesWithoutStdoutFallback()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.Projection.EmptyOutputPath",
+            "README.md",
+            "must-not-reach-stdout");
+        try
+        {
+            foreach (string option in new[] { "--out", "--output", "-o" })
+            {
+                foreach (string[] prefix in new[]
+                {
+                    new[] { "package", packagePath },
+                    new[] { packagePath },
+                })
+                {
+                    var result = await RunAppAsync(
+                        [
+                            .. prefix,
+                            "-S", "Package README file", "--print", "--bare",
+                            option, "",
+                        ]);
+
+                    Assert.Equal(1, result.Exit);
+                    Assert.Empty(result.Output);
+                    Assert.Contains(
+                        "--out requires a non-empty path.",
+                        result.Error,
+                        StringComparison.Ordinal);
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task PackageExactTransferLineWindows_PreserveAbsentAndExistingDestinations()
     {
         var (packagePath, tempDir) = CreateLocalReadmePackage(

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -52,22 +52,6 @@ public class CommandLineTests
         Assert.Equal("--out requires a non-empty path.", error.Message);
     }
 
-    [Theory]
-    [InlineData("--out")]
-    [InlineData("--output")]
-    [InlineData("-o")]
-    public void RoutedPackageOutputPath_RejectsExplicitEmptyValues(string option)
-    {
-        var root = CommandLineBuilder.CreateRootCommand();
-        string[] processed = CommandLineBuilder.PreprocessArgs(
-            ["Newtonsoft.Json", option, ""],
-            root);
-        var result = root.Parse(processed);
-
-        var error = Assert.Single(result.Errors);
-        Assert.Equal("--out requires a non-empty path.", error.Message);
-    }
-
     [Fact]
     public void RootCommand_WithVerbosityQuiet_ParsesCorrectly()
     {

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -33,6 +33,41 @@ public class CommandLineTests
         Assert.Empty(result.Errors);
     }
 
+    [Theory]
+    [InlineData("package", "Newtonsoft.Json", "--out")]
+    [InlineData("package", "Newtonsoft.Json", "--output")]
+    [InlineData("package", "Newtonsoft.Json", "-o")]
+    [InlineData("project", ".", "--out")]
+    [InlineData("project", ".", "--output")]
+    [InlineData("project", ".", "-o")]
+    public void ProjectionOutputPath_RejectsExplicitEmptyValues(
+        string command,
+        string target,
+        string option)
+    {
+        var result = CommandLineBuilder.CreateRootCommand()
+            .Parse([command, target, option, ""]);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("--out requires a non-empty path.", error.Message);
+    }
+
+    [Theory]
+    [InlineData("--out")]
+    [InlineData("--output")]
+    [InlineData("-o")]
+    public void RoutedPackageOutputPath_RejectsExplicitEmptyValues(string option)
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        string[] processed = CommandLineBuilder.PreprocessArgs(
+            ["Newtonsoft.Json", option, ""],
+            root);
+        var result = root.Parse(processed);
+
+        var error = Assert.Single(result.Errors);
+        Assert.Equal("--out requires a non-empty path.", error.Message);
+    }
+
     [Fact]
     public void RootCommand_WithVerbosityQuiet_ParsesCorrectly()
     {

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -59,9 +59,7 @@ public static class PackageCommandDefinitions
         var frontmatterOption = new Option<bool>("--frontmatter") { Description = "When printing markdown content, output only the leading YAML frontmatter block" };
         frontmatterOption.Aliases.Add("--yaml-header");
         var bodyOption = new Option<bool>("--body") { Description = "When printing markdown content, output only content after YAML frontmatter" };
-        var outOption = new Option<string?>("--out") { Description = "Write output to file instead of stdout" };
-        outOption.Aliases.Add("--output");
-        outOption.Aliases.Add("-o");
+        var outOption = SharedOptions.CreateOutputPathOption();
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library by TFM (e.g., net8.0)" };
         var typeFilterOption = new Option<string?>("-t") { Description = "Filter SourceLink: Files rows by type glob/name (e.g., *Json*)" };
         typeFilterOption.Aliases.Add("--type");

--- a/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
@@ -37,12 +37,7 @@ public static class ProjectCommandDefinitions
         {
             Description = "With --readme, print only content after YAML frontmatter"
         };
-        var outOption = new Option<string?>("--out")
-        {
-            Description = "Write output to file instead of stdout"
-        };
-        outOption.Aliases.Add("--output");
-        outOption.Aliases.Add("-o");
+        var outOption = SharedOptions.CreateOutputPathOption();
 
         projectCommand.Arguments.Add(pathArg);
         projectCommand.Options.Add(agentsIndexOption);

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -3362,13 +3362,34 @@ public class PackageCommand
             && !options.Jsonl
             && !options.JsonArray;
 
+    private static bool IsGuaranteedSkillPayload(InspectionOptions options)
+    {
+        if (options.Print
+            && options.IncludeSections is { Count: 1 } sections
+            && sections.Single().Equals(
+                PackageSections.FilesSkills,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        string[] selectors = PathSelectors(options);
+        return options.ShowContent
+            && selectors.Length > 0
+            && selectors.All(static selector =>
+                !selector.Contains('*')
+                && !selector.Contains('?')
+                && PackageFileFamily.IsSkillDocumentPath(selector));
+    }
+
     private static ProjectionDestination PackagePayloadDestination(InspectionOptions options)
         => new(
             options.OutputPath,
             options.Rows,
             ExactTransfer: (options.Print || RequiresUnaryPackageContent(options))
                 && HasUnstructuredOutputPath(options)
-                && options.ContentScope == PackageFileContentScope.Full);
+                && options.ContentScope == PackageFileContentScope.Full
+                && !IsGuaranteedSkillPayload(options));
 
     /// <summary>
     /// Restores the readme role to the document the manifest declares when

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -185,6 +185,22 @@ public class SharedOptions
         AddSource.Validators.Add(ValidateSourceUrls);
     }
 
+    public static Option<string?> CreateOutputPathOption()
+    {
+        var option = new Option<string?>("--out")
+        {
+            Description = "Write output to file instead of stdout"
+        };
+        option.Aliases.Add("--output");
+        option.Aliases.Add("-o");
+        option.Validators.Add(result =>
+        {
+            if (result.Tokens is [{ Value.Length: 0 }])
+                result.AddError("--out requires a non-empty path.");
+        });
+        return option;
+    }
+
     /// <summary>
     /// Rejects an explicit comma/semicolon-separated projection list that contains no names or
     /// names the same entry more than once. Matching is case-insensitive because column matching is.

--- a/src/dotnet-inspect/Views/PackageFileFamily.cs
+++ b/src/dotnet-inspect/Views/PackageFileFamily.cs
@@ -49,9 +49,6 @@ public static class PackageFileFamily
 
     public static bool IsFamilySection(string? section) => PredicateFor(section) is not null;
 
-    static bool HasRoot(PackageFile file, string root)
-        => file.Path.StartsWith(root, StringComparison.OrdinalIgnoreCase);
-
     static bool HasExtension(PackageFile file, string extension)
         => file.Path.EndsWith(extension, StringComparison.OrdinalIgnoreCase);
 
@@ -60,7 +57,13 @@ public static class PackageFileFamily
     /// command's skill discovery uses.
     /// </summary>
     public static bool IsSkillDocument(PackageFile file)
-        => HasRoot(file, "skills/")
-           && (file.Path.EndsWith("/SKILL.md", StringComparison.OrdinalIgnoreCase)
-               || file.Path.Equals("skills/SKILL.md", StringComparison.OrdinalIgnoreCase));
+        => IsSkillDocumentPath(file.Path);
+
+    public static bool IsSkillDocumentPath(string path)
+    {
+        path = path.Replace('\\', '/');
+        return path.StartsWith("skills/", StringComparison.OrdinalIgnoreCase)
+               && (path.EndsWith("/SKILL.md", StringComparison.OrdinalIgnoreCase)
+                   || path.Equals("skills/SKILL.md", StringComparison.OrdinalIgnoreCase));
+    }
 }


### PR DESCRIPTION
## Summary

- Treat package skill selections known before acquisition as rendered,
  containment-selected text, so `-n`/`--tail` can write their line windows to
  `--out`.
- Reject explicit empty `--out`, `--output`, and `-o` values at parse time for
  package and project commands, including routed package execution.
- Keep ordinary and ambiguous package payloads on the exact-transfer path:
  line windows still fail before acquisition or destination mutation.

This is the focused follow-up to the two post-merge review findings from #4927.

## Demo

Before this fix, selecting one safe package skill with a file line window
failed as an exact transfer:

```text
Error: a rendered line limit cannot be combined with exact --out transfer because it would change the payload bytes.
```

The same invocation now writes the selected rendered line:

```powershell
dotnet run --project src\dotnet-inspect -c Release -- `
  package Probe.Skill.1.0.0.nupkg `
  -S "Package skill files" --print --row 2 --bare `
  -n1 --out selected.md --tips q

Get-Content -Raw selected.md
```

```text
safe-first
```

An explicit empty destination now fails without leaking the payload to stdout:

```text
Error: --out requires a non-empty path.
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src\dotnet-inspect.Tests -c Release -- -class "DotnetInspector.Tests.CommandLineTests"` — 267 passed
- Focused package skill-window, empty-output-path, and exact-transfer
  destination gates — 3 passed
- `dotnet run --project src\dotnet-inspect.Tests -c Release --no-build` —
  5,252 total, 0 failed, 25 expected environment/platform skips
- `npx markdownlint-cli docs\design\output-shapes.md`

Candidate head: `ba51f73dc3a3722cc4d453e57609a1ac2bb8b284`
against base `039af793d04c9a7b9d2a9b979d6d198e94f38e76`.
