### PR TITLE
Record source oracle syntax inventory

### DIFF
--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "printerComparisonVersion": 1,
+  "syntaxInventoryVersion": 1,
   "files": [
     {
       "sourceUrl": "https://raw.githubusercontent.com/dotnet/dotnet/f7d90799ce4ef09a0bb257852a57248d2a8fb8dd/src/runtime/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs",
@@ -8,6 +9,11 @@
       "checksum": "CD1085BF738003442ABE2532A2693D2C14E608423A8D477ABD0055E0DDB14730",
       "printerProfile": "default-v1",
       "requirePrinterExact": true,
+      "expectedFeatures": [
+        "expression.identifier-name",
+        "expression.object-creation",
+        "statement.return"
+      ],
       "members": [
         {
           "assembly": "System.Text.Encodings.Web",


### PR DESCRIPTION
Advances #5001.

The enrolled `JavaScriptEncoder.cs` oracle now declares syntax inventory
version 1 and the exact sorted feature union observed in its two Printer-exact
bodies. This migrates the vendor baseline to the fail-closed inventory contract
landed by #5242; it changes no corpus row, member identity, source pin, checksum,
or printer expectation.

## Demo

```text
Source-oracle files:
  Valid         : 1 / 1
  Correct       : 1 / 1
  Printer exact : 1 / 1 required

Syntax inventory:
  Files tracked : 1 / 1
  Features      : 3
    expression.identifier-name
    expression.object-creation
    statement.return
```

What to notice: the benchmark recomputed these features from the captured
Printer bodies. Either an omitted observed feature or an invented declaration
fails the gate.

With this verified baseline, the candidate ledger scanned 21 pinned .NET
10.0.10 platform assemblies: 12,624 eligible targets across 1,500 files. It
qualified 32 files and ranked three with positive incremental syntax gain:

1. `BinaryAssemblyInfo.cs`: +8 features
2. `VirtualPropertyBase.PropertyGetterBase.cs`: +1 feature
3. `HandleKind.cs`: +1 feature

Those files are evidence for the next enrollment slice; this PR only makes the
existing baseline eligible for measured ranking.

## Validation

- Whole-file source oracle: 1/1 Valid, 1/1 Correct, 1/1 Printer exact
- Syntax inventory: 1/1 tracked, exact three-feature union
- Expanded candidate ledger: 21 assemblies, 12,624 eligible targets, 1,500
  files, 32 qualified, 1 unevaluable
