### PR TITLE
Extract ref enum bitwise fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -5416,12 +5416,6 @@ public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }
 public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
 public enum CfgTiny : byte { A = 1, B = 2 }
 
-// A flags enum with a named member at a non-low bit (Gamma = 16): a `ref CfgStyles`
-// bitwise test reads the enum via `ldind.i4`, so the importer must register the
-// pointee's shape and member names for the int constant to name `Gamma`.
-[System.Flags]
-public enum CfgStyles { None = 0, Alpha = 1, Beta = 2, Gamma = 16 }
-
 public sealed class CfgNullableTarget
 {
     public int Value;

--- a/src/ILInspector.Decompiler.Tests/RefEnumBitwiseSamples.cs
+++ b/src/ILInspector.Decompiler.Tests/RefEnumBitwiseSamples.cs
@@ -1,0 +1,7 @@
+namespace ILInspector.Decompiler.Tests;
+
+// A flags enum with a named member at a non-low bit (Gamma = 16): a `ref CfgStyles`
+// bitwise test reads the enum via `ldind.i4`, so the importer must register the
+// pointee's shape and member names for the int constant to name `Gamma`.
+[System.Flags]
+public enum CfgStyles { None = 0, Alpha = 1, Beta = 2, Gamma = 16 }


### PR DESCRIPTION
Moves `CfgStyles` beside its owning ref-enum bitwise test in the feature-focused `RefEnumBitwiseSamples.cs` file while preserving the compiler input and metadata identity.

Part of #3913.

## Demo

`RefEnumBitwise_NamesEnumMember` continues to render the compiler-produced `ldind.i4` enum operand as `styles & CfgStyles.Gamma`, rather than the invalid enum/integer expression `styles & 16`.

## Validation

Exact head: `7dbcb3d093c8d65553b3a5f22de0a074bce62513`
Exact integrated base: `8489700b09bfabc3d0453634edb5f09fd2d2767e`

- `RefEnumBitwiseTests`: 1 passed in Release
- Release solution build: succeeded with 0 warnings and 0 errors
- Decompiler fast gate: 5,734 passed, 0 failed, 8 expected Windows skips
- Stable-path render A/B: 22,322 methods, 0 changed, 0 added, 0 removed

Current-head `ci-required` passed. Fixed-head GPT-5.6 Sol and Claude Opus 5 adversarial reviews returned clean.

## Non-action boundary

No symbols, enum members or values, attributes, method bodies, tests, or product behavior changed. PDB document provenance and metadata row order may change as expected for a source-file move.
