### PR TITLE
Keep RID implementation assets out of compile fallback

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -1870,6 +1870,11 @@ Here, a compile asset is a package assembly selected as a compile-time
 reference; a focused description of
 [NuGet package structure and asset roles](https://github.com/richlander/dotnet-inspect/issues/5294)
 is tracked separately.
+When no real reference group supplies the selected framework, compile fallback
+uses that framework's neutral `lib` assets. RID-specific
+`runtimes/<rid>/lib/<tfm>` replacement applies only to the independently
+selected implementation role, so one neutral library compile asset may
+correspond to a different RID-specific implementation asset.
 
 The related identity concepts have distinct jobs:
 
@@ -1958,6 +1963,11 @@ folders, and resolved framework/RID correspondence are gated by
 `PackageRootBinding_UnrepresentableSelectionTargetUsesFrameworkNeutralCoordinate`,
 `PackageRootBinding_ResolvedCoordinatePreservesAcquisitionTargetAndRuntime`,
 and `PackageRootBinding_SourceRuntimeRequiresFramework`.
+Neutral-library compile fallback and RID-specific implementation
+correspondence are gated by
+`RidSpecificImplementation_DoesNotReplaceLibraryCompileFallback` and
+`RidSpecificImplementation_UsesSeparateNeutralCompileRole`; Browser adoption
+is gated by `RidSpecificPackage_SeparatesCompileAndImplementationAssets`.
 
 Compile-library availability is a capability of that Root, not a precondition
 for the Root to exist. The host workspace retains every requested Root.

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1392,6 +1392,49 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public void RidSpecificPackage_SeparatesCompileAndImplementationAssets()
+    {
+        const string packageId = "Rid.Specific";
+        byte[] image =
+            File.ReadAllBytes(
+                typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        var package = new BrowserPackage(
+            packageId,
+            "1.0.0",
+            PackageEntries(
+                ("lib/net11.0/Rid.Specific.dll", image),
+                ("runtimes/linux-x64/lib/net11.0/Rid.Specific.dll", image)),
+            fromCache: false);
+        var coordinate = new BrowserPackageCoordinate(
+            package,
+            new PackageRootRealization(
+                package.Content,
+                packageId,
+                package.Version,
+                "net11.0",
+                "linux-x64"));
+
+        PackageCompileAsset compile =
+            coordinate.CompileAsset("Rid.Specific.dll");
+        Assert.Equal("lib/net11.0/Rid.Specific.dll", compile.Path);
+        Assert.Equal(
+            "runtimes/linux-x64/lib/net11.0/Rid.Specific.dll",
+            coordinate.ImplementationAsset("Rid.Specific.dll").Path);
+        using var scope = new BrowserInspectionScope([coordinate]);
+        BrowserWorkspaceParticipant surface =
+            Assert.Single(scope.SurfaceParticipants);
+        BrowserWorkspaceParticipant implementation =
+            Assert.Single(scope.ImplementationParticipants);
+        Assert.Equal(compile.Path, surface.Asset.Path);
+        Assert.Equal(
+            "runtimes/linux-x64/lib/net11.0/Rid.Specific.dll",
+            implementation.Asset.Path);
+        Assert.Same(
+            implementation,
+            scope.ImplementationParticipant(surface));
+    }
+
+    [Fact]
     public async Task PackageFrameworkUnavailability_DoesNotEmitArtifactFramework()
     {
         const char bidi = '\u202E';

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1398,11 +1398,15 @@ public sealed class BrowserEngineBoundaryTests
         byte[] image =
             File.ReadAllBytes(
                 typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        byte[] unrelatedImage =
+            File.ReadAllBytes(
+                typeof(PackageAssemblyContextRealization).Assembly.Location);
         var package = new BrowserPackage(
             packageId,
             "1.0.0",
             PackageEntries(
                 ("lib/net11.0/Rid.Specific.dll", image),
+                ("lib/net11.0/shadow/Rid.Specific.dll", unrelatedImage),
                 ("runtimes/linux-x64/lib/net11.0/Rid.Specific.dll", image)),
             fromCache: false);
         var coordinate = new BrowserPackageCoordinate(
@@ -1424,11 +1428,18 @@ public sealed class BrowserEngineBoundaryTests
         BrowserWorkspaceParticipant surface =
             Assert.Single(scope.SurfaceParticipants);
         BrowserWorkspaceParticipant implementation =
-            Assert.Single(scope.ImplementationParticipants);
+            scope.ImplementationParticipants.Single(candidate =>
+                candidate.Asset.Path
+                    == "runtimes/linux-x64/lib/net11.0/Rid.Specific.dll");
         Assert.Equal(compile.Path, surface.Asset.Path);
         Assert.Equal(
             "runtimes/linux-x64/lib/net11.0/Rid.Specific.dll",
             implementation.Asset.Path);
+        Assert.Contains(
+            scope.ImplementationParticipants,
+            candidate =>
+                candidate.Asset.Path
+                    == "lib/net11.0/shadow/Rid.Specific.dll");
         Assert.Same(
             implementation,
             scope.ImplementationParticipant(surface));

--- a/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageWorkspace.cs
@@ -1727,16 +1727,13 @@ internal sealed class BrowserPackageCoordinate
     }
 
     /// <summary>
-    /// The implementation assembly for one assembly name. Reference assemblies carry no method
-    /// bodies, so body-backed work resolves the matching asset from the shared effective
-    /// implementation universe rather than reasoning about package paths.
+    /// The implementation assembly for one assembly name. Body-backed work resolves the matching
+    /// asset from the shared effective implementation universe rather than reasoning about
+    /// package paths.
     /// </summary>
     public PackageCompileAsset ImplementationAsset(string assemblyIdOrName)
     {
         PackageCompileAsset selected = CompileAsset(assemblyIdOrName);
-        if (selected.Kind == PackageCompileAssetKind.Library)
-            return selected;
-
         return Selection.FindImplementationAsset(selected)
             ?? throw new InvalidOperationException(
                 $"The requested compile assembly in {PackageId} {Version} is a reference "

--- a/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
+++ b/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
@@ -75,8 +75,9 @@ public sealed record PackageCompileAssetSelection(
     }
 
     /// <summary>
-    /// Finds the implementation counterpart of one selected compile asset. A library asset is
-    /// its own counterpart; a reference asset matches by framework and assembly name.
+    /// Finds the implementation counterpart of one selected compile asset. An exact retained
+    /// library asset is its own counterpart; otherwise correspondence uses assembly name so a
+    /// neutral library compile fallback can map to its RID-specific implementation replacement.
     /// </summary>
     public PackageCompileAsset? FindImplementationAsset(PackageCompileAsset compileAsset)
     {
@@ -88,9 +89,9 @@ public sealed record PackageCompileAssetSelection(
                 nameof(compileAsset));
         }
 
-        return compileAsset.Kind == PackageCompileAssetKind.Library
-            ? compileAsset
-            : ImplementationAssets.FirstOrDefault(asset =>
+        return ImplementationAssets.FirstOrDefault(asset =>
+                   asset.Id.Equals(compileAsset.Id, StringComparison.Ordinal))
+            ?? ImplementationAssets.FirstOrDefault(asset =>
                 asset.AssemblyName.Equals(
                     compileAsset.AssemblyName,
                     StringComparison.OrdinalIgnoreCase));
@@ -248,12 +249,21 @@ public static class PackageCompileAssetSelector
 
         bool hasReferenceAssets = frameworkAssets.Any(
             asset => asset.Kind == PackageCompileAssetKind.Reference);
+        PackageCompileAsset[] libraryFallback =
+        [
+            .. frameworkAssets
+                .Where(asset => asset.Kind == PackageCompileAssetKind.Library)
+                .Select(asset =>
+                    implementationAssets.FirstOrDefault(candidate =>
+                        candidate.Id.Equals(asset.Id, StringComparison.Ordinal))
+                    ?? asset),
+        ];
         PackageCompileAsset[] selected =
         [
             .. (hasReferenceAssets
                     ? frameworkAssets.Where(
                         asset => asset.Kind == PackageCompileAssetKind.Reference)
-                    : implementationAssets)
+                    : libraryFallback)
                 .OrderBy(asset => asset.Path, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(asset => asset.Path, StringComparer.Ordinal),
         ];

--- a/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
+++ b/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
@@ -76,8 +76,8 @@ public sealed record PackageCompileAssetSelection(
 
     /// <summary>
     /// Finds the implementation counterpart of one selected compile asset. An exact retained
-    /// library asset is its own counterpart; otherwise correspondence uses assembly name so a
-    /// neutral library compile fallback can map to its RID-specific implementation replacement.
+    /// library asset is its own counterpart; otherwise correspondence uses the selector-owned
+    /// relative path so a neutral compile asset maps only to its RID-specific replacement.
     /// </summary>
     public PackageCompileAsset? FindImplementationAsset(PackageCompileAsset compileAsset)
     {
@@ -89,12 +89,43 @@ public sealed record PackageCompileAssetSelection(
                 nameof(compileAsset));
         }
 
-        return ImplementationAssets.FirstOrDefault(asset =>
-                   asset.Id.Equals(compileAsset.Id, StringComparison.Ordinal))
-            ?? ImplementationAssets.FirstOrDefault(asset =>
-                asset.AssemblyName.Equals(
-                    compileAsset.AssemblyName,
-                    StringComparison.OrdinalIgnoreCase));
+        PackageCompileAsset? exact =
+            ImplementationAssets.FirstOrDefault(asset =>
+                asset.Id.Equals(compileAsset.Id, StringComparison.Ordinal));
+        if (exact is not null)
+            return exact;
+
+        string? relativePath = TryGetRelativePath(compileAsset);
+        return relativePath is null
+            ? null
+            : ImplementationAssets.FirstOrDefault(asset =>
+                TryGetRelativePath(asset)?.Equals(
+                    relativePath,
+                    StringComparison.OrdinalIgnoreCase)
+                is true);
+    }
+
+    static string? TryGetRelativePath(PackageCompileAsset asset)
+    {
+        string[] segments = asset.Path.Split('/');
+        if (segments.Length >= 3
+            && (segments[0].Equals("ref", StringComparison.OrdinalIgnoreCase)
+                || segments[0].Equals("lib", StringComparison.OrdinalIgnoreCase))
+            && segments[1].Equals(
+                asset.TargetFramework,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Join('/', segments[2..]);
+        }
+
+        return segments.Length >= 5
+            && segments[0].Equals("runtimes", StringComparison.OrdinalIgnoreCase)
+            && segments[2].Equals("lib", StringComparison.OrdinalIgnoreCase)
+            && segments[3].Equals(
+                asset.TargetFramework,
+                StringComparison.OrdinalIgnoreCase)
+                ? string.Join('/', segments[4..])
+                : null;
     }
 }
 

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -579,13 +579,16 @@ public sealed class PackageAssemblyContextRealizationTests
     [Fact]
     public void RidSpecificImplementation_UsesSeparateNeutralCompileRole()
     {
-        byte[] image =
-            File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
+        byte[] selectedImage =
+            IntegrationAssembly("Rid.Sample", "SelectedType");
+        byte[] unrelatedImage =
+            IntegrationAssembly("Unrelated.Rid.Sample", "UnrelatedType");
         PackageRootRealization package = new(
             new InMemoryPackageContent(
                 Archive(
-                    ("lib/net11.0/Rid.Sample.dll", image),
-                    ("runtimes/linux-x64/lib/net11.0/Rid.Sample.dll", image)),
+                    ("lib/net11.0/Rid.Sample.dll", selectedImage),
+                    ("lib/net11.0/shadow/Rid.Sample.dll", unrelatedImage),
+                    ("runtimes/linux-x64/lib/net11.0/Rid.Sample.dll", selectedImage)),
                 fromCache: false,
                 producerKey: "tests"),
             "Rid.Sample",
@@ -602,11 +605,18 @@ public sealed class PackageAssemblyContextRealizationTests
         PackageAssemblyRoleParticipant surface =
             Assert.Single(realization.SurfaceParticipants);
         PackageAssemblyRoleParticipant implementation =
-            Assert.Single(realization.ImplementationParticipants);
+            realization.ImplementationParticipants.Single(candidate =>
+                candidate.Asset.Path
+                    == "runtimes/linux-x64/lib/net11.0/Rid.Sample.dll");
         Assert.Equal("lib/net11.0/Rid.Sample.dll", surface.Asset.Path);
         Assert.Equal(
             "runtimes/linux-x64/lib/net11.0/Rid.Sample.dll",
             implementation.Asset.Path);
+        Assert.Contains(
+            realization.ImplementationParticipants,
+            candidate =>
+                candidate.Asset.Path
+                    == "lib/net11.0/shadow/Rid.Sample.dll");
         Assert.Same(
             implementation,
             realization.ImplementationParticipant(surface));

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -436,12 +436,16 @@ public sealed class PackageAssemblyContextRealizationTests
         Assert.Equal("linux-x64", binding.Coordinate.RuntimeIdentifier);
         Assert.Equal("net10.0", binding.Root.RequestedTargetFramework);
         Assert.Equal(
-            ["runtimes/linux-x64/lib/net10.0/Net10.dll"],
+            ["lib/net10.0/Net10.dll"],
             binding.Root.AssetSelection.Assets.Select(asset => asset.Path));
         Assert.Equal(
             ["runtimes/linux-x64/lib/net10.0/Net10.dll"],
             binding.Root.AssetSelection.ImplementationAssets.Select(
                 asset => asset.Path));
+        Assert.Equal(
+            "runtimes/linux-x64/lib/net10.0/Net10.dll",
+            binding.Root.AssetSelection.FindImplementationAsset(
+                Assert.Single(binding.Root.AssetSelection.Assets))!.Path);
         Assert.Equal(
             "linux-x64",
             binding.Root.RequestedRuntimeIdentifier);
@@ -567,6 +571,42 @@ public sealed class PackageAssemblyContextRealizationTests
         PackageAssemblyRoleParticipant implementation =
             Assert.Single(realization.ImplementationParticipants);
         Assert.Same(surface.Participant, implementation.Participant);
+        Assert.Same(
+            implementation,
+            realization.ImplementationParticipant(surface));
+    }
+
+    [Fact]
+    public void RidSpecificImplementation_UsesSeparateNeutralCompileRole()
+    {
+        byte[] image =
+            File.ReadAllBytes(typeof(PackageAssemblyContextRealizationTests).Assembly.Location);
+        PackageRootRealization package = new(
+            new InMemoryPackageContent(
+                Archive(
+                    ("lib/net11.0/Rid.Sample.dll", image),
+                    ("runtimes/linux-x64/lib/net11.0/Rid.Sample.dll", image)),
+                fromCache: false,
+                producerKey: "tests"),
+            "Rid.Sample",
+            "1.0.0",
+            Framework,
+            "linux-x64");
+        using var workspace = new InspectionWorkspace();
+        using PackageAssemblyContextRealization realization =
+            workspace.RealizePackageAssemblyContextRoles(
+                [package],
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(realization.SharesGroup);
+        PackageAssemblyRoleParticipant surface =
+            Assert.Single(realization.SurfaceParticipants);
+        PackageAssemblyRoleParticipant implementation =
+            Assert.Single(realization.ImplementationParticipants);
+        Assert.Equal("lib/net11.0/Rid.Sample.dll", surface.Asset.Path);
+        Assert.Equal(
+            "runtimes/linux-x64/lib/net11.0/Rid.Sample.dll",
+            implementation.Asset.Path);
         Assert.Same(
             implementation,
             realization.ImplementationParticipant(surface));

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
@@ -705,10 +705,6 @@ public sealed partial class InspectionWorkspace
         var implementationsByAsset = new Dictionary<RoleAsset, RoleAssembly>(
             implementations.Length,
             RoleAssetIdentityComparer.Instance);
-        var implementationsByName =
-            new Dictionary<ImplementationNameKey, RoleAsset>(
-                implementations.Length,
-                ImplementationNameKeyComparer.Instance);
         foreach (RoleAssembly implementation in implementations)
         {
             var roleAsset = new RoleAsset(
@@ -720,33 +716,23 @@ public sealed partial class InspectionWorkspace
                 throw new InvalidOperationException(
                     "Package asset selection produced duplicate implementation role assets.");
             }
-            implementationsByName.TryAdd(
-                new ImplementationNameKey(
-                    implementation.Package,
-                    implementation.Asset.AssemblyName),
-                roleAsset);
         }
 
         var pairs =
             ImmutableArray.CreateBuilder<PackageAssemblyRoleCorrespondence>();
         foreach (RoleAssembly surface in surfaces)
         {
-            RoleAsset implementationAsset;
-            if (surface.Asset.Kind == PackageCompileAssetKind.Library)
-            {
-                implementationAsset = new RoleAsset(
-                    surface.PackageIndex,
-                    surface.Package,
+            PackageCompileAsset? selectedImplementation =
+                surface.Package.AssetSelection.FindImplementationAsset(
                     surface.Asset);
-            }
-            else if (!implementationsByName.TryGetValue(
-                new ImplementationNameKey(
-                    surface.Package,
-                    surface.Asset.AssemblyName),
-                out implementationAsset!))
+            if (selectedImplementation is null)
             {
                 continue;
             }
+            var implementationAsset = new RoleAsset(
+                surface.PackageIndex,
+                surface.Package,
+                selectedImplementation);
 
             if (!implementationsByAsset.TryGetValue(
                 implementationAsset,
@@ -832,10 +818,6 @@ public sealed partial class InspectionWorkspace
         PackageRootRealization Package,
         PackageCompileAsset Asset);
 
-    sealed record ImplementationNameKey(
-        PackageRootRealization Package,
-        string AssemblyName);
-
     sealed class RoleAssetIdentityComparer : IEqualityComparer<RoleAsset>
     {
         internal static RoleAssetIdentityComparer Instance { get; } = new();
@@ -853,28 +835,6 @@ public sealed partial class InspectionWorkspace
             HashCode.Combine(
                 RuntimeHelpers.GetHashCode(asset.Package),
                 StringComparer.Ordinal.GetHashCode(asset.Asset.Path));
-    }
-
-    sealed class ImplementationNameKeyComparer :
-        IEqualityComparer<ImplementationNameKey>
-    {
-        internal static ImplementationNameKeyComparer Instance { get; } = new();
-
-        public bool Equals(
-            ImplementationNameKey? left,
-            ImplementationNameKey? right) =>
-            ReferenceEquals(left, right)
-            || (left is not null
-                && right is not null
-                && ReferenceEquals(left.Package, right.Package)
-                && left.AssemblyName.Equals(
-                    right.AssemblyName,
-                    StringComparison.OrdinalIgnoreCase));
-
-        public int GetHashCode(ImplementationNameKey key) =>
-            HashCode.Combine(
-                RuntimeHelpers.GetHashCode(key.Package),
-                StringComparer.OrdinalIgnoreCase.GetHashCode(key.AssemblyName));
     }
 
     internal sealed record RoleAssembly(

--- a/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
@@ -72,6 +72,41 @@ public class PackageCompileAssetSelectorTests : IDisposable
     }
 
     [Fact]
+    public void RidSpecificImplementation_DoesNotReplaceLibraryCompileFallback()
+    {
+        IPackageContent content = InMemory(
+            "lib/net8.0/Example.dll",
+            "lib/net8.0/Example.Companion.dll",
+            "runtimes/linux-x64/lib/net8.0/Example.dll");
+
+        PackageCompileAssetSelection selection =
+            PackageCompileAssetSelector.Select(
+                content,
+                "Example",
+                "net8.0",
+                "linux-x64");
+
+        Assert.True(selection.IsSelected);
+        Assert.Equal(
+            ["lib/net8.0/Example.Companion.dll", "lib/net8.0/Example.dll"],
+            selection.Assets.Select(asset => asset.Path));
+        Assert.Equal(
+            [
+                "lib/net8.0/Example.Companion.dll",
+                "runtimes/linux-x64/lib/net8.0/Example.dll",
+            ],
+            selection.ImplementationAssets.Select(asset => asset.Path));
+        Assert.Equal("lib/net8.0/Example.dll", selection.DefaultAsset!.Path);
+        Assert.Equal(
+            "runtimes/linux-x64/lib/net8.0/Example.dll",
+            selection.FindImplementationAsset(selection.DefaultAsset)!.Path);
+        PackageCompileAsset companion = selection.Assets[0];
+        Assert.Same(
+            companion,
+            selection.FindImplementationAsset(companion));
+    }
+
+    [Fact]
     public void ReferenceSelection_UsesSharedImplementationFrameworkReduction()
     {
         IPackageContent content = InMemory(

--- a/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
@@ -77,6 +77,7 @@ public class PackageCompileAssetSelectorTests : IDisposable
         IPackageContent content = InMemory(
             "lib/net8.0/Example.dll",
             "lib/net8.0/Example.Companion.dll",
+            "lib/net8.0/shadow/Example.dll",
             "runtimes/linux-x64/lib/net8.0/Example.dll");
 
         PackageCompileAssetSelection selection =
@@ -93,6 +94,7 @@ public class PackageCompileAssetSelectorTests : IDisposable
         Assert.Equal(
             [
                 "lib/net8.0/Example.Companion.dll",
+                "lib/net8.0/shadow/Example.dll",
                 "runtimes/linux-x64/lib/net8.0/Example.dll",
             ],
             selection.ImplementationAssets.Select(asset => asset.Path));


### PR DESCRIPTION
## Summary

- Keep compile fallback on the selected framework's neutral `lib/<tfm>`
  assets instead of allowing exact-RID implementation replacement to change
  the compile surface.
- Retain RID-aware implementation selection and make the selector's typed
  correspondence authoritative for workspace realization.
- Apply the same correspondence in the Browser package adapter so body-backed
  operations use the RID-specific implementation while API/surface operations
  use the neutral compile asset.

## Demo

The new gates use a package containing both:

```text
lib/net11.0/Rid.Sample.dll
lib/net11.0/shadow/Rid.Sample.dll
runtimes/linux-x64/lib/net11.0/Rid.Sample.dll
```

For a `net11.0` / `linux-x64` request:

| Role | Before | After |
| --- | --- | --- |
| Compile/surface | `runtimes/linux-x64/lib/net11.0/Rid.Sample.dll` | `lib/net11.0/Rid.Sample.dll` |
| Implementation | `runtimes/linux-x64/lib/net11.0/Rid.Sample.dll` | RID asset plus unrelated nested asset |
| Correspondence | Shared runtime asset | Neutral root surface maps only to its same-relative-path RID replacement |

Run the focused product gate:

```bash
dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -method 'DotnetInspector.Queries.Tests.PackageAssemblyContextRealizationTests.RidSpecificImplementation_UsesSeparateNeutralCompileRole'
```

What to notice: RID selection still changes implementation evidence, but no
longer changes the compile/API surface, and an unrelated nested asset with the
same filename cannot capture correspondence. The neighboring no-RID,
real-reference, and explicit-empty-reference-group scenarios remain unchanged.

## Compatibility

No-RID library fallback still shares one surface/implementation role. Real
`ref` assets remain preferred, and applicable `ref/<tfm>/_._` groups still
suppress library fallback. A package without a neutral compile asset does not
gain a compile surface merely from a RID-specific runtime asset.

## NuGet grounding

- [NuGet's asset-selection guidance](https://learn.microsoft.com/en-us/nuget/create-packages/native-files-in-net-packages#understanding-nuget-package-asset-selection)
  defines compile assets as `ref/{tfm}` falling back to `lib/{tfm}`, runtime
  assets as `runtimes/{rid}/lib/{tfm}` falling back to `lib/{tfm}`, and states
  that NuGet has no RID-specific compile-assembly capability.
- [`ManagedCodeConventions`](https://github.com/NuGet/NuGet.Client/blob/a173713d680ed2f40600034599e2c41108ca0c59/src/NuGet.Core/NuGet.Packaging/ContentModel/ManagedCodeConventions.cs#L517-L553)
  encodes RID-aware runtime patterns separately from compile `ref` and `lib`
  patterns.
- [`LockFileUtils`](https://github.com/NuGet/NuGet.Client/blob/a173713d680ed2f40600034599e2c41108ca0c59/src/NuGet.Core/NuGet.Commands/RestoreCommand/Utility/LockFileUtils.cs#L220-L240)
  applies `ref`-before-`lib` compile selection and runtime selection as
  distinct operations.

These references ground the role separation. dotnet-inspect's exact-RID,
no-RID-fallback implementation universe remains its deliberately narrower
product contract; relative-path correspondence follows that selector-owned
replacement identity rather than claiming complete NuGet restore parity.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
- `dotnet run --project prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release`
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md`
- `git diff --check`

Closes #5423
