### PR TITLE
Bind memory-safety rules to primary metadata resolver

### DIFF
--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -322,8 +322,8 @@ gates partial-result accumulation.
 memory-safety opt-in and unsafe/generated attribute judgments,
 token/member/type/field/calli/value-type and delegate facts,
 async-state-machine caching, and the narrow resolver adapters. The assembly
-builder's per-method infrastructure and the result accumulator consume the same
-memory-safety judgment.
+builder consumes its method identities, while the result accumulator publishes
+the same memory-safety judgment.
 `CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn` and
 `CallerUnsafeMode_RequiresUnsafeIsExplicitWhenModuleOptedIn` gate the legacy
 and updated-rule states. `LibraryBodyStableReceiverGetterClassifier` owns the

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -319,10 +319,16 @@ exception-type assembly projections, and constructs the immutable
 output, while `BuildCallTree_PreservesRecoverableBodyAnalysisFailure` also
 gates partial-result accumulation.
 `LibraryBodyPrimaryMetadataResolver` owns primary-image method identity,
-unsafe/generated attribute judgments, token/member/type/field/calli/value-type
-and delegate facts, async-state-machine caching, and the narrow resolver
-adapters. `LibraryBodyStableReceiverGetterClassifier` owns the narrow
-PE-backed readonly-field getter judgment and its acquisition-scoped cache;
+memory-safety opt-in and unsafe/generated attribute judgments,
+token/member/type/field/calli/value-type and delegate facts,
+async-state-machine caching, and the narrow resolver adapters. The assembly
+builder's per-method infrastructure and the result accumulator consume the same
+memory-safety judgment.
+`CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn` and
+`CallerUnsafeMode_RequiresUnsafeIsExplicitWhenModuleOptedIn` gate the legacy
+and updated-rule states. `LibraryBodyStableReceiverGetterClassifier` owns the
+narrow PE-backed readonly-field getter judgment and its acquisition-scoped
+cache;
 `OptimizationOpportunities_StableReceiverGetter_IsClassifiedOnce` gates that
 the optimization adapter shares one classification. The classifier does not
 own optimization policy or general method-body scheduling.

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -45,6 +45,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.TopLevelAsyncFixtures\ILInspector.Analysis.TopLevelAsyncFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.TopLevelClassicAsyncFixtures\ILInspector.Analysis.TopLevelClassicAsyncFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.UnoptimizedAsyncFixtures\ILInspector.Analysis.UnoptimizedAsyncFixtures.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -11946,6 +11946,19 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void CallerUnsafeMode_RequiresUnsafeIsExplicitWhenModuleOptedIn()
+    {
+        var index = LibraryBodyIndex.Open(
+            FixtureCatalog.DecompilerUnsafeNew.AssemblyPath());
+
+        Assert.True(index.MemorySafetyRulesEnabled);
+        Assert.NotEqual(0, index.UnsafeModes.Explicit);
+        Assert.DoesNotContain(
+            index.Methods,
+            method => method.CallerUnsafeMode == CallerUnsafeMode.Implicit);
+    }
+
+    [Fact]
     public void CallerUnsafeMode_CallingUnsafeApiIsNotRequiresUnsafe()
     {
         // The authoritative model is RequiresUnsafeAttribute || pointer signature.

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -52,7 +52,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
         TypeDefinitionHandle>? _localTypeDefinitions;
     readonly string _assemblyName;
     readonly Guid _mvid;
-    readonly bool _memorySafetyRulesEnabled;
     readonly Action? _parallelBuildStarting;
 
     internal LibraryBodyAnalysisBuilder(
@@ -87,7 +86,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
                 null,
                 null,
                 null);
-        _memorySafetyRulesEnabled = DetectMemorySafetyRules();
         _parallelBuildStarting = parallelBuildStarting;
         _methodReferenceResolver =
             new LibraryBodyMethodReferenceResolver(
@@ -431,19 +429,8 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
         }
     }
 
-    // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
-    // when MemorySafetyRulesAttribute is applied (emitted [module:], like
-    // RefSafetyRulesAttribute). Check the module and assembly scopes.
-    public bool MemorySafetyRulesEnabled => _memorySafetyRulesEnabled;
-
-    bool DetectMemorySafetyRules()
-    {
-        const string ns = "System.Runtime.CompilerServices";
-        if (HasAttributeNamed(_reader.GetModuleDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns))
-            return true;
-        return _reader.IsAssembly
-            && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
-    }
+    public bool MemorySafetyRulesEnabled =>
+        _primaryMetadataResolver.MemorySafetyRulesEnabled;
 
     internal bool ScopeMayRequireStateMachineBody(
         IReadOnlySet<int> bodyScope) =>
@@ -589,33 +576,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
     // Assemblies with at least this many methods use the parallel per-method analysis path.
     // Below it (and for all scoped member/type builds) the sequential path avoids thread overhead.
     const int ParallelBuildMethodThreshold = 200;
-
-    bool HasAttributeNamed(CustomAttributeHandleCollection attributes, string simpleName, params string[] namespaces)
-    {
-        foreach (var handle in attributes)
-        {
-            var (ns, name) = AttributeTypeName(_reader.GetCustomAttribute(handle).Constructor);
-            if (name == simpleName && (namespaces.Length == 0 || Array.IndexOf(namespaces, ns) >= 0))
-                return true;
-        }
-        return false;
-    }
-
-    (string Namespace, string Name) AttributeTypeName(EntityHandle constructor)
-    {
-        if (constructor.Kind == HandleKind.MemberReference
-            && _reader.GetMemberReference((MemberReferenceHandle)constructor).Parent is { Kind: HandleKind.TypeReference } parent)
-        {
-            var typeRef = _reader.GetTypeReference((TypeReferenceHandle)parent);
-            return (_reader.GetString(typeRef.Namespace), _reader.GetString(typeRef.Name));
-        }
-        if (constructor.Kind == HandleKind.MethodDefinition)
-        {
-            var declType = _reader.GetTypeDefinition(_reader.GetMethodDefinition((MethodDefinitionHandle)constructor).GetDeclaringType());
-            return (_reader.GetString(declType.Namespace), _reader.GetString(declType.Name));
-        }
-        return ("", "");
-    }
 
     TypeRef TypeFromEntity(EntityHandle handle)
     {

--- a/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
+++ b/src/ILInspector.Analysis/LibraryBodyAnalysisBuilder.cs
@@ -429,9 +429,6 @@ internal sealed partial class LibraryBodyAnalysisBuilder :
         }
     }
 
-    public bool MemorySafetyRulesEnabled =>
-        _primaryMetadataResolver.MemorySafetyRulesEnabled;
-
     internal bool ScopeMayRequireStateMachineBody(
         IReadOnlySet<int> bodyScope) =>
         _asyncSourceResolver.ScopeMayRequireStateMachineBody(


### PR DESCRIPTION
## Summary

- remove `LibraryBodyAnalysisBuilder`'s duplicate memory-safety field,
  attribute scan, dead property, and attribute-name decoder
- retain `LibraryBodyPrimaryMetadataResolver` as the single owner used for
  resolver-created method identities and accumulated output
- add a positive updated-rules gate alongside the existing legacy-rules gate
- add the consumed updated-rules fixture to the Analysis test build graph
- reduce `LibraryBodyAnalysisBuilder` from 642 to 595 lines

## Ownership boundary

`docs/design/method-body-inspection.md` owns the boundary:
`LibraryBodyPrimaryMetadataResolver` owns the primary-image memory-safety
opt-in judgment. Its resolver-created method identities carry caller modes,
while `LibraryBodyAnalysisAccumulator` publishes that same judgment.

The builder continues to own the metadata-ordered work list, parallel
scheduling, and acquisition-scoped service lifetime. This change does not move
unsafe-mode policy, method identity, result accumulation, or metadata lifetime.

## Demo

The branch-built Analysis app reports the legacy and updated fixtures through
the affected `LibraryBodyIndex` path.

```text
$ dotnet run --project src/ILInspector.Analysis.App -c Release --no-build -- \
    unsafe artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll 2
Module opted into updated memory-safety rules: False
Methods: 80
  None     (no requires-unsafe):              71
  Implicit (requires-unsafe, module not opted in): 9
  Explicit (requires-unsafe, module opted in):     0

$ dotnet run --project src/ILInspector.Analysis.App -c Release --no-build -- \
    unsafe artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll 2
Module opted into updated memory-safety rules: True
Methods: 80
  None     (no requires-unsafe):              69
  Implicit (requires-unsafe, module not opted in): 0
  Explicit (requires-unsafe, module opted in):     11
```

What to notice: the module opt-in and the per-method mode census remain
coherent for both sides of the boundary while now sharing one metadata
judgment.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
  - 0 warnings, 0 errors
- focused Release gates:
  - `CallerUnsafeMode_PointerSignatureIsImplicitWhenModuleNotOptedIn`
  - `CallerUnsafeMode_RequiresUnsafeIsExplicitWhenModuleOptedIn`
  - 2/2 passed, 0 skipped
  - the project-scoped command rebuilt the removed NewUnsafe fixture output
    through its build-only `ProjectReference`
- `npx markdownlint-cli docs/design/method-body-inspection.md`
- `git diff --check`

## Compatibility

No public API, output shape, diagnostic, ordering, metadata lifetime, network
behavior, NativeAOT dependency, or Browser/Wasm behavior changes. The removed
code was a duplicate SRM attribute scan whose result is already owned and used
by the primary metadata resolver. The added project edge is test-only and does
not reference the fixture output assembly.