### PR TITLE
Explain the mixed caret/comment styles when --focus is active (#5022 item 8)

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
@@ -459,6 +460,57 @@ public class ResearchFactRegistryTests
         Assert.Equal(
             expected,
             ResearchViews.RenderMixedStream(stream, AnnotationGestureSelector.SideOnly));
+    }
+
+    [Fact]
+    public void MixedRendererNeverSignalsACaretForAnIlOnlyAnchoredFact()
+    {
+        // A fact anchored only to an interleaved IL line always renders as a
+        // side comment (see MixedStreamKeepsIlFactsStructuredUntilRendering
+        // above) -- IL never gets caret geometry, no matter what gesture a
+        // focus promotes it to. FocusRenderedCaret has to agree: a --focus
+        // match against this fact must not claim a caret rendered when the
+        // fact never left the IL side-comment. Round-2 review flagged this as
+        // a remaining false-positive path in the whole-member fact check the
+        // round-1 fix used; the caretSignal is now read off the actual render
+        // instead, and this proves it comes back false for exactly this case.
+        var marker = new Annotation(
+            new AnnotationDescriptor("test.portable", AnnotationCategory.Cost, "portable marker"),
+            SourceOffset: 0,
+            Detail: "not-in-text");
+        BoundSourceLine[] stream =
+        [
+            new("return value;", 0, SourceLineKind.CSharp),
+            new("IL_0000: ldarg.0", 0, SourceLineKind.Il, [marker]),
+        ];
+        var gestures = AnnotationGestureSelector.Focus("test");
+        var caretSignal = new StrongBox<bool>(false);
+
+        string rendered = ResearchViews.RenderMixedStream(stream, gestures, caretSignal: caretSignal);
+
+        Assert.DoesNotContain("^^^^", rendered);
+        Assert.False(caretSignal.Value);
+    }
+
+    [Fact]
+    public void MixedRendererSignalsACaretWhenAFocusedFactPromotesOnACSharpLine()
+    {
+        // The positive counterpart to the IL-only case above: a fact that does
+        // anchor to a printed C# line, and is promoted by the focus, must set
+        // the signal so the CLI's legend note (issue #5022 item 8) can tell
+        // the two apart.
+        var marker = new Annotation(
+            new AnnotationDescriptor("test.portable", AnnotationCategory.Cost, "portable marker"),
+            SourceOffset: 0,
+            Detail: "not-in-text");
+        BoundSourceLine[] stream = [new("return value;", 0, SourceLineKind.CSharp, [marker])];
+        var gestures = AnnotationGestureSelector.Focus("test");
+        var caretSignal = new StrongBox<bool>(false);
+
+        string rendered = ResearchViews.RenderMixedStream(stream, gestures, caretSignal: caretSignal);
+
+        Assert.Contains("^^^^", rendered);
+        Assert.True(caretSignal.Value);
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -188,6 +189,9 @@ public static partial class ResearchViews
             }
 
             DecompilerResult? annotatedSource = null;
+            var annotatedSourceCaretSignal = new StrongBox<bool>(false);
+            var costCaretSignal = new StrongBox<bool>(false);
+            var semanticsCaretSignal = new StrongBox<bool>(false);
             if (request.AnnotatedSource)
             {
                 // Printing raises and rewrites the IR in place, so the annotated
@@ -211,7 +215,8 @@ public static partial class ResearchViews
                         request.PublicOnly,
                         request.MethodToken,
                         request.PrinterOptions,
-                        gestures),
+                        gestures,
+                        annotatedSourceCaretSignal),
                         emptyOutputIsFailure: false),
                     request.Source);
             }
@@ -239,7 +244,8 @@ public static partial class ResearchViews
                             costAnnotations,
                             request.Source,
                             OverlayPrinterOptions(request.PrinterOptions),
-                            gestures), emptyOutputIsFailure: false),
+                            gestures,
+                            costCaretSignal), emptyOutputIsFailure: false),
                         request.Source);
                     costOverlay = new CostOverlayResult(body, costHeaderFacts);
                 }
@@ -257,7 +263,8 @@ public static partial class ResearchViews
                         semanticsAnnotations,
                         request.Source,
                         OverlayPrinterOptions(request.PrinterOptions),
-                        gestures), emptyOutputIsFailure: false),
+                        gestures,
+                        semanticsCaretSignal), emptyOutputIsFailure: false),
                     request.Source);
             }
 
@@ -265,18 +272,19 @@ public static partial class ResearchViews
             if (request.FactRows)
                 factRows = BuildFactRows(request.Type, request.Method, imported, facts, headerFacts, request.Source);
 
-            // Each caret-capable section renders its own filtered fact subset
-            // (Cost/Semantics Overlay narrow to their own category before
-            // gestures are ever applied), so whether a caret actually rendered
-            // has to be checked per requested section against its own subset,
-            // not against the whole-member fact collection UnmatchedFocusAlternatives
-            // already checks.
+            // Whether a caret actually rendered has to be read off the render
+            // itself, not inferred from the pre-render fact collection: a fact
+            // may match focus yet never reach a caret because its section
+            // filtered it out (Cost/Semantics Overlay's own category narrowing),
+            // its owning statement never correlated onto a printed C# line, or
+            // it is anchored only to an interleaved IL line (Annotated Source
+            // always renders IL as a side comment, never a caret). Each render
+            // call above sets its own signal only when it actually emitted a
+            // caret underline for a promoted fact.
             bool focusRenderedCaret =
-                (request.AnnotatedSource && AnyCaretGesture(gestures, facts))
-                || (request.CostOverlay
-                    && AnyCaretGesture(gestures, facts.Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)))
-                || (request.SemanticsOverlay
-                    && AnyCaretGesture(gestures, facts.Where(fact => fact.Descriptor.Category == AnnotationCategory.Semantics)));
+                (request.AnnotatedSource && annotatedSourceCaretSignal.Value)
+                || (request.CostOverlay && costCaretSignal.Value)
+                || (request.SemanticsOverlay && semanticsCaretSignal.Value);
 
             return new MemberProjectionResult(
                 annotatedSource,
@@ -336,22 +344,6 @@ public static partial class ResearchViews
             families.Add(dot > 0 ? descriptor.Id[..dot] : descriptor.Id);
         }
         return [.. families];
-    }
-
-    /// <summary>
-    /// True when at least one of <paramref name="facts"/> is promoted to the
-    /// caret gesture by <paramref name="gestures"/>. Callers pass the exact
-    /// filtered subset a section renders from (e.g. Cost Overlay's own
-    /// category-narrowed facts), not the whole-member collection -- matching
-    /// against the full set would say a caret rendered even when the matching
-    /// fact was excluded from this particular section.
-    /// </summary>
-    static bool AnyCaretGesture(AnnotationGestureSelector gestures, IEnumerable<IAnnotation> facts)
-    {
-        foreach (var fact in facts)
-            if (gestures.For(fact) == AnnotationGesture.Caret)
-                return true;
-        return false;
     }
 
     public static IReadOnlyList<IAnnotation> CollectFacts(
@@ -435,7 +427,8 @@ public static partial class ResearchViews
         bool publicOnly,
         int? methodToken = null,
         PrinterOptions? printerOptions = null,
-        AnnotationGestureSelector? gestures = null)
+        AnnotationGestureSelector? gestures = null,
+        StrongBox<bool>? caretSignal = null)
     {
 
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
@@ -471,7 +464,7 @@ public static partial class ResearchViews
         var stream = CorrelateMixedSource(imported, csText, printedRanges, annotations, annotatedInstrLines);
         var extents = AnnotationAnchor.ComputeCaretExtents(
             annotations, AnnotationAnchor.ComputeSpans(imported), printedRanges);
-        return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly, extents) };
+        return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly, extents, caretSignal) };
     }
 
     static AnnotatedSourceDocument BuildAnnotatedSourceDocument(
@@ -1081,7 +1074,8 @@ public static partial class ResearchViews
     internal static string RenderMixedStream(
         IReadOnlyList<BoundSourceLine> stream,
         AnnotationGestureSelector gestures,
-        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null,
+        StrongBox<bool>? caretSignal = null)
     {
         var sb = new StringBuilder();
         string csIndent = "";
@@ -1094,7 +1088,9 @@ public static partial class ResearchViews
                 // This renderer's established IL gesture is a side comment.
                 // Keeping the facts structured until here lets a portable
                 // consumer choose differently without making this slice invent
-                // caret geometry for already-comment-framed IL.
+                // caret geometry for already-comment-framed IL. A fact anchored
+                // only to an IL line therefore never renders a caret, no matter
+                // what gesture it is promoted to.
                 sb.AppendLf($"{csIndent}    // {RenderSideAnnotations(line.Text, line.Annotations)}");
                 continue;
             }
@@ -1105,6 +1101,8 @@ public static partial class ResearchViews
             if (side.Count > 0)
                 text = $"{text}  // {string.Join("; ", side.Select(a => AnnotationText.Format(a)))}";
             sb.AppendLf(text);
+            if (caret.Count > 0 && caretSignal is not null)
+                caretSignal.Value = true;
             foreach (string caretLine in AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents))
                 sb.AppendLf(caretLine);
         }
@@ -1121,7 +1119,8 @@ public static partial class ResearchViews
         IReadOnlyList<IAnnotation> annotations,
         MetadataSource source,
         PrinterOptions? options,
-        AnnotationGestureSelector? gestures = null)
+        AnnotationGestureSelector? gestures = null,
+        StrongBox<bool>? caretSignal = null)
     {
         var result = CSharpPrinter.PrintRaised(
             imported,
@@ -1133,7 +1132,7 @@ public static partial class ResearchViews
             return result;
         var projected = annotations.Count == 0
             ? output
-            : AddTrailingComments(imported, output, printedRanges, annotations, gestures ?? AnnotationGestureSelector.SideOnly);
+            : AddTrailingComments(imported, output, printedRanges, annotations, gestures ?? AnnotationGestureSelector.SideOnly, caretSignal);
         return result with { Output = projected };
     }
 
@@ -1179,12 +1178,13 @@ public static partial class ResearchViews
         string output,
         PrintedRangeMap printedRanges,
         IReadOnlyList<IAnnotation> annotations,
-        AnnotationGestureSelector gestures)
+        AnnotationGestureSelector gestures,
+        StrongBox<bool>? caretSignal = null)
     {
         var stream = CorrelateOverlay(raised, output, printedRanges, annotations);
         var extents = AnnotationAnchor.ComputeCaretExtents(
             annotations, AnnotationAnchor.ComputeSpans(raised), printedRanges);
-        return RenderOverlayStream(output, stream, gestures, extents);
+        return RenderOverlayStream(output, stream, gestures, extents, caretSignal);
     }
 
     // The C#-only correlation: anchor each annotation group to its printed C# line
@@ -1241,7 +1241,8 @@ public static partial class ResearchViews
         string output,
         IReadOnlyList<BoundSourceLine> stream,
         AnnotationGestureSelector gestures,
-        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null)
+        IReadOnlyDictionary<IAnnotation, AnnotationAnchor.CaretExtent>? extents = null,
+        StrongBox<bool>? caretSignal = null)
     {
         bool any = false;
         foreach (var line in stream)
@@ -1261,6 +1262,8 @@ public static partial class ResearchViews
             lines.Add(side.Count > 0
                 ? $"{line.Text.TrimEnd()}  // {AnnotationText.Format(side)}"
                 : line.Text);
+            if (caret.Count > 0 && caretSignal is not null)
+                caretSignal.Value = true;
             lines.AddRange(AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents));
         }
         return string.Join("\n", lines);

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -72,6 +72,22 @@ public static partial class ResearchViews
         IReadOnlyList<string>? UnmatchedFocusAlternatives = null,
 
         /// <summary>
+        /// True when a caret focus was requested and actually promoted at
+        /// least one fact to the caret gesture within a requested
+        /// caret-capable section (Annotated Source, Cost Overlay, Semantics
+        /// Overlay). False for every other case a focus can be in: no focus
+        /// requested, an unmatched focus (see
+        /// <see cref="UnmatchedFocusAlternatives"/>), a focus that matches
+        /// only facts outside every requested section's own category filter
+        /// (Cost Overlay and Semantics Overlay each narrow to their own
+        /// category before rendering), or a request that asked for no
+        /// caret-capable section at all (Facts, Annotated Source Document).
+        /// Matching against the whole-member fact collection is not enough
+        /// to know a caret rendered — a caller must check this instead.
+        /// </summary>
+        bool FocusRenderedCaret = false,
+
+        /// <summary>
         /// Portable interleaved source, produced only when
         /// <see cref="MemberProjectionRequest.SourceDocument"/> is requested.
         /// </summary>
@@ -249,6 +265,19 @@ public static partial class ResearchViews
             if (request.FactRows)
                 factRows = BuildFactRows(request.Type, request.Method, imported, facts, headerFacts, request.Source);
 
+            // Each caret-capable section renders its own filtered fact subset
+            // (Cost/Semantics Overlay narrow to their own category before
+            // gestures are ever applied), so whether a caret actually rendered
+            // has to be checked per requested section against its own subset,
+            // not against the whole-member fact collection UnmatchedFocusAlternatives
+            // already checks.
+            bool focusRenderedCaret =
+                (request.AnnotatedSource && AnyCaretGesture(gestures, facts))
+                || (request.CostOverlay
+                    && AnyCaretGesture(gestures, facts.Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)))
+                || (request.SemanticsOverlay
+                    && AnyCaretGesture(gestures, facts.Where(fact => fact.Descriptor.Category == AnnotationCategory.Semantics)));
+
             return new MemberProjectionResult(
                 annotatedSource,
                 costOverlay,
@@ -256,6 +285,7 @@ public static partial class ResearchViews
                 factRows,
                 annotatedSource?.Trace ?? costOverlay?.Body.Trace ?? semanticsOverlay?.Trace,
                 UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts),
+                focusRenderedCaret,
                 sourceDocument,
                 sourceDocumentFailure,
                 imported.MetadataToken);
@@ -306,6 +336,22 @@ public static partial class ResearchViews
             families.Add(dot > 0 ? descriptor.Id[..dot] : descriptor.Id);
         }
         return [.. families];
+    }
+
+    /// <summary>
+    /// True when at least one of <paramref name="facts"/> is promoted to the
+    /// caret gesture by <paramref name="gestures"/>. Callers pass the exact
+    /// filtered subset a section renders from (e.g. Cost Overlay's own
+    /// category-narrowed facts), not the whole-member collection -- matching
+    /// against the full set would say a caret rendered even when the matching
+    /// fact was excluded from this particular section.
+    /// </summary>
+    static bool AnyCaretGesture(AnnotationGestureSelector gestures, IEnumerable<IAnnotation> facts)
+    {
+        foreach (var fact in facts)
+            if (gestures.For(fact) == AnnotationGesture.Caret)
+                return true;
+        return false;
     }
 
     public static IReadOnlyList<IAnnotation> CollectFacts(

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -1081,6 +1081,7 @@ public static partial class ResearchViews
         string csIndent = "";
         string memberIndent = AnnotationCaret.MemberIndent(
             [.. stream.Where(line => line.Kind == SourceLineKind.CSharp).Select(line => line.Text)]);
+        bool renderedCaret = false;
         foreach (var line in stream)
         {
             if (line.Kind == SourceLineKind.Il)
@@ -1101,11 +1102,17 @@ public static partial class ResearchViews
             if (side.Count > 0)
                 text = $"{text}  // {string.Join("; ", side.Select(a => AnnotationText.Format(a)))}";
             sb.AppendLf(text);
-            if (caret.Count > 0 && caretSignal is not null)
-                caretSignal.Value = true;
+            if (caret.Count > 0)
+                renderedCaret = true;
             foreach (string caretLine in AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents))
                 sb.AppendLf(caretLine);
         }
+        // Only report success to the caller's signal once the whole stream has
+        // rendered without throwing -- a caller-visible RunProjection catch
+        // must never see a "caret rendered" signal left over from a render
+        // this method didn't actually finish producing.
+        if (renderedCaret && caretSignal is not null)
+            caretSignal.Value = true;
         return sb.ToString().TrimEnd();
     }
 
@@ -1256,16 +1263,22 @@ public static partial class ResearchViews
 
         string memberIndent = AnnotationCaret.MemberIndent([.. stream.Select(line => line.Text)]);
         var lines = new List<string>(stream.Count);
+        bool renderedCaret = false;
         foreach (var line in stream)
         {
             var (side, caret) = SplitByGesture(line.Annotations, gestures);
             lines.Add(side.Count > 0
                 ? $"{line.Text.TrimEnd()}  // {AnnotationText.Format(side)}"
                 : line.Text);
-            if (caret.Count > 0 && caretSignal is not null)
-                caretSignal.Value = true;
+            if (caret.Count > 0)
+                renderedCaret = true;
             lines.AddRange(AnnotationCaret.Render(line.Text, memberIndent, caret, hoist: true, extents));
         }
+        // Same rule as RenderMixedStream: only report success once the whole
+        // stream has rendered without throwing, so a caught exception never
+        // leaves the caller's signal claiming a caret that never made it out.
+        if (renderedCaret && caretSignal is not null)
+            caretSignal.Value = true;
         return string.Join("\n", lines);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15881,7 +15881,10 @@ public partial class CommandExecutionTests
                 "Make", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
 
             Assert.Equal(0, exit);
-            Assert.Empty(error);
+            // A matched --focus now writes its own caret/comment legend note
+            // (issue #5022 item 8); this test's own concern is untrusted-text
+            // containment, not the note's absence.
+            Assert.Contains("--focus 'allocation' renders that fact family with a caret", error);
 
             // Non-vacuity: the caret gesture and the fact must both render, or
             // there would be no untrusted text on the surface under test.
@@ -15940,6 +15943,27 @@ public partial class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain("matched no facts", error);
+    }
+
+    [Fact]
+    public async Task Member_AnnotatedSource_MatchedFocus_ExplainsTheMixedCaretAndCommentStyles()
+    {
+        // Issue #5022 item 8: --focus promotes only the requested fact family
+        // to the caret gesture; every other family keeps the default trailing
+        // comment. Without this note, seeing one fact underlined and the rest
+        // as comments in the same body reads as if the caret'd fact were "the
+        // one that changed" -- it's purely a reporting choice, and needs to
+        // say so every time --focus actually renders a caret, not just when
+        // it fails to match anything (see the sibling
+        // UnknownFocus_SaysSoAndNamesTheAvailableFamilies test above).
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Annotated Source", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("^^^^", output);
+        Assert.Contains("--focus 'allocation' renders that fact family with a caret", error);
+        Assert.Contains("every other fact family keeps the default trailing comment", error);
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -15966,6 +15966,41 @@ public partial class CommandExecutionTests
         Assert.Contains("every other fact family keeps the default trailing comment", error);
     }
 
+    [Fact]
+    public async Task Member_CostOverlay_FocusMatchesOnlyAnExcludedCategory_SaysNothing()
+    {
+        // Round-1 review (both reviewers, independently): matching against the
+        // whole-member fact collection is not proof a caret rendered. Pump has
+        // allocation facts, so a whole-member match would say "allocation"
+        // matched -- but Cost Overlay narrows to its own Cost-category facts
+        // before rendering, and Pump has none, so no caret appears here. The
+        // legend note must not claim otherwise.
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Cost Overlay", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("^^^^", output);
+        Assert.DoesNotContain("renders that fact family with a caret", error);
+        // Not the unmatched-focus note either: "allocation" is a real family on
+        // this member as a whole, so claiming a typo would be its own false
+        // statement.
+        Assert.DoesNotContain("matched no facts", error);
+    }
+
+    [Fact]
+    public async Task Member_FactsSection_MatchedFocus_SaysNothing()
+    {
+        // Round-1 review: Facts renders no caret at all -- it's a table, not an
+        // annotated body -- so a matched focus must not claim one rendered.
+        var (exit, _, error) = await RunAppAsync(
+            "member", typeof(CommandCaretGestureFixture).FullName!, "--library", TestAssemblyPath,
+            "Pump:1", "-S", "Facts", "--focus", "allocation", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("renders that fact family with a caret", error);
+    }
+
     /// <summary>
     /// Every projection that can carry a caret block, each through a different
     /// formatting call. Two properties per case: the caret actually renders (so

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -238,6 +238,19 @@ internal static class MemberCodeProvider
                         $"--focus '{request.CaretFocus}' matched no facts here; "
                         + $"available: {string.Join(", ", alternatives)}");
                 }
+                else if (request.CaretFocus is not null)
+                {
+                    // Issue #5022 item 8: --focus promotes only the requested fact
+                    // family to the caret gesture; every other family still uses
+                    // the default trailing comment. Without this note, the mixed
+                    // styling in the rendered body reads as if the caret'd fact
+                    // were somehow "the one that changed," which isn't what
+                    // --focus means -- it's purely a reporting choice.
+                    CommandError.WriteNote(
+                        $"--focus '{request.CaretFocus}' renders that fact family with a caret "
+                        + "underline beneath the statement; every other fact family keeps the "
+                        + "default trailing comment.");
+                }
             }
 
             // Annotated source: raised C# with hidden-fact comments and the

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -238,7 +238,7 @@ internal static class MemberCodeProvider
                         $"--focus '{request.CaretFocus}' matched no facts here; "
                         + $"available: {string.Join(", ", alternatives)}");
                 }
-                else if (request.CaretFocus is not null)
+                else if (request.CaretFocus is not null && researchProjection.FocusRenderedCaret)
                 {
                     // Issue #5022 item 8: --focus promotes only the requested fact
                     // family to the caret gesture; every other family still uses
@@ -246,6 +246,15 @@ internal static class MemberCodeProvider
                     // styling in the rendered body reads as if the caret'd fact
                     // were somehow "the one that changed," which isn't what
                     // --focus means -- it's purely a reporting choice.
+                    //
+                    // Round-1 review (both reviewers, independently): matching
+                    // against the whole-member fact collection is not proof a
+                    // caret actually rendered -- Cost/Semantics Overlay each
+                    // narrow to their own category first, and Facts/Annotated
+                    // Source Document render no caret at all. FocusRenderedCaret
+                    // is computed per requested section against its own
+                    // rendered subset, so this note only fires when a caret
+                    // genuinely appears in this run's output.
                     CommandError.WriteNote(
                         $"--focus '{request.CaretFocus}' renders that fact family with a caret "
                         + "underline beneath the statement; every other fact family keeps the "


### PR DESCRIPTION
Implements item 8 of #5022's raise-annotator printer improvement plan.

## Motivation

**Evidence (#4952's #3574 example):** `alloc.new` rendered as a trailing `//`
comment while the `--focus`'d `alloc.array` rendered as a caret on its own
line. That split is solely an artifact of `--focus` promoting one fact
family to the caret gesture — every other fact still uses the tool's default
trailing-comment style. It is not a signal that the caret'd fact is "the one
that changed" in general; that's only true by coincidence when the PR's fix
happens to be about the focused fact specifically. Confirmed by re-reading
the actual CLI invocation, not by inspection of rendered output alone.

## Change

Adds a one-line stderr note whenever `--focus` successfully renders at least
one caret in the requested section(s), explaining the split: "`--focus
'<value>' renders that fact family with a caret underline beneath the
statement; every other fact family keeps the default trailing comment." This
sits alongside the existing note for an *unmatched* `--focus` (which already
explains why nothing rendered) — now both outcomes of `--focus` are
self-explanatory without reading the invoked command.

The note is gated on the render actually having produced a caret in the
specific requested section (Annotated Source, Cost Overlay, or Semantics
Overlay), not merely on `--focus` matching a fact somewhere in the member —
see the review history below for how that distinction was tightened across
three rounds.

Lower-priority, documentation-only change per item 8's original scoping —
no rendering behavior changes, only the added stderr note.

## Demo

Real invocation, using the exact fixture #4952 cited for #3574's own
regeneration (`ILInspector.Decompiler.Tests.AllocSampleClass.AllocatesTwice`,
built from this repo's own test assembly). stdout and stderr captured
separately to confirm the note is additive-only:

```
$ dotnet-inspect member ILInspector.Decompiler.Tests.AllocSampleClass \
    --library ILInspector.Decompiler.Tests.dll AllocatesTwice \
    -S "Annotated Source" --focus alloc.array --tips q
```

**stderr — new in this PR:**

```
Note: --focus 'alloc.array' renders that fact family with a caret underline beneath the statement; every other fact family keeps the default trailing comment.
```

**stdout — unchanged before and after this PR** (the annotated body itself):

```csharp
public static object[] AllocatesTwice()
{
    object first = new object();  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once)
        // IL_0000: newobj       object::.ctor()  // alloc.new(object; alloc=System.Object; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes; escape-kind=escapes-collection; multiplicity=once); stack: [object]
        // IL_0005: stloc.0                       // local: first; stack: []
        // IL_0006: ldc.i4.1                      // stack: [int]
    return new object[] { first };
//         ^^^^^^^^^^^^^^^^^^^^^^ alloc.array(object[]; alloc=System.Object[]; path=straight-line;
//                                path-confidence=dominates-return;
//                                post-dominance=return-post-dominates; multiplicity=once)
        // IL_0007: newarr       object  // alloc.array(object[]; alloc=System.Object[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; multiplicity=once); stack: [object[]]
        // IL_000C: dup                           // stack: [object[], object[]]
        // IL_000D: ldc.i4.0                      // stack: [object[], object[], int]
        // IL_000E: ldloc.0                       // local: first; stack: [object[], object[], int, object]
        // IL_000F: stelem.ref                    // stack: [object[]]
        // IL_0010: ret                           // stack: []
}
```

Before this PR, a reader unfamiliar with `--focus` had no way to tell why
`alloc.new` renders as a trailing comment while `alloc.array` renders as a
caret two lines below — the note now says so every time, without needing to
re-read the invoked command.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 warnings, 0 errors.
- Focused `--focus`/caret-gesture tests (`src/dotnet-inspect.Tests -method
  "*Focus*"`): 33/33 pass.
- `src/ILInspector.Research.Tests`: 201/201 pass (includes 2 new regressions
  proving the caret signal stays false for a fact anchored only to an IL
  line, and true for one that survives onto a printed C# line).
- Full `dotnet-inspect.Tests` suite: 5248 total, 0 failed, 32 skipped
  (pre-existing environment-dependent skips: case-insensitive filesystem,
  missing netstandard reference pack, missing ildasm/ilasm).
- Manually confirmed via the demo above that stdout is byte-identical
  before/after and the note appears only on stderr.

### Review history

- **Round 1** (2 reviewers): the note fired on any whole-member fact match,
  even when no caret rendered in the specific requested section. Fixed by
  computing a per-section `FocusRenderedCaret` from each section's own
  filtered fact subset.
- **Round 2** (2 reviewers): that fix still matched pre-render facts rather
  than the actual render output (false positives from Cost Overlay's
  header-facts-failure short-circuit, and from facts anchored only to an IL
  line, which Annotated Source always renders as a side comment, never a
  caret). Fixed by threading a `StrongBox<bool>` signal through the actual
  render functions, set only on the branch that genuinely emits a caret.
- **Round 3** (1 finding): the signal writes happened mid-render, so a
  mid-render exception could leave a stale `true` on a failed render. Fixed
  by only writing the signal after the whole render completes without
  throwing.
- **Round 4** (2 reviewers): no significant issues found; explicit
  mergeability confirmation ("PR #5212 is mergeable at commit `2ebbf951a`").
