### PR TITLE
Preserve malformed exported type evidence

### DIFF
--- a/docs/design/assembly-inspection-query.md
+++ b/docs/design/assembly-inspection-query.md
@@ -808,6 +808,19 @@ one or more forwarding hops retains the
 terminal assembly identity rather than being attributed to the initial facade
 (`ForwardedUnboundDependencyPreservesTerminalAssemblyIdentity` and
 `ForwardedModuleExportRejectionPreservesTerminalAssemblyIdentity`). An
+AssemblyRef-terminated exported root that lacks the Forwarder flag is retained
+as a bounded type-forwarder inspection failure rather than disappearing from
+the API surface
+(`ExtractApiSurface_AssemblyRefExportWithoutForwarderPreservesFailure` and
+`BoundedApiSurface_AssemblyRefExportWithoutForwarderUsesFailureBudget`).
+Legitimate module exports and nested rows beneath a marked forwarding root
+remain outside that failure
+(`ExtractApiSurface_ModuleExportWithoutForwarderRemainsValid` and
+`ExtractApiSurface_NestedForwarderWithoutFlagRemainsValid`). Resolution-aware
+composition does not add a duplicate inventory failure when that exact cause is
+already retained by the API surface
+(`ExtractApiSurface_MalformedRootAdjacencyIsNotDuplicated` and
+`MalformedRootAdjacency_KeepsHealthySelectedTypeAndIsFatal`). An
 API surface that copies a resolved forwarded type also carries that target surface's bounded,
 deduplicated generic-constraint failure instead of presenting `Undetermined` without its
 cause. The failure retains its owning assembly identity, so its metadata token remains scoped

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -399,6 +399,9 @@ public sealed record ApiSurfaceInspectionFailure(
         "type forwarder identity";
     public const string TypeForwarderRowOperation =
         "type forwarder row";
+    internal const string UnmarkedAssemblyForwarderDetail =
+        "The selected image has an AssemblyRef-terminated ExportedType "
+            + "chain that is not a forwarder.";
 
     [JsonIgnore]
     public string? SourceAssemblyPath { get; init; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -2005,9 +2005,22 @@ public static class ApiSurfaceExtractor
             {
                 var exportedType = reader.GetExportedType(exportedTypeHandle);
 
-                // Type forwarders have IsForwarder flag set
                 if (!exportedType.IsForwarder)
+                {
+                    if (exportedType.Implementation.Kind
+                        == HandleKind.AssemblyReference)
+                    {
+                        throw new MetadataRowRejectedException(
+                            ApiSurfaceInspectionFailure
+                                .TypeForwarderIdentityOperation,
+                            MetadataTypeNameFailure.Malformed(
+                                exportedTypeHandle,
+                                ApiSurfaceInspectionFailure
+                                    .UnmarkedAssemblyForwarderDetail));
+                    }
+
                     continue;
+                }
 
                 budget?.BeginTypeForwarder();
                 MetadataTypeDefinitionName? definitionName;

--- a/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
+++ b/src/ILInspector.Metadata/InspectionAcquisitionPlan.cs
@@ -431,8 +431,8 @@ internal sealed class InspectionAcquisitionPlan : IDisposable
                         if (!reader.GetExportedType(rootToLeaf[0]).IsForwarder)
                         {
                             entry.RecordRootAdjacencyFailure(
-                                "The selected image has an AssemblyRef-terminated "
-                                    + "ExportedType chain that is not a forwarder.");
+                                ApiSurfaceInspectionFailure
+                                    .UnmarkedAssemblyForwarderDetail);
                             continue;
                         }
 

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -214,7 +214,15 @@ public sealed class TypeResolutionCatalog : IDisposable
                     bindingPolicy,
                     includeAll,
                     typesOnly);
-        if (readyRegistration.InventoryFailure is { } inventoryFailure)
+        if (readyRegistration.InventoryFailure is { } inventoryFailure
+            && !surface.InspectionFailures.Any(
+                failure =>
+                    failure.Mechanism
+                        == MetadataTypeNameFailureMechanism.Metadata
+                    && string.Equals(
+                        failure.Detail,
+                        inventoryFailure.Detail,
+                        StringComparison.Ordinal)))
         {
             surface.InspectionFailures.Add(
                 new ApiSurfaceInspectionFailure(

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
@@ -10,6 +10,85 @@ namespace ILInspector.Metadata.Tests;
 public class ApiSurfaceRelationshipFailureTests
 {
     [Fact]
+    public void ExtractApiSurface_AssemblyRefExportWithoutForwarderPreservesFailure()
+    {
+        using var stream = new MemoryStream(
+            BuildExportedTypeImage(ExportedTypeShape.MalformedAssemblyReference));
+
+        var surface = AssemblyReader.ExtractApiSurface(
+            stream,
+            includeAll: true,
+            typesOnly: true);
+
+        Assert.NotNull(surface);
+        Assert.Empty(surface.TypeForwarders);
+        ApiSurfaceInspectionFailure failure =
+            Assert.Single(surface.InspectionFailures);
+        Assert.Equal(
+            ApiSurfaceInspectionFailure.TypeForwarderIdentityOperation,
+            failure.Operation);
+        Assert.Equal(0x27000001, failure.SubjectToken);
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Metadata,
+            failure.Mechanism);
+        Assert.Equal("MalformedMetadata", failure.Kind);
+    }
+
+    [Fact]
+    public void BoundedApiSurface_AssemblyRefExportWithoutForwarderUsesFailureBudget()
+    {
+        using var stream = new MemoryStream(
+            BuildExportedTypeImage(ExportedTypeShape.MalformedAssemblyReference));
+        using var peReader = new PEReader(stream);
+
+        ApiSurfaceExtractionResult result = ApiSurfaceExtractor.ExtractBounded(
+            peReader,
+            ApiSurfaceExtractionScope.IncludeAll,
+            new ApiSurfaceExtractionBounds(0, 0, 1, 0, int.MaxValue),
+            typesOnly: true);
+
+        ApiSurface surface =
+            Assert.IsType<ApiSurfaceExtractionResult.Extracted>(result).Surface;
+        Assert.Equal(
+            ApiSurfaceInspectionFailure.TypeForwarderIdentityOperation,
+            Assert.Single(surface.InspectionFailures).Operation);
+    }
+
+    [Fact]
+    public void ExtractApiSurface_ModuleExportWithoutForwarderRemainsValid()
+    {
+        using var stream = new MemoryStream(
+            BuildExportedTypeImage(ExportedTypeShape.ModuleExport));
+
+        var surface = AssemblyReader.ExtractApiSurface(
+            stream,
+            includeAll: true,
+            typesOnly: true);
+
+        Assert.NotNull(surface);
+        Assert.Empty(surface.TypeForwarders);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
+    public void ExtractApiSurface_NestedForwarderWithoutFlagRemainsValid()
+    {
+        using var stream = new MemoryStream(
+            BuildExportedTypeImage(ExportedTypeShape.NestedForwarder));
+
+        var surface = AssemblyReader.ExtractApiSurface(
+            stream,
+            includeAll: true,
+            typesOnly: true);
+
+        Assert.NotNull(surface);
+        Assert.Equal(
+            "N.Outer",
+            Assert.Single(surface.TypeForwarders).TypeName);
+        Assert.Empty(surface.InspectionFailures);
+    }
+
+    [Fact]
     public void ExtractApiSurface_CyclicTypePreservesValidSiblingAndFailure()
     {
         using var stream = new MemoryStream(BuildImage(
@@ -248,6 +327,94 @@ public class ApiSurfaceRelationshipFailureTests
         var image = new BlobBuilder();
         pe.Serialize(image);
         return image.ToArray();
+    }
+
+    static byte[] BuildExportedTypeImage(ExportedTypeShape shape)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        AssemblyReferenceHandle target = metadata.AddAssemblyReference(
+            metadata.GetOrAddString("Target"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKeyOrToken: default,
+            flags: default,
+            hashValue: default);
+        switch (shape)
+        {
+            case ExportedTypeShape.MalformedAssemblyReference:
+                metadata.AddExportedType(
+                    TypeAttributes.Public,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Type"),
+                    target,
+                    typeDefinitionId: 0);
+                break;
+            case ExportedTypeShape.ModuleExport:
+                AssemblyFileHandle module = metadata.AddAssemblyFile(
+                    metadata.GetOrAddString("Part.netmodule"),
+                    metadata.GetOrAddBlob(new byte[] { 1, 2, 3 }),
+                    containsMetadata: true);
+                metadata.AddExportedType(
+                    TypeAttributes.Public,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Type"),
+                    module,
+                    typeDefinitionId: 0);
+                break;
+            case ExportedTypeShape.NestedForwarder:
+                ExportedTypeHandle root = metadata.AddExportedType(
+                    TypeAttributes.Public | (TypeAttributes)0x00200000,
+                    metadata.GetOrAddString("N"),
+                    metadata.GetOrAddString("Outer"),
+                    target,
+                    typeDefinitionId: 0);
+                metadata.AddExportedType(
+                    TypeAttributes.NestedPublic,
+                    default,
+                    metadata.GetOrAddString("Inner"),
+                    root,
+                    typeDefinitionId: 0);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(shape));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    enum ExportedTypeShape
+    {
+        MalformedAssemblyReference,
+        ModuleExport,
+        NestedForwarder,
     }
 
     static byte[] BuildEnumDefaultImage()

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
@@ -64,6 +64,33 @@ public class TypeResolutionContextTests
     }
 
     [Fact]
+    public void ExtractApiSurface_MalformedRootAdjacencyIsNotDuplicated()
+    {
+        byte[] image = BuildAssembly(
+            "Facade",
+            definesType: false,
+            forwardTarget: Identity("Target"),
+            omitForwarderFlag: true);
+        ResolvedAssemblyReference source = Descriptor(image);
+        using var catalog = new TypeResolutionCatalog();
+
+        var read = Assert.IsType<ResolutionAwareApiSurfaceOutcome.Read>(
+            catalog.ExtractApiSurface(
+                source,
+                new RecordingPolicy(
+                    _ => AssemblyBindingSelection.NotFound()),
+                includeAll: true,
+                typesOnly: true));
+
+        ApiSurfaceInspectionFailure failure =
+            Assert.Single(read.Surface.InspectionFailures);
+        Assert.Equal(
+            ApiSurfaceInspectionFailure.TypeForwarderIdentityOperation,
+            failure.Operation);
+        Assert.Equal(0x27000001, failure.SubjectToken);
+    }
+
+    [Fact]
     public void DirectDefinition_ResolvesAndCachesFrozenOutcome()
     {
         byte[] image = BuildAssembly("Definitions", definesType: true);
@@ -2584,7 +2611,8 @@ public class TypeResolutionContextTests
         int forwarderCount = 1,
         bool definesOtherType = false,
         Guid? moduleVersionId = null,
-        ImmutableArray<string> typeSegments = default)
+        ImmutableArray<string> typeSegments = default,
+        bool omitForwarderFlag = false)
     {
         ImmutableArray<string> segments = typeSegments.IsDefault
             ? ["Type"]
@@ -2667,7 +2695,8 @@ public class TypeResolutionContextTests
                 {
                     implementation = metadata.AddExportedType(
                         segment == 0
-                            ? TypeAttributes.Public | Forwarder
+                            ? TypeAttributes.Public
+                                | (omitForwarderFlag ? 0 : Forwarder)
                             : TypeAttributes.NestedPublic,
                         segment == 0
                             ? metadata.GetOrAddString("N")


### PR DESCRIPTION
Closes #5220.

`ILInspector.Metadata` owns this focused change under
`docs/design/assembly-inspection-query.md`.

An `ExportedType` root that terminates at an `AssemblyRef` without the
Forwarder flag is now retained as a typed, row-specific API-surface inspection
failure. Resolution-aware composition keeps that precise failure instead of
adding a second broad inventory failure. Valid module exports and nested rows
beneath a marked forwarding root remain unchanged.

## Demo

This prerequisite intentionally does not change standalone product CLI output:
the existing CLI already emits a broad one-row rejection warning. It changes
the Metadata evidence consumed by #5189 from an empty surface to a typed
failure:

```text
before: forwarders=0 failures=0
after:  forwarders=0 failures=1
        operation=type forwarder identity
        token=0x27000001
        kind=MalformedMetadata
```

That lets the Research consumer distinguish incomplete metadata from a truly
absent declaration without reopening the assembly or duplicating Metadata
relationship rules.

## Validation

```text
ILInspector.Metadata.Tests: 2340 passed, 0 failed, 0 skipped
MalformedRootAdjacency_KeepsHealthySelectedTypeAndIsFatal: 2 passed
dotnet build dotnet-inspect.slnx -c Release: succeeded
npx markdownlint-cli docs/design/assembly-inspection-query.md: succeeded
git diff --check: succeeded
```
