### PR TITLE
Implement initial navigation subject recommendation

### DIFF
--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -17,8 +17,11 @@ identity foundation is implemented by
 `MemberIdentity_BindsExactDeclaringTypeAndAnchor`, and
 `Construction_RejectsAbsentOwnerIssuedComponents`. Exact lens identity,
 retained evaluation bases, and pure lens recommendation are implemented by
-`NavigationLensRecommendation` and gated at their claims below. Initial
-subject selection, activation, reconciliation, revision behavior, retained
+`NavigationLensRecommendation` and gated at their claims below. Pure initial
+subject ranking over already trustworthy Type candidates and already available
+Library candidates is implemented by `NavigationInitialSubjectRecommendation`
+and gated at its claim below. Candidate availability and failure
+classification, activation, reconciliation, revision behavior, retained
 sessions, synchronization, and restoration remain unverified until their
 implementation gates in [Verification](#verification) land.
 
@@ -311,6 +314,15 @@ subject is selected.
 
 When no Library is available, Root is selected. This allows root-only package
 coordinates, including the tools-v2 pointer-package case tracked by #4829.
+
+The pure ranking over already trustworthy Type candidates and already
+available Library candidates is gated by
+`NavigationInitialSubjectRecommendationTests.InitialRecommendation_PrefersTypeThenLibraryThenRoot`,
+`TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder`, and
+`InitialRecommendation_NeverChoosesMember`. Candidate coordinate, Library,
+Type, primary-role, and accessibility consistency is gated by
+`CandidateConstruction_RejectsInconsistentOwnerIssuedEvidence`. Producer
+trust, availability, and failure classification remain unverified.
 
 ### Lens recommendation
 

--- a/src/DotnetInspector.Queries.Tests/NavigationInitialSubjectRecommendationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/NavigationInitialSubjectRecommendationTests.cs
@@ -1,0 +1,382 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class NavigationInitialSubjectRecommendationTests
+{
+    [Fact]
+    public void InitialRecommendation_PrefersTypeThenLibraryThenRoot()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate("1.0.0");
+        StructuralSubjectIdentity.RootSubject root =
+            StructuralSubjectIdentity.ForRoot(coordinate);
+        StructuralSubjectIdentity.AllLibrariesSubject allLibraries =
+            StructuralSubjectIdentity.ForAllLibraries(coordinate);
+        NavigationInitialLibraryCandidate primary = LibraryCandidate(
+            coordinate,
+            "Primary",
+            isPrimary: true);
+        NavigationInitialLibraryCandidate other = LibraryCandidate(
+            coordinate,
+            "Other",
+            isPrimary: false,
+            ("Widget", "public"));
+        NavigationInitialLibraryCandidate otherWithoutTypes =
+            LibraryCandidate(
+                coordinate,
+                "OtherWithoutTypes",
+                isPrimary: false);
+
+        NavigationInitialSubjectOutcome type =
+            NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries,
+                [primary, other]);
+        Assert.Same(other.Types[0].Subject, type.Subject);
+        Assert.Same(root, type.Basis.Root);
+        Assert.Same(allLibraries, type.Basis.AllLibraries);
+        Assert.Equal([primary, other], type.Basis.Libraries);
+
+        NavigationInitialSubjectOutcome aggregate =
+            NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries,
+                [primary, otherWithoutTypes]);
+        Assert.Same(allLibraries, aggregate.Subject);
+
+        NavigationInitialSubjectOutcome primaryLibrary =
+            NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [otherWithoutTypes, primary]);
+        Assert.Same(primary.Subject, primaryLibrary.Subject);
+
+        NavigationInitialSubjectOutcome firstLibrary =
+            NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [otherWithoutTypes, LibraryCandidate(
+                    coordinate,
+                    "Later",
+                    isPrimary: false)]);
+        Assert.Same(otherWithoutTypes.Subject, firstLibrary.Subject);
+
+        NavigationInitialSubjectOutcome rootOnly =
+            NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                []);
+        Assert.Same(root, rootOnly.Subject);
+
+        NavigationInitialLibraryCandidate equalPrimary =
+            EqualCandidate(primary);
+        NavigationInitialLibraryCandidate equalOther =
+            EqualCandidate(other);
+        var equalBasis = new NavigationInitialSubjectBasis(
+            root,
+            allLibraries,
+            [equalPrimary, equalOther]);
+        Assert.Equal(primary, equalPrimary);
+        Assert.Equal(
+            primary.GetHashCode(),
+            equalPrimary.GetHashCode());
+        Assert.All(
+            equalOther.Types,
+            typeCandidate =>
+                Assert.Equal(0, typeCandidate.Accessibility.Count));
+        Assert.Equal(type.Basis, equalBasis);
+        Assert.Equal(
+            type.Basis.GetHashCode(),
+            equalBasis.GetHashCode());
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries,
+                default));
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [
+                    primary,
+                    LibraryCandidate(
+                        coordinate,
+                        "OtherPrimary",
+                        isPrimary: true),
+                ]));
+    }
+
+    [Fact]
+    public void CandidateConstruction_RejectsInconsistentOwnerIssuedEvidence()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate("1.0.0");
+        StructuralSubjectIdentity.RootSubject root =
+            StructuralSubjectIdentity.ForRoot(coordinate);
+        NavigationInitialLibraryCandidate first = LibraryCandidate(
+            coordinate,
+            "First",
+            isPrimary: true,
+            ("FirstType", "public"));
+        NavigationInitialLibraryCandidate other = LibraryCandidate(
+            coordinate,
+            "Other",
+            isPrimary: false,
+            ("OtherType", "public"));
+
+        Assert.Throws<ArgumentException>(
+            () => new NavigationInitialLibraryCandidate(
+                first.Subject,
+                isPrimary: false,
+                default));
+        Assert.Throws<ArgumentException>(
+            () => new NavigationInitialLibraryCandidate(
+                first.Subject,
+                isPrimary: false,
+                [other.Types[0]]));
+        Assert.Throws<ArgumentException>(
+            () => new NavigationInitialTypeCandidate(
+                first.Types[0].Subject,
+                new ApiAccessibilityBucket(
+                    "private",
+                    "private",
+                    Order: 3,
+                    IsDefault: true,
+                    Count: 1)));
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                StructuralSubjectIdentity.ForAllLibraries(
+                    Coordinate("2.0.0")),
+                []));
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [
+                    LibraryCandidate(
+                        Coordinate("2.0.0"),
+                        "OtherCoordinate",
+                        isPrimary: false),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [first, first]));
+        Assert.Throws<ArgumentException>(
+            () => NavigationInitialSubjectRecommendation.Recommend(
+                root,
+                allLibraries: null,
+                [
+                    first,
+                    new NavigationInitialLibraryCandidate(
+                        other.Subject,
+                        isPrimary: true,
+                        other.Types),
+                ]));
+    }
+
+    [Fact]
+    public void TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate("1.0.0");
+        StructuralSubjectIdentity.RootSubject root =
+            StructuralSubjectIdentity.ForRoot(coordinate);
+        NavigationInitialLibraryCandidate primary = LibraryCandidate(
+            coordinate,
+            "Primary",
+            isPrimary: true,
+            ("PrivateFirst", "private"),
+            ("PublicFirst", "public"),
+            ("PublicSecond", "public"));
+        NavigationInitialLibraryCandidate otherFirst = LibraryCandidate(
+            coordinate,
+            "OtherFirst",
+            isPrimary: false,
+            ("OtherPublicFirst", "public"),
+            ("OtherPublicSecond", "public"));
+        NavigationInitialLibraryCandidate otherLater = LibraryCandidate(
+            coordinate,
+            "OtherLater",
+            isPrimary: false,
+            ("LaterPublic", "public"));
+
+        Assert.Same(
+            primary.Types[1].Subject,
+            Recommend(root, primary, otherFirst, otherLater).Subject);
+
+        NavigationInitialLibraryCandidate primaryNonDefault =
+            LibraryCandidate(
+                coordinate,
+                "PrimaryNonDefault",
+                isPrimary: true,
+                ("PrivateFirst", "private"),
+                ("ProtectedSecond", "protected"));
+        Assert.Same(
+            otherFirst.Types[0].Subject,
+            Recommend(
+                root,
+                primaryNonDefault,
+                otherFirst,
+                otherLater).Subject);
+
+        NavigationInitialLibraryCandidate otherNonDefault =
+            LibraryCandidate(
+                coordinate,
+                "OtherNonDefault",
+                isPrimary: false,
+                ("OtherPrivate", "private"));
+        Assert.Same(
+            primaryNonDefault.Types[0].Subject,
+            Recommend(
+                root,
+                primaryNonDefault,
+                otherNonDefault).Subject);
+
+        NavigationInitialLibraryCandidate firstOtherNonDefault =
+            LibraryCandidate(
+                coordinate,
+                "FirstOtherNonDefault",
+                isPrimary: false,
+                ("PrivateBeforeProtected", "private"),
+                ("ProtectedLater", "protected"));
+        NavigationInitialLibraryCandidate laterOtherNonDefault =
+            LibraryCandidate(
+                coordinate,
+                "LaterOtherNonDefault",
+                isPrimary: false,
+                ("LaterPrivate", "private"));
+        Assert.Same(
+            firstOtherNonDefault.Types[0].Subject,
+            Recommend(
+                root,
+                firstOtherNonDefault,
+                laterOtherNonDefault).Subject);
+    }
+
+    [Fact]
+    public void InitialRecommendation_NeverChoosesMember()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate("1.0.0");
+        StructuralSubjectIdentity.RootSubject root =
+            StructuralSubjectIdentity.ForRoot(coordinate);
+        NavigationInitialLibraryCandidate library = LibraryCandidate(
+            coordinate,
+            "Primary",
+            isPrimary: true,
+            ("Widget", "public"));
+        StructuralSubjectIdentity.TypeSubject type = library.Types[0].Subject;
+        StructuralSubjectIdentity.MemberSubject member =
+            StructuralSubjectIdentity.ForMember(
+                type,
+                new MemberAnchor(
+                    "Run()",
+                    "Sample.Widget.Run()",
+                    MemberAnchor.ComputeFingerprint(
+                        "Sample.Widget.Run()"),
+                    "Sample.Widget",
+                    "Run"));
+
+        NavigationInitialSubjectOutcome outcome = Recommend(root, library);
+
+        Assert.Same(type, outcome.Subject);
+        Assert.IsNotType<StructuralSubjectIdentity.MemberSubject>(
+            outcome.Subject);
+        Assert.Throws<ArgumentException>(
+            () => new NavigationInitialSubjectOutcome(
+                outcome.Basis,
+                member));
+    }
+
+    static NavigationInitialSubjectOutcome Recommend(
+        StructuralSubjectIdentity.RootSubject root,
+        params NavigationInitialLibraryCandidate[] libraries) =>
+        NavigationInitialSubjectRecommendation.Recommend(
+            root,
+            allLibraries: null,
+            [.. libraries]);
+
+    static NavigationInitialLibraryCandidate EqualCandidate(
+        NavigationInitialLibraryCandidate candidate) =>
+        new(
+            candidate.Subject,
+            candidate.IsPrimary,
+            [
+                .. candidate.Types.Select(
+                    type => new NavigationInitialTypeCandidate(
+                        type.Subject,
+                        type.Accessibility with
+                        {
+                            Count = type.Accessibility.Count + 7,
+                        })),
+            ]);
+
+    static NavigationInitialLibraryCandidate LibraryCandidate(
+        RealizedMemberCoordinate.Package coordinate,
+        string name,
+        bool isPrimary,
+        params (string Name, string Accessibility)[] types)
+    {
+        StructuralSubjectIdentity.LibrarySubject library =
+            StructuralSubjectIdentity.ForLibrary(
+                Library(coordinate, name));
+        return new NavigationInitialLibraryCandidate(
+            library,
+            isPrimary,
+            [
+                .. types.Select(
+                    type => new NavigationInitialTypeCandidate(
+                        StructuralSubjectIdentity.ForType(
+                            library,
+                            TypeName("Sample", type.Name)),
+                        ApiAccessibility.Classify(type.Accessibility))),
+            ]);
+    }
+
+    static RealizedMemberCoordinate.Package Coordinate(string version) =>
+        new(
+            "sample.package",
+            version,
+            "nuget-org",
+            "net11.0",
+            runtimeIdentifier: null);
+
+    static WorkspaceContextMember Library(
+        RealizedMemberCoordinate.Package coordinate,
+        string name)
+    {
+        ResolvedAssemblyReference assembly = ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                name,
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            path: null,
+            () => new MemoryStream([0], writable: false),
+            AssemblyResolutionProvenance.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier));
+        return new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            coordinate,
+            new AssemblyContextParticipant(
+                assembly,
+                NoResolverAssemblyBindingPolicy.Instance));
+    }
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        string name) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [name])).Name;
+}

--- a/src/DotnetInspector.Queries/NavigationInitialSubjectRecommendation.cs
+++ b/src/DotnetInspector.Queries/NavigationInitialSubjectRecommendation.cs
@@ -1,0 +1,253 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One trustworthy Type candidate in its producer-issued navigation order.
+/// </summary>
+public sealed record NavigationInitialTypeCandidate
+{
+    public NavigationInitialTypeCandidate(
+        StructuralSubjectIdentity.TypeSubject subject,
+        ApiAccessibilityBucket accessibility)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(accessibility);
+        ApiAccessibilityBucket? canonicalAccessibility =
+            ApiAccessibility.Values.FirstOrDefault(
+                value =>
+                    value.Id == accessibility.Id
+                    && value.Label == accessibility.Label
+                    && value.Order == accessibility.Order
+                    && value.IsDefault == accessibility.IsDefault);
+        if (accessibility.Count < 0
+            || canonicalAccessibility is null)
+        {
+            throw new ArgumentException(
+                "Type candidates require a product-owned accessibility bucket.",
+                nameof(accessibility));
+        }
+
+        Subject = subject;
+        Accessibility = canonicalAccessibility;
+    }
+
+    public StructuralSubjectIdentity.TypeSubject Subject { get; }
+    public ApiAccessibilityBucket Accessibility { get; }
+}
+
+/// <summary>
+/// One available Library and its trustworthy Types in producer order.
+/// </summary>
+public sealed record NavigationInitialLibraryCandidate
+{
+    public NavigationInitialLibraryCandidate(
+        StructuralSubjectIdentity.LibrarySubject subject,
+        bool isPrimary,
+        ImmutableArray<NavigationInitialTypeCandidate> types)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        if (types.IsDefault)
+        {
+            throw new ArgumentException(
+                "Type candidates must be an initialized immutable array.",
+                nameof(types));
+        }
+        foreach (NavigationInitialTypeCandidate? type in types)
+        {
+            if (type is null || type.Subject.Library != subject)
+            {
+                throw new ArgumentException(
+                    "Every Type candidate must belong to its containing Library.",
+                    nameof(types));
+            }
+        }
+
+        Subject = subject;
+        IsPrimary = isPrimary;
+        Types = types;
+    }
+
+    public StructuralSubjectIdentity.LibrarySubject Subject { get; }
+    public bool IsPrimary { get; }
+    public ImmutableArray<NavigationInitialTypeCandidate> Types { get; }
+
+    public bool Equals(NavigationInitialLibraryCandidate? other) =>
+        ReferenceEquals(this, other)
+        || other is not null
+        && Subject == other.Subject
+        && IsPrimary == other.IsPrimary
+        && Types.SequenceEqual(other.Types);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Subject);
+        hash.Add(IsPrimary);
+        foreach (NavigationInitialTypeCandidate type in Types)
+            hash.Add(type);
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>The exact preclassified input retained for initial recommendation.</summary>
+public sealed record NavigationInitialSubjectBasis
+{
+    internal NavigationInitialSubjectBasis(
+        StructuralSubjectIdentity.RootSubject root,
+        StructuralSubjectIdentity.AllLibrariesSubject? allLibraries,
+        ImmutableArray<NavigationInitialLibraryCandidate> libraries)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        if (libraries.IsDefault)
+        {
+            throw new ArgumentException(
+                "Library candidates must be an initialized immutable array.",
+                nameof(libraries));
+        }
+        if (allLibraries is not null
+            && allLibraries.Coordinate != root.Coordinate)
+        {
+            throw new ArgumentException(
+                "The aggregate Library candidate must belong to the Root coordinate.",
+                nameof(allLibraries));
+        }
+
+        var identities =
+            new HashSet<StructuralSubjectIdentity.LibrarySubject>();
+        bool hasPrimary = false;
+        foreach (NavigationInitialLibraryCandidate? library in libraries)
+        {
+            if (library is null
+                || library.Subject.Coordinate != root.Coordinate)
+            {
+                throw new ArgumentException(
+                    "Every Library candidate must belong to the Root coordinate.",
+                    nameof(libraries));
+            }
+            if (!identities.Add(library.Subject))
+            {
+                throw new ArgumentException(
+                    "Library candidates must have distinct exact identities.",
+                    nameof(libraries));
+            }
+            if (library.IsPrimary && hasPrimary)
+            {
+                throw new ArgumentException(
+                    "At most one Library candidate may be primary.",
+                    nameof(libraries));
+            }
+            hasPrimary |= library.IsPrimary;
+        }
+
+        Root = root;
+        AllLibraries = allLibraries;
+        Libraries = libraries;
+    }
+
+    public StructuralSubjectIdentity.RootSubject Root { get; }
+    public StructuralSubjectIdentity.AllLibrariesSubject? AllLibraries
+    {
+        get;
+    }
+    public ImmutableArray<NavigationInitialLibraryCandidate> Libraries
+    {
+        get;
+    }
+
+    public bool Equals(NavigationInitialSubjectBasis? other) =>
+        ReferenceEquals(this, other)
+        || other is not null
+        && Root == other.Root
+        && AllLibraries == other.AllLibraries
+        && Libraries.SequenceEqual(other.Libraries);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Root);
+        hash.Add(AllLibraries);
+        foreach (NavigationInitialLibraryCandidate library in Libraries)
+            hash.Add(library);
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>An exact recommended structural subject and its retained basis.</summary>
+public sealed record NavigationInitialSubjectOutcome
+{
+    internal NavigationInitialSubjectOutcome(
+        NavigationInitialSubjectBasis basis,
+        StructuralSubjectIdentity subject)
+    {
+        ArgumentNullException.ThrowIfNull(basis);
+        ArgumentNullException.ThrowIfNull(subject);
+        if (!Contains(basis, subject))
+        {
+            throw new ArgumentException(
+                "The recommended subject must occur in the retained basis.",
+                nameof(subject));
+        }
+
+        Basis = basis;
+        Subject = subject;
+    }
+
+    public NavigationInitialSubjectBasis Basis { get; }
+    public StructuralSubjectIdentity Subject { get; }
+
+    static bool Contains(
+        NavigationInitialSubjectBasis basis,
+        StructuralSubjectIdentity subject) =>
+        subject == basis.Root
+        || subject == basis.AllLibraries
+        || basis.Libraries.Any(
+            library =>
+                subject == library.Subject
+                || library.Types.Any(type => subject == type.Subject));
+}
+
+/// <summary>Pure product policy for an initial structural subject.</summary>
+public static class NavigationInitialSubjectRecommendation
+{
+    public static NavigationInitialSubjectOutcome Recommend(
+        StructuralSubjectIdentity.RootSubject root,
+        StructuralSubjectIdentity.AllLibrariesSubject? allLibraries,
+        ImmutableArray<NavigationInitialLibraryCandidate> libraries)
+    {
+        var basis = new NavigationInitialSubjectBasis(
+            root,
+            allLibraries,
+            libraries);
+        StructuralSubjectIdentity subject =
+            FindType(basis, isPrimary: true, isDefault: true)
+            ?? FindType(basis, isPrimary: false, isDefault: true)
+            ?? FindType(basis, isPrimary: true, isDefault: false)
+            ?? FindType(basis, isPrimary: false, isDefault: false)
+            ?? (StructuralSubjectIdentity?)basis.AllLibraries
+            ?? (StructuralSubjectIdentity?)basis.Libraries.FirstOrDefault(
+                library => library.IsPrimary)?.Subject
+            ?? (StructuralSubjectIdentity?)basis.Libraries
+                .FirstOrDefault()?.Subject
+            ?? basis.Root;
+        return new NavigationInitialSubjectOutcome(basis, subject);
+    }
+
+    static StructuralSubjectIdentity.TypeSubject? FindType(
+        NavigationInitialSubjectBasis basis,
+        bool isPrimary,
+        bool isDefault)
+    {
+        foreach (NavigationInitialLibraryCandidate library in basis.Libraries)
+        {
+            if (library.IsPrimary != isPrimary)
+                continue;
+            foreach (NavigationInitialTypeCandidate type in library.Types)
+            {
+                if (type.Accessibility.IsDefault == isDefault)
+                    return type.Subject;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Implement host-neutral initial structural-subject ranking over already
trustworthy Type candidates and already available Library candidates.

The policy now selects Type, then Library, then Root without browser-local
fallback. Type choice follows the exact primary-Library/accessibility tiers and
producer order; Library choice follows aggregate, primary, then declaration
order. Member is structurally excluded from initial outcomes.

## Design basis

Normative owner:
`docs/design/inspection-subject-navigation.md#initial-subject` and
`#initial-library-and-root`.

Supporting contracts:

- `StructuralSubjectIdentity` supplies exact Root, Library, and Type identity.
- `ApiAccessibility` supplies the product-owned default-accessibility
  descriptor.
- Workspace acquisition supplies exact coordinate and acquired-Library
  identity.
- Inspect Web remains a future consumer and does not participate in ranking.

The Navigation TLA+ models intentionally treat subjects as opaque and do not
claim this pure identity-ranking policy.

## Demo

```text
Primary non-default vs other default: OtherPublic
Root-only coordinate: Root
```

The first case demonstrates that the product tier table outranks primary
Library preference: an other-Library default-accessibility Type beats a
primary-Library non-default Type. The neighboring root-only case demonstrates
that a valid coordinate needs no host-invented fallback.

## Implementation

- Add immutable exact Type and Library candidate shapes.
- Retain the complete Root, aggregate, Library, Type, primary-role, and
  accessibility basis.
- Canonicalize per-Type accessibility to `ApiAccessibility.Values`, excluding
  irrelevant per-surface bucket counts from basis equality.
- Validate initialized arrays, coordinate ownership, Type-to-Library
  containment, distinct Libraries, one primary Library at most, and
  product-owned accessibility descriptors.
- Rank the four Type tiers without sorting producer input.
- Fall back through All Libraries, primary Library, first Library, then Root.
- Reject any outcome subject absent from the retained basis, which
  structurally prevents implicit Member selection.

## Boundaries

This slice consumes candidates already classified as trustworthy and
available. Producer trust, unavailable/failed evidence, inventory extraction,
activation, reconciliation, revisions, retained sessions, restoration, and
inspect-web composition remain explicitly unverified.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -class DotnetInspector.Queries.Tests.NavigationInitialSubjectRecommendationTests`
  — 4/4 passed
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  — 985/985 passed
- `npx markdownlint-cli docs/design/inspection-subject-navigation.md`
- `git diff --check origin/main...HEAD`
- Consumer demo shown above
- Pre-publication GPT-5.6 Sol code review: clean

Focused mutations confirmed the gates fail when Type tiers are swapped,
producer order is reversed, nested immutable-array equality regresses to
backing-array identity, accessibility counts leak into basis equality, or
retained-basis membership is removed.

Closes #5410.
