### PR TITLE
Implement the View Facet Registry

### DIFF
--- a/docs/design/view-facet-registry.md
+++ b/docs/design/view-facet-registry.md
@@ -5,7 +5,9 @@ facets. It gives navigation, portable-definition owners, and other hosts one
 stable identity and descriptor space without turning a browser label, CLI
 section name, or command flag into a contract.
 
-This is a target contract. The registry is not implemented yet.
+The registry contract and initial inspection-lens catalog are implemented in
+`DotnetInspector.Queries`. Adjacent Navigation, workspace-definition, and host
+consumers remain separate work.
 
 ## Why this is a separate owner
 
@@ -379,7 +381,23 @@ restoration own stateful interactions.
 
 ## Implementation status
 
-The registry and gates are not implemented.
+The immutable registry, initial 16-facet catalog, private execution bindings,
+typed applicability and availability inputs, exact resolution outcomes, and
+append-only compatibility manifest are implemented by
+`ViewFacetRegistry.cs`, `InspectionViewFacetCatalog.cs`, and
+`eng/view-facet-compatibility.json`.
+
+The required contract is enforced by
+`ViewFacetRegistryTests.Catalog_IsCompleteUniqueAndDeterministicallyOrdered`,
+`ViewFacetRegistryCompatibilityTests.ShippedFacets_RetainIdentityKindAndPurpose`,
+`ViewFacetRegistryTests.RegistrationsAndBindingsAgree`,
+`ViewFacetRegistryTests.Tombstone_PreservesApplicabilityAndReturnsRetired`,
+`ViewFacetRegistryTests.StaticDiscovery_DoesNotExecuteOrAcquire`,
+`ViewFacetRegistryTests.TargetDiscovery_PreservesOrderAndFailureEvidence`,
+`ViewFacetRegistryTests.Lookup_DistinguishesEveryOutcome`,
+`ViewFacetRegistryTests.RootApplicability_PartitionsPackageAndNonPackageFacets`,
+and
+`ViewFacetRegistryTests.InitialInspectionLensInventory_MatchesContract`.
 
 Current transitional surfaces are:
 

--- a/eng/view-facet-compatibility.json
+++ b/eng/view-facet-compatibility.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "root.package-overview",
+    "kind": "Root",
+    "purpose": "Package identity, selected target, assets, and summary facts."
+  },
+  {
+    "id": "root.package-dependencies",
+    "kind": "Root",
+    "purpose": "Declared package dependencies for the selected target framework."
+  },
+  {
+    "id": "root.overview",
+    "kind": "Root",
+    "purpose": "Coordinate identity, selected target, and available structural subjects."
+  },
+  {
+    "id": "library.references",
+    "kind": "Library",
+    "purpose": "Direct assembly references for the active Library."
+  },
+  {
+    "id": "library.integrations",
+    "kind": "Library",
+    "purpose": "Framework and ecosystem integrations found in the active Library."
+  },
+  {
+    "id": "library.opportunities",
+    "kind": "Library",
+    "purpose": "Framework and ecosystem integrations the active Library could adopt."
+  },
+  {
+    "id": "library.analysis",
+    "kind": "Library",
+    "purpose": "Static analysis findings and code characteristics for the active Library."
+  },
+  {
+    "id": "library.metadata",
+    "kind": "Library",
+    "purpose": "Physical ECMA-335 metadata and PE structure for the active Library."
+  },
+  {
+    "id": "type.api",
+    "kind": "Type",
+    "purpose": "API shape and member inventory for the active Type."
+  },
+  {
+    "id": "type.metadata",
+    "kind": "Type",
+    "purpose": "Metadata records and attributes for the active Type."
+  },
+  {
+    "id": "type.source",
+    "kind": "Type",
+    "purpose": "Source or decompiled code for the active Type."
+  },
+  {
+    "id": "member.overview",
+    "kind": "Member",
+    "purpose": "Signature, documentation, and overload context for the active Member."
+  },
+  {
+    "id": "member.call-graph",
+    "kind": "Member",
+    "purpose": "Incoming and outgoing calls for the active Member."
+  },
+  {
+    "id": "member.facts",
+    "kind": "Member",
+    "purpose": "Metadata, IL, safety, and analysis facts for the active Member."
+  },
+  {
+    "id": "member.source",
+    "kind": "Member",
+    "purpose": "Source or decompiled code for the active Member."
+  },
+  {
+    "id": "member.annotated-source",
+    "kind": "Member",
+    "purpose": "Source for the active Member with product analysis annotations."
+  }
+]

--- a/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
+++ b/src/DotnetInspector.Queries.Tests/DotnetInspector.Queries.Tests.csproj
@@ -42,5 +42,7 @@
   <ItemGroup>
     <EmbeddedResource Include="..\..\eng\package-manifest-corpus.json"
                       LogicalName="DotnetInspector.Queries.Tests.PackageManifestCorpus.json" />
+    <EmbeddedResource Include="..\..\eng\view-facet-compatibility.json"
+                      LogicalName="DotnetInspector.Queries.Tests.ViewFacetCompatibility.json" />
   </ItemGroup>
 </Project>

--- a/src/DotnetInspector.Queries.Tests/ViewFacetRegistryCompatibilityTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ViewFacetRegistryCompatibilityTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed partial class ViewFacetRegistryCompatibilityTests
+{
+    [Fact]
+    public void ShippedFacets_RetainIdentityKindAndPurpose()
+    {
+        using Stream stream = typeof(ViewFacetRegistryCompatibilityTests)
+            .Assembly.GetManifestResourceStream(
+                "DotnetInspector.Queries.Tests.ViewFacetCompatibility.json")
+            ?? throw new InvalidOperationException(
+                "The View Facet Registry compatibility manifest is missing.");
+        CompatibilityEntry[] manifest =
+            JsonSerializer.Deserialize(
+                stream,
+                ViewFacetCompatibilityJsonContext.Default
+                    .CompatibilityEntryArray)
+            ?? throw new InvalidOperationException(
+                "The View Facet Registry compatibility manifest is invalid.");
+
+        ViewFacetRegistration[] registrations =
+        [
+            .. InspectionViewFacetCatalog.Registry.Registrations,
+        ];
+        Assert.Equal(
+            registrations.Select(registration =>
+                    registration.Descriptor.Id.Value)
+                .Order(),
+            manifest.Select(entry => entry.Id).Order());
+        foreach (CompatibilityEntry entry in manifest)
+        {
+            ViewFacetRegistration registration = Assert.Single(
+                registrations,
+                candidate =>
+                    candidate.Descriptor.Id.Value == entry.Id);
+            Assert.Equal(
+                entry.Kind,
+                registration.Descriptor.Kind.ToString());
+            Assert.Equal(entry.Purpose, registration.Purpose);
+        }
+    }
+
+    sealed record CompatibilityEntry(
+        [property: JsonPropertyName("id")]
+        string Id,
+        [property: JsonPropertyName("kind")]
+        string Kind,
+        [property: JsonPropertyName("purpose")]
+        string Purpose);
+
+    [JsonSerializable(typeof(CompatibilityEntry[]))]
+    sealed partial class ViewFacetCompatibilityJsonContext :
+        JsonSerializerContext;
+}

--- a/src/DotnetInspector.Queries.Tests/ViewFacetRegistryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ViewFacetRegistryTests.cs
@@ -1,0 +1,797 @@
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class ViewFacetRegistryTests
+{
+    [Fact]
+    public void Catalog_IsCompleteUniqueAndDeterministicallyOrdered()
+    {
+        ViewFacetRegistry registry = InspectionViewFacetCatalog.Registry;
+        ViewFacetDescriptor[] descriptors = [.. registry.Descriptors];
+
+        Assert.NotEmpty(descriptors);
+        Assert.Equal(
+            descriptors.Length,
+            descriptors.Select(descriptor => descriptor.Id).Distinct().Count());
+        Assert.Equal(
+            descriptors,
+            descriptors.OrderBy(descriptor => descriptor.Kind)
+                .ThenBy(descriptor => descriptor.Order));
+        Assert.Equal(
+            [
+                StructuralSubjectKind.Root,
+                StructuralSubjectKind.Library,
+                StructuralSubjectKind.Type,
+                StructuralSubjectKind.Member,
+            ],
+            descriptors.Select(descriptor => descriptor.Kind).Distinct());
+        Assert.All(
+            descriptors,
+            descriptor =>
+            {
+                Assert.InRange(
+                    descriptor.Id.Value.Length,
+                    1,
+                    ViewFacetId.MaximumLength);
+                Assert.True(
+                    ViewFacetId.TryGetKind(
+                        descriptor.Id.Value,
+                        out StructuralSubjectKind prefix));
+                Assert.Equal(descriptor.Kind, prefix);
+                Assert.False(string.IsNullOrWhiteSpace(descriptor.Title));
+                Assert.False(string.IsNullOrWhiteSpace(descriptor.Summary));
+            });
+        Assert.All(
+            descriptors.GroupBy(descriptor => descriptor.Kind),
+            group => Assert.Equal(
+                group.Count(),
+                group.Select(descriptor => descriptor.Order).Distinct().Count()));
+        Assert.Equal(
+            Enum.GetValues<ViewFacetRole>(),
+            descriptors.Where(descriptor => descriptor.Role is not null)
+                .Select(descriptor => descriptor.Role!.Value)
+                .Order());
+        Assert.All(
+            descriptors.Where(descriptor => descriptor.Role is not null)
+                .GroupBy(descriptor => descriptor.Kind),
+            group => Assert.Equal(
+                group.Count(),
+                group.Select(descriptor => descriptor.Role).Distinct().Count()));
+
+        string maximum =
+            $"root.a{new string('a', ViewFacetId.MaximumLength - 6)}";
+        Assert.Equal(
+            ViewFacetId.MaximumLength,
+            new ViewFacetId(maximum).Value.Length);
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetId($"{maximum}a"));
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetId("root.overview\n"));
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetId("Root.overview"));
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetId("root.overview "));
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetId("root.-overview"));
+    }
+
+    [Fact]
+    public void RegistrationsAndBindingsAgree()
+    {
+        ViewFacetRegistry registry = InspectionViewFacetCatalog.Registry;
+        ViewFacetRegistration[] registrations = [.. registry.Registrations];
+        ViewFacetRegistration.Active[] active =
+        [
+            .. registrations.OfType<ViewFacetRegistration.Active>(),
+        ];
+        ViewFacetRegistration.Tombstone[] tombstones =
+        [
+            .. registrations.OfType<ViewFacetRegistration.Tombstone>(),
+        ];
+
+        Assert.Equal(
+            registry.Descriptors.Select(descriptor => descriptor.Id).OrderBy(Id),
+            active.Select(registration => registration.Descriptor.Id)
+                .Concat(
+                    tombstones.Select(registration =>
+                        registration.Descriptor.Id))
+                .OrderBy(Id));
+        Assert.Equal(
+            active.Select(registration => registration.Descriptor.Id)
+                .OrderBy(Id),
+            registry.ActiveBindings.Select(binding => binding.Id).OrderBy(Id));
+        Assert.All(
+            active,
+            registration =>
+            {
+                ViewFacetExecutionBinding binding = Assert.Single(
+                    registry.ActiveBindings,
+                    candidate => candidate.Id == registration.Descriptor.Id);
+                Assert.Same(binding, registration.Binding);
+                Assert.NotNull(binding.Target);
+            });
+        Assert.All(tombstones, registration => Assert.Null(registration.Binding));
+
+        ViewFacetRegistration.Tombstone synthetic = Tombstone(
+            Descriptor(
+                "root.retired",
+                StructuralSubjectKind.Root,
+                100),
+            AppliesToPackageRoot);
+        ViewFacetRegistry syntheticRegistry = Registry([synthetic]);
+        ViewFacetOption option = Assert.Single(
+            syntheticRegistry.Discover(
+                RootTarget(ViewFacetRootKind.PackageCapable),
+                ThrowingFacts.Instance));
+        ViewFacetAvailability.Unavailable unavailable =
+            Assert.IsType<ViewFacetAvailability.Unavailable>(
+                option.Availability);
+        Assert.Equal(
+            ViewFacetUnavailabilityKind.Retired,
+            unavailable.Reason.Kind);
+        Assert.Empty(syntheticRegistry.ActiveBindings);
+
+        Assert.Throws<ArgumentException>(
+            () => new ViewFacetRegistry(
+                [Active(
+                    Descriptor(
+                        "root.active",
+                        StructuralSubjectKind.Root,
+                        100),
+                    AppliesToPackageRoot)],
+                []));
+        ViewFacetDescriptor invalidActive =
+            Descriptor(
+                "root.invalid-active",
+                StructuralSubjectKind.Root,
+                200);
+        ViewFacetRegistry invalidActiveRegistry = Registry(
+        [
+            new ViewFacetRegistration.Active(
+                invalidActive,
+                invalidActive.Summary,
+                AppliesToPackageRoot,
+                new ViewFacetExecutionBinding(
+                    invalidActive.Id,
+                    new TestExecutionTarget(invalidActive.Id)),
+                (_, _) => new ViewFacetAvailability.Unavailable(
+                    ViewFacetUnavailableReason.Retired())),
+        ]);
+        Assert.Throws<InvalidOperationException>(
+            () => invalidActiveRegistry.Discover(
+                RootTarget(ViewFacetRootKind.PackageCapable),
+                ThrowingFacts.Instance));
+    }
+
+    [Fact]
+    public void Tombstone_PreservesApplicabilityAndReturnsRetired()
+    {
+        ViewFacetRegistration.Tombstone tombstone = Tombstone(
+            Descriptor(
+                "root.retired",
+                StructuralSubjectKind.Root,
+                100),
+            AppliesToPackageRoot);
+        ViewFacetRegistry registry = Registry([tombstone]);
+
+        ViewFacetOption option = Assert.Single(
+            registry.Discover(
+                RootTarget(ViewFacetRootKind.PackageCapable),
+                ThrowingFacts.Instance));
+        ViewFacetAvailability.Unavailable unavailable =
+            Assert.IsType<ViewFacetAvailability.Unavailable>(
+                option.Availability);
+        Assert.Equal(
+            ViewFacetUnavailabilityKind.Retired,
+            unavailable.Reason.Kind);
+        Assert.Empty(
+            registry.Discover(
+                RootTarget(ViewFacetRootKind.NonPackage),
+                ThrowingFacts.Instance));
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            registry.Resolve(
+                "root.retired",
+                RootTarget(ViewFacetRootKind.NonPackage),
+                ThrowingFacts.Instance));
+    }
+
+    [Fact]
+    public void StaticDiscovery_DoesNotExecuteOrAcquire()
+    {
+        var sentinels = new NoWorkSentinels();
+        ViewFacetDescriptor descriptor =
+            Descriptor("library.static", StructuralSubjectKind.Library, 100);
+        var registration = new ViewFacetRegistration.Active(
+            descriptor,
+            descriptor.Summary,
+            AppliesToLibrary,
+            new ViewFacetExecutionBinding(
+                descriptor.Id,
+                new TestExecutionTarget(descriptor.Id)),
+            (_, _) =>
+            {
+                sentinels.TouchAll();
+                return ViewFacetAvailability.Available.Instance;
+            });
+        ViewFacetRegistry registry = Registry([registration]);
+
+        Assert.Equal(
+            registry.Descriptors,
+            Enum.GetValues<StructuralSubjectKind>()
+                .SelectMany(kind => registry.Discover(kind)));
+        Assert.All(
+            registry.Registrations,
+            registration => Assert.NotNull(registration.Descriptor));
+        sentinels.AssertUntouched();
+    }
+
+    [Fact]
+    public void TargetDiscovery_PreservesOrderAndFailureEvidence()
+    {
+        var evidence = new TestDiagnosticEvidence("decode failed");
+        ViewFacetUnavailableReason capabilityAbsent =
+            ViewFacetUnavailableReason.CapabilityAbsent(
+                "The required analysis capability is absent.");
+        ViewFacetDescriptor available =
+            Descriptor("library.available", StructuralSubjectKind.Library, 100);
+        ViewFacetDescriptor empty =
+            Descriptor("library.empty", StructuralSubjectKind.Library, 200);
+        ViewFacetDescriptor unavailable =
+            Descriptor("library.unavailable", StructuralSubjectKind.Library, 300);
+        ViewFacetDescriptor retired =
+            Descriptor("library.retired", StructuralSubjectKind.Library, 400);
+        ViewFacetDescriptor failed =
+            Descriptor("library.failed", StructuralSubjectKind.Library, 500);
+        ViewFacetDescriptor inapplicable =
+            Descriptor("root.inapplicable", StructuralSubjectKind.Root, 100);
+        var sentinels = new NoWorkSentinels();
+        var inapplicableRegistration = new ViewFacetRegistration.Active(
+            inapplicable,
+            inapplicable.Summary,
+            AppliesToPackageRoot,
+            new ViewFacetExecutionBinding(
+                inapplicable.Id,
+                new TestExecutionTarget(inapplicable.Id)),
+            (_, _) =>
+            {
+                sentinels.TouchAll();
+                return ViewFacetAvailability.Available.Instance;
+            });
+        ViewFacetRegistry registry = Registry(
+        [
+            Active(failed, AppliesToLibrary),
+            Tombstone(retired, AppliesToLibrary),
+            Active(unavailable, AppliesToLibrary),
+            Active(empty, AppliesToLibrary),
+            Active(available, AppliesToLibrary),
+            inapplicableRegistration,
+        ]);
+        ViewFacetAvailabilitySnapshot facts = new(
+        [
+            Fact(available, ViewFacetAvailability.Available.Instance),
+            Fact(empty, ViewFacetAvailability.Available.Instance),
+            Fact(
+                unavailable,
+                new ViewFacetAvailability.Unavailable(capabilityAbsent)),
+            Fact(
+                failed,
+                new ViewFacetAvailability.Failed(
+                    "The facet could not be prepared.",
+                    evidence)),
+        ]);
+
+        ViewFacetOption[] options =
+        [
+            .. registry.Discover(LibraryTarget(), facts),
+        ];
+
+        Assert.Equal(
+            [
+                available.Id,
+                empty.Id,
+                unavailable.Id,
+                retired.Id,
+                failed.Id,
+            ],
+            options.Select(option => option.Descriptor.Id));
+        Assert.IsType<ViewFacetAvailability.Available>(
+            options[0].Availability);
+        Assert.IsType<ViewFacetAvailability.Available>(
+            options[1].Availability);
+        Assert.Same(
+            capabilityAbsent,
+            Assert.IsType<ViewFacetAvailability.Unavailable>(
+                options[2].Availability).Reason);
+        Assert.Equal(
+            ViewFacetUnavailabilityKind.Retired,
+            Assert.IsType<ViewFacetAvailability.Unavailable>(
+                options[3].Availability).Reason.Kind);
+        Assert.Same(
+            evidence,
+            Assert.IsType<ViewFacetAvailability.Failed>(
+                options[4].Availability).Evidence);
+        sentinels.AssertUntouched();
+    }
+
+    [Fact]
+    public void Lookup_DistinguishesEveryOutcome()
+    {
+        var evidence = new TestDiagnosticEvidence("query failed");
+        ViewFacetUnavailableReason capabilityAbsent =
+            ViewFacetUnavailableReason.CapabilityAbsent(
+                "The required capability is absent.");
+        ViewFacetDescriptor available =
+            Descriptor("library.available", StructuralSubjectKind.Library, 100);
+        ViewFacetDescriptor unavailable =
+            Descriptor("library.unavailable", StructuralSubjectKind.Library, 200);
+        ViewFacetDescriptor failed =
+            Descriptor("library.failed", StructuralSubjectKind.Library, 300);
+        ViewFacetDescriptor wrongSubject =
+            Descriptor("root.wrong-subject", StructuralSubjectKind.Root, 100);
+        var sentinels = new NoWorkSentinels();
+        var wrongSubjectRegistration = new ViewFacetRegistration.Active(
+            wrongSubject,
+            wrongSubject.Summary,
+            AppliesToPackageRoot,
+            new ViewFacetExecutionBinding(
+                wrongSubject.Id,
+                new TestExecutionTarget(wrongSubject.Id)),
+            (_, _) =>
+            {
+                sentinels.TouchAll();
+                return ViewFacetAvailability.Available.Instance;
+            });
+        ViewFacetRegistry registry = Registry(
+        [
+            Active(available, AppliesToLibrary),
+            Active(unavailable, AppliesToLibrary),
+            Active(failed, AppliesToLibrary),
+            wrongSubjectRegistration,
+        ]);
+        ViewFacetAvailabilitySnapshot facts = new(
+        [
+            Fact(available, ViewFacetAvailability.Available.Instance),
+            Fact(
+                unavailable,
+                new ViewFacetAvailability.Unavailable(capabilityAbsent)),
+            Fact(
+                failed,
+                new ViewFacetAvailability.Failed(
+                    "The facet could not be prepared.",
+                    evidence)),
+        ]);
+        ViewFacetTarget target = LibraryTarget();
+
+        Assert.True(
+            registry.TryGetDescriptor(
+                "library.available",
+                out ViewFacetDescriptor? knownDescriptor));
+        Assert.Same(available, knownDescriptor);
+        Assert.False(
+            registry.TryGetDescriptor(
+                "library.unknown",
+                out ViewFacetDescriptor? validUnknownDescriptor));
+        Assert.Null(validUnknownDescriptor);
+        Assert.False(
+            registry.TryGetDescriptor(
+                "library.unknown\n",
+                out ViewFacetDescriptor? invalidUnknownDescriptor));
+        Assert.Null(invalidUnknownDescriptor);
+        Assert.IsType<ViewFacetResolution.Available>(
+            registry.Resolve("library.available", target, facts));
+        ViewFacetResolution.Unavailable unavailableResult =
+            Assert.IsType<ViewFacetResolution.Unavailable>(
+                registry.Resolve("library.unavailable", target, facts));
+        Assert.Same(capabilityAbsent, unavailableResult.Reason);
+        ViewFacetResolution.Failed failedResult =
+            Assert.IsType<ViewFacetResolution.Failed>(
+                registry.Resolve("library.failed", target, facts));
+        Assert.Same(evidence, failedResult.Evidence);
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            registry.Resolve(
+                "root.wrong-subject",
+                target,
+                ThrowingFacts.Instance));
+        Assert.IsType<ViewFacetResolution.Unknown>(
+            registry.Resolve(
+                "library.unknown",
+                target,
+                ThrowingFacts.Instance));
+        Assert.IsType<ViewFacetResolution.Unknown>(
+            registry.Resolve(
+                "library.unknown\n",
+                target,
+                ThrowingFacts.Instance));
+        sentinels.AssertUntouched();
+    }
+
+    [Fact]
+    public void RootApplicability_PartitionsPackageAndNonPackageFacets()
+    {
+        ViewFacetRegistry registry = InspectionViewFacetCatalog.Registry;
+        ViewFacetTarget package =
+            RootTarget(ViewFacetRootKind.PackageCapable);
+        ViewFacetTarget nonPackage =
+            RootTarget(ViewFacetRootKind.NonPackage);
+        ViewFacetAvailabilitySnapshot facts = AllAvailable(registry);
+
+        Assert.Equal(
+            [
+                "root.package-overview",
+                "root.package-dependencies",
+            ],
+            registry.Discover(package, facts)
+                .Select(option => option.Descriptor.Id.Value));
+        Assert.Equal(
+            ["root.overview"],
+            registry.Discover(nonPackage, facts)
+                .Select(option => option.Descriptor.Id.Value));
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            registry.Resolve("root.overview", package, ThrowingFacts.Instance));
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            registry.Resolve(
+                "root.package-overview",
+                nonPackage,
+                ThrowingFacts.Instance));
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            registry.Resolve(
+                "root.package-dependencies",
+                nonPackage,
+                ThrowingFacts.Instance));
+    }
+
+    [Fact]
+    public void InitialInspectionLensInventory_MatchesContract()
+    {
+        ViewFacetRegistry registry = InspectionViewFacetCatalog.Registry;
+        ExpectedFacet[] expected =
+        [
+            new("root.package-overview", StructuralSubjectKind.Root, "Overview",
+                "Package identity, selected target, assets, and summary facts.",
+                100, ViewFacetRole.PackageOverview, ViewFacetRootKind.PackageCapable),
+            new("root.package-dependencies", StructuralSubjectKind.Root, "Dependencies",
+                "Declared package dependencies for the selected target framework.",
+                200, null, ViewFacetRootKind.PackageCapable),
+            new("root.overview", StructuralSubjectKind.Root, "Overview",
+                "Coordinate identity, selected target, and available structural subjects.",
+                300, ViewFacetRole.RootOverview, ViewFacetRootKind.NonPackage),
+            new("library.references", StructuralSubjectKind.Library, "References",
+                "Direct assembly references for the active Library.",
+                100, ViewFacetRole.LibraryReferences),
+            new("library.integrations", StructuralSubjectKind.Library, "Integrations",
+                "Framework and ecosystem integrations found in the active Library.",
+                200),
+            new("library.opportunities", StructuralSubjectKind.Library, "Opportunities",
+                "Framework and ecosystem integrations the active Library could adopt.",
+                300),
+            new("library.analysis", StructuralSubjectKind.Library, "Analysis",
+                "Static analysis findings and code characteristics for the active Library.",
+                400),
+            new("library.metadata", StructuralSubjectKind.Library, "Metadata",
+                "Physical ECMA-335 metadata and PE structure for the active Library.",
+                500),
+            new("type.api", StructuralSubjectKind.Type, "API",
+                "API shape and member inventory for the active Type.",
+                100, ViewFacetRole.TypeApi),
+            new("type.metadata", StructuralSubjectKind.Type, "Metadata",
+                "Metadata records and attributes for the active Type.",
+                200),
+            new("type.source", StructuralSubjectKind.Type, "Source",
+                "Source or decompiled code for the active Type.",
+                300),
+            new("member.overview", StructuralSubjectKind.Member, "Overview",
+                "Signature, documentation, and overload context for the active Member.",
+                100, ViewFacetRole.MemberOverview),
+            new("member.call-graph", StructuralSubjectKind.Member, "Call graph",
+                "Incoming and outgoing calls for the active Member.",
+                200),
+            new("member.facts", StructuralSubjectKind.Member, "Facts",
+                "Metadata, IL, safety, and analysis facts for the active Member.",
+                300),
+            new("member.source", StructuralSubjectKind.Member, "Source",
+                "Source or decompiled code for the active Member.",
+                400),
+            new("member.annotated-source", StructuralSubjectKind.Member, "Annotated source",
+                "Source for the active Member with product analysis annotations.",
+                500),
+        ];
+
+        Assert.Equal(
+            expected.Select(item => item.Descriptor),
+            registry.Descriptors.Select(descriptor => new DescriptorShape(
+                descriptor.Id.Value,
+                descriptor.Kind,
+                descriptor.Title,
+                descriptor.Summary,
+                descriptor.Order,
+                descriptor.Role)));
+        Assert.Equal(
+            new (string Id, InspectionViewFacetExecution Target)[]
+            {
+                ("root.package-overview",
+                    InspectionViewFacetExecution.PackageOverview),
+                ("root.package-dependencies",
+                    InspectionViewFacetExecution.PackageDependencies),
+                ("root.overview",
+                    InspectionViewFacetExecution.RootOverview),
+                ("library.references",
+                    InspectionViewFacetExecution.LibraryReferences),
+                ("library.integrations",
+                    InspectionViewFacetExecution.LibraryIntegrations),
+                ("library.opportunities",
+                    InspectionViewFacetExecution.LibraryOpportunities),
+                ("library.analysis",
+                    InspectionViewFacetExecution.LibraryAnalysis),
+                ("library.metadata",
+                    InspectionViewFacetExecution.LibraryMetadata),
+                ("type.api",
+                    InspectionViewFacetExecution.TypeApi),
+                ("type.metadata",
+                    InspectionViewFacetExecution.TypeMetadata),
+                ("type.source",
+                    InspectionViewFacetExecution.TypeSource),
+                ("member.overview",
+                    InspectionViewFacetExecution.MemberOverview),
+                ("member.call-graph",
+                    InspectionViewFacetExecution.MemberCallGraph),
+                ("member.facts",
+                    InspectionViewFacetExecution.MemberFacts),
+                ("member.source",
+                    InspectionViewFacetExecution.MemberSource),
+                ("member.annotated-source",
+                    InspectionViewFacetExecution.MemberAnnotatedSource),
+            },
+            registry.ActiveBindings.Select(binding => (
+                binding.Id.Value,
+                Assert.IsType<InspectionViewFacetExecution>(
+                    binding.Target))));
+
+        ViewFacetAvailabilitySnapshot facts = AllAvailable(registry);
+        foreach (ExpectedFacet item in expected)
+        {
+            ViewFacetRegistration registration = Assert.Single(
+                registry.Registrations,
+                candidate => candidate.Descriptor.Id.Value == item.Id);
+            Assert.Equal(item.Summary, registration.Purpose);
+            foreach (ViewFacetTarget target in Targets())
+            {
+                bool expectedApplicability =
+                    target.Subject.Kind == item.Kind
+                    && (item.Kind != StructuralSubjectKind.Root
+                        || target.RootKind == item.RootKind);
+                Assert.Equal(expectedApplicability, registration.Applies(target));
+                ViewFacetResolution resolution = registry.Resolve(
+                    item.Id,
+                    target,
+                    expectedApplicability ? facts : ThrowingFacts.Instance);
+                Assert.Equal(
+                    expectedApplicability,
+                    resolution is ViewFacetResolution.Available);
+                if (!expectedApplicability)
+                {
+                    Assert.IsType<ViewFacetResolution.Inapplicable>(resolution);
+                }
+            }
+        }
+    }
+
+    static ViewFacetRegistry Registry(
+        IEnumerable<ViewFacetRegistration> registrations)
+    {
+        ViewFacetRegistration[] registrationArray = [.. registrations];
+        return new(
+            registrationArray,
+            registrationArray
+                .OfType<ViewFacetRegistration.Active>()
+                .Select(registration => registration.Binding));
+    }
+
+    static ViewFacetRegistration.Active Active(
+        ViewFacetDescriptor descriptor,
+        Func<ViewFacetTarget, bool> applies) =>
+        new(
+            descriptor,
+            descriptor.Summary,
+            applies,
+            new ViewFacetExecutionBinding(
+                descriptor.Id,
+                new TestExecutionTarget(descriptor.Id)),
+            (_, facts) => facts.Get(descriptor.Id));
+
+    static ViewFacetRegistration.Tombstone Tombstone(
+        ViewFacetDescriptor descriptor,
+        Func<ViewFacetTarget, bool> applies) =>
+        new(descriptor, descriptor.Summary, applies);
+
+    static ViewFacetDescriptor Descriptor(
+        string id,
+        StructuralSubjectKind kind,
+        int order) =>
+        new(
+            new ViewFacetId(id),
+            kind,
+            id,
+            $"Purpose for {id}.",
+            order);
+
+    static ViewFacetAvailabilityFact Fact(
+        ViewFacetDescriptor descriptor,
+        ViewFacetAvailability availability) =>
+        new(descriptor.Id, availability);
+
+    static ViewFacetAvailabilitySnapshot AllAvailable(
+        ViewFacetRegistry registry) =>
+        new(
+            registry.Descriptors.Select(descriptor =>
+                new ViewFacetAvailabilityFact(
+                    descriptor.Id,
+                    ViewFacetAvailability.Available.Instance)));
+
+    static string Id(ViewFacetId id) => id.Value;
+
+    static bool AppliesToPackageRoot(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Root
+        && target.RootKind == ViewFacetRootKind.PackageCapable;
+
+    static bool AppliesToLibrary(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Library;
+
+    static ViewFacetTarget RootTarget(ViewFacetRootKind rootKind) =>
+        ViewFacetTarget.ForRoot(
+            StructuralSubjectIdentity.ForRoot(
+                rootKind == ViewFacetRootKind.PackageCapable
+                    ? Coordinate()
+                    : PlatformCoordinate()));
+
+    static ViewFacetTarget LibraryTarget() =>
+        ViewFacetTarget.ForSubject(
+            StructuralSubjectIdentity.ForAllLibraries(Coordinate()));
+
+    static IEnumerable<ViewFacetTarget> Targets()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        StructuralSubjectIdentity.LibrarySubject library =
+            StructuralSubjectIdentity.ForLibrary(Library(coordinate));
+        StructuralSubjectIdentity.TypeSubject type =
+            StructuralSubjectIdentity.ForType(
+                library,
+                TypeName("Sample", "Widget"));
+        yield return ViewFacetTarget.ForRoot(
+            StructuralSubjectIdentity.ForRoot(coordinate));
+        yield return ViewFacetTarget.ForRoot(
+            StructuralSubjectIdentity.ForRoot(PlatformCoordinate()));
+        yield return ViewFacetTarget.ForSubject(library);
+        yield return ViewFacetTarget.ForSubject(type);
+        yield return ViewFacetTarget.ForSubject(
+            StructuralSubjectIdentity.ForMember(
+                type,
+                new MemberAnchor(
+                    "Run()",
+                    "Sample.Widget.Run()",
+                    MemberAnchor.ComputeFingerprint("Sample.Widget.Run()"),
+                    "Sample.Widget",
+                    "Run")));
+    }
+
+    static RealizedMemberCoordinate.Package Coordinate() =>
+        new(
+            "sample.package",
+            "1.0.0",
+            "nuget-org",
+            "net11.0",
+            runtimeIdentifier: null);
+
+    static RealizedMemberCoordinate.Platform PlatformCoordinate() =>
+        new(
+            "runtime",
+            "11.0.0",
+            "fixture",
+            "net11.0",
+            assembly: null);
+
+    static WorkspaceContextMember Library(
+        RealizedMemberCoordinate.Package coordinate)
+    {
+        ResolvedAssemblyReference assembly = ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                "Sample",
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            path: null,
+            () => new MemoryStream([0], writable: false),
+            AssemblyResolutionProvenance.Package(
+                "sample.package",
+                "1.0.0",
+                "net11.0",
+                rid: null));
+        return new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            coordinate,
+            new AssemblyContextParticipant(
+                assembly,
+                NoResolverAssemblyBindingPolicy.Instance));
+    }
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        string name) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [name])).Name;
+
+    sealed record TestDiagnosticEvidence(string Detail) :
+        IViewFacetDiagnosticEvidence;
+
+    sealed record TestExecutionTarget(ViewFacetId Id);
+
+    sealed class ThrowingFacts : IViewFacetAvailabilityFacts
+    {
+        public static ThrowingFacts Instance { get; } = new();
+
+        public ViewFacetAvailability Get(ViewFacetId id) =>
+            throw new InvalidOperationException(
+                $"Availability was consulted for '{id.Value}'.");
+    }
+
+    sealed class NoWorkSentinels
+    {
+        bool _alias;
+        bool _artifactOpenOrAcquisition;
+        bool _cache;
+        bool _dynamicProvider;
+        bool _execution;
+        bool _filesystem;
+        bool _network;
+
+        public void TouchAll()
+        {
+            _execution = true;
+            _artifactOpenOrAcquisition = true;
+            _cache = true;
+            _alias = true;
+            _dynamicProvider = true;
+            _filesystem = true;
+            _network = true;
+        }
+
+        public void AssertUntouched()
+        {
+            Assert.False(_execution);
+            Assert.False(_artifactOpenOrAcquisition);
+            Assert.False(_cache);
+            Assert.False(_alias);
+            Assert.False(_dynamicProvider);
+            Assert.False(_filesystem);
+            Assert.False(_network);
+        }
+    }
+
+    sealed record DescriptorShape(
+        string Id,
+        StructuralSubjectKind Kind,
+        string Title,
+        string Summary,
+        int Order,
+        ViewFacetRole? Role);
+
+    sealed record ExpectedFacet(
+        string Id,
+        StructuralSubjectKind Kind,
+        string Title,
+        string Summary,
+        int Order,
+        ViewFacetRole? Role = null,
+        ViewFacetRootKind? RootKind = null)
+    {
+        public DescriptorShape Descriptor =>
+            new(Id, Kind, Title, Summary, Order, Role);
+    }
+}

--- a/src/DotnetInspector.Queries/InspectionViewFacetCatalog.cs
+++ b/src/DotnetInspector.Queries/InspectionViewFacetCatalog.cs
@@ -1,0 +1,279 @@
+namespace DotnetInspector.Queries;
+
+/// <summary>The immutable product View Facet Registry.</summary>
+public static class InspectionViewFacetCatalog
+{
+    static readonly ViewFacetExecutionBinding[] Bindings =
+    [
+        Binding(
+            "root.package-overview",
+            InspectionViewFacetExecution.PackageOverview),
+        Binding(
+            "root.package-dependencies",
+            InspectionViewFacetExecution.PackageDependencies),
+        Binding(
+            "root.overview",
+            InspectionViewFacetExecution.RootOverview),
+        Binding(
+            "library.references",
+            InspectionViewFacetExecution.LibraryReferences),
+        Binding(
+            "library.integrations",
+            InspectionViewFacetExecution.LibraryIntegrations),
+        Binding(
+            "library.opportunities",
+            InspectionViewFacetExecution.LibraryOpportunities),
+        Binding(
+            "library.analysis",
+            InspectionViewFacetExecution.LibraryAnalysis),
+        Binding(
+            "library.metadata",
+            InspectionViewFacetExecution.LibraryMetadata),
+        Binding(
+            "type.api",
+            InspectionViewFacetExecution.TypeApi),
+        Binding(
+            "type.metadata",
+            InspectionViewFacetExecution.TypeMetadata),
+        Binding(
+            "type.source",
+            InspectionViewFacetExecution.TypeSource),
+        Binding(
+            "member.overview",
+            InspectionViewFacetExecution.MemberOverview),
+        Binding(
+            "member.call-graph",
+            InspectionViewFacetExecution.MemberCallGraph),
+        Binding(
+            "member.facts",
+            InspectionViewFacetExecution.MemberFacts),
+        Binding(
+            "member.source",
+            InspectionViewFacetExecution.MemberSource),
+        Binding(
+            "member.annotated-source",
+            InspectionViewFacetExecution.MemberAnnotatedSource),
+    ];
+
+    static readonly ViewFacetRegistration[] Registrations =
+    [
+        Active(
+            Descriptor(
+                "root.package-overview",
+                StructuralSubjectKind.Root,
+                "Overview",
+                "Package identity, selected target, assets, and summary facts.",
+                100,
+                ViewFacetRole.PackageOverview),
+            "Package identity, selected target, assets, and summary facts.",
+            AppliesToPackageRoot),
+        Active(
+            Descriptor(
+                "root.package-dependencies",
+                StructuralSubjectKind.Root,
+                "Dependencies",
+                "Declared package dependencies for the selected target framework.",
+                200),
+            "Declared package dependencies for the selected target framework.",
+            AppliesToPackageRoot),
+        Active(
+            Descriptor(
+                "root.overview",
+                StructuralSubjectKind.Root,
+                "Overview",
+                "Coordinate identity, selected target, and available structural subjects.",
+                300,
+                ViewFacetRole.RootOverview),
+            "Coordinate identity, selected target, and available structural subjects.",
+            AppliesToNonPackageRoot),
+        Active(
+            Descriptor(
+                "library.references",
+                StructuralSubjectKind.Library,
+                "References",
+                "Direct assembly references for the active Library.",
+                100,
+                ViewFacetRole.LibraryReferences),
+            "Direct assembly references for the active Library.",
+            AppliesToLibrary),
+        Active(
+            Descriptor(
+                "library.integrations",
+                StructuralSubjectKind.Library,
+                "Integrations",
+                "Framework and ecosystem integrations found in the active Library.",
+                200),
+            "Framework and ecosystem integrations found in the active Library.",
+            AppliesToLibrary),
+        Active(
+            Descriptor(
+                "library.opportunities",
+                StructuralSubjectKind.Library,
+                "Opportunities",
+                "Framework and ecosystem integrations the active Library could adopt.",
+                300),
+            "Framework and ecosystem integrations the active Library could adopt.",
+            AppliesToLibrary),
+        Active(
+            Descriptor(
+                "library.analysis",
+                StructuralSubjectKind.Library,
+                "Analysis",
+                "Static analysis findings and code characteristics for the active Library.",
+                400),
+            "Static analysis findings and code characteristics for the active Library.",
+            AppliesToLibrary),
+        Active(
+            Descriptor(
+                "library.metadata",
+                StructuralSubjectKind.Library,
+                "Metadata",
+                "Physical ECMA-335 metadata and PE structure for the active Library.",
+                500),
+            "Physical ECMA-335 metadata and PE structure for the active Library.",
+            AppliesToLibrary),
+        Active(
+            Descriptor(
+                "type.api",
+                StructuralSubjectKind.Type,
+                "API",
+                "API shape and member inventory for the active Type.",
+                100,
+                ViewFacetRole.TypeApi),
+            "API shape and member inventory for the active Type.",
+            AppliesToType),
+        Active(
+            Descriptor(
+                "type.metadata",
+                StructuralSubjectKind.Type,
+                "Metadata",
+                "Metadata records and attributes for the active Type.",
+                200),
+            "Metadata records and attributes for the active Type.",
+            AppliesToType),
+        Active(
+            Descriptor(
+                "type.source",
+                StructuralSubjectKind.Type,
+                "Source",
+                "Source or decompiled code for the active Type.",
+                300),
+            "Source or decompiled code for the active Type.",
+            AppliesToType),
+        Active(
+            Descriptor(
+                "member.overview",
+                StructuralSubjectKind.Member,
+                "Overview",
+                "Signature, documentation, and overload context for the active Member.",
+                100,
+                ViewFacetRole.MemberOverview),
+            "Signature, documentation, and overload context for the active Member.",
+            AppliesToMember),
+        Active(
+            Descriptor(
+                "member.call-graph",
+                StructuralSubjectKind.Member,
+                "Call graph",
+                "Incoming and outgoing calls for the active Member.",
+                200),
+            "Incoming and outgoing calls for the active Member.",
+            AppliesToMember),
+        Active(
+            Descriptor(
+                "member.facts",
+                StructuralSubjectKind.Member,
+                "Facts",
+                "Metadata, IL, safety, and analysis facts for the active Member.",
+                300),
+            "Metadata, IL, safety, and analysis facts for the active Member.",
+            AppliesToMember),
+        Active(
+            Descriptor(
+                "member.source",
+                StructuralSubjectKind.Member,
+                "Source",
+                "Source or decompiled code for the active Member.",
+                400),
+            "Source or decompiled code for the active Member.",
+            AppliesToMember),
+        Active(
+            Descriptor(
+                "member.annotated-source",
+                StructuralSubjectKind.Member,
+                "Annotated source",
+                "Source for the active Member with product analysis annotations.",
+                500),
+            "Source for the active Member with product analysis annotations.",
+            AppliesToMember),
+    ];
+
+    public static ViewFacetRegistry Registry { get; } =
+        new(Registrations, Bindings);
+
+    static ViewFacetDescriptor Descriptor(
+        string id,
+        StructuralSubjectKind kind,
+        string title,
+        string summary,
+        int order,
+        ViewFacetRole? role = null) =>
+        new(new ViewFacetId(id), kind, title, summary, order, role);
+
+    static ViewFacetRegistration Active(
+        ViewFacetDescriptor descriptor,
+        string purpose,
+        Func<ViewFacetTarget, bool> applies)
+    {
+        ViewFacetExecutionBinding binding = Bindings.Single(
+            candidate => candidate.Id == descriptor.Id);
+        return new ViewFacetRegistration.Active(
+            descriptor,
+            purpose,
+            applies,
+            binding,
+            (_, facts) => facts.Get(descriptor.Id));
+    }
+
+    static ViewFacetExecutionBinding Binding(
+        string id,
+        InspectionViewFacetExecution target) =>
+        new(new ViewFacetId(id), target);
+
+    static bool AppliesToPackageRoot(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Root
+        && target.RootKind == ViewFacetRootKind.PackageCapable;
+
+    static bool AppliesToNonPackageRoot(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Root
+        && target.RootKind == ViewFacetRootKind.NonPackage;
+
+    static bool AppliesToLibrary(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Library;
+
+    static bool AppliesToType(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Type;
+
+    static bool AppliesToMember(ViewFacetTarget target) =>
+        target.Subject.Kind == StructuralSubjectKind.Member;
+}
+
+internal enum InspectionViewFacetExecution
+{
+    PackageOverview,
+    PackageDependencies,
+    RootOverview,
+    LibraryReferences,
+    LibraryIntegrations,
+    LibraryOpportunities,
+    LibraryAnalysis,
+    LibraryMetadata,
+    TypeApi,
+    TypeMetadata,
+    TypeSource,
+    MemberOverview,
+    MemberCallGraph,
+    MemberFacts,
+    MemberSource,
+    MemberAnnotatedSource,
+}

--- a/src/DotnetInspector.Queries/ViewFacetRegistry.cs
+++ b/src/DotnetInspector.Queries/ViewFacetRegistry.cs
@@ -1,0 +1,718 @@
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>A canonical, globally unique product view-facet identifier.</summary>
+public sealed record ViewFacetId
+{
+    public const int MaximumLength = 80;
+
+    public ViewFacetId(string value)
+    {
+        if (!TryGetKind(value, out _))
+        {
+            throw new ArgumentException(
+                "A view-facet id must be a canonical absolute subject-prefixed identifier.",
+                nameof(value));
+        }
+
+        Value = value;
+    }
+
+    public string Value { get; }
+
+    public override string ToString() => Value;
+
+    internal static bool TryGetKind(
+        string? value,
+        out StructuralSubjectKind kind)
+    {
+        kind = default;
+        if (value is null
+            || value.Length == 0
+            || value.Length > MaximumLength)
+        {
+            return false;
+        }
+
+        int dot = value.IndexOf('.');
+        if (dot <= 0 || dot == value.Length - 1)
+            return false;
+
+        ReadOnlySpan<char> prefix = value.AsSpan(0, dot);
+        if (prefix.SequenceEqual("root"))
+            kind = StructuralSubjectKind.Root;
+        else if (prefix.SequenceEqual("library"))
+            kind = StructuralSubjectKind.Library;
+        else if (prefix.SequenceEqual("type"))
+            kind = StructuralSubjectKind.Type;
+        else if (prefix.SequenceEqual("member"))
+            kind = StructuralSubjectKind.Member;
+        else
+            return false;
+
+        ReadOnlySpan<char> name = value.AsSpan(dot + 1);
+        if (!IsLowerAsciiLetter(name[0]))
+            return false;
+
+        bool afterSeparator = false;
+        for (int i = 1; i < name.Length; i++)
+        {
+            char character = name[i];
+            if (character == '-')
+            {
+                if (afterSeparator || i == name.Length - 1)
+                    return false;
+                afterSeparator = true;
+                continue;
+            }
+
+            if (!IsLowerAsciiLetter(character)
+                && !IsAsciiDigit(character))
+            {
+                return false;
+            }
+
+            afterSeparator = false;
+        }
+
+        return true;
+    }
+
+    static bool IsLowerAsciiLetter(char value) =>
+        value is >= 'a' and <= 'z';
+
+    static bool IsAsciiDigit(char value) =>
+        value is >= '0' and <= '9';
+}
+
+/// <summary>Semantic roles consumed by adjacent product policy.</summary>
+public enum ViewFacetRole
+{
+    PackageOverview,
+    RootOverview,
+    LibraryReferences,
+    TypeApi,
+    MemberOverview,
+}
+
+/// <summary>One immutable selectable view-facet descriptor.</summary>
+public sealed record ViewFacetDescriptor
+{
+    public ViewFacetDescriptor(
+        ViewFacetId id,
+        StructuralSubjectKind kind,
+        string title,
+        string summary,
+        int order,
+        ViewFacetRole? role = null)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        if (!ViewFacetId.TryGetKind(id.Value, out StructuralSubjectKind prefix)
+            || prefix != kind)
+        {
+            throw new ArgumentException(
+                "The view-facet id prefix must agree with its structural subject kind.",
+                nameof(id));
+        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(summary);
+        if (role is not null && !Enum.IsDefined(role.Value))
+            throw new ArgumentOutOfRangeException(nameof(role));
+
+        Id = id;
+        Kind = kind;
+        Title = title;
+        Summary = summary;
+        Order = order;
+        Role = role;
+    }
+
+    public ViewFacetId Id { get; }
+    public StructuralSubjectKind Kind { get; }
+    public string Title { get; }
+    public string Summary { get; }
+    public int Order { get; }
+    public ViewFacetRole? Role { get; }
+}
+
+/// <summary>Why one known and applicable facet is unavailable.</summary>
+public enum ViewFacetUnavailabilityKind
+{
+    CapabilityAbsent,
+    Retired,
+}
+
+/// <summary>Typed unavailability plus owner-issued presentation text.</summary>
+public sealed record ViewFacetUnavailableReason
+{
+    ViewFacetUnavailableReason(
+        ViewFacetUnavailabilityKind kind,
+        string message)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        Kind = kind;
+        Message = message;
+    }
+
+    public ViewFacetUnavailabilityKind Kind { get; }
+    public string Message { get; }
+
+    public static ViewFacetUnavailableReason CapabilityAbsent(
+        string message) =>
+        new(ViewFacetUnavailabilityKind.CapabilityAbsent, message);
+
+    internal static ViewFacetUnavailableReason Retired() =>
+        new(
+            ViewFacetUnavailabilityKind.Retired,
+            "This view is retired.");
+}
+
+/// <summary>Owner-issued typed evidence for failed facet preparation.</summary>
+public interface IViewFacetDiagnosticEvidence
+{
+}
+
+/// <summary>Availability of one known, structurally applicable facet.</summary>
+public abstract record ViewFacetAvailability
+{
+    private protected ViewFacetAvailability()
+    {
+    }
+
+    public sealed record Available : ViewFacetAvailability
+    {
+        public static Available Instance { get; } = new();
+
+        private Available()
+        {
+        }
+    }
+
+    public sealed record Unavailable : ViewFacetAvailability
+    {
+        public Unavailable(ViewFacetUnavailableReason reason)
+        {
+            ArgumentNullException.ThrowIfNull(reason);
+            Reason = reason;
+        }
+
+        public ViewFacetUnavailableReason Reason { get; }
+    }
+
+    public sealed record Failed : ViewFacetAvailability
+    {
+        public Failed(
+            string message,
+            IViewFacetDiagnosticEvidence evidence)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(message);
+            ArgumentNullException.ThrowIfNull(evidence);
+            Message = message;
+            Evidence = evidence;
+        }
+
+        public string Message { get; }
+        public IViewFacetDiagnosticEvidence Evidence { get; }
+    }
+}
+
+/// <summary>One explicit producer-issued availability fact.</summary>
+public sealed record ViewFacetAvailabilityFact
+{
+    public ViewFacetAvailabilityFact(
+        ViewFacetId id,
+        ViewFacetAvailability availability)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(availability);
+        Id = id;
+        Availability = availability;
+    }
+
+    public ViewFacetId Id { get; }
+    public ViewFacetAvailability Availability { get; }
+}
+
+/// <summary>
+/// Explicit target facts consumed by active registry availability evaluators.
+/// </summary>
+public interface IViewFacetAvailabilityFacts
+{
+    ViewFacetAvailability Get(ViewFacetId id);
+}
+
+/// <summary>An immutable exact-ID availability snapshot.</summary>
+public sealed class ViewFacetAvailabilitySnapshot :
+    IViewFacetAvailabilityFacts
+{
+    readonly Dictionary<ViewFacetId, ViewFacetAvailability> _facts;
+
+    public ViewFacetAvailabilitySnapshot(
+        IEnumerable<ViewFacetAvailabilityFact> facts)
+    {
+        ArgumentNullException.ThrowIfNull(facts);
+        _facts = [];
+        foreach (ViewFacetAvailabilityFact fact in facts)
+        {
+            ArgumentNullException.ThrowIfNull(fact);
+            if (!_facts.TryAdd(fact.Id, fact.Availability))
+            {
+                throw new ArgumentException(
+                    "Availability facts must contain each view-facet id at most once.",
+                    nameof(facts));
+            }
+        }
+    }
+
+    public ViewFacetAvailability Get(ViewFacetId id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return _facts.TryGetValue(id, out ViewFacetAvailability? fact)
+            ? fact
+            : throw new KeyNotFoundException(
+                $"No availability fact was supplied for view facet '{id.Value}'.");
+    }
+}
+
+/// <summary>Typed Root facts used only for Root-facet applicability.</summary>
+public enum ViewFacetRootKind
+{
+    PackageCapable,
+    NonPackage,
+}
+
+/// <summary>One exact structural subject plus applicability facts.</summary>
+public sealed record ViewFacetTarget
+{
+    ViewFacetTarget(
+        StructuralSubjectIdentity subject,
+        ViewFacetRootKind? rootKind)
+    {
+        Subject = subject;
+        RootKind = rootKind;
+    }
+
+    public StructuralSubjectIdentity Subject { get; }
+    public ViewFacetRootKind? RootKind { get; }
+
+    public static ViewFacetTarget ForRoot(
+        StructuralSubjectIdentity.RootSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ViewFacetRootKind rootKind = subject.Coordinate switch
+        {
+            RealizedMemberCoordinate.Package =>
+                ViewFacetRootKind.PackageCapable,
+            RealizedMemberCoordinate.Platform
+                or RealizedMemberCoordinate.Embedded =>
+                ViewFacetRootKind.NonPackage,
+            _ => throw new InvalidOperationException(
+                "Unknown realized coordinate kind."),
+        };
+        return new(subject, rootKind);
+    }
+
+    public static ViewFacetTarget ForSubject(
+        StructuralSubjectIdentity subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        if (subject.Kind == StructuralSubjectKind.Root)
+        {
+            throw new ArgumentException(
+                "Root targets require an explicit typed Root kind.",
+                nameof(subject));
+        }
+
+        return new(subject, rootKind: null);
+    }
+}
+
+/// <summary>One applicable descriptor and its exact availability.</summary>
+public sealed record ViewFacetOption
+{
+    public ViewFacetOption(
+        ViewFacetDescriptor descriptor,
+        ViewFacetAvailability availability)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(availability);
+        Descriptor = descriptor;
+        Availability = availability;
+    }
+
+    public ViewFacetDescriptor Descriptor { get; }
+    public ViewFacetAvailability Availability { get; }
+}
+
+/// <summary>The exact result of resolving one requested facet.</summary>
+public abstract record ViewFacetResolution
+{
+    private protected ViewFacetResolution()
+    {
+    }
+
+    public sealed record Available : ViewFacetResolution
+    {
+        internal Available(ViewFacetDescriptor descriptor) =>
+            Descriptor = descriptor;
+
+        public ViewFacetDescriptor Descriptor { get; }
+    }
+
+    public sealed record Unavailable : ViewFacetResolution
+    {
+        internal Unavailable(
+            ViewFacetDescriptor descriptor,
+            ViewFacetUnavailableReason reason)
+        {
+            Descriptor = descriptor;
+            Reason = reason;
+        }
+
+        public ViewFacetDescriptor Descriptor { get; }
+        public ViewFacetUnavailableReason Reason { get; }
+    }
+
+    public sealed record Failed : ViewFacetResolution
+    {
+        internal Failed(
+            ViewFacetDescriptor descriptor,
+            string message,
+            IViewFacetDiagnosticEvidence evidence)
+        {
+            Descriptor = descriptor;
+            Message = message;
+            Evidence = evidence;
+        }
+
+        public ViewFacetDescriptor Descriptor { get; }
+        public string Message { get; }
+        public IViewFacetDiagnosticEvidence Evidence { get; }
+    }
+
+    public sealed record Inapplicable : ViewFacetResolution
+    {
+        internal Inapplicable(ViewFacetDescriptor descriptor) =>
+            Descriptor = descriptor;
+
+        public ViewFacetDescriptor Descriptor { get; }
+    }
+
+    public sealed record Unknown : ViewFacetResolution
+    {
+        internal Unknown()
+        {
+        }
+    }
+}
+
+internal sealed class ViewFacetExecutionBinding
+{
+    internal ViewFacetExecutionBinding(ViewFacetId id, object target)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        ArgumentNullException.ThrowIfNull(target);
+        Id = id;
+        Target = target;
+    }
+
+    internal ViewFacetId Id { get; }
+    internal object Target { get; }
+}
+
+internal abstract record ViewFacetRegistration
+{
+    private protected ViewFacetRegistration(
+        ViewFacetDescriptor descriptor,
+        string purpose,
+        Func<ViewFacetTarget, bool> applies)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentException.ThrowIfNullOrWhiteSpace(purpose);
+        ArgumentNullException.ThrowIfNull(applies);
+        Descriptor = descriptor;
+        Purpose = purpose;
+        Applies = applies;
+    }
+
+    internal ViewFacetDescriptor Descriptor { get; }
+    internal string Purpose { get; }
+    internal Func<ViewFacetTarget, bool> Applies { get; }
+    internal abstract ViewFacetExecutionBinding? Binding { get; }
+
+    internal abstract ViewFacetAvailability Evaluate(
+        ViewFacetTarget target,
+        IViewFacetAvailabilityFacts facts);
+
+    internal sealed record Active : ViewFacetRegistration
+    {
+        readonly Func<
+            ViewFacetTarget,
+            IViewFacetAvailabilityFacts,
+            ViewFacetAvailability> _evaluate;
+
+        internal Active(
+            ViewFacetDescriptor descriptor,
+            string purpose,
+            Func<ViewFacetTarget, bool> applies,
+            ViewFacetExecutionBinding binding,
+            Func<
+                ViewFacetTarget,
+                IViewFacetAvailabilityFacts,
+                ViewFacetAvailability> evaluate)
+            : base(descriptor, purpose, applies)
+        {
+            ArgumentNullException.ThrowIfNull(binding);
+            ArgumentNullException.ThrowIfNull(evaluate);
+            if (binding.Id != descriptor.Id)
+            {
+                throw new ArgumentException(
+                    "The execution binding id must equal its descriptor id.",
+                    nameof(binding));
+            }
+            Binding = binding;
+            _evaluate = evaluate;
+        }
+
+        internal override ViewFacetExecutionBinding Binding { get; }
+
+        internal override ViewFacetAvailability Evaluate(
+            ViewFacetTarget target,
+            IViewFacetAvailabilityFacts facts)
+        {
+            ViewFacetAvailability availability =
+                _evaluate(target, facts)
+                ?? throw new InvalidOperationException(
+                    "A view-facet availability evaluator returned null.");
+            if (availability is ViewFacetAvailability.Unavailable
+                {
+                    Reason.Kind: ViewFacetUnavailabilityKind.Retired,
+                })
+            {
+                throw new InvalidOperationException(
+                    "An active view facet cannot return the tombstone-only Retired reason.");
+            }
+            return availability;
+        }
+    }
+
+    internal sealed record Tombstone : ViewFacetRegistration
+    {
+        static readonly ViewFacetUnavailableReason Retired =
+            ViewFacetUnavailableReason.Retired();
+
+        internal Tombstone(
+            ViewFacetDescriptor descriptor,
+            string purpose,
+            Func<ViewFacetTarget, bool> applies)
+            : base(descriptor, purpose, applies)
+        {
+        }
+
+        internal override ViewFacetExecutionBinding? Binding => null;
+
+        internal override ViewFacetAvailability Evaluate(
+            ViewFacetTarget target,
+            IViewFacetAvailabilityFacts facts) =>
+            new ViewFacetAvailability.Unavailable(Retired);
+    }
+}
+
+/// <summary>
+/// Closed product registry for static discovery and exact facet resolution.
+/// </summary>
+public sealed class ViewFacetRegistry
+{
+    readonly ImmutableArray<ViewFacetRegistration> _registrations;
+    readonly Dictionary<string, ViewFacetRegistration> _registrationById;
+
+    internal ViewFacetRegistry(
+        IEnumerable<ViewFacetRegistration> registrations,
+        IEnumerable<ViewFacetExecutionBinding> activeBindings)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+        ArgumentNullException.ThrowIfNull(activeBindings);
+        ViewFacetRegistration[] input = [.. registrations];
+        if (input.Any(static registration => registration is null))
+        {
+            throw new ArgumentException(
+                "Registrations cannot contain null.",
+                nameof(registrations));
+        }
+
+        _registrations =
+        [
+            .. input.OrderBy(static registration =>
+                    registration.Descriptor.Kind)
+                .ThenBy(static registration =>
+                    registration.Descriptor.Order),
+        ];
+        _registrationById = new(StringComparer.Ordinal);
+        var orders = new HashSet<(StructuralSubjectKind Kind, int Order)>();
+        var roles = new HashSet<(StructuralSubjectKind Kind, ViewFacetRole Role)>();
+        foreach (ViewFacetRegistration registration in _registrations)
+        {
+            ViewFacetDescriptor descriptor = registration.Descriptor;
+            if (!_registrationById.TryAdd(descriptor.Id.Value, registration))
+            {
+                throw new ArgumentException(
+                    "View-facet ids must be unique.",
+                    nameof(registrations));
+            }
+            if (!orders.Add((descriptor.Kind, descriptor.Order)))
+            {
+                throw new ArgumentException(
+                    "View-facet order must be unique within one structural kind.",
+                    nameof(registrations));
+            }
+            if (descriptor.Role is ViewFacetRole role
+                && !roles.Add((descriptor.Kind, role)))
+            {
+                throw new ArgumentException(
+                    "A semantic role may occur at most once within one structural kind.",
+                    nameof(registrations));
+            }
+        }
+
+        ActiveBindings = [.. activeBindings];
+        if (ActiveBindings.Any(static binding => binding is null))
+        {
+            throw new ArgumentException(
+                "Execution bindings cannot contain null.",
+                nameof(activeBindings));
+        }
+        if (ActiveBindings.Select(static binding => binding.Id)
+            .Distinct()
+            .Count() != ActiveBindings.Length)
+        {
+            throw new ArgumentException(
+                "Execution binding ids must be unique.",
+                nameof(activeBindings));
+        }
+
+        ViewFacetId[] activeRegistrationIds =
+        [
+            .. _registrations
+                .OfType<ViewFacetRegistration.Active>()
+                .Select(static registration => registration.Descriptor.Id),
+        ];
+        if (!activeRegistrationIds.OrderBy(static id => id.Value)
+            .SequenceEqual(
+                ActiveBindings.Select(static binding => binding.Id)
+                    .OrderBy(static id => id.Value)))
+        {
+            throw new ArgumentException(
+                "Active registrations and execution bindings must have identical ids.",
+                nameof(activeBindings));
+        }
+
+        Descriptors =
+        [
+            .. _registrations.Select(static registration =>
+                registration.Descriptor),
+        ];
+    }
+
+    public ImmutableArray<ViewFacetDescriptor> Descriptors { get; }
+
+    internal ImmutableArray<ViewFacetRegistration> Registrations =>
+        _registrations;
+
+    internal ImmutableArray<ViewFacetExecutionBinding> ActiveBindings
+    {
+        get;
+    }
+
+    public ImmutableArray<ViewFacetDescriptor> Discover(
+        StructuralSubjectKind kind)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        return
+        [
+            .. Descriptors.Where(descriptor => descriptor.Kind == kind),
+        ];
+    }
+
+    public bool TryGetDescriptor(
+        string requestedId,
+        [NotNullWhen(true)] out ViewFacetDescriptor? descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(requestedId);
+        if (ViewFacetId.TryGetKind(requestedId, out _)
+            && _registrationById.TryGetValue(
+                requestedId,
+                out ViewFacetRegistration? registration))
+        {
+            descriptor = registration.Descriptor;
+            return true;
+        }
+
+        descriptor = null;
+        return false;
+    }
+
+    public ImmutableArray<ViewFacetOption> Discover(
+        ViewFacetTarget target,
+        IViewFacetAvailabilityFacts facts)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(facts);
+        var options = ImmutableArray.CreateBuilder<ViewFacetOption>();
+        foreach (ViewFacetRegistration registration in _registrations)
+        {
+            if (!registration.Applies(target))
+                continue;
+            options.Add(
+                new ViewFacetOption(
+                    registration.Descriptor,
+                    registration.Evaluate(target, facts)));
+        }
+        return options.ToImmutable();
+    }
+
+    public ViewFacetResolution Resolve(
+        string requestedId,
+        ViewFacetTarget target,
+        IViewFacetAvailabilityFacts facts)
+    {
+        ArgumentNullException.ThrowIfNull(requestedId);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(facts);
+        if (!ViewFacetId.TryGetKind(requestedId, out _)
+            || !_registrationById.TryGetValue(
+                requestedId,
+                out ViewFacetRegistration? registration))
+        {
+            return new ViewFacetResolution.Unknown();
+        }
+
+        if (!registration.Applies(target))
+            return new ViewFacetResolution.Inapplicable(
+                registration.Descriptor);
+
+        return registration.Evaluate(target, facts) switch
+        {
+            ViewFacetAvailability.Available =>
+                new ViewFacetResolution.Available(
+                    registration.Descriptor),
+            ViewFacetAvailability.Unavailable unavailable =>
+                new ViewFacetResolution.Unavailable(
+                    registration.Descriptor,
+                    unavailable.Reason),
+            ViewFacetAvailability.Failed failed =>
+                new ViewFacetResolution.Failed(
+                    registration.Descriptor,
+                    failed.Message,
+                    failed.Evidence),
+            _ => throw new InvalidOperationException(
+                "Unknown view-facet availability result."),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implement the product-owned View Facet Registry as the stable catalog consumed
by Navigation and future inspect-web composition.

- issue canonical, bounded `ViewFacetId` values and immutable descriptors;
- classify typed structural applicability before availability evaluation;
- preserve available, unavailable, failed, inapplicable, and unknown outcomes;
- make active and tombstone registrations disjoint, with private execution
  bindings only for active facets;
- ship the exact initial 16-facet inventory and append-only compatibility
  manifest; and
- expose static discovery and exact descriptor or target-aware resolution
  without browser, CLI, acquisition, cache, filesystem, or network policy.

## Demo

The consumer probe:

```bash
dotnet run -c Release --project facet-demo.csproj
```

prints the product catalog in structural and explicit per-kind order:

```text
Root:
  100: root.package-overview - Overview [PackageOverview]
  200: root.package-dependencies - Dependencies
  300: root.overview - Overview [RootOverview]
Library:
  100: library.references - References [LibraryReferences]
  200: library.integrations - Integrations
  300: library.opportunities - Opportunities
  400: library.analysis - Analysis
  500: library.metadata - Metadata
Type:
  100: type.api - API [TypeApi]
  200: type.metadata - Metadata
  300: type.source - Source
Member:
  100: member.overview - Overview [MemberOverview]
  200: member.call-graph - Call graph
  300: member.facts - Facts
  400: member.source - Source
  500: member.annotated-source - Annotated source

Exact lookup: member.call-graph - Incoming and outgoing calls for the active Member.
Terminal-LF lookup: unknown
```

Notice that repeated labels remain separate opaque IDs, semantic roles are
product metadata rather than host inference, and a non-exact persisted value
does not normalize into a match.

## Design basis

Normative owner:
`docs/design/view-facet-registry.md` -- the complete immutable registry,
identity, descriptor, applicability, availability, registration, compatibility,
and exact-resolution contract.

Supporting contracts:

- `docs/design/inspection-subject-navigation.md` supplies the structural kind
  and exact subject identity currencies.
- `docs/design/workspace-definitions.md` consumes canonical facet IDs later;
  this PR does not choose a portable schema.
- `docs/design/inspect-web-ui.md` consumes Navigation output later; this PR
  does not migrate browser presentation.

## Boundaries

This PR does not implement Navigation recommendation, activation, transitions,
reconciliation, retained sessions, workspace-definition restoration, facet
payloads, query execution, or inspect-web rendering.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -class DotnetInspector.Queries.Tests.ViewFacetRegistryTests -class DotnetInspector.Queries.Tests.ViewFacetRegistryCompatibilityTests`
  - 9 passed
- complete `DotnetInspector.Queries.Tests`
  - both complete local runs passed 921/922; the same unrelated pre-existing
    timing gate exceeded its threshold only within the full-suite load
  - the exact timing gate passed immediately on isolated rerun, and this PR
    does not change its product or test paths
- `npx markdownlint-cli docs/design/view-facet-registry.md`
- `git diff --check origin/main...HEAD`

Closes #5344.
