### PR TITLE
Define Finding value semantics contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -64,6 +64,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
 | [Finding Nomenclature](design/finding-nomenclature.md) | Canonical observation/change vocabulary, arity ladder, operation outcomes, and Research composition boundary. |
 | [Finding Producer Design](design/finding-producers.md) | Choosing producer ownership, payloads, identities, result shapes, matching modes, and higher-rung boundaries. |
+| [Finding Value Semantics](design/finding-value-equality.md) | Equality and hashing for Finding-owned structural values, ordered collections, identity sets, union cases, and operation objects. |
 | [Performance Analysis Baselines](analysis-baselines.md) | Internal baselines of what each analysis type finds over a fixed corpus, with effectiveness ratings for the one-stop-shop Performance Analysis view. |
 | [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |

--- a/docs/design/finding-adoption.md
+++ b/docs/design/finding-adoption.md
@@ -194,7 +194,7 @@ gives Finding collection records sequence- and set-aware value equality while
 keeping matching key-driven. The test that pins this behavior is
 `FindingPayloadEquality_IsProducerOwnedButMatchingRemainsKeyDriven`: equal keys
 still match while unequal payload content reports unequal, and that is correct.
-See [Finding Value Equality](finding-value-equality.md) and
+See [Finding value semantics](finding-value-equality.md) and
 [`FindingValueEquality`](../../src/ILInspector.Findings/FindingValueEquality.cs).
 
 ## 9. Retain provenance without promoting judgments

--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -14,11 +14,11 @@ how consumers use these values.
 
 ## Contract
 
-Finding-owned types expose one of four equality shapes:
+Finding-owned values compose four equality shapes:
 
 | Shape | Examples | Equality contract |
 | --- | --- | --- |
-| Structural value | `FindingSubject`, `FindingKey`, `Finding<T>`, and the cases of `PairFinding<T>` | Every equality-participating field is equal. Generic payload fields use `EqualityComparer<T>.Default`. |
+| Structural composition | `FindingSubject`, `Finding<T>`, and the cases of `PairFinding<T>` | Every equality-participating field composes its own contract. Generic payload fields use `EqualityComparer<T>.Default`. |
 | Ordered collection value | Complete censuses, match evidence, completed transition streams, and correlated occurrences | Sequence equality: order and multiplicity are significant. |
 | Identity-set value | `FindingEquivalence` allow lists | Set equality: enumeration order and duplicate input are insignificant. |
 | Operation object | `FindingCensusCorrelation<T>` and `FindingCorrelation<T>` | Reference identity. Their durable inputs and projected values retain their own contracts. |
@@ -41,6 +41,7 @@ These public collections carry sequence semantics:
 
 | Collection | Order means |
 | --- | --- |
+| `FindingKey.SoftKeys` | Producer-supplied soft-tier projection order |
 | `FindingInspection<T>.Complete.Findings` | Producer census order |
 | `FindingMatch.Edges` | Committed alignment order |
 | `FindingMatch.MoveCandidates` | Deferred move-candidate order |
@@ -53,10 +54,15 @@ equal and produce equal hash codes. Reordering elements, adding a duplicate, or
 removing a duplicate changes the value. An initialized empty array is a valid
 value; a default `ImmutableArray<T>` is not.
 
-The owning value rejects null elements where a collection contains
-Finding-owned reference values. Invalid collection state fails at construction
-or `init` with an argument exception rather than becoming a value with weaker
-equality.
+`FindingKey` permits at most one projection per named soft tier but does not
+canonicalize tier order. Soft-key order therefore affects value equality and
+hashing even though it does not become matching or correspondence authority.
+Producers that require equal keys must emit the projections deterministically.
+
+The collection-bearing constructors and properties named here reject default
+arrays and reject null elements where a collection contains Finding-owned
+reference values. Invalid collection state fails at construction or `init`
+with an argument exception rather than becoming a value with weaker equality.
 
 ## Identity sets
 
@@ -111,16 +117,17 @@ The Release test
 `src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs` verifies:
 
 - sequence equality and hashing for complete censuses, match evidence,
-  completed comparisons, and correlated occurrences;
+  Finding soft keys, completed comparisons, and correlated occurrences;
 - set equality, hashing, duplicate normalization, and comparer normalization
   for `FindingEquivalence`;
 - construction rejection for default arrays, null elements, and null sets; and
 - the boundary between producer payload equality and key-driven matching.
 
 `FindingMatch.SoftCandidates` uses the same sequence-equality path as edges and
-move candidates. Its candidate construction and ordering are covered by
-`src/ILInspector.ILDiff.Tests/FindingPilotTests.cs`; non-empty soft-candidate
-value equality does not currently have a focused test.
+move candidates. Its non-empty value equality is covered by
+`FindingMatch_UsesOrderedSequenceEquality`; candidate construction and ordering
+are covered separately by
+`src/ILInspector.ILDiff.Tests/FindingPilotTests.cs`.
 
 ## Non-claims
 

--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -1,73 +1,134 @@
-# Finding Value Equality
+# Finding value semantics
 
-Finding correspondence and .NET value equality are separate contracts.
-`FindingKey` controls cross-version correspondence. Equality answers whether
-two already-materialized information or outcome values represent the same
-content.
+This document owns .NET equality and hashing for values issued by
+`ILInspector.Findings`. Equality answers whether two already-materialized
+values carry the same content. It does not establish correspondence between
+observations.
 
-## Core collection contracts
+[Finding nomenclature](finding-nomenclature.md) defines the information and
+operation-outcome types whose values are compared. [Finding
+coordinates](finding-coordinates.md) owns subject, correspondence, ordering,
+and provenance. [Finding producer design](finding-producers.md) owns producer
+payload and comparer choices. [Finding adoption](finding-adoption.md) governs
+how consumers use these values.
 
-Public Finding records use the semantics of the collection they expose:
+## Contract
 
-| Shape | Collection meaning | Equality |
+Finding-owned types expose one of four equality shapes:
+
+| Shape | Examples | Equality contract |
 | --- | --- | --- |
-| `FindingInspection<T>.Complete.Findings` | Ordered census | Sequence equality |
-| `FindingMatch.Edges` | Ordered committed alignment | Sequence equality |
-| `FindingMatch.MoveCandidates` | Ordered candidate evidence | Sequence equality |
-| `FindingComparison<T>.Complete.Pairs` | Ordered transition stream | Sequence equality |
-| `CorrelatedFinding<T>.Occurrences` | Version-position order | Sequence equality |
-| `FindingEquivalence` allow-lists | Identity sets | Set equality |
+| Structural value | `FindingSubject`, `FindingKey`, `Finding<T>`, and the cases of `PairFinding<T>` | Every equality-participating field is equal. Generic payload fields use `EqualityComparer<T>.Default`. |
+| Ordered collection value | Complete censuses, match evidence, completed transition streams, and correlated occurrences | Sequence equality: order and multiplicity are significant. |
+| Identity-set value | `FindingEquivalence` allow lists | Set equality: enumeration order and duplicate input are insignificant. |
+| Operation object | `FindingCensusCorrelation<T>` and `FindingCorrelation<T>` | Reference identity. Their durable inputs and projected values retain their own contracts. |
 
-Sequence equality is order- and multiplicity-sensitive. Independently allocated
-arrays with equal elements are equal and produce equal hash codes. Reordering
-elements, adding a duplicate, or removing a duplicate changes the value.
-Default `ImmutableArray<T>` values are rejected at construction; empty
-initialized arrays remain valid values.
+Closed union wrappers compose the equality of their active case. Two
+`FindingInspection<T>` values, for example, are equal only when they have the
+same active case and that case's content is equal. A successful empty census is
+therefore distinct from either absence case and from failure.
 
-Set equality is independent of enumeration and construction order. Duplicate
-inputs are normalized by `ImmutableHashSet<T>` and do not change the value.
-Null sets are rejected at construction. Allow-lists normalize custom collection
-comparers to the enum's default identity comparer so equal policies cannot
-behave differently.
+Equality is transitive through nested Finding values. A
+`FindingComparison<T>.Complete` composes its ordered pairs, match evidence, and
+old/new inspections. A failed comparison composes the inspections that
+prevented matching. `CorrelatedFinding<T>` is a durable value and composes its
+correlation key with its ordered occurrences; the operation object that
+produced it remains reference-identity state.
 
-The union wrappers compose the active case's equality. Consequently,
-independently materialized inspections and comparisons are equal when their
-cases and complete ordered content are equal. `FindingCorrelation<T>` remains a
-reference-identity operation object; its durable `CorrelatedFinding<T>` value
-has collection-aware equality.
+## Ordered collections
+
+These public collections carry sequence semantics:
+
+| Collection | Order means |
+| --- | --- |
+| `FindingInspection<T>.Complete.Findings` | Producer census order |
+| `FindingMatch.Edges` | Committed alignment order |
+| `FindingMatch.MoveCandidates` | Deferred move-candidate order |
+| `FindingMatch.SoftCandidates` | Deferred soft-correspondence order |
+| `FindingComparison<T>.Complete.Pairs` | Transition-stream order |
+| `CorrelatedFinding<T>.Occurrences` | Version-position order |
+
+Independently allocated arrays with equal elements in equal positions are
+equal and produce equal hash codes. Reordering elements, adding a duplicate, or
+removing a duplicate changes the value. An initialized empty array is a valid
+value; a default `ImmutableArray<T>` is not.
+
+The owning value rejects null elements where a collection contains
+Finding-owned reference values. Invalid collection state fails at construction
+or `init` with an argument exception rather than becoming a value with weaker
+equality.
+
+## Identity sets
+
+`FindingEquivalence` policies are sets of allowed pair kinds and difference
+kinds. Equal policies remain equal regardless of input or enumeration order.
+Duplicate inputs do not change the value.
+
+Construction rejects null sets and normalizes custom collection comparers to
+the enum's default identity comparer. A caller-supplied comparer therefore
+cannot make two equal policies behave differently after construction.
+
+The set hash is order-independent and includes set cardinality. Equal sets
+produce equal hash codes.
 
 ## Payload boundary
 
-`Finding<T>` and `PairFinding<T>` compose `EqualityComparer<T>.Default`.
-Payload types therefore own their .NET equality contract. A producer record
-that contains `ImmutableArray<T>` or `ImmutableHashSet<T>` must define
-collection-aware equality if it promises semantic value equality; the generic
-Finding layer does not reinterpret opaque payloads.
+`Finding<T>` and `PairFinding<T>` compose the payload's
+`EqualityComparer<T>.Default` behavior; the Finding layer does not reinterpret
+opaque payloads. A collection-bearing producer payload that promises semantic
+value equality must define that equality itself or supply the producer
+operation with an explicit comparer.
 
 Payload equality never controls correspondence. `FindingMatcher` consumes
-`FindingKey` streams and does not call `T.Equals` or `T.GetHashCode`. Two
-findings may therefore correspond by key even when their producer-owned
-payload equality reports them as different.
+`FindingKey` streams and does not call payload equality or payload hashing. Two
+observations may therefore correspond by key while their producer-owned
+payload values are unequal.
 
-## Producer inventory
+Consumers must choose the contract they need:
 
-The current Finding payloads fall into three groups:
+- use `FindingKey` and the matcher for cross-version correspondence;
+- use Finding value equality for already-materialized content;
+- use a producer-owned comparer for a domain-specific payload equivalence; and
+- use object identity when retaining one correlation operation instance.
 
-- scalar-only value records such as `CanonicalIlOperation`,
-  `CSharpCanonicalLine`, and `DecompilerFidelityCause` already have correct
-  generated equality;
-- `MethodIdentity` and `MemberRef` carry ordered type/name arrays and define
-  sequence equality and matching hashes. `DirectCall`, `UnsafetyOccurrence`,
-  and `UnsafeEvidence` compose those leaf contracts;
-- Metadata's union payload comparison supplies its own set-oriented comparer
-  instead of relying on the payload record's generated equality.
+Substituting one of these contracts for another is a correctness error even
+when a current payload happens to make the results agree.
 
-Generic producer promotion may use `EqualityComparer<T>.Default` when no
-producer comparer is supplied. A collection-bearing payload must therefore
-either define semantic equality itself or supply the producer operation with
-an explicit comparer.
+## Hashing and lifetime
 
-Collection-bearing Analysis summaries and Research diff/composition results
-are operation or presentation outputs rather than Finding payload values. They
-are not cache or correspondence identities and retain their existing
-operation-result semantics.
+Every Finding-owned value that implements semantic equality also supplies a
+hash consistent with that equality. Sequence hashes retain order and
+multiplicity; set hashes do not depend on enumeration order.
+
+Hash codes are process-local implementation values. This design does not make
+them durable identifiers, serialized coordinates, cache keys across runtime
+versions, or evidence of correspondence. The typed identities owned by
+[Finding coordinates](finding-coordinates.md) serve those roles.
+
+## Validation status
+
+The Release test
+`src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs` verifies:
+
+- sequence equality and hashing for complete censuses, match evidence,
+  completed comparisons, and correlated occurrences;
+- set equality, hashing, duplicate normalization, and comparer normalization
+  for `FindingEquivalence`;
+- construction rejection for default arrays, null elements, and null sets; and
+- the boundary between producer payload equality and key-driven matching.
+
+`FindingMatch.SoftCandidates` uses the same sequence-equality path as edges and
+move candidates. Its candidate construction and ordering are covered by
+`src/ILInspector.ILDiff.Tests/FindingPilotTests.cs`; non-empty soft-candidate
+value equality does not currently have a focused test.
+
+## Non-claims
+
+This design does not:
+
+- define `FindingKey` correspondence, match tiers, confidence, or acceptance;
+- require semantic equality for every producer payload or operation result;
+- make equality imply stable identity, provenance, or serialization;
+- make correlation operation objects durable values; or
+- enumerate producer payload implementations, which evolve under their owning
+  producer designs and code.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -218,6 +218,9 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Finding nomenclature](design/finding-nomenclature.md): observation/change semantics, operation outcomes, and Research composition boundaries.
 - [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
 - [Finding coordinates](design/finding-coordinates.md): separation of subject identity, correspondence, optional producer order, and typed provenance.
+- [Finding value semantics](design/finding-value-equality.md): .NET equality
+  and hashing for Finding-owned structural values, ordered collections,
+  identity sets, union cases, and reference-identity operation objects.
 - [Finding adoption](design/finding-adoption.md): consumer migration, failure visibility, native-case presentation, and quality-gate rules.
 - [Source Finding producers](design/source-finding-producers.md): portable-PDB source/build-context inputs, outputs, identities, and migration boundaries.
 - [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by the opt-in `diff` section, RTS, and harnesses.

--- a/src/ILInspector.Findings/FindingCorrelation.cs
+++ b/src/ILInspector.Findings/FindingCorrelation.cs
@@ -374,6 +374,13 @@ static class FindingCorrelationValidation
         where T : notnull
     {
         ArgumentNullException.ThrowIfNull(inspections);
+        if (inspections is ImmutableArray<VersionedFindingInspection<T>> inspectionArray
+            && inspectionArray.IsDefault)
+        {
+            throw new ArgumentException(
+                "Inspections must be initialized.",
+                nameof(inspections));
+        }
 
         var evaluated = inspections.ToImmutableArray();
         if (evaluated.Any(item => item is null))

--- a/src/ILInspector.Findings/FindingKey.cs
+++ b/src/ILInspector.Findings/FindingKey.cs
@@ -80,6 +80,13 @@ public readonly record struct FindingKey
     {
         ArgumentNullException.ThrowIfNull(IdentityKey);
         ArgumentNullException.ThrowIfNull(SoftKeys);
+        if (SoftKeys is ImmutableArray<FindingSoftKey> softKeyArray
+            && softKeyArray.IsDefault)
+        {
+            throw new ArgumentException(
+                "Soft keys must be initialized.",
+                nameof(SoftKeys));
+        }
 
         var softKeys = SoftKeys.ToImmutableArray();
         if (softKeys.Any(key => key is null))

--- a/src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs
+++ b/src/ILInspector.Instructions.Tests/FindingValueEqualityTests.cs
@@ -15,6 +15,59 @@ public class FindingValueEqualityTests
     static ImmutableArray<Finding<string>> Atoms(params string[] keys)
         => [.. keys.Select(Atom)];
 
+    static FindingSoftMatchCandidate SoftCandidate(
+        int oldIndex,
+        int newIndex,
+        string tier,
+        int confidence)
+        => new(
+            oldIndex,
+            newIndex,
+            new FindingMatchProvenance(
+                new FindingMatchTier(tier, confidence),
+                confidence));
+
+    [Fact]
+    public void FindingKey_UsesOrderedSoftKeyEquality()
+    {
+        var first = new FindingKey(
+            "identity",
+            "scope",
+            [
+                new FindingSoftKey(new FindingMatchTier("name", 80), "n", "v1"),
+                new FindingSoftKey(new FindingMatchTier("shape", 70), "s", "v2"),
+            ]);
+        var equivalent = new FindingKey(
+            "identity",
+            "scope",
+            [
+                new FindingSoftKey(new FindingMatchTier("name", 80), "n", "v1"),
+                new FindingSoftKey(new FindingMatchTier("shape", 70), "s", "v2"),
+            ]);
+        var reordered = new FindingKey(
+            "identity",
+            "scope",
+            [
+                new FindingSoftKey(new FindingMatchTier("shape", 70), "s", "v2"),
+                new FindingSoftKey(new FindingMatchTier("name", 80), "n", "v1"),
+            ]);
+
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+    }
+
+    [Fact]
+    public void FindingKey_RejectsDefaultSoftKeyArray()
+    {
+        ImmutableArray<FindingSoftKey> softKeys = default;
+
+        var error = Assert.Throws<ArgumentException>(
+            () => new FindingKey("identity", null, softKeys));
+
+        Assert.Equal("SoftKeys", error.ParamName);
+    }
+
     [Fact]
     public void InspectionComplete_UsesOrderedSequenceEquality()
     {
@@ -47,7 +100,14 @@ public class FindingValueEqualityTests
             [
                 new FindingMoveCandidate(0, 1, 75, "content+scope"),
                 new FindingMoveCandidate(0, 1, 75, "content+scope"),
-            ]);
+            ])
+        {
+            SoftCandidates =
+            [
+                SoftCandidate(0, 1, "name", 80),
+                SoftCandidate(2, 3, "shape", 70),
+            ],
+        };
         var equivalent = new FindingMatch(
             [
                 new FindingEdge(FindingEdgeKind.Matched, 0, 0, 100),
@@ -56,18 +116,38 @@ public class FindingValueEqualityTests
             [
                 new FindingMoveCandidate(0, 1, 75, "content+scope"),
                 new FindingMoveCandidate(0, 1, 75, "content+scope"),
-            ]);
+            ])
+        {
+            SoftCandidates =
+            [
+                SoftCandidate(0, 1, "name", 80),
+                SoftCandidate(2, 3, "shape", 70),
+            ],
+        };
         var reordered = new FindingMatch(
             [first.Edges[1], first.Edges[0]],
-            first.MoveCandidates);
+            first.MoveCandidates)
+        {
+            SoftCandidates = first.SoftCandidates,
+        };
         var fewerDuplicates = new FindingMatch(
             first.Edges,
-            [first.MoveCandidates[0]]);
+            [first.MoveCandidates[0]])
+        {
+            SoftCandidates = first.SoftCandidates,
+        };
+        var reorderedSoftCandidates = new FindingMatch(
+            first.Edges,
+            first.MoveCandidates)
+        {
+            SoftCandidates = [first.SoftCandidates[1], first.SoftCandidates[0]],
+        };
 
         Assert.Equal(first, equivalent);
         Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
         Assert.NotEqual(first, reordered);
         Assert.NotEqual(first, fewerDuplicates);
+        Assert.NotEqual(first, reorderedSoftCandidates);
         Assert.Throws<ArgumentException>(
             () => new FindingMatch(default, []));
         Assert.Throws<ArgumentException>(
@@ -76,6 +156,8 @@ public class FindingValueEqualityTests
             () => new FindingMatch([null!], []));
         Assert.Throws<ArgumentException>(
             () => first with { MoveCandidates = default });
+        Assert.Throws<ArgumentException>(
+            () => first with { SoftCandidates = default });
     }
 
     [Fact]
@@ -160,6 +242,17 @@ public class FindingValueEqualityTests
 
         Assert.Equal(first, equivalent);
         Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+    }
+
+    [Fact]
+    public void FindingCensusCorrelation_RejectsDefaultInspectionArray()
+    {
+        ImmutableArray<VersionedFindingInspection<string>> inspections = default;
+
+        var error = Assert.Throws<ArgumentException>(
+            () => FindingCensusCorrelation<string>.Create(inspections));
+
+        Assert.Equal("inspections", error.ParamName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- establishes `docs/design/finding-value-equality.md` as the focused owner for Finding .NET equality and hashing
- aligns the contract with current soft-match candidates, `FindingKey.SoftKeys`, typed inspection topology, and reference-identity correlation operations
- rejects boxed default immutable-array inputs at the two public construction paths discovered during round 1, replacing `NullReferenceException` with argument validation
- adds focused equality and constructor tests, and exposes the design in the contributor index and Overview owner map

There is no public API surface change. Invalid `FindingKey` and correlation inputs now fail with `ArgumentException` instead of leaking `NullReferenceException`.

## Demo

Before, a visitor reached a short implementation inventory that omitted `FindingKey.SoftKeys` and `FindingMatch.SoftCandidates`, did not distinguish durable correlation values from operation objects, and was absent from the design index. A boxed default immutable array also escaped the intended constructor-validation boundary.

After, the indexed owner document starts with one decision table:

| Shape | Equality contract |
| --- | --- |
| Structural composition | Equality-participating fields compose |
| Ordered collection value | Order and multiplicity are significant |
| Identity-set value | Enumeration order and duplicate input are insignificant |
| Operation object | Reference identity |

The document names every Finding-owned sequence field, including soft-key order, and the implementation now makes the stated invalid-input failure contract true.

## Validation

- `DOTNET_ROOT="$PWD/artifacts/dotnet/11.0.100-preview.7.26381.103" "$PWD/artifacts/dotnet/11.0.100-preview.7.26381.103/dotnet" run --project src/ILInspector.Instructions.Tests -c Release` — 46 passed
- `npx markdownlint-cli docs/README.md docs/overview.md docs/design/finding-value-equality.md docs/design/finding-adoption.md`
- `git diff --check`

Closes #5322