### PR TITLE
Implement bounded local-directory artifact acquisition

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2320,7 +2320,9 @@ or bytes across artifacts or generations.
 `LocalArtifactSourceTests` enforce pre-registration local snapshots, typed
 path-admission outcomes, expected kinds, link handling, pre-open rejection of
 stable non-regular entries, once-opened generation identity, mutation and
-deletion resistance, and cancellation remaining cancellation. The executable
+deletion resistance, bounded deterministic top-level directory selection,
+atomic empty and failed directory batches, directory provenance, immutable
+directory snapshots, and cancellation remaining cancellation. The executable
 NativeAOT and Browser/Wasm probes enforce the normalized `Stat`/`FStat` imports
 and the platform-specific missing, not-directory, and link-loop outcome
 mappings. Deep Inspect's Windows `platform-test` execution of
@@ -2329,18 +2331,17 @@ mappings. Deep Inspect's Windows `platform-test` execution of
 `LocalPathAdmission_WindowsAncestorLinkLoopIsRejected` enforces
 extended-coordinate admission through a parent-relative symbolic-link target,
 absolute-target syntax preservation, and rejected ancestor link cycles.
-The three named `LocalDirectoryAcquisition_*` gates remain unverified. Together
-they require bounded deterministic top-level selection, source-neutral
-exclusions, atomic empty and failure outcomes, directory provenance, immutable
-batch snapshots, and cancellation preservation. Shared local-path admission
-remains with the
+The three named `LocalDirectoryAcquisition_*` gates enforce bounded
+deterministic top-level selection, source-neutral exclusions, atomic empty and
+failure outcomes, directory provenance, immutable batch snapshots, and
+cancellation preservation. Shared local-path admission remains with the
 [local adapter](#shared-local-path-admission) rather than these directory
 gates.
-The eleven named `SupplementalAcquisition_*` gates remain unverified. Together
-they require the one-way required checkpoint, reuse of checkpointed snapshots,
-finite pre-adapter capacity, empty-batch lease ownership, exact visible
-failure, atomic scoped nonempty admission, validation-failure cleanup,
-termination cleanup, late-diagnostic projection, and cancellation preservation.
+The eleven named `SupplementalAcquisition_*` gates enforce the one-way required
+checkpoint, reuse of checkpointed snapshots, finite pre-adapter capacity,
+empty-batch lease ownership, exact visible failure, atomic scoped nonempty
+admission, validation-failure cleanup, termination cleanup, late-diagnostic
+projection, and cancellation preservation.
 `LocalOnlyHost_InspectsCallerSuppliedLocalAssembly`
 deletes its temporary source after publication, then passes an
 `ArtifactContentReference`'s guarded published snapshot opener to Metadata, so
@@ -2352,8 +2353,7 @@ compile assets. `BrowserEngineBoundaryTests` enforce the tools-v2 pointer and
 explicit-empty-group cases, including typed compile-library absence, package
 documents, manifest dependencies, and no fabricated default assembly.
 
-Supplemental acquisition, workspace-wide admission budgets,
-single-flight/reentrancy, directory acquisition, content digests,
+Workspace-wide admission budgets, single-flight/reentrancy, content digests,
 dependent-group quiescence, and Metadata consumption of workspace roles remain
 unverified.
 

--- a/src/DotnetInspector.Artifacts.Local/DotnetInspector.Artifacts.Local.csproj
+++ b/src/DotnetInspector.Artifacts.Local/DotnetInspector.Artifacts.Local.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
-    <Description>Bounded immutable local-file acquisition for source-neutral artifact sessions</Description>
+    <Description>Bounded immutable local file and directory acquisition for source-neutral artifact sessions</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 

--- a/src/DotnetInspector.Artifacts.Local/LocalArtifactSource.cs
+++ b/src/DotnetInspector.Artifacts.Local/LocalArtifactSource.cs
@@ -82,9 +82,10 @@ public sealed record LocalArtifactDiagnostic :
 /// <c>LocalPathAdmission_ConsumerReceivesTheVerifiedOpenGeneration</c>.
 /// Pre-open rejection of stable non-regular entries is gated by
 /// <c>LocalPathAdmission_StableNonRegularEntriesRejectBeforeOpen</c>.
-/// Directory acquisition remains unverified.
+/// Bounded directory acquisition is gated by the three
+/// <c>LocalDirectoryAcquisition_*</c> tests.
 /// </remarks>
-public static class LocalArtifactSource
+public static partial class LocalArtifactSource
 {
     public static async ValueTask<ArtifactAcquisitionOutcome>
         AcquireFileAsync(

--- a/src/DotnetInspector.Artifacts.Local/LocalDirectoryArtifactSource.cs
+++ b/src/DotnetInspector.Artifacts.Local/LocalDirectoryArtifactSource.cs
@@ -1,0 +1,563 @@
+using System.IO.Enumeration;
+
+namespace DotnetInspector.Artifacts.Local;
+
+public sealed record LocalDirectoryArtifactAcquisitionOptions
+{
+    public const int DefaultMaxObservedEntries = 1024;
+    public const int DefaultMaxSelectedFiles = 1024;
+    public const long DefaultMaxFileBytes = 512L * 1024 * 1024;
+    public const long DefaultMaxTotalBytes = 512L * 1024 * 1024;
+
+    public IReadOnlyCollection<string> ExcludedFileNames { get; init; } =
+        Array.Empty<string>();
+
+    public IReadOnlyCollection<string> IncludedFileExtensions { get; init; } =
+        new[] { ".dll" };
+
+    public int MaxObservedEntries { get; init; } =
+        DefaultMaxObservedEntries;
+
+    public int MaxSelectedFiles { get; init; } =
+        DefaultMaxSelectedFiles;
+
+    public long MaxFileBytes { get; init; } =
+        DefaultMaxFileBytes;
+
+    public long MaxTotalBytes { get; init; } =
+        DefaultMaxTotalBytes;
+}
+
+/// <summary>
+/// Typed evidence for one top-level file copied from a local directory.
+/// </summary>
+public sealed record LocalDirectoryArtifactProvenance :
+    IArtifactProvenance
+{
+    public LocalDirectoryArtifactProvenance(
+        string canonicalRoot,
+        string relativeName,
+        string fullPath,
+        long contentLength,
+        DateTime observedLastWriteTimeUtc)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(relativeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullPath);
+        ArgumentOutOfRangeException.ThrowIfNegative(contentLength);
+        CanonicalRoot = canonicalRoot;
+        RelativeName = relativeName;
+        FullPath = fullPath;
+        ContentLength = contentLength;
+        ObservedLastWriteTimeUtc = observedLastWriteTimeUtc;
+    }
+
+    public string CanonicalRoot { get; }
+    public string RelativeName { get; }
+    public string FullPath { get; }
+    public long ContentLength { get; }
+    public DateTime ObservedLastWriteTimeUtc { get; }
+}
+
+public sealed record LocalDirectoryArtifactDiagnostic :
+    IArtifactAcquisitionDiagnostic
+{
+    public LocalDirectoryArtifactDiagnostic(
+        string code,
+        string summary,
+        string requestedRoot,
+        string? canonicalRoot,
+        string? relativeName = null,
+        string? fullPath = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(summary);
+        ArgumentException.ThrowIfNullOrWhiteSpace(requestedRoot);
+        if (relativeName is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(relativeName);
+        if (fullPath is not null)
+            ArgumentException.ThrowIfNullOrWhiteSpace(fullPath);
+        Code = code;
+        Summary = summary;
+        RequestedRoot = requestedRoot;
+        CanonicalRoot = canonicalRoot;
+        RelativeName = relativeName;
+        FullPath = fullPath;
+    }
+
+    public string Code { get; }
+    public string Summary { get; }
+    public string RequestedRoot { get; }
+    public string? CanonicalRoot { get; }
+    public string? RelativeName { get; }
+    public string? FullPath { get; }
+}
+
+public static partial class LocalArtifactSource
+{
+    /// <summary>
+    /// Acquires a bounded, deterministic batch of top-level files from one
+    /// explicit local directory.
+    /// </summary>
+    public static async ValueTask<ArtifactAcquisitionOutcome>
+        AcquireDirectoryAsync(
+            ArtifactContributionScope scope,
+            string path,
+            LocalDirectoryArtifactAcquisitionOptions? options = null,
+            CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        DirectoryOptionsSnapshot configured = ValidateAndCopy(
+            options ?? new LocalDirectoryArtifactAcquisitionOptions());
+
+        LocalPathClassification root =
+            LocalPathAdmission.AdmitDirectory(path, cancellationToken);
+        if (root.Outcome != LocalPathOutcome.Classified)
+            return ProjectDirectoryRootOutcome(root);
+
+        string canonicalRoot = root.CanonicalPath!;
+        List<ObservedDirectoryEntry> observed = [];
+        try
+        {
+            var entries = new FileSystemEnumerable<ObservedDirectoryEntry>(
+                canonicalRoot,
+                static (ref FileSystemEntry entry) =>
+                    new ObservedDirectoryEntry(
+                        entry.FileName.ToString(),
+                        entry.ToFullPath(),
+                        entry.Attributes),
+                new EnumerationOptions
+                {
+                    AttributesToSkip = 0,
+                    IgnoreInaccessible = false,
+                    RecurseSubdirectories = false,
+                    ReturnSpecialDirectories = false,
+                });
+            foreach (ObservedDirectoryEntry entry in entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (observed.Count == configured.MaxObservedEntries)
+                {
+                    return DirectoryOutcome.Rejected(
+                        "local.directory.entry-limit",
+                        "The local directory exceeds the configured observed-entry limit.",
+                        root);
+                }
+
+                observed.Add(entry);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or NotSupportedException)
+        {
+            return DirectoryOutcome.Failed(
+                "local.directory.enumeration-failed",
+                "The local directory could not be enumerated.",
+                root);
+        }
+
+        observed.Sort(
+            static (left, right) =>
+                StringComparer.Ordinal.Compare(
+                    left.RelativeName,
+                    right.RelativeName));
+
+        List<DirectoryArtifactSnapshot> snapshots = [];
+        long copiedBytes = 0;
+        int selectedFiles = 0;
+        foreach (ObservedDirectoryEntry entry in observed)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if ((entry.Attributes & FileAttributes.Directory) != 0
+                && (entry.Attributes & FileAttributes.ReparsePoint) == 0)
+            {
+                continue;
+            }
+
+            if (!configured.Includes(entry.RelativeName))
+                continue;
+
+            LocalPathClassification classification =
+                LocalPathAdmission.Classify(
+                    entry.FullPath,
+                    cancellationToken);
+            if (classification.Outcome == LocalPathOutcome.Classified
+                && classification.Kind == LocalPathKind.Directory)
+            {
+                continue;
+            }
+
+            if (classification.Outcome != LocalPathOutcome.Classified)
+            {
+                return ProjectDirectoryEntryOutcome(
+                    root,
+                    entry,
+                    classification);
+            }
+
+            selectedFiles++;
+            if (selectedFiles > configured.MaxSelectedFiles)
+            {
+                return DirectoryOutcome.Rejected(
+                    "local.directory.selected-file-limit",
+                    "The local directory exceeds the configured selected-file limit.",
+                    root,
+                    entry);
+            }
+
+            await using LocalFileAdmission admission =
+                LocalPathAdmission.AdmitRegularFile(
+                    classification,
+                    cancellationToken);
+            if (admission.Classification.Outcome
+                != LocalPathOutcome.Classified)
+            {
+                return ProjectDirectoryEntryOutcome(
+                    root,
+                    entry,
+                    admission.Classification);
+            }
+
+            FileStream stream = admission.Stream
+                ?? throw new InvalidOperationException(
+                    "Successful local-file admission did not return a stream.");
+            try
+            {
+                long remainingTotalBytes =
+                    configured.MaxTotalBytes - copiedBytes;
+                long observedLength = stream.Length;
+                ThrowIfKnownLengthExceedsLimit(
+                    observedLength,
+                    configured.MaxFileBytes,
+                    remainingTotalBytes);
+                byte[] snapshot = await ReadDirectorySnapshotAsync(
+                        stream,
+                        configured.MaxFileBytes,
+                        remainingTotalBytes,
+                        checked((int)observedLength),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                DateTime observedLastWriteTimeUtc =
+                    File.GetLastWriteTimeUtc(stream.SafeFileHandle);
+                cancellationToken.ThrowIfCancellationRequested();
+                snapshots.Add(
+                    new DirectoryArtifactSnapshot(
+                        entry,
+                        snapshot,
+                        observedLastWriteTimeUtc));
+                copiedBytes += snapshot.LongLength;
+            }
+            catch (LocalDirectoryFileSizeLimitException)
+            {
+                return DirectoryOutcome.Rejected(
+                    "local.directory.file-size-limit",
+                    "A selected local-directory file exceeds the configured per-file byte limit.",
+                    root,
+                    entry);
+            }
+            catch (LocalDirectoryTotalSizeLimitException)
+            {
+                return DirectoryOutcome.Rejected(
+                    "local.directory.total-size-limit",
+                    "The selected local-directory files exceed the configured aggregate byte limit.",
+                    root,
+                    entry);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (
+                ex is IOException
+                    or UnauthorizedAccessException
+                    or NotSupportedException)
+            {
+                return DirectoryOutcome.Failed(
+                    "local.directory.read-failed",
+                    "A selected local-directory file could not be read.",
+                    root,
+                    entry);
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        ArtifactContribution[] contributions =
+            new ArtifactContribution[snapshots.Count];
+        for (int index = 0; index < snapshots.Count; index++)
+        {
+            DirectoryArtifactSnapshot snapshot = snapshots[index];
+            var provenance = new LocalDirectoryArtifactProvenance(
+                canonicalRoot,
+                snapshot.Entry.RelativeName,
+                snapshot.Entry.FullPath,
+                snapshot.Bytes.LongLength,
+                snapshot.ObservedLastWriteTimeUtc);
+            contributions[index] = scope.Register(
+                provenance,
+                () => OpenSnapshot(snapshot.Bytes),
+                kind: "local-directory-entry");
+        }
+
+        return new ArtifactAcquisitionOutcome.Acquired(
+            contributions,
+            ArtifactAcquisitionLeases.None);
+    }
+
+    internal static ArtifactAcquisitionOutcome ProjectDirectoryRootOutcome(
+        LocalPathClassification classification) =>
+        classification.Outcome switch
+        {
+            LocalPathOutcome.Unavailable =>
+                DirectoryOutcome.Unavailable(
+                    "local.directory.root-missing",
+                    "The requested local directory does not exist.",
+                    classification),
+            LocalPathOutcome.Rejected
+                when classification.Reason == LocalPathReason.InvalidPath =>
+                DirectoryOutcome.Rejected(
+                    "local.directory.root-invalid-path",
+                    "The requested local directory path is invalid.",
+                    classification),
+            LocalPathOutcome.Rejected =>
+                DirectoryOutcome.Rejected(
+                    "local.directory.root-unsupported",
+                    "The requested local path is not a supported directory.",
+                    classification),
+            LocalPathOutcome.Failed =>
+                DirectoryOutcome.Failed(
+                    "local.directory.root-admission-failed",
+                    "The requested local directory could not be classified.",
+                    classification),
+            _ => throw new InvalidOperationException(
+                "A classified directory must be enumerated."),
+        };
+
+    private static ArtifactAcquisitionOutcome ProjectDirectoryEntryOutcome(
+        LocalPathClassification root,
+        ObservedDirectoryEntry entry,
+        LocalPathClassification classification) =>
+        classification.Outcome switch
+        {
+            LocalPathOutcome.Unavailable =>
+                DirectoryOutcome.Unavailable(
+                    "local.directory.entry-missing",
+                    "A selected local-directory entry does not exist.",
+                    root,
+                    entry),
+            LocalPathOutcome.Rejected =>
+                DirectoryOutcome.Rejected(
+                    "local.directory.entry-unsupported",
+                    "A selected local-directory entry is not a supported regular file.",
+                    root,
+                    entry),
+            LocalPathOutcome.Failed =>
+                DirectoryOutcome.Failed(
+                    "local.directory.entry-admission-failed",
+                    "A selected local-directory entry could not be admitted.",
+                    root,
+                    entry),
+            _ => throw new InvalidOperationException(
+                "A classified regular file must be copied."),
+        };
+
+    private static DirectoryOptionsSnapshot ValidateAndCopy(
+        LocalDirectoryArtifactAcquisitionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options.ExcludedFileNames);
+        ArgumentNullException.ThrowIfNull(options.IncludedFileExtensions);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            options.MaxObservedEntries);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(
+            options.MaxSelectedFiles);
+        ValidateByteLimit(options.MaxFileBytes);
+        ValidateByteLimit(options.MaxTotalBytes);
+
+        string[] excludedFileNames = [.. options.ExcludedFileNames];
+        foreach (string fileName in excludedFileNames)
+        {
+            if (string.IsNullOrWhiteSpace(fileName)
+                || Path.IsPathRooted(fileName)
+                || fileName is "." or ".."
+                || fileName.IndexOfAny(['/', '\\']) >= 0)
+            {
+                throw new ArgumentException(
+                    "Each excluded file name must be one non-rooted name without separators or parent traversal.",
+                    nameof(options));
+            }
+        }
+
+        string[] includedFileExtensions =
+            [.. options.IncludedFileExtensions];
+        foreach (string extension in includedFileExtensions)
+        {
+            if (string.IsNullOrWhiteSpace(extension)
+                || extension.Length < 2
+                || extension[0] != '.'
+                || extension.IndexOfAny(
+                    [
+                        '/',
+                        '\\',
+                        '*',
+                        '?',
+                    ]) >= 0
+                || !string.Equals(
+                    Path.GetExtension($"entry{extension}"),
+                    extension,
+                    StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    "Each included file extension must be one non-empty extension, not a glob or path.",
+                    nameof(options));
+            }
+        }
+
+        return new DirectoryOptionsSnapshot(
+            new HashSet<string>(
+                excludedFileNames,
+                StringComparer.OrdinalIgnoreCase),
+            new HashSet<string>(
+                includedFileExtensions,
+                StringComparer.OrdinalIgnoreCase),
+            options.MaxObservedEntries,
+            options.MaxSelectedFiles,
+            options.MaxFileBytes,
+            options.MaxTotalBytes);
+    }
+
+    private static void ValidateByteLimit(long value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, int.MaxValue);
+    }
+
+    private static void ThrowIfKnownLengthExceedsLimit(
+        long length,
+        long maxFileBytes,
+        long remainingTotalBytes)
+    {
+        if (length <= maxFileBytes && length <= remainingTotalBytes)
+            return;
+        if (maxFileBytes <= remainingTotalBytes
+            && length > maxFileBytes)
+        {
+            throw new LocalDirectoryFileSizeLimitException();
+        }
+
+        throw new LocalDirectoryTotalSizeLimitException();
+    }
+
+    private static async ValueTask<byte[]> ReadDirectorySnapshotAsync(
+        Stream source,
+        long maxFileBytes,
+        long remainingTotalBytes,
+        int initialCapacity,
+        CancellationToken cancellationToken)
+    {
+        using var destination = new MemoryStream(initialCapacity);
+        byte[] buffer = new byte[81920];
+        while (true)
+        {
+            int read = await source.ReadAsync(
+                    buffer,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+                return destination.ToArray();
+
+            long remainingFileBytes =
+                maxFileBytes - destination.Length;
+            long remainingBatchBytes =
+                remainingTotalBytes - destination.Length;
+            if (read > remainingFileBytes
+                || read > remainingBatchBytes)
+            {
+                if (remainingFileBytes <= remainingBatchBytes
+                    && read > remainingFileBytes)
+                {
+                    throw new LocalDirectoryFileSizeLimitException();
+                }
+
+                throw new LocalDirectoryTotalSizeLimitException();
+            }
+
+            destination.Write(buffer, 0, read);
+        }
+    }
+
+    private readonly record struct DirectoryOptionsSnapshot(
+        HashSet<string> ExcludedFileNames,
+        HashSet<string> IncludedFileExtensions,
+        int MaxObservedEntries,
+        int MaxSelectedFiles,
+        long MaxFileBytes,
+        long MaxTotalBytes)
+    {
+        internal bool Includes(string fileName) =>
+            !ExcludedFileNames.Contains(fileName)
+            && IncludedFileExtensions.Contains(
+                Path.GetExtension(fileName));
+    }
+
+    private readonly record struct ObservedDirectoryEntry(
+        string RelativeName,
+        string FullPath,
+        FileAttributes Attributes);
+
+    private readonly record struct DirectoryArtifactSnapshot(
+        ObservedDirectoryEntry Entry,
+        byte[] Bytes,
+        DateTime ObservedLastWriteTimeUtc);
+
+    private static class DirectoryOutcome
+    {
+        internal static ArtifactAcquisitionOutcome Unavailable(
+            string code,
+            string summary,
+            LocalPathClassification root,
+            ObservedDirectoryEntry? entry = null) =>
+            new ArtifactAcquisitionOutcome.Unavailable(
+                Diagnostic(code, summary, root, entry));
+
+        internal static ArtifactAcquisitionOutcome Rejected(
+            string code,
+            string summary,
+            LocalPathClassification root,
+            ObservedDirectoryEntry? entry = null) =>
+            new ArtifactAcquisitionOutcome.Rejected(
+                Diagnostic(code, summary, root, entry));
+
+        internal static ArtifactAcquisitionOutcome Failed(
+            string code,
+            string summary,
+            LocalPathClassification root,
+            ObservedDirectoryEntry? entry = null) =>
+            new ArtifactAcquisitionOutcome.Failed(
+                Diagnostic(code, summary, root, entry));
+
+        private static LocalDirectoryArtifactDiagnostic Diagnostic(
+            string code,
+            string summary,
+            LocalPathClassification root,
+            ObservedDirectoryEntry? entry) =>
+            new(
+                code,
+                summary,
+                root.RequestedPath,
+                root.CanonicalPath,
+                entry?.RelativeName,
+                entry?.FullPath);
+    }
+
+    private sealed class LocalDirectoryFileSizeLimitException :
+        IOException;
+
+    private sealed class LocalDirectoryTotalSizeLimitException :
+        IOException;
+}

--- a/src/DotnetInspector.Artifacts.Local/LocalPathAdmission.cs
+++ b/src/DotnetInspector.Artifacts.Local/LocalPathAdmission.cs
@@ -298,6 +298,21 @@ internal static partial class LocalPathAdmission
         LocalPathClassification classification = RequireKind(
             Classify(requestedPath, cancellationToken),
             LocalPathKind.RegularFile);
+        return AdmitRegularFile(classification, cancellationToken);
+    }
+
+    internal static LocalFileAdmission AdmitRegularFile(
+        LocalPathClassification classification,
+        CancellationToken cancellationToken = default)
+    {
+        if (classification.Outcome == LocalPathOutcome.Classified
+            && classification.Kind != LocalPathKind.RegularFile)
+        {
+            throw new ArgumentException(
+                "A classified admission must identify a regular file.",
+                nameof(classification));
+        }
+
         if (classification.Outcome != LocalPathOutcome.Classified)
             return new LocalFileAdmission(classification);
 
@@ -340,7 +355,7 @@ internal static partial class LocalPathAdmission
             stream?.Dispose();
             return new LocalFileAdmission(
                 LocalPathClassification.Unavailable(
-                    requestedPath,
+                    classification.RequestedPath,
                     classification.CanonicalPath));
         }
         catch (Exception ex) when (IsClassificationUnsupported(ex))
@@ -349,7 +364,7 @@ internal static partial class LocalPathAdmission
             return new LocalFileAdmission(
                 LocalPathClassification.Failed(
                     LocalPathReason.ClassificationUnsupported,
-                    requestedPath,
+                    classification.RequestedPath,
                     classification.CanonicalPath));
         }
         catch (Exception ex) when (IsAdmissionFailure(ex))
@@ -358,7 +373,7 @@ internal static partial class LocalPathAdmission
             return new LocalFileAdmission(
                 LocalPathClassification.Failed(
                     LocalPathReason.AdmissionFailed,
-                    requestedPath,
+                    classification.RequestedPath,
                     classification.CanonicalPath));
         }
     }

--- a/src/DotnetInspector.Artifacts.Tests/LocalArtifactSourceTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/LocalArtifactSourceTests.cs
@@ -978,6 +978,529 @@ public sealed class LocalArtifactSourceTests
         }
     }
 
+    [Fact]
+    public async Task
+        LocalDirectoryAcquisition_BoundedDeterministicSelection()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        string root = TempDirectory();
+        string nestedDirectory = Path.Combine(root, "nested.dll");
+        string linkedDirectory = Path.Combine(root, "linked-directory.dll");
+        string linkedFile = Path.Combine(root, "linked-file.dll");
+        string linkTarget = Path.Combine(root, "link-target.bin");
+        string hardLink = Path.Combine(root, "hard-link.dll");
+        bool linkedDirectoryCreated = false;
+        bool linkedFileCreated = false;
+        bool hardLinkCreated = false;
+        try
+        {
+            Directory.CreateDirectory(nestedDirectory);
+            await File.WriteAllBytesAsync(
+                Path.Combine(nestedDirectory, "child.dll"),
+                [9],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(root, "B.dll"),
+                [2],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(root, "a.DLL"),
+                [1],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(root, "excluded.dll"),
+                [3],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(root, "ignored.txt"),
+                [4],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                linkTarget,
+                [5],
+                cancellationToken);
+            hardLinkCreated = TryCreateHardLink(
+                hardLink,
+                Path.Combine(root, "B.dll"));
+            try
+            {
+                Directory.CreateSymbolicLink(
+                    linkedDirectory,
+                    nestedDirectory);
+                linkedDirectoryCreated = true;
+                File.CreateSymbolicLink(linkedFile, linkTarget);
+                linkedFileCreated = true;
+            }
+            catch (Exception ex) when (OperatingSystem.IsWindows()
+                && ex is IOException or UnauthorizedAccessException)
+            {
+            }
+
+            var acquired =
+                Assert.IsType<ArtifactAcquisitionOutcome.Acquired>(
+                    await AcquireDirectoryAsync(
+                        root,
+                        new LocalDirectoryArtifactAcquisitionOptions
+                        {
+                            ExcludedFileNames = ["EXCLUDED.DLL"],
+                            IncludedFileExtensions = [".DLL"],
+                        },
+                        cancellationToken));
+            string[] expectedNames =
+            [
+                "B.dll",
+                "a.DLL",
+                .. hardLinkCreated
+                    ? new[] { "hard-link.dll" }
+                    : Array.Empty<string>(),
+                .. linkedFileCreated
+                    ? new[] { "linked-file.dll" }
+                    : Array.Empty<string>(),
+            ];
+            Assert.Equal(
+                expectedNames.Order(StringComparer.Ordinal),
+                acquired.Artifacts.Select(
+                    artifact =>
+                        Assert.IsType<LocalDirectoryArtifactProvenance>(
+                            artifact.Registration.Provenance)
+                        .RelativeName));
+            Assert.All(
+                acquired.Artifacts,
+                artifact =>
+                {
+                    Assert.Equal(
+                        "local-directory-entry",
+                        artifact.Descriptor.Kind);
+                    Assert.Null(artifact.Descriptor.MediaType);
+                });
+            if (linkedDirectoryCreated)
+            {
+                Assert.DoesNotContain(
+                    acquired.Artifacts,
+                    artifact =>
+                        Assert.IsType<LocalDirectoryArtifactProvenance>(
+                            artifact.Registration.Provenance)
+                        .RelativeName == "linked-directory.dll");
+            }
+
+            var observedLimit =
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    await AcquireDirectoryAsync(
+                        root,
+                        new LocalDirectoryArtifactAcquisitionOptions
+                        {
+                            MaxObservedEntries = 1,
+                        },
+                        cancellationToken));
+            Assert.Equal(
+                "local.directory.entry-limit",
+                observedLimit.Diagnostic.Code);
+
+            var selectedLimit =
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    await AcquireDirectoryAsync(
+                        root,
+                        new LocalDirectoryArtifactAcquisitionOptions
+                        {
+                            ExcludedFileNames =
+                                linkedFileCreated
+                                    ? ["linked-file.dll"]
+                                    : Array.Empty<string>(),
+                            MaxSelectedFiles = 1,
+                        },
+                        cancellationToken));
+            Assert.Equal(
+                "local.directory.selected-file-limit",
+                selectedLimit.Diagnostic.Code);
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => await AcquireDirectoryAsync(
+                    Path.Combine(root, "missing"),
+                    new LocalDirectoryArtifactAcquisitionOptions
+                    {
+                        IncludedFileExtensions = ["*.dll"],
+                    },
+                    cancellationToken));
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => await AcquireDirectoryAsync(
+                    Path.Combine(root, "missing"),
+                    new LocalDirectoryArtifactAcquisitionOptions
+                    {
+                        ExcludedFileNames = ["..", "input.dll"],
+                    },
+                    cancellationToken));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                async () => await AcquireDirectoryAsync(
+                    Path.Combine(root, "missing"),
+                    new LocalDirectoryArtifactAcquisitionOptions
+                    {
+                        MaxTotalBytes = (long)int.MaxValue + 1,
+                    },
+                    cancellationToken));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task
+        LocalDirectoryAcquisition_EmptyOrFailedBatchPublishesNothing()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        string emptyRoot = TempDirectory();
+        string fileLimitRoot = TempDirectory();
+        string totalLimitRoot = TempDirectory();
+        string missingEntryRoot = TempDirectory();
+        string enumerationFailureRoot = TempDirectory();
+        string unsupportedEntryRoot = TempDirectory();
+        string admissionFailureRoot = TempDirectory();
+        string readFailureRoot = TempDirectory();
+        try
+        {
+            await File.WriteAllBytesAsync(
+                Path.Combine(emptyRoot, "ignored.txt"),
+                [1],
+                cancellationToken);
+            var empty =
+                Assert.IsType<ArtifactAcquisitionOutcome.Acquired>(
+                    await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                        emptyRoot,
+                        options: null,
+                        cancellationToken));
+            Assert.Empty(empty.Artifacts);
+            Assert.Same(
+                ArtifactAcquisitionLeases.None,
+                empty.Lease);
+
+            ArtifactAcquisitionOutcome missingRoot =
+                await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                    Path.Combine(emptyRoot, "missing"),
+                    options: null,
+                    cancellationToken);
+            Assert.Equal(
+                "local.directory.root-missing",
+                Assert.IsType<ArtifactAcquisitionOutcome.Unavailable>(
+                    missingRoot).Diagnostic.Code);
+
+            ArtifactAcquisitionOutcome invalidRoot =
+                await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                    "invalid\0path",
+                    options: null,
+                    cancellationToken);
+            Assert.Equal(
+                "local.directory.root-invalid-path",
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    invalidRoot).Diagnostic.Code);
+
+            string fileAsRoot = Path.Combine(emptyRoot, "root.dll");
+            await File.WriteAllBytesAsync(
+                fileAsRoot,
+                [1],
+                cancellationToken);
+            ArtifactAcquisitionOutcome unsupportedRoot =
+                await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                    fileAsRoot,
+                    options: null,
+                    cancellationToken);
+            Assert.Equal(
+                "local.directory.root-unsupported",
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    unsupportedRoot).Diagnostic.Code);
+            ArtifactAcquisitionOutcome rootAdmissionFailure =
+                LocalArtifactSource.ProjectDirectoryRootOutcome(
+                    LocalPathClassification.Failed(
+                        LocalPathReason.AdmissionFailed,
+                        emptyRoot,
+                        Path.GetFullPath(emptyRoot)));
+            Assert.Equal(
+                "local.directory.root-admission-failed",
+                Assert.IsType<ArtifactAcquisitionOutcome.Failed>(
+                    rootAdmissionFailure).Diagnostic.Code);
+
+            await File.WriteAllBytesAsync(
+                Path.Combine(fileLimitRoot, "a.dll"),
+                [1],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(fileLimitRoot, "z.dll"),
+                [2, 3],
+                cancellationToken);
+            ArtifactAcquisitionOutcome fileLimit =
+                await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                    fileLimitRoot,
+                    new LocalDirectoryArtifactAcquisitionOptions
+                    {
+                        MaxFileBytes = 1,
+                        MaxTotalBytes = 2,
+                    },
+                    cancellationToken);
+            Assert.Equal(
+                "local.directory.file-size-limit",
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    fileLimit).Diagnostic.Code);
+
+            await File.WriteAllBytesAsync(
+                Path.Combine(totalLimitRoot, "a.dll"),
+                [1, 2],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                Path.Combine(totalLimitRoot, "b.dll"),
+                [3, 4],
+                cancellationToken);
+            ArtifactAcquisitionOutcome totalLimit =
+                await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                    totalLimitRoot,
+                    new LocalDirectoryArtifactAcquisitionOptions
+                    {
+                        MaxFileBytes = 2,
+                        MaxTotalBytes = 3,
+                    },
+                    cancellationToken);
+            Assert.Equal(
+                "local.directory.total-size-limit",
+                Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                    totalLimit).Diagnostic.Code);
+
+            await File.WriteAllBytesAsync(
+                Path.Combine(missingEntryRoot, "a.dll"),
+                [1],
+                cancellationToken);
+            string danglingEntry =
+                Path.Combine(missingEntryRoot, "z.dll");
+            if (TryCreateFileLink(
+                danglingEntry,
+                Path.Combine(missingEntryRoot, "missing.dll")))
+            {
+                ArtifactAcquisitionOutcome missingEntry =
+                    await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                        missingEntryRoot,
+                        options: null,
+                        cancellationToken);
+                Assert.Equal(
+                    "local.directory.entry-missing",
+                    Assert.IsType<ArtifactAcquisitionOutcome.Unavailable>(
+                        missingEntry).Diagnostic.Code);
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                string fifo =
+                    Path.Combine(unsupportedEntryRoot, "input.dll");
+                await CreateFifoAsync(fifo, cancellationToken);
+                ArtifactAcquisitionOutcome unsupportedEntry =
+                    await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                        unsupportedEntryRoot,
+                        options: null,
+                        cancellationToken);
+                Assert.Equal(
+                    "local.directory.entry-unsupported",
+                    Assert.IsType<ArtifactAcquisitionOutcome.Rejected>(
+                        unsupportedEntry).Diagnostic.Code);
+
+                string inaccessibleFile =
+                    Path.Combine(admissionFailureRoot, "input.dll");
+                await File.WriteAllBytesAsync(
+                    inaccessibleFile,
+                    [1],
+                    cancellationToken);
+                UnixFileMode originalFileMode =
+                    File.GetUnixFileMode(inaccessibleFile);
+                try
+                {
+                    File.SetUnixFileMode(
+                        inaccessibleFile,
+                        UnixFileMode.None);
+                    ArtifactAcquisitionOutcome admissionFailure =
+                        await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                            admissionFailureRoot,
+                            options: null,
+                            cancellationToken);
+                    Assert.Equal(
+                        "local.directory.entry-admission-failed",
+                        Assert.IsType<ArtifactAcquisitionOutcome.Failed>(
+                            admissionFailure).Diagnostic.Code);
+                }
+                finally
+                {
+                    File.SetUnixFileMode(
+                        inaccessibleFile,
+                        originalFileMode);
+                }
+
+                if (OperatingSystem.IsLinux()
+                    && File.Exists("/proc/self/mem"))
+                {
+                    File.CreateSymbolicLink(
+                        Path.Combine(readFailureRoot, "input.dll"),
+                        "/proc/self/mem");
+                    ArtifactAcquisitionOutcome readFailure =
+                        await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                            readFailureRoot,
+                            options: null,
+                            cancellationToken);
+                    Assert.Equal(
+                        "local.directory.read-failed",
+                        Assert.IsType<ArtifactAcquisitionOutcome.Failed>(
+                            readFailure).Diagnostic.Code);
+                }
+
+                await File.WriteAllBytesAsync(
+                    Path.Combine(enumerationFailureRoot, "input.dll"),
+                    [1],
+                    cancellationToken);
+                UnixFileMode originalMode =
+                    File.GetUnixFileMode(enumerationFailureRoot);
+                try
+                {
+                    File.SetUnixFileMode(
+                        enumerationFailureRoot,
+                        UnixFileMode.None);
+                    ArtifactAcquisitionOutcome enumerationFailure =
+                        await AcquireDirectoryAndCompleteEmptyGenerationAsync(
+                            enumerationFailureRoot,
+                            options: null,
+                            cancellationToken);
+                    Assert.Equal(
+                        "local.directory.enumeration-failed",
+                        Assert.IsType<ArtifactAcquisitionOutcome.Failed>(
+                            enumerationFailure).Diagnostic.Code);
+                }
+                finally
+                {
+                    File.SetUnixFileMode(
+                        enumerationFailureRoot,
+                        originalMode);
+                }
+            }
+
+            var owner = new ArtifactGenerationAuthority();
+            ArtifactAdmissionAuthorization authorization =
+                owner.CreateAdmissionAuthorization();
+            ArtifactContributionScope disposedScope =
+                owner.BeginContribution(authorization);
+            disposedScope.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                async () => await LocalArtifactSource.AcquireDirectoryAsync(
+                    disposedScope,
+                    fileLimitRoot,
+                    cancellationToken: cancellationToken));
+            owner.CompleteAdmission(authorization);
+        }
+        finally
+        {
+            Directory.Delete(emptyRoot, recursive: true);
+            Directory.Delete(fileLimitRoot, recursive: true);
+            Directory.Delete(totalLimitRoot, recursive: true);
+            Directory.Delete(missingEntryRoot, recursive: true);
+            Directory.Delete(enumerationFailureRoot, recursive: true);
+            Directory.Delete(unsupportedEntryRoot, recursive: true);
+            Directory.Delete(admissionFailureRoot, recursive: true);
+            Directory.Delete(readFailureRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task
+        LocalDirectoryAcquisition_ProvenanceSnapshotAndCancellationArePreserved()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        string root = TempDirectory();
+        string firstPath = Path.Combine(root, "first.dll");
+        string secondPath = Path.Combine(root, "second.DLL");
+        DateTime writeTimeSample = DateTime.UtcNow.AddMinutes(-5);
+        DateTime firstWriteTime = new(
+            writeTimeSample.Ticks
+                - (writeTimeSample.Ticks % TimeSpan.TicksPerSecond),
+            DateTimeKind.Utc);
+        try
+        {
+            await File.WriteAllBytesAsync(
+                firstPath,
+                [1, 2, 3],
+                cancellationToken);
+            await File.WriteAllBytesAsync(
+                secondPath,
+                [4, 5],
+                cancellationToken);
+            File.SetLastWriteTimeUtc(firstPath, firstWriteTime);
+
+            List<string> includedExtensions = [".dll"];
+            List<string> excludedFileNames = [];
+            var options = new LocalDirectoryArtifactAcquisitionOptions
+            {
+                IncludedFileExtensions =
+                    new SingleEnumerationCollection(
+                        includedExtensions),
+                ExcludedFileNames =
+                    new SingleEnumerationCollection(
+                        excludedFileNames),
+            };
+            var owner = new ArtifactGenerationAuthority();
+            ArtifactAdmissionAuthorization authorization =
+                owner.CreateAdmissionAuthorization();
+            using ArtifactContributionScope scope =
+                owner.BeginContribution(authorization);
+            ValueTask<ArtifactAcquisitionOutcome> pending =
+                LocalArtifactSource.AcquireDirectoryAsync(
+                    scope,
+                    root,
+                    options,
+                    cancellationToken);
+            includedExtensions.Clear();
+            excludedFileNames.Add("first.dll");
+            var acquired =
+                Assert.IsType<ArtifactAcquisitionOutcome.Acquired>(
+                    await pending);
+
+            await File.WriteAllBytesAsync(
+                firstPath,
+                [9],
+                cancellationToken);
+            File.Delete(secondPath);
+
+            using ArtifactAdmissionLease lease =
+                owner.IssueLease(authorization);
+            Assert.Equal(
+                ["first.dll", "second.DLL"],
+                acquired.Artifacts.Select(
+                    artifact =>
+                        Assert.IsType<LocalDirectoryArtifactProvenance>(
+                            artifact.Registration.Provenance)
+                        .RelativeName));
+            Assert.Equal(
+                [1, 2, 3],
+                ReadAll(acquired.Artifacts[0].OpenRead(lease)));
+            Assert.Equal(
+                [4, 5],
+                ReadAll(acquired.Artifacts[1].OpenRead(lease)));
+
+            var provenance =
+                Assert.IsType<LocalDirectoryArtifactProvenance>(
+                    acquired.Artifacts[0].Registration.Provenance);
+            Assert.Equal(Path.GetFullPath(root), provenance.CanonicalRoot);
+            Assert.Equal(firstPath, provenance.FullPath);
+            Assert.Equal(3, provenance.ContentLength);
+            Assert.Equal(firstWriteTime, provenance.ObservedLastWriteTimeUtc);
+
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await AcquireDirectoryAsync(
+                    root,
+                    options: null,
+                    cancellation.Token));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     private static string TempPath() =>
         Path.Combine(
             Path.GetTempPath(),
@@ -1030,6 +1553,48 @@ public sealed class LocalArtifactSourceTests
             scope,
             path,
             cancellationToken: cancellationToken);
+    }
+
+    private static async ValueTask<ArtifactAcquisitionOutcome>
+        AcquireDirectoryAsync(
+            string path,
+            LocalDirectoryArtifactAcquisitionOptions? options,
+            CancellationToken cancellationToken)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization authorization =
+            owner.CreateAdmissionAuthorization();
+        using ArtifactContributionScope scope =
+            owner.BeginContribution(authorization);
+        return await LocalArtifactSource.AcquireDirectoryAsync(
+            scope,
+            path,
+            options,
+            cancellationToken);
+    }
+
+    private static async ValueTask<ArtifactAcquisitionOutcome>
+        AcquireDirectoryAndCompleteEmptyGenerationAsync(
+            string path,
+            LocalDirectoryArtifactAcquisitionOptions? options,
+            CancellationToken cancellationToken)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization authorization =
+            owner.CreateAdmissionAuthorization();
+        ArtifactAcquisitionOutcome outcome;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(authorization))
+        {
+            outcome = await LocalArtifactSource.AcquireDirectoryAsync(
+                scope,
+                path,
+                options,
+                cancellationToken);
+        }
+
+        owner.CompleteAdmission(authorization);
+        return outcome;
     }
 
     private static async Task AssertRejectedWithoutBlockingAsync(
@@ -1146,5 +1711,26 @@ public sealed class LocalArtifactSourceTests
         using var destination = new MemoryStream();
         stream.CopyTo(destination);
         return destination.ToArray();
+    }
+
+    private sealed class SingleEnumerationCollection(
+        IReadOnlyCollection<string> values) :
+        IReadOnlyCollection<string>
+    {
+        private int _enumerated;
+
+        public int Count => values.Count;
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            Assert.Equal(
+                1,
+                Interlocked.Increment(ref _enumerated));
+            return values.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator
+            System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
     }
 }


### PR DESCRIPTION
Closes #5394.

## Summary

Implements the designed bounded top-level local-directory adapter in
`DotnetInspector.Artifacts.Local`.

- Adds copied and validated directory options, incremental observation bounds,
  ordinal deterministic selection, lexical extension/exclusion policy, and
  independent selected-file and byte ceilings.
- Reuses shared local-path admission for root classification and every selected
  candidate, then consumes the verified open generation into immutable,
  source-neutral `local-directory-entry` contributions.
- Registers only after the complete selected batch is snapshotted, preserves
  typed root/entry/enumeration/read outcomes and cancellation, and records
  directory-root, observed-name, full-path, copied-length, and same-handle
  last-write provenance.
- Adds the three named `LocalDirectoryAcquisition_*` gates and corrects the
  owner document's stale directory and supplemental implementation status.

This slice does not add workspace or CLI adoption, binding policy, recursion,
assembly inference, or NuGet folder-feed behavior.

## Design basis

The normative owner is `DotnetInspector.Artifacts.Local`; the exact owned claim
is the `Bounded directory coordinate` section of
`docs/design/artifact-acquisition-and-workspaces.md`.

Supporting evidence:

- The repository's package-content admission walk guards the complete lazy
  enumeration and rejects hostile fan-out incrementally. This adapter keeps
  that bounded-enumeration convention but deliberately remains top-level,
  counts every observed entry, preserves typed outcomes, and sorts publication
  candidates ordinally.
- .NET's
  [`FileSystemEnumerable<TResult>` implementation at `b0f34d51`](https://github.com/dotnet/dotnet/blob/b0f34d51fccc69fd334253924abd8d6853fad7aa/src/runtime/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerable.cs)
  supplies the conventional lazy transform over entry names, full paths, and
  enumeration attributes. No runtime code or architecture was copied.
- No new TLA+ model is needed: acquisition is sequential and introduces no
  publication, interleaving, or lifetime state machine.

## Demo

A .NET file-based app referenced the changed local-artifact project, created
`z.dll`, `foo.dll`, and `A.DLL`, excluded the explicitly acquired `foo.dll`,
then exercised an empty directory and a two-file batch whose second file
crossed the per-file and remaining-total limits on the same byte.

```console
$ dotnet run /tmp/dotnet-inspect-directory-demo.cs
selected: A.DLL, z.dll
empty: 0 artifacts
failure: local.directory.file-size-limit
partial batch published: False
```

Notice that filesystem creation order does not become contribution order,
case-insensitive exclusion prevents `foo.dll` from reappearing, a valid empty
directory is successful, and the pathological late failure leaves no
publishable prefix.

The neighboring automated fixtures also cover irrelevant-entry fan-out,
selected-file fan-out, physical aliases, plain and linked directories, links to
regular files, dangling entries, FIFOs, inaccessible files/directories,
post-open read failure, source mutation/deletion, and cancellation.

## Validation

- `dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `bash eng/run-local-path-admission-platform-probe.sh nativeaot linux-x64`
- `bash eng/run-local-path-admission-platform-probe.sh browser`
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md`
- `dotnet run /tmp/dotnet-inspect-directory-demo.cs`
