### PR TITLE
Add canonical adversarial review prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,27 +488,19 @@ feedback, since the settled PR still requires its full round.
 
 ### Running the round
 
-Give every reviewer the same self-contained prompt and a separate worktree.
-Review the whole head unless the user narrows scope. Reproduce findings before
-acting on them, wait for all locked-head reviews, and reconcile publicly. Word
-the prompt as a description of the property under test, not as an attack
-brief — an exploit-tutorial-style prompt can trip a model's content filter and
-fail silently (empty response, looks broken); suspect the prompt before the
-model. Follow
+Start every reviewer prompt with the complete canonical
+[adversarial-review prompt template](docs/templates/adversarial-review-prompt.md);
+do not omit, paraphrase, reorder, or precede it with domain instructions. Fill
+every placeholder with the same self-contained candidate instructions for every
+seat, and follow
 [running a round](docs/round-orchestration.md#running-a-round) for mechanics
 and reporting.
 
 ### Keep review proportional to the contract
 
-Review the invariant the design promises, not arbitrary misuse outside the
-threat model. A surviving mutation justifies a gate only when it exposes a
-plausible regression of promised behavior. Prefer outcome-level tests and
-simple, auditable enforcement over fixture seams or abstractions hardened
-against callers the contract excludes.
-
-A reviewer concern that materially expands functionality is a scope proposal,
-not a landing requirement — reject it as out of scope or record it as
-follow-up work unless the operator explicitly approves it.
+The template's finding-admission and trust-boundary rules are binding. A
+reviewer concern outside them is a scope proposal, not a landing requirement,
+unless the operator explicitly approves it.
 
 ### Stop after six rounds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,16 +489,16 @@ feedback, since the settled PR still requires its full round.
 ### Running the round
 
 Start every reviewer prompt with the complete canonical
-[adversarial-review prompt template](docs/templates/adversarial-review-prompt.md);
-do not omit, paraphrase, reorder, or precede it with domain instructions. Fill
-every placeholder with the same self-contained candidate instructions for every
-seat, and follow
+[adversarial-review prompt](docs/adversarial-review-prompt.md); do not omit,
+paraphrase, reorder, or precede it with domain instructions. Append the same
+self-contained candidate instructions for every seat, directly or with the
+optional [fill-in template](docs/templates/adversarial-review-prompt.md). Follow
 [running a round](docs/round-orchestration.md#running-a-round) for mechanics
 and reporting.
 
 ### Keep review proportional to the contract
 
-The template's finding-admission and trust-boundary rules are binding. A
+The prompt's finding-admission and trust-boundary rules are binding. A
 reviewer concern outside them is a scope proposal, not a landing requirement,
 unless the operator explicitly approves it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,9 @@ PR templates live under `docs/templates/`: `decompiler-pr.md` (raising,
 structuring, validity, fidelity, or corpus behavior), `decompiler-burndown-fix-pr.md`
 (a focused invalid-`Full` or burndown row fix), and
 `decompiler-compile-back-harness-pr.md` (compile-back harness, fidelity
-skeleton, or ReturnToSender coverage).
+skeleton, or ReturnToSender coverage). The canonical
+`adversarial-review-prompt.md` starts every non-trivial fixed-head reviewer
+prompt and carries the repository trust model and finding-admission contract.
 
 ### Design history and backlog
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,13 +115,17 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [TLA+ Methodology](tla-plus-methodology.md) | TLA+ modeling methodology and curated examples. |
 | [IL Round-trip Tests](../tests/DotnetInspector.ILRoundtrip.Tests/README.md) | Dependency restore and fast/full test commands for the IL round-trip suite. |
 
+The canonical [`adversarial-review-prompt.md`](adversarial-review-prompt.md) is
+the directly usable fixed prefix for every non-trivial reviewer prompt and
+carries the repository trust model and finding-admission contract.
+
 PR templates live under `docs/templates/`: `decompiler-pr.md` (raising,
 structuring, validity, fidelity, or corpus behavior), `decompiler-burndown-fix-pr.md`
 (a focused invalid-`Full` or burndown row fix), and
 `decompiler-compile-back-harness-pr.md` (compile-back harness, fidelity
-skeleton, or ReturnToSender coverage). The canonical
-`adversarial-review-prompt.md` starts every non-trivial fixed-head reviewer
-prompt and carries the repository trust model and finding-admission contract.
+skeleton, or ReturnToSender coverage). The optional
+[`adversarial-review-prompt.md`](templates/adversarial-review-prompt.md)
+template provides the full fill-in form.
 
 ### Design history and backlog
 

--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -64,6 +64,15 @@ contract findings. Ignore style preferences and speculative hardening. A clean
 result is successful: if no qualifying findings remain, report **CLEAN** and
 name the exact reviewed head.
 
+Do not begin review if the candidate context contains unresolved placeholders,
+names multiple normative owners, or cannot connect the supported input to the
+claimed consequence. Return the framing defect instead of inventing a broader
+review property.
+
+Treat the assigned review worktree as read-only. Do not run `git reset`,
+`git add`, or `git commit`; do not rebase or checkout another revision. Put
+scratch files under `/tmp/`. Do not modify tracked files.
+
 ## Report contract
 
 For every finding, provide:

--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -1,12 +1,4 @@
-# Adversarial review prompt template
-
-<!--
-This optional fill-in form includes the complete fixed repository review
-contract from ../adversarial-review-prompt.md. Replace every {...} placeholder,
-then append domain-specific instructions where indicated. Keep the fixed
-contract aligned with the primary prompt; do not remove, weaken, paraphrase,
-reorder, or put other instructions before it.
--->
+# Adversarial review prompt
 
 ## Repository review contract
 
@@ -72,74 +64,6 @@ contract findings. Ignore style preferences and speculative hardening. A clean
 result is successful: if no qualifying findings remain, report **CLEAN** and
 name the exact reviewed head.
 
-## Required review frame
-
-- **Normative owner:** {document and section that own the reviewed claim}
-- **Exact owned claim:** {one precise claim the change must satisfy}
-- **Supporting designs and models:** {documents and their supporting roles,
-  not additional owners}
-- **Change intent:** {what behavior or contract this candidate changes}
-- **Supported actor or caller:** {ordinary caller, producer, user, or external
-  actor relevant to the claim}
-- **Controlled or variable input:** {artifact, data, operation, event, or state
-  that reaches the component}
-- **Boundary and supported path:** {where trust or ownership changes and how
-  the input reaches the claim}
-- **Trusted parties and state:** {cooperating code, caller-owned values, local
-  environment, or other trusted context}
-- **Explicit exclusions:** {misuse and scenarios the owner does not promise to
-  defend against}
-- **Observable consequence:** {what failure a real defect would produce}
-- **Falsifier and required evidence:** {the observation and execution evidence
-  that would disprove the claim}
-
-Do not begin review if the frame uses placeholders, names multiple normative
-owners, or cannot connect the supported input to the claimed consequence.
-Return the framing defect instead of inventing a broader review property.
-
-## Candidate
-
-- **Repository:** {owner/repository}
-- **Pull request:** {number and title}
-- **Review round:** {round number}
-- **Base commit:** {full base SHA}
-- **Head commit:** {full locked head SHA}
-- **Review worktree:** {absolute isolated worktree path}
-- **Diff command:** {exact command for the base-to-head diff}
-
-Treat the worktree as read-only. Do not run `git reset`, `git add`, or
-`git commit`; do not rebase or checkout another revision. Put scratch files
-under `/tmp/`. Do not modify tracked files.
-
-## Candidate-specific context
-
-### Design intent and changed surfaces
-
-{Describe the intended behavior, relevant files, and how the change implements
-the exact owned claim.}
-
-### Properties to verify
-
-{List concrete properties derived from the review frame. Describe properties,
-not attacks, and do not broaden the actor, input, boundary, or exclusions.}
-
-### Prior findings and carried-forward obligations
-
-{List earlier findings that must be verified at this head. Distinguish accepted
-findings, dismissed findings, disclosed limitations, and out-of-scope
-proposals. Do not invite variants outside the review frame.}
-
-### Required real-run evidence
-
-{Name focused tests, commands, fixtures, corpus witnesses, mutations, or
-probes. Require evidence proportional to the claim and supported path.}
-
-### Domain-specific instructions
-
-{Append instructions needed for this subsystem. They may narrow the review or
-ask for deeper evidence, but must not weaken or broaden the repository review
-contract.}
-
 ## Report contract
 
 For every finding, provide:
@@ -154,8 +78,4 @@ For every finding, provide:
 
 Separate blocking findings from non-blocking observations and scope proposals.
 Do not turn a scope proposal into a defect by assigning it a severity. If there
-are no qualifying findings, write:
-
-```text
-CLEAN — exact head {full locked head SHA}
-```
+are no qualifying findings, write **CLEAN** and name the exact reviewed head.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -244,20 +244,21 @@ filled. One round evaluates one settled head with all required reviewers.
 ### Dispatch
 
 Start every reviewer prompt with the complete contents of
-[`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md).
+[`docs/adversarial-review-prompt.md`](adversarial-review-prompt.md).
 Read it directly before composing the prompt:
 
 ```bash
-cat docs/templates/adversarial-review-prompt.md
+cat docs/adversarial-review-prompt.md
 ```
 
 Do not summarize, paraphrase, reorder, or put candidate-specific instructions
-before the template. Replace every placeholder throughout the template,
-including the candidate's exact base and head, design intent, relevant diff,
-concrete properties under test, prior findings, and required real-run evidence.
-Add domain-specific material only in the designated section. It may narrow the
-review but must not weaken or broaden the template's trust model and
-finding-admission rules.
+before the fixed prompt. Append the candidate's exact base and head, design
+intent, relevant diff, concrete properties under test, prior findings, and
+required real-run evidence. The appended material may narrow the review but
+must not weaken or broaden the prompt's trust model and finding-admission rules.
+Agents that prefer a structured composition aid may instead fill the optional
+[`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md),
+which includes the same fixed prompt followed by candidate placeholders.
 
 Do not dispatch with a generic or incoherent frame. The prompt must name one
 normative owner and exact claim, the supported actor or caller, the controlled
@@ -269,7 +270,7 @@ cannot be filled, return to design or scope clarification before spending a
 review round.
 
 Give every seat the same completed prompt except for its worktree path. State
-candidate facts rather than rewarding findings; the canonical template already
+candidate facts rather than rewarding findings; the canonical prompt already
 makes reporting CLEAN an explicit successful outcome.
 
 Isolate every reviewer in a separate linked review worktree under the primary
@@ -285,7 +286,7 @@ so reproduce the finding and measure it before accepting its severity.
 
 ### Wording the prompt
 
-The canonical template requires a property description rather than an attack
+The canonical prompt requires a property description rather than an attack
 brief. An exploit-tutorial-style prompt can trip a model's content filter, and
 **that failure is silent**: the reviewer returns an empty or near-empty
 response with a clean worktree, which is indistinguishable from a broken model

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -243,11 +243,34 @@ filled. One round evaluates one settled head with all required reviewers.
 
 ### Dispatch
 
-Give each reviewer the same self-contained prompt: exact base and head, design
-intent, relevant diff, concrete attack points, and required real-run evidence.
+Start every reviewer prompt with the complete contents of
+[`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md).
+Read it directly before composing the prompt:
 
-State plainly that reporting CLEAN is an acceptable outcome. A prompt that only
-rewards findings will produce findings.
+```bash
+cat docs/templates/adversarial-review-prompt.md
+```
+
+Do not summarize, paraphrase, reorder, or put candidate-specific instructions
+before the template. Replace every placeholder throughout the template,
+including the candidate's exact base and head, design intent, relevant diff,
+concrete properties under test, prior findings, and required real-run evidence.
+Add domain-specific material only in the designated section. It may narrow the
+review but must not weaken or broaden the template's trust model and
+finding-admission rules.
+
+Do not dispatch with a generic or incoherent frame. The prompt must name one
+normative owner and exact claim, the supported actor or caller, the controlled
+or variable input, the boundary through which it reaches the claim, trusted
+parties and excluded scenarios, the observable consequence, and the evidence
+that would falsify the claim. For a correctness review without an untrusted
+actor, name the ordinary supported caller and input instead. If those fields
+cannot be filled, return to design or scope clarification before spending a
+review round.
+
+Give every seat the same completed prompt except for its worktree path. State
+candidate facts rather than rewarding findings; the canonical template already
+makes reporting CLEAN an explicit successful outcome.
 
 Isolate every reviewer in a separate linked review worktree under the primary
 checkout's `.worktrees/` directory or an operating-system temporary directory;
@@ -262,10 +285,11 @@ so reproduce the finding and measure it before accepting its severity.
 
 ### Wording the prompt
 
-Write the prompt as a description of the property under test. A prompt written
-as an attack brief can trip a model's content filter, and **that failure is
-silent**: the reviewer returns an empty or near-empty response with a clean
-worktree, which is indistinguishable from a broken model or a stalled harness.
+The canonical template requires a property description rather than an attack
+brief. An exploit-tutorial-style prompt can trip a model's content filter, and
+**that failure is silent**: the reviewer returns an empty or near-empty
+response with a clean worktree, which is indistinguishable from a broken model
+or a stalled harness.
 
 This has happened here, and it cost most of a day. A seat returned empty
 several times across two heads and was nearly reported to the user as a

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -1,0 +1,160 @@
+# Adversarial review prompt template
+
+<!--
+Use this complete file as the beginning of every non-trivial adversarial-review
+prompt. Replace every {...} placeholder, then append domain-specific
+instructions where indicated. Do not remove, weaken, paraphrase, reorder, or
+put other instructions before the fixed repository review contract.
+-->
+
+## Repository review contract
+
+Adversarial describes the rigor of the review, not a simulated hostile actor.
+Review the named invariant against the owning design's actual actor, input path,
+trust boundary, and supported behavior. Do not substitute a broader property
+such as "nothing can bypass this" or "every invalid state must be rejected."
+
+Unless the normative owner explicitly opts in, do not treat our own code,
+cooperating in-process callers, another contributor or agent, or a user who can
+act on the local machine as a hostile actor. Do not add findings that require
+reflection or private access, deliberate internal-state corruption, local
+symlinks or reparse points, same-machine interference, files changing during
+inspection, or deliberately authored repository states whose only path is
+reviewed code. Existing explicit controls remain in scope according to their
+owning designs.
+
+Ordinary mistakes by trusted code can still be correctness defects when they
+are reachable through a supported surface and violate the named claim. Prefer
+simple, auditable code, structured types, compiler-enforced invariants, and
+outcome-level tests. Do not demand runtime policing of trusted components or
+states that the normal type shape and code-review boundary make
+unrepresentable.
+
+For security and containment findings, identify how an actor outside the
+trusted boundary controls data that reaches the product. For ordinary
+correctness findings, identify the supported caller or producer, the ordinary
+input or state, and the promised observable behavior. A security label does not
+make a correctness concern more important.
+
+Before reporting a blocking finding, establish all of the following:
+
+1. **Actor or source:** who or what supplies the relevant input or state.
+2. **Controlled input:** the concrete value, artifact, event, or supported
+   operation that can vary.
+3. **Boundary and path:** how that input reaches the reviewed component through
+   supported behavior.
+4. **Owned claim:** the exact normative claim or required observable behavior
+   that is violated.
+5. **Consequence:** the user-visible, correctness, reliability, security, or
+   contract failure that follows.
+6. **Exact-head evidence:** a code path, focused probe, test, or execution
+   result demonstrating the consequence at the reviewed commit.
+
+If one of these elements is absent, do not present the concern as a defect.
+Classify it as a scope proposal, robustness idea, design question, or
+non-blocking observation. A concern that materially expands functionality or
+the threat model is not a landing requirement without operator approval.
+
+A mutation is useful evidence only when it represents a plausible regression
+of promised behavior. The fact that an artificial mutation survives a gate
+does not by itself justify another gate. Prefer evidence from public product
+outcomes over tests that inspect seams introduced only for the test.
+
+If the design contains substantial machinery primarily to constrain trusted
+components, report that once as a design or proportionality concern. Do not
+reward the machinery by searching indefinitely for another replay, identity,
+staleness, aliasing, or malformed-internal-state bypass.
+
+Review the whole exact head unless the prompt explicitly narrows the scope.
+Report only high-confidence, actionable correctness, security, reliability, or
+contract findings. Ignore style preferences and speculative hardening. A clean
+result is successful: if no qualifying findings remain, report **CLEAN** and
+name the exact reviewed head.
+
+## Required review frame
+
+- **Normative owner:** {document and section that own the reviewed claim}
+- **Exact owned claim:** {one precise claim the change must satisfy}
+- **Supporting designs and models:** {documents and their supporting roles,
+  not additional owners}
+- **Change intent:** {what behavior or contract this candidate changes}
+- **Supported actor or caller:** {ordinary caller, producer, user, or external
+  actor relevant to the claim}
+- **Controlled or variable input:** {artifact, data, operation, event, or state
+  that reaches the component}
+- **Boundary and supported path:** {where trust or ownership changes and how
+  the input reaches the claim}
+- **Trusted parties and state:** {cooperating code, caller-owned values, local
+  environment, or other trusted context}
+- **Explicit exclusions:** {misuse and scenarios the owner does not promise to
+  defend against}
+- **Observable consequence:** {what failure a real defect would produce}
+- **Falsifier and required evidence:** {the observation and execution evidence
+  that would disprove the claim}
+
+Do not begin review if the frame uses placeholders, names multiple normative
+owners, or cannot connect the supported input to the claimed consequence.
+Return the framing defect instead of inventing a broader review property.
+
+## Candidate
+
+- **Repository:** {owner/repository}
+- **Pull request:** {number and title}
+- **Review round:** {round number}
+- **Base commit:** {full base SHA}
+- **Head commit:** {full locked head SHA}
+- **Review worktree:** {absolute isolated worktree path}
+- **Diff command:** {exact command for the base-to-head diff}
+
+Treat the worktree as read-only. Do not run `git reset`, `git add`, or
+`git commit`; do not rebase or checkout another revision. Put scratch files
+under `/tmp/`. Do not modify tracked files.
+
+## Candidate-specific context
+
+### Design intent and changed surfaces
+
+{Describe the intended behavior, relevant files, and how the change implements
+the exact owned claim.}
+
+### Properties to verify
+
+{List concrete properties derived from the review frame. Describe properties,
+not attacks, and do not broaden the actor, input, boundary, or exclusions.}
+
+### Prior findings and carried-forward obligations
+
+{List earlier findings that must be verified at this head. Distinguish accepted
+findings, dismissed findings, disclosed limitations, and out-of-scope
+proposals. Do not invite variants outside the review frame.}
+
+### Required real-run evidence
+
+{Name focused tests, commands, fixtures, corpus witnesses, mutations, or
+probes. Require evidence proportional to the claim and supported path.}
+
+### Domain-specific instructions
+
+{Append instructions needed for this subsystem. They may narrow the review or
+ask for deeper evidence, but must not weaken or broaden the repository review
+contract.}
+
+## Report contract
+
+For every finding, provide:
+
+- severity and confidence;
+- file and line references;
+- actor or source, controlled input, boundary and supported path;
+- exact owned claim violated;
+- concrete consequence;
+- exact-head evidence or a reproducible probe; and
+- the smallest plausible fix direction.
+
+Separate blocking findings from non-blocking observations and scope proposals.
+Do not turn a scope proposal into a defect by assigning it a severity. If there
+are no qualifying findings, write:
+
+```text
+CLEAN — exact head {full locked head SHA}
+```

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -1,12 +1,4 @@
-# Adversarial review prompt template
-
-<!--
-This optional fill-in form includes the complete fixed repository review
-contract from ../adversarial-review-prompt.md. Replace every {...} placeholder,
-then append domain-specific instructions where indicated. Keep the fixed
-contract aligned with the primary prompt; do not remove, weaken, paraphrase,
-reorder, or put other instructions before it.
--->
+# Adversarial review prompt
 
 ## Repository review contract
 
@@ -72,6 +64,37 @@ contract findings. Ignore style preferences and speculative hardening. A clean
 result is successful: if no qualifying findings remain, report **CLEAN** and
 name the exact reviewed head.
 
+Do not begin review if the candidate context contains unresolved placeholders,
+names multiple normative owners, or cannot connect the supported input to the
+claimed consequence. Return the framing defect instead of inventing a broader
+review property.
+
+Treat the assigned review worktree as read-only. Do not run `git reset`,
+`git add`, or `git commit`; do not rebase or checkout another revision. Put
+scratch files under `/tmp/`. Do not modify tracked files.
+
+## Report contract
+
+For every finding, provide:
+
+- severity and confidence;
+- file and line references;
+- actor or source, controlled input, boundary and supported path;
+- exact owned claim violated;
+- concrete consequence;
+- exact-head evidence or a reproducible probe; and
+- the smallest plausible fix direction.
+
+Separate blocking findings from non-blocking observations and scope proposals.
+Do not turn a scope proposal into a defect by assigning it a severity. If there
+are no qualifying findings, write **CLEAN** and name the exact reviewed head.
+
+## Optional fill-in template
+
+Replace every `{...}` placeholder below, then append domain-specific
+instructions where indicated. Do not remove, weaken, paraphrase, reorder, or
+put other instructions before the fixed prompt above.
+
 ## Required review frame
 
 - **Normative owner:** {document and section that own the reviewed claim}
@@ -93,10 +116,6 @@ name the exact reviewed head.
 - **Falsifier and required evidence:** {the observation and execution evidence
   that would disprove the claim}
 
-Do not begin review if the frame uses placeholders, names multiple normative
-owners, or cannot connect the supported input to the claimed consequence.
-Return the framing defect instead of inventing a broader review property.
-
 ## Candidate
 
 - **Repository:** {owner/repository}
@@ -106,10 +125,6 @@ Return the framing defect instead of inventing a broader review property.
 - **Head commit:** {full locked head SHA}
 - **Review worktree:** {absolute isolated worktree path}
 - **Diff command:** {exact command for the base-to-head diff}
-
-Treat the worktree as read-only. Do not run `git reset`, `git add`, or
-`git commit`; do not rebase or checkout another revision. Put scratch files
-under `/tmp/`. Do not modify tracked files.
 
 ## Candidate-specific context
 
@@ -140,21 +155,9 @@ probes. Require evidence proportional to the claim and supported path.}
 ask for deeper evidence, but must not weaken or broaden the repository review
 contract.}
 
-## Report contract
+### Exact clean result
 
-For every finding, provide:
-
-- severity and confidence;
-- file and line references;
-- actor or source, controlled input, boundary and supported path;
-- exact owned claim violated;
-- concrete consequence;
-- exact-head evidence or a reproducible probe; and
-- the smallest plausible fix direction.
-
-Separate blocking findings from non-blocking observations and scope proposals.
-Do not turn a scope proposal into a defect by assigning it a severity. If there
-are no qualifying findings, write:
+If there are no qualifying findings, write:
 
 ```text
 CLEAN — exact head {full locked head SHA}


### PR DESCRIPTION
## Summary

- add a canonical adversarial-review prompt that is directly usable without
  substitutions
- retain the structured placeholder form as an optional template for agents
  that prefer it
- make the primary `cat` workflow and the optional template explicit in the
  binding policy and round-orchestration mechanics
- keep the fixed trust-boundary and finding-admission contract aligned across
  both forms

## Demo

The primary workflow now reads a complete prompt with no placeholders:

```console
$ grep -E '\{[^}]+\}' docs/adversarial-review-prompt.md
$ cat docs/adversarial-review-prompt.md
# Adversarial review prompt

## Repository review contract

Adversarial describes the rigor of the review, not a simulated hostile actor.
...
## Report contract

For every finding, provide:
...
```

Agents that prefer a fill-in form can instead use:

```console
$ grep -n '^## Optional fill-in template$' \
    docs/templates/adversarial-review-prompt.md
92:## Optional fill-in template
```

**What to notice:** the primary artifact can be concatenated directly with
candidate-specific context. It contains no replacement tokens. The optional
template starts with that primary artifact byte-for-byte, then adds the complete
review frame, candidate fields, domain-specific sections, and exact-head result
form.

## Design basis

- **Normative owner:** `docs/adversarial-review-prompt.md` — the directly usable
  fixed reviewer-facing trust model, finding-admission test, and report
  contract.
- **Binding policy:** `AGENTS.md#Running the round` — every non-trivial review
  begins with the complete canonical prompt.
- **Operational support:** `docs/round-orchestration.md#Dispatch` — direct
  composition, optional template use, frame completeness, identical-seat
  dispatch, and pre-dispatch scope recovery.
- **Optional composition aid:**
  `docs/templates/adversarial-review-prompt.md` — the same fixed contract plus
  the structured candidate placeholders.
- **Threat-model support:**
  `docs/design/untrusted-data-threat-model.md#Trust boundaries`.

## Compatibility

Documentation and contributor workflow only. Product code, commands, CI
behavior, reviewer roster, round eligibility, and merge rules are unchanged.
The original template remains available at its existing path.

## Validation

- `npx markdownlint-cli AGENTS.md docs/README.md
  docs/round-orchestration.md docs/adversarial-review-prompt.md
  docs/templates/adversarial-review-prompt.md`
- `wc -l AGENTS.md` — 592, below the 600-line cap
- placeholder scan proves the primary prompt contains no fill-in tokens
- byte-prefix comparison proves the template begins with the complete primary
  prompt
- `git diff --check`
- current effective base `c91ee6101f5df44b19693edf709cbf21a318fa5c`
  is the merge base of head `82d2406ed6c1c5a196e0dc9a0a42e02ba401403d`
