### PR TITLE
Define canonical development practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ development model and rationale. The binding summary:
 - **Demonstrate the pathological case.** Build boundary and failure fixtures;
   preserve valuable non-CI fixtures as reproducible design evidence.
 - **Survey analogous implementations.** Use their behavior, omissions, and
-  boundaries as evidence, not as authority or a source of copied architecture.
+  boundaries as evidence, not authority; transfer code or architecture only
+  when license, provenance, assumptions, and architectural fit all transfer.
 - **Bias toward progress through narrow slices.** Land independently coherent
   planned shapes before later hardening when the design makes that safe; never
   present unfinished behavior as supported.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,42 +16,39 @@ documentation.
 
 ### How work runs on this repo
 
-- **Design first and state the basis.** Before starting new work, visibly name
-  one normative owner and exact owned claim, then supporting designs and models
-  by role. If ownership is unclear or multiple, apply the design-scope rules or
-  ask the user; finding design defects is cheaper than finding them in code.
-- **Requested work hot-starts through PR and review.** Agents may branch, commit,
-  push, and open its PR without separate approval. Once eligible, round 1 and
-  replacements inside the current six-round block dispatch automatically; only
-  a new block requires approval. Merge remains separately authorized.
-- **Markdown-only PRs hot-start immediately at non-boundary rounds.** When every
-  changed file is `*.md`, `markdownlint` is the pre-review and per-round gate.
-  Open the PR and dispatch review without asking or waiting for `ci-required`.
-- **Complicated features need extraordinary evidence and pre-work** before
-  code is written: corpus evidence, an established oracle, a TLA+ model, or a
-  spec developed with close user input are examples of high-value levers.
-  Much of this work is about bounding or making invariant a component's
-  contract — defining those bounds well *is* the design and the architecture.
-  The code itself is easy once the bounds are right.
-- **We practice demo-driven development.** Every PR demonstrates a demo (a
-  mockup for docs-only PRs). Demos find bugs and let later readers grasp the
-  goal quickly. Demos are the accessibility lever; a missing demo is usually a
-  sign that user scenarios were never defined, though we avoid over-fitting to
-  the demo itself.
-- **Adversarial review is the primary way we find unaddressed defects.** Most
-  changes get two-seat review (see [How many reviewers, and from which
-  models](#how-many-reviewers-and-from-which-models)).
-- **Adversarial review is bounded.** Unbounded rounds are themselves a signal
-  that the design doesn't close. When reviewers keep finding things, we listen
-  and often switch back to a design phase to clarify goals, bounds, and
-  approach (see [Stop after six rounds](#stop-after-six-rounds)).
-- **Security focus is targeted, not general-purpose.** The primary scenario is
-  untrusted internet-origin data (packages, symbols, source); the tool never
-  executes code, which narrows the threat model. We don't defend against
-  local or intra-repo actors. `InertString` and `HardenedJson` are the model:
-  construction-time containment threaded through the object model (see
-  [Keep design and adversarial review within
-  scope](#keep-design-and-adversarial-review-within-scope)).
+[`docs/development-practices.md`](docs/development-practices.md) owns the full
+development model and rationale. The binding summary:
+
+- **Start from convention and best practice.** Name and justify any deliberate
+  divergence, whether stricter or looser, and document its scope.
+- **Design first and state the basis.** Name one normative owner and exact
+  claim, then supporting designs, models, constraints, and evidence by role.
+- **Demonstrate the pathological case.** Build boundary and failure fixtures;
+  preserve valuable non-CI fixtures as reproducible design evidence.
+- **Survey analogous implementations.** Use their behavior, omissions, and
+  boundaries as evidence, not as authority or a source of copied architecture.
+- **Bias toward progress through narrow slices.** Land independently coherent
+  planned shapes before later hardening when the design makes that safe; never
+  present unfinished behavior as supported.
+- **Lead with a demo.** Every PR demonstrates the scenario (a mockup for
+  docs-only PRs) without fitting the implementation only to that example.
+- **Treat critical review feedback as a design question first.** Ask whether
+  the owning design addresses it before repairing code; keep paired design
+  work moving quickly when the contract needs clarification.
+- **Use extraordinary pre-work for complicated features.** Corpus evidence,
+  an established oracle, a TLA+ model, or a closely developed specification
+  should bound the contract before implementation.
+- **Hot-start requested work through PR and review.** Agents may branch,
+  commit, push, open the PR, and dispatch eligible rounds without separate
+  approval; merge remains separately authorized.
+- **Use the Markdown fast path.** For Markdown-only PRs at non-boundary rounds,
+  `markdownlint` replaces `ci-required` as the pre-review and per-round gate.
+- **Use bounded adversarial review to find design and implementation gaps.**
+  Most changes get two seats; repeated findings are evidence to revisit design,
+  and six rounds ends the current review block.
+- **Keep security work inside the repository threat model.** Focus on
+  untrusted internet-origin data and construction-time containment, not local
+  or intra-repository actors unless an owning design explicitly opts in.
 
 > A change spanning Markout and this repo is rare and uses a separate
 > co-development loop: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ development model and rationale. The binding summary:
 - **Design first and state the basis.** Name one normative owner and exact
   claim, then supporting designs, models, constraints, and evidence by role.
 - **Demonstrate the pathological case.** Build boundary and failure fixtures;
-  preserve valuable non-CI fixtures as reproducible design evidence.
+  run contract-defining cases in CI and preserve valuable non-CI probes as
+  reproducible design evidence.
 - **Survey analogous implementations.** Use their behavior, omissions, and
   boundaries as evidence, not authority; transfer code or architecture only
   when license, provenance, assumptions, and architectural fit all transfer.
@@ -283,7 +284,9 @@ trust-boundary and containment guidance:
 [`docs/design/untrusted-data-threat-model.md`](docs/design/untrusted-data-threat-model.md#trust-boundaries).
 For a credible external-input threat, first define its actor, input path,
 boundary, containment invariant, and enforcement gate in the owning design.
-Prefer construction-time containment (`HardenedJson`, `InertText.InertString`).
+Prefer typed construction-time containment such as `InertText.InertString`;
+when that shape is unavailable, a centralized entry point such as
+`HardenedJson` is weaker but still auditable.
 
 ### Platform compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ development model and rationale. The binding summary:
 - **Use the Markdown fast path.** For Markdown-only PRs at non-boundary rounds,
   `markdownlint` replaces `ci-required` as the pre-review and per-round gate.
 - **Use bounded adversarial review to find design and implementation gaps.**
-  Most changes get two seats; repeated findings are evidence to revisit design,
-  and six rounds ends the current review block.
+  Every non-trivial change gets two seats; repeated findings are evidence to
+  revisit design, and six rounds ends the current review block.
 - **Keep security work inside the repository threat model.** Focus on
   untrusted internet-origin data and construction-time containment, not local
   or intra-repository actors unless an owning design explicitly opts in.

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 
 | Document | Need served |
 | -------- | ----------- |
+| [Development Practices](development-practices.md) | How convention, design, pathological fixtures, analogous implementations, narrow slices, demos, and review work together. |
 | [Design Scope and Composition](../docs/design-scope.md) | Full mechanics for one-owner-per-design, broad-design gating, TLA+ modeling, and over-broad-design recovery. |
 | [Evidence and Validation](evidence-and-validation.md) | Matching evidence to claims, the style-oracle consultation procedure, and the harness/product boundary. |
 | [Round Orchestration](round-orchestration.md) | Running an adversarial review round: status discovery, dispatch, reconciliation, carry-forward, and block boundaries. |

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -1,6 +1,7 @@
 # Design scope and composition
 
-[How work runs on this repo](../AGENTS.md#how-work-runs-on-this-repo) and
+[Development practices](development-practices.md#design-establishes-the-footing)
+and
 [Design scope and composition](../AGENTS.md#design-scope-and-composition) state
 the binding rules: one architectural owner per design effort, and a broad,
 multi-component design requires explicit user approval. This document owns the

--- a/docs/design-scope.md
+++ b/docs/design-scope.md
@@ -1,11 +1,11 @@
 # Design scope and composition
 
 [Development practices](development-practices.md#design-establishes-the-footing)
-and
-[Design scope and composition](../AGENTS.md#design-scope-and-composition) state
+places design before implementation.
+[Design scope and composition](../AGENTS.md#design-scope-and-composition) states
 the binding rules: one architectural owner per design effort, and a broad,
-multi-component design requires explicit user approval. This document owns the
-full mechanics and recovery procedure.
+multi-component design requires explicit user approval. This document owns
+the full mechanics and recovery procedure.
 
 ## One owner per focused design
 

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -55,15 +55,18 @@ cleanup.
 
 Build a fixture or reproducible probe early enough to change the design. Record
 the exact input, command or procedure, expected observation, and what the result
-establishes. Prefer a checked-in test when it is deterministic and suitable for
-normal CI.
+establishes. Prefer a checked-in automated test when it is deterministic and
+suitable for normal CI. Run it in CI when accepting or rejecting the fixture is
+an important boundary of the supported contract.
 
-Preserve a useful fixture even when it is too slow, large, environment-specific,
-or tool-dependent for CI. Keep it in the appropriate corpus, harness, sample,
-or focused documentation; pin its inputs; explain why CI does not run it; and
-name the ordinary gate that covers the supported contract. A saved fixture is
-evidence that future design and review can reproduce, not an unrecorded local
-experiment or a substitute for required automated coverage.
+Preserve a useful fixture outside normal CI when it is too slow, large,
+environment-specific, or tool-dependent. Keep it in the appropriate corpus,
+harness, sample, or focused documentation; pin its inputs; and explain why CI
+does not run it. Distinguish the design evidence it provides from an enforcing
+gate: name the ordinary gate for each supported property or mark that property
+unverified. A saved fixture is evidence that future design and review can
+reproduce, not an unrecorded local experiment or a substitute for required
+automated coverage.
 
 Follow the [harness boundary](evidence-and-validation.md#harness-boundary):
 fixtures and harnesses may expose product behavior, but must not manufacture or

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -156,7 +156,7 @@ accumulate patches indefinitely.
 
 Requested work hot-starts through branch, commit, push, PR, and eligible review
 without separate approval. Markdown-only changes use `markdownlint` as their
-non-boundary pre-review and per-round gate. Most non-trivial changes receive
+non-boundary pre-review and per-round gate. Every non-trivial change receives
 two-seat adversarial review, and review blocks stop after six rounds so an
 unclosed design becomes an explicit decision rather than an endless loop.
 

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -165,8 +165,9 @@ requires separate authorization.
 
 The primary threat is untrusted internet-origin content such as packages,
 symbols, and source. The tool does not execute inspected code. Prefer
-construction-time containment threaded through typed models, following
-`InertString` and `HardenedJson`, and do not broaden work to local,
-same-machine, or intra-repository actors unless an owning design explicitly
-opts in. The complete boundary is owned by the
+construction-time containment threaded through typed models, with
+`InertString` as the stronger pattern. `HardenedJson` is a weaker centralized
+entry point, not a type whose construction enforces containment. Do not broaden
+work to local, same-machine, or intra-repository actors unless an owning design
+explicitly opts in. The complete boundary is owned by the
 [Untrusted data threat model](design/untrusted-data-threat-model.md).

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -1,0 +1,172 @@
+# Development practices
+
+This document owns the repository's development-practice model: how convention,
+design, evidence, implementation, demos, and review work together. `AGENTS.md`
+states the binding summary. Focused documents such as
+[Design scope and composition](design-scope.md),
+[Evidence and validation](evidence-and-validation.md), and
+[Round orchestration](round-orchestration.md) own their specialized contracts
+and mechanics.
+
+## Convention and best practice are the baseline
+
+Start from the applicable convention and best practice rather than inventing a
+local approach by default.
+
+A **convention** is an established, relevant pattern: first in this repository
+and owning subsystem, then in the directly analogous ecosystem. A **best
+practice** is a well-supported approach whose benefits and tradeoffs apply to
+the constraints at hand. Neither means "the first precedent found," and neither
+overrides an owning design.
+
+When the repository should be stricter or looser than the baseline, document:
+
+- the convention or best practice being used as the comparison point;
+- the exact divergence and its scope;
+- why this repository's constraints require or justify it;
+- the costs or behavior the divergence accepts; and
+- the design, test, fixture, or other evidence that keeps the choice honest.
+
+Silence is not a divergence policy. If no meaningful convention exists, say so
+and derive the choice from the owning contract and available evidence.
+
+## Design establishes the footing
+
+Before implementation, visibly name one normative owner and its exact claim.
+Identify supporting designs, models, constraints, analogous implementations,
+and evidence by role rather than treating them as co-owners. Apply
+[Design scope and composition](design-scope.md) when ownership is unclear or
+the claim crosses independently owned components.
+
+Complicated features need unusually strong pre-work. Corpus measurements, an
+established oracle, a TLA+ model, a pathological fixture, or a specification
+developed closely with the user can reveal the actual boundary before code
+makes an accidental behavior expensive to undo. Much of the architecture is
+the act of bounding a contract and making its important properties invariant.
+
+## Demonstrate the pathological case
+
+Do not demonstrate only the expected or friendly case. Identify the case, or
+spectrum of cases, that the design intends to avoid or bound: an ambiguous
+input, an extreme shape, a near miss, a scale limit, an invalid transition, or
+a legal construction that stresses an assumption. Boundary cases often behave
+differently from intuition; constructing one is design work, not merely test
+cleanup.
+
+Build a fixture or reproducible probe early enough to change the design. Record
+the exact input, command or procedure, expected observation, and what the result
+establishes. Prefer a checked-in test when it is deterministic and suitable for
+normal CI.
+
+Preserve a useful fixture even when it is too slow, large, environment-specific,
+or tool-dependent for CI. Keep it in the appropriate corpus, harness, sample,
+or focused documentation; pin its inputs; explain why CI does not run it; and
+name the ordinary gate that covers the supported contract. A saved fixture is
+evidence that future design and review can reproduce, not an unrecorded local
+experiment or a substitute for required automated coverage.
+
+Follow the [harness boundary](evidence-and-validation.md#harness-boundary):
+fixtures and harnesses may expose product behavior, but must not manufacture or
+repair the evidence they claim to check.
+
+## Survey analogous implementations
+
+The repository's SRM-only, Roslyn-free, NativeAOT-friendly architecture is
+unusual, but many of its algorithms and product surfaces have analogues: IL
+readers, decompiler transforms, metadata tools, query systems, and CLI
+disclosure models.
+
+Survey relevant implementations to learn:
+
+- whether they implement the behavior at all;
+- which inputs, boundaries, and failure modes they recognize;
+- which cases they deliberately decline or leave unsupported;
+- how tests, issues, or design notes explain surprising choices; and
+- whether multiple independent implementations converge on a convention.
+
+Record stable source links, versions or commits, and the observed behavior.
+Absence is evidence too when a mature analogous implementation declines a
+seemingly obvious feature or boundary.
+
+Treat this survey as comparative evidence, not authority. Reconcile it with
+this repository's owning design and constraints. Borrow code or internal
+architecture only when license, provenance, assumptions, and architectural fit
+all transfer; the behavioral comparison remains useful when none of them do.
+
+## Bias toward progress through narrow slices
+
+Prefer small, independently coherent slices that establish a useful contract
+for dependent features and waiting work. When the design has stable footing,
+landing the planned API or behavior shape before every hardening follow-up can
+reduce coordination delay and let consumers develop against the intended
+boundary.
+
+An early slice is acceptable only when it:
+
+- has one clear owner and claim;
+- is useful and correct for the behavior it currently promises;
+- preserves behavior-safe defaults and visible failure;
+- does not expose a stub, silent fallback, or unsupported behavior as complete;
+- carries evidence proportionate to the current claim; and
+- records residual hardening and later adoption as focused follow-up work.
+
+Do not split work when a slice depends on later work for its own correctness.
+Fold that dependency into the slice. Design work earns the bias to progress by
+reducing the chance that dependent work builds on shaky or reversible footing;
+it does not eliminate the need to revise a weak design when evidence disproves
+it.
+
+## Lead with the demo
+
+Every PR demonstrates the scenario it serves, using a mockup for documentation
+work when no product output exists yet. Post the intended demo early enough to
+change the design and implementation. A good demo makes the goal accessible,
+shows what to notice, and exercises a neighboring case so the implementation
+is not fitted only to the showcase. Follow
+[Lead with the demo](../AGENTS.md#lead-with-the-demo) for the PR contract.
+
+## Treat critical review feedback as a design question
+
+For critical review feedback, first ask whether the owning design addresses the
+reported case:
+
+- If the design already states the required behavior and boundary, diagnose why
+  the implementation or evidence fails to enforce it.
+- If the design is silent, ambiguous, or contradicted, treat the finding as a
+  design question before choosing a code repair.
+- If the concern changes another owner's contract or expands scope, apply the
+  design-scope rules instead of absorbing it as an implementation fix.
+
+It is acceptable and encouraged to keep a fast-moving focused design PR paired
+with implementation when discoveries clarify the contract. Cross-link the
+design and implementation, keep the design ahead of or synchronized with the
+behavior it authorizes, and use the Markdown-only review fast path rather than
+waiting on expensive product CI that cannot validate prose. A design PR still
+needs a coherent claim, a mockup or other demonstration, Markdown validation,
+and adversarial review.
+
+Repeated critical findings are evidence that the design may not close.
+Bounded review is a signal to return to the contract, not an invitation to
+accumulate patches indefinitely.
+
+## Move through PR and review
+
+Requested work hot-starts through branch, commit, push, PR, and eligible review
+without separate approval. Markdown-only changes use `markdownlint` as their
+non-boundary pre-review and per-round gate. Most non-trivial changes receive
+two-seat adversarial review, and review blocks stop after six rounds so an
+unclosed design becomes an explicit decision rather than an endless loop.
+
+The exact candidate, eligibility, reconciliation, status, and recovery rules
+remain owned by [Round orchestration](round-orchestration.md). Merge always
+requires separate authorization.
+
+## Keep security work targeted
+
+The primary threat is untrusted internet-origin content such as packages,
+symbols, and source. The tool does not execute inspected code. Prefer
+construction-time containment threaded through typed models, following
+`InertString` and `HardenedJson`, and do not broaden work to local,
+same-machine, or intra-repository actors unless an owning design explicitly
+opts in. The complete boundary is owned by the
+[Untrusted data threat model](design/untrusted-data-threat-model.md).


### PR DESCRIPTION
Defines one canonical development-practice model while keeping `AGENTS.md`
small and binding. The new guide establishes convention and best practice as
the baseline, makes pathological fixtures and analogous implementations
first-class design evidence, permits independently coherent narrow slices, and
routes critical review feedback through the owning design before code repair.

The existing design-scope, evidence, demo, security, and round-orchestration
contracts remain authoritative for their specialized mechanics.

## Demo

Before, a contributor encountered a dense mixed-purpose summary:

```text
AGENTS.md
└── How work runs on this repo
    └── policy, rationale, examples, and workflow details
```

After, the entry point is a skimmable 12-point binding summary with a focused
path to the rationale:

```text
AGENTS.md
└── How work runs on this repo
    └── docs/development-practices.md
        ├── Convention and best practice are the baseline
        ├── Demonstrate the pathological case
        ├── Survey analogous implementations
        ├── Bias toward progress through narrow slices
        └── Treat critical review feedback as a design question
```

The neighboring design-scope document now links to the canonical design-footing
section rather than depending on rationale embedded in `AGENTS.md`.

## Validation

```text
npx markdownlint-cli AGENTS.md docs/development-practices.md docs/README.md docs/design-scope.md
wc -l AGENTS.md
# 593
```
