### PR TITLE
Expose product-issued Annotated Source viewer catalog

### DIFF
--- a/prototypes/inspect-web/engine.Tests/BrowserAnnotatedSourceViewerCatalogTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserAnnotatedSourceViewerCatalogTests.cs
@@ -108,6 +108,39 @@ public sealed class BrowserAnnotatedSourceViewerCatalogTests
     }
 
     [Fact]
+    public void CatalogCollectionsRemainImmutableAcrossInputAndOutputMutation()
+    {
+        int[] defaultFindingIds = [1];
+        BrowserAnnotatedSourceMedium[] supportedMedia =
+            [BrowserAnnotatedSourceMedium.CSharp];
+        string[] invocationLikeNodeKinds = ["InvocationExpression"];
+        var unavailable = new BrowserAnnotatedSourceCapabilityAvailability(
+            Available: false,
+            BrowserAnnotatedSourceCapabilityUnavailableReason.NotProjected);
+        var catalog = new BrowserAnnotatedSourceViewerCatalog(
+            defaultFindingIds,
+            supportedMedia,
+            invocationLikeNodeKinds,
+            unavailable,
+            unavailable);
+
+        defaultFindingIds[0] = 99;
+        supportedMedia[0] = BrowserAnnotatedSourceMedium.Il;
+        invocationLikeNodeKinds[0] = "MemberAccessExpression";
+        catalog.DefaultFindingIds[0] = 98;
+        catalog.SupportedMedia[0] = BrowserAnnotatedSourceMedium.Il;
+        catalog.InvocationLikeNodeKinds[0] = "MemberAccessExpression";
+
+        Assert.Equal([1], catalog.DefaultFindingIds);
+        Assert.Equal(
+            [BrowserAnnotatedSourceMedium.CSharp],
+            catalog.SupportedMedia);
+        Assert.Equal(
+            ["InvocationExpression"],
+            catalog.InvocationLikeNodeKinds);
+    }
+
+    [Fact]
     public void Create_ProjectsDocumentRelativeDefaultsAndInvocationKinds()
     {
         AnnotatedSourceDocument document = CreateMixedDocument();

--- a/prototypes/inspect-web/engine.Tests/BrowserAnnotatedSourceViewerCatalogTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserAnnotatedSourceViewerCatalogTests.cs
@@ -1,0 +1,311 @@
+using System.Runtime.Versioning;
+using System.Text.Json;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Annotations;
+
+namespace InspectWeb.Engine.Tests;
+
+[SupportedOSPlatform("browser")]
+public sealed class BrowserAnnotatedSourceViewerCatalogTests
+{
+    [Fact]
+    public void Create_EmptyDocumentProjectsOnlyCSharpAndUnavailableCapabilities()
+    {
+        BrowserAnnotatedSourceViewerCatalog catalog =
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(
+                new AnnotatedSourceDocument("", [], [], [], []));
+
+        Assert.Empty(catalog.DefaultFindingIds);
+        Assert.Equal(
+            [BrowserAnnotatedSourceMedium.CSharp],
+            catalog.SupportedMedia);
+        Assert.Empty(catalog.InvocationLikeNodeKinds);
+        Assert.False(catalog.FindingEvidence.Available);
+        Assert.Equal(
+            BrowserAnnotatedSourceCapabilityUnavailableReason.NotProjected,
+            catalog.FindingEvidence.UnavailableReason);
+        Assert.False(catalog.Destinations.Available);
+        Assert.Equal(
+            BrowserAnnotatedSourceCapabilityUnavailableReason.NotProjected,
+            catalog.Destinations.UnavailableReason);
+    }
+
+    [Theory]
+    [InlineData(nameof(AnnotationCategory.Allocation))]
+    [InlineData(nameof(AnnotationCategory.Unsafety))]
+    [InlineData(nameof(AnnotationCategory.Cost))]
+    [InlineData(nameof(AnnotationCategory.Semantics))]
+    [InlineData(nameof(AnnotationCategory.Lifetime))]
+    public void Create_IncludesEveryCurrentDefaultFindingCategory(string category)
+    {
+        var document = new AnnotatedSourceDocument(
+            "body",
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "MemberBody",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 4)]),
+            ],
+            [],
+            [
+                new AnnotatedSourceFact(
+                    0,
+                    "example.fact",
+                    category,
+                    AnnotationConditionality.Always,
+                    Detail: null,
+                    SourceOffset: 0,
+                    AnnotatedSourceFactOrigin.Body),
+            ],
+            [new AnnotatedSourceTarget(0, 0)]);
+
+        BrowserAnnotatedSourceViewerCatalog catalog =
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(document);
+
+        Assert.Equal([0], catalog.DefaultFindingIds);
+        Assert.Equal(
+            [BrowserAnnotatedSourceMedium.CSharp],
+            catalog.SupportedMedia);
+    }
+
+    [Fact]
+    public void DefaultFindingCategoriesRequireAnExplicitDecisionForEveryCategory()
+    {
+        Assert.Equal(
+            [
+                AnnotationCategory.Allocation,
+                AnnotationCategory.Unsafety,
+                AnnotationCategory.Lifetime,
+                AnnotationCategory.Cost,
+                AnnotationCategory.Semantics,
+                AnnotationCategory.Relationship,
+            ],
+            Enum.GetValues<AnnotationCategory>());
+        Assert.Equal(
+            [
+                AnnotationCategory.Allocation,
+                AnnotationCategory.Unsafety,
+                AnnotationCategory.Lifetime,
+                AnnotationCategory.Cost,
+                AnnotationCategory.Semantics,
+            ],
+            BrowserAnnotatedSourceViewerCatalogFactory.DefaultFindingCategories
+                .Order());
+    }
+
+    [Fact]
+    public void CapabilityAvailabilityRequiresExactlyOneOutcome()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new BrowserAnnotatedSourceCapabilityAvailability(
+                Available: true,
+                BrowserAnnotatedSourceCapabilityUnavailableReason.NotProjected));
+        Assert.Throws<ArgumentException>(() =>
+            new BrowserAnnotatedSourceCapabilityAvailability(
+                Available: false,
+                UnavailableReason: null));
+    }
+
+    [Fact]
+    public void Create_ProjectsDocumentRelativeDefaultsAndInvocationKinds()
+    {
+        AnnotatedSourceDocument document = CreateMixedDocument();
+
+        BrowserAnnotatedSourceViewerCatalog catalog =
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(document);
+
+        Assert.Equal([0, 2], catalog.DefaultFindingIds);
+        Assert.Equal(
+            [
+                BrowserAnnotatedSourceMedium.CSharp,
+                BrowserAnnotatedSourceMedium.Il,
+            ],
+            catalog.SupportedMedia);
+        Assert.Equal(
+            [
+                "InvocationExpression",
+                "IndirectInvocationExpression",
+            ],
+            catalog.InvocationLikeNodeKinds);
+    }
+
+    [Fact]
+    public void Create_ExcludesRelationshipAndUnanchoredDefaultFacts()
+    {
+        BrowserAnnotatedSourceViewerCatalog catalog =
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(
+                CreateMixedDocument());
+
+        Assert.DoesNotContain(1, catalog.DefaultFindingIds);
+        Assert.DoesNotContain(3, catalog.DefaultFindingIds);
+    }
+
+    [Fact]
+    public void Create_ProjectsPresentInvocationLikeKindsInCapabilityOrder()
+    {
+        var document = new AnnotatedSourceDocument(
+            "x",
+            [
+                new AnnotatedSourceNode(
+                    0,
+                    "DelegateCreationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 1)]),
+                new AnnotatedSourceNode(
+                    1,
+                    "ObjectCreationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 1)]),
+                new AnnotatedSourceNode(
+                    2,
+                    "IndirectInvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 1)]),
+                new AnnotatedSourceNode(
+                    3,
+                    "InvocationExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 1)]),
+                new AnnotatedSourceNode(
+                    4,
+                    "MemberAccessExpression",
+                    SourceLineKind.CSharp,
+                    [new AnnotatedSourceSpan(0, 1)]),
+            ],
+            [],
+            [],
+            []);
+
+        BrowserAnnotatedSourceViewerCatalog catalog =
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(document);
+
+        Assert.Equal(
+            [
+                "InvocationExpression",
+                "IndirectInvocationExpression",
+                "ObjectCreationExpression",
+                "DelegateCreationExpression",
+            ],
+            catalog.InvocationLikeNodeKinds);
+    }
+
+    [Fact]
+    public void EnvelopeSerializationPreservesPortableDocumentBytes()
+    {
+        AnnotatedSourceDocument document = CreateMixedDocument();
+        string envelopeJson = JsonSerializer.Serialize(
+            BrowserAnnotatedSource.Create(
+                document,
+                "test provenance",
+                contextLimitation: null),
+            BrowserJsonContext.Default.BrowserAnnotatedSource);
+        using JsonDocument envelope = JsonDocument.Parse(envelopeJson);
+        string documentJson = JsonSerializer.Serialize(
+            document,
+            AnnotatedSourceDocumentCompactJsonContext.Default.AnnotatedSourceDocument);
+
+        Assert.Equal(
+            documentJson,
+            envelope.RootElement.GetProperty("document").GetRawText());
+        JsonElement catalog = envelope.RootElement.GetProperty("viewerCatalog");
+        Assert.Equal(
+            ["CSharp", "Il"],
+            catalog.GetProperty("supportedMedia")
+                .EnumerateArray()
+                .Select(item => item.GetString()));
+        Assert.False(
+            catalog.GetProperty("findingEvidence")
+                .GetProperty("available")
+                .GetBoolean());
+        Assert.Equal(
+            "NotProjected",
+            catalog.GetProperty("findingEvidence")
+                .GetProperty("unavailableReason")
+                .GetString());
+        Assert.False(
+            catalog.GetProperty("destinations")
+                .GetProperty("available")
+                .GetBoolean());
+        Assert.Equal(
+            "NotProjected",
+            catalog.GetProperty("destinations")
+                .GetProperty("unavailableReason")
+                .GetString());
+    }
+
+    private static AnnotatedSourceDocument CreateMixedDocument()
+    {
+        const string text = "Call();\nIndirect();\nIL_0000: ret";
+        AnnotatedSourceNode[] nodes =
+        [
+            new(
+                0,
+                "MemberBody",
+                SourceLineKind.CSharp,
+                [
+                    new AnnotatedSourceSpan(0, 7),
+                    new AnnotatedSourceSpan(8, 11),
+                ]),
+            new(
+                1,
+                "InvocationExpression",
+                SourceLineKind.CSharp,
+                [new AnnotatedSourceSpan(0, 6)]),
+            new(
+                2,
+                "IndirectInvocationExpression",
+                SourceLineKind.CSharp,
+                [new AnnotatedSourceSpan(8, 10)]),
+            new(
+                3,
+                AnnotatedSourceNode.InstructionKind,
+                SourceLineKind.Il,
+                [new AnnotatedSourceSpan(20, 12)],
+                IlOffset: 0),
+        ];
+        AnnotatedSourceFact[] facts =
+        [
+            new(
+                0,
+                "alloc.call",
+                nameof(AnnotationCategory.Allocation),
+                AnnotationConditionality.Always,
+                Detail: null,
+                SourceOffset: 0,
+                AnnotatedSourceFactOrigin.Body),
+            new(
+                1,
+                "call.edge",
+                nameof(AnnotationCategory.Relationship),
+                AnnotationConditionality.Always,
+                Detail: null,
+                SourceOffset: 0,
+                AnnotatedSourceFactOrigin.Body),
+            new(
+                2,
+                "cost.call",
+                nameof(AnnotationCategory.Cost),
+                AnnotationConditionality.Always,
+                Detail: null,
+                SourceOffset: 0,
+                AnnotatedSourceFactOrigin.Body),
+            new(
+                3,
+                "semantics.header",
+                nameof(AnnotationCategory.Semantics),
+                AnnotationConditionality.Always,
+                Detail: null,
+                SourceOffset: -1,
+                AnnotatedSourceFactOrigin.MemberHeader),
+        ];
+        AnnotatedSourceTarget[] targets =
+        [
+            new(0, 1),
+            new(1, 2),
+            new(2, 3),
+        ];
+
+        return new AnnotatedSourceDocument(text, nodes, [], facts, targets);
+    }
+}

--- a/prototypes/inspect-web/engine/BrowserAnnotatedSourceViewerCatalogFactory.cs
+++ b/prototypes/inspect-web/engine/BrowserAnnotatedSourceViewerCatalogFactory.cs
@@ -1,0 +1,82 @@
+using System.Collections.Frozen;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Annotations;
+
+namespace InspectWeb.Engine;
+
+internal static class BrowserAnnotatedSourceViewerCatalogFactory
+{
+    internal static readonly IReadOnlySet<AnnotationCategory> DefaultFindingCategories =
+        new[]
+        {
+            AnnotationCategory.Allocation,
+            AnnotationCategory.Unsafety,
+            AnnotationCategory.Cost,
+            AnnotationCategory.Semantics,
+            AnnotationCategory.Lifetime,
+        }.ToFrozenSet();
+
+    private static readonly BrowserAnnotatedSourceCapabilityAvailability NotProjected =
+        new(
+            Available: false,
+            UnavailableReason:
+                BrowserAnnotatedSourceCapabilityUnavailableReason.NotProjected);
+
+    // Call-shaped syntax wins hit testing independently of whether a destination is available.
+    private static readonly string[] InvocationLikeNodeKinds =
+    [
+        "InvocationExpression",
+        "IndirectInvocationExpression",
+        "ObjectCreationExpression",
+        "DelegateCreationExpression",
+    ];
+
+    public static BrowserAnnotatedSourceViewerCatalog Create(
+        AnnotatedSourceDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        var targetedFacts = new bool[document.Facts.Count];
+        foreach (AnnotatedSourceTarget target in document.Targets)
+            targetedFacts[target.FactId] = true;
+
+        int[] defaultFindingIds =
+        [
+            .. document.Facts
+                .Where(fact =>
+                    targetedFacts[fact.Id]
+                        && IsDefaultFindingCategory(fact.Category))
+                .Select(fact => fact.Id),
+        ];
+        BrowserAnnotatedSourceMedium[] supportedMedia =
+            document.Nodes.Any(node => node.Medium == SourceLineKind.Il)
+                ?
+                [
+                    BrowserAnnotatedSourceMedium.CSharp,
+                    BrowserAnnotatedSourceMedium.Il,
+                ]
+                : [BrowserAnnotatedSourceMedium.CSharp];
+        string[] invocationLikeNodeKinds =
+        [
+            .. InvocationLikeNodeKinds.Where(kind =>
+                document.Nodes.Any(node =>
+                    node.Medium == SourceLineKind.CSharp
+                        && string.Equals(node.Kind, kind, StringComparison.Ordinal))),
+        ];
+
+        return new BrowserAnnotatedSourceViewerCatalog(
+            defaultFindingIds,
+            supportedMedia,
+            invocationLikeNodeKinds,
+            NotProjected,
+            NotProjected);
+    }
+
+    private static bool IsDefaultFindingCategory(string category) =>
+        DefaultFindingCategories.Any(
+            defaultCategory =>
+                string.Equals(
+                    category,
+                    defaultCategory.ToString(),
+                    StringComparison.Ordinal));
+}

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ILInspector.Decompiler;
 
 namespace InspectWeb.Engine;
 
@@ -661,20 +662,98 @@ public sealed record BrowserDependencyCoordinateMatch(
     BrowserDependencyCoordinateMatchOutcome Outcome,
     string? CandidateKey);
 
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserAnnotatedSourceMedium>))]
+public enum BrowserAnnotatedSourceMedium
+{
+    CSharp,
+    Il,
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserAnnotatedSourceCapabilityUnavailableReason>))]
+public enum BrowserAnnotatedSourceCapabilityUnavailableReason
+{
+    NotProjected,
+}
+
+public sealed record BrowserAnnotatedSourceCapabilityAvailability
+{
+    public BrowserAnnotatedSourceCapabilityAvailability(
+        bool Available,
+        BrowserAnnotatedSourceCapabilityUnavailableReason? UnavailableReason)
+    {
+        if (Available == (UnavailableReason is not null))
+        {
+            throw new ArgumentException(
+                Available
+                    ? "An available capability cannot carry an unavailable reason."
+                    : "An unavailable capability must carry an unavailable reason.",
+                nameof(UnavailableReason));
+        }
+
+        this.Available = Available;
+        this.UnavailableReason = UnavailableReason;
+    }
+
+    public bool Available { get; }
+    public BrowserAnnotatedSourceCapabilityUnavailableReason? UnavailableReason { get; }
+}
+
+public sealed record BrowserAnnotatedSourceViewerCatalog(
+    int[] DefaultFindingIds,
+    BrowserAnnotatedSourceMedium[] SupportedMedia,
+    string[] InvocationLikeNodeKinds,
+    BrowserAnnotatedSourceCapabilityAvailability FindingEvidence,
+    BrowserAnnotatedSourceCapabilityAvailability Destinations);
+
 /// <summary>
 /// The annotated-source envelope: the product's portable <c>AnnotatedSourceDocument</c> serialized
-/// by its owning <c>AnnotatedSourceDocumentJsonContext</c>, plus the provenance of the artifact it
-/// was raised from. The document travels as a <see cref="JsonElement"/> so the wire shape stays
-/// exactly the one the viewer's model validates — the host neither reshapes nor renames a field.
+/// by its owning <c>AnnotatedSourceDocumentJsonContext</c>, the product-issued viewer catalog, and
+/// the provenance of the artifact it was raised from. The document travels as a
+/// <see cref="JsonElement"/> so the wire shape stays exactly the one the viewer's model validates —
+/// the host neither reshapes nor renames a field.
 /// </summary>
 /// <param name="ContextLimitation">
 /// Set when the projection's whole-assembly fact context was narrower than a complete one, so a
 /// short fact list is never mistaken for an honest absence of facts.
 /// </param>
-public sealed record BrowserAnnotatedSource(
-    JsonElement Document,
-    string Provenance,
-    string? ContextLimitation);
+public sealed record BrowserAnnotatedSource
+{
+    private BrowserAnnotatedSource(
+        JsonElement Document,
+        BrowserAnnotatedSourceViewerCatalog ViewerCatalog,
+        string Provenance,
+        string? ContextLimitation)
+    {
+        this.Document = Document;
+        this.ViewerCatalog = ViewerCatalog;
+        this.Provenance = Provenance;
+        this.ContextLimitation = ContextLimitation;
+    }
+
+    public JsonElement Document { get; }
+    public BrowserAnnotatedSourceViewerCatalog ViewerCatalog { get; }
+    public string Provenance { get; }
+    public string? ContextLimitation { get; }
+
+    internal static BrowserAnnotatedSource Create(
+        AnnotatedSourceDocument document,
+        string provenance,
+        string? contextLimitation)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentException.ThrowIfNullOrWhiteSpace(provenance);
+
+        using JsonDocument serialized = JsonDocument.Parse(
+            JsonSerializer.Serialize(
+                document,
+                AnnotatedSourceDocumentCompactJsonContext.Default.AnnotatedSourceDocument));
+        return new BrowserAnnotatedSource(
+            serialized.RootElement.Clone(),
+            BrowserAnnotatedSourceViewerCatalogFactory.Create(document),
+            provenance,
+            contextLimitation);
+    }
+}
 
 public sealed record BrowserSource(
     string Provider,

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -698,12 +698,38 @@ public sealed record BrowserAnnotatedSourceCapabilityAvailability
     public BrowserAnnotatedSourceCapabilityUnavailableReason? UnavailableReason { get; }
 }
 
-public sealed record BrowserAnnotatedSourceViewerCatalog(
-    int[] DefaultFindingIds,
-    BrowserAnnotatedSourceMedium[] SupportedMedia,
-    string[] InvocationLikeNodeKinds,
-    BrowserAnnotatedSourceCapabilityAvailability FindingEvidence,
-    BrowserAnnotatedSourceCapabilityAvailability Destinations);
+public sealed record BrowserAnnotatedSourceViewerCatalog
+{
+    private readonly int[] _defaultFindingIds;
+    private readonly BrowserAnnotatedSourceMedium[] _supportedMedia;
+    private readonly string[] _invocationLikeNodeKinds;
+
+    public BrowserAnnotatedSourceViewerCatalog(
+        int[] DefaultFindingIds,
+        BrowserAnnotatedSourceMedium[] SupportedMedia,
+        string[] InvocationLikeNodeKinds,
+        BrowserAnnotatedSourceCapabilityAvailability FindingEvidence,
+        BrowserAnnotatedSourceCapabilityAvailability Destinations)
+    {
+        ArgumentNullException.ThrowIfNull(DefaultFindingIds);
+        ArgumentNullException.ThrowIfNull(SupportedMedia);
+        ArgumentNullException.ThrowIfNull(InvocationLikeNodeKinds);
+        ArgumentNullException.ThrowIfNull(FindingEvidence);
+        ArgumentNullException.ThrowIfNull(Destinations);
+
+        _defaultFindingIds = [.. DefaultFindingIds];
+        _supportedMedia = [.. SupportedMedia];
+        _invocationLikeNodeKinds = [.. InvocationLikeNodeKinds];
+        this.FindingEvidence = FindingEvidence;
+        this.Destinations = Destinations;
+    }
+
+    public int[] DefaultFindingIds => [.. _defaultFindingIds];
+    public BrowserAnnotatedSourceMedium[] SupportedMedia => [.. _supportedMedia];
+    public string[] InvocationLikeNodeKinds => [.. _invocationLikeNodeKinds];
+    public BrowserAnnotatedSourceCapabilityAvailability FindingEvidence { get; }
+    public BrowserAnnotatedSourceCapabilityAvailability Destinations { get; }
+}
 
 /// <summary>
 /// The annotated-source envelope: the product's portable <c>AnnotatedSourceDocument</c> serialized

--- a/prototypes/inspect-web/engine/InspectionEngine.cs
+++ b/prototypes/inspect-web/engine/InspectionEngine.cs
@@ -414,12 +414,9 @@ public static partial class InspectionEngine
                     : "Annotated source projection produced no document.");
         }
 
-        // The document's wire shape belongs to ILInspector.Decompiler; carry it verbatim so the
-        // viewer's model validates the same artifact the CLI writes.
-        using JsonDocument serialized = SerializeAnnotatedSourceDocument(document);
         return JsonSerializer.Serialize(
-            new BrowserAnnotatedSource(
-                serialized.RootElement,
+            BrowserAnnotatedSource.Create(
+                document,
                 $"Annotated by dotnet-inspect from {participant.Coordinate.PackageId} "
                     + $"{participant.Coordinate.Version} {participant.Asset.Path}",
                 projection.ContextLimitation is { } limitation
@@ -427,12 +424,6 @@ public static partial class InspectionEngine
                     : null),
             BrowserJsonContext.Default.BrowserAnnotatedSource);
     }
-
-    static JsonDocument SerializeAnnotatedSourceDocument(AnnotatedSourceDocument document) =>
-        JsonDocument.Parse(
-            JsonSerializer.Serialize(
-                document,
-                AnnotatedSourceDocumentCompactJsonContext.Default.AnnotatedSourceDocument));
 
     /// <summary>
     /// Exact method-body Analysis and metadata evidence for one implementation

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -4,6 +4,10 @@
 //   eng/generate-inspect-web-engine-dts.sh
 // CI fails if the committed file drifts from this output.
 
+export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" | number;
+
+export type BrowserAnnotatedSourceMedium = "CSharp" | "Il" | number;
+
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 
 export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Ambiguous" | number;
@@ -42,8 +46,22 @@ export interface BrowserAllocationFact {
 
 export interface BrowserAnnotatedSource {
   readonly document: unknown;
+  readonly viewerCatalog: BrowserAnnotatedSourceViewerCatalog;
   readonly provenance: string;
   readonly contextLimitation: string | null;
+}
+
+export interface BrowserAnnotatedSourceCapabilityAvailability {
+  readonly available: boolean;
+  readonly unavailableReason: BrowserAnnotatedSourceCapabilityUnavailableReason | null;
+}
+
+export interface BrowserAnnotatedSourceViewerCatalog {
+  readonly defaultFindingIds: ReadonlyArray<number>;
+  readonly supportedMedia: ReadonlyArray<BrowserAnnotatedSourceMedium>;
+  readonly invocationLikeNodeKinds: ReadonlyArray<string>;
+  readonly findingEvidence: BrowserAnnotatedSourceCapabilityAvailability;
+  readonly destinations: BrowserAnnotatedSourceCapabilityAvailability;
 }
 
 export interface BrowserAssemblyMetadata {

--- a/prototypes/inspect-web/test/annotated-source-result-fixture.ts
+++ b/prototypes/inspect-web/test/annotated-source-result-fixture.ts
@@ -1,0 +1,31 @@
+import type {
+  BrowserAnnotatedSourceViewerCatalog,
+} from "../src/inspect-web-engine.d.ts";
+
+export const sampleViewerCatalog = {
+  defaultFindingIds: [0, 1],
+  supportedMedia: ["CSharp", "Il"],
+  invocationLikeNodeKinds: ["ObjectCreationExpression"],
+  findingEvidence: {
+    available: false,
+    unavailableReason: "NotProjected",
+  },
+  destinations: {
+    available: false,
+    unavailableReason: "NotProjected",
+  },
+} as const satisfies BrowserAnnotatedSourceViewerCatalog;
+
+export const csharpOnlyEmptyViewerCatalog = {
+  defaultFindingIds: [],
+  supportedMedia: ["CSharp"],
+  invocationLikeNodeKinds: [],
+  findingEvidence: {
+    available: false,
+    unavailableReason: "NotProjected",
+  },
+  destinations: {
+    available: false,
+    unavailableReason: "NotProjected",
+  },
+} as const satisfies BrowserAnnotatedSourceViewerCatalog;

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -9,6 +9,10 @@ import {
 import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
+import {
+  csharpOnlyEmptyViewerCatalog,
+  sampleViewerCatalog,
+} from "./annotated-source-result-fixture.ts";
 import { fakeDom } from "./fake-dom.ts";
 
 validateAnnotatedSourceDocument(sampleDocumentFixture);
@@ -136,6 +140,7 @@ function escapeHtml(value: unknown) {
 
 const result: AnnotatedSourceRenderResult = {
   document: sampleDocument,
+  viewerCatalog: sampleViewerCatalog,
   provenance: "decompiled from IL",
 };
 
@@ -285,6 +290,7 @@ test("source text is escaped as it is rendered into spans", () => {
         facts: [],
         targets: [],
       },
+      viewerCatalog: csharpOnlyEmptyViewerCatalog,
       provenance: "decompiled from IL",
       contextLimitation: null,
     },

--- a/prototypes/inspect-web/test/member-detail-inspection.test.ts
+++ b/prototypes/inspect-web/test/member-detail-inspection.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { sampleDocument } from "../../annotated-source-viewer/src/sample-document.js";
 import type { AnnotatedSourceResult } from "../src/annotated-source.ts";
 import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import { sampleViewerCatalog } from "./annotated-source-result-fixture.ts";
 import {
   cancelAnnotatedSourceRequest,
   createMemberDetailInspectionCoordinator,
@@ -116,6 +117,7 @@ function annotatedResult(): AnnotatedSourceResult {
   validateAnnotatedSourceDocument(document);
   return {
     document,
+    viewerCatalog: sampleViewerCatalog,
     provenance: "decompiled from IL",
     contextLimitation: null,
   };


### PR DESCRIPTION
The Annotated Source browser result now carries one product-issued, document-relative viewer catalog. It supplies exact default Finding IDs, supported media, invocation-like hit-test kinds, and typed availability outcomes without changing the portable `AnnotatedSourceDocument` wire shape.

This is slice 1 of 2. #5205 will implement the embedded and modal viewer against this contract. Closes #5204.

## Demo

A real `QueryMemberAnnotatedSource` query for `System.Text.Json` 10.0.0 / `net10.0`, `System.Text.Json.JsonElement.GetDecimal()`, produced:

```text
{"defaultFindingIds":[0],"supportedMedia":["CSharp","Il"],"invocationLikeNodeKinds":["InvocationExpression"],"findingEvidence":{"available":false,"unavailableReason":"NotProjected"},"destinations":{"available":false,"unavailableReason":"NotProjected"}}
document: text=694, nodes=14, facts=1, targets=2
```

The catalog is constructed from the same product `AnnotatedSourceDocument` instance serialized into the envelope, so callers cannot conventionally pair a document with a catalog for another document. The nested document bytes remain identical to the owning compact serializer output.

## Validation

- `PATH="$PWD/artifacts/node/bin:$PATH" npm --prefix prototypes/inspect-web run build`
- `PATH="$PWD/artifacts/node/bin:$PATH" npm --prefix prototypes/inspect-web test` — 793 passed
- `PATH="$PWD/artifacts/node/bin:$PATH" dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 188 passed
- `PATH="$PWD/artifacts/node/bin:$PATH" eng/generate-inspect-web-engine-dts.sh`
- `git diff --check`

## Compatibility and boundaries

C# remains universally supported; IL is advertised only when IL nodes are present. Relationship and unanchored member-header Findings are intentionally excluded from annotation defaults. Finding evidence and destinations remain visibly unavailable as `NotProjected`; this slice does not add Research composition, destination construction, rendering, modal state, focus, Escape handling, or hit testing.