### PR TITLE
Align adversarial review with development practices

### DIFF
--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -48,10 +48,36 @@ Classify it as a scope proposal, robustness idea, design question, or
 non-blocking observation. A concern that materially expands functionality or
 the threat model is not a landing requirement without operator approval.
 
+Treat critical feedback as a design question before prescribing a repair.
+Determine whether the owning design already states the required behavior, is
+silent or contradictory, or whether the concern would change another owner's
+contract. When the design already covers the case, identify the implementation
+or evidence failure. When it does not, report the resolution as design work or,
+for a cross-owner expansion, as a scope proposal rather than jumping directly
+to a code fix.
+
 A mutation is useful evidence only when it represents a plausible regression
 of promised behavior. The fact that an artificial mutation survives a gate
 does not by itself justify another gate. Prefer evidence from public product
 outcomes over tests that inspect seams introduced only for the test.
+
+Treat conventions, best practices, and analogous implementations as
+comparative evidence, not authority. A deliberate divergence is not a defect
+merely because it is unusual; connect it to an owned-claim violation and
+observable consequence. An analogous implementation's behavior or omission is
+relevant only when its assumptions transfer.
+
+Review the current slice for the behavior it presently promises. Residual
+hardening or follow-up work is not a defect when the current contract is
+independently coherent, behavior-safe, visibly fails outside its support, and
+does not depend on that later work for correctness. Do report success-shaped
+unfinished behavior or a slice whose current correctness depends on a future
+change.
+
+Push on the named pathological or boundary case. When accepting or rejecting
+that case is part of the supported contract, require exact-head gate evidence.
+A preserved non-CI fixture is design evidence, not the enforcing gate; the
+candidate must name the ordinary gate or mark the property unverified.
 
 If the design contains substantial machinery primarily to constrain trusted
 components, report that once as a design or proportionality concern. Do not
@@ -63,6 +89,11 @@ Report only high-confidence, actionable correctness, security, reliability, or
 contract findings. Ignore style preferences and speculative hardening. A clean
 result is successful: if no qualifying findings remain, report **CLEAN** and
 name the exact reviewed head.
+
+Use the candidate's stated user purpose to explain consequence, not to create a
+subjective taste gate. Do not block because a feature seems insufficiently
+foundational, compelling, conventional, delightful, new, or unique unless the
+owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
@@ -83,7 +114,8 @@ For every finding, provide:
 - exact owned claim violated;
 - concrete consequence;
 - exact-head evidence or a reproducible probe; and
-- the smallest plausible fix direction.
+- the smallest plausible resolution direction: design, evidence, or
+  implementation.
 
 Separate blocking findings from non-blocking observations and scope proposals.
 Do not turn a scope proposal into a defect by assigning it a severity. If there

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -256,6 +256,11 @@ before the fixed prompt. Append the candidate's exact base and head, design
 intent, relevant diff, concrete properties under test, prior findings, and
 required real-run evidence. The appended material may narrow the review but
 must not weaken or broaden the prompt's trust model and finding-admission rules.
+It also records the user purpose, convention or best-practice baseline,
+intentional divergence, analogous implementation evidence, pathological or
+boundary case and gate, current slice and residual work, and the demo with a
+neighboring case. Use `Not applicable — <reason>` for a field that genuinely
+does not apply.
 Agents that prefer a structured composition aid may instead fill the optional
 [`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md),
 which includes the same fixed prompt followed by candidate placeholders.
@@ -263,11 +268,13 @@ which includes the same fixed prompt followed by candidate placeholders.
 Do not dispatch with a generic or incoherent frame. The prompt must name one
 normative owner and exact claim, the supported actor or caller, the controlled
 or variable input, the boundary through which it reaches the claim, trusted
-parties and excluded scenarios, the observable consequence, and the evidence
-that would falsify the claim. For a correctness review without an untrusted
-actor, name the ordinary supported caller and input instead. If those fields
-cannot be filled, return to design or scope clarification before spending a
-review round.
+parties and excluded scenarios, the user purpose, baseline and any divergence,
+relevant analogous evidence, pathological case and gate, current slice,
+residual work, demo and neighboring case, the observable consequence, and the
+evidence that would falsify the claim. For a correctness review without an
+untrusted actor, name the ordinary supported caller and input instead. If those
+fields cannot be filled or explained as not applicable, return to design or
+scope clarification before spending a review round.
 
 Give every seat the same completed prompt except for its worktree path. State
 candidate facts rather than rewarding findings; the canonical prompt already

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -48,10 +48,36 @@ Classify it as a scope proposal, robustness idea, design question, or
 non-blocking observation. A concern that materially expands functionality or
 the threat model is not a landing requirement without operator approval.
 
+Treat critical feedback as a design question before prescribing a repair.
+Determine whether the owning design already states the required behavior, is
+silent or contradictory, or whether the concern would change another owner's
+contract. When the design already covers the case, identify the implementation
+or evidence failure. When it does not, report the resolution as design work or,
+for a cross-owner expansion, as a scope proposal rather than jumping directly
+to a code fix.
+
 A mutation is useful evidence only when it represents a plausible regression
 of promised behavior. The fact that an artificial mutation survives a gate
 does not by itself justify another gate. Prefer evidence from public product
 outcomes over tests that inspect seams introduced only for the test.
+
+Treat conventions, best practices, and analogous implementations as
+comparative evidence, not authority. A deliberate divergence is not a defect
+merely because it is unusual; connect it to an owned-claim violation and
+observable consequence. An analogous implementation's behavior or omission is
+relevant only when its assumptions transfer.
+
+Review the current slice for the behavior it presently promises. Residual
+hardening or follow-up work is not a defect when the current contract is
+independently coherent, behavior-safe, visibly fails outside its support, and
+does not depend on that later work for correctness. Do report success-shaped
+unfinished behavior or a slice whose current correctness depends on a future
+change.
+
+Push on the named pathological or boundary case. When accepting or rejecting
+that case is part of the supported contract, require exact-head gate evidence.
+A preserved non-CI fixture is design evidence, not the enforcing gate; the
+candidate must name the ordinary gate or mark the property unverified.
 
 If the design contains substantial machinery primarily to constrain trusted
 components, report that once as a design or proportionality concern. Do not
@@ -63,6 +89,11 @@ Report only high-confidence, actionable correctness, security, reliability, or
 contract findings. Ignore style preferences and speculative hardening. A clean
 result is successful: if no qualifying findings remain, report **CLEAN** and
 name the exact reviewed head.
+
+Use the candidate's stated user purpose to explain consequence, not to create a
+subjective taste gate. Do not block because a feature seems insufficiently
+foundational, compelling, conventional, delightful, new, or unique unless the
+owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
@@ -83,7 +114,8 @@ For every finding, provide:
 - exact owned claim violated;
 - concrete consequence;
 - exact-head evidence or a reproducible probe; and
-- the smallest plausible fix direction.
+- the smallest plausible resolution direction: design, evidence, or
+  implementation.
 
 Separate blocking findings from non-blocking observations and scope proposals.
 Do not turn a scope proposal into a defect by assigning it a severity. If there
@@ -93,14 +125,24 @@ are no qualifying findings, write **CLEAN** and name the exact reviewed head.
 
 Replace every `{...}` placeholder below, then append domain-specific
 instructions where indicated. Do not remove, weaken, paraphrase, reorder, or
-put other instructions before the fixed prompt above.
+put other instructions before the fixed prompt above. Fill every field; when a
+field genuinely does not apply, write `Not applicable — <reason>` rather than
+leaving a placeholder.
 
 ## Required review frame
 
 - **Normative owner:** {document and section that own the reviewed claim}
 - **Exact owned claim:** {one precise claim the change must satisfy}
+- **User purpose and outcome:** {foundational capability or compelling user
+  experience served; use for consequence, not subjective finding admission}
 - **Supporting designs and models:** {documents and their supporting roles,
   not additional owners}
+- **Convention or best-practice baseline:** {relevant repository or ecosystem
+  baseline, or why none applies}
+- **Intentional divergence or novelty:** {stricter, looser, new, or unique
+  choice; its scope, rationale, and evidence, or state none}
+- **Analogous implementation evidence:** {observed behaviors, omissions, and
+  boundaries; identify what assumptions transfer, or why none applies}
 - **Change intent:** {what behavior or contract this candidate changes}
 - **Supported actor or caller:** {ordinary caller, producer, user, or external
   actor relevant to the claim}
@@ -112,6 +154,12 @@ put other instructions before the fixed prompt above.
   environment, or other trusted context}
 - **Explicit exclusions:** {misuse and scenarios the owner does not promise to
   defend against}
+- **Pathological or boundary case:** {fixture or probe, expected observation,
+  and whether it runs in CI; otherwise name the enforcing gate or `unverified`}
+- **Slice boundary and residual work:** {what is independently correct now,
+  what follows later, and why later work is not required for current correctness}
+- **Demo and neighboring case:** {real invocation and output, or docs mockup,
+  plus an adjacent scenario that guards against fitting only the showcase}
 - **Observable consequence:** {what failure a real defect would produce}
 - **Falsifier and required evidence:** {the observation and execution evidence
   that would disprove the claim}
@@ -136,7 +184,11 @@ the exact owned claim.}
 ### Properties to verify
 
 {List concrete properties derived from the review frame. Describe properties,
-not attacks, and do not broaden the actor, input, boundary, or exclusions.}
+not attacks, and do not broaden the actor, input, boundary, or exclusions.
+Include the baseline or divergence, pathological case and gate, analogous
+evidence transfer, current-slice coherence, and demonstrated neighboring case
+when applicable. Do not turn subjective product purpose or taste into a
+property.}
 
 ### Prior findings and carried-forward obligations
 
@@ -147,7 +199,10 @@ proposals. Do not invite variants outside the review frame.}
 ### Required real-run evidence
 
 {Name focused tests, commands, fixtures, corpus witnesses, mutations, or
-probes. Require evidence proportional to the claim and supported path.}
+probes. Require evidence proportional to the claim and supported path. Identify
+which contract-defining pathological case runs in CI; for non-CI evidence,
+name the enforcing gate or `unverified`. Include the demo, neighboring case,
+and any analogous implementation evidence whose assumptions must transfer.}
 
 ### Domain-specific instructions
 


### PR DESCRIPTION
Aligns adversarial review with the repository development model without
weakening finding admission. The fixed prompt now classifies critical feedback
through design before code, treats conventions and analogous implementations
as evidence rather than authority, reviews the current slice on its present
contract, and distinguishes pathological design evidence from enforcing gates.

The fill-in frame now records user purpose, baseline and divergence, analogous
evidence, pathological fixtures and CI gates, slice boundaries and residual
work, and the demo with a neighboring case. Subjective judgments about whether
a feature is sufficiently compelling, delightful, or novel remain explicitly
non-blocking unless the owning contract defines an observable requirement.

## Demo

Before, candidate framing could omit the development evidence behind a claim:

```text
Required review frame
├── owner and exact claim
├── actor, input, and boundary
└── consequence and falsifier
```

After, the same contract is grounded in the development model:

```text
Required review frame
├── user purpose and outcome
├── convention or best-practice baseline
├── intentional divergence or novelty
├── analogous implementation evidence
├── pathological case and CI/enforcement gate
├── independently coherent current slice and residual work
└── demo and neighboring case
```

A reviewer must resolve a critical concern as a design, evidence, or
implementation direction instead of jumping directly to a code fix.

## Validation

```text
npx markdownlint-cli docs/adversarial-review-prompt.md docs/templates/adversarial-review-prompt.md docs/round-orchestration.md
diff -u docs/adversarial-review-prompt.md <fixed-prefix-from-template>
```
