### PR TITLE
Align Annotated Source with the page surface

### DIFF
--- a/docs/design/inspect-web-ui.md
+++ b/docs/design/inspect-web-ui.md
@@ -271,9 +271,12 @@ They do not repeat:
 - the package and version.
 
 API content begins immediately after lens navigation. Source places only its
-compact provenance and action row before source content. The removed fields do
-not leave placeholders or reserved vertical space. They are also not moved
-into collapsed duplicate headers on either lens.
+compact provenance and action row before source content. Annotated Source puts
+its **Copy** and **Explore** actions in the page-owned inspection-command row,
+begins immediately with highlighted source content, and places compact
+provenance after that content. The removed fields do not leave placeholders or
+reserved vertical space. They are also not moved into collapsed duplicate
+headers on either lens.
 
 This makes the API surface or source document the primary content of its page
 and increases the amount visible without scrolling.
@@ -1169,15 +1172,24 @@ Their layout is:
 ```text
 Types or Members | PDB Source                    open source   copy
                  | source content
+
+Types or Members | selected subject                         Copy   Explore
+                 | annotated source content
+                 | product provenance
 ```
 
-The compact provenance/action row remains attached to the source pane. The
-navigation pane and source content may scroll independently. Collapsing
-navigation gives the working surface the full viewport width.
+Source retains its compact provenance/action row. Annotated Source gives the
+page-owned inspection-command row its contextual actions and keeps provenance
+as a compact footer attached to the source pane. It does not add another
+visible title or presentation summary inside the pane. The navigation pane and
+source content may scroll independently. Collapsing navigation gives the
+working surface the full viewport width.
 
 Annotated Source appears inline by default and may open the full-bleed modal
 viewer governed by the shared transient-surface contract. This document owns
-that composition, not the Annotated Source document model or viewer internals.
+that composition, including C# highlighting that preserves the product
+document's exact text and coordinates, not the Annotated Source document model
+or viewer internals.
 
 Decompiler style is contextual:
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -615,15 +615,18 @@ span walk. `src/document-model.ts` provides typed aliases over that owner for
 Vite and the tests; Vite bundles the shared implementation into the deployable
 browser artifact without copying its logic.
 
-The embedded reader shows complete product-issued C# with the catalog's default
-Finding annotations, Finding detail, source-only copy, and **Explore**. Each
-**Explore** activation creates a fresh full-bleed modal session with C# visible,
-IL and UTF-16 ranges hidden, default annotations active, and no transferred
-detail. The modal adds catalog-driven annotation and medium controls,
-product-issued structure, deterministic invocation-preferred source hit
-testing, node selection, and one persistent inspector action for every Finding,
-including unanchored Findings. Annotation rows preserve the product-issued
-source prefix as layout geometry, so each CodeLens-like row appears immediately
+The inline working surface shows complete product-issued, C#-highlighted source
+with the catalog's default Finding annotations and Finding detail. The
+page-owned contextual bar supplies source-only **Copy** and **Explore**, while
+compact product provenance follows the source instead of introducing a second
+reader header. Each **Explore** activation creates a fresh full-bleed modal
+session with C# visible, IL and UTF-16 ranges hidden, default annotations
+active, and no transferred detail. The modal adds catalog-driven annotation
+and medium controls, product-issued structure, deterministic
+invocation-preferred source hit testing, node selection, and one persistent
+inspector action for every Finding, including unanchored Findings. Annotation
+rows preserve the product-issued source prefix as layout geometry, so each
+CodeLens-like row appears immediately
 before its target line and begins at the anchored span without flattening the
 language's visible indentation. Dismissal destroys modal-local presentation
 and annotation state while retaining only an eligible embedded Finding primary.

--- a/prototypes/inspect-web/browser/annotated-source-harness.ts
+++ b/prototypes/inspect-web/browser/annotated-source-harness.ts
@@ -2,6 +2,7 @@ import {
   annotatedFocusSelector,
   bindAnnotatedSource,
   renderAnnotatedSource,
+  renderAnnotatedSourcePageActions,
   renderAnnotatedSourceModal,
 } from "../src/annotated-source.ts";
 import type {
@@ -32,6 +33,9 @@ import type {
 import type {
   AnnotatedSourceDocument,
 } from "../src/document-model.ts";
+import {
+  createCSharpRangeHighlighter,
+} from "../src/csharp-highlighting.ts";
 import {
   validateDocument,
 } from "../src/document-model.ts";
@@ -96,11 +100,47 @@ function renderAndFocus(
   surface: "embedded" | "modal" = modal ? "modal" : "embedded",
 ): void {
   app.innerHTML = `
-    <main id="harness-background"${modal ? " inert" : ""}>
-      ${renderAnnotatedSource({ result, session: embedded, escapeHtml })}
+    <main id="harness-background" class="detail-pane"
+      style="height: 100%"${modal ? " inert" : ""}>
+      <header class="detail-head">
+        <div class="breadcrumbs">
+          <span>System.Text.Json</span><b>/</b>
+          <span>System.Text.Json</span><b>/</b>
+          <strong>JsonSerializer</strong><b>/</b>
+          <strong>GetTypeInfo</strong>
+        </div>
+        <div class="detail-actions annotated-page-actions">
+          ${renderAnnotatedSourcePageActions(true)}
+        </div>
+      </header>
+      <article class="detail-scroll annotated-working-surface">
+        ${renderAnnotatedSource({
+          result,
+          session: embedded,
+          escapeHtml,
+          highlightCSharp: (source, tokenizationSource) =>
+            createCSharpRangeHighlighter(
+              source,
+              window.Prism,
+              escapeHtml,
+              tokenizationSource,
+            ),
+        })}
+      </article>
     </main>
     ${modal
-      ? renderAnnotatedSourceModal({ result, session: modal, escapeHtml })
+      ? renderAnnotatedSourceModal({
+          result,
+          session: modal,
+          escapeHtml,
+          highlightCSharp: (source, tokenizationSource) =>
+            createCSharpRangeHighlighter(
+              source,
+              window.Prism,
+              escapeHtml,
+              tokenizationSource,
+            ),
+        })
       : ""}`;
   bindAnnotatedSource(app, { onAction });
   if (!target) return;

--- a/prototypes/inspect-web/browser/annotated-source-harness.ts
+++ b/prototypes/inspect-web/browser/annotated-source-harness.ts
@@ -118,12 +118,13 @@ function renderAndFocus(
           result,
           session: embedded,
           escapeHtml,
-          highlightCSharp: (source, tokenizationSource) =>
+          highlightCSharp: (source, tokenizationSource, excludedRanges) =>
             createCSharpRangeHighlighter(
               source,
               window.Prism,
               escapeHtml,
               tokenizationSource,
+              excludedRanges,
             ),
         })}
       </article>
@@ -133,12 +134,13 @@ function renderAndFocus(
           result,
           session: modal,
           escapeHtml,
-          highlightCSharp: (source, tokenizationSource) =>
+          highlightCSharp: (source, tokenizationSource, excludedRanges) =>
             createCSharpRangeHighlighter(
               source,
               window.Prism,
               escapeHtml,
               tokenizationSource,
+              excludedRanges,
             ),
         })
       : ""}`;

--- a/prototypes/inspect-web/browser/annotated-source.html
+++ b/prototypes/inspect-web/browser/annotated-source.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Annotated Source browser gate</title>
     <link rel="stylesheet" href="../src/styles.css">
+    <script
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-core.min.js"
+      integrity="sha384-zLRFO4dwowZvh8kzutOb5AWhH7f39HeJp+N7PtHF1SQtTBnifRx0AtmvTYs3F4YV"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-clike.min.js"
+      integrity="sha384-7LHwxHIDSHTBleLmgDWZbC/IMJsfYfFVOihKhvsrxYW4j47YQcRwZja4ToFE3bA8"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-csharp.min.js"
+      integrity="sha384-nMKYzg6yfy0qgpaRpVhHvZp0gT5sgvmZYlFC0XAKZSp+zFUB9rE6zsdmIEiou4bV"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <div id="app"></div>

--- a/prototypes/inspect-web/browser/annotated-source.spec.ts
+++ b/prototypes/inspect-web/browser/annotated-source.spec.ts
@@ -14,6 +14,25 @@ test("inline source uses the page bar and ends with provenance", async ({ page }
   );
 });
 
+test("inline source owns horizontal scrolling for long product lines", async ({ page }) => {
+  const source = page.locator(".annotated-reader > .annotated-source-code");
+  await source.locator(".annotated-source-line code").first().evaluate(element => {
+    element.textContent = "return " + "VeryLongIdentifier.".repeat(80) + "Value;";
+  });
+
+  const metrics = await source.evaluate(element => {
+    element.scrollLeft = 240;
+    return {
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      scrollLeft: element.scrollLeft,
+    };
+  });
+
+  expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+  expect(metrics.scrollLeft).toBeGreaterThan(0);
+});
+
 test("source copy excludes annotation and inspector chrome", async ({ page }) => {
   await page.locator("#copy-annotated").click();
   const copied = await page.locator("body").getAttribute("data-copied-source");

--- a/prototypes/inspect-web/browser/annotated-source.spec.ts
+++ b/prototypes/inspect-web/browser/annotated-source.spec.ts
@@ -5,6 +5,15 @@ test.beforeEach(async ({ page }) => {
   await expect(page.locator("#explore-annotated")).toBeVisible();
 });
 
+test("inline source uses the page bar and ends with provenance", async ({ page }) => {
+  await expect(page.locator(".annotated-reader-head")).toHaveCount(0);
+  await expect(page.locator(".detail-head #copy-annotated")).toHaveText("Copy");
+  await expect(page.locator(".detail-head #explore-annotated")).toHaveText("Explore");
+  await expect(page.locator(".annotated-reader-footer")).toContainText(
+    "browser-gate product fixture",
+  );
+});
+
 test("source copy excludes annotation and inspector chrome", async ({ page }) => {
   await page.locator("#copy-annotated").click();
   const copied = await page.locator("body").getAttribute("data-copied-source");

--- a/prototypes/inspect-web/src/annotated-source-view.ts
+++ b/prototypes/inspect-web/src/annotated-source-view.ts
@@ -167,6 +167,32 @@ export function factsForNode(
   return document.facts.filter(fact => factIds.has(fact.id));
 }
 
+export function csharpHighlightingText(
+  document: AnnotatedSourceDocument,
+): string {
+  validateDocument(document);
+  const text = document.text.split("");
+  for (const line of buildLines(document.text)) {
+    const medium = lineMedium(document, line);
+    if (medium === "CSharp") continue;
+    if (medium === "Il") {
+      maskRange(text, line.start, line.end);
+      continue;
+    }
+    for (const segment of segmentsForLine(document, line, [])) {
+      if (segment.media.length > 0
+        && !segment.media.includes("CSharp")) {
+        maskRange(text, segment.start, segment.start + segment.text.length);
+      }
+    }
+  }
+  return text.join("");
+}
+
+function maskRange(text: string[], start: number, end: number): void {
+  for (let index = start; index < end; index++) text[index] = " ";
+}
+
 function isVisible(
   medium: LineMedium,
   media: Readonly<Record<SourceMedium, boolean | undefined>>,

--- a/prototypes/inspect-web/src/annotated-source-view.ts
+++ b/prototypes/inspect-web/src/annotated-source-view.ts
@@ -167,30 +167,80 @@ export function factsForNode(
   return document.facts.filter(fact => factIds.has(fact.id));
 }
 
-export function csharpHighlightingText(
+export interface CSharpHighlightingInput {
+  text: string;
+  excludedRanges: readonly {
+    start: number;
+    length: number;
+  }[];
+}
+
+export function csharpHighlightingInput(
   document: AnnotatedSourceDocument,
-): string {
+): CSharpHighlightingInput {
   validateDocument(document);
   const text = document.text.split("");
+  const excluded = Array.from(
+    { length: document.text.length },
+    () => false);
   for (const line of buildLines(document.text)) {
     const medium = lineMedium(document, line);
     if (medium === "CSharp") continue;
     if (medium === "Il") {
-      maskRange(text, line.start, line.end);
+      maskRange(text, excluded, line.start, line.end);
       continue;
     }
     for (const segment of segmentsForLine(document, line, [])) {
       if (segment.media.length > 0
         && !segment.media.includes("CSharp")) {
-        maskRange(text, segment.start, segment.start + segment.text.length);
+        maskRange(
+          text,
+          excluded,
+          segment.start,
+          segment.start + segment.text.length);
       }
     }
   }
-  return text.join("");
+  return {
+    text: text.join(""),
+    excludedRanges: exclusionRanges(excluded),
+  };
 }
 
-function maskRange(text: string[], start: number, end: number): void {
-  for (let index = start; index < end; index++) text[index] = " ";
+export function csharpHighlightingText(
+  document: AnnotatedSourceDocument,
+): string {
+  return csharpHighlightingInput(document).text;
+}
+
+function maskRange(
+  text: string[],
+  excluded: boolean[],
+  start: number,
+  end: number,
+): void {
+  for (let index = start; index < end; index++) {
+    text[index] = " ";
+    excluded[index] = true;
+  }
+}
+
+function exclusionRanges(
+  excluded: readonly boolean[],
+): CSharpHighlightingInput["excludedRanges"] {
+  const ranges: { start: number; length: number }[] = [];
+  let start = -1;
+  for (let index = 0; index <= excluded.length; index++) {
+    if (excluded[index] === true) {
+      if (start < 0) start = index;
+      continue;
+    }
+    if (start >= 0) {
+      ranges.push({ start, length: index - start });
+      start = -1;
+    }
+  }
+  return ranges;
 }
 
 function isVisible(

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -1,5 +1,6 @@
 import {
   buildAnnotatedView,
+  csharpHighlightingText,
   MEDIUM_LABELS,
 } from "./annotated-source-view.ts";
 import {
@@ -25,6 +26,9 @@ import type {
   AnnotatedSourceNode,
   SourceMedium,
 } from "./document-model.ts";
+import type {
+  CSharpRangeHighlighter,
+} from "./csharp-highlighting.ts";
 
 export type { AnnotatedSourceResult } from "./annotated-source-session.ts";
 
@@ -32,6 +36,10 @@ export interface AnnotatedSourceRenderOptions {
   result: AnnotatedSourceResult;
   session: AnnotatedSourceSession;
   escapeHtml: (value: unknown) => string;
+  highlightCSharp?: (
+    source: string,
+    tokenizationSource: string,
+  ) => CSharpRangeHighlighter;
 }
 
 export type AnnotatedSourceAction =
@@ -56,6 +64,7 @@ interface SourceRenderContext {
   model: AnnotatedSourceViewerModel;
   session: AnnotatedSourceSession;
   escapeHtml: (value: unknown) => string;
+  highlighting: CSharpRangeHighlighter;
 }
 
 type RenderedLineAnnotation =
@@ -82,25 +91,25 @@ export function renderAnnotatedSource(
   const context = renderContext(options);
   const { result, escapeHtml } = options;
   return `
-    <section class="annotated-reader" aria-labelledby="annotated-reader-title">
-      <header class="annotated-reader-head">
-        <div>
-          <p class="section-eyebrow">Annotated Source</p>
-          <h3 id="annotated-reader-title">C# with default findings</h3>
-          <p>${escapeHtml(result.provenance)}</p>
-        </div>
-        <div class="annotated-reader-actions">
-          <button id="copy-annotated" type="button" data-annotated-action="copy">copy source</button>
-          <button id="explore-annotated" class="primary-action" type="button"
-            data-annotated-action="explore">Explore</button>
-        </div>
-      </header>
-      ${result.contextLimitation
-        ? `<p class="annotated-context">${escapeHtml(result.contextLimitation)}</p>`
-        : ""}
+    <section class="annotated-reader" aria-label="Annotated source">
       ${renderSource(context)}
       ${renderDetail(context)}
+      <footer class="annotated-reader-footer">
+        ${result.contextLimitation
+          ? `<span class="annotated-context">${escapeHtml(result.contextLimitation)}</span>`
+          : ""}
+        <span>${escapeHtml(result.provenance)}</span>
+      </footer>
     </section>`;
+}
+
+export function renderAnnotatedSourcePageActions(enabled: boolean): string {
+  const disabled = enabled ? "" : " disabled";
+  return `
+    <button id="copy-annotated" type="button" data-annotated-action="copy"
+      title="Copy annotated source"${disabled}>Copy</button>
+    <button id="explore-annotated" class="primary-action" type="button"
+      data-annotated-action="explore"${disabled}>Explore</button>`;
 }
 
 export function renderAnnotatedSourceModal(
@@ -254,15 +263,25 @@ export function annotatedFocusSelector(
 function renderContext(
   options: AnnotatedSourceRenderOptions,
 ): SourceRenderContext {
+  const model = createAnnotatedSourceViewerModel(options.result);
+  const source = model.document.text;
   return {
-    model: createAnnotatedSourceViewerModel(options.result),
+    model,
     session: options.session,
     escapeHtml: options.escapeHtml,
+    highlighting: options.highlightCSharp?.(
+      source,
+      csharpHighlightingText(model.document),
+    ) ?? {
+      render(start, length) {
+        return options.escapeHtml(source.slice(start, start + length));
+      },
+    },
   };
 }
 
 function renderSource(context: SourceRenderContext): string {
-  const { model, session, escapeHtml } = context;
+  const { model, session, escapeHtml, highlighting } = context;
   const selectedFactId =
     session.primary?.kind === "finding" ? session.primary.id : null;
   const selectedNodeIds =
@@ -353,7 +372,7 @@ function renderSource(context: SourceRenderContext): string {
                           data-annotated-source-start="${segment.start}"
                           data-medium="${segmentMedium}"`
                       : ""}
-                    >${escapeHtml(segment.text)}</span>`;
+                    >${highlighting.render(segment.start, segment.text.length)}</span>`;
                 }).join("")
               : " "}</code>
             ${session.coordinatesVisible

--- a/prototypes/inspect-web/src/annotated-source.ts
+++ b/prototypes/inspect-web/src/annotated-source.ts
@@ -1,6 +1,6 @@
 import {
   buildAnnotatedView,
-  csharpHighlightingText,
+  csharpHighlightingInput,
   MEDIUM_LABELS,
 } from "./annotated-source-view.ts";
 import {
@@ -27,6 +27,7 @@ import type {
   SourceMedium,
 } from "./document-model.ts";
 import type {
+  CSharpHighlightExclusion,
   CSharpRangeHighlighter,
 } from "./csharp-highlighting.ts";
 
@@ -39,6 +40,7 @@ export interface AnnotatedSourceRenderOptions {
   highlightCSharp?: (
     source: string,
     tokenizationSource: string,
+    excludedRanges: readonly CSharpHighlightExclusion[],
   ) => CSharpRangeHighlighter;
 }
 
@@ -265,13 +267,15 @@ function renderContext(
 ): SourceRenderContext {
   const model = createAnnotatedSourceViewerModel(options.result);
   const source = model.document.text;
+  const highlightingInput = csharpHighlightingInput(model.document);
   return {
     model,
     session: options.session,
     escapeHtml: options.escapeHtml,
     highlighting: options.highlightCSharp?.(
       source,
-      csharpHighlightingText(model.document),
+      highlightingInput.text,
+      highlightingInput.excludedRanges,
     ) ?? {
       render(start, length) {
         return options.escapeHtml(source.slice(start, start + length));

--- a/prototypes/inspect-web/src/csharp-highlighting.ts
+++ b/prototypes/inspect-web/src/csharp-highlighting.ts
@@ -1,0 +1,151 @@
+export type EscapeHtml = (value: unknown) => string;
+
+interface PrismToken {
+  type: string;
+  alias?: string | readonly string[];
+  content: PrismTokenContent;
+}
+
+type PrismTokenContent =
+  | string
+  | PrismToken
+  | readonly (string | PrismToken)[];
+
+interface PrismCSharpTokenizer {
+  languages: {
+    csharp?: unknown;
+  };
+  tokenize(value: string, grammar: unknown): readonly (string | PrismToken)[];
+}
+
+interface PrismCSharpHighlighter extends PrismCSharpTokenizer {
+  highlight(value: string, grammar: unknown, language: string): string;
+}
+
+declare global {
+  interface Window {
+    Prism?: PrismCSharpHighlighter;
+  }
+}
+
+export interface CSharpRangeHighlighter {
+  render(start: number, length: number): string;
+}
+
+interface HighlightRun {
+  start: number;
+  end: number;
+  classes: readonly string[];
+}
+
+export function createCSharpRangeHighlighter(
+  source: string,
+  prism: PrismCSharpTokenizer | undefined,
+  escapeHtml: EscapeHtml,
+  tokenizationSource: string = source,
+): CSharpRangeHighlighter {
+  if (tokenizationSource.length !== source.length) {
+    return plainHighlighter(source, escapeHtml);
+  }
+  const grammar = prism?.languages.csharp;
+  if (!prism || !grammar) return plainHighlighter(source, escapeHtml);
+
+  const runs: HighlightRun[] = [];
+  let tokenizedText = "";
+  let offset = 0;
+  const append = (
+    content: PrismTokenContent,
+    classes: readonly string[] = [],
+  ): void => {
+    if (typeof content === "string") {
+      if (content.length > 0) {
+        tokenizedText += content;
+        runs.push({
+          start: offset,
+          end: offset + content.length,
+          classes,
+        });
+        offset += content.length;
+      }
+      return;
+    }
+    if (isTokenList(content)) {
+      for (const item of content) append(item, classes);
+      return;
+    }
+
+    const token = content;
+    append(token.content, [
+      ...classes,
+      token.type,
+      ...normalizeAliases(token.alias),
+    ]);
+  };
+
+  append(prism.tokenize(tokenizationSource, grammar));
+  if (tokenizedText !== tokenizationSource
+    || offset !== tokenizationSource.length
+    || runs.some(run => run.end > tokenizationSource.length)) {
+    return plainHighlighter(source, escapeHtml);
+  }
+
+  return {
+    render(start, length) {
+      const end = checkedRangeEnd(source, start, length);
+      let html = "";
+      for (const run of runs) {
+        if (run.end <= start) continue;
+        if (run.start >= end) break;
+        const sliceStart = Math.max(start, run.start);
+        const sliceEnd = Math.min(end, run.end);
+        const text = escapeHtml(source.slice(sliceStart, sliceEnd));
+        const classes = uniqueCssClasses(run.classes);
+        html += classes.length > 0
+          ? `<span class="token ${classes.join(" ")}">${text}</span>`
+          : text;
+      }
+      return html;
+    },
+  };
+}
+
+function plainHighlighter(
+  source: string,
+  escapeHtml: EscapeHtml,
+): CSharpRangeHighlighter {
+  return {
+    render(start, length) {
+      const end = checkedRangeEnd(source, start, length);
+      return escapeHtml(source.slice(start, end));
+    },
+  };
+}
+
+function checkedRangeEnd(source: string, start: number, length: number): number {
+  if (!Number.isInteger(start)
+    || !Number.isInteger(length)
+    || start < 0
+    || length < 0
+    || start + length > source.length) {
+    throw new RangeError(
+      `C# highlight range ${start}..${start + length} is outside source length ${source.length}.`);
+  }
+  return start + length;
+}
+
+function normalizeAliases(
+  alias: PrismToken["alias"],
+): readonly string[] {
+  if (typeof alias === "string") return [alias];
+  return alias ?? [];
+}
+
+function isTokenList(
+  content: PrismTokenContent,
+): content is readonly (string | PrismToken)[] {
+  return Array.isArray(content);
+}
+
+function uniqueCssClasses(classes: readonly string[]): string[] {
+  return [...new Set(classes.filter(value => /^[A-Za-z0-9_-]+$/.test(value)))];
+}

--- a/prototypes/inspect-web/src/csharp-highlighting.ts
+++ b/prototypes/inspect-web/src/csharp-highlighting.ts
@@ -32,10 +32,20 @@ export interface CSharpRangeHighlighter {
   render(start: number, length: number): string;
 }
 
+export interface CSharpHighlightExclusion {
+  start: number;
+  length: number;
+}
+
 interface HighlightRun {
   start: number;
   end: number;
   classes: readonly string[];
+}
+
+interface NormalizedExclusion {
+  start: number;
+  end: number;
 }
 
 export function createCSharpRangeHighlighter(
@@ -43,10 +53,13 @@ export function createCSharpRangeHighlighter(
   prism: PrismCSharpTokenizer | undefined,
   escapeHtml: EscapeHtml,
   tokenizationSource: string = source,
+  excludedRanges: readonly CSharpHighlightExclusion[] = [],
 ): CSharpRangeHighlighter {
   if (tokenizationSource.length !== source.length) {
     return plainHighlighter(source, escapeHtml);
   }
+  const exclusions = normalizeExclusions(source, excludedRanges);
+  if (!exclusions) return plainHighlighter(source, escapeHtml);
   const grammar = prism?.languages.csharp;
   if (!prism || !grammar) return plainHighlighter(source, escapeHtml);
 
@@ -98,15 +111,89 @@ export function createCSharpRangeHighlighter(
         if (run.start >= end) break;
         const sliceStart = Math.max(start, run.start);
         const sliceEnd = Math.min(end, run.end);
-        const text = escapeHtml(source.slice(sliceStart, sliceEnd));
         const classes = uniqueCssClasses(run.classes);
-        html += classes.length > 0
-          ? `<span class="token ${classes.join(" ")}">${text}</span>`
-          : text;
+        html += renderRun(
+          source,
+          sliceStart,
+          sliceEnd,
+          classes,
+          exclusions,
+          escapeHtml);
       }
       return html;
     },
   };
+}
+
+function renderRun(
+  source: string,
+  start: number,
+  end: number,
+  classes: readonly string[],
+  exclusions: readonly NormalizedExclusion[],
+  escapeHtml: EscapeHtml,
+): string {
+  let html = "";
+  let cursor = start;
+  for (const exclusion of exclusions) {
+    if (exclusion.end <= cursor) continue;
+    if (exclusion.start >= end) break;
+    const exclusionStart = Math.max(cursor, exclusion.start);
+    if (cursor < exclusionStart) {
+      html += renderStyledText(
+        source.slice(cursor, exclusionStart),
+        classes,
+        escapeHtml);
+    }
+    const exclusionEnd = Math.min(end, exclusion.end);
+    html += escapeHtml(source.slice(exclusionStart, exclusionEnd));
+    cursor = exclusionEnd;
+    if (cursor >= end) return html;
+  }
+  return html + renderStyledText(source.slice(cursor, end), classes, escapeHtml);
+}
+
+function renderStyledText(
+  source: string,
+  classes: readonly string[],
+  escapeHtml: EscapeHtml,
+): string {
+  const text = escapeHtml(source);
+  return classes.length > 0
+    ? `<span class="token ${classes.join(" ")}">${text}</span>`
+    : text;
+}
+
+function normalizeExclusions(
+  source: string,
+  ranges: readonly CSharpHighlightExclusion[],
+): readonly NormalizedExclusion[] | null {
+  const sorted: NormalizedExclusion[] = [];
+  for (const range of ranges) {
+    if (!Number.isInteger(range.start)
+      || !Number.isInteger(range.length)
+      || range.start < 0
+      || range.length <= 0
+      || range.start + range.length > source.length) {
+      return null;
+    }
+    sorted.push({
+      start: range.start,
+      end: range.start + range.length,
+    });
+  }
+  sorted.sort((left, right) => left.start - right.start || left.end - right.end);
+
+  const normalized: NormalizedExclusion[] = [];
+  for (const range of sorted) {
+    const previous = normalized.at(-1);
+    if (previous && range.start <= previous.end) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      normalized.push({ ...range });
+    }
+  }
+  return normalized;
 }
 
 function plainHighlighter(

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -191,6 +191,9 @@ import {
   validateAnnotatedSourceDocument,
 } from "./annotated-source-view.ts";
 import {
+  createCSharpRangeHighlighter,
+} from "./csharp-highlighting.ts";
+import {
   clearAnnotations,
   closeFindingDetail,
   createAnnotatedSourceViewerModel,
@@ -226,6 +229,7 @@ import {
 } from "./graph-source.ts";
 import {
   annotatedFocusSelector,
+  renderAnnotatedSourcePageActions,
   bindAnnotatedSource,
   renderAnnotatedSource as renderAnnotatedSourcePure,
   renderAnnotatedSourceModal as renderAnnotatedSourceModalPure,
@@ -451,10 +455,6 @@ async function loadEngineModule() {
 
 declare global {
   interface Window {
-    Prism?: {
-      languages: { csharp?: unknown };
-      highlight: (value: string, grammar: unknown, language: string) => string;
-    };
     __platformIndex?: Promise<PlatformIndex | null>;
   }
 }
@@ -2627,6 +2627,10 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     state.lens = "api";
   }
   state.typeCursor = Math.min(state.typeCursor, Math.max(visible.length - 1, 0));
+  const annotatedWorkingSurface =
+    scope() === "member" && state.memberSection === "annotated";
+  const annotatedActionsEnabled =
+    annotatedWorkingSurface && state.memberAnnotatedEmbedded !== null;
 
   app.innerHTML = `
     <div class="workbench"${state.memberAnnotatedModal ? " inert" : ""}>
@@ -2702,9 +2706,13 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
                 : `<span>${escapeHtml(packageDisplayName(pkg))}</span><b>/</b><span>${escapeHtml(current?.namespace ?? "")}</span><b>/</b><strong>${escapeHtml(typeDisplayName(current))}</strong>
               ${state.selectedMemberKey ? `<b>/</b><strong>${escapeHtml(selectedMember(current)?.name ?? "")}</strong>` : ""}`}
             </div>
-            <div class="detail-actions"><button id="copy-name" type="button">copy name</button><button id="taste-btn" class="${state.taste.length ? "active" : ""}" title="Decompiler style (taste)">taste${state.taste.length ? ` · ${state.taste.length}` : ""}</button></div>
+            <div class="detail-actions${annotatedWorkingSurface ? " annotated-page-actions" : ""}">
+              ${annotatedWorkingSurface
+                ? renderAnnotatedSourcePageActions(annotatedActionsEnabled)
+                : `<button id="copy-name" type="button">copy name</button><button id="taste-btn" class="${state.taste.length ? "active" : ""}" title="Decompiler style (taste)">taste${state.taste.length ? ` · ${state.taste.length}` : ""}</button>`}
+            </div>
           </header>
-          <article class="detail-scroll">
+          <article class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}">
             ${renderLens(current)}
           </article>
         </section>
@@ -4270,6 +4278,7 @@ function renderAnnotatedSource(result: AnnotatedSourceResult) {
       result,
       session,
       escapeHtml,
+      highlightCSharp: annotatedSourceHighlighter,
     });
   } catch (error) {
     if (!(error instanceof TypeError)) throw error;
@@ -4284,6 +4293,7 @@ function renderAnnotatedSourceModal() {
       result: state.memberAnnotated,
       session: state.memberAnnotatedModal,
       escapeHtml,
+      highlightCSharp: annotatedSourceHighlighter,
     });
   } catch (error) {
     if (!(error instanceof TypeError)) throw error;
@@ -4483,6 +4493,18 @@ function highlightCSharp(value: string) {
       "csharp");
   }
   return escapeHtml(source);
+}
+
+function annotatedSourceHighlighter(
+  source: string,
+  tokenizationSource: string,
+) {
+  return createCSharpRangeHighlighter(
+    source,
+    window.Prism,
+    escapeHtml,
+    tokenizationSource,
+  );
 }
 
 const packageViewActions: PackageViewBindingActions = {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -193,6 +193,9 @@ import {
 import {
   createCSharpRangeHighlighter,
 } from "./csharp-highlighting.ts";
+import type {
+  CSharpHighlightExclusion,
+} from "./csharp-highlighting.ts";
 import {
   clearAnnotations,
   closeFindingDetail,
@@ -2627,10 +2630,14 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     state.lens = "api";
   }
   state.typeCursor = Math.min(state.typeCursor, Math.max(visible.length - 1, 0));
+  const annotatedPageContext =
+    scope() === "member"
+    && state.memberSection === "annotated"
+    && memberSourceHasConcreteOverload();
   const annotatedWorkingSurface =
-    scope() === "member" && state.memberSection === "annotated";
+    annotatedPageContext && state.memberAnnotatedEmbedded !== null;
   const annotatedActionsEnabled =
-    annotatedWorkingSurface && state.memberAnnotatedEmbedded !== null;
+    annotatedWorkingSurface;
 
   app.innerHTML = `
     <div class="workbench"${state.memberAnnotatedModal ? " inert" : ""}>
@@ -2706,8 +2713,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
                 : `<span>${escapeHtml(packageDisplayName(pkg))}</span><b>/</b><span>${escapeHtml(current?.namespace ?? "")}</span><b>/</b><strong>${escapeHtml(typeDisplayName(current))}</strong>
               ${state.selectedMemberKey ? `<b>/</b><strong>${escapeHtml(selectedMember(current)?.name ?? "")}</strong>` : ""}`}
             </div>
-            <div class="detail-actions${annotatedWorkingSurface ? " annotated-page-actions" : ""}">
-              ${annotatedWorkingSurface
+            <div class="detail-actions${annotatedPageContext ? " annotated-page-actions" : ""}">
+              ${annotatedPageContext
                 ? renderAnnotatedSourcePageActions(annotatedActionsEnabled)
                 : `<button id="copy-name" type="button">copy name</button><button id="taste-btn" class="${state.taste.length ? "active" : ""}" title="Decompiler style (taste)">taste${state.taste.length ? ` · ${state.taste.length}` : ""}</button>`}
             </div>
@@ -4498,12 +4505,14 @@ function highlightCSharp(value: string) {
 function annotatedSourceHighlighter(
   source: string,
   tokenizationSource: string,
+  excludedRanges: readonly CSharpHighlightExclusion[],
 ) {
   return createCSharpRangeHighlighter(
     source,
     window.Prism,
     escapeHtml,
     tokenizationSource,
+    excludedRanges,
   );
 }
 

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -514,6 +514,9 @@ kbd {
 .detail-actions button:first-child { padding: 0 8px; }
 .detail-actions button:last-child { width: 27px; }
 .detail-scroll { overflow: auto; padding: clamp(24px, 4vw, 52px) clamp(26px, 5vw, 72px) 70px; }
+.detail-actions.annotated-page-actions button { width: auto; padding: 0 10px; }
+.detail-actions.annotated-page-actions .primary-action { border-color: var(--accent); color: var(--text); }
+.detail-scroll.annotated-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 
 .type-heading {
   display: grid;
@@ -2233,16 +2236,12 @@ kbd {
 
 /* Annotated Source keeps the portable text selectable while Findings and source-node
    selection use explicit controls and non-underline treatments. */
-.annotated-reader { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: 4px; background: var(--panel); }
-.annotated-reader-head,
+.annotated-reader { position: relative; min-height: 0; height: 100%; display: grid; grid-template-rows: minmax(0, 1fr) auto auto; overflow: hidden; background: var(--panel); }
 .annotated-modal-head { display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 12px 14px; border-bottom: 1px solid var(--line); }
-.annotated-reader-head h3,
 .annotated-modal-head h2,
 .annotated-inspector-section h3,
 .annotated-detail h3,
 .annotated-detail h4 { margin: 0; }
-.annotated-reader-head p:not(.section-eyebrow) { margin: 3px 0 0; color: var(--dim); font: 11px var(--mono); }
-.annotated-reader-actions,
 .annotated-modal-head-actions,
 .annotated-control-row { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
 .annotated-reader button,
@@ -2252,10 +2251,12 @@ kbd {
 .annotated-reader button:focus-visible,
 .annotated-modal button:focus-visible,
 .annotated-source-segment:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
-.annotated-reader .primary-action { border-color: var(--accent); color: var(--text); }
-.annotated-context { margin: 0; padding: 8px 12px; border-bottom: 1px solid var(--line); background: color-mix(in srgb, var(--yellow) 8%, transparent); color: var(--dim); font: 12px/1.5 var(--mono); }
+.annotated-reader-footer { display: flex; align-items: center; gap: 12px; min-height: 32px; padding: 6px 14px; border-top: 1px solid var(--line); color: var(--dim); font: 11px/1.5 var(--mono); }
+.annotated-reader-footer > span:last-child { margin-left: auto; }
+.annotated-context { color: var(--yellow); }
 
-.annotated-source-code { min-width: max-content; padding: 10px 0 18px; overflow: auto; background: var(--code-bg); color: var(--code-text); font: 13px/1.65 var(--mono); }
+.annotated-source-code { min-width: max-content; min-height: 0; padding: 10px 0 18px; overflow: auto; background: var(--code-bg); color: var(--code-text); font: 13px/1.65 var(--mono); }
+.annotated-reader > .annotated-source-code { height: 100%; }
 .annotated-source-line { display: grid; align-items: baseline; min-height: 22px; padding: 0 14px; white-space: pre; }
 .annotated-source-code[data-annotated-surface="embedded"] .annotated-source-line { grid-template-columns: 4ch minmax(max-content, 1fr) auto; gap: 12px; }
 .annotated-source-code[data-annotated-surface="modal"] .annotated-source-line { grid-template-columns: 4ch 4ch minmax(max-content, 1fr) auto; gap: 10px; }
@@ -2265,6 +2266,22 @@ kbd {
 .annotated-medium-label { color: var(--blue); font-size: 10px; user-select: none; }
 .medium-il .annotated-medium-label { color: var(--purple); }
 .annotated-source-line code { white-space: pre; }
+.annotated-source-code .token.comment { color: #6f7669; font-style: italic; }
+.annotated-source-code .token.keyword { color: #d98a70; }
+.annotated-source-code .token.class-name,
+.annotated-source-code .token.return-type,
+.annotated-source-code .token.type-expression { color: #84b1c7; }
+.annotated-source-code .token.string,
+.annotated-source-code .token.char,
+.annotated-source-code .token.interpolation-string { color: #a9bd82; }
+.annotated-source-code .token.number,
+.annotated-source-code .token.boolean { color: #d3a76b; }
+.annotated-source-code .token.function { color: #d7c477; }
+.annotated-source-code .token.operator,
+.annotated-source-code .token.punctuation { color: #94978e; }
+.annotated-source-code .token.attribute,
+.annotated-source-code .token.namespace { color: #b89ac6; }
+.annotated-source-code .token.preprocessor { color: #a48ad0; }
 .annotated-source-segment { border-radius: 2px; user-select: text; }
 .annotated-source-segment.addressable { cursor: pointer; }
 .annotated-source-segment.addressable:hover,
@@ -2346,10 +2363,25 @@ kbd {
 .annotated-detail-capabilities p { margin: 5px 0 0; color: var(--dim); font: 11px/1.5 var(--mono); }
 
 @media (max-width: 820px) {
-  .annotated-reader-head { align-items: flex-start; flex-direction: column; }
   .annotated-modal-workspace { grid-template-columns: 1fr; }
   .annotated-modal-inspector { border-top: 1px solid var(--line); }
   .annotated-modal-source { border-right: 0; }
 }
 
 :root[data-theme="light"] .annotated-source-segment.selected { background: #f6e2d8; }
+:root[data-theme="light"] .annotated-source-code .token.comment { color: #6a7268; }
+:root[data-theme="light"] .annotated-source-code .token.keyword { color: #b04a2c; }
+:root[data-theme="light"] .annotated-source-code .token.class-name,
+:root[data-theme="light"] .annotated-source-code .token.return-type,
+:root[data-theme="light"] .annotated-source-code .token.type-expression { color: #245f86; }
+:root[data-theme="light"] .annotated-source-code .token.string,
+:root[data-theme="light"] .annotated-source-code .token.char,
+:root[data-theme="light"] .annotated-source-code .token.interpolation-string { color: #397044; }
+:root[data-theme="light"] .annotated-source-code .token.number,
+:root[data-theme="light"] .annotated-source-code .token.boolean { color: #8a5a12; }
+:root[data-theme="light"] .annotated-source-code .token.function { color: #8a650d; }
+:root[data-theme="light"] .annotated-source-code .token.operator,
+:root[data-theme="light"] .annotated-source-code .token.punctuation { color: #6b7065; }
+:root[data-theme="light"] .annotated-source-code .token.attribute,
+:root[data-theme="light"] .annotated-source-code .token.namespace,
+:root[data-theme="light"] .annotated-source-code .token.preprocessor { color: #6c4d91; }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -2256,7 +2256,7 @@ kbd {
 .annotated-context { color: var(--yellow); }
 
 .annotated-source-code { min-width: max-content; min-height: 0; padding: 10px 0 18px; overflow: auto; background: var(--code-bg); color: var(--code-text); font: 13px/1.65 var(--mono); }
-.annotated-reader > .annotated-source-code { height: 100%; }
+.annotated-reader > .annotated-source-code { width: 100%; min-width: 0; height: 100%; }
 .annotated-source-line { display: grid; align-items: baseline; min-height: 22px; padding: 0 14px; white-space: pre; }
 .annotated-source-code[data-annotated-surface="embedded"] .annotated-source-line { grid-template-columns: 4ch minmax(max-content, 1fr) auto; gap: 12px; }
 .annotated-source-code[data-annotated-surface="modal"] .annotated-source-line { grid-template-columns: 4ch 4ch minmax(max-content, 1fr) auto; gap: 10px; }

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -5,9 +5,13 @@ import {
   bindAnnotatedSource,
   renderAnnotatedSource,
   renderAnnotatedSourceModal,
+  renderAnnotatedSourcePageActions,
   type AnnotatedSourceAction,
   type AnnotatedSourceBindingActions,
 } from "../src/annotated-source.ts";
+import {
+  createCSharpRangeHighlighter,
+} from "../src/csharp-highlighting.ts";
 import {
   createAnnotatedSourceViewerModel,
   createEmbeddedSession,
@@ -20,7 +24,10 @@ import {
 import type {
   AnnotatedSourceResult,
 } from "../src/annotated-source-session.ts";
-import { validateAnnotatedSourceDocument } from "../src/annotated-source-view.ts";
+import {
+  csharpHighlightingText,
+  validateAnnotatedSourceDocument,
+} from "../src/annotated-source-view.ts";
 import type { AnnotatedSourceDocument } from "../src/annotated-source-view.ts";
 import { sampleDocument as sampleDocumentFixture } from "../../annotated-source-viewer/src/sample-document.js";
 import {
@@ -202,19 +209,149 @@ test("the pure renderer rejects an invalid document for the shell to surface", (
   );
 });
 
-test("embedded reader renders complete C# defaults, source copy, and Explore", () => {
+test("inline working surface starts with complete C# and ends with provenance", () => {
   const html = embeddedHtml();
+  const source = html.indexOf("medium-csharp");
+  const provenance = html.indexOf("decompiled from IL");
 
-  assert.match(html, /id="annotated-reader-title">C# with default findings/);
-  assert.match(html, /decompiled from IL/);
-  assert.match(html, /id="copy-annotated"[^>]*data-annotated-action="copy"/);
-  assert.match(html, /id="explore-annotated"[^>]*data-annotated-action="explore"/);
+  assert.doesNotMatch(html, /Annotated Source|C# with default findings/);
+  assert.doesNotMatch(html, /data-annotated-action="(?:copy|explore)"/);
+  assert.match(html, /class="annotated-reader-footer"/);
+  assert.ok(source >= 0);
+  assert.ok(provenance > source);
   assert.match(html, /medium-csharp/);
   assert.doesNotMatch(html, /medium-il/);
   assert.match(html, /annotated-chip-embedded-0-1-CSharp/);
   assert.match(html, /annotated-chip-embedded-1-0-CSharp/);
   assert.doesNotMatch(html, /annotated-chip-embedded-0-3-Il/);
   assert.doesNotMatch(html, /data-annotated-source-start/);
+});
+
+test("page-owned actions expose Copy and Explore only when the document is ready", () => {
+  const enabled = renderAnnotatedSourcePageActions(true);
+  const disabled = renderAnnotatedSourcePageActions(false);
+
+  assert.match(
+    enabled,
+    /id="copy-annotated"[^>]*data-annotated-action="copy"[^>]*>Copy<\/button>/,
+  );
+  assert.match(
+    enabled,
+    /id="explore-annotated"[^>]*data-annotated-action="explore"[^>]*>Explore<\/button>/,
+  );
+  assert.doesNotMatch(enabled, / disabled/);
+  assert.match(disabled, /id="copy-annotated"[^>]* disabled/);
+  assert.match(disabled, /id="explore-annotated"[^>]* disabled/);
+});
+
+test("C# highlighting crosses product segments without changing source text", () => {
+  const source = 'return Widget.Create("x");';
+  const highlighter = createCSharpRangeHighlighter(
+    source,
+    {
+      languages: { csharp: {} },
+      tokenize: () => [
+        { type: "keyword", content: "return" },
+        " ",
+        { type: "class-name", content: "Widget" },
+        { type: "punctuation", content: "." },
+        { type: "function", content: "Create" },
+        { type: "punctuation", content: "(" },
+        { type: "string", content: '"x"' },
+        { type: "punctuation", content: ");" },
+      ],
+    },
+    escapeHtml,
+  );
+  const start = 2;
+  const length = source.length - 4;
+  const html = highlighter.render(start, length);
+
+  assert.match(html, /class="token keyword">turn<\/span>/);
+  assert.match(html, /class="token class-name">Widget<\/span>/);
+  assert.match(html, /class="token function">Create<\/span>/);
+  assert.equal(
+    html
+      .replaceAll(/<[^>]+>/g, "")
+      .replaceAll("&quot;", '"'),
+    source.slice(start, start + length),
+  );
+});
+
+test("annotated source renderer keeps syntax tokens inside structural spans", () => {
+  const html = renderAnnotatedSource({
+    result,
+    session: createEmbeddedSession(createAnnotatedSourceViewerModel(result)),
+    escapeHtml,
+    highlightCSharp: source => createCSharpRangeHighlighter(
+      source,
+      {
+        languages: { csharp: {} },
+        tokenize: () => [{ type: "keyword", content: source }],
+      },
+      escapeHtml,
+    ),
+  });
+
+  assert.match(
+    html,
+    /class="annotated-source-segment"[^>]*><span class="token keyword">/,
+  );
+});
+
+test("C# tokenization masks IL while preserving document UTF-16 offsets", () => {
+  const document: AnnotatedSourceDocument = {
+    text: "cs\nil\nab",
+    nodes: [
+      {
+        id: 0,
+        kind: "CSharp",
+        medium: "CSharp",
+        spans: [{ start: 0, length: 2 }],
+      },
+      {
+        id: 1,
+        kind: "Instruction",
+        medium: "Il",
+        spans: [{ start: 3, length: 2 }],
+        il_offset: 0,
+      },
+      {
+        id: 2,
+        kind: "CSharp",
+        medium: "CSharp",
+        spans: [{ start: 6, length: 1 }],
+      },
+      {
+        id: 3,
+        kind: "Instruction",
+        medium: "Il",
+        spans: [{ start: 7, length: 1 }],
+        il_offset: 1,
+      },
+    ],
+    regions: [],
+    facts: [],
+    targets: [],
+  };
+  const tokenizationSource = csharpHighlightingText(document);
+
+  assert.equal(tokenizationSource, "cs\n  \na ");
+  assert.equal(tokenizationSource.length, document.text.length);
+});
+
+test("C# highlighting falls back to escaped source when token text diverges", () => {
+  const source = '<T value="x">';
+  const highlighter = createCSharpRangeHighlighter(
+    source,
+    {
+      languages: { csharp: {} },
+      tokenize: () => ["x".repeat(source.length)],
+    },
+    escapeHtml,
+  );
+
+  assert.equal(highlighter.render(0, source.length), "&lt;T value=&quot;x&quot;&gt;");
 });
 
 test("annotation rows begin at their product-issued source span", () => {
@@ -415,7 +552,7 @@ test("source text is escaped while source actions and chrome remain separate", (
 
   assert.match(html, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
   assert.doesNotMatch(html, /<script>alert/);
-  assert.match(html, />copy source<\/button>/);
+  assert.doesNotMatch(html, /data-annotated-action="(?:copy|explore)"/);
 });
 
 test("every chip-shaped rendered action is a button with one documented verb", () => {
@@ -436,7 +573,9 @@ test("every chip-shaped rendered action is a button with one documented verb", (
     ),
     escapeHtml,
   });
-  const html = `${embeddedHtml()}${modalHtml()}${selectedModal}${detailedModal}`;
+  const html =
+    `${renderAnnotatedSourcePageActions(true)}${embeddedHtml()}`
+    + `${modalHtml()}${selectedModal}${detailedModal}`;
   const actionTags = [...html.matchAll(
     /<([a-z]+)[^>]*data-annotated-action="([^"]+)"[^>]*>/g,
   )];

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -25,6 +25,7 @@ import type {
   AnnotatedSourceResult,
 } from "../src/annotated-source-session.ts";
 import {
+  csharpHighlightingInput,
   csharpHighlightingText,
   validateAnnotatedSourceDocument,
 } from "../src/annotated-source-view.ts";
@@ -278,6 +279,36 @@ test("C# highlighting crosses product segments without changing source text", ()
   );
 });
 
+test("C# highlighting leaves excluded IL ranges unstyled inside one Prism token", () => {
+  const source = 'var s = @"start\nIL_0000: nop\nend";';
+  const ilStart = source.indexOf("IL_0000");
+  const ilLength = "IL_0000: nop".length;
+  const tokenizationSource =
+    source.slice(0, ilStart)
+    + " ".repeat(ilLength)
+    + source.slice(ilStart + ilLength);
+  const highlighter = createCSharpRangeHighlighter(
+    source,
+    {
+      languages: { csharp: {} },
+      tokenize: value => [{ type: "string", content: value }],
+    },
+    escapeHtml,
+    tokenizationSource,
+    [{ start: ilStart, length: ilLength }],
+  );
+  const html = highlighter.render(0, source.length);
+
+  assert.match(html, /class="token string">var s = @&quot;start\n<\/span>IL_0000: nop/);
+  assert.doesNotMatch(html, /class="token string">IL_0000: nop/);
+  assert.equal(
+    html
+      .replaceAll(/<[^>]+>/g, "")
+      .replaceAll("&quot;", '"'),
+    source,
+  );
+});
+
 test("annotated source renderer keeps syntax tokens inside structural spans", () => {
   const html = renderAnnotatedSource({
     result,
@@ -334,10 +365,18 @@ test("C# tokenization masks IL while preserving document UTF-16 offsets", () => 
     facts: [],
     targets: [],
   };
+  const highlightingInput = csharpHighlightingInput(document);
   const tokenizationSource = csharpHighlightingText(document);
 
   assert.equal(tokenizationSource, "cs\n  \na ");
   assert.equal(tokenizationSource.length, document.text.length);
+  assert.deepEqual(highlightingInput, {
+    text: tokenizationSource,
+    excludedRanges: [
+      { start: 3, length: 2 },
+      { start: 7, length: 1 },
+    ],
+  });
 });
 
 test("C# highlighting falls back to escaped source when token text diverges", () => {
@@ -616,4 +655,24 @@ test("persistent source affordances use no underline treatment", () => {
     /\.annotated-row-items\s*\{([^}]*)\}/.exec(styles)?.[1] ?? "";
   assert.ok(annotationRows.length > 0);
   assert.doesNotMatch(annotationRows, /border-left|padding-left/);
+});
+
+test("Annotated Source composition requires a concrete overload and validated session", () => {
+  const appSource = readFileSync(
+    new URL("../src/dotnet-inspect.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    appSource,
+    /const annotatedPageContext =\s*scope\(\) === "member"\s*&& state\.memberSection === "annotated"\s*&& memberSourceHasConcreteOverload\(\);/);
+  assert.match(
+    appSource,
+    /const annotatedWorkingSurface =\s*annotatedPageContext && state\.memberAnnotatedEmbedded !== null;/);
+  assert.match(
+    appSource,
+    /detail-actions\$\{annotatedPageContext \? " annotated-page-actions" : ""\}/);
+  assert.match(
+    appSource,
+    /detail-scroll\$\{annotatedWorkingSurface \? " annotated-working-surface" : ""\}/);
 });


### PR DESCRIPTION
## Summary

Make inline Annotated Source the full-area working surface already specified by `docs/design/inspect-web-ui.md`: the reader no longer renders a second title card, the page-owned subject bar supplies **Copy** and **Explore**, highlighted source fills the available pane, and provenance follows the source.

C# highlighting tokenizes an offset-preserving view that masks product-issued IL spans, then renders the original document text through those token ranges. Source copy, UTF-16 coordinates, annotation anchors, source-node hit testing, and modal behavior remain unchanged.

Closes #5398.

## Demo

Run the checked browser surface at `browser/annotated-source.html` and compare the inline reader with #5266:

- the subject path and **Copy**/**Explore** share the page bar;
- source begins immediately, without visible `Annotated Source` or `C# with default findings` chrome;
- C# tokens are highlighted while Finding overlays retain their exact source indentation; and
- product provenance sits at the bottom of the working surface.

Opening **Explore** demonstrates the neighboring modal scenario and preserves its existing pointer, keyboard, focus, and Escape behavior.

## Validation

- `npm run analyze`
- `npm run build`
- full Node frontend test suite
- 10 Playwright Firefox Annotated Source interaction tests
- `markdownlint` on changed Markdown

![Annotated Source full-area working surface](https://github.com/user-attachments/assets/76c2f7c7-7105-4bed-b942-3ddc85715e78)