### PR TITLE
Execute Integration Census sequentially

### DIFF
--- a/docs/design/analysis-universe-realization.md
+++ b/docs/design/analysis-universe-realization.md
@@ -19,9 +19,10 @@ Issuance remains synchronous and sequential, reacquires authorization for each
 plan, and publishes no partial access.
 
 The first intended adopter is Workspace-backed analysis. Integration defines
-its owner-specific typed binding-context roster and incidence payload for this
-handoff; its Census executor remains a prospective consumer and is not part of
-this owner's contract.
+its owner-specific typed participant, selected-Type, binding-context,
+producer-policy, peer-binding, exact-resolution, and completeness payloads for
+this handoff. Its sequential Census executor consumes those exact bindings
+without becoming part of this owner's contract.
 
 ## Authority
 
@@ -365,7 +366,7 @@ implementation.
 3. Define the Integration-owned typed binding-context roster and incidence
    payload and derive Census attempt addresses from it. Complete.
 4. Adopt the executable bindings in the Integration Census executor under the
-   Integration owner.
+   Integration owner. Complete.
 5. Let later analysis owners adopt the same pattern independently.
 
 The generic Workspace adoption does not implement an Integration capability,

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -366,7 +366,11 @@ The projection-neutral core model is also implemented:
 selected Type set, owner-issued binding-context roster and source incidence,
 terminal source and producer receipts, coalesced candidates,
 candidate-attempt addresses, dispositions, and suppression proofs. Census
-execution, inventory, graph correspondence, matrix projection, and their
+execution is implemented by `IntegrationCensusExecutor`, which consumes exact
+Workspace-issued capability bindings, validates their correspondence before
+producer execution, runs producer policies sequentially, binds and resolves
+complete context-local candidate batches, and constructs the immutable
+snapshot. Inventory, graph correspondence, matrix projection, and their
 remaining gates are still target design.
 
 The Census is one Integration analysis over one finite universe. It is not a
@@ -490,15 +494,85 @@ display or boundary data.
 [Analysis universe realization](analysis-universe-realization.md) owns the
 execution-time handoff that binds those exact requirements to Workspace-backed,
 capability-owner-issued rosters, context incidence, resolution access, and
-lifetimes. The Integration Census executor will retrieve this payload from the
-exact executable requirement binding and reject invalid cross-capability
-coverage before producer execution. The immutable snapshot retains only the
-issued participant and context identities and their incidence, not the
-operation-scoped access or lease. It receives no mutable Workspace state and
-infers no context identity from a group object or binding-policy version.
-The capability owner either supplies a valid `IntegrationBindingContextAccess`
-or returns a typed acquisition rejection; registering another payload type is
-a provider contract violation rather than a Census outcome.
+lifetimes. The Integration Census executor retrieves each Integration-owned
+payload from its exact executable requirement binding and rejects invalid
+cross-capability coverage before producer execution. The selected-Type and
+exact-resolution bindings retain the same owner-issued Type-identity domain;
+the binding-context, peer-binding, and exact-resolution bindings retain the
+same ordered context identities; and executable completeness retains the exact
+description completeness and failure objects. Participant incidence must
+exactly cover the ordered participant roster, and every selected Type must name
+one of those participants.
+
+The immutable snapshot retains only issued identities, evidence, and receipts,
+not operation-scoped access or leases. It receives no mutable Workspace state
+and infers no context identity from a group object or binding-policy version.
+A capability owner either supplies its exact typed access payload or returns a
+typed acquisition rejection. A missing or wrongly typed executable payload is
+an Integration execution rejection rather than a producer attempt.
+
+### Sequential Census execution
+
+`IntegrationCensusExecutor` is the Integration-owned coordinator for one exact
+validated plan and its retained `AnalysisUniverseOffer`. It requests fresh
+execution access, validates every capability correspondence above, and then
+executes only through those owner-issued operations. Its terminal result is one
+of:
+
+- `Ready`, carrying the complete immutable Census snapshot;
+- `IssuanceRejected`, preserving the generic realization rejection;
+- `ExecutionRejected`, carrying a typed Integration provider-correspondence or
+  receipt rejection; or
+- `Cancelled`, after releasing every acquired capability lease.
+
+The executor is synchronous and sequential. It invokes producer policies in
+participant order and retained policy order. A rejected or failed source
+participant does not invoke a producer; the executor emits one typed
+`Unavailable` producer receipt for each required policy address. Cancellation
+is checked before and after every owner operation. Matching cancellation
+remains cancellation, while unexpected producer defects remain visible.
+
+Producer evidence is context-free. A completed observed-candidate receipt may
+also retain ordered structured Type lookups for extension receivers or other
+Integration-owned fulfillment sources. Those lookups are supporting evidence,
+not candidate identity. The ecosystem-observed policy therefore declares both
+the Integrations and extension-method query prerequisites; providers may share
+one retained scan across policy accesses.
+
+After coalescing the candidate frontier, the executor submits the complete
+ordered evaluation request set for each binding context to peer binding in one
+batch. The batch includes every candidate address incident to that context and
+the producer-issued fulfillment-source lookups associated with each candidate.
+This is the admission point for Metadata's frozen binding and resolution
+manifest: the provider may plan all exact candidate and supporting Type
+lookups together rather than discover a new root during frozen resolution.
+Contexts execute sequentially in provider order. Within each context, exact
+resolution consumes the exact peer-binding batch and returns one typed terminal
+receipt for every successfully bound address. Batch receipts must exactly cover
+their requested addresses; missing, duplicate, extraneous, wrong-context, or
+foreign-batch receipts reject execution.
+
+A successful observed-candidate resolution retains the resolved paths for its
+declared fulfillment-source lookups. That resolution set exactly covers the
+distinct declared lookups; omission, duplication, or an undeclared lookup
+rejects a successful receipt. A provider that cannot resolve any declared
+fulfillment source returns a failed candidate resolution rather than a partial
+success. The executor performs suppression only after all candidate
+resolutions are available. An opportunity is suppressed by the first
+coalesced observed candidate in the same context and concept whose resolved
+target equals the opportunity target and whose resolved fulfillment source
+equals the opportunity source Type. The opportunity's own target must also
+have resolved successfully. Otherwise the executor classifies the candidate
+`In` or `Out` from exact selected-Type membership. The snapshot revalidates the
+declared lookup, resolved source, target, context, and fulfilling-attempt
+correspondence, so a same-concept target without matching receiver evidence
+cannot suppress an opportunity.
+
+The executor groups requests context-first only to satisfy the complete frozen
+resolution manifest. Final candidate-attempt order remains candidate evidence
+order followed by each candidate source's incident context order. This
+grouping is not concurrency and adds no thread, scheduler, or asynchronous API;
+single-threaded Browser/Wasm remains the normative baseline.
 
 ### Producer-policy attempt accounting
 
@@ -536,6 +610,11 @@ provenance, not candidate or candidate-attempt identity. The coalesced candidate
 is evaluated once in each binding context incident to its source participant,
 while distinct binding contexts continue to produce distinct candidate-attempt
 addresses.
+
+Observed producer evidence may retain fulfillment-source lookups beside the
+candidate identity. Equal candidate identities coalesce while preserving all
+ordered producer evidence and producer-attempt correspondence. Fulfillment
+lookups do not split identity and cannot create an independent candidate.
 
 ### Evidence-visible frontier
 
@@ -654,15 +733,16 @@ its successful resolution must use the attempt address's exact binding-context
 identity; evidence from another context cannot suppress this attempt. The
 suppression receipt also retains the exact acquired source Type and resolved
 target path used by the fulfillment policy. The source must match the
-opportunity source, the path must retain the opportunity's exact policy-issued
-lookup, and its terminal must match the classified observation's terminal
-target. The observation's candidate source remains the adapter member or Type
-that supplied observed evidence; it is not required to equal the SDK source
-Type retained by the fulfillment proof. A classified `In` or `Out` observation
-may fulfill the opportunity because both are successful exact resolution
-outcomes in the same binding context. `Failed` retains its typed cause and
-makes the affected Census incomplete. Only `Classified` attempts contribute
-candidate inventory.
+opportunity source and one producer-declared fulfillment-source lookup on the
+classified observation must resolve to that exact Type. The path must retain
+the opportunity's exact policy-issued lookup, and its terminal must match the
+classified observation's terminal target. The observation's candidate source
+remains the adapter member or Type that supplied observed evidence; it is not
+required to equal the SDK source Type retained by the fulfillment proof. A
+classified `In` or `Out` observation may fulfill the opportunity because both
+are successful exact resolution outcomes in the same binding context.
+`Failed` retains its typed cause and makes the affected Census incomplete.
+Only `Classified` attempts contribute candidate inventory.
 
 ### Candidate disposition
 
@@ -898,10 +978,12 @@ Implementation should land as focused slices:
    capability declarations (implemented);
 2. candidate identity, producer-policy and candidate attempts, disposition,
    and the projection-neutral Census snapshot (implemented core model);
-3. `Integration Inventory` row Section and structured row output;
-4. graph correspondence from `In` candidates without changing graph semantics;
-5. sparse matrix projection and WASM demo; and
-6. separately owned #4979 `find` prerequisite or optional enrichment for
+3. sequential Workspace-backed execution over exact typed capability bindings
+   (implemented);
+4. `Integration Inventory` row Section and structured row output;
+5. graph correspondence from `In` candidates without changing graph semantics;
+6. sparse matrix projection and WASM demo; and
+7. separately owned #4979 `find` prerequisite or optional enrichment for
    discovering an unknown parent.
 
 Each slice must preserve current focused Library sections and explicit
@@ -1017,6 +1099,21 @@ The projection-neutral core-model slice is verified by:
 - `IntegrationCensus_SuppressionRejectsUnclassifiedFulfiller`
 - `IntegrationCensus_SuppressionRejectsWrongProofSourceOrTarget`
 - `IntegrationCensus_SnapshotCompatibilityIgnoresProjectionButRequiresSharedInputs`
+- `IntegrationCensusExecutor_ExecutesSparseUniverseSequentiallyAndSuppressesWithResolvedSourceEvidence`
+- `IntegrationCensusExecutor_RejectsCrossCapabilityMismatchBeforeProducerExecution`
+- `IntegrationCensusExecutor_DoesNotInvokeProducersForUnavailableParticipants`
+- `IntegrationCensusExecutor_PreservesCandidateFailureWithoutManufacturingOut`
+- `IntegrationCensusExecutor_CancellationAfterOwnerOperationReleasesAccess`
+- `IntegrationCensusExecutor_BindingBatchesExactlyCoverOneContext`
+- `IntegrationCensusExecutor_RejectsWrongExecutablePayloadType`
+- `IntegrationCensusExecutor_RejectsParticipantIncidenceMismatchBeforeProducerExecution`
+- `IntegrationCensusExecutor_RejectsSelectedTypeOutsideParticipantRoster`
+- `IntegrationCensusExecutor_RejectsContextAndCompletenessDomainMismatch`
+- `IntegrationCensusExecutor_RejectsMismatchedProducerPolicyAccess`
+- `IntegrationCensusExecutor_RejectsMismatchedProducerReceipt`
+- `IntegrationCensusExecutor_ResolutionBatchMustConsumeEveryExactBinding`
+- `IntegrationCensusExecutor_ResolvedFulfillmentSourcesExactlyCoverDeclaredLookups`
+- `IntegrationCensusExecutor_FulfillmentResolutionCannotRepeatLookup`
 
 The remaining target implementation is unverified until these named gates
 land:

--- a/src/DotnetInspector.Queries.Tests/IntegrationAnalysisCatalogTests.cs
+++ b/src/DotnetInspector.Queries.Tests/IntegrationAnalysisCatalogTests.cs
@@ -162,7 +162,7 @@ public sealed class IntegrationAnalysisCatalogTests
         Assert.Same(
             IntegrationAnalysisCatalog.BindingContextsRequirement,
             bindingContexts);
-        Assert.Equal(2, IntegrationAnalysisCatalog.Analysis.Revision);
+        Assert.Equal(3, IntegrationAnalysisCatalog.Analysis.Revision);
         Assert.Contains(
             "incidence",
             IntegrationAnalysisCatalog.BindingContexts.Summary,
@@ -290,6 +290,26 @@ public sealed class IntegrationAnalysisCatalogTests
         Assert.Same(
             binding.Query,
             binding.QueryPrerequisite.Query);
+        Assert.Equal(
+            binding.QueryPrerequisites,
+            binding.QueryPrerequisites
+                .Where(prerequisite =>
+                    IntegrationAnalysisCatalog.Analysis
+                        .StructuralPrerequisites.Contains(
+                            prerequisite,
+                            ReferenceEqualityComparer.Instance)));
+        if (ReferenceEquals(
+                binding,
+                IntegrationAnalysisCatalog.EcosystemObserved))
+        {
+            Assert.Equal(
+                [
+                    AssemblyContextIntegrationsQuery.Definition,
+                    ExtensionMethodsQuery.Definition,
+                ],
+                binding.QueryPrerequisites.Select(
+                    prerequisite => prerequisite.Query));
+        }
     }
 
     static ImmutableArray<IntegrationConceptDescriptor> ConceptsAffectedBy(
@@ -345,6 +365,13 @@ public sealed class IntegrationAnalysisCatalogTests
                 {
                     executed?.Invoke();
                     return new AssemblyContextIntegrationsResult([]);
+                })
+            .Add(
+                ExtensionMethodsQuery.Definition,
+                _ =>
+                {
+                    executed?.Invoke();
+                    return new ExtensionMethodsResult.Available([]);
                 })
             .Add(
                 AssemblyContextIntegrationOpportunitiesQuery.Definition,

--- a/src/DotnetInspector.Queries.Tests/IntegrationCensusExecutorTests.cs
+++ b/src/DotnetInspector.Queries.Tests/IntegrationCensusExecutorTests.cs
@@ -1,0 +1,1048 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class IntegrationCensusExecutorTests
+{
+    static readonly Version Version = new(1, 0, 0, 0);
+
+    [Fact]
+    public void IntegrationCensusExecutor_ExecutesSparseUniverseSequentiallyAndSuppressesWithResolvedSourceEvidence()
+    {
+        IntegrationSourceParticipantIdentity sourceA = Participant("source-a");
+        IntegrationSourceParticipantIdentity sourceB = Participant("source-b");
+        IntegrationSourceParticipantIdentity peerA = Participant("peer-a");
+        IntegrationSourceParticipantIdentity peerB = Participant("peer-b");
+        Context context1 = new("net8");
+        Context context2 = new("net9");
+
+        MetadataTypeDefinitionName adapterType =
+            TypeName("Adapters", "ClientExtensions");
+        MetadataTypeDefinitionName opportunitySourceType =
+            TypeName("Sdk", "Client");
+        MetadataTypeDefinitionName sourceBType =
+            TypeName("Source", "B");
+        MetadataTypeDefinitionName peerAType =
+            TypeName("Peer", "A");
+        MetadataTypeDefinitionName peerBType =
+            TypeName("Peer", "B");
+        IntegrationCandidatePeerIdentity.NamedType peerALookup =
+            AssemblyPeer("Peer.A", peerAType);
+        IntegrationCandidatePeerIdentity.NamedType peerBLookup =
+            AssemblyPeer("Peer.B", peerBType);
+        IntegrationCandidatePeerIdentity.NamedType fulfillmentSourceLookup =
+            NamedPeer(
+                new MetadataTypeReferenceScope.CurrentAssembly(),
+                opportunitySourceType);
+
+        IntegrationCandidateIdentity observedA = new(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                sourceA,
+                new IntegrationCandidateSourceElement.Member(
+                    adapterType,
+                    Anchor(adapterType))),
+            peerALookup);
+        IntegrationCandidateIdentity opportunityA = new(
+            InspectionGraphIntegrationsCatalog.IntegrationOpportunity,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                sourceA,
+                new IntegrationCandidateSourceElement.Type(
+                    opportunitySourceType)),
+            new IntegrationCandidatePeerIdentity.PolicyTarget(
+                new IntegrationOpportunityTarget("Peer.A", peerAType)));
+        IntegrationCandidateIdentity observedB = new(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            IntegrationConceptCatalog.Aspire,
+            new IntegrationCandidateSourceIdentity(
+                sourceB,
+                new IntegrationCandidateSourceElement.Type(sourceBType)),
+            peerBLookup);
+
+        var operations = new List<string>();
+        var harness = new Harness(
+            [sourceA, sourceB, peerA, peerB],
+            [
+                new IntegrationTypeIdentity(sourceA, adapterType),
+                new IntegrationTypeIdentity(sourceA, opportunitySourceType),
+                new IntegrationTypeIdentity(sourceB, sourceBType),
+                new IntegrationTypeIdentity(peerA, peerAType),
+            ],
+            [context1, context2],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    sourceA,
+                    [context1, context2]),
+                new IntegrationSourceBindingContextIncidence(
+                    sourceB,
+                    [context1]),
+                new IntegrationSourceBindingContextIncidence(
+                    peerA,
+                    [context1]),
+                new IntegrationSourceBindingContextIncidence(
+                    peerB,
+                    [context1]),
+            ])
+        {
+            Record = operations.Add,
+            Produce = address =>
+            {
+                if (address.Participant.Equals(sourceA)
+                    && ReferenceEquals(
+                        address.Policy,
+                        IntegrationAnalysisCatalog.EcosystemObserved))
+                {
+                    return IntegrationProducerPolicyAttempt.Completed
+                        .WithEvidence(
+                            address,
+                            [
+                                new IntegrationCandidateEvidence(
+                                    observedA,
+                                    [fulfillmentSourceLookup]),
+                            ]);
+                }
+                if (address.Participant.Equals(sourceA)
+                    && ReferenceEquals(
+                        address.Policy,
+                        IntegrationAnalysisCatalog.Opportunity))
+                {
+                    return new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        [opportunityA]);
+                }
+                if (address.Participant.Equals(sourceB)
+                    && ReferenceEquals(
+                        address.Policy,
+                        IntegrationAnalysisCatalog.EcosystemObserved))
+                {
+                    return new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        [observedB]);
+                }
+                return new IntegrationProducerPolicyAttempt.Completed(
+                    address,
+                    []);
+            },
+            Resolve = binding =>
+            {
+                IntegrationCandidateAttemptAddress address =
+                    binding.Address;
+                if (address.Candidate.Equals(observedA))
+                {
+                    return new IntegrationCandidateResolutionAttempt.Resolved(
+                        binding,
+                        Resolved(observedA.Peer, peerA, peerAType),
+                        [
+                            Resolved(
+                                fulfillmentSourceLookup,
+                                sourceA,
+                                opportunitySourceType),
+                        ]);
+                }
+                if (address.Candidate.Equals(opportunityA))
+                {
+                    return new IntegrationCandidateResolutionAttempt.Resolved(
+                        binding,
+                        Resolved(opportunityA.Peer, peerA, peerAType));
+                }
+                return new IntegrationCandidateResolutionAttempt.Resolved(
+                    binding,
+                    Resolved(observedB.Peer, peerB, peerBType));
+            },
+        };
+
+        IntegrationCensusSnapshot snapshot =
+            Assert.IsType<IntegrationCensusExecutionResult.Ready>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken)).Snapshot;
+
+        Assert.Equal(3, snapshot.Candidates.Length);
+        Assert.Equal(5, snapshot.CandidateAttempts.Length);
+        Assert.Equal(2, snapshot.SuppressedAttempts.Length);
+        Assert.Equal(3, snapshot.ClassifiedAttempts.Length);
+        Assert.Equal(
+            2,
+            snapshot.ClassifiedAttempts.Count(attempt =>
+                attempt.Disposition is IntegrationCandidateDisposition.In));
+        Assert.Single(
+            snapshot.ClassifiedAttempts,
+            attempt =>
+                attempt.Disposition is IntegrationCandidateDisposition.Out);
+        Assert.True(snapshot.IsComplete);
+        Assert.Equal(
+            [
+                "produce:source-a:producer.integration.ecosystem-observed",
+                "produce:source-a:producer.integration.opentelemetry-observed",
+                "produce:source-a:producer.integration.opportunity",
+                "produce:source-b:producer.integration.ecosystem-observed",
+                "produce:source-b:producer.integration.opentelemetry-observed",
+                "produce:source-b:producer.integration.opportunity",
+                "produce:peer-a:producer.integration.ecosystem-observed",
+                "produce:peer-a:producer.integration.opentelemetry-observed",
+                "produce:peer-a:producer.integration.opportunity",
+                "produce:peer-b:producer.integration.ecosystem-observed",
+                "produce:peer-b:producer.integration.opentelemetry-observed",
+                "produce:peer-b:producer.integration.opportunity",
+                "bind:net8:3",
+                "resolve:net8:3",
+                "bind:net9:2",
+                "resolve:net9:2",
+            ],
+            operations);
+        Assert.Equal(9, harness.Releases);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsCrossCapabilityMismatchBeforeProducerExecution()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        Context context = new("one");
+        var harness = new Harness(
+            [participant],
+            [],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ])
+        {
+            ResolutionIdentityDomain = new IdentityDomain(),
+        };
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .TypeIdentityDomainMismatch,
+            rejected.Rejection.Reason);
+        Assert.Equal(0, harness.ProducerCalls);
+        Assert.Equal(9, harness.Releases);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsWrongExecutablePayloadType()
+    {
+        Harness harness = BasicHarness();
+        harness.WrongSelectedAccessType = true;
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .ExecutableBindingTypeMismatch,
+            rejected.Rejection.Reason);
+        Assert.Same(
+            IntegrationAnalysisCatalog.SelectedTypesRequirement,
+            rejected.Rejection.Requirement);
+        Assert.Equal(0, harness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsParticipantIncidenceMismatchBeforeProducerExecution()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        IntegrationSourceParticipantIdentity foreign = Participant("foreign");
+        Context context = new("one");
+        var harness = new Harness(
+            [participant],
+            [],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    foreign,
+                    [context]),
+            ]);
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .ParticipantContextMismatch,
+            rejected.Rejection.Reason);
+        Assert.Equal(0, harness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsSelectedTypeOutsideParticipantRoster()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        IntegrationSourceParticipantIdentity foreign = Participant("foreign");
+        Context context = new("one");
+        var harness = new Harness(
+            [participant],
+            [new IntegrationTypeIdentity(foreign, TypeName("Foreign", "Type"))],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ]);
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .SelectedTypeParticipantMismatch,
+            rejected.Rejection.Reason);
+        Assert.Equal(0, harness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsContextAndCompletenessDomainMismatch()
+    {
+        Harness contextHarness = BasicHarness();
+        contextHarness.OperationBindingContexts = [new Context("foreign")];
+        IntegrationCensusExecutionResult.ExecutionRejected contextRejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                contextHarness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .BindingContextDomainMismatch,
+            contextRejected.Rejection.Reason);
+        Assert.Equal(0, contextHarness.ProducerCalls);
+
+        Harness completenessHarness = BasicHarness();
+        completenessHarness.UseForeignCompleteness = true;
+        IntegrationCensusExecutionResult.ExecutionRejected
+            completenessRejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                completenessHarness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason.CompletenessMismatch,
+            completenessRejected.Rejection.Reason);
+        Assert.Equal(0, completenessHarness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsMismatchedProducerPolicyAccess()
+    {
+        Harness harness = BasicHarness();
+        harness.MismatchProducerPolicy = true;
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .ProducerPolicyMismatch,
+            rejected.Rejection.Reason);
+        Assert.Equal(0, harness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_RejectsMismatchedProducerReceipt()
+    {
+        Harness harness = BasicHarness();
+        IntegrationSourceParticipantIdentity foreign = Participant("foreign");
+        harness.Produce = address =>
+                new IntegrationProducerPolicyAttempt.Completed(
+                    new IntegrationProducerPolicyAttemptAddress(
+                        foreign,
+                        address.Policy),
+                    []);
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason.InvalidProducerReceipt,
+            rejected.Rejection.Reason);
+        Assert.Equal(1, harness.ProducerCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_DoesNotInvokeProducersForUnavailableParticipants()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        Context context = new("one");
+        var sourceAttempt =
+            new IntegrationSourceParticipantAttempt.Rejected(
+                participant,
+                new ParticipantRejection());
+        var harness = new Harness(
+            [participant],
+            [],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ],
+            [sourceAttempt]);
+
+        IntegrationCensusSnapshot snapshot =
+            Assert.IsType<IntegrationCensusExecutionResult.Ready>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken)).Snapshot;
+
+        Assert.Equal(0, harness.ProducerCalls);
+        Assert.Equal(3, snapshot.ProducerPolicyAttempts.Length);
+        Assert.All(
+            snapshot.ProducerPolicyAttempts,
+            attempt => Assert.IsType<
+                IntegrationProducerPolicyAttempt.Unavailable>(attempt));
+        Assert.False(snapshot.IsComplete);
+        Assert.Empty(snapshot.Candidates);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_PreservesCandidateFailureWithoutManufacturingOut()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        Context context = new("one");
+        MetadataTypeDefinitionName sourceType = TypeName("Source", "Client");
+        IntegrationCandidateIdentity candidate = new(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                participant,
+                new IntegrationCandidateSourceElement.Type(sourceType)),
+            AssemblyPeer("Peer", TypeName("Peer", "Client")));
+        var harness = new Harness(
+            [participant],
+            [new IntegrationTypeIdentity(participant, sourceType)],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ])
+        {
+            Produce = address =>
+                ReferenceEquals(
+                    address.Policy,
+                    IntegrationAnalysisCatalog.EcosystemObserved)
+                    ? new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        [candidate])
+                    : new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        []),
+            Bind = request =>
+                new IntegrationPeerBindingAttempt.Failed(
+                    request.Address,
+                    new CandidateFailure()),
+        };
+
+        IntegrationCensusSnapshot snapshot =
+            Assert.IsType<IntegrationCensusExecutionResult.Ready>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken)).Snapshot;
+
+        Assert.Single(snapshot.FailedCandidateAttempts);
+        Assert.Empty(snapshot.ClassifiedAttempts);
+        Assert.False(snapshot.IsComplete);
+        Assert.Equal(0, harness.ResolutionCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_CancellationAfterOwnerOperationReleasesAccess()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        Context context = new("one");
+        using var cancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                Xunit.TestContext.Current.CancellationToken);
+        var harness = new Harness(
+            [participant],
+            [],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ])
+        {
+            Produce = address =>
+            {
+                cancellation.Cancel();
+                return new IntegrationProducerPolicyAttempt.Completed(
+                    address,
+                    []);
+            },
+        };
+
+        Assert.IsType<IntegrationCensusExecutionResult.Cancelled>(
+            harness.Run(cancellation.Token));
+        Assert.Equal(1, harness.ProducerCalls);
+        Assert.Equal(9, harness.Releases);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_BindingBatchesExactlyCoverOneContext()
+    {
+        IntegrationSourceParticipantIdentity participant = Participant("source");
+        Context context = new("one");
+        MetadataTypeDefinitionName sourceType = TypeName("Source", "Client");
+        IntegrationCandidateIdentity candidate = new(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                participant,
+                new IntegrationCandidateSourceElement.Type(sourceType)),
+            AssemblyPeer("Peer", TypeName("Peer", "Client")));
+        var harness = new Harness(
+            [participant],
+            [new IntegrationTypeIdentity(participant, sourceType)],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ])
+        {
+            Produce = address =>
+                ReferenceEquals(
+                    address.Policy,
+                    IntegrationAnalysisCatalog.EcosystemObserved)
+                    ? new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        [candidate])
+                    : new IntegrationProducerPolicyAttempt.Completed(
+                        address,
+                        []),
+            BindBatch = (bindingContext, requests) =>
+                new IntegrationPeerBindingBatch(
+                    bindingContext,
+                    []),
+        };
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason.InvalidPeerBindingBatch,
+            rejected.Rejection.Reason);
+        Assert.Equal(0, harness.ResolutionCalls);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_ResolutionBatchMustConsumeEveryExactBinding()
+    {
+        (Harness harness, _) = CandidateHarness();
+        harness.ResolveBatch = batch =>
+            new IntegrationCandidateResolutionBatch(batch, []);
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason.InvalidResolutionBatch,
+            rejected.Rejection.Reason);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_ResolvedFulfillmentSourcesExactlyCoverDeclaredLookups()
+    {
+        (Harness harness, IntegrationCandidateIdentity candidate) =
+            CandidateHarness(includeFulfillmentSource: true);
+        harness.Resolve = binding =>
+            new IntegrationCandidateResolutionAttempt.Resolved(
+                binding,
+                Resolved(
+                    candidate.Peer,
+                    candidate.Source.Participant,
+                    candidate.Peer.Type));
+
+        IntegrationCensusExecutionResult.ExecutionRejected rejected =
+            Assert.IsType<IntegrationCensusExecutionResult.ExecutionRejected>(
+                harness.Run(
+                    Xunit.TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            IntegrationCensusExecutionRejectionReason
+                .InvalidResolutionEvidence,
+            rejected.Rejection.Reason);
+    }
+
+    [Fact]
+    public void IntegrationCensusExecutor_FulfillmentResolutionCannotRepeatLookup()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Participant("source");
+        MetadataTypeDefinitionName type = TypeName("Source", "Client");
+        IntegrationCandidatePeerIdentity.NamedType lookup =
+            NamedPeer(
+                new MetadataTypeReferenceScope.CurrentAssembly(),
+                type);
+        var address = new IntegrationCandidateAttemptAddress(
+            new IntegrationCandidateIdentity(
+                InspectionGraphIntegrationsCatalog.IntegrationObserved,
+                IntegrationConceptCatalog.AI,
+                new IntegrationCandidateSourceIdentity(
+                    participant,
+                    new IntegrationCandidateSourceElement.Type(type)),
+                AssemblyPeer("Peer", TypeName("Peer", "Client"))),
+            new Context("one"));
+        var binding = new IntegrationPeerBindingAttempt.Bound(
+            address,
+            new PeerBinding());
+        IntegrationResolvedPeer resolution =
+            Resolved(lookup, participant, type);
+
+        Assert.Throws<ArgumentException>(() =>
+            new IntegrationCandidateResolutionAttempt.Resolved(
+                binding,
+                Resolved(
+                    address.Candidate.Peer,
+                    participant,
+                    address.Candidate.Peer.Type),
+                [resolution, resolution]));
+    }
+
+    static IntegrationSourceParticipantIdentity Participant(string name) =>
+        IntegrationSourceParticipantIdentity.Portable(
+            new RealizedMemberCoordinate.Package(
+                name,
+                "1.0.0",
+                "fixture",
+                "net11.0",
+                null),
+            new AssemblyReferenceIdentity(name, Version, null, null));
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        string name) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(@namespace, [name])).Name;
+
+    static MemberAnchor Anchor(MetadataTypeDefinitionName declaringType) =>
+        new(
+            $"{declaringType.ToMetadataFullName()}.Create()",
+            $"{declaringType.ToMetadataFullName()}.Create",
+            "0000000000",
+            declaringType.ToMetadataFullName(),
+            "Create");
+
+    static IntegrationCandidatePeerIdentity.NamedType NamedPeer(
+        MetadataTypeReferenceScope scope,
+        MetadataTypeDefinitionName type) =>
+        new(new MetadataNamedTypeReference(scope, type));
+
+    static IntegrationCandidatePeerIdentity.NamedType AssemblyPeer(
+        string assembly,
+        MetadataTypeDefinitionName type) =>
+        NamedPeer(
+            new MetadataTypeReferenceScope.AssemblyReference(
+                new AssemblyReferenceIdentity(
+                    assembly,
+                    Version,
+                    null,
+                    null)),
+            type);
+
+    static IntegrationResolvedPeer Resolved(
+        IntegrationCandidatePeerIdentity lookup,
+        IntegrationSourceParticipantIdentity participant,
+        MetadataTypeDefinitionName type) =>
+        new(lookup, [new IntegrationTypeIdentity(participant, type)]);
+
+    static Harness BasicHarness()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Participant("source");
+        Context context = new("one");
+        return new Harness(
+            [participant],
+            [],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ]);
+    }
+
+    static (Harness Harness, IntegrationCandidateIdentity Candidate)
+        CandidateHarness(bool includeFulfillmentSource = false)
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Participant("source");
+        Context context = new("one");
+        MetadataTypeDefinitionName sourceType =
+            TypeName("Source", "Client");
+        IntegrationCandidateIdentity candidate = new(
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                participant,
+                new IntegrationCandidateSourceElement.Type(sourceType)),
+            AssemblyPeer("Peer", TypeName("Peer", "Client")));
+        var harness = new Harness(
+            [participant],
+            [new IntegrationTypeIdentity(participant, sourceType)],
+            [context],
+            [
+                new IntegrationSourceBindingContextIncidence(
+                    participant,
+                    [context]),
+            ]);
+        IntegrationCandidatePeerIdentity.NamedType? sourceLookup =
+            includeFulfillmentSource
+                ? NamedPeer(
+                    new MetadataTypeReferenceScope.CurrentAssembly(),
+                    sourceType)
+                : null;
+        harness.Produce = address =>
+        {
+            if (!ReferenceEquals(
+                    address.Policy,
+                    IntegrationAnalysisCatalog.EcosystemObserved))
+            {
+                return new IntegrationProducerPolicyAttempt.Completed(
+                    address,
+                    []);
+            }
+            return sourceLookup is null
+                ? new IntegrationProducerPolicyAttempt.Completed(
+                    address,
+                    [candidate])
+                : IntegrationProducerPolicyAttempt.Completed.WithEvidence(
+                    address,
+                    [
+                        new IntegrationCandidateEvidence(
+                            candidate,
+                            [sourceLookup]),
+                    ]);
+        };
+        return (harness, candidate);
+    }
+
+    sealed class Harness
+    {
+        readonly ImmutableArray<IntegrationSourceParticipantIdentity>
+            _participants;
+        readonly ImmutableArray<IntegrationTypeIdentity> _selectedTypes;
+        readonly ImmutableArray<IIntegrationBindingContextIdentity> _contexts;
+        readonly ImmutableArray<IntegrationSourceBindingContextIncidence>
+            _incidence;
+        readonly ImmutableArray<IntegrationSourceParticipantAttempt>
+            _sourceAttempts;
+        readonly IdentityDomain _identityDomain = new();
+
+        public Harness(
+            IEnumerable<IntegrationSourceParticipantIdentity> participants,
+            IEnumerable<IntegrationTypeIdentity> selectedTypes,
+            IEnumerable<IIntegrationBindingContextIdentity> contexts,
+            IEnumerable<IntegrationSourceBindingContextIncidence> incidence,
+            IEnumerable<IntegrationSourceParticipantAttempt>?
+                sourceAttempts = null)
+        {
+            _participants = [.. participants];
+            _selectedTypes = [.. selectedTypes];
+            _contexts = [.. contexts];
+            _incidence = [.. incidence];
+            _sourceAttempts =
+            [
+                .. sourceAttempts
+                    ?? _participants.Select(participant =>
+                        new IntegrationSourceParticipantAttempt.Available(
+                            participant)),
+            ];
+        }
+
+        public Action<string>? Record { get; set; }
+        public Func<
+            IntegrationProducerPolicyAttemptAddress,
+            IntegrationProducerPolicyAttempt>? Produce { get; set; }
+        public Func<
+            IntegrationCandidateEvaluationRequest,
+            IntegrationPeerBindingAttempt>? Bind { get; set; }
+        public Func<
+            IIntegrationBindingContextIdentity,
+            ImmutableArray<IntegrationCandidateEvaluationRequest>,
+            IntegrationPeerBindingBatch>? BindBatch { get; set; }
+        public Func<
+            IntegrationPeerBindingAttempt.Bound,
+            IntegrationCandidateResolutionAttempt>? Resolve { get; set; }
+        public IIntegrationTypeIdentityDomain? ResolutionIdentityDomain
+            { get; set; }
+        public IEnumerable<IIntegrationBindingContextIdentity>?
+            OperationBindingContexts { get; set; }
+        public bool UseForeignCompleteness { get; set; }
+        public bool MismatchProducerPolicy { get; set; }
+        public bool WrongSelectedAccessType { get; set; }
+        public Func<
+            IntegrationPeerBindingBatch,
+            IntegrationCandidateResolutionBatch>? ResolveBatch { get; set; }
+        public int ProducerCalls { get; private set; }
+        public int ResolutionCalls { get; private set; }
+        public int Releases { get; private set; }
+
+        public IntegrationCensusExecutionResult Run(
+            CancellationToken cancellationToken = default)
+        {
+            using var workspace = new InspectionWorkspace();
+            var completeness = new UniverseCompleteness();
+            var participantAccess =
+                new IntegrationSourceParticipantAccess(
+                    _participants,
+                    _sourceAttempts);
+            var selectedAccess =
+                new IntegrationSelectedTypeAccess(
+                    _identityDomain,
+                    _selectedTypes);
+            var contextAccess =
+                new IntegrationBindingContextAccess(
+                    _contexts,
+                    _incidence);
+            ImmutableArray<IIntegrationBindingContextIdentity>
+                operationContexts =
+            [
+                .. OperationBindingContexts ?? _contexts,
+            ];
+            var bindingAccess =
+                new IntegrationPeerBindingAccess(
+                    operationContexts,
+                    (context, requests, token) =>
+                    {
+                        Record?.Invoke(
+                            $"bind:{((Context)context).Name}:{requests.Length}");
+                        token.ThrowIfCancellationRequested();
+                        if (BindBatch is not null)
+                            return BindBatch(context, requests);
+                        return new IntegrationPeerBindingBatch(
+                            context,
+                            requests.Select(request =>
+                                Bind?.Invoke(request)
+                                    ?? new IntegrationPeerBindingAttempt.Bound(
+                                        request.Address,
+                                        new PeerBinding())));
+                    });
+            var resolutionAccess =
+                new IntegrationExactPeerResolutionAccess(
+                    ResolutionIdentityDomain ?? _identityDomain,
+                    operationContexts,
+                    (batch, token) =>
+                    {
+                        ImmutableArray<IntegrationPeerBindingAttempt.Bound>
+                            bound =
+                        [
+                            .. batch.Attempts.OfType<
+                                IntegrationPeerBindingAttempt.Bound>(),
+                        ];
+                        Record?.Invoke(
+                            $"resolve:{((Context)batch.BindingContext).Name}:{bound.Length}");
+                        ResolutionCalls++;
+                        token.ThrowIfCancellationRequested();
+                        if (ResolveBatch is not null)
+                            return ResolveBatch(batch);
+                        return new IntegrationCandidateResolutionBatch(
+                            batch,
+                            bound.Select(attempt =>
+                                Resolve?.Invoke(attempt)
+                                    ?? new IntegrationCandidateResolutionAttempt
+                                        .Failed(
+                                            attempt,
+                                            new CandidateFailure())));
+                    });
+            var completenessAccess =
+                new IntegrationCompletenessAccess(
+                    UseForeignCompleteness
+                        ? new UniverseCompleteness()
+                        : completeness);
+
+            AnalysisUniverseCapabilityDescriptor[] capabilities =
+            [
+                .. IntegrationAnalysisCatalog.UniverseRequirements
+                    .Select(requirement => requirement.Capability)
+                    .Distinct<AnalysisUniverseCapabilityDescriptor>(
+                        ReferenceEqualityComparer.Instance),
+            ];
+            AnalysisUniverseOffer offer =
+                workspace.CreateAnalysisUniverseOffer(
+                    new UniverseIdentity(),
+                    new UniverseBoundary(),
+                    new UniverseBoundary(),
+                    capabilities,
+                    completeness,
+                    capabilities.Select(capability =>
+                        Registration(
+                            capability,
+                            participantAccess,
+                            selectedAccess,
+                            contextAccess,
+                            bindingAccess,
+                            resolutionAccess,
+                            completenessAccess)));
+            AnalysisRequestPlan plan = Plan(offer.Description);
+            return IntegrationCensusExecutor.Execute(
+                offer,
+                plan,
+                cancellationToken);
+        }
+
+        AnalysisUniverseCapabilityRegistration Registration(
+            AnalysisUniverseCapabilityDescriptor capability,
+            IntegrationSourceParticipantAccess participants,
+            IntegrationSelectedTypeAccess selected,
+            IntegrationBindingContextAccess contexts,
+            IntegrationPeerBindingAccess binding,
+            IntegrationExactPeerResolutionAccess resolution,
+            IntegrationCompletenessAccess completeness)
+        {
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.OrderedParticipants))
+            {
+                return Ready(capability, participants);
+            }
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.SelectedTypes))
+            {
+                if (WrongSelectedAccessType)
+                    return Ready(capability, new object());
+                return Ready(capability, selected);
+            }
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.BindingContexts))
+            {
+                return Ready(capability, contexts);
+            }
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.PeerBinding))
+            {
+                return Ready(capability, binding);
+            }
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.ExactPeerResolution))
+            {
+                return Ready(capability, resolution);
+            }
+            if (ReferenceEquals(
+                    capability,
+                    IntegrationAnalysisCatalog.Completeness))
+            {
+                return Ready(capability, completeness);
+            }
+
+            IntegrationProducerPolicyBinding policy =
+                IntegrationAnalysisCatalog.ProducerPolicies.Single(item =>
+                    ReferenceEquals(
+                        item.EvidenceCapability,
+                        capability));
+            IntegrationProducerPolicyBinding accessPolicy =
+                MismatchProducerPolicy
+                    ? IntegrationAnalysisCatalog.ProducerPolicies.First(
+                        candidate => !ReferenceEquals(candidate, policy))
+                    : policy;
+            var access = new IntegrationProducerPolicyAccess(
+                accessPolicy,
+                (address, token) =>
+                {
+                    Record?.Invoke(
+                        $"produce:{Package(address.Participant)}:{policy.Policy.Id.Value}");
+                    ProducerCalls++;
+                    token.ThrowIfCancellationRequested();
+                    return Produce?.Invoke(address)
+                        ?? new IntegrationProducerPolicyAttempt.Completed(
+                            address,
+                            []);
+                });
+            return Ready(capability, access);
+        }
+
+        AnalysisUniverseCapabilityRegistration Ready<TAccess>(
+            AnalysisUniverseCapabilityDescriptor capability,
+            TAccess access)
+            where TAccess : class =>
+            new AnalysisUniverseCapabilityRegistration<TAccess>(
+                capability,
+                (_, _) =>
+                    new AnalysisUniverseCapabilityAcquisition<TAccess>.Ready(
+                        new AnalysisUniverseCapabilityLease<TAccess>(
+                            access,
+                            () => Releases++)));
+
+        static string Package(
+            IntegrationSourceParticipantIdentity participant) =>
+            Assert.IsType<RealizedMemberCoordinate.Package>(
+                participant.Coordinate).PackageId;
+    }
+
+    static AnalysisRequestPlan Plan(
+        AnalysisUniverseDescription universe) =>
+        Assert.IsType<AnalysisRequestPlanResult.Accepted>(
+            IntegrationAnalysisCatalog.Capabilities.Plan(
+                new AnalysisRequest(
+                    IntegrationAnalysisCatalog.Analysis,
+                    new AnalysisReportSurface(
+                        AnalysisReportSurfaceKind.Workspace,
+                        new SurfaceIdentity(),
+                        [
+                            new AnalysisTargetBinding(
+                                IntegrationAnalysisCatalog.WorkspaceDomain,
+                                new TargetIdentity()),
+                        ]),
+                    universe,
+                    AnalysisQuestionMode.Census,
+                    IntegrationAnalysisCatalog.Rows),
+                new AnalysisPlanningEnvironment(
+                    new InspectionQueryRegistry<object>()
+                        .Add(
+                            AssemblyContextIntegrationsQuery.Definition,
+                            _ => new AssemblyContextIntegrationsResult([]))
+                        .Add(
+                            ExtensionMethodsQuery.Definition,
+                            _ => new ExtensionMethodsResult.Available([]))
+                        .Add(
+                            AssemblyContextIntegrationOpportunitiesQuery
+                                .Definition,
+                            (_, _) =>
+                                new AssemblyContextIntegrationOpportunitiesResult(
+                                    []),
+                            AssemblyContextIntegrationsQuery.Definition)
+                        .Compile(),
+                    IntegrationAnalysisCatalog.ProducerPolicies.Select(
+                        policy => policy.ProducerPrerequisite))))
+        .Plan;
+
+    sealed class Context(string name) :
+        IIntegrationBindingContextIdentity
+    {
+        public string Name { get; } = name;
+    }
+
+    sealed class IdentityDomain : IIntegrationTypeIdentityDomain;
+    sealed class PeerBinding : IIntegrationPeerBinding;
+    sealed class CandidateFailure : IIntegrationCandidateFailure;
+    sealed class ParticipantRejection :
+        IIntegrationSourceParticipantRejection;
+    sealed class UniverseCompleteness : IAnalysisUniverseCompleteness;
+    sealed class UniverseIdentity : IAnalysisUniverseIdentity;
+    sealed class UniverseBoundary : IAnalysisUniverseBoundary;
+    sealed class SurfaceIdentity : IAnalysisReportSurfaceIdentity;
+    sealed class TargetIdentity : IAnalysisTargetIdentity;
+}

--- a/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
+++ b/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
@@ -881,6 +881,11 @@ public sealed class IntegrationCensusTests
             participant,
             IntegrationConceptCatalog.AI,
             PolicyTargetPeer("Peer", TypeName("Peer", "Client")));
+        var fulfillmentSourceLookup =
+            Assert.IsType<IntegrationCandidatePeerIdentity.NamedType>(
+                NamedPeer(
+                    new MetadataTypeReferenceScope.CurrentAssembly(),
+                    opportunity.Source.SourceType));
         IntegrationCandidateIdentity observedEquivalent =
             IndependentEquivalentCandidate(observed);
         Assert.Equal(observed, observedEquivalent);
@@ -926,9 +931,19 @@ public sealed class IntegrationCensusTests
                             suppressedCandidate,
                             PeerTerminal(fulfillerCandidate)))));
             attempts.Add(
-                ClassifiedOut(
-                    classifiedCandidate,
-                    classifiedContext));
+                new IntegrationCandidateAttempt.Classified(
+                    new IntegrationCandidateAttemptAddress(
+                        classifiedCandidate,
+                        classifiedContext),
+                    new IntegrationCandidateDisposition.Out(
+                        Resolved(
+                            classifiedCandidate,
+                            PeerTerminal(classifiedCandidate))),
+                    [
+                        Resolved(
+                            fulfillmentSourceLookup,
+                            SourceType(suppressedCandidate)),
+                    ]));
         }
         attempts.Reverse();
 
@@ -937,11 +952,15 @@ public sealed class IntegrationCensusTests
             participants,
             producerAttempts: Producers(
                 participants,
-                Completed(
+                CompletedWithEvidence(
                     participant,
                     Ecosystem,
-                    observed,
-                    IndependentEquivalentCandidate(observed)),
+                    new IntegrationCandidateEvidence(
+                        observed,
+                        [fulfillmentSourceLookup]),
+                    new IntegrationCandidateEvidence(
+                        IndependentEquivalentCandidate(observed),
+                        [fulfillmentSourceLookup])),
                 Completed(
                     participant,
                     Opportunity,
@@ -1719,6 +1738,19 @@ public sealed class IntegrationCensusTests
         SuppressionFixture fixture = new(this);
         IntegrationSourceParticipantIdentity participant = Portable();
 
+        // Every declared fulfillment-source lookup requires one exact
+        // resolution before the observation can suppress an opportunity.
+        Assert.Throws<ArgumentException>(() =>
+            fixture.Snapshot(
+                fixture.Suppressed(fixture.ObservedAttemptAddress),
+                observedAttempt:
+                    new IntegrationCandidateAttempt.Classified(
+                        fixture.ObservedAttemptAddress,
+                        new IntegrationCandidateDisposition.In(
+                            Resolved(
+                                fixture.ObservedCandidate,
+                                fixture.ObservedTerminal)))));
+
         // Proof source must equal the opportunity source, not some other Type.
         IntegrationOpportunityFulfillment wrongSource =
             new IntegrationOpportunityFulfillment(
@@ -1942,6 +1974,11 @@ public sealed class IntegrationCensusTests
         IntegrationTypeIdentity terminal) =>
         new(candidate.Peer, [terminal]);
 
+    static IntegrationResolvedPeer Resolved(
+        IntegrationCandidatePeerIdentity lookup,
+        IntegrationTypeIdentity terminal) =>
+        new(lookup, [terminal]);
+
     static IntegrationSourceParticipantAttempt Available(
         IntegrationSourceParticipantIdentity participant) =>
         new IntegrationSourceParticipantAttempt.Available(participant);
@@ -1953,6 +1990,14 @@ public sealed class IntegrationCensusTests
         new IntegrationProducerPolicyAttempt.Completed(
             new IntegrationProducerPolicyAttemptAddress(participant, policy),
             candidates);
+
+    static IntegrationProducerPolicyAttempt CompletedWithEvidence(
+        IntegrationSourceParticipantIdentity participant,
+        IntegrationProducerPolicyBinding policy,
+        params IntegrationCandidateEvidence[] evidence) =>
+        IntegrationProducerPolicyAttempt.Completed.WithEvidence(
+            new IntegrationProducerPolicyAttemptAddress(participant, policy),
+            evidence);
 
     static IntegrationProducerPolicyAttempt Unavailable(
         IntegrationSourceParticipantIdentity participant,
@@ -2173,6 +2218,9 @@ public sealed class IntegrationCensusTests
                     AssemblyContextIntegrationsQuery.Definition,
                     _ => new AssemblyContextIntegrationsResult([]))
                 .Add(
+                    ExtensionMethodsQuery.Definition,
+                    _ => new ExtensionMethodsResult.Available([]))
+                .Add(
                     AssemblyContextIntegrationOpportunitiesQuery.Definition,
                     (_, _) => new AssemblyContextIntegrationOpportunitiesResult([]),
                     AssemblyContextIntegrationsQuery.Definition)
@@ -2229,6 +2277,9 @@ public sealed class IntegrationCensusTests
     {
         readonly IntegrationSourceParticipantIdentity _participant;
         readonly IntegrationTypeIdentity _observedTerminal;
+        readonly IntegrationCandidatePeerIdentity.NamedType
+            _fulfillmentSourceLookup;
+        readonly IntegrationResolvedPeer _fulfillmentSourceResolution;
 
         public SuppressionFixture(IntegrationCensusTests _)
         {
@@ -2249,6 +2300,14 @@ public sealed class IntegrationCensusTests
                     TypeName("Adapters", "ChatClientAdapter"),
                     Anchor("Adapters.ChatClientAdapter")));
             _observedTerminal = PeerTerminal(ObservedCandidate);
+            _fulfillmentSourceLookup =
+                Assert.IsType<IntegrationCandidatePeerIdentity.NamedType>(
+                    NamedPeer(
+                        new MetadataTypeReferenceScope.CurrentAssembly(),
+                        OpportunityCandidateId.Source.SourceType));
+            _fulfillmentSourceResolution = Resolved(
+                _fulfillmentSourceLookup,
+                SourceType(OpportunityCandidateId));
             Fulfillment = new IntegrationOpportunityFulfillment(
                 SourceType(OpportunityCandidateId),
                 Resolved(OpportunityCandidateId, _observedTerminal));
@@ -2286,7 +2345,12 @@ public sealed class IntegrationCensusTests
                 producerAttempts: Producers(
                     participants,
                     Completed(_participant, Opportunity, OpportunityCandidateId),
-                    Completed(_participant, Ecosystem, ObservedCandidate)),
+                    CompletedWithEvidence(
+                        _participant,
+                        Ecosystem,
+                        new IntegrationCandidateEvidence(
+                            ObservedCandidate,
+                            [_fulfillmentSourceLookup]))),
                 selectedTypes: [_observedTerminal],
                 contexts: [Context],
                 candidateAttempts:
@@ -2297,7 +2361,8 @@ public sealed class IntegrationCensusTests
                             new IntegrationCandidateDisposition.In(
                                 Resolved(
                                     ObservedCandidate,
-                                    _observedTerminal))),
+                                    _observedTerminal)),
+                            [_fulfillmentSourceResolution]),
                     opportunityAttempt,
                 ]);
         }

--- a/src/DotnetInspector.Queries/IntegrationAnalysisCatalog.cs
+++ b/src/DotnetInspector.Queries/IntegrationAnalysisCatalog.cs
@@ -31,7 +31,9 @@ public sealed class IntegrationProducerPolicyBinding
         IntegrationProducerPolicyDescriptor policy,
         InspectionQueryDefinition query,
         InspectionGraphRelationshipDescriptor relationship,
-        IEnumerable<IntegrationConceptRequirementIdentity> affected)
+        IEnumerable<IntegrationConceptRequirementIdentity> affected,
+        IEnumerable<(string Id, InspectionQueryDefinition Query)>?
+            additionalQueries = null)
     {
         ArgumentNullException.ThrowIfNull(policy);
         ArgumentNullException.ThrowIfNull(query);
@@ -62,9 +64,36 @@ public sealed class IntegrationProducerPolicyBinding
 
         ProducerPrerequisite = new AnalysisProducerPrerequisiteDescriptor(
             Declaration($"{policy.Id.Value}.registration"));
-        QueryPrerequisite = new AnalysisQueryPrerequisiteDescriptor(
-            Declaration($"{policy.Id.Value}.query"),
-            query);
+        ImmutableArray<(string Id, InspectionQueryDefinition Query)> queries =
+        [
+            ("primary", query),
+            .. additionalQueries ?? [],
+        ];
+        if (queries.Any(candidate =>
+                string.IsNullOrWhiteSpace(candidate.Id)
+                || candidate.Query is null)
+            || queries.Select(candidate => candidate.Id)
+                .Distinct(StringComparer.Ordinal)
+                .Count() != queries.Length
+            || queries.Select(candidate => candidate.Query)
+                .Distinct()
+                .Count() != queries.Length)
+        {
+            throw new ArgumentException(
+                "Producer-policy queries require unique stable ids and query identities.",
+                nameof(additionalQueries));
+        }
+        QueryPrerequisites =
+        [
+            .. queries.Select(candidate =>
+                new AnalysisQueryPrerequisiteDescriptor(
+                    Declaration(
+                        candidate.Id == "primary"
+                            ? $"{policy.Id.Value}.query"
+                            : $"{policy.Id.Value}.query.{candidate.Id}"),
+                    candidate.Query)),
+        ];
+        QueryPrerequisite = QueryPrerequisites[0];
         EvidenceCapability = new AnalysisUniverseCapabilityDescriptor(
             Declaration($"{policy.Id.Value}.evidence"),
             $"Structured evidence for producer policy {policy.Id.Value}.");
@@ -81,6 +110,8 @@ public sealed class IntegrationProducerPolicyBinding
     public ImmutableArray<IntegrationConceptRequirementIdentity> Affected { get; }
     public AnalysisProducerPrerequisiteDescriptor ProducerPrerequisite { get; }
     public AnalysisQueryPrerequisiteDescriptor QueryPrerequisite { get; }
+    public ImmutableArray<AnalysisQueryPrerequisiteDescriptor>
+        QueryPrerequisites { get; }
     public AnalysisUniverseCapabilityDescriptor EvidenceCapability { get; }
     public AnalysisUniverseRequirementDescriptor UniverseRequirement { get; }
 
@@ -93,7 +124,7 @@ public sealed class IntegrationProducerPolicyBinding
 /// </summary>
 public static class IntegrationAnalysisCatalog
 {
-    const int AnalysisRevision = 2;
+    const int AnalysisRevision = 3;
 
     static readonly Dictionary<
         IntegrationConceptDescriptor,
@@ -120,7 +151,8 @@ public static class IntegrationAnalysisCatalog
         EcosystemObserved = Bind(
             IntegrationConceptCatalog.EcosystemObserved,
             AssemblyContextIntegrationsQuery.Definition,
-            InspectionGraphIntegrationsCatalog.IntegrationObserved);
+            InspectionGraphIntegrationsCatalog.IntegrationObserved,
+            [("extension-methods", ExtensionMethodsQuery.Definition)]);
         OpenTelemetryObserved = Bind(
             IntegrationConceptCatalog.OpenTelemetryObserved,
             AssemblyContextIntegrationsQuery.Definition,
@@ -161,22 +193,22 @@ public static class IntegrationAnalysisCatalog
 
         CommonUniverseRequirements =
         [
-            Requirement(
+            SelectedTypesRequirement = Requirement(
                 "requirement.integration.selected-types",
                 SelectedTypes),
-            Requirement(
+            OrderedParticipantsRequirement = Requirement(
                 "requirement.integration.ordered-participants",
                 OrderedParticipants),
             BindingContextsRequirement = Requirement(
                 "requirement.integration.binding-contexts",
                 BindingContexts),
-            Requirement(
+            PeerBindingRequirement = Requirement(
                 "requirement.integration.peer-binding",
                 PeerBinding),
-            Requirement(
+            ExactPeerResolutionRequirement = Requirement(
                 "requirement.integration.exact-peer-resolution",
                 ExactPeerResolution),
-            Requirement(
+            CompletenessRequirement = Requirement(
                 "requirement.integration.completeness",
                 Completeness),
         ];
@@ -216,8 +248,7 @@ public static class IntegrationAnalysisCatalog
                     new AnalysisStructuralPrerequisiteDescriptor[]
                     {
                         binding.ProducerPrerequisite,
-                        binding.QueryPrerequisite,
-                    }),
+                    }.Concat(binding.QueryPrerequisites)),
             ],
             [
                 new AnalysisHostRequirementDescriptor(
@@ -253,13 +284,23 @@ public static class IntegrationAnalysisCatalog
     public static IntegrationProducerPolicyBinding Opportunity { get; }
 
     public static AnalysisUniverseCapabilityDescriptor SelectedTypes { get; }
+    public static AnalysisUniverseRequirementDescriptor
+        SelectedTypesRequirement { get; }
     public static AnalysisUniverseCapabilityDescriptor OrderedParticipants { get; }
+    public static AnalysisUniverseRequirementDescriptor
+        OrderedParticipantsRequirement { get; }
     public static AnalysisUniverseCapabilityDescriptor BindingContexts { get; }
     public static AnalysisUniverseRequirementDescriptor
         BindingContextsRequirement { get; }
     public static AnalysisUniverseCapabilityDescriptor PeerBinding { get; }
+    public static AnalysisUniverseRequirementDescriptor
+        PeerBindingRequirement { get; }
     public static AnalysisUniverseCapabilityDescriptor ExactPeerResolution { get; }
+    public static AnalysisUniverseRequirementDescriptor
+        ExactPeerResolutionRequirement { get; }
     public static AnalysisUniverseCapabilityDescriptor Completeness { get; }
+    public static AnalysisUniverseRequirementDescriptor
+        CompletenessRequirement { get; }
 
     public static AnalysisTargetRoleDescriptor WorkspaceDomain { get; }
     public static AnalysisProjectionDescriptor Rows { get; }
@@ -303,13 +344,16 @@ public static class IntegrationAnalysisCatalog
     static IntegrationProducerPolicyBinding Bind(
         IntegrationProducerPolicyDescriptor policy,
         InspectionQueryDefinition query,
-        InspectionGraphRelationshipDescriptor relationship) =>
+        InspectionGraphRelationshipDescriptor relationship,
+        IEnumerable<(string Id, InspectionQueryDefinition Query)>?
+            additionalQueries = null) =>
         new(
             policy,
             query,
             relationship,
             policy.Concepts.Select(concept =>
-                AffectedByConcept[concept]));
+                AffectedByConcept[concept]),
+            additionalQueries);
 
     static AnalysisUniverseCapabilityDescriptor Capability(
         string id,

--- a/src/DotnetInspector.Queries/IntegrationCensus.cs
+++ b/src/DotnetInspector.Queries/IntegrationCensus.cs
@@ -528,6 +528,50 @@ public sealed class IntegrationProducerPolicyAttemptAddress :
         HashCode.Combine(Participant, Policy);
 }
 
+/// <summary>
+/// One candidate plus structured source lookups that may prove an observed
+/// Integration fulfills an opportunity.
+/// </summary>
+public sealed class IntegrationCandidateEvidence
+{
+    public IntegrationCandidateEvidence(
+        IntegrationCandidateIdentity candidate,
+        IEnumerable<IntegrationCandidatePeerIdentity.NamedType>?
+            fulfillmentSourceLookups = null)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        Candidate = candidate;
+        FulfillmentSourceLookups =
+            [.. fulfillmentSourceLookups ?? []];
+        if (FulfillmentSourceLookups.Any(lookup => lookup is null))
+        {
+            throw new ArgumentException(
+                "Fulfillment-source lookups cannot contain null.",
+                nameof(fulfillmentSourceLookups));
+        }
+        if (FulfillmentSourceLookups.Distinct().Count()
+            != FulfillmentSourceLookups.Length)
+        {
+            throw new ArgumentException(
+                "Fulfillment-source lookups cannot contain duplicates.",
+                nameof(fulfillmentSourceLookups));
+        }
+        if (!FulfillmentSourceLookups.IsEmpty
+            && !ReferenceEquals(
+                candidate.Relationship,
+                InspectionGraphIntegrationsCatalog.IntegrationObserved))
+        {
+            throw new ArgumentException(
+                "Only observed Integration evidence can declare fulfillment-source lookups.",
+                nameof(fulfillmentSourceLookups));
+        }
+    }
+
+    public IntegrationCandidateIdentity Candidate { get; }
+    public ImmutableArray<IntegrationCandidatePeerIdentity.NamedType>
+        FulfillmentSourceLookups { get; }
+}
+
 /// <summary>One terminal producer-policy receipt.</summary>
 public abstract class IntegrationProducerPolicyAttempt
 {
@@ -548,36 +592,84 @@ public abstract class IntegrationProducerPolicyAttempt
             : base(address)
         {
             ArgumentNullException.ThrowIfNull(candidates);
-            Candidates = [.. candidates];
-            if (Candidates.Any(candidate => candidate is null))
+            ImmutableArray<IntegrationCandidateIdentity> copied =
+                [.. candidates];
+            if (copied.Any(candidate => candidate is null))
             {
                 throw new ArgumentException(
                     "Completed candidate evidence cannot contain null.",
                     nameof(candidates));
             }
-            if (Candidates.Any(candidate =>
-                    !candidate.Source.Participant.Equals(
-                        address.Participant)))
+            Initialize(
+                [.. copied.Select(candidate =>
+                    new IntegrationCandidateEvidence(candidate))]);
+        }
+
+        Completed(
+            IntegrationProducerPolicyAttemptAddress address,
+            ImmutableArray<IntegrationCandidateEvidence> evidence)
+            : base(address)
+            => Initialize(evidence);
+
+        public static Completed WithEvidence(
+            IntegrationProducerPolicyAttemptAddress address,
+            IEnumerable<IntegrationCandidateEvidence> evidence)
+        {
+            ArgumentNullException.ThrowIfNull(evidence);
+            return new Completed(address, [.. evidence]);
+        }
+
+        void Initialize(
+            ImmutableArray<IntegrationCandidateEvidence> evidence)
+        {
+            Evidence = evidence;
+            if (Evidence.Any(candidate => candidate is null))
+            {
+                throw new ArgumentException(
+                    "Completed candidate evidence cannot contain null.",
+                    nameof(evidence));
+            }
+            if (Evidence.Any(candidate =>
+                    !candidate.Candidate.Source.Participant.Equals(
+                        Address.Participant)))
             {
                 throw new ArgumentException(
                     "Completed candidate evidence must belong to the addressed participant.",
-                    nameof(candidates));
+                    nameof(evidence));
             }
-            if (Candidates.Any(candidate =>
+            if (Evidence.Any(evidence =>
                     !ReferenceEquals(
-                        candidate.Relationship,
-                        address.Policy.Relationship)
-                    || !address.Policy.Policy.Concepts.Contains(
-                        candidate.Concept,
+                        evidence.Candidate.Relationship,
+                        Address.Policy.Relationship)
+                    || !Address.Policy.Policy.Concepts.Contains(
+                        evidence.Candidate.Concept,
                         ReferenceEqualityComparer.Instance)))
             {
                 throw new ArgumentException(
                     "Completed candidate evidence must match the addressed producer policy.",
-                    nameof(candidates));
+                    nameof(evidence));
             }
+            if (!ReferenceEquals(
+                    Address.Policy,
+                    IntegrationAnalysisCatalog.EcosystemObserved)
+                && Evidence.Any(evidence =>
+                    !evidence.FulfillmentSourceLookups.IsEmpty))
+            {
+                throw new ArgumentException(
+                    "Only the ecosystem-observed producer policy can declare fulfillment-source lookups.",
+                    nameof(evidence));
+            }
+
+            Candidates =
+            [
+                .. Evidence.Select(static evidence => evidence.Candidate),
+            ];
         }
 
-        public ImmutableArray<IntegrationCandidateIdentity> Candidates { get; }
+        public ImmutableArray<IntegrationCandidateEvidence> Evidence
+            { get; private set; } = [];
+        public ImmutableArray<IntegrationCandidateIdentity> Candidates
+            { get; private set; } = [];
     }
 
     public sealed class Unavailable : IntegrationProducerPolicyAttempt
@@ -797,14 +889,37 @@ public abstract class IntegrationCandidateAttempt
     {
         public Classified(
             IntegrationCandidateAttemptAddress address,
-            IntegrationCandidateDisposition disposition)
+            IntegrationCandidateDisposition disposition,
+            IEnumerable<IntegrationResolvedPeer>?
+                fulfillmentSourceResolutions = null)
             : base(address)
         {
             ArgumentNullException.ThrowIfNull(disposition);
             Disposition = disposition;
+            FulfillmentSourceResolutions =
+                [.. fulfillmentSourceResolutions ?? []];
+            if (FulfillmentSourceResolutions.Any(
+                    resolution => resolution is null))
+            {
+                throw new ArgumentException(
+                    "Fulfillment-source resolutions cannot contain null.",
+                    nameof(fulfillmentSourceResolutions));
+            }
+            if (FulfillmentSourceResolutions
+                    .Select(resolution => resolution.Lookup)
+                    .Distinct()
+                    .Count()
+                != FulfillmentSourceResolutions.Length)
+            {
+                throw new ArgumentException(
+                    "Fulfillment-source resolutions cannot repeat a lookup.",
+                    nameof(fulfillmentSourceResolutions));
+            }
         }
 
         public IntegrationCandidateDisposition Disposition { get; }
+        public ImmutableArray<IntegrationResolvedPeer>
+            FulfillmentSourceResolutions { get; }
     }
 
     public sealed class Suppressed : IntegrationCandidateAttempt
@@ -849,15 +964,18 @@ public sealed class IntegrationCensusCandidate
 {
     internal IntegrationCensusCandidate(
         IntegrationCandidateIdentity identity,
-        IEnumerable<IntegrationProducerPolicyAttemptAddress> producerAttempts)
+        IEnumerable<IntegrationProducerPolicyAttemptAddress> producerAttempts,
+        IEnumerable<IntegrationCandidateEvidence> evidence)
     {
         Identity = identity;
         ProducerAttempts = [.. producerAttempts];
+        Evidence = [.. evidence];
     }
 
     public IntegrationCandidateIdentity Identity { get; }
     public ImmutableArray<IntegrationProducerPolicyAttemptAddress>
         ProducerAttempts { get; }
+    public ImmutableArray<IntegrationCandidateEvidence> Evidence { get; }
 }
 
 /// <summary>
@@ -869,6 +987,9 @@ public sealed class IntegrationCensusSnapshot
     readonly Dictionary<
         IntegrationCandidateAttemptAddress,
         IntegrationCandidateAttempt> _candidateAttemptsByAddress;
+    readonly Dictionary<
+        IntegrationCandidateIdentity,
+        IntegrationCensusCandidate> _candidatesByIdentity;
     readonly HashSet<IntegrationTypeIdentity> _selectedTypeSet;
 
     public IntegrationCensusSnapshot(
@@ -936,7 +1057,9 @@ public sealed class IntegrationCensusSnapshot
             nameof(producerPolicyAttempts));
         ValidateProducerAttempts();
 
-        Candidates = BuildCandidates();
+        Candidates = BuildCandidates(ProducerPolicyAttempts);
+        _candidatesByIdentity = Candidates.ToDictionary(
+            static candidate => candidate.Identity);
         var expectedCandidateAddresses =
             ImmutableArray.CreateBuilder<
                 IntegrationCandidateAttemptAddress>();
@@ -1069,26 +1192,31 @@ public sealed class IntegrationCensusSnapshot
         }
     }
 
-    ImmutableArray<IntegrationCensusCandidate> BuildCandidates()
+    internal static ImmutableArray<IntegrationCensusCandidate> BuildCandidates(
+        IEnumerable<IntegrationProducerPolicyAttempt> producerPolicyAttempts)
     {
         var candidateOrder = new List<IntegrationCandidateIdentity>();
         var candidateProducers = new Dictionary<
             IntegrationCandidateIdentity,
             (
                 List<IntegrationProducerPolicyAttemptAddress> Order,
-                HashSet<IntegrationProducerPolicyAttemptAddress> Set)>();
+                HashSet<IntegrationProducerPolicyAttemptAddress> Set,
+                List<IntegrationCandidateEvidence> Evidence)>();
         foreach (IntegrationProducerPolicyAttempt.Completed attempt
-            in ProducerPolicyAttempts.OfType<
+            in producerPolicyAttempts.OfType<
                 IntegrationProducerPolicyAttempt.Completed>())
         {
-            foreach (IntegrationCandidateIdentity candidate
-                in attempt.Candidates)
+            foreach (IntegrationCandidateEvidence evidence
+                in attempt.Evidence)
             {
+                IntegrationCandidateIdentity candidate =
+                    evidence.Candidate;
                 if (!candidateProducers.TryGetValue(
                         candidate,
                         out var producers))
                 {
                     producers = (
+                        [],
                         [],
                         []);
                     candidateProducers.Add(candidate, producers);
@@ -1099,6 +1227,7 @@ public sealed class IntegrationCensusSnapshot
                 {
                     producers.Order.Add(attempt.Address);
                 }
+                producers.Evidence.Add(evidence);
             }
         }
 
@@ -1107,7 +1236,8 @@ public sealed class IntegrationCensusSnapshot
             .. candidateOrder.Select(candidate =>
                 new IntegrationCensusCandidate(
                     candidate,
-                    candidateProducers[candidate].Order)),
+                    candidateProducers[candidate].Order,
+                    candidateProducers[candidate].Evidence)),
         ];
     }
 
@@ -1132,6 +1262,38 @@ public sealed class IntegrationCensusSnapshot
     {
         IntegrationCandidateIdentity candidate = attempt.Address.Candidate;
         ValidateResolution(candidate, attempt.Disposition.Peer);
+        IntegrationCensusCandidate censusCandidate =
+            _candidatesByIdentity[candidate];
+        IntegrationCandidatePeerIdentity.NamedType[] declaredSources =
+        [
+            .. censusCandidate.Evidence
+                .SelectMany(evidence =>
+                    evidence.FulfillmentSourceLookups)
+                .Distinct(),
+        ];
+        if (declaredSources.Length
+            != attempt.FulfillmentSourceResolutions.Length)
+        {
+            throw new ArgumentException(
+                "Fulfillment-source resolutions must exactly cover the declared lookups.",
+                nameof(CandidateAttempts));
+        }
+        foreach (IntegrationResolvedPeer source
+            in attempt.FulfillmentSourceResolutions)
+        {
+            if (!ReferenceEquals(
+                    candidate.Relationship,
+                    InspectionGraphIntegrationsCatalog.IntegrationObserved)
+                || !censusCandidate.Evidence.Any(evidence =>
+                    evidence.FulfillmentSourceLookups.Any(
+                        lookup => lookup.Equals(source.Lookup))))
+            {
+                throw new ArgumentException(
+                    "Fulfillment-source resolution requires a declared observed-source lookup.",
+                    nameof(CandidateAttempts));
+            }
+            ValidateResolvedLookup(source.Lookup, source);
+        }
 
         IntegrationTypeIdentity terminal =
             attempt.Disposition.Peer.Terminal;
@@ -1200,22 +1362,25 @@ public sealed class IntegrationCensusSnapshot
         if (!attempt.Fulfillment.SourceType.Equals(
                 SourceTypeOf(suppressed))
             || !attempt.Fulfillment.Target.Terminal.Equals(
-                classified.Disposition.Peer.Terminal))
+                classified.Disposition.Peer.Terminal)
+            || !classified.FulfillmentSourceResolutions.Any(
+                source => source.Terminal.Equals(
+                    attempt.Fulfillment.SourceType)))
         {
             throw new ArgumentException(
-                "Suppression fulfillment must retain the opportunity's exact source and resolved target Types.",
+                "Suppression fulfillment must retain an observed source and the opportunity's exact resolved target Type.",
                 nameof(CandidateAttempts));
         }
         ValidateResolution(suppressed, attempt.Fulfillment.Target);
     }
 
-    static IntegrationTypeIdentity SourceTypeOf(
+    internal static IntegrationTypeIdentity SourceTypeOf(
         IntegrationCandidateIdentity candidate) =>
         new(
             candidate.Source.Participant,
             candidate.Source.SourceType);
 
-    static void ValidateResolution(
+    internal static void ValidateResolution(
         IntegrationCandidateIdentity candidate,
         IntegrationResolvedPeer resolved)
     {
@@ -1225,8 +1390,16 @@ public sealed class IntegrationCensusSnapshot
                 "Resolved peer evidence must retain its exact candidate lookup.",
                 nameof(CandidateAttempts));
         }
-        if (resolved.ResolutionPath.Any(
-                type => type.Type != candidate.Peer.Type))
+        ValidateResolvedLookup(candidate.Peer, resolved);
+    }
+
+    internal static void ValidateResolvedLookup(
+        IntegrationCandidatePeerIdentity lookup,
+        IntegrationResolvedPeer resolved)
+    {
+        if (!lookup.Equals(resolved.Lookup)
+            || resolved.ResolutionPath.Any(
+                type => type.Type != lookup.Type))
         {
             throw new ArgumentException(
                 "Every resolved peer hop must retain the candidate Type name.",
@@ -1246,7 +1419,7 @@ public sealed class IntegrationCensusSnapshot
         }
     }
 
-    static void ValidatePlan(AnalysisRequestPlan plan)
+    internal static void ValidatePlan(AnalysisRequestPlan plan)
     {
         if (!ReferenceEquals(
                 plan.Analysis,
@@ -1269,7 +1442,7 @@ public sealed class IntegrationCensusSnapshot
         }
     }
 
-    static ImmutableArray<IntegrationProducerPolicyBinding>
+    internal static ImmutableArray<IntegrationProducerPolicyBinding>
         RequiredPolicies(AnalysisRequestPlan plan)
     {
         var policies =
@@ -1294,7 +1467,7 @@ public sealed class IntegrationCensusSnapshot
         return policies.ToImmutable();
     }
 
-    static ImmutableArray<IntegrationSourceBindingContextIncidence>
+    internal static ImmutableArray<IntegrationSourceBindingContextIncidence>
         CanonicalizeIncidence(
             ImmutableArray<IntegrationSourceParticipantIdentity> participants,
             ImmutableArray<IntegrationSourceBindingContextIncidence> supplied,

--- a/src/DotnetInspector.Queries/IntegrationCensusExecution.cs
+++ b/src/DotnetInspector.Queries/IntegrationCensusExecution.cs
@@ -1,0 +1,1307 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Owner-issued identity for the Type-identity table shared by population and
+/// exact-resolution access.
+/// </summary>
+public interface IIntegrationTypeIdentityDomain
+{
+}
+
+/// <summary>Ordered selected-Type population for one executable Census.</summary>
+public sealed class IntegrationSelectedTypeAccess
+{
+    public IntegrationSelectedTypeAccess(
+        IIntegrationTypeIdentityDomain identityDomain,
+        IEnumerable<IntegrationTypeIdentity> selectedTypes)
+    {
+        ArgumentNullException.ThrowIfNull(identityDomain);
+        ArgumentNullException.ThrowIfNull(selectedTypes);
+        IdentityDomain = identityDomain;
+        SelectedTypes = CopyUnique(
+            selectedTypes,
+            nameof(selectedTypes));
+    }
+
+    public IIntegrationTypeIdentityDomain IdentityDomain { get; }
+    public ImmutableArray<IntegrationTypeIdentity> SelectedTypes { get; }
+
+    static ImmutableArray<IntegrationTypeIdentity> CopyUnique(
+        IEnumerable<IntegrationTypeIdentity> values,
+        string parameterName)
+    {
+        ImmutableArray<IntegrationTypeIdentity> copied = [.. values];
+        var seen = new HashSet<IntegrationTypeIdentity>();
+        foreach (IntegrationTypeIdentity value in copied)
+        {
+            if (value is null || !seen.Add(value))
+            {
+                throw new ArgumentException(
+                    "Selected Types cannot contain null or duplicate identities.",
+                    parameterName);
+            }
+        }
+        return copied;
+    }
+}
+
+/// <summary>
+/// Ordered source participants and their owner-issued terminal availability
+/// receipts.
+/// </summary>
+public sealed class IntegrationSourceParticipantAccess
+{
+    public IntegrationSourceParticipantAccess(
+        IEnumerable<IntegrationSourceParticipantIdentity> participants,
+        IEnumerable<IntegrationSourceParticipantAttempt> attempts)
+    {
+        ArgumentNullException.ThrowIfNull(participants);
+        ArgumentNullException.ThrowIfNull(attempts);
+        Participants = CopyUnique(participants, nameof(participants));
+
+        ImmutableArray<IntegrationSourceParticipantAttempt> supplied =
+            [.. attempts];
+        if (supplied.Any(attempt => attempt is null))
+        {
+            throw new ArgumentException(
+                "Source-participant attempts cannot contain null.",
+                nameof(attempts));
+        }
+
+        var byParticipant = new Dictionary<
+            IntegrationSourceParticipantIdentity,
+            IntegrationSourceParticipantAttempt>();
+        foreach (IntegrationSourceParticipantAttempt attempt in supplied)
+        {
+            if (!byParticipant.TryAdd(attempt.Participant, attempt))
+            {
+                throw new ArgumentException(
+                    "Source-participant attempts cannot repeat a participant.",
+                    nameof(attempts));
+            }
+        }
+
+        var ordered =
+            ImmutableArray.CreateBuilder<IntegrationSourceParticipantAttempt>(
+                Participants.Length);
+        foreach (IntegrationSourceParticipantIdentity participant
+            in Participants)
+        {
+            if (!byParticipant.Remove(
+                    participant,
+                    out IntegrationSourceParticipantAttempt? attempt))
+            {
+                throw new ArgumentException(
+                    "Source-participant attempts must exactly cover the participant roster.",
+                    nameof(attempts));
+            }
+            ordered.Add(attempt);
+        }
+        if (byParticipant.Count != 0)
+        {
+            throw new ArgumentException(
+                "Source-participant attempts contain an extraneous participant.",
+                nameof(attempts));
+        }
+
+        Attempts = ordered.MoveToImmutable();
+    }
+
+    public ImmutableArray<IntegrationSourceParticipantIdentity> Participants
+        { get; }
+    public ImmutableArray<IntegrationSourceParticipantAttempt> Attempts
+        { get; }
+
+    static ImmutableArray<IntegrationSourceParticipantIdentity> CopyUnique(
+        IEnumerable<IntegrationSourceParticipantIdentity> values,
+        string parameterName)
+    {
+        ImmutableArray<IntegrationSourceParticipantIdentity> copied =
+            [.. values];
+        var seen = new HashSet<IntegrationSourceParticipantIdentity>();
+        foreach (IntegrationSourceParticipantIdentity value in copied)
+        {
+            if (value is null || !seen.Add(value))
+            {
+                throw new ArgumentException(
+                    "Source participants cannot contain null or duplicate identities.",
+                    parameterName);
+            }
+        }
+        return copied;
+    }
+}
+
+/// <summary>
+/// Executable completeness evidence corresponding to the exact universe
+/// description.
+/// </summary>
+public sealed class IntegrationCompletenessAccess
+{
+    public IntegrationCompletenessAccess(
+        IAnalysisUniverseCompleteness completeness,
+        IEnumerable<IAnalysisUniverseFailure>? failures = null)
+    {
+        ArgumentNullException.ThrowIfNull(completeness);
+        Completeness = completeness;
+        Failures = [.. failures ?? []];
+        if (Failures.Any(failure => failure is null))
+        {
+            throw new ArgumentException(
+                "Universe failures cannot contain null.",
+                nameof(failures));
+        }
+    }
+
+    public IAnalysisUniverseCompleteness Completeness { get; }
+    public ImmutableArray<IAnalysisUniverseFailure> Failures { get; }
+}
+
+/// <summary>Executable operation for one exact Integration producer policy.</summary>
+public sealed class IntegrationProducerPolicyAccess
+{
+    readonly Func<
+        IntegrationProducerPolicyAttemptAddress,
+        CancellationToken,
+        IntegrationProducerPolicyAttempt> _execute;
+
+    public IntegrationProducerPolicyAccess(
+        IntegrationProducerPolicyBinding policy,
+        Func<
+            IntegrationProducerPolicyAttemptAddress,
+            CancellationToken,
+            IntegrationProducerPolicyAttempt> execute)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(execute);
+        Policy = policy;
+        _execute = execute;
+    }
+
+    public IntegrationProducerPolicyBinding Policy { get; }
+
+    public IntegrationProducerPolicyAttempt Execute(
+        IntegrationProducerPolicyAttemptAddress address,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        if (!ReferenceEquals(address.Policy, Policy))
+        {
+            throw new ArgumentException(
+                "The producer address must use this access's exact policy.",
+                nameof(address));
+        }
+        return _execute(address, cancellationToken);
+    }
+}
+
+/// <summary>Opaque owner currency for one bound peer-evaluation request.</summary>
+public interface IIntegrationPeerBinding
+{
+}
+
+/// <summary>One terminal peer-binding receipt.</summary>
+public abstract class IntegrationPeerBindingAttempt
+{
+    private protected IntegrationPeerBindingAttempt(
+        IntegrationCandidateAttemptAddress address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        Address = address;
+    }
+
+    public IntegrationCandidateAttemptAddress Address { get; }
+
+    public sealed class Bound : IntegrationPeerBindingAttempt
+    {
+        public Bound(
+            IntegrationCandidateAttemptAddress address,
+            IIntegrationPeerBinding binding)
+            : base(address)
+        {
+            ArgumentNullException.ThrowIfNull(binding);
+            Binding = binding;
+        }
+
+        public IIntegrationPeerBinding Binding { get; }
+    }
+
+    public sealed class Failed : IntegrationPeerBindingAttempt
+    {
+        public Failed(
+            IntegrationCandidateAttemptAddress address,
+            IIntegrationCandidateFailure failure)
+            : base(address)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            Failure = failure;
+        }
+
+        public IIntegrationCandidateFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// One candidate evaluation request plus every producer-issued source lookup
+/// needed by Integration suppression policy.
+/// </summary>
+public sealed class IntegrationCandidateEvaluationRequest
+{
+    internal IntegrationCandidateEvaluationRequest(
+        IntegrationCandidateAttemptAddress address,
+        ImmutableArray<IntegrationCandidateEvidence> evidence)
+    {
+        Address = address;
+        Evidence = evidence;
+    }
+
+    public IntegrationCandidateAttemptAddress Address { get; }
+    public ImmutableArray<IntegrationCandidateEvidence> Evidence { get; }
+}
+
+/// <summary>
+/// Complete peer-binding result for one context-local frozen request batch.
+/// </summary>
+public sealed class IntegrationPeerBindingBatch
+{
+    public IntegrationPeerBindingBatch(
+        IIntegrationBindingContextIdentity bindingContext,
+        IEnumerable<IntegrationPeerBindingAttempt> attempts)
+    {
+        ArgumentNullException.ThrowIfNull(bindingContext);
+        ArgumentNullException.ThrowIfNull(attempts);
+        BindingContext = bindingContext;
+        Attempts = [.. attempts];
+        if (Attempts.Any(attempt => attempt is null))
+        {
+            throw new ArgumentException(
+                "Peer-binding attempts cannot contain null.",
+                nameof(attempts));
+        }
+    }
+
+    public IIntegrationBindingContextIdentity BindingContext { get; }
+    public ImmutableArray<IntegrationPeerBindingAttempt> Attempts { get; }
+}
+
+/// <summary>
+/// Context-batched peer binding over the complete candidate request set.
+/// </summary>
+public sealed class IntegrationPeerBindingAccess
+{
+    readonly Func<
+        IIntegrationBindingContextIdentity,
+        ImmutableArray<IntegrationCandidateEvaluationRequest>,
+        CancellationToken,
+        IntegrationPeerBindingBatch> _bind;
+
+    public IntegrationPeerBindingAccess(
+        IEnumerable<IIntegrationBindingContextIdentity> bindingContexts,
+        Func<
+            IIntegrationBindingContextIdentity,
+            ImmutableArray<IntegrationCandidateEvaluationRequest>,
+            CancellationToken,
+            IntegrationPeerBindingBatch> bind)
+    {
+        ArgumentNullException.ThrowIfNull(bindingContexts);
+        ArgumentNullException.ThrowIfNull(bind);
+        BindingContexts = CopyContexts(bindingContexts);
+        _bind = bind;
+    }
+
+    public ImmutableArray<IIntegrationBindingContextIdentity> BindingContexts
+        { get; }
+
+    public IntegrationPeerBindingBatch Bind(
+        IIntegrationBindingContextIdentity bindingContext,
+        ImmutableArray<IntegrationCandidateEvaluationRequest> requests,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bindingContext);
+        if (!BindingContexts.Contains(bindingContext)
+            || requests.Any(request =>
+                request is null
+                || !EqualityComparer<IIntegrationBindingContextIdentity>
+                    .Default.Equals(
+                        request.Address.BindingContext,
+                        bindingContext)))
+        {
+            throw new ArgumentException(
+                "Peer-binding requests must belong to one declared binding context.",
+                nameof(requests));
+        }
+        return _bind(bindingContext, requests, cancellationToken);
+    }
+
+    internal static ImmutableArray<IIntegrationBindingContextIdentity>
+        CopyContexts(
+            IEnumerable<IIntegrationBindingContextIdentity> contexts)
+    {
+        ImmutableArray<IIntegrationBindingContextIdentity> copied =
+            [.. contexts];
+        var seen = new HashSet<IIntegrationBindingContextIdentity>();
+        foreach (IIntegrationBindingContextIdentity context in copied)
+        {
+            if (context is null || !seen.Add(context))
+            {
+                throw new ArgumentException(
+                    "Binding contexts cannot contain null or duplicate identities.",
+                    nameof(contexts));
+            }
+        }
+        return copied;
+    }
+}
+
+/// <summary>One terminal exact-resolution receipt.</summary>
+public abstract class IntegrationCandidateResolutionAttempt
+{
+    private protected IntegrationCandidateResolutionAttempt(
+        IntegrationPeerBindingAttempt.Bound binding)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        Binding = binding;
+    }
+
+    public IntegrationPeerBindingAttempt.Bound Binding { get; }
+    public IntegrationCandidateAttemptAddress Address => Binding.Address;
+
+    public sealed class Resolved : IntegrationCandidateResolutionAttempt
+    {
+        public Resolved(
+            IntegrationPeerBindingAttempt.Bound binding,
+            IntegrationResolvedPeer peer,
+            IEnumerable<IntegrationResolvedPeer>?
+                fulfillmentSourceResolutions = null)
+            : base(binding)
+        {
+            ArgumentNullException.ThrowIfNull(peer);
+            Peer = peer;
+            FulfillmentSourceResolutions =
+                [.. fulfillmentSourceResolutions ?? []];
+            if (FulfillmentSourceResolutions.Any(
+                    resolution => resolution is null))
+            {
+                throw new ArgumentException(
+                    "Fulfillment-source resolutions cannot contain null.",
+                    nameof(fulfillmentSourceResolutions));
+            }
+            if (FulfillmentSourceResolutions
+                    .Select(resolution => resolution.Lookup)
+                    .Distinct()
+                    .Count()
+                != FulfillmentSourceResolutions.Length)
+            {
+                throw new ArgumentException(
+                    "Fulfillment-source resolutions cannot repeat a lookup.",
+                    nameof(fulfillmentSourceResolutions));
+            }
+        }
+
+        public IntegrationResolvedPeer Peer { get; }
+        public ImmutableArray<IntegrationResolvedPeer>
+            FulfillmentSourceResolutions { get; }
+    }
+
+    public sealed class Failed : IntegrationCandidateResolutionAttempt
+    {
+        public Failed(
+            IntegrationPeerBindingAttempt.Bound binding,
+            IIntegrationCandidateFailure failure)
+            : base(binding)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            Failure = failure;
+        }
+
+        public IIntegrationCandidateFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// Exact-resolution receipts for every successfully bound request in one
+/// context batch.
+/// </summary>
+public sealed class IntegrationCandidateResolutionBatch
+{
+    public IntegrationCandidateResolutionBatch(
+        IntegrationPeerBindingBatch bindingBatch,
+        IEnumerable<IntegrationCandidateResolutionAttempt> attempts)
+    {
+        ArgumentNullException.ThrowIfNull(bindingBatch);
+        ArgumentNullException.ThrowIfNull(attempts);
+        BindingBatch = bindingBatch;
+        Attempts = [.. attempts];
+        if (Attempts.Any(attempt => attempt is null))
+        {
+            throw new ArgumentException(
+                "Candidate-resolution attempts cannot contain null.",
+                nameof(attempts));
+        }
+    }
+
+    public IntegrationPeerBindingBatch BindingBatch { get; }
+    public ImmutableArray<IntegrationCandidateResolutionAttempt> Attempts
+        { get; }
+}
+
+/// <summary>
+/// Exact context-batched peer resolution over one owner-issued Type identity
+/// domain.
+/// </summary>
+public sealed class IntegrationExactPeerResolutionAccess
+{
+    readonly Func<
+        IntegrationPeerBindingBatch,
+        CancellationToken,
+        IntegrationCandidateResolutionBatch> _resolve;
+
+    public IntegrationExactPeerResolutionAccess(
+        IIntegrationTypeIdentityDomain identityDomain,
+        IEnumerable<IIntegrationBindingContextIdentity> bindingContexts,
+        Func<
+            IntegrationPeerBindingBatch,
+            CancellationToken,
+            IntegrationCandidateResolutionBatch> resolve)
+    {
+        ArgumentNullException.ThrowIfNull(identityDomain);
+        ArgumentNullException.ThrowIfNull(resolve);
+        IdentityDomain = identityDomain;
+        BindingContexts =
+            IntegrationPeerBindingAccess.CopyContexts(bindingContexts);
+        _resolve = resolve;
+    }
+
+    public IIntegrationTypeIdentityDomain IdentityDomain { get; }
+    public ImmutableArray<IIntegrationBindingContextIdentity> BindingContexts
+        { get; }
+
+    public IntegrationCandidateResolutionBatch Resolve(
+        IntegrationPeerBindingBatch bindingBatch,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bindingBatch);
+        if (!BindingContexts.Contains(bindingBatch.BindingContext))
+        {
+            throw new ArgumentException(
+                "The binding batch must belong to this resolution access.",
+                nameof(bindingBatch));
+        }
+        return _resolve(bindingBatch, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Why executable Integration capability access could not produce a Census.
+/// </summary>
+public enum IntegrationCensusExecutionRejectionReason
+{
+    ExecutableBindingTypeMismatch,
+    ParticipantContextMismatch,
+    SelectedTypeParticipantMismatch,
+    TypeIdentityDomainMismatch,
+    BindingContextDomainMismatch,
+    CompletenessMismatch,
+    ProducerPolicyMismatch,
+    InvalidProducerReceipt,
+    InvalidPeerBindingBatch,
+    InvalidResolutionBatch,
+    InvalidResolutionEvidence,
+}
+
+/// <summary>Typed Integration execution rejection.</summary>
+public sealed class IntegrationCensusExecutionRejection
+{
+    internal IntegrationCensusExecutionRejection(
+        IntegrationCensusExecutionRejectionReason reason,
+        AnalysisUniverseRequirementDescriptor? requirement = null,
+        IntegrationProducerPolicyAttemptAddress? producerAddress = null,
+        IntegrationCandidateAttemptAddress? candidateAddress = null,
+        IIntegrationBindingContextIdentity? bindingContext = null)
+    {
+        if (!Enum.IsDefined(reason))
+            throw new ArgumentOutOfRangeException(nameof(reason));
+        Reason = reason;
+        Requirement = requirement;
+        ProducerAddress = producerAddress;
+        CandidateAddress = candidateAddress;
+        BindingContext = bindingContext;
+    }
+
+    public IntegrationCensusExecutionRejectionReason Reason { get; }
+    public AnalysisUniverseRequirementDescriptor? Requirement { get; }
+    public IntegrationProducerPolicyAttemptAddress? ProducerAddress { get; }
+    public IntegrationCandidateAttemptAddress? CandidateAddress { get; }
+    public IIntegrationBindingContextIdentity? BindingContext { get; }
+}
+
+/// <summary>One terminal sequential Integration Census execution outcome.</summary>
+public abstract class IntegrationCensusExecutionResult
+{
+    private protected IntegrationCensusExecutionResult()
+    {
+    }
+
+    public sealed class Ready : IntegrationCensusExecutionResult
+    {
+        internal Ready(IntegrationCensusSnapshot snapshot) =>
+            Snapshot = snapshot;
+
+        public IntegrationCensusSnapshot Snapshot { get; }
+    }
+
+    public sealed class IssuanceRejected : IntegrationCensusExecutionResult
+    {
+        internal IssuanceRejected(
+            AnalysisUniverseIssuanceRejection rejection) =>
+            Rejection = rejection;
+
+        public AnalysisUniverseIssuanceRejection Rejection { get; }
+    }
+
+    public sealed class ExecutionRejected : IntegrationCensusExecutionResult
+    {
+        internal ExecutionRejected(
+            IntegrationCensusExecutionRejection rejection) =>
+            Rejection = rejection;
+
+        public IntegrationCensusExecutionRejection Rejection { get; }
+    }
+
+    public sealed class Cancelled : IntegrationCensusExecutionResult
+    {
+        internal Cancelled()
+        {
+        }
+    }
+}
+
+/// <summary>
+/// A producer-policy receipt synthesized when its source participant cannot be
+/// executed.
+/// </summary>
+public sealed class IntegrationParticipantProducerUnavailable :
+    IIntegrationProducerPolicyUnavailable
+{
+    internal IntegrationParticipantProducerUnavailable(
+        IntegrationSourceParticipantAttempt sourceAttempt) =>
+        SourceAttempt = sourceAttempt;
+
+    public IntegrationSourceParticipantAttempt SourceAttempt { get; }
+}
+
+/// <summary>
+/// Executes one Workspace-backed Integration Census deterministically and
+/// sequentially.
+/// </summary>
+public static class IntegrationCensusExecutor
+{
+    public static IntegrationCensusExecutionResult Execute(
+        AnalysisUniverseOffer offer,
+        AnalysisRequestPlan plan,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(offer);
+        ArgumentNullException.ThrowIfNull(plan);
+        IntegrationCensusSnapshot.ValidatePlan(plan);
+        ImmutableArray<IntegrationProducerPolicyBinding> requiredPolicies =
+            IntegrationCensusSnapshot.RequiredPolicies(plan);
+
+        AnalysisUniverseIssuanceResult issuance =
+            offer.IssueExecutionAccess(plan, cancellationToken);
+        if (issuance is AnalysisUniverseIssuanceResult.Rejected rejected)
+        {
+            return new IntegrationCensusExecutionResult.IssuanceRejected(
+                rejected.Rejection);
+        }
+        if (issuance is AnalysisUniverseIssuanceResult.Cancelled)
+            return new IntegrationCensusExecutionResult.Cancelled();
+        if (issuance is not AnalysisUniverseIssuanceResult.Ready ready)
+        {
+            throw new InvalidOperationException(
+                "Unknown analysis-universe issuance outcome.");
+        }
+
+        using (ready.Access)
+        {
+            try
+            {
+                return ExecuteCore(
+                    ready.Access,
+                    requiredPolicies,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                return new IntegrationCensusExecutionResult.Cancelled();
+            }
+        }
+    }
+
+    static IntegrationCensusExecutionResult ExecuteCore(
+        AnalysisUniverseExecutionAccess execution,
+        ImmutableArray<IntegrationProducerPolicyBinding> requiredPolicies,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.SelectedTypesRequirement,
+                out IntegrationSelectedTypeAccess? selected,
+                out IntegrationCensusExecutionResult? rejection)
+            || !TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.OrderedParticipantsRequirement,
+                out IntegrationSourceParticipantAccess? participants,
+                out rejection)
+            || !TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.BindingContextsRequirement,
+                out IntegrationBindingContextAccess? contexts,
+                out rejection)
+            || !TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.PeerBindingRequirement,
+                out IntegrationPeerBindingAccess? binding,
+                out rejection)
+            || !TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.ExactPeerResolutionRequirement,
+                out IntegrationExactPeerResolutionAccess? resolution,
+                out rejection)
+            || !TryGetAccess(
+                execution,
+                IntegrationAnalysisCatalog.CompletenessRequirement,
+                out IntegrationCompletenessAccess? completeness,
+                out rejection))
+        {
+            return rejection!;
+        }
+
+        var producerAccesses =
+            new Dictionary<
+                IntegrationProducerPolicyBinding,
+                IntegrationProducerPolicyAccess>(
+                    ReferenceEqualityComparer.Instance);
+        foreach (IntegrationProducerPolicyBinding policy
+            in requiredPolicies)
+        {
+            if (!TryGetAccess(
+                    execution,
+                    policy.UniverseRequirement,
+                    out IntegrationProducerPolicyAccess? access,
+                    out rejection))
+            {
+                return rejection!;
+            }
+            if (!ReferenceEquals(access.Policy, policy))
+            {
+                return Reject(
+                    IntegrationCensusExecutionRejectionReason
+                        .ProducerPolicyMismatch,
+                    policy.UniverseRequirement);
+            }
+            producerAccesses.Add(policy, access);
+        }
+
+        if (!ReferenceEquals(
+                selected.IdentityDomain,
+                resolution.IdentityDomain))
+        {
+            return Reject(
+                IntegrationCensusExecutionRejectionReason
+                    .TypeIdentityDomainMismatch);
+        }
+        if (!SameIdentities(
+                contexts.BindingContexts,
+                binding.BindingContexts)
+            || !SameIdentities(
+                contexts.BindingContexts,
+                resolution.BindingContexts))
+        {
+            return Reject(
+                IntegrationCensusExecutionRejectionReason
+                    .BindingContextDomainMismatch);
+        }
+        if (!ReferenceEquals(
+                completeness.Completeness,
+                execution.Plan.UniverseCompleteness)
+            || !SameReferences(
+                completeness.Failures,
+                execution.Plan.UniverseFailures))
+        {
+            return Reject(
+                IntegrationCensusExecutionRejectionReason
+                    .CompletenessMismatch);
+        }
+
+        ImmutableArray<IntegrationSourceBindingContextIncidence>
+            canonicalIncidence;
+        try
+        {
+            canonicalIncidence =
+                IntegrationCensusSnapshot.CanonicalizeIncidence(
+                    participants.Participants,
+                    contexts.SourceIncidence,
+                    nameof(contexts));
+        }
+        catch (ArgumentException)
+        {
+            return Reject(
+                IntegrationCensusExecutionRejectionReason
+                    .ParticipantContextMismatch);
+        }
+
+        var participantSet =
+            participants.Participants.ToHashSet();
+        if (selected.SelectedTypes.Any(type =>
+                !participantSet.Contains(type.Participant)))
+        {
+            return Reject(
+                IntegrationCensusExecutionRejectionReason
+                    .SelectedTypeParticipantMismatch);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var producerAttempts =
+            ImmutableArray.CreateBuilder<IntegrationProducerPolicyAttempt>(
+                participants.Participants.Length * requiredPolicies.Length);
+        var selectedTypeSet = selected.SelectedTypes.ToHashSet();
+        for (int participantIndex = 0;
+            participantIndex < participants.Participants.Length;
+            participantIndex++)
+        {
+            IntegrationSourceParticipantIdentity participant =
+                participants.Participants[participantIndex];
+            IntegrationSourceParticipantAttempt sourceAttempt =
+                participants.Attempts[participantIndex];
+            foreach (IntegrationProducerPolicyBinding policy
+                in requiredPolicies)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var address =
+                    new IntegrationProducerPolicyAttemptAddress(
+                        participant,
+                        policy);
+                if (sourceAttempt
+                    is not IntegrationSourceParticipantAttempt.Available)
+                {
+                    producerAttempts.Add(
+                        new IntegrationProducerPolicyAttempt.Unavailable(
+                            address,
+                            new IntegrationParticipantProducerUnavailable(
+                                sourceAttempt)));
+                    continue;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                IntegrationProducerPolicyAttempt? attempt =
+                    producerAccesses[policy].Execute(
+                        address,
+                        cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+                if (attempt is null
+                    || !attempt.Address.Equals(address)
+                    || attempt
+                        is IntegrationProducerPolicyAttempt.Completed completed
+                        && completed.Candidates.Any(candidate =>
+                            !selectedTypeSet.Contains(
+                                IntegrationCensusSnapshot.SourceTypeOf(
+                                    candidate))))
+                {
+                    return Reject(
+                        IntegrationCensusExecutionRejectionReason
+                            .InvalidProducerReceipt,
+                        policy.UniverseRequirement,
+                        producerAddress: address);
+                }
+                producerAttempts.Add(attempt);
+            }
+        }
+
+        ImmutableArray<IntegrationProducerPolicyAttempt> produced =
+            producerAttempts.MoveToImmutable();
+        ImmutableArray<IntegrationCensusCandidate> candidates =
+            IntegrationCensusSnapshot.BuildCandidates(produced);
+        Dictionary<
+            IntegrationCandidateIdentity,
+            IntegrationCensusCandidate> candidateByIdentity =
+                candidates.ToDictionary(static candidate => candidate.Identity);
+        var incidenceByParticipant =
+            canonicalIncidence.ToDictionary(
+                static incidence => incidence.Participant);
+        var requestsByContext = contexts.BindingContexts.ToDictionary(
+            static context => context,
+            static _ =>
+                ImmutableArray.CreateBuilder<
+                    IntegrationCandidateEvaluationRequest>());
+        foreach (IntegrationCensusCandidate candidate in candidates)
+        {
+            foreach (IIntegrationBindingContextIdentity context
+                in incidenceByParticipant[
+                    candidate.Identity.Source.Participant].BindingContexts)
+            {
+                var address = new IntegrationCandidateAttemptAddress(
+                    candidate.Identity,
+                    context);
+                requestsByContext[context].Add(
+                    new IntegrationCandidateEvaluationRequest(
+                        address,
+                        candidate.Evidence));
+            }
+        }
+
+        var candidateFailures =
+            new Dictionary<
+                IntegrationCandidateAttemptAddress,
+                IIntegrationCandidateFailure>();
+        var candidateResolutions =
+            new Dictionary<
+                IntegrationCandidateAttemptAddress,
+                IntegrationCandidateResolutionAttempt.Resolved>();
+        foreach (IIntegrationBindingContextIdentity context
+            in contexts.BindingContexts)
+        {
+            ImmutableArray<IntegrationCandidateEvaluationRequest> requests =
+                requestsByContext[context].ToImmutable();
+            if (requests.IsEmpty)
+                continue;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            IntegrationPeerBindingBatch? batch =
+                binding.Bind(
+                    context,
+                    requests,
+                    cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (batch is null
+                || !EqualityComparer<IIntegrationBindingContextIdentity>
+                    .Default.Equals(batch.BindingContext, context)
+                || !TryCanonicalize(
+                    requests.Select(static request => request.Address),
+                    batch.Attempts,
+                    static attempt => attempt.Address,
+                    out ImmutableArray<IntegrationPeerBindingAttempt>
+                        bindingAttempts))
+            {
+                return Reject(
+                    IntegrationCensusExecutionRejectionReason
+                        .InvalidPeerBindingBatch,
+                    bindingContext: context);
+            }
+
+            var boundAddresses =
+                ImmutableArray.CreateBuilder<
+                    IntegrationCandidateAttemptAddress>();
+            foreach (IntegrationPeerBindingAttempt attempt
+                in bindingAttempts)
+            {
+                switch (attempt)
+                {
+                    case IntegrationPeerBindingAttempt.Bound:
+                        boundAddresses.Add(attempt.Address);
+                        break;
+                    case IntegrationPeerBindingAttempt.Failed failed:
+                        candidateFailures.Add(
+                            failed.Address,
+                            failed.Failure);
+                        break;
+                    default:
+                        return Reject(
+                            IntegrationCensusExecutionRejectionReason
+                                .InvalidPeerBindingBatch,
+                            candidateAddress: attempt.Address,
+                            bindingContext: context);
+                }
+            }
+
+            if (boundAddresses.Count == 0)
+                continue;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            IntegrationCandidateResolutionBatch? resolved =
+                resolution.Resolve(batch, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (resolved is null
+                || !ReferenceEquals(resolved.BindingBatch, batch)
+                || !TryCanonicalize(
+                    bindingAttempts.OfType<
+                        IntegrationPeerBindingAttempt.Bound>(),
+                    resolved.Attempts,
+                    static attempt => attempt.Binding,
+                    out ImmutableArray<
+                        IntegrationCandidateResolutionAttempt>
+                        resolutionAttempts))
+            {
+                return Reject(
+                    IntegrationCensusExecutionRejectionReason
+                        .InvalidResolutionBatch,
+                    bindingContext: context);
+            }
+
+            foreach (IntegrationCandidateResolutionAttempt attempt
+                in resolutionAttempts)
+            {
+                switch (attempt)
+                {
+                    case IntegrationCandidateResolutionAttempt.Resolved success:
+                        if (!ValidateResolutionEvidence(
+                                candidateByIdentity,
+                                success))
+                        {
+                            return Reject(
+                                IntegrationCensusExecutionRejectionReason
+                                    .InvalidResolutionEvidence,
+                                candidateAddress: success.Address,
+                                bindingContext: context);
+                        }
+                        candidateResolutions.Add(
+                            success.Address,
+                            success);
+                        break;
+                    case IntegrationCandidateResolutionAttempt.Failed failed:
+                        candidateFailures.Add(
+                            failed.Address,
+                            failed.Failure);
+                        break;
+                    default:
+                        return Reject(
+                            IntegrationCensusExecutionRejectionReason
+                                .InvalidResolutionBatch,
+                            candidateAddress: attempt.Address,
+                            bindingContext: context);
+                }
+            }
+        }
+
+        var observationsByContextAndConcept =
+            new Dictionary<ObservationKey, List<
+                IntegrationCandidateResolutionAttempt.Resolved>>();
+        foreach (IntegrationCensusCandidate candidate in candidates)
+        {
+            if (!ReferenceEquals(
+                    candidate.Identity.Relationship,
+                    InspectionGraphIntegrationsCatalog.IntegrationObserved))
+            {
+                continue;
+            }
+            foreach (IIntegrationBindingContextIdentity context
+                in incidenceByParticipant[
+                    candidate.Identity.Source.Participant].BindingContexts)
+            {
+                var address = new IntegrationCandidateAttemptAddress(
+                    candidate.Identity,
+                    context);
+                if (!candidateResolutions.TryGetValue(
+                        address,
+                        out IntegrationCandidateResolutionAttempt.Resolved?
+                            resolved))
+                {
+                    continue;
+                }
+
+                var key = new ObservationKey(
+                    candidate.Identity.Concept,
+                    context);
+                if (!observationsByContextAndConcept.TryGetValue(
+                        key,
+                        out List<
+                            IntegrationCandidateResolutionAttempt.Resolved>?
+                            observations))
+                {
+                    observations = [];
+                    observationsByContextAndConcept.Add(key, observations);
+                }
+                observations.Add(resolved);
+            }
+        }
+
+        var candidateAttempts =
+            ImmutableArray.CreateBuilder<IntegrationCandidateAttempt>();
+        foreach (IntegrationCensusCandidate candidate in candidates)
+        {
+            foreach (IIntegrationBindingContextIdentity context
+                in incidenceByParticipant[
+                    candidate.Identity.Source.Participant].BindingContexts)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var address = new IntegrationCandidateAttemptAddress(
+                    candidate.Identity,
+                    context);
+                if (candidateFailures.TryGetValue(
+                        address,
+                        out IIntegrationCandidateFailure? failure))
+                {
+                    candidateAttempts.Add(
+                        new IntegrationCandidateAttempt.Failed(
+                            address,
+                            failure));
+                    continue;
+                }
+
+                IntegrationCandidateResolutionAttempt.Resolved resolved =
+                    candidateResolutions[address];
+                IntegrationCandidateAttempt.Suppressed? suppressed =
+                    TrySuppress(
+                        address,
+                        resolved,
+                        observationsByContextAndConcept);
+                if (suppressed is not null)
+                {
+                    candidateAttempts.Add(suppressed);
+                    continue;
+                }
+
+                IntegrationCandidateDisposition disposition =
+                    selectedTypeSet.Contains(resolved.Peer.Terminal)
+                        ? new IntegrationCandidateDisposition.In(
+                            resolved.Peer)
+                        : new IntegrationCandidateDisposition.Out(
+                            resolved.Peer);
+                candidateAttempts.Add(
+                    new IntegrationCandidateAttempt.Classified(
+                        address,
+                        disposition,
+                        resolved.FulfillmentSourceResolutions));
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return new IntegrationCensusExecutionResult.Ready(
+            new IntegrationCensusSnapshot(
+                execution.Plan,
+                participants.Participants,
+                selected.SelectedTypes,
+                contexts,
+                participants.Attempts,
+                produced,
+                candidateAttempts.ToImmutable()));
+    }
+
+    static IntegrationCandidateAttempt.Suppressed? TrySuppress(
+        IntegrationCandidateAttemptAddress address,
+        IntegrationCandidateResolutionAttempt.Resolved resolved,
+        Dictionary<
+            ObservationKey,
+            List<IntegrationCandidateResolutionAttempt.Resolved>>
+            observationsByContextAndConcept)
+    {
+        IntegrationCandidateIdentity candidate = address.Candidate;
+        if (!ReferenceEquals(
+                candidate.Relationship,
+                InspectionGraphIntegrationsCatalog.IntegrationOpportunity))
+        {
+            return null;
+        }
+
+        IntegrationTypeIdentity source =
+            IntegrationCensusSnapshot.SourceTypeOf(candidate);
+        if (!observationsByContextAndConcept.TryGetValue(
+                new ObservationKey(
+                    candidate.Concept,
+                    address.BindingContext),
+                out List<
+                    IntegrationCandidateResolutionAttempt.Resolved>?
+                    observations))
+        {
+            return null;
+        }
+
+        foreach (IntegrationCandidateResolutionAttempt.Resolved fulfilling
+            in observations)
+        {
+            if (!fulfilling.Peer.Terminal.Equals(
+                    resolved.Peer.Terminal)
+                || !fulfilling.FulfillmentSourceResolutions.Any(
+                    receiver => receiver.Terminal.Equals(source)))
+            {
+                continue;
+            }
+
+            return new IntegrationCandidateAttempt.Suppressed(
+                address,
+                fulfilling.Address,
+                new IntegrationOpportunityFulfillment(
+                    source,
+                    resolved.Peer));
+        }
+
+        return null;
+    }
+
+    static bool ValidateResolutionEvidence(
+        Dictionary<
+            IntegrationCandidateIdentity,
+            IntegrationCensusCandidate> candidates,
+        IntegrationCandidateResolutionAttempt.Resolved resolved)
+    {
+        try
+        {
+            IntegrationCensusSnapshot.ValidateResolution(
+                resolved.Address.Candidate,
+                resolved.Peer);
+            IntegrationCensusCandidate candidate =
+                candidates[resolved.Address.Candidate];
+            if (!ReferenceEquals(
+                    candidate.Identity.Relationship,
+                    InspectionGraphIntegrationsCatalog.IntegrationObserved)
+                && !resolved.FulfillmentSourceResolutions.IsEmpty)
+            {
+                return false;
+            }
+            IntegrationCandidatePeerIdentity.NamedType[] declaredSources =
+            [
+                .. candidate.Evidence
+                    .SelectMany(evidence =>
+                        evidence.FulfillmentSourceLookups)
+                    .Distinct(),
+            ];
+            if (declaredSources.Length
+                != resolved.FulfillmentSourceResolutions.Length)
+            {
+                return false;
+            }
+            foreach (IntegrationResolvedPeer source
+                in resolved.FulfillmentSourceResolutions)
+            {
+                if (!candidate.Evidence.Any(evidence =>
+                        evidence.FulfillmentSourceLookups.Any(
+                            lookup => lookup.Equals(source.Lookup))))
+                {
+                    return false;
+                }
+                IntegrationCensusSnapshot.ValidateResolvedLookup(
+                    source.Lookup,
+                    source);
+            }
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    static bool TryGetAccess<TAccess>(
+        AnalysisUniverseExecutionAccess execution,
+        AnalysisUniverseRequirementDescriptor requirement,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
+        out TAccess? access,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(false)]
+        out IntegrationCensusExecutionResult? rejection)
+        where TAccess : class
+    {
+        AnalysisUniverseRequirementBinding? binding =
+            execution.Bindings.FirstOrDefault(candidate =>
+                ReferenceEquals(candidate.Requirement, requirement));
+        if (binding
+            is AnalysisUniverseRequirementBinding<TAccess> typed)
+        {
+            access = typed.Access;
+            rejection = null;
+            return true;
+        }
+
+        access = null;
+        rejection = Reject(
+            IntegrationCensusExecutionRejectionReason
+                .ExecutableBindingTypeMismatch,
+            requirement);
+        return false;
+    }
+
+    static bool TryCanonicalize<TAddress, TAttempt>(
+        IEnumerable<TAddress> expected,
+        IEnumerable<TAttempt> supplied,
+        Func<TAttempt, TAddress> addressOf,
+        out ImmutableArray<TAttempt> canonical)
+        where TAddress : class
+        where TAttempt : class
+    {
+        var byAddress = new Dictionary<TAddress, TAttempt>();
+        foreach (TAttempt attempt in supplied)
+        {
+            if (attempt is null
+                || !byAddress.TryAdd(addressOf(attempt), attempt))
+            {
+                canonical = [];
+                return false;
+            }
+        }
+
+        var ordered = ImmutableArray.CreateBuilder<TAttempt>();
+        foreach (TAddress address in expected)
+        {
+            if (!byAddress.Remove(address, out TAttempt? attempt))
+            {
+                canonical = [];
+                return false;
+            }
+            ordered.Add(attempt);
+        }
+        if (byAddress.Count != 0)
+        {
+            canonical = [];
+            return false;
+        }
+
+        canonical = ordered.ToImmutable();
+        return true;
+    }
+
+    static bool SameIdentities<T>(
+        ImmutableArray<T> left,
+        ImmutableArray<T> right)
+        where T : class
+    {
+        if (left.Length != right.Length)
+            return false;
+        for (int index = 0; index < left.Length; index++)
+        {
+            if (!EqualityComparer<T>.Default.Equals(
+                    left[index],
+                    right[index]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool SameReferences<T>(
+        ImmutableArray<T> left,
+        ImmutableArray<T> right)
+        where T : class
+    {
+        if (left.Length != right.Length)
+            return false;
+        for (int index = 0; index < left.Length; index++)
+        {
+            if (!ReferenceEquals(left[index], right[index]))
+                return false;
+        }
+        return true;
+    }
+
+    static IntegrationCensusExecutionResult.ExecutionRejected Reject(
+        IntegrationCensusExecutionRejectionReason reason,
+        AnalysisUniverseRequirementDescriptor? requirement = null,
+        IntegrationProducerPolicyAttemptAddress? producerAddress = null,
+        IntegrationCandidateAttemptAddress? candidateAddress = null,
+        IIntegrationBindingContextIdentity? bindingContext = null) =>
+        new(
+            new IntegrationCensusExecutionRejection(
+                reason,
+                requirement,
+                producerAddress,
+                candidateAddress,
+                bindingContext));
+
+    readonly record struct ObservationKey(
+        IntegrationConceptDescriptor Concept,
+        IIntegrationBindingContextIdentity BindingContext);
+}


### PR DESCRIPTION
## Summary

Execute the Workspace Integration Census from exact owner-issued universe bindings with deterministic sequential scheduling.

- Introduces Integration-owned executable payloads for selected Types, source participants, binding contexts, producer policies, peer binding, exact resolution, and completeness.
- Admits each context's complete candidate request batch before Metadata freezes resolution, then consumes the exact returned `Bound` objects.
- Retains independently verifiable fulfillment-source evidence and suppresses opportunities only when source Type, concept, context, and terminal target all correspond.
- Preserves unavailable participants, producer failures, candidate failures, cancellation, and capability lifetime release as typed outcomes instead of success-shaped absence.

The executor is synchronous and introduces no scheduler, task, thread, or concurrency requirement, preserving the Browser/Wasm sequential baseline. It does not add a CLI surface.

Part of #3629.

## Demo

The contract test runs a sparse two-context universe:

```text
A -> [net8, net9]
B -> [net8]
```

It executes participant/policy producers in retained order, binds one complete batch per context, and produces this Census:

| Candidate | net8 | net9 |
| --- | --- | --- |
| opportunity fulfilled by an observed adapter | Suppressed | Suppressed |
| selected peer | In | n/a |
| healthy unselected peer | Out | n/a |

All nine capability leases are released after execution. The neighboring failure fixtures demonstrate that omitted, duplicate, undeclared, or wrong-domain evidence rejects execution rather than manufacturing a complete Census.

Run the executable demo with:

```bash
dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class DotnetInspector.Queries.Tests.IntegrationCensusExecutorTests \
  -reporter quiet
```

## Design

`docs/design/integrations.md` owns Census execution and suppression semantics. `docs/design/analysis-universe-realization.md` supplies exact executable bindings and leases. Metadata's `docs/design/type-forwarding-resolution.md` continues to own binding, frozen request manifests, exact resolution, and forwarding evidence.

The implementation follows the repository's existing deterministic sequential query convention and Metadata's existing complete-manifest resolution boundary. Integration analysis revision 3 adds the extension-method prerequisite required to produce structured receiver evidence honestly.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- -reporter quiet`
- `npx markdownlint-cli docs/design/integrations.md docs/design/analysis-universe-realization.md`
- `git diff --check FETCH_HEAD..HEAD`
