### PR TITLE
Define agent-first CLI compatibility policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,9 @@ development model and rationale. The binding summary:
 - **Survey analogous implementations.** Use their behavior, omissions, and
   boundaries as evidence, not authority; transfer code or architecture only
   when license, provenance, assumptions, and architectural fit all transfer.
-- **Bias toward progress through narrow slices.** Land independently coherent
-  planned shapes before later hardening when the design makes that safe; never
-  present unfinished behavior as supported.
+- **Bias toward progress and low carrying cost.** Land independently coherent
+  slices; never present unfinished behavior as supported or preserve CLI flags
+  solely for compatibility. Shipped product skills must match current behavior.
 - **Lead with a demo.** Every PR demonstrates the scenario (a mockup for
   docs-only PRs) without fitting the implementation only to that example.
 - **Treat critical review feedback as a design question first.** Ask whether

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,7 +110,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 
 | Document | Need served |
 | -------- | ----------- |
-| [Development Practices](development-practices.md) | How convention, design, pathological fixtures, analogous implementations, narrow slices, demos, and review work together. |
+| [Development Practices](development-practices.md) | How convention, design, pathological fixtures, analogous implementations, narrow slices, agent-current compatibility, demos, and review work together. |
 | [Design Scope and Composition](../docs/design-scope.md) | Full mechanics for one-owner-per-design, broad-design gating, TLA+ modeling, and over-broad-design recovery. |
 | [Evidence and Validation](evidence-and-validation.md) | Matching evidence to claims, the style-oracle consultation procedure, and the harness/product boundary. |
 | [Round Orchestration](round-orchestration.md) | Running an adversarial review round: status discovery, dispatch, reconciliation, carry-forward, and block boundaries. |

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -131,6 +131,33 @@ reducing the chance that dependent work builds on shaky or reversible footing;
 it does not eliminate the need to revise a weak design when evidence disproves
 it.
 
+## Prefer current agent guidance over CLI compatibility
+
+`dotnet-inspect` is a fast-moving, agent-focused tool. Prefer development speed,
+a simple current design, and low carrying cost over preserving yesterday's CLI
+surface. Agents using the current tool can retrieve its current product skills;
+they do not need the command behavior that the tool had yesterday.
+
+Do not add or retain flags, aliases, shims, dual parsing, or warnings solely so
+old CLI invocations continue to work. When the best current command shape
+changes, remove the obsolete spelling. Existing compatibility-only paths are
+removal candidates, not precedent. An alias may remain only when its owning
+design justifies it as a useful part of today's interface, not merely because
+it existed before.
+
+The primary compatibility bar is that every product `skills/*/SKILL.md` shipped
+inside the tool accurately describes that exact tool. Update the owning skills
+in the same change as any command, flag, default, workflow, or output-shape
+change they teach, and rerun affected examples rather than preserving stale
+syntax. The skills are the compatibility mitigation: an agent learns the
+current reliable workflow from the current binary.
+
+`README.md` remains shipped documentation and must also describe current
+behavior, but it is not a reason to carry obsolete CLI paths. This policy does
+not redefine platform support, inspected-library compatibility analysis,
+serialized formats, protocols, library APIs, or another explicitly owned
+compatibility contract.
+
 ## Lead with the demo
 
 Every PR demonstrates the scenario it serves, using a mockup for documentation

--- a/taste/skill-guidance.md
+++ b/taste/skill-guidance.md
@@ -1,10 +1,28 @@
 # Embedded skill guidance
 
-Use this when editing `skills/dotnet-inspect/SKILL.md`.
+Use this when editing user-facing product skills under `skills/`, especially
+`skills/dotnet-inspect/SKILL.md`.
 
 ## Purpose
 
-The embedded skill is the authoritative agent guide for `dotnet-inspect`. It should teach reliable workflows, syntax guardrails, output-shape expectations, and high-value examples. It should not be a changelog or an exhaustive command manual.
+The embedded skills are the authoritative current agent guides for
+`dotnet-inspect`. They should teach reliable workflows, syntax guardrails,
+output-shape expectations, and high-value examples. They should not be a
+changelog or an exhaustive command manual.
+
+## Current guidance is the compatibility layer
+
+Product skills are the primary compatibility mitigation for this fast-moving
+agent-focused CLI. The checked-in skill and the behavior it teaches move
+together: an agent asks the current binary for current guidance rather than
+relying on yesterday's flags or defaults.
+
+Update every affected product skill in the same change as a command, flag,
+default, workflow, or output-shape change. Re-run examples against the changed
+tool. Do not retain obsolete CLI syntax solely because an earlier skill taught
+it, and do not describe migration history; replace it with the current best
+workflow. A stale shipped skill is a compatibility failure even when an old
+invocation still happens to work.
 
 ## Good
 
@@ -56,6 +74,7 @@ Why it is bad:
 - Explain `--preview` as the single prerelease opt-in alias in the skill, even when other aliases exist.
 - Keep SourceLink/PDB wording precise: PDBs carry SourceLink data; they are not SourceLink themselves.
 - Keep Signals row ownership clear; avoid describing rows as belonging to multiple sections.
+- Update every affected product skill in the same PR as the behavior it teaches.
 - Update examples when output shape changes, especially compact context rows and selected-section output.
 
 ## User-facing vs. repo-local skills


### PR DESCRIPTION
Defines `dotnet-inspect` compatibility around its primary users: agents running
the current fast-moving tool. Development speed, a simple current CLI, and low
carrying cost outrank preserving yesterday's flags, aliases, shims, or dual
parsing solely for backward compatibility.

The primary compatibility mitigation is current embedded guidance. Every
affected product `skills/*/SKILL.md` must move in the same change as the
command, flag, default, workflow, or output shape it teaches. An agent retrieves
the reliable workflow from the current binary instead of depending on the
previous version's syntax.

This focused policy does not remove existing aliases in this PR and does not
redefine platform support, inspected-library compatibility analysis, serialized
formats, protocols, library APIs, or other explicitly owned compatibility
contracts. Compatibility-only CLI paths are follow-up removal candidates; an
alias may remain only when its owner justifies it as useful current UX.

## Demo

Before, an obsolete flag could create two continuing obligations:

```text
CLI change
├── implement the better current shape
└── carry the old spelling indefinitely
```

After, current guidance is the compatibility layer:

```text
CLI change
├── implement the best current shape
├── remove compatibility-only syntax
├── update every affected shipped SKILL.md in the same PR
└── agent asks the current binary for the current workflow
```

The neighboring case remains available: an alias with present-day usability
value may stay when its owning design justifies it independently of history.

## Validation

```text
npx markdownlint-cli AGENTS.md docs/development-practices.md docs/README.md taste/skill-guidance.md
wc -l AGENTS.md
# 597
```
