### PR TITLE
Document package admission caller deferral

### DIFF
--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -1083,13 +1083,14 @@ This boundary does not define:
 
 ## Package-realization exact-request admission
 
-**Status:** target design, scoped independently of #4745; unimplemented. This
-is a separate responsibility of the same L1 owner, not an extension of the
+**Status:** target design, scoped independently of #4745; implementation
+deferred because no approved retained product caller exists. This is a separate
+responsibility of the same L1 owner, not an extension of the
 [Package-role planning and cleanup boundary](#package-role-planning-and-cleanup-boundary)'s
-plan/realize/cleanup contract or gate list. Admission decides whether one
-whole package-role operation starts or whether an exact earlier operation is
-joined or reused. The adjacent boundary still owns planning, group
-construction, binding, aggregate limit enforcement, quiescence, and cleanup.
+plan/realize/cleanup contract or gate list. Admission decides whether one whole
+package-role operation starts or whether an exact earlier operation is joined
+or reused. The adjacent boundary still owns planning, group construction,
+binding, aggregate limit enforcement, quiescence, and cleanup.
 
 This contract supersedes the earlier per-coordinate target. The current
 compatibility API does not produce independently composable per-coordinate
@@ -1111,7 +1112,12 @@ The API has no product caller today. Its only non-test consumer is the
 a higher registry boundary with its own exact-content check. It does not make
 a workspace-local admission hit reachable. Implementing this contract before a
 retained multi-call product workspace adopts it would add unreachable
-infrastructure rather than product value.
+infrastructure rather than product value. The workspace owner records the
+[retained-caller decision](../inspection-space.md#retained-package-realization-caller):
+the current prototype registry answers repeated exact requests before its
+workspace sees them, while replacing that registry with a session-wide
+projection-backed workspace would be a separately approved product-topology
+migration rather than a narrow admission caller.
 
 ### Why the whole exact request is the cache unit
 
@@ -1400,7 +1406,11 @@ Implementation of #4960 must not begin until:
   (#5185; the direct asynchronous foundation landed in #5192);
   and
 - an approved retained multi-call workspace caller makes exact-request join or
-  reuse reachable (#5123).
+  reuse reachable. This prerequisite is satisfied only when the workspace owner
+  names that caller and its lifetime. The
+  [current retained-caller decision](../inspection-space.md#retained-package-realization-caller)
+  records that no existing product topology satisfies this prerequisite, so
+  #4960 remains deferred.
 
 The target contract remains unimplemented until these named gates land:
 

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -832,7 +832,8 @@ failed. Cleanup failure never selects or replaces the terminal primary.
 
 **Status:** implemented for #5122 and verified by the named
 `PackageAssemblyContextCompletionTests` Release gates below. Coordinated
-workspace adoption remains separate under #5185.
+workspace adoption is implemented under #5185 and verified by the
+[workspace-close composition gates](../inspection-space.md#workspace-close-and-group-release-authority).
 
 One successfully opened package-role operation produces one
 workspace-owned `PackageAssemblyContextCompletion`. The completion owns the
@@ -931,7 +932,7 @@ Coordinated workspace registration, workspace-close signaling, late
 completion, and preservation of existing lease-holder access during workspace
 close remain owned by
 [Workspace close and group release authority](../inspection-space.md#workspace-close-and-group-release-authority)
-and are adopted separately by #5185.
+and were adopted separately under #5185.
 
 The adjacent exact-request admission and assembly-context group lifecycle
 models bound cache leases and group quiescence respectively. Neither model
@@ -1256,9 +1257,10 @@ does not release capacity still owned by the physical operation.
 If any reservation would exceed its workspace limit, that demand receives a
 typed capacity rejection before an operation id is minted or package-role work
 starts. Capacity rejection is not cached and does not disturb an existing
-entry. The retained caller in #5123 must choose explicit workspace limits; the
-admission implementation cannot inherit unbounded cardinality from caller
-input.
+entry. The
+[retained-caller decision](../inspection-space.md#retained-package-realization-caller)
+requires any approved caller to choose explicit workspace limits; the admission
+implementation cannot inherit unbounded cardinality from caller input.
 
 One operation publishes one combined result atomically. Every demand attached
 to that operation receives the same success and realization identity, or every
@@ -1376,15 +1378,15 @@ Target workspace disposal is asynchronous. The
 [workspace close contract](../inspection-space.md#workspace-close-and-group-release-authority),
 defined by #5156, owns sole terminal release authority, coordinated
 lease-draining access, late-completion cleanup, and non-blocking close. Its
-direct-group asynchronous foundation is implemented by #5192. Coordinated
-package-role registration and release remain unimplemented and are tracked by
-issue #5185; the current package-role path still disposes its groups
-independently.
-Admission implementation therefore depends on that coordinated adoption after
-issue #5122 and this contract supply their owner-issued completion, projection,
-and lease handoffs. The target may wait indefinitely for a lease whose holder
-never returns it; weak-fairness model results therefore state the explicit
-caller assumption that every issued lease is eventually returned.
+direct-group asynchronous foundation is implemented by #5192, and coordinated
+package-role registration and release are implemented by #5185. The synchronous
+caller-owned `PackageAssemblyContextRealization` compatibility path still
+disposes its groups independently and is not the admission result. Admission
+implementation depends on the landed coordinated adoption and uses the
+owner-issued completion, projection, and lease handoffs from #5122 and this
+contract. The target may wait indefinitely for a lease whose holder never
+returns it; weak-fairness model results therefore state the explicit caller
+assumption that every issued lease is eventually returned.
 
 Cleanup failure remains visible through the package-role completion and does
 not produce a ready entry. Once cleanup completes, successfully or with

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -587,6 +587,49 @@ artifact acquisition lifetime, query-specific participant release policy, or
 the implementation of
 [#4960](https://github.com/richlander/dotnet-inspect/issues/4960).
 
+#### Retained package-realization caller
+
+**Status:** no approved product caller.
+
+The `inspect-web` prototype is the only current multi-operation consumer of
+package roles. Its `BrowserPackageWorkspace` retains a bounded registry of
+complete `BrowserInspectionScope` instances keyed by an exact
+package-coordinate set; the prototype's README owns that retention and eviction
+policy. Each scope owns one `InspectionWorkspace` and one package-role
+realization. The registry returns the already-open scope for a later exact
+request, so the workspace never receives a second independent package-role
+demand and cannot exercise workspace-local exact-request admission.
+
+Moving reuse below that boundary would be a product-topology migration, not a
+narrow caller adoption. A Browser-session owner would need to adopt the landed
+demand-projection and coordinated-release contracts across the prototype:
+replace retained whole scopes with independently returned demand projections,
+migrate every scope query to projection-safe access, attach package-archive
+retention to the shared completion instead of one demand, and define awaited
+session reset or shutdown so retained entries eventually close.
+
+A one-request workspace beneath each existing registry key cannot receive a
+second independent exact demand because the outer registry returns the retained
+scope first. An Integrations-only workspace would duplicate the ordinary
+realization solely to resubmit a demand that Integrations already answers from
+the retained scope. Neither topology adds an independently useful product
+lifetime.
+
+The retained Browser platform path is not a package-role caller: each cumulative
+rebuild creates a fresh `InspectionWorkspace` through `WorkspaceContextLoader`
+instead of submitting repeated package-role demands. The CLI, the only shipped
+host, remains operation-scoped. Therefore no existing component justifies the
+lower-level retained cache, and
+[#4960](https://github.com/richlander/dotnet-inspect/issues/4960) remains
+deferred. A future caller proposal must establish its product lifetime first,
+including explicit bounds for retained or in-flight exact requests, concurrent
+physical operations, and aggregate retained-byte reservation, and must name one
+real repeated exact-demand scenario plus one neighboring distinct-demand
+scenario. Once that caller is approved, the admission implementation owns the
+observable ready-reuse, non-hit, capacity-rejection, and terminal-cleanup gates
+through that caller. Admission must not be implemented or a caller lifetime
+manufactured solely to make those gates pass.
+
 `WorkspaceContextLoader` now realizes package, platform, and embedded
 coordinates without requiring a filesystem. A platform coordinate maps the
 `runtime` or `aspnetcore` family to its product-owned implementation-pack


### PR DESCRIPTION
## Summary

- records that no existing product topology justifies a retained
  package-realization workspace below the current host boundary
- explains why the inspect-web whole-scope registry, its platform path, and
  narrower per-key or Integrations-only alternatives do not create a genuine
  workspace-local admission caller
- leaves the exact-request admission contract intact while explicitly
  deferring #4960 until the workspace owner approves a real caller and lifetime

## Demo

Before, the admission design listed an approved retained caller as an open
prerequisite without recording whether the repository actually had one.

After, the owning workspace design states:

> **Status:** no approved product caller.

It shows that repeated inspect-web package requests are answered by the
already-open `BrowserInspectionScope` before its `InspectionWorkspace` sees a
second demand. It also names the neighboring retained platform path and
explains why it does not call package-role realization. A future proposal must
first supply a real repeated-demand scenario, a distinct neighboring demand,
explicit capacity bounds, cancellation ownership, and awaited lifetime
closure; #4960 then owns the observation gates through that caller.

## Compatibility

This changes no product behavior, Browser registry policy, package-role
contract, admission key, or TLA+ model. It prevents unreachable admission
infrastructure from being presented as ready work.

## Validation

- `npx markdownlint-cli docs/inspection-space.md docs/design/inspection-layers.md`
- `git diff --check`

Closes #5123
