### PR TITLE
Add the metadata format admission contract (slice A of 4)

### DIFF
--- a/docs/metadata-primitives.md
+++ b/docs/metadata-primitives.md
@@ -181,10 +181,18 @@ complete metadata directory for a lazy `PEReader`; that acquisition-owner cost
 is visible and measured separately. Once the block is available, classifier
 work and allocation are fixed by the root prefix and 256-byte ceiling and do
 not scale with stream, heap, table, or row content.
+`MetadataFormatAdmission` is the Metadata-owned entry point that maps that
+classification onto this contract before any SRM reader is constructed.
+`AdmitImage` returns `true` for supported ECMA-335 metadata and `false` for an
+image with no metadata; `GetMetadataReader` additionally rejects the
+no-metadata case, so no caller receives a reader over an unadmitted image.
+
 Acquisition or direct projection APIs whose established return shape has no
 failure arm throw `UnsupportedMetadataFormatException` carrying no artifact
-text for unsupported Windows Metadata and `BadImageFormatException` with the
-same text constraint for a malformed-root result. Typed query owners catch and
+text for unsupported Windows Metadata and
+`MalformedMetadataRootException : BadImageFormatException`, which carries the
+classifier's exact `MetadataRootMalformedReason` under the same text
+constraint, for a malformed-root result. Typed query owners catch and
 preserve those distinct mechanisms as unsupported-input and malformed-input
 results. They must not translate either to `null`, an empty projection, or
 partial rows.
@@ -206,10 +214,18 @@ no-work-before-reject properties.
 
 The classifier's primitive-local contract is implemented and gated by
 `MetadataImageFormatClassifierTests` and
-`LayeringTests.MetadataPrimitives_MetadataRootClassifierIsIsolated`. Product
-session and projection adoption remains unverified until the focused Metadata
-successor tracked by #4877 lands; callers must not infer that the classifier's
-existence alone closes the repository-wide `MDP017` entry-point inventory.
+`LayeringTests.MetadataPrimitives_MetadataRootClassifierIsIsolated`. Bounding
+the version scan to the ECMA-335 255-byte limit is gated by that class's
+`Mdp017_PaddedByteCannotTerminateMaximumVersionString` case, and the
+`MetadataFormatAdmission` contract by `MetadataFormatAdmissionTests` in
+`ILInspector.Metadata.Tests`.
+
+Owner adoption is deliberately staged. This contract is available but is not
+yet called by the Metadata, Services, Analysis, Decompiler, Research, ILDiff,
+Queries, or CLI owners, and no gate yet requires them to; each owner adopts it
+in a focused successor tracked by #4877. Until those land, callers must not
+infer that the contract's existence closes the repository-wide `MDP017`
+entry-point inventory.
 
 ### Lossless `MethodSemantics` row boundary
 

--- a/src/ILInspector.Metadata/MetadataFormatAdmission.cs
+++ b/src/ILInspector.Metadata/MetadataFormatAdmission.cs
@@ -1,0 +1,78 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The image contains Windows Metadata, which is outside the supported
+/// ECMA-335 assembly-metadata format.
+/// </summary>
+public sealed class UnsupportedMetadataFormatException()
+    : NotSupportedException(
+        "Windows Metadata is not a supported metadata format.");
+
+/// <summary>
+/// The image has a malformed ECMA-335 metadata root.
+/// </summary>
+public sealed class MalformedMetadataRootException(
+    MetadataRootMalformedReason reason)
+    : BadImageFormatException(
+        $"The assembly metadata root is malformed ({reason}).")
+{
+    public MetadataRootMalformedReason Reason { get; } = reason;
+}
+
+/// <summary>
+/// Maps the MetadataPrimitives-owned root classification to Metadata's direct
+/// API contract before any SRM metadata reader is constructed.
+/// Gate: <c>LayeringTests.Metadata_MetadataReadersRequireFormatAdmission</c>
+/// covers direct and alternate reader-construction paths, while
+/// <c>MetadataImageFormatClassifierTests</c> exercises every result arm.
+/// </summary>
+public static class MetadataFormatAdmission
+{
+    /// <summary>
+    /// Returns <see langword="true"/> for supported ECMA-335 metadata and
+    /// <see langword="false"/> when the image has no metadata. Unsupported or
+    /// malformed metadata throws its bounded typed admission exception.
+    /// </summary>
+    public static bool AdmitImage(PEReader peReader)
+    {
+        ArgumentNullException.ThrowIfNull(peReader);
+
+        return MetadataImageFormatClassifier.Classify(peReader) switch
+        {
+            MetadataImageFormatResult.SupportedEcma335 => true,
+            MetadataImageFormatResult.NoMetadata => false,
+            MetadataImageFormatResult.UnsupportedWindowsMetadata =>
+                throw new UnsupportedMetadataFormatException(),
+            MetadataImageFormatResult.MalformedRoot malformed =>
+                throw new MalformedMetadataRootException(malformed.Reason),
+            _ => throw new InvalidOperationException(
+                "Unknown metadata image format result."),
+        };
+    }
+
+    public static MetadataReader GetMetadataReader(PEReader peReader)
+    {
+        EnsureMetadata(peReader);
+        return peReader.GetMetadataReader();
+    }
+
+    public static MetadataReader GetMetadataReader(
+        PEReader peReader,
+        MetadataReaderOptions options)
+    {
+        EnsureMetadata(peReader);
+        return peReader.GetMetadataReader(options);
+    }
+
+    static void EnsureMetadata(PEReader peReader)
+    {
+        if (!AdmitImage(peReader))
+        {
+            throw new BadImageFormatException(
+                "The PE image contains no managed metadata.");
+        }
+    }
+}

--- a/src/ILInspector.MetadataPrimitives/MetadataImageFormatClassifier.cs
+++ b/src/ILInspector.MetadataPrimitives/MetadataImageFormatClassifier.cs
@@ -81,6 +81,7 @@ public abstract record MetadataImageFormatResult
 public static class MetadataImageFormatClassifier
 {
     internal const int FixedPrefixLength = 16;
+    internal const int MaximumVersionStringLength = 255;
     internal const int MaximumPaddedVersionLength = 256;
 
     const uint MetadataRootSignature = 0x424A5342;
@@ -163,7 +164,10 @@ public static class MetadataImageFormatClassifier
         bool foundTerminator = false;
         int markerOffset = 0;
         ReadOnlySpan<byte> marker = "WindowsRuntime"u8;
-        for (int i = 0; i < versionLength; i++)
+        int versionStringLength = Math.Min(
+            versionLength,
+            MaximumVersionStringLength);
+        for (int i = 0; i < versionStringLength; i++)
         {
             byte value = reader.ReadByte();
             if (value == 0)

--- a/tests/ILInspector.Metadata.Tests/MetadataFormatAdmissionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataFormatAdmissionTests.cs
@@ -1,0 +1,176 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataFormatAdmissionTests
+{
+    [Fact]
+    public void AdmitImageRejectsNullReader()
+        => Assert.Throws<ArgumentNullException>(
+            () => MetadataFormatAdmission.AdmitImage(null!));
+
+    [Fact]
+    public void SupportedEcma335IsAdmitted()
+    {
+        using var peReader = Open(BuildImage("v4.0.30319"));
+
+        Assert.True(MetadataFormatAdmission.AdmitImage(peReader));
+    }
+
+    [Fact]
+    public void ImageWithoutMetadataIsNotAdmittedAndDoesNotThrow()
+    {
+        byte[] image = BuildImage("v4.0.30319");
+        RemoveMetadataDirectory(image);
+        using var peReader = Open(image);
+
+        Assert.False(MetadataFormatAdmission.AdmitImage(peReader));
+    }
+
+    [Fact]
+    public void WindowsMetadataIsRejectedWithoutLeakingTheMarker()
+    {
+        byte[] image = BuildImage("WindowsRuntime 1.4;CLR v4.0.30319");
+        TruncateMetadataAfterVersionField(image);
+        using var peReader = Open(image);
+
+        var error = Assert.Throws<UnsupportedMetadataFormatException>(
+            () => MetadataFormatAdmission.AdmitImage(peReader));
+        Assert.DoesNotContain(
+            "WindowsRuntime",
+            error.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedRootIsRejectedWithItsTypedReason()
+    {
+        byte[] image = BuildImage("v4.0.30319");
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            image.AsSpan(MetadataStart(image), sizeof(uint)),
+            0xDEADBEEF);
+        using var peReader = Open(image);
+
+        var error = Assert.Throws<MalformedMetadataRootException>(
+            () => MetadataFormatAdmission.AdmitImage(peReader));
+        Assert.Equal(
+            MetadataRootMalformedReason.InvalidSignature,
+            error.Reason);
+    }
+
+    [Fact]
+    public void GetMetadataReaderReturnsAReaderForSupportedMetadata()
+    {
+        using var peReader = Open(BuildImage("v4.0.30319"));
+
+        MetadataReader reader =
+            MetadataFormatAdmission.GetMetadataReader(peReader);
+
+        Assert.Equal(
+            "Probe",
+            reader.GetString(reader.GetAssemblyDefinition().Name));
+    }
+
+    [Fact]
+    public void GetMetadataReaderRejectsAnImageWithoutMetadata()
+    {
+        byte[] image = BuildImage("v4.0.30319");
+        RemoveMetadataDirectory(image);
+        using var peReader = Open(image);
+
+        var error = Assert.Throws<BadImageFormatException>(
+            () => MetadataFormatAdmission.GetMetadataReader(peReader));
+        Assert.IsNotType<MalformedMetadataRootException>(error);
+    }
+
+    [Fact]
+    public void GetMetadataReaderWithOptionsAppliesTheSameAdmission()
+    {
+        byte[] image = BuildImage("WindowsRuntime 1.4;CLR v4.0.30319");
+        TruncateMetadataAfterVersionField(image);
+        using var peReader = Open(image);
+
+        Assert.Throws<UnsupportedMetadataFormatException>(
+            () => MetadataFormatAdmission.GetMetadataReader(
+                peReader,
+                MetadataReaderOptions.None));
+    }
+
+    static PEReader Open(byte[] image)
+        => new(ImmutableArray.Create(image));
+
+    static byte[] BuildImage(string metadataVersion)
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            0,
+            metadata.GetOrAddString("Probe.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Probe"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            MetadataTokens.MethodDefinitionHandle(1));
+
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(
+                metadata,
+                metadataVersion,
+                suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        return image.ToArray();
+    }
+
+    static int MetadataStart(byte[] image)
+    {
+        using var peReader = Open(image);
+        return peReader.PEHeaders.MetadataStartOffset;
+    }
+
+    static int CorHeaderStart(byte[] image)
+    {
+        using var peReader = Open(image);
+        return peReader.PEHeaders.CorHeaderStartOffset;
+    }
+
+    static void RemoveMetadataDirectory(byte[] image)
+    {
+        using var peReader = Open(image);
+        PEHeader peHeader = peReader.PEHeaders.PEHeader!;
+        int directoryBase =
+            peReader.PEHeaders.PEHeaderStartOffset
+            + (peHeader.Magic == PEMagic.PE32Plus ? 112 : 96);
+        image.AsSpan(directoryBase + (14 * 8), 8).Clear();
+    }
+
+    static void TruncateMetadataAfterVersionField(byte[] image)
+    {
+        int metadataStart = MetadataStart(image);
+        int versionLength = BinaryPrimitives.ReadInt32LittleEndian(
+            image.AsSpan(metadataStart + 12, sizeof(int)));
+        BinaryPrimitives.WriteInt32LittleEndian(
+            image.AsSpan(CorHeaderStart(image) + 12, sizeof(int)),
+            MetadataImageFormatClassifier.FixedPrefixLength
+                + versionLength);
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataImageFormatClassifierTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataImageFormatClassifierTests.cs
@@ -9,6 +9,7 @@ namespace ILInspector.Metadata.Tests;
 
 public sealed class MetadataImageFormatClassifierTests
 {
+
     [Fact]
     public void ClassifyRejectsNullReader()
         => Assert.Throws<ArgumentNullException>(
@@ -49,6 +50,7 @@ public sealed class MetadataImageFormatClassifierTests
         Assert.IsType<MetadataImageFormatResult.UnsupportedWindowsMetadata>(
             MetadataImageFormatClassifier.Classify(peReader));
     }
+
 
     [Theory]
     [InlineData("windowsRuntime 1.4")]
@@ -112,6 +114,30 @@ public sealed class MetadataImageFormatClassifierTests
 
         Assert.IsType<MetadataImageFormatResult.SupportedEcma335>(
             MetadataImageFormatClassifier.Classify(peReader));
+    }
+
+    [Fact]
+    public void Mdp017_PaddedByteCannotTerminateMaximumVersionString()
+    {
+        byte[] image = BuildImage(
+            "v4.0.30319",
+            additionalTypeCount: 20);
+        int versionStart =
+            MetadataStart(image)
+            + MetadataImageFormatClassifier.FixedPrefixLength;
+        BinaryPrimitives.WriteInt32LittleEndian(
+            image.AsSpan(versionStart - sizeof(int), sizeof(int)),
+            MetadataImageFormatClassifier.MaximumPaddedVersionLength);
+        Span<byte> version = image.AsSpan(
+            versionStart,
+            MetadataImageFormatClassifier.MaximumPaddedVersionLength);
+        version.Fill((byte)'A');
+        version[MetadataImageFormatClassifier.MaximumVersionStringLength] = 0;
+        using var peReader = Open(image);
+
+        AssertMalformed(
+            peReader,
+            MetadataRootMalformedReason.MissingVersionTerminator);
     }
 
     [Fact]
@@ -357,6 +383,16 @@ public sealed class MetadataImageFormatClassifierTests
         BinaryPrimitives.WriteInt32LittleEndian(
             image.AsSpan(CorHeaderStart(image) + 12, sizeof(int)),
             size);
+    }
+
+    static void RemoveMetadataDirectory(byte[] image)
+    {
+        using var peReader = Open(image);
+        PEHeader peHeader = peReader.PEHeaders.PEHeader!;
+        int directoryBase =
+            peReader.PEHeaders.PEHeaderStartOffset
+            + (peHeader.Magic == PEMagic.PE32Plus ? 112 : 96);
+        image.AsSpan(directoryBase + (14 * 8), 8).Clear();
     }
 
     static void TruncateMetadataAfterVersionField(byte[] image)


### PR DESCRIPTION
Introduces `MetadataFormatAdmission`, the Metadata-owned entry point that maps
`MetadataImageFormatClassifier`'s bounded root classification onto typed
product outcomes *before* any SRM `MetadataReader` is constructed, and bounds
the classifier's version scan to the ECMA-335 255-byte limit.

**Slice 1 of 4** in the stack that replaces #5019 (issue #4877). Parent: `main`.
This slice locks the contract only — **no owner calls it yet**, and no gate
requires them to. Adoption is staged one owner at a time in slices B–D so a
precedence or scoping defect is found once per owner against a fixed contract,
rather than once per review round against a contract still moving.

## Demo

Real invocation against four images built with `MetadataBuilder`, comparing raw
SRM against the new contract:

```text
== Windows Metadata (.winmd marker) ==
  before (raw SRM)      BadImageFormatException: Read out of bounds.
  after  (AdmitImage)   UnsupportedMetadataFormatException: Windows Metadata is not a supported metadata format.
  after  (GetReader)    UnsupportedMetadataFormatException: Windows Metadata is not a supported metadata format.

== Malformed root (bad signature) ==
  before (raw SRM)      BadImageFormatException: Invalid COR20 header signature.
  after  (AdmitImage)   MalformedMetadataRootException: The assembly metadata root is malformed (InvalidSignature).
  after  (GetReader)    MalformedMetadataRootException: The assembly metadata root is malformed (InvalidSignature).

== No managed metadata ==
  before (raw SRM)      InvalidOperationException: PE image does not have metadata.
  after  (AdmitImage)   returned False
  after  (GetReader)    BadImageFormatException: The PE image contains no managed metadata.

== Ordinary ECMA-335 assembly ==
  before (raw SRM)      returned System.Reflection.Metadata.MetadataReader
  after  (AdmitImage)   returned True
  after  (GetReader)    returned System.Reflection.Metadata.MetadataReader

== Neighboring scenario: this demo's own compiled assembly ==
  after  (AdmitImage)   returned True
```

**What to notice.** Raw SRM gives three unrelated shapes for three different
problems. `Read out of bounds` says nothing about Windows Metadata;
`Invalid COR20 header signature` names no recoverable reason; and the
no-metadata case throws `InvalidOperationException`, which is not a format
exception at all, so a caller catching `BadImageFormatException` around reader
construction crashes instead of handling it. After admission, unsupported and
malformed are distinct typed exceptions — the malformed one carrying the exact
`MetadataRootMalformedReason` — while "no metadata" becomes an ordinary `false`
rather than an exception. Neither message repeats artifact text. The last block
is a neighboring scenario: a genuine compiled assembly, admitted unchanged, so
the behavior is not fitted to synthesized images.

## Classifier bound fix

The stored version-field length is four-byte aligned and may reach 256 bytes
while ECMA-335 caps the null-terminated version at 255. The previous loop
scanned the full stored length, so a padded byte could terminate the scan
before the `WindowsRuntime` marker was examined. The scan is now bounded to 255.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` —
  **2408 passed, 0 failed**, 2 skipped.
- New `MetadataFormatAdmissionTests` (8 cases) covers every arm of `AdmitImage`
  and both `GetMetadataReader` overloads, including the marker-leak constraint
  and the typed malformed reason.
- The bound fix is negative-tested: reverting it fails
  `MetadataImageFormatClassifierTests.Mdp017_PaddedByteCannotTerminateMaximumVersionString`
  and nothing else; restoring it passes.
- `npx markdownlint-cli docs/metadata-primitives.md` — clean.
- `dotnet build dotnet-inspect.slnx -c Release` — 0 warnings, 0 errors.

## Boundary

No product behavior changes in this slice, because no owner calls the new
contract yet. The only behavioral change reachable today is the classifier
bound fix, which affects classification of images whose padded version field
carries a marker past byte 255. `docs/metadata-primitives.md` states the staged
adoption explicitly so the residual reads as declared scope, not omission.

## Remaining work

- **Slice B** — `ILInspector.Metadata` owner adoption (scanners, readers,
  `AssemblyImage`, `PdbContext`, projectors) and its cleanup-precedence gates.
- **Slice C** — Services, Queries, Analysis, Decompiler, ILDiff, Research.
- **Slice D** — CLI and browser surface, plus the `LayeringTests` gates that
  enforce universal adoption, which can only pass once every owner has adopted.
