### PR TITLE
Define binding miss name ownership

### DIFF
--- a/docs/design/models/binding-name-ownership/BindingNameOwnership.tla
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnership.tla
@@ -16,7 +16,11 @@ CONSTANTS
     Unavailable,
     Rejected,
     NoResult,
+    AssemblyReference,
+    IntrinsicCoreLibrary,
     CompositionMode,
+    TargetValidationMode,
+    ChainMode,
     FreezeMode
 
 Tiers == <<TierOne, TierTwo>>
@@ -24,15 +28,19 @@ TierSet == {TierOne, TierTwo}
 Misses == {NoNameOwner, NameOwnedNoMatch, Undifferentiated}
 TerminalResults == {Selected, Ambiguous, Unavailable, Rejected}
 PolicyResults == Misses \union TerminalResults
+Targets == {AssemblyReference, IntrinsicCoreLibrary}
 Phases == {"Selecting", "Selected", "Frozen"}
 
 ASSUME
     /\ Cardinality(TierSet) = 2
     /\ Cardinality(PolicyResults) = 7
+    /\ Cardinality(Targets) = 2
     /\ NoResult \notin PolicyResults
     /\ CompositionMode \in
         {"Policy", "FallThroughOwned", "FallThroughLegacy",
          "PrematureNoOwner"}
+    /\ TargetValidationMode \in {"Policy", "AfterComposition"}
+    /\ ChainMode \in {"Complete", "OmitEligibleTier"}
     /\ FreezeMode \in {"Policy", "CollapseMisses"}
 
 CanContinue(result) ==
@@ -44,6 +52,14 @@ CanContinue(result) ==
             result \in {NoNameOwner, Undifferentiated}
       [] OTHER -> FALSE
 
+InvalidMissing(result, requestTarget) ==
+    /\ requestTarget = IntrinsicCoreLibrary
+    /\ result \in Misses
+
+ValidateMissingNow(result, requestTarget) ==
+    /\ TargetValidationMode = "Policy"
+    /\ InvalidMissing(result, requestTarget)
+
 FrozenResult(result) ==
     IF /\ FreezeMode = "CollapseMisses"
        /\ result \in Misses
@@ -53,19 +69,26 @@ FrozenResult(result) ==
 VARIABLES
     phase,
     issued,
-    eligibleTierCount,
+    target,
+    requestEligibleTierCount,
+    configuredTierCount,
     current,
     evaluated,
     selection,
     frozen
 
 vars ==
-    <<phase, issued, eligibleTierCount, current, evaluated, selection, frozen>>
+    <<phase, issued, target, requestEligibleTierCount, configuredTierCount,
+      current, evaluated, selection, frozen>>
 
 Init ==
     /\ phase = "Selecting"
     /\ issued \in [TierSet -> PolicyResults]
-    /\ eligibleTierCount \in 1..Len(Tiers)
+    /\ target \in Targets
+    /\ requestEligibleTierCount \in 1..Len(Tiers)
+    /\ configuredTierCount \in 1..requestEligibleTierCount
+    /\ (ChainMode = "Complete" =>
+        configuredTierCount = requestEligibleTierCount)
     /\ current = 1
     /\ evaluated = <<>>
     /\ selection = NoResult
@@ -77,23 +100,32 @@ Evaluate ==
     IN
         /\ phase = "Selecting"
         /\ evaluated' = Append(evaluated, tier)
-        /\ IF /\ CanContinue(result)
-              /\ current < eligibleTierCount
+        /\ IF ValidateMissingNow(result, target)
            THEN
-                /\ current' = current + 1
-                /\ UNCHANGED <<phase, selection>>
-           ELSE
                 /\ phase' = "Selected"
                 /\ current' = current
-                /\ selection' = result
-        /\ UNCHANGED <<issued, eligibleTierCount, frozen>>
+                /\ selection' = Rejected
+           ELSE
+                IF /\ CanContinue(result)
+                   /\ current < configuredTierCount
+                THEN
+                    /\ current' = current + 1
+                    /\ UNCHANGED <<phase, selection>>
+                ELSE
+                    /\ phase' = "Selected"
+                    /\ current' = current
+                    /\ selection' = result
+        /\ UNCHANGED
+            <<issued, target, requestEligibleTierCount,
+              configuredTierCount, frozen>>
 
 Freeze ==
     /\ phase = "Selected"
     /\ phase' = "Frozen"
     /\ frozen' = FrozenResult(selection)
     /\ UNCHANGED
-        <<issued, eligibleTierCount, current, evaluated, selection>>
+        <<issued, target, requestEligibleTierCount, configuredTierCount,
+          current, evaluated, selection>>
 
 Next == Evaluate \/ Freeze
 
@@ -106,7 +138,9 @@ Spec ==
 TypeOK ==
     /\ phase \in Phases
     /\ issued \in [TierSet -> PolicyResults]
-    /\ eligibleTierCount \in 1..Len(Tiers)
+    /\ target \in Targets
+    /\ requestEligibleTierCount \in 1..Len(Tiers)
+    /\ configuredTierCount \in 1..requestEligibleTierCount
     /\ current \in 1..Len(Tiers)
     /\ evaluated \in Seq(TierSet)
     /\ Len(evaluated) <= Len(Tiers)
@@ -116,10 +150,27 @@ TypeOK ==
 OnlyNoNameOwnerReachesLowerTier ==
     Len(evaluated) = 2 => issued[TierOne] = NoNameOwner
 
+IntrinsicMissingRejectedBeforeContinuation ==
+    /\ target = IntrinsicCoreLibrary
+    /\ issued[TierOne] \in Misses
+    =>
+        /\ Len(evaluated) <= 1
+        /\ phase # "Selecting" => selection = Rejected
+
+TargetValidationPreventsHiddenSelection ==
+    /\ target = IntrinsicCoreLibrary
+    /\ requestEligibleTierCount = 2
+    /\ issued[TierOne] = NoNameOwner
+    /\ issued[TierTwo] = Selected
+    /\ phase # "Selecting"
+    =>
+        /\ Len(evaluated) = 1
+        /\ selection = Rejected
+
 CompositeNoNameOwnerRequiresCompleteExhaustion ==
     /\ phase \in {"Selected", "Frozen"}
     /\ selection = NoNameOwner
-    => Len(evaluated) = eligibleTierCount
+    => Len(evaluated) = requestEligibleTierCount
 
 NameOwnedNoMatchStops ==
     issued[TierOne] = NameOwnedNoMatch => Len(evaluated) <= 1
@@ -129,8 +180,8 @@ UndifferentiatedStops ==
 
 AllNoNameOwnerRemainsNoNameOwner ==
     /\ phase \in {"Selected", "Frozen"}
-    /\ issued[TierOne] = NoNameOwner
-    /\ \A index \in 1..eligibleTierCount:
+    /\ target = AssemblyReference
+    /\ \A index \in 1..requestEligibleTierCount:
         issued[Tiers[index]] = NoNameOwner
     => selection = NoNameOwner
 

--- a/docs/design/models/binding-name-ownership/BindingNameOwnership.tla
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnership.tla
@@ -1,0 +1,145 @@
+------------------------- MODULE BindingNameOwnership -------------------------
+EXTENDS FiniteSets, Integers, Sequences, TLC
+
+\* Owned by docs/design/type-forwarding-resolution.md.
+\* Policy owners have already issued one result for each tier under one stable
+\* version. The model owns only miss fallthrough and frozen preservation.
+
+CONSTANTS
+    TierOne,
+    TierTwo,
+    NoNameOwner,
+    NameOwnedNoMatch,
+    Undifferentiated,
+    Selected,
+    Ambiguous,
+    Unavailable,
+    Rejected,
+    NoResult,
+    CompositionMode,
+    FreezeMode
+
+Tiers == <<TierOne, TierTwo>>
+TierSet == {TierOne, TierTwo}
+Misses == {NoNameOwner, NameOwnedNoMatch, Undifferentiated}
+TerminalResults == {Selected, Ambiguous, Unavailable, Rejected}
+PolicyResults == Misses \union TerminalResults
+Phases == {"Selecting", "Selected", "Frozen"}
+
+ASSUME
+    /\ Cardinality(TierSet) = 2
+    /\ Cardinality(PolicyResults) = 7
+    /\ NoResult \notin PolicyResults
+    /\ CompositionMode \in
+        {"Policy", "FallThroughOwned", "FallThroughLegacy",
+         "PrematureNoOwner"}
+    /\ FreezeMode \in {"Policy", "CollapseMisses"}
+
+CanContinue(result) ==
+    CASE CompositionMode = "Policy" ->
+            result = NoNameOwner
+      [] CompositionMode = "FallThroughOwned" ->
+            result \in {NoNameOwner, NameOwnedNoMatch}
+      [] CompositionMode = "FallThroughLegacy" ->
+            result \in {NoNameOwner, Undifferentiated}
+      [] OTHER -> FALSE
+
+FrozenResult(result) ==
+    IF /\ FreezeMode = "CollapseMisses"
+       /\ result \in Misses
+    THEN Undifferentiated
+    ELSE result
+
+VARIABLES
+    phase,
+    issued,
+    eligibleTierCount,
+    current,
+    evaluated,
+    selection,
+    frozen
+
+vars ==
+    <<phase, issued, eligibleTierCount, current, evaluated, selection, frozen>>
+
+Init ==
+    /\ phase = "Selecting"
+    /\ issued \in [TierSet -> PolicyResults]
+    /\ eligibleTierCount \in 1..Len(Tiers)
+    /\ current = 1
+    /\ evaluated = <<>>
+    /\ selection = NoResult
+    /\ frozen = NoResult
+
+Evaluate ==
+    LET tier == Tiers[current]
+        result == issued[tier]
+    IN
+        /\ phase = "Selecting"
+        /\ evaluated' = Append(evaluated, tier)
+        /\ IF /\ CanContinue(result)
+              /\ current < eligibleTierCount
+           THEN
+                /\ current' = current + 1
+                /\ UNCHANGED <<phase, selection>>
+           ELSE
+                /\ phase' = "Selected"
+                /\ current' = current
+                /\ selection' = result
+        /\ UNCHANGED <<issued, eligibleTierCount, frozen>>
+
+Freeze ==
+    /\ phase = "Selected"
+    /\ phase' = "Frozen"
+    /\ frozen' = FrozenResult(selection)
+    /\ UNCHANGED
+        <<issued, eligibleTierCount, current, evaluated, selection>>
+
+Next == Evaluate \/ Freeze
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Evaluate)
+    /\ WF_vars(Freeze)
+
+TypeOK ==
+    /\ phase \in Phases
+    /\ issued \in [TierSet -> PolicyResults]
+    /\ eligibleTierCount \in 1..Len(Tiers)
+    /\ current \in 1..Len(Tiers)
+    /\ evaluated \in Seq(TierSet)
+    /\ Len(evaluated) <= Len(Tiers)
+    /\ selection \in PolicyResults \union {NoResult}
+    /\ frozen \in PolicyResults \union {NoResult}
+
+OnlyNoNameOwnerReachesLowerTier ==
+    Len(evaluated) = 2 => issued[TierOne] = NoNameOwner
+
+CompositeNoNameOwnerRequiresCompleteExhaustion ==
+    /\ phase \in {"Selected", "Frozen"}
+    /\ selection = NoNameOwner
+    => Len(evaluated) = eligibleTierCount
+
+NameOwnedNoMatchStops ==
+    issued[TierOne] = NameOwnedNoMatch => Len(evaluated) <= 1
+
+UndifferentiatedStops ==
+    issued[TierOne] = Undifferentiated => Len(evaluated) <= 1
+
+AllNoNameOwnerRemainsNoNameOwner ==
+    /\ phase \in {"Selected", "Frozen"}
+    /\ issued[TierOne] = NoNameOwner
+    /\ \A index \in 1..eligibleTierCount:
+        issued[Tiers[index]] = NoNameOwner
+    => selection = NoNameOwner
+
+TerminalFirstTierStops ==
+    issued[TierOne] \in TerminalResults => Len(evaluated) <= 1
+
+FrozenDispositionPreserved ==
+    phase = "Frozen" => frozen = selection
+
+SelectionConverges == <>(phase = "Frozen")
+
+=============================================================================

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenExhaustion.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenExhaustion.cfg
@@ -1,0 +1,20 @@
+\* Mutation: the composite reports no owner before exhausting eligible tiers.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "PrematureNoOwner"
+    FreezeMode = "Policy"
+
+SPECIFICATION Spec
+
+INVARIANT CompositeNoNameOwnerRequiresCompleteExhaustion

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenExhaustion.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenExhaustion.cfg
@@ -12,7 +12,11 @@ CONSTANTS
     Unavailable = unavailable
     Rejected = rejected
     NoResult = noResult
+    AssemblyReference = assemblyReference
+    IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "PrematureNoOwner"
+    TargetValidationMode = "Policy"
+    ChainMode = "Complete"
     FreezeMode = "Policy"
 
 SPECIFICATION Spec

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenFreeze.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenFreeze.cfg
@@ -1,0 +1,20 @@
+\* Mutation: frozen outcomes collapse every miss to an undifferentiated result.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "Policy"
+    FreezeMode = "CollapseMisses"
+
+SPECIFICATION Spec
+
+INVARIANT FrozenDispositionPreserved

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenLegacyFallthrough.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenLegacyFallthrough.cfg
@@ -1,0 +1,20 @@
+\* Mutation: an undifferentiated legacy miss incorrectly permits the next tier.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "FallThroughLegacy"
+    FreezeMode = "Policy"
+
+SPECIFICATION Spec
+
+INVARIANT UndifferentiatedStops

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenLegacyFallthrough.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenLegacyFallthrough.cfg
@@ -12,7 +12,11 @@ CONSTANTS
     Unavailable = unavailable
     Rejected = rejected
     NoResult = noResult
+    AssemblyReference = assemblyReference
+    IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "FallThroughLegacy"
+    TargetValidationMode = "Policy"
+    ChainMode = "Complete"
     FreezeMode = "Policy"
 
 SPECIFICATION Spec

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOmittedTier.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOmittedTier.cfg
@@ -1,4 +1,4 @@
-\* Mutation: frozen outcomes collapse every miss to an undifferentiated result.
+\* Mutation: the configured chain omits one request-eligible tier.
 CHECK_DEADLOCK FALSE
 
 CONSTANTS
@@ -16,9 +16,9 @@ CONSTANTS
     IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "Policy"
     TargetValidationMode = "Policy"
-    ChainMode = "Complete"
-    FreezeMode = "CollapseMisses"
+    ChainMode = "OmitEligibleTier"
+    FreezeMode = "Policy"
 
 SPECIFICATION Spec
 
-INVARIANT FrozenDispositionPreserved
+INVARIANT CompositeNoNameOwnerRequiresCompleteExhaustion

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOwnedFallthrough.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOwnedFallthrough.cfg
@@ -12,7 +12,11 @@ CONSTANTS
     Unavailable = unavailable
     Rejected = rejected
     NoResult = noResult
+    AssemblyReference = assemblyReference
+    IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "FallThroughOwned"
+    TargetValidationMode = "Policy"
+    ChainMode = "Complete"
     FreezeMode = "Policy"
 
 SPECIFICATION Spec

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOwnedFallthrough.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenOwnedFallthrough.cfg
@@ -1,0 +1,20 @@
+\* Mutation: a name-owned miss incorrectly permits the next tier.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "FallThroughOwned"
+    FreezeMode = "Policy"
+
+SPECIFICATION Spec
+
+INVARIANT NameOwnedNoMatchStops

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenTargetValidation.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipBrokenTargetValidation.cfg
@@ -1,4 +1,4 @@
-\* Mutation: frozen outcomes collapse every miss to an undifferentiated result.
+\* Mutation: a composite validates a target-invalid miss only after fallthrough.
 CHECK_DEADLOCK FALSE
 
 CONSTANTS
@@ -15,10 +15,10 @@ CONSTANTS
     AssemblyReference = assemblyReference
     IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "Policy"
-    TargetValidationMode = "Policy"
+    TargetValidationMode = "AfterComposition"
     ChainMode = "Complete"
-    FreezeMode = "CollapseMisses"
+    FreezeMode = "Policy"
 
 SPECIFICATION Spec
 
-INVARIANT FrozenDispositionPreserved
+INVARIANT TargetValidationPreventsHiddenSelection

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipLiveness.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipLiveness.cfg
@@ -1,0 +1,28 @@
+\* Bounded liveness exploration under weak fairness.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "Policy"
+    FreezeMode = "Policy"
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    OnlyNoNameOwnerReachesLowerTier
+    CompositeNoNameOwnerRequiresCompleteExhaustion
+    NameOwnedNoMatchStops
+    UndifferentiatedStops
+    FrozenDispositionPreserved
+
+PROPERTY SelectionConverges

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipLiveness.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipLiveness.cfg
@@ -12,7 +12,11 @@ CONSTANTS
     Unavailable = unavailable
     Rejected = rejected
     NoResult = noResult
+    AssemblyReference = assemblyReference
+    IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "Policy"
+    TargetValidationMode = "Policy"
+    ChainMode = "Complete"
     FreezeMode = "Policy"
 
 SPECIFICATION Spec
@@ -20,6 +24,7 @@ SPECIFICATION Spec
 INVARIANTS
     TypeOK
     OnlyNoNameOwnerReachesLowerTier
+    IntrinsicMissingRejectedBeforeContinuation
     CompositeNoNameOwnerRequiresCompleteExhaustion
     NameOwnedNoMatchStops
     UndifferentiatedStops

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipSafety.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipSafety.cfg
@@ -12,7 +12,11 @@ CONSTANTS
     Unavailable = unavailable
     Rejected = rejected
     NoResult = noResult
+    AssemblyReference = assemblyReference
+    IntrinsicCoreLibrary = intrinsicCoreLibrary
     CompositionMode = "Policy"
+    TargetValidationMode = "Policy"
+    ChainMode = "Complete"
     FreezeMode = "Policy"
 
 SPECIFICATION Spec
@@ -20,6 +24,8 @@ SPECIFICATION Spec
 INVARIANTS
     TypeOK
     OnlyNoNameOwnerReachesLowerTier
+    IntrinsicMissingRejectedBeforeContinuation
+    TargetValidationPreventsHiddenSelection
     CompositeNoNameOwnerRequiresCompleteExhaustion
     NameOwnedNoMatchStops
     UndifferentiatedStops

--- a/docs/design/models/binding-name-ownership/BindingNameOwnershipSafety.cfg
+++ b/docs/design/models/binding-name-ownership/BindingNameOwnershipSafety.cfg
@@ -1,0 +1,28 @@
+\* Full bounded safety exploration.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    TierOne = tierOne
+    TierTwo = tierTwo
+    NoNameOwner = noNameOwner
+    NameOwnedNoMatch = nameOwnedNoMatch
+    Undifferentiated = undifferentiated
+    Selected = selected
+    Ambiguous = ambiguous
+    Unavailable = unavailable
+    Rejected = rejected
+    NoResult = noResult
+    CompositionMode = "Policy"
+    FreezeMode = "Policy"
+
+SPECIFICATION Spec
+
+INVARIANTS
+    TypeOK
+    OnlyNoNameOwnerReachesLowerTier
+    CompositeNoNameOwnerRequiresCompleteExhaustion
+    NameOwnedNoMatchStops
+    UndifferentiatedStops
+    AllNoNameOwnerRemainsNoNameOwner
+    TerminalFirstTierStops
+    FrozenDispositionPreserved

--- a/docs/design/models/binding-name-ownership/README.md
+++ b/docs/design/models/binding-name-ownership/README.md
@@ -1,0 +1,139 @@
+# Binding name-ownership model
+
+This TLA+ model is the executable interaction companion to
+[Structured type-forwarding resolution](../../type-forwarding-resolution.md#binding-miss-name-ownership).
+It checks how one binding policy composes two already-issued tier results and
+then freezes the selected result for Metadata-owned reuse.
+
+The model answers four focused questions:
+
+- Can any result other than `NoNameOwner` invoke the next tier?
+- Does `NameOwnedNoMatch` remain authoritative?
+- Does an undifferentiated legacy miss fail closed?
+- Can a composite report `NoNameOwner` before exhausting its complete
+  request-eligible tier chain?
+- Does Metadata preserve the exact miss disposition when it freezes the
+  result?
+
+## Relationship to the product
+
+Each initial state chooses a complete request-eligible chain of one or two
+ordered policy tiers and one result for each tier: `NoNameOwner`,
+`NameOwnedNoMatch`, `Undifferentiated`, `Selected`, `Ambiguous`, `Unavailable`,
+or `Rejected`. The policy mode advances only after `NoNameOwner`; every other
+result is terminal. A composite can report `NoNameOwner` only after evaluating
+every tier in the complete chain and receiving that result from each. A second
+transition freezes the result without changing it.
+
+The two-tier bound is sufficient for the composition rule: any longer policy
+chain is repeated application of the same current-tier/next-tier decision.
+TLC explores every one-tier result and all 49 two-tier result pairs rather than
+relying on selected scenarios.
+
+## Assumptions and non-claims
+
+The model assumes each policy owner has already issued a valid result for the
+exact request under one stable policy version. It does not model how package,
+project, sibling, platform, or local owners decide name ownership; identity
+matching; candidate acquisition; platform precedence; complete eligible
+candidate domains; or workspace lifecycle.
+
+Atomic association between an answer and its governing policy version belongs
+to #5213 and is outside this model. The #5214 composition handoff may consume
+`NoNameOwner`, but its candidate-domain semantics are also outside this model.
+TLC results establish properties of this bounded state machine, not of the
+shipped implementation. Formal model-to-implementation correspondence is
+unverified.
+
+## Checked configurations
+
+| Configuration | Purpose |
+| --- | --- |
+| `BindingNameOwnershipSafety.cfg` | Explores every one- and two-tier result assignment and checks type safety, exclusive no-owner fallthrough, complete exhaustion, terminal owned and legacy misses, all-no-owner preservation, terminal success/failure behavior, and exact frozen disposition. |
+| `BindingNameOwnershipLiveness.cfg` | Checks that every complete chain and result assignment reaches a frozen terminal result under weak fairness. |
+| `BindingNameOwnershipBrokenOwnedFallthrough.cfg` | Permits `NameOwnedNoMatch` to invoke the next tier. It must violate `NameOwnedNoMatchStops`. |
+| `BindingNameOwnershipBrokenLegacyFallthrough.cfg` | Permits `Undifferentiated` to invoke the next tier. It must violate `UndifferentiatedStops`. |
+| `BindingNameOwnershipBrokenExhaustion.cfg` | Reports `NoNameOwner` before exhausting a two-tier eligible chain. It must violate `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
+| `BindingNameOwnershipBrokenFreeze.cfg` | Collapses every frozen miss to `Undifferentiated`. It must violate `FrozenDispositionPreserved`. |
+
+All configurations disable TLC's deadlock check because `Frozen` is an
+intentional terminal phase. The temporal specification permits stuttering in
+that state.
+
+## Running TLC
+
+Follow the repository
+[TLA+ setup runbook](../../../runbooks/tla-plus-setup.md) for the pinned
+toolchain. Run configurations sequentially because concurrent TLC processes
+using `-cleanup` can remove one another's metadata.
+
+```bash
+TLA_TOOLS_JAR=/path/to/tla2tools.jar
+cd docs/design/models/binding-name-ownership
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers auto -cleanup -coverage 1 \
+  -config BindingNameOwnershipSafety.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers auto -cleanup -coverage 1 \
+  -config BindingNameOwnershipLiveness.cfg \
+  BindingNameOwnership.tla
+```
+
+The mutation configurations are expected to exit unsuccessfully:
+
+```bash
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenOwnedFallthrough.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenLegacyFallthrough.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenExhaustion.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenFreeze.cfg \
+  BindingNameOwnership.tla
+```
+
+## Recorded result
+
+The positive configurations completed with no errors:
+
+| Configuration | Generated states | Distinct states | Maximum depth | Result |
+| --- | ---: | ---: | ---: | --- |
+| Safety | 301 | 301 | 4 | All eight invariants passed. |
+| Liveness | 301 | 301 | 4 | `SelectionConverges` passed. |
+
+The safety graph covers all 49 tier-result pairs for both one- and two-tier
+eligible chains. It executed 105 `Evaluate` transitions and 98 `Freeze`
+transitions, including seven paths that advanced from the first tier after
+`NoNameOwner`.
+
+Each mutation exited with TLC status 12 on its intended invariant:
+
+| Configuration | Generated / distinct | Maximum depth | Counterexample |
+| --- | ---: | ---: | --- |
+| Broken owned fallthrough | 212 / 212 | 3 | A first-tier `NameOwnedNoMatch` advanced to the second tier, violating `NameOwnedNoMatchStops`. |
+| Broken legacy fallthrough | 226 / 226 | 3 | A first-tier `Undifferentiated` result advanced to the second tier, violating `UndifferentiatedStops`. |
+| Broken complete exhaustion | 100 / 100 | 2 | A two-tier chain reported `NoNameOwner` after evaluating only its first tier, violating `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
+| Broken frozen preservation | 197 / 197 | 3 | A frozen explicit miss became `Undifferentiated`, violating `FrozenDispositionPreserved`. |
+
+The runs used the repository-pinned TLA+ v1.8.0 tools, TLC build
+`2026.08.21.155922` revision `9787e65`. The checked
+`tla2tools.jar` SHA-256 was
+`eabd140a70f49eb9305a3bd3f3df944eddf87e5a90d329789085f8953a80533a`.
+The available runtime was OpenJDK `21.0.12`; the runbook's preferred Java 25
+runtime was not installed on this shared host. Java 21 satisfies the tool's
+Java 11-or-later requirement, so the machine configuration was left unchanged
+and the runtime deviation is recorded here.

--- a/docs/design/models/binding-name-ownership/README.md
+++ b/docs/design/models/binding-name-ownership/README.md
@@ -10,6 +10,8 @@ The model answers four focused questions:
 - Can any result other than `NoNameOwner` invoke the next tier?
 - Does `NameOwnedNoMatch` remain authoritative?
 - Does an undifferentiated legacy miss fail closed?
+- Is a target-invalid intrinsic-core-library miss rejected before another tier
+  can hide it?
 - Can a composite report `NoNameOwner` before exhausting its complete
   request-eligible tier chain?
 - Does Metadata preserve the exact miss disposition when it freezes the
@@ -17,26 +19,31 @@ The model answers four focused questions:
 
 ## Relationship to the product
 
-Each initial state chooses a complete request-eligible chain of one or two
-ordered policy tiers and one result for each tier: `NoNameOwner`,
-`NameOwnedNoMatch`, `Undifferentiated`, `Selected`, `Ambiguous`, `Unavailable`,
-or `Rejected`. The policy mode advances only after `NoNameOwner`; every other
-result is terminal. A composite can report `NoNameOwner` only after evaluating
-every tier in the complete chain and receiving that result from each. A second
+Each initial state chooses an assembly-reference or intrinsic-core-library
+target, a complete request-eligible chain of one or two ordered policy tiers,
+and one result for each tier: `NoNameOwner`, `NameOwnedNoMatch`,
+`Undifferentiated`, `Selected`, `Ambiguous`, `Unavailable`, or `Rejected`.
+The policy mode validates the target before interpreting a miss, advances only
+after a valid assembly-reference `NoNameOwner`, and treats every other result
+as terminal. A composite can report `NoNameOwner` only after evaluating every
+tier in the complete chain and receiving that result from each. A second
 transition freezes the result without changing it.
 
 The two-tier bound is sufficient for the composition rule: any longer policy
 chain is repeated application of the same current-tier/next-tier decision.
-TLC explores every one-tier result and all 49 two-tier result pairs rather than
-relying on selected scenarios.
+TLC explores both targets, every one-tier result, and all 49 two-tier result
+pairs rather than relying on selected scenarios. A mutation independently
+varies the configured chain from the request-eligible chain to check that
+declared exhaustion cannot substitute for completeness.
 
 ## Assumptions and non-claims
 
-The model assumes each policy owner has already issued a valid result for the
-exact request under one stable policy version. It does not model how package,
-project, sibling, platform, or local owners decide name ownership; identity
-matching; candidate acquisition; platform precedence; complete eligible
-candidate domains; or workspace lifecycle.
+The model assumes each policy owner has issued a result for the exact request
+under one stable policy version. A policy may issue a target-invalid miss; the
+composition boundary must reject it before interpreting the disposition. The
+model does not define how package, project, sibling, platform, or local owners
+decide name ownership; identity matching; candidate acquisition; platform
+precedence; complete eligible candidate domains; or workspace lifecycle.
 
 Atomic association between an answer and its governing policy version belongs
 to #5213 and is outside this model. The #5214 composition handoff may consume
@@ -49,11 +56,13 @@ unverified.
 
 | Configuration | Purpose |
 | --- | --- |
-| `BindingNameOwnershipSafety.cfg` | Explores every one- and two-tier result assignment and checks type safety, exclusive no-owner fallthrough, complete exhaustion, terminal owned and legacy misses, all-no-owner preservation, terminal success/failure behavior, and exact frozen disposition. |
-| `BindingNameOwnershipLiveness.cfg` | Checks that every complete chain and result assignment reaches a frozen terminal result under weak fairness. |
+| `BindingNameOwnershipSafety.cfg` | Explores both targets and every one- and two-tier result assignment. It checks type safety, pre-composition target validation, exclusive no-owner fallthrough, complete exhaustion, terminal owned and legacy misses, all-no-owner preservation, terminal success/failure behavior, and exact frozen disposition. |
+| `BindingNameOwnershipLiveness.cfg` | Checks that every target, complete chain, and result assignment reaches a frozen terminal result under weak fairness. |
 | `BindingNameOwnershipBrokenOwnedFallthrough.cfg` | Permits `NameOwnedNoMatch` to invoke the next tier. It must violate `NameOwnedNoMatchStops`. |
 | `BindingNameOwnershipBrokenLegacyFallthrough.cfg` | Permits `Undifferentiated` to invoke the next tier. It must violate `UndifferentiatedStops`. |
+| `BindingNameOwnershipBrokenTargetValidation.cfg` | Interprets a target-invalid intrinsic miss before validation and allows a later tier to hide it with a selection. It must violate `TargetValidationPreventsHiddenSelection`. |
 | `BindingNameOwnershipBrokenExhaustion.cfg` | Reports `NoNameOwner` before exhausting a two-tier eligible chain. It must violate `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
+| `BindingNameOwnershipBrokenOmittedTier.cfg` | Omits a request-eligible tier from the configured chain. It must violate `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
 | `BindingNameOwnershipBrokenFreeze.cfg` | Collapses every frozen miss to `Undifferentiated`. It must violate `FrozenDispositionPreserved`. |
 
 All configurations disable TLC's deadlock check because `Frozen` is an
@@ -97,7 +106,17 @@ java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
 
 java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
   -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenTargetValidation.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
   -config BindingNameOwnershipBrokenExhaustion.cfg \
+  BindingNameOwnership.tla
+
+java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
+  -workers 1 -cleanup -noGenerateSpecTE \
+  -config BindingNameOwnershipBrokenOmittedTier.cfg \
   BindingNameOwnership.tla
 
 java -XX:+UseParallelGC -cp "$TLA_TOOLS_JAR" tlc2.TLC \
@@ -112,22 +131,24 @@ The positive configurations completed with no errors:
 
 | Configuration | Generated states | Distinct states | Maximum depth | Result |
 | --- | ---: | ---: | ---: | --- |
-| Safety | 301 | 301 | 4 | All eight invariants passed. |
-| Liveness | 301 | 301 | 4 | `SelectionConverges` passed. |
+| Safety | 595 | 595 | 4 | All ten invariants passed. |
+| Liveness | 595 | 595 | 4 | `SelectionConverges` passed. |
 
-The safety graph covers all 49 tier-result pairs for both one- and two-tier
-eligible chains. It executed 105 `Evaluate` transitions and 98 `Freeze`
-transitions, including seven paths that advanced from the first tier after
-`NoNameOwner`.
+The safety graph covers both targets and all 49 tier-result pairs for both
+one- and two-tier eligible chains. It executed 203 `Evaluate` transitions and
+196 `Freeze` transitions, including seven valid assembly-reference paths that
+advanced from the first tier after `NoNameOwner`.
 
 Each mutation exited with TLC status 12 on its intended invariant:
 
 | Configuration | Generated / distinct | Maximum depth | Counterexample |
 | --- | ---: | ---: | --- |
-| Broken owned fallthrough | 212 / 212 | 3 | A first-tier `NameOwnedNoMatch` advanced to the second tier, violating `NameOwnedNoMatchStops`. |
-| Broken legacy fallthrough | 226 / 226 | 3 | A first-tier `Undifferentiated` result advanced to the second tier, violating `UndifferentiatedStops`. |
-| Broken complete exhaustion | 100 / 100 | 2 | A two-tier chain reported `NoNameOwner` after evaluating only its first tier, violating `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
-| Broken frozen preservation | 197 / 197 | 3 | A frozen explicit miss became `Undifferentiated`, violating `FrozenDispositionPreserved`. |
+| Broken owned fallthrough | 422 / 422 | 3 | A first-tier `NameOwnedNoMatch` advanced to the second tier, violating `NameOwnedNoMatchStops`. |
+| Broken legacy fallthrough | 450 / 450 | 3 | A first-tier `Undifferentiated` result advanced to the second tier, violating `UndifferentiatedStops`. |
+| Broken target validation | 408 / 408 | 3 | An intrinsic-core-library `NoNameOwner` reached a second tier whose successful selection hid the invalid result, violating `TargetValidationPreventsHiddenSelection`. |
+| Broken complete exhaustion | 198 / 198 | 2 | A complete two-tier chain reported `NoNameOwner` after evaluating only its first tier, violating `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
+| Broken omitted tier | 296 / 296 | 2 | A configured one-tier chain omitted an independently request-eligible second tier and still reported `NoNameOwner`, violating `CompositeNoNameOwnerRequiresCompleteExhaustion`. |
+| Broken frozen preservation | 393 / 393 | 3 | A frozen explicit miss became `Undifferentiated`, violating `FrozenDispositionPreserved`. |
 
 The runs used the repository-pinned TLA+ v1.8.0 tools, TLC build
 `2026.08.21.155922` revision `9787e65`. The checked

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1161,10 +1161,12 @@ An explicit disposition is valid only for
 `AssemblyBindingTarget.AssemblyReference`, whose structured identity supplies
 the requested name. An intrinsic-core-library request has no requested
 assembly name and continues to use a selected, unavailable, or rejected
-outcome rather than a name-ownership miss. The Metadata adapter converts any
-missing result for an intrinsic-core-library request to
-`Rejected(InvalidPolicyResult)`; no public missing factory can bypass target
-validation.
+outcome rather than a name-ownership miss. Every wrapper or composite validates
+each delegated result against the original request before interpreting it. A
+missing result for an intrinsic-core-library request immediately becomes
+`Rejected(InvalidPolicyResult)` and no later tier is invoked. The Metadata
+adapter applies the same validation to a final policy result, so direct and
+composed policies share one closed rule.
 
 Only the policy owner that holds the complete frozen name-ownership decision
 for the exact request may issue `NoNameOwner` or `NameOwnedNoMatch`. This
@@ -1184,10 +1186,17 @@ Composition preserves each policy result exactly:
   frozen request-eligible tier chain and receiving `NoNameOwner` from every
   tier in that chain.
 
-That final disposition attests only that the exact composite, origin, scope,
-and version exhausted its own eligible tiers. It is not evidence that no owner
-exists globally or in a later independently owned composite. A skipped,
-unconfigured, or unevaluated eligible tier prevents the composite from issuing
+The complete request-eligible chain is an owner-attested input independent of
+the results its tiers return. A configured tier list without that completeness
+attestation is an invalid policy input and produces
+`Rejected(InvalidPolicyResult)` before a no-owner result can be issued. This
+contract consumes the closed chain and does not define how an adjacent
+workspace owner constructs or publishes it.
+
+A final `NoNameOwner` attests only that the exact composite, origin, scope, and
+version exhausted that complete chain. It is not evidence that no owner exists
+globally or in a later independently owned composite. A skipped, unconfigured,
+or unevaluated request-eligible tier prevents the composite from issuing
 `NoNameOwner`.
 
 A wrapper around `IAssemblyBindingPolicy` preserves the delegated disposition.
@@ -3679,15 +3688,21 @@ Claim: direct callers and transitive call graphs share one definition identity.
 - An external fake policy can construct every `AssemblyBindingFailureKind`.
 - An external fake policy can construct all three
   `AssemblyBindingMissDisposition` arms only through the closed missing-result
-  factories, and Metadata converts any missing intrinsic-core-library result
-  to `Rejected(InvalidPolicyResult)`.
+  factories.
+- `AssemblyBindingMissDisposition_IntrinsicMissingRejectedBeforeComposition`
+  returns each public missing result from a first tier for an
+  intrinsic-core-library request while a second tier could select. Every
+  wrapper and composite returns `Rejected(InvalidPolicyResult)` without
+  invoking that second tier, and Metadata applies the same rule to a direct
+  final result.
 - `AssemblyBindingMissDisposition_OnlyNoNameOwnerContinues` derives every
   two-tier result pair from one declaration and proves that only
   `NoNameOwner` invokes the next tier; selected, ambiguous, unavailable,
   rejected, `NameOwnedNoMatch`, and `Undifferentiated` remain terminal.
 - `AssemblyBindingMissDisposition_CompleteExhaustionRequired` proves a
-  composite cannot issue `NoNameOwner` while any request-eligible tier in its
-  frozen chain remains unevaluated.
+  composite cannot issue `NoNameOwner` when its configured chain omits an
+  independently owner-attested request-eligible tier or while any tier in the
+  complete chain remains unevaluated.
 - `AssemblyBindingMissDisposition_AllNoOwnerRemainsNoOwner` proves a complete,
   exhausted policy chain containing only `NoNameOwner` results retains that
   disposition.

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -939,6 +939,13 @@ public enum AssemblyBindingFailureKind
 public sealed record AssemblyBindingFailure(
     AssemblyBindingFailureKind Kind);
 
+public enum AssemblyBindingMissDisposition
+{
+    Undifferentiated,
+    NoNameOwner,
+    NameOwnedNoMatch
+}
+
 public sealed class AssemblyBindingPolicyVersion
 {
     public AssemblyBindingPolicyVersion() { }
@@ -993,7 +1000,14 @@ public abstract class AssemblyBindingSelection
         ResolvedAssemblyReference assembly) =>
         new Selected(assembly);
 
-    public static AssemblyBindingSelection NotFound() => new Missing();
+    public static AssemblyBindingSelection NotFound() =>
+        new Missing(AssemblyBindingMissDisposition.Undifferentiated);
+
+    public static AssemblyBindingSelection NameNotOwned() =>
+        new Missing(AssemblyBindingMissDisposition.NoNameOwner);
+
+    public static AssemblyBindingSelection NameOwnedButNoMatch() =>
+        new Missing(AssemblyBindingMissDisposition.NameOwnedNoMatch);
 
     public static AssemblyBindingSelection CannotSelect(
         AssemblyBindingFailure failure) =>
@@ -1017,7 +1031,10 @@ public abstract class AssemblyBindingSelection
 
     public sealed class Missing : AssemblyBindingSelection
     {
-        internal Missing() { }
+        internal Missing(AssemblyBindingMissDisposition disposition) =>
+            Disposition = disposition;
+
+        public AssemblyBindingMissDisposition Disposition { get; }
     }
 
     public sealed class Unavailable : AssemblyBindingSelection
@@ -1067,7 +1084,10 @@ public abstract class AssemblyBindingOutcome
 
     public sealed class Missing : AssemblyBindingOutcome
     {
-        internal Missing() { }
+        internal Missing(AssemblyBindingMissDisposition disposition) =>
+            Disposition = disposition;
+
+        public AssemblyBindingMissDisposition Disposition { get; }
     }
 
     public sealed class Unavailable : AssemblyBindingOutcome
@@ -1112,6 +1132,98 @@ internal interface IAssemblyBindingResolver
         AssemblyResolutionScope scope);
 }
 ```
+
+#### Binding miss name ownership
+
+`AssemblyBindingMissDisposition` is the policy owner's typed statement about
+one missing `AssemblyReference` request. It is scoped to the complete
+`AssemblyBindingRequest` -- target, origin, and scope -- and to the policy
+version that produced it:
+
+- `NoNameOwner` means the issuing policy's frozen ownership rule proves that
+  its tier does not own the requested assembly name for that request.
+- `NameOwnedNoMatch` means that tier owns the name but produced no candidate
+  under its own identity and scope rules.
+- `Undifferentiated` means the producer has not supplied owner-attested name
+  ownership. It preserves the current nullable/legacy meaning without
+  pretending that the name is owned or unowned.
+
+These are composition facts, not candidate evidence. `NoNameOwner` permits a
+composite policy to invoke its next policy tier or request the next composition
+step defined by #5214, but it does not establish identity eligibility,
+authorize candidate selection, or permit inactive-shadow promotion.
+`NameOwnedNoMatch` and `Undifferentiated` are terminal for composition.
+Treating `Undifferentiated` as terminal is fail-closed behavior, not evidence
+that the producer owned the name. A concrete unavailable or rejected result
+remains that typed failure; `NameOwnedNoMatch` is not a way to erase it.
+
+An explicit disposition is valid only for
+`AssemblyBindingTarget.AssemblyReference`, whose structured identity supplies
+the requested name. An intrinsic-core-library request has no requested
+assembly name and continues to use a selected, unavailable, or rejected
+outcome rather than a name-ownership miss. The Metadata adapter converts any
+missing result for an intrinsic-core-library request to
+`Rejected(InvalidPolicyResult)`; no public missing factory can bypass target
+validation.
+
+Only the policy owner that holds the complete frozen name-ownership decision
+for the exact request may issue `NoNameOwner` or `NameOwnedNoMatch`. This
+contract does not define how a package, project, sibling, platform, or local
+owner decides which names it owns. It requires that decision to be
+owner-issued; Metadata and composing policies cannot reconstruct it from
+paths, provenance, file names, candidate enumeration, or a failed identity
+match.
+
+Composition preserves each policy result exactly:
+
+- selected, ambiguous, unavailable, and rejected results are terminal;
+- `NoNameOwner` alone permits evaluation of the next tier;
+- `NameOwnedNoMatch` stops at the issuing tier;
+- `Undifferentiated` stops rather than falling through; and
+- a composite may return `NoNameOwner` only after exhausting its complete
+  frozen request-eligible tier chain and receiving `NoNameOwner` from every
+  tier in that chain.
+
+That final disposition attests only that the exact composite, origin, scope,
+and version exhausted its own eligible tiers. It is not evidence that no owner
+exists globally or in a later independently owned composite. A skipped,
+unconfigured, or unevaluated eligible tier prevents the composite from issuing
+`NoNameOwner`.
+
+A wrapper around `IAssemblyBindingPolicy` preserves the delegated disposition.
+The nullable `IAssemblyReferenceResolver` adapter cannot infer ownership from a
+null result and therefore emits `Undifferentiated`. A policy backed by a known
+empty inventory, such as `NoResolverAssemblyBindingPolicy`, may explicitly
+emit `NoNameOwner` for an assembly-reference target because that policy owns
+the complete empty decision.
+
+The Metadata adapter copies the disposition unchanged from
+`AssemblyBindingSelection.Missing` to `AssemblyBindingOutcome.Missing`.
+`AssemblyBindingSnapshot` and every frozen binding dependency include the
+disposition, so cache equality never collapses `NoNameOwner`,
+`NameOwnedNoMatch`, and `Undifferentiated`. A disposition change for an equal
+request is a policy-answer change and therefore requires a different
+`AssemblyBindingPolicyVersion`; #5213 owns the future atomic association
+between that version and the returned answer. Until that association exists,
+same-version stability is a producer obligation rather than proof that an
+observed answer was atomically governed by one observed version.
+
+Type resolution may continue to project every binding miss to
+`TypeResolutionOutcome.UnboundBinding`. This issue does not widen the type
+resolution outcome hierarchy or expose tier internals through presentation.
+
+This focused contract does not define adjacent package, project, sibling,
+platform, or local name-ownership rules; #5214's complete identity-eligible
+candidate currency; #5213's atomic answer/version association; #5216's
+workspace realization; or the #5133 successor's designated/platform role
+arbitration.
+
+The executable
+[binding name-ownership model](models/binding-name-ownership/README.md)
+checks multi-tier fallthrough, terminal owned and undifferentiated misses,
+exact disposition preservation, and eventual completion. It models policy
+results already issued under one stable version; atomic version association is
+the separate #5213 claim.
 
 A package or platform resolver normally returns one selected assembly. A local
 unordered directory containing several plausible candidates returns
@@ -1751,9 +1863,9 @@ It stores:
 - the exact `AssemblyBindingCacheKey` dependencies and their closed,
   structurally comparable `AssemblyBindingSnapshot` values.
 
-`AssemblyBindingSnapshot` contains only the binding arm, selected candidate ids,
-and typed failure payload; it never compares public outcome objects or
-descriptors. Freeze stores recipes by
+`AssemblyBindingSnapshot` contains only the binding arm, missing disposition,
+selected candidate ids, and typed failure payload; it never compares public
+outcome objects or descriptors. Freeze stores recipes by
 `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)` and materializes the
 public outcome and definition keys for that generation. A later epoch carries
 each dependency forward without a policy call while its owning policy version
@@ -3565,6 +3677,51 @@ Claim: direct callers and transitive call graphs share one definition identity.
   intrinsic-core-library binding targets; no core-library identity is
   synthesized.
 - An external fake policy can construct every `AssemblyBindingFailureKind`.
+- An external fake policy can construct all three
+  `AssemblyBindingMissDisposition` arms only through the closed missing-result
+  factories, and Metadata converts any missing intrinsic-core-library result
+  to `Rejected(InvalidPolicyResult)`.
+- `AssemblyBindingMissDisposition_OnlyNoNameOwnerContinues` derives every
+  two-tier result pair from one declaration and proves that only
+  `NoNameOwner` invokes the next tier; selected, ambiguous, unavailable,
+  rejected, `NameOwnedNoMatch`, and `Undifferentiated` remain terminal.
+- `AssemblyBindingMissDisposition_CompleteExhaustionRequired` proves a
+  composite cannot issue `NoNameOwner` while any request-eligible tier in its
+  frozen chain remains unevaluated.
+- `AssemblyBindingMissDisposition_AllNoOwnerRemainsNoOwner` proves a complete,
+  exhausted policy chain containing only `NoNameOwner` results retains that
+  disposition.
+- `AssemblyBindingMissDisposition_UndifferentiatedLegacyMissFailsClosed`
+  proves nullable resolver adapters and unchanged `NotFound()` callers cannot
+  reach a lower tier or become owner-attested evidence.
+- `AssemblyBindingMissDisposition_SurvivesInterningAndFrozenReuse` proves all
+  three dispositions remain distinct through `AssemblyBindingOutcome.Missing`,
+  structural `AssemblyBindingSnapshot` comparison, frozen recipe dependencies,
+  and unchanged-version cache reuse.
+- `AssemblyBindingMissDisposition_ObservedVersionChangeRefreshesDisposition`
+  proves a changed observed policy version refreshes a frozen miss and recipe
+  dependency rather than reusing the prior disposition. Same-version answer
+  stability remains a producer obligation; #5213 owns atomic
+  answer-to-version observation.
+- `NoResolverAssemblyBindingPolicy_ReportsNoNameOwner` proves its complete
+  empty assembly-reference inventory issues `NoNameOwner`, while its
+  intrinsic-core-library behavior remains the existing typed failure.
+- `AssemblyReferenceBindingPolicy_NullRemainsUndifferentiated` proves the
+  nullable resolver adapter neither invents ownership nor permits
+  fallthrough.
+- `KnownInventoryBindingPolicy_DistinguishesNameAbsenceFromIdentityMiss`
+  proves a complete frozen inventory reports `NoNameOwner` when the requested
+  name is absent and `NameOwnedNoMatch` when its owner-issued name domain
+  contains the name but no identity candidate is selected.
+- `AssemblyDependencyResolver_PreservesOwnerIssuedNameDisposition` covers
+  package, sibling, project, and platform close negatives without deriving
+  ownership from an empty final identity match.
+- `SourceRelativeAssemblyGroupBindingPolicy_ContinuesOnlyAfterNoNameOwner`
+  covers both global and requesting-assembly origins and proves
+  `NameOwnedNoMatch` and `Undifferentiated` remain authoritative.
+- `AssemblyBindingMissDisposition_OriginScopesRemainDistinct` proves global
+  and requesting-assembly requests can carry different owner-issued
+  dispositions and retain separate frozen cache entries.
 - Reusing the canonical descriptor, including `candidate.Assembly`, yields one
   candidate id, one inventory snapshot, at most one demanded durable session,
   and `Same` correspondence.

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -381,7 +381,7 @@ into a display string or a durable identifier.
 | --- | --- | --- | --- |
 | `TypeResolutionCatalog` | One inspection and its progressive generations | Which acquisition, declaration, stable-policy binding, and resolution-recipe caches generations share | A frozen answer set or ownership by one context |
 | `TypeResolutionContext` | One frozen catalog generation | Which manifested bindings and type requests may execute without policy or source work | Requests absent from the manifest or answers after catalog disposal |
-| `AssemblyBindingRequest`, `AssemblyBindingSelection`, and `AssemblyBindingOutcome` | One source-relative or global binding question | Which structured target policy selected and whether it resolved, missed, was unavailable, ambiguous, rejected, or requires expansion | Type lookup or hidden fallback probing |
+| `AssemblyBindingRequest`, `AssemblyBindingSelection`, and `AssemblyBindingOutcome` | One source-relative or global binding question | Which structured target policy selected and, for a miss, whether it proved no name owner, reported a name-owned mismatch, or retained an undifferentiated legacy result | Type lookup or hidden fallback probing |
 | `TypeResolutionRequest` | One resolution operation | Which typed start candidate/binding target and exact name to resolve | Decoded provenance or reusable identity |
 | `TypeResolutionRequestComparer` | One request manifest | Whether separately constructed requests occupy the same frozen manifest entry | Type correspondence, outcome equality, or cross-generation reuse |
 | `TypeResolutionOutcome` | One frozen catalog generation | The complete resolution verdict, non-success evidence, and ordered hops | Definition equality or a nullable success result |


### PR DESCRIPTION
Defines the Metadata-owned binding-miss name-ownership currency required before
assembly-binding policies can compose safely. A missing selection now
distinguishes an owner-attested `NoNameOwner`, an authoritative
`NameOwnedNoMatch`, and an `Undifferentiated` legacy result that fails closed.

**Owner:** structured type-forwarding resolution,
`docs/design/type-forwarding-resolution.md`.

**Focused claim:** only `NoNameOwner` permits the next policy tier; a composite
may issue it only after exhausting its complete frozen request-eligible chain,
every composition boundary rejects target-invalid misses before fallthrough,
and Metadata preserves the exact disposition through interned outcomes and
frozen cache dependencies.

**Supporting work:** `type-member-api-representation.md` remains a currency map.
The focused TLA+ model checks tier fallthrough, complete-chain exhaustion,
terminal legacy/owned misses, frozen preservation, and progress. #5213 retains
atomic answer/version association, #5214 retains complete identity-eligible
candidate composition, #5216 retains workspace realization, and the #5133
successor retains designated/platform role arbitration.

## Demo

Before this contract, every policy miss was the same:

```text
primary policy -> Missing -> lower tier may be consulted
```

After this contract, the owner-issued disposition controls continuation:

```text
primary policy -> NoNameOwner       -> consult the next tier
primary policy -> NameOwnedNoMatch  -> stop at the owning tier
primary policy -> Undifferentiated  -> stop; legacy evidence is insufficient
core-library   -> any Missing       -> reject before consulting another tier
```

What to notice: an ordinary no-owner case can continue without allowing a
same-name identity miss—or an unchanged nullable resolver—to fall through to a
lower-priority candidate.

## Validation

- `markdownlint` passed for all changed Markdown.
- TLA+ safety: 595 generated/distinct states, depth 4, all ten invariants
  passed.
- TLA+ liveness: 595 generated/distinct states, depth 4,
  `SelectionConverges` passed.
- Six intended-failure mutations each failed on their target invariant:
  owned-miss fallthrough, legacy-miss fallthrough, delayed target validation,
  premature no-owner exhaustion, omitted eligible tier, and
  frozen-disposition collapse.

Closes #5210.
