### PR TITLE
Add Dependabot version updates and enable vulnerability alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
-# Security updates are driven by Dependabot alerts and do not need an entry here.
-# These entries add scheduled version updates so a dependency is already current
-# when an advisory lands, rather than needing an upgrade under time pressure.
+# Security updates are driven by Dependabot alerts and do not need an entry
+# here. These entries add scheduled version updates, so a dependency is already
+# current when an advisory lands rather than needing an upgrade under pressure.
 #
 # Minor and patch updates are grouped per ecosystem to keep the PR volume low.
 # Major updates stay ungrouped: they are the ones that need to be read.
@@ -33,9 +33,24 @@ updates:
           - minor
           - patch
 
-  # Versions are centrally managed in Directory.Packages.props.
+  # Versions are centrally managed in Directory.Packages.props, but Dependabot
+  # only proposes an update for a package it can see referenced. Discovery from
+  # `/` expands dotnet-inspect.slnx, and 17 tracked projects are outside that
+  # solution, so the two that matter are listed explicitly:
+  #
+  #   eng/CiChangeDetection     opts out of central package management and pins
+  #                             YamlDotNet inline, so `/` governs nothing here.
+  #   inspect-web/msdl-proxy    the only referrer of the three
+  #                             Microsoft.Azure.Functions.Worker* versions, and
+  #                             it is deployed by the inspect-web workflows.
+  #
+  # The remaining 15 reference no package that an in-solution project does not
+  # already reference, so `/` covers their versions.
   - package-ecosystem: nuget
-    directory: /
+    directories:
+      - /
+      - /eng/CiChangeDetection
+      - /prototypes/inspect-web/msdl-proxy
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -53,6 +68,9 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     groups:
-      actions-all:
+      actions-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+# Security updates are driven by Dependabot alerts and do not need an entry here.
+# These entries add scheduled version updates so a dependency is already current
+# when an advisory lands, rather than needing an upgrade under time pressure.
+#
+# Minor and patch updates are grouped per ecosystem to keep the PR volume low.
+# Major updates stay ungrouped: they are the ones that need to be read.
+updates:
+  - package-ecosystem: npm
+    directory: /prototypes/inspect-web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /prototypes/annotated-source-viewer
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # Versions are centrally managed in Directory.Packages.props.
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      nuget-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Demo

Dependabot alerts were **off**, so an advisory published against a shipped
dependency would not have surfaced anywhere in this repository.

Before:

```console
$ gh api repos/richlander/dotnet-inspect/vulnerability-alerts -i | head -1
HTTP/2.0 404 Not Found

$ gh api repos/richlander/dotnet-inspect --jq '.security_and_analysis.dependabot_security_updates.status'
disabled
```

After (repository settings, applied alongside this PR):

```console
$ gh api repos/richlander/dotnet-inspect/vulnerability-alerts -i | head -1
HTTP/2.0 204 No Content

$ gh api repos/richlander/dotnet-inspect --jq '.security_and_analysis.dependabot_security_updates.status'
enabled

$ gh api "repos/richlander/dotnet-inspect/dependabot/alerts?state=open" --jq 'length'
0
```

**What that zero covers, and what it does not.** It is a real result for the 301
exactly versioned npm packages in the dependency graph, and it agrees with the
`npm audit --audit-level=info` already running in CI. Beyond npm it narrows
sharply:

| Population | In the graph | Can an alert fire? |
| --- | --- | --- |
| npm, 301 packages | exact versions | yes |
| GitHub Actions referenced by semver, 10 | exact versions | yes |
| GitHub Actions pinned by SHA, 6 | 40-hex commit | **no** — advisories match semantic versions |
| NuGet under central package management, 11 | `">= 0"` | **no** — see #5324 |
| NuGet declared inline, 1 (`YamlDotNet`) | `18.1.0` | yes |

So the zero is evidence for 312 of the 330 records, and silence for the other 18.
`Azure/static-web-apps-deploy` is worth calling out: it is referenced only by
SHA, in all three deployment workflows, so no alert can ever fire for it.

The neighbouring scenario this holds up for: `YamlDotNet` is the one NuGet
package the graph has an exact version for, and
`eng/CiChangeDetection/CiChangeDetection.csproj` is the one project that opts out
of central package management and pins it inline. The exception lands exactly
where the explanation predicts.

## Claim

Add `.github/dependabot.yml` covering every dependency ecosystem in the
repository, and enable the repository-level alert toggles that make it useful.

First of several PRs adding conventional, off-the-shelf controls this repository
was missing. It adds no bespoke gate and no new test.

## Ecosystems

| Ecosystem | Directories | Why |
| --- | --- | --- |
| npm | `/prototypes/inspect-web` | Ships to `dotnet-inspect.net`; bundles mermaid, marked, and DOMPurify |
| npm | `/prototypes/annotated-source-viewer` | Second npm project |
| nuget | `/`, `/eng/CiChangeDetection`, `/prototypes/inspect-web/msdl-proxy` | See below |
| github-actions | `/` | Actions used by the nine workflows |

NuGet needs three directories rather than one. Discovery from `/` routes through
`dotnet-inspect.slnx`, and 17 tracked projects sit outside that solution. Two are
not covered by `/` alone:

- `eng/CiChangeDetection` sets `ManagePackageVersionsCentrally=false` and pins
  `YamlDotNet` inline, so `Directory.Packages.props` governs nothing there. CI
  runs it at `ci.yml:88`.
- `prototypes/inspect-web/msdl-proxy` is the only referrer of the three
  `Microsoft.Azure.Functions.Worker*` versions, and it is deployed by
  `deploy-inspect-web.yml` and `deploy-inspect-web-coreclr.yml`.

The other 15 reference no package that an in-solution project does not already
reference, so `/` covers their versions.

Minor and patch updates are grouped so routine churn arrives as one PR per
ecosystem. Major updates stay ungrouped, because those are the ones that need to
be read.

## Boundary

- **Not a code scanner.** Dependabot reports published advisories against
  declared dependencies. It does not analyze this repository's own code; that is
  CodeQL, a separate PR.
- **Version updates are proposals.** Nothing merges automatically.
- **`open-pull-requests-limit: 5` is per entry, not per ecosystem.** npm is
  configured as two entries, so its ceiling is 10, and the NuGet entry spans
  three directories which Dependabot processes independently. The practical
  volume is far lower, because grouping collapses minor and patch updates into
  one PR and only majors arrive individually — but the configured bound is not a
  single ecosystem-wide five.
- **NuGet alert coverage is currently ineffective** — #5324. Version updates for
  NuGet are unaffected, because dependabot-core supports central package
  management natively and evaluates MSBuild rather than parsing it.
- **`NuGetAudit` is not a complete fallback.** It runs in `direct` mode for any
  project below `net10.0`, which includes the deployed `net8.0` MSDL proxy, so
  that component's transitive closure is audited by neither tool — #5364.
- **SHA-pinned Actions get version updates but never alerts**, per the table
  above.
- **CDN-loaded code is invisible by construction.** Dependabot reads manifests.
  Prism still loads from a CDN and so is outside both this and `npm audit`. That
  belongs to the CSP work, not here.
- Test-fixture projects under `eng/package-fixtures` are deliberately left out.
  Their pinned inputs are part of the fixture contract.

## Validation

```console
$ npx js-yaml .github/dependabot.yml > /tmp/dependabot.json   # parses
$ npx ajv-cli validate -s dependabot-2.0.json -d /tmp/dependabot.json --spec=draft7
/tmp/dependabot.json valid
```

Schema from `SchemaStore/schemastore`, the same schema editors use for this
filename. Schema validity is necessary but not sufficient, so the directory set,
the group semantics, and every factual claim in the file's comments were checked
against the repository directly — see the round 1 and round 2 reconciliation
comments.

No product code, test, or build change; no product build or test run.
