### PR TITLE
Define architectural contract ownership

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,8 +5,7 @@ components own contracts. An owner defines the guarantees and typed affordances
 that consumers may rely on, the requirements that implementations must uphold,
 and the behavior the contract does not promise. Consumers compose owner-issued
 identities, operations, and evidence without reconstructing stronger semantics
-from implementation details. Ownership is architectural: it is not determined
-solely by a person, project, namespace, or directory.
+from implementation details.
 
 This document maps the current implementation and its explicit migration
 boundaries to the architecture owned by the rest of the documentation set. It

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,13 @@
 # Architecture
 
+`dotnet-inspect` uses a layered architecture in which focused designs and
+components own contracts. An owner defines the guarantees and typed affordances
+that consumers may rely on, the requirements that implementations must uphold,
+and the behavior the contract does not promise. Consumers compose owner-issued
+identities, operations, and evidence without reconstructing stronger semantics
+from implementation details. Ownership is architectural: it is not determined
+solely by a person, project, namespace, or directory.
+
 This document maps the current implementation and its explicit migration
 boundaries to the architecture owned by the rest of the documentation set. It
 is a guide to composition, project boundaries, and code location; it is not an


### PR DESCRIPTION
## Summary

- define architectural owners as focused designs and components that own
  contracts
- distinguish consumer-facing guarantees and typed affordances from
  implementation obligations and explicit non-promises

This is architecture groundwork for #3629. It does not define the planned
Workspace analysis-universe handoff or make `docs/architecture.md` an umbrella
specification.

## Demo

Before, the architecture map said authority was distributed but did not define
what owning a contract meant. The opening now establishes this composition
model:

```text
focused design or component
  -> guarantees and typed affordances for consumers
  -> requirements implementations must uphold
  -> behavior the contract does not promise
```

Consumers can therefore rely on owner-issued identities, operations, and
evidence without reconstructing stronger semantics from implementation
details.

## Validation

- `npx markdownlint-cli docs/architecture.md`
- `git diff --check origin/main...HEAD`
