### PR TITLE
Scope browser pending acquisition by client

### DIFF
--- a/docs/design/browser-package-sources.md
+++ b/docs/design/browser-package-sources.md
@@ -1296,6 +1296,32 @@ and its migration:
 - changing the selected source set never reinterprets bytes from an
   unauthorized configured authority.
 
+### Browser pending-acquisition association
+
+The Browser workspace coalesces one in-flight payload transfer by exact package
+coordinate and the reference identity of the selected `IPackageSourceClient`
+handle. The key is session-local and non-persistent. Repeating a coordinate
+through the same handle shares work; a distinct handle remains distinct even
+when it reports the same producer or uses another transport for that producer.
+If package composition proves that Gallery and v3 transports implement one
+configured authority, it supplies one composed client handle rather than asking
+the Browser to infer equivalence.
+
+Producer identity remains provenance and is not pending-work authority. The
+Browser does not place its legacy `Value` or target `Key` or `Display` into the
+pending key, pass any of them to `NuGetCache.GetSourceKey`, parse them as a URL
+or local path, or consult the process working directory. The key's lifetime is
+bounded by the exact in-flight task, and completion removes only that task's
+entry.
+
+`PendingAcquisitionAssociation_UsesCoordinateAndExactClientReference` gates the
+closed key shape, same-handle equivalence, and distinct Gallery/v3 handles with
+one producer.
+`PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller` proves that
+equivalent callers share one transfer, while
+`PackageAcquisition_DistinctSameProducerClientsDoNotSharePendingTransfer`
+proves that producer equality alone cannot merge pending work.
+
 Search metadata does not authorize payload bytes from every active source.
 Candidate authority and provenance together determine which source may fulfill
 a discovered coordinate.
@@ -1969,6 +1995,12 @@ Implementation is not complete until gates prove:
   authorities, including two authorities with the same producer label; this
   end-to-end property remains unverified pending owner gates from #4797 and
   #4805;
+- Browser pending acquisition coalesces the same coordinate only through the
+  exact selected client handle and remains distinct for separate Gallery and v3
+  handles with one producer, gated by
+  `PendingAcquisitionAssociation_UsesCoordinateAndExactClientReference`,
+  `PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller`, and
+  `PackageAcquisition_DistinctSameProducerClientsDoNotSharePendingTransfer`;
 - a keyword-search/latest cache entry cannot answer complete listing-aware
   enumeration, and incomplete listing metadata cannot populate that cache;
 - source-relative listing states cover `listed`, `unlisted`, `unknown`, and

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5064,6 +5064,96 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void PendingAcquisitionAssociation_UsesCoordinateAndExactClientReference()
+    {
+        using IPackageSourceClient gallery =
+            PackageSourceClientFactory.CreateGallery();
+        using IPackageSourceClient v3 =
+            PackageSourceClientFactory.Create(
+                PackageSourceDescriptor.NuGetV3(
+                    "nuget-v3",
+                    "NuGet.org v3",
+                    new Uri("https://api.nuget.org/v3/index.json")));
+        const string coordinate = "example@1.0.0";
+
+        Assert.Equal(gallery.Identity, v3.Identity);
+        Assert.NotEqual(gallery.Kind, v3.Kind);
+
+        var galleryKey =
+            new BrowserPackageWorkspace.PendingAcquisitionKey(
+                coordinate,
+                gallery);
+        var equivalentGalleryKey =
+            new BrowserPackageWorkspace.PendingAcquisitionKey(
+                coordinate,
+                gallery);
+        var v3Key =
+            new BrowserPackageWorkspace.PendingAcquisitionKey(
+                coordinate,
+                v3);
+
+        Assert.Equal(galleryKey, equivalentGalleryKey);
+        Assert.Equal(
+            galleryKey.GetHashCode(),
+            equivalentGalleryKey.GetHashCode());
+        Assert.NotEqual(galleryKey, v3Key);
+
+        FieldInfo[] fields = typeof(
+                BrowserPackageWorkspace.PendingAcquisitionKey)
+            .GetFields(
+                BindingFlags.Instance
+                | BindingFlags.NonPublic);
+        Assert.Equal(2, fields.Length);
+        Assert.Contains(fields, field => field.FieldType == typeof(string));
+        Assert.Contains(
+            fields,
+            field => field.FieldType == typeof(IPackageSourceClient));
+    }
+
+    [Fact]
+    public async Task PackageAcquisition_DistinctSameProducerClientsDoNotSharePendingTransfer()
+    {
+        string packageId =
+            $"distinct.pending.package.{Guid.NewGuid():N}";
+        const string version = "1.0.0";
+        var stalledHandler = new StallingPackageHandler();
+        var servingHandler = new GalleryPackageHandler(
+            packageId,
+            version,
+            PackageDocuments(1));
+        using IPackageSourceClient stalledSource =
+            Gallery(stalledHandler);
+        using IPackageSourceClient servingSource =
+            Gallery(servingHandler);
+
+        Assert.Equal(stalledSource.Identity, servingSource.Identity);
+        Assert.NotSame(stalledSource, servingSource);
+
+        Task<BrowserPackage> stalled =
+            BrowserPackageWorkspace.AcquireAsync(
+                packageId,
+                version,
+                stalledSource,
+                TimeSpan.FromMilliseconds(500));
+        await stalledHandler.RequestStarted.Task.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+
+        BrowserPackage served =
+            await BrowserPackageWorkspace.AcquireAsync(
+                packageId,
+                version,
+                servingSource,
+                TimeSpan.FromSeconds(5));
+
+        Assert.Equal(packageId, served.PackageId);
+        Assert.Equal(version, served.Version);
+        await Assert.ThrowsAsync<TimeoutException>(() => stalled);
+        Assert.Equal(1, stalledHandler.Requests);
+        Assert.Single(servingHandler.Requested);
+    }
+
+    [Fact]
     public void PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent()
     {
         using var deadline =

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Text;
 using DotnetInspector.Packages;
@@ -43,6 +44,11 @@ namespace InspectWeb.Engine;
 /// and payload acquisition.
 /// <c>BrowserEngineBoundaryTests.PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller</c>
 /// gates per-caller deadlines over a shared transfer, and
+/// <c>BrowserEngineBoundaryTests.PendingAcquisitionAssociation_UsesCoordinateAndExactClientReference</c>
+/// and
+/// <c>BrowserEngineBoundaryTests.PackageAcquisition_DistinctSameProducerClientsDoNotSharePendingTransfer</c>
+/// gate Browser-owned pending-acquisition association without reparsing producer identity,
+/// and
 /// <c>BrowserEngineBoundaryTests.PackageAcquisition_ExpiredDeadlineCannotPublishReservedContent</c>
 /// gates the final monotonic check before cache publication, and
 /// <c>BrowserEngineBoundaryTests.PackageOperation_LateFailureBecomesVisibleTimeout</c>
@@ -101,8 +107,8 @@ internal static class BrowserPackageWorkspace
     static readonly Dictionary<string, PackageDownloadReservation> Reservations =
         new(StringComparer.Ordinal);
     static readonly Dictionary<string, int> Leases = new(StringComparer.Ordinal);
-    static readonly Dictionary<string, Task<AcquiredPackageSourcePayload>> PendingAcquisitions =
-        new(StringComparer.Ordinal);
+    static readonly Dictionary<PendingAcquisitionKey, Task<AcquiredPackageSourcePayload>>
+        PendingAcquisitions = [];
     static readonly HashSet<string> Downloaded = new(StringComparer.Ordinal);
     static long _clock;
 
@@ -219,8 +225,7 @@ internal static class BrowserPackageWorkspace
             resolutionCancellation.Token).ConfigureAwait(false);
 
         string key = PackageKey(coordinate.PackageId, coordinate.Version);
-        string pendingKey =
-            $"{key}@{NuGetCache.GetSourceKey(source.Identity.Value)}";
+        var pendingKey = new PendingAcquisitionKey(key, source);
         if (!PendingAcquisitions.TryGetValue(
                 pendingKey,
                 out Task<AcquiredPackageSourcePayload>? pending))
@@ -619,7 +624,7 @@ internal static class BrowserPackageWorkspace
     }
 
     static void ObserveAndRemovePendingAcquisition(
-        string key,
+        PendingAcquisitionKey key,
         Task<AcquiredPackageSourcePayload> acquisition)
     {
         _ = acquisition.ContinueWith(
@@ -638,6 +643,38 @@ internal static class BrowserPackageWorkspace
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
+    }
+
+    internal sealed class PendingAcquisitionKey
+        : IEquatable<PendingAcquisitionKey>
+    {
+        readonly string _coordinateKey;
+        readonly IPackageSourceClient _source;
+
+        internal PendingAcquisitionKey(
+            string coordinateKey,
+            IPackageSourceClient source)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(coordinateKey);
+            ArgumentNullException.ThrowIfNull(source);
+            _coordinateKey = coordinateKey;
+            _source = source;
+        }
+
+        public bool Equals(PendingAcquisitionKey? other) =>
+            other is not null
+            && _coordinateKey.Equals(
+                other._coordinateKey,
+                StringComparison.Ordinal)
+            && ReferenceEquals(_source, other._source);
+
+        public override bool Equals(object? obj) =>
+            obj is PendingAcquisitionKey other && Equals(other);
+
+        public override int GetHashCode() =>
+            HashCode.Combine(
+                StringComparer.Ordinal.GetHashCode(_coordinateKey),
+                RuntimeHelpers.GetHashCode(_source));
     }
 
     static Task<AcquiredPackageSourcePayload> AcquirePayloadWithinOperationAsync(


### PR DESCRIPTION
Closes #4805.

## Summary

Browser pending package acquisition now uses the exact selected
`IPackageSourceClient` handle as authority together with the exact coordinate.
It no longer reparses producer identity through `NuGetCache.GetSourceKey`, so
opaque producer keys cannot become working-directory-dependent local-source
keys.

Repeated callers using one client still share a transfer. Distinct clients
remain distinct even when they report the same producer; package composition
must supply one composed handle when Gallery and v3 deliberately represent one
configured authority.

## Demo

The focused gate starts one stalled Gallery transfer, then requests the same
coordinate through another Gallery client carrying the same NuGet.org producer:

```text
Before
  client A / Contoso@1.0.0: stalled
  client B / Contoso@1.0.0: joined A by producer-derived string key
  result: both callers time out

After
  client A / Contoso@1.0.0: stalled
  client B / Contoso@1.0.0: separate transfer completes
  result: B succeeds; A reaches only its own deadline

Neighbor
  client A / Contoso@1.0.0 requested twice
  result: one shared transfer, with independent caller deadlines
```

What to notice: producer equality remains provenance, not Browser pending-work
authority. The neighboring same-handle case proves coalescing was narrowed
rather than disabled.

## Ownership and compatibility

**Normative owner:** Browser Package Sources,
`docs/design/browser-package-sources.md`.

The pending key is session-local and contains only normalized coordinate text
and client reference identity. It is not serialized and does not inspect
legacy `Value`, target `Key`, target `Display`, URLs, paths, or the process
working directory.

This PR does not change NuGetFetch identity construction, desktop package cache
authorization, browser source registration, or package-source composition.

## Validation

- `PendingAcquisitionAssociation_UsesCoordinateAndExactClientReference`
- `PackageAcquisition_SharedStallIsAVisibleTimeoutForEveryCaller`
- `PackageAcquisition_DistinctSameProducerClientsDoNotSharePendingTransfer`
- `dotnet run --project prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release --no-build`: 194 passed
- `npx markdownlint-cli docs/design/browser-package-sources.md`
- `git diff --check`
