### PR TITLE
Implement artifact content access quiescence

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -382,20 +382,27 @@ opens, so the target design registers each admitted open atomically with
 generation end, runs its potentially blocking opener after registration, ends
 access immediately at termination, cancels registered openers and an in-flight
 materialization read it owns, and releases acquisition leases only at content
-quiescence. The target configurations pass safety and
-liveness; three committed current-mechanics configurations produce
+quiescence. Source and retained-content openers therefore accept the
+generation owner's cancellation token; a potentially blocking opener must
+observe it promptly without depending on a worker thread. Admission stream
+wrappers combine that token with the caller token for asynchronous
+materialization reads. Returned query streams are the
+intentional exception: they remain readable after generation end and pin
+backing leases until disposal. `DisposeAsync` has no timeout and remains
+incomplete for an abandoned query stream; query consumers are required to
+dispose every returned stream. This follows the repository's
+`AssemblyContextGroup` gate-and-active-count release pattern and its
+`NuGetOperationDeadline.DeadlineStream` linked-cancellation pattern, while
+preserving the artifact contract's longer-lived returned stream.
+The target configurations pass safety and liveness; three committed
+current-mechanics configurations produce
 counterexamples showing an open can complete after `EndGeneration`, a
 disposal racing `SealAsync` disposes acquisition leases under an active
 materialization read, and leases can be released while a published
 generation's query stream is open. Its `README.md` records the checked
-bounds, results, assumptions, and the three termination-policy obligations it
-exposes: a registered opener must be owner-interruptible (today
-`OpenReadable` invokes a synchronous `Func<Stream>` with no cancellation or
-bounded-completion contract), an in-flight materialization read must likewise
-be owner-interruptible (today it awaits `Stream.ReadAsync` with only the caller
-token), and abandoned returned query streams need a stated policy (bound the
-wait, or invalidate visibly). These results establish evidence about the
-model, not the implementation.
+bounds, results, assumptions, and the three termination-policy obligations
+enforced by this contract. These results establish evidence about the model,
+not the implementation.
 
 ### Supplemental acquisition bridge
 
@@ -2418,7 +2425,16 @@ The target is complete only when tests equivalent to these exist:
 - `ArtifactSetSession_DisposalDuringAcquisitionDisposesLateLease`
 - `ArtifactSetSession_SealRejectsAcquisitionInProgress`
 - `ArtifactSetSession_DisposalDuringSealCannotPublish`
+- `ArtifactAccess_OpenRegistrationIsAtomicWithGenerationEnd`
+- `ArtifactAccess_RetainedOpenerIsCancelledAfterGateAdmission`
+- `ArtifactAccess_AuthorizationReplacementIsAtomicWithOpenRegistration`
+- `ArtifactAccess_LeaseDisposalIsAtomicWithOpenRegistration`
+- `ArtifactAccess_ReturnedStreamKeepsGenerationAliveUntilDisposed`
+- `ArtifactAccess_StreamDisposalFailureStillReportsQuiescence`
+- `ArtifactAccess_MaterializationReadPreservesCallerCancellation`
 - `ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce`
+- `ArtifactSetSession_DisposalCancelsInFlightMaterialization`
+- `ArtifactSetSession_CancellationCallbackFailureDoesNotSkipLeaseCleanup`
 - `ArtifactSetSession_PreservesPrimaryFailureWhenCleanupFails`
 - `SupplementalAcquisition_RequiredCheckpointPreservesSealOutcome`
 - `SupplementalAcquisition_SealUsesCheckpointedSnapshots`
@@ -2542,6 +2558,12 @@ checkpoint, reuse of checkpointed snapshots, finite pre-adapter capacity,
 empty-batch lease ownership, exact visible failure, atomic scoped nonempty
 admission, validation-failure cleanup, termination cleanup, late-diagnostic
 projection, and cancellation preservation.
+The seven named `ArtifactAccess_*` gates and three
+`ArtifactSetSession_*` content-quiescence gates enforce gate-atomic open and
+lease-disposal admission, owner interruption of stalled opening and
+materialization, returned-stream validity through generation end, deferred
+acquisition-lease release, and quiescence reporting even when stream cleanup
+fails.
 `LocalOnlyHost_InspectsCallerSuppliedLocalAssembly`
 deletes its temporary source after publication, then passes an
 `ArtifactContentReference`'s guarded published snapshot opener to Metadata, so
@@ -2554,8 +2576,7 @@ explicit-empty-group cases, including typed compile-library absence, package
 documents, manifest dependencies, and no fabricated default assembly.
 
 Workspace-wide admission budgets, single-flight/reentrancy, content digests,
-dependent-group quiescence, and Metadata consumption of workspace roles remain
-unverified.
+and Metadata consumption of workspace roles remain unverified.
 
 ## Non-goals
 

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -384,9 +384,11 @@ access immediately at termination, cancels registered openers and an in-flight
 materialization read it owns, and releases acquisition leases only at content
 quiescence. Source and retained-content openers therefore accept the
 generation owner's cancellation token; a potentially blocking opener must
-observe it promptly without depending on a worker thread. Admission stream
-wrappers combine that token with the caller token for asynchronous
-materialization reads. Returned query streams are the
+observe it promptly without depending on a worker thread. The token is scoped
+to opener execution and detached under the authority gate before a successful
+stream escapes; it is not a returned-stream lifetime signal. Admission stream
+wrappers separately combine generation cancellation with the caller token for
+asynchronous materialization reads. Returned query streams are the
 intentional exception: they remain readable after generation end and pin
 backing leases until disposal. `DisposeAsync` has no timeout and remains
 incomplete for an abandoned query stream; query consumers are required to
@@ -2430,6 +2432,7 @@ The target is complete only when tests equivalent to these exist:
 - `ArtifactAccess_AuthorizationReplacementIsAtomicWithOpenRegistration`
 - `ArtifactAccess_LeaseDisposalIsAtomicWithOpenRegistration`
 - `ArtifactAccess_ReturnedStreamKeepsGenerationAliveUntilDisposed`
+- `ArtifactAccess_RetainedOpenerCancellationEndsAtCallbackReturn`
 - `ArtifactAccess_StreamDisposalFailureStillReportsQuiescence`
 - `ArtifactAccess_MaterializationReadPreservesCallerCancellation`
 - `ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce`
@@ -2558,7 +2561,7 @@ checkpoint, reuse of checkpointed snapshots, finite pre-adapter capacity,
 empty-batch lease ownership, exact visible failure, atomic scoped nonempty
 admission, validation-failure cleanup, termination cleanup, late-diagnostic
 projection, and cancellation preservation.
-The seven named `ArtifactAccess_*` gates and three
+The eight named `ArtifactAccess_*` gates and three
 `ArtifactSetSession_*` content-quiescence gates enforce gate-atomic open and
 lease-disposal admission, owner interruption of stalled opening and
 materialization, returned-stream validity through generation end, deferred
@@ -2576,7 +2579,8 @@ explicit-empty-group cases, including typed compile-library absence, package
 documents, manifest dependencies, and no fabricated default assembly.
 
 Workspace-wide admission budgets, single-flight/reentrancy, content digests,
-and Metadata consumption of workspace roles remain unverified.
+assembly-group reporting into session quiescence, and Metadata consumption of
+workspace roles remain unverified.
 
 ## Non-goals
 

--- a/docs/design/models/artifact-generation-access/README.md
+++ b/docs/design/models/artifact-generation-access/README.md
@@ -181,7 +181,9 @@ java -cp /path/to/tla2tools.jar tlc2.TLC \
 - The target design's liveness carries three obligations now stated by the
   owning document. A registered opener receives and must observe the owner's
   cancellation token whenever it may block, without depending on a worker
-  thread. An in-flight
+  thread. That token is opener-scoped and is detached before a successful
+  returned stream escapes; returned-stream lifetime remains represented by
+  the access registration. An in-flight
   asynchronous materialization read combines caller and owner cancellation.
   Returned query streams remain valid after generation end and pin release
   until disposal; there is deliberately no timeout or invisible invalidation,

--- a/docs/design/models/artifact-generation-access/README.md
+++ b/docs/design/models/artifact-generation-access/README.md
@@ -32,49 +32,42 @@ models demand admission, single-flight joining, and disposal-forced draining,
 and treats "the dependent group reports quiescent" as an abstract given event
 (its `GroupBecomesQuiescent` action). This model is about what quiescence must
 mean for content access — registered opener callbacks, materialization reads,
-and returned streams — and shows that the current mechanics have no way to
-observe it. The two models share no state; each names the other's scope as a
-non-claim.
+and returned streams — and shows that the pre-implementation mechanics had no way to observe it. The
+two models share no state; each names the other's scope as a non-claim.
 
-## Current mechanics versus target design
+## Pre-implementation mechanics versus target design
 
-Two constant-selected policy dimensions separate the shipped mechanics
-(`src/DotnetInspector.Artifacts/ArtifactAccess.cs`,
-`src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs`) from the
-design intent:
+Two constant-selected policy dimensions preserve the pre-implementation
+mechanics as counterexample configurations and the implemented target in
+`src/DotnetInspector.Artifacts/ArtifactAccess.cs` and
+`src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs` as positive
+configurations:
 
-- **`OpenMode`.** `"Recheck"` (current): `ArtifactContribution.OpenRead`
-  (`ArtifactAccess.cs:142`) and `RetainedArtifactContent.OpenRead`
-  (`ArtifactAccess.cs:190`) validate volatile flags outside the authority
-  gate (`ArtifactAccessLease.EnsureAccess`, `ArtifactAccess.cs:568`) and then
-  run the opener unconditionally, so an open can complete strictly after
-  `EndGeneration` (`ArtifactAccess.cs:399`) despite its contract to reject
-  "every future open or mint". `"Gated"` (target): registering an open is
-  atomic with the ended decision; the potentially blocking opener runs after
-  registration and before a stream is returned.
-- **`ReleaseMode`.** `"Immediate"` (current):
-  `ArtifactSetSession.TerminateAsync` (`ArtifactSetSession.cs:627`) sets the
-  disposed state, calls `EndGeneration` (line 654), and disposes every
-  acquisition lease (line 657) without waiting for an in-flight sealing read
-  (`MaterializeAsync`, `ArtifactSetSession.cs:577`) or an open query stream.
-  `"AwaitQuiescence"` (target): termination ends the generation immediately
-  — closing new access, exactly as `EndGeneration` documents — cancels
-  registered opener callbacks and an in-flight materialization read it owns,
-  and releases acquisition leases only once no registered opener, read, or
-  returned stream remains.
+- **`OpenMode`.** `"Recheck"` preserves the former validate-then-open window,
+  in which an opener could complete strictly after `EndGeneration`.
+  `"Gated"` matches the implementation: registering an open is atomic with
+  generation end or lease disposal; the potentially blocking opener runs
+  after registration and before a stream is returned.
+- **`ReleaseMode`.** `"Immediate"` preserves the former termination sequence,
+  which disposed acquisition leases without waiting for an in-flight sealing
+  read or open query stream. `"AwaitQuiescence"` matches the implementation:
+  termination ends the generation immediately, cancels registered opener
+  callbacks and an in-flight materialization read it owns, and releases
+  acquisition leases only once no registered opener, read, or returned stream
+  remains.
 
 `OpeningCancelMode = "Disabled"` is a mutation that removes target owner
 cancellation of registered openers. `PublishMode = "Unguarded"` removes
 publication's sealing-state guard, mirroring the existing product test
 `ArtifactSetSession_DisposalDuringSealCannotPublish`.
 
-The structural root is that nothing reports content quiescence:
-`ArtifactAccessLease.Dispose` (`ArtifactAccess.cs:596`) only latches a local
-flag and never informs the authority, opener callbacks run after validation
-without registration, and returned streams are untracked. `TerminateAsync`
-therefore has nothing it could wait on even if it wanted to. The session's own
-remarks (`ArtifactSetSession.cs:80`) state the slice "does not yet implement …
-dependent-group quiescence".
+The structural root preserved by the modeled current configurations is that
+nothing reports content quiescence: lease disposal is outside the authority
+gate, opener callbacks run after validation without registration, and returned
+streams are untracked. The implementation closes those gaps through
+authority-gated access registration, tracked stream disposal, owner
+cancellation for admission reads, and `EndGenerationAsync` before acquisition
+lease release.
 
 ## Files
 
@@ -185,19 +178,15 @@ java -cp /path/to/tla2tools.jar tlc2.TLC \
   stream surviving `EndGeneration` is not a defect — it is the documented
   access contract — which is why the target design waits for streams at
   release rather than revoking them at the end.
-- The target design's liveness carries three obligations the owning document
-  does not state today. First, a registered opener must be interruptible by
-  its owner: `OpenReadable` invokes a synchronous `Func<Stream>` with no
-  cancellation or bounded-completion contract, so a stalled callback can
-  otherwise block termination. Second, an in-flight materialization read must
-  likewise be owner-interruptible: the implementation awaits
-  `Stream.ReadAsync` with only the caller token. The model includes both
-  cancellation paths and makes no fairness assumption that an opener or
-  adapter read completes on its own. Third, abandoned returned query streams
-  need a policy (bound the wait, or invalidate visibly): termination completes
-  only because every consumer eventually closes its stream, encoded as a
-  fairness assumption the authority cannot enforce today. All three belong in
-  the owning document's termination contract.
+- The target design's liveness carries three obligations now stated by the
+  owning document. A registered opener receives and must observe the owner's
+  cancellation token whenever it may block, without depending on a worker
+  thread. An in-flight
+  asynchronous materialization read combines caller and owner cancellation.
+  Returned query streams remain valid after generation end and pin release
+  until disposal; there is deliberately no timeout or invisible invalidation,
+  so an abandoned stream leaves `DisposeAsync` incomplete. `ReaderClose`
+  fairness encodes that explicit consumer-disposal obligation.
 
 ## Assumptions and simplifications
 
@@ -222,5 +211,4 @@ The model says nothing about demand admission or single-flight joining
 digests, adapter behavior behind a disposed lease, multiple concurrent
 generations, or the assembly-group quiescence protocol above this layer.
 These results establish evidence about the model, not the implementation;
-the implementation-facing statements above cite the exact code they
-describe.
+the named product gates establish implementation conformance.

--- a/src/DotnetInspector.Artifacts.Local/LocalArtifactSource.cs
+++ b/src/DotnetInspector.Artifacts.Local/LocalArtifactSource.cs
@@ -128,7 +128,7 @@ public static partial class LocalArtifactSource
                 observedLastWriteTimeUtc);
             ArtifactContribution contribution = scope.Register(
                 provenance,
-                () => OpenSnapshot(snapshot),
+                _ => OpenSnapshot(snapshot),
                 kind: "local-file");
             return new ArtifactAcquisitionOutcome.Acquired(
                 [contribution],

--- a/src/DotnetInspector.Artifacts.Local/LocalDirectoryArtifactSource.cs
+++ b/src/DotnetInspector.Artifacts.Local/LocalDirectoryArtifactSource.cs
@@ -301,7 +301,7 @@ public static partial class LocalArtifactSource
                 snapshot.ObservedLastWriteTimeUtc);
             contributions[index] = scope.Register(
                 provenance,
-                () => OpenSnapshot(snapshot.Bytes),
+                _ => OpenSnapshot(snapshot.Bytes),
                 kind: "local-directory-entry");
         }
 

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactContractTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactContractTests.cs
@@ -437,6 +437,40 @@ public sealed class ArtifactContractTests
     }
 
     [Fact]
+    public void ArtifactAccess_RetainedOpenerCancellationEndsAtCallbackReturn()
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("opener-scoped-cancellation"),
+                _ => StreamFor([1]));
+        }
+        RetainedArtifactContent retained =
+            owner.CreateRetainedContent(
+                contribution.Registration,
+                cancellationToken =>
+                {
+                    var stream = StreamFor([7, 8]);
+                    _ = cancellationToken.Register(stream.Dispose);
+                    return stream;
+                });
+        owner.CompleteAdmission(admission);
+        ArtifactQueryAuthorization query =
+            owner.CreateQueryAuthorization();
+        using ArtifactQueryLease lease = owner.IssueLease(query);
+        using Stream opened = retained.OpenRead(lease);
+
+        Assert.Equal(7, opened.ReadByte());
+        owner.EndGeneration();
+        Assert.Equal(8, opened.ReadByte());
+    }
+
+    [Fact]
     public async Task ArtifactAccess_StreamDisposalFailureStillReportsQuiescence()
     {
         var owner = new ArtifactGenerationAuthority();

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactContractTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactContractTests.cs
@@ -17,10 +17,10 @@ public sealed class ArtifactContractTests
         {
             first = scope.Register(
                 new Provenance("first"),
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
             second = scope.Register(
                 new Provenance("second"),
-                () => StreamFor([2]));
+                _ => StreamFor([2]));
         }
 
         var secondOwner = new ArtifactGenerationAuthority();
@@ -32,7 +32,7 @@ public sealed class ArtifactContractTests
         {
             foreign = scope.Register(
                 new Provenance("foreign"),
-                () => StreamFor([3]));
+                _ => StreamFor([3]));
         }
 
         Assert.NotSame(first.Descriptor.Identity, second.Descriptor.Identity);
@@ -49,7 +49,7 @@ public sealed class ArtifactContractTests
         Assert.Throws<ArgumentException>(
             () => secondOwner.CreateRetainedContent(
                 first.Registration,
-                () => StreamFor([4])));
+                _ => StreamFor([4])));
     }
 
     [Fact]
@@ -62,19 +62,19 @@ public sealed class ArtifactContractTests
             owner.BeginContribution(authorization);
         ArtifactContribution contribution = scope.Register(
             new Provenance("local"),
-            () => StreamFor([1, 2, 3]));
+            _ => StreamFor([1, 2, 3]));
         ArtifactAdmissionLease lease = owner.IssueLease(authorization);
         scope.Dispose();
 
         Assert.Throws<ObjectDisposedException>(
             () => scope.Register(
                 new Provenance("late"),
-                () => StreamFor([4])));
+                _ => StreamFor([4])));
 
         using Stream opened = contribution.OpenRead(lease);
         owner.CreateRetainedContent(
             contribution.Registration,
-            () => StreamFor([1, 2, 3]));
+            _ => StreamFor([1, 2, 3]));
         owner.CompleteAdmission(authorization);
 
         Assert.Equal(1, opened.ReadByte());
@@ -109,7 +109,7 @@ public sealed class ArtifactContractTests
         {
             contribution = scope.Register(
                 new Provenance("local"),
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
         }
 
         Assert.Throws<InvalidOperationException>(
@@ -117,11 +117,11 @@ public sealed class ArtifactContractTests
 
         owner.CreateRetainedContent(
             contribution.Registration,
-            () => StreamFor([1]));
+            _ => StreamFor([1]));
         Assert.Throws<InvalidOperationException>(
             () => owner.CreateRetainedContent(
                 contribution.Registration,
-                () => StreamFor([2])));
+                _ => StreamFor([2])));
 
         owner.CompleteAdmission(authorization);
     }
@@ -142,7 +142,7 @@ public sealed class ArtifactContractTests
                             owner.BeginContribution(authorization);
                         return scope.Register(
                             new Provenance(index.ToString()),
-                            () => StreamFor([unchecked((byte)index)]));
+                            _ => StreamFor([unchecked((byte)index)]));
                     })));
 
         Assert.Equal(
@@ -163,7 +163,7 @@ public sealed class ArtifactContractTests
         {
             owner.CreateRetainedContent(
                 contribution.Registration,
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
         }
         owner.CompleteAdmission(authorization);
     }
@@ -181,13 +181,13 @@ public sealed class ArtifactContractTests
         {
             contribution = scope.Register(
                 new Provenance("snapshot"),
-                () => StreamFor(snapshot));
+                _ => StreamFor(snapshot));
         }
 
         RetainedArtifactContent retained =
             owner.CreateRetainedContent(
                 contribution.Registration,
-                () => StreamFor(snapshot));
+                _ => StreamFor(snapshot));
         owner.CompleteAdmission(admission);
 
         ArtifactQueryAuthorization query =
@@ -227,6 +227,283 @@ public sealed class ArtifactContractTests
     }
 
     [Fact]
+    public async Task ArtifactAccess_OpenRegistrationIsAtomicWithGenerationEnd()
+    {
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("blocking-opener"),
+                cancellationToken =>
+                {
+                    entered.TrySetResult();
+                    cancellationToken.WaitHandle.WaitOne();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return StreamFor([1]);
+                });
+        }
+        using ArtifactAdmissionLease lease = owner.IssueLease(admission);
+
+        Task<Stream> opening =
+            Task.Run(() => contribution.OpenRead(lease));
+        await entered.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        Task ending = owner.EndGenerationAsync().AsTask();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await opening);
+        await ending;
+        Assert.Throws<UnauthorizedAccessException>(
+            () => contribution.OpenRead(lease));
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_RetainedOpenerIsCancelledAfterGateAdmission()
+    {
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("retained-opener"),
+                _ => StreamFor([1]));
+        }
+        RetainedArtifactContent retained =
+            owner.CreateRetainedContent(
+                contribution.Registration,
+                cancellationToken =>
+                {
+                    entered.TrySetResult();
+                    cancellationToken.WaitHandle.WaitOne();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return StreamFor([1]);
+                });
+        owner.CompleteAdmission(admission);
+        ArtifactQueryAuthorization query =
+            owner.CreateQueryAuthorization();
+        using ArtifactQueryLease lease = owner.IssueLease(query);
+
+        Task<Stream> opening =
+            Task.Run(() => retained.OpenRead(lease));
+        await entered.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        Task ending = owner.EndGenerationAsync().AsTask();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await opening);
+        await ending;
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_AuthorizationReplacementIsAtomicWithOpenRegistration()
+    {
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        int openCount = 0;
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("replacement-race"),
+                _ => StreamFor([1]));
+        }
+        RetainedArtifactContent retained =
+            owner.CreateRetainedContent(
+                contribution.Registration,
+                _ =>
+                {
+                    Interlocked.Increment(ref openCount);
+                    entered.TrySetResult();
+                    release.Task.GetAwaiter().GetResult();
+                    return StreamFor([1]);
+                });
+        owner.CompleteAdmission(admission);
+        ArtifactQueryAuthorization query =
+            owner.CreateQueryAuthorization();
+        using ArtifactQueryLease lease = owner.IssueLease(query);
+
+        Task<Stream> opening =
+            Task.Run(() => retained.OpenRead(lease));
+        await entered.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        ArtifactQueryAuthorization replacement =
+            owner.ReplaceQueryAuthorization(query);
+        release.SetResult();
+
+        using Stream opened = await opening;
+        Assert.Equal(1, opened.ReadByte());
+        Assert.Throws<UnauthorizedAccessException>(
+            () => retained.OpenRead(lease));
+        Assert.Equal(1, Volatile.Read(ref openCount));
+        using ArtifactQueryLease replacementLease =
+            owner.IssueLease(replacement);
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_MaterializationReadPreservesCallerCancellation()
+    {
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("caller-cancelled-read"),
+                _ => new CancellationCaptureReadStream(
+                    entered,
+                    cancellationObserved));
+        }
+        using ArtifactAdmissionLease lease = owner.IssueLease(admission);
+        using Stream opened = contribution.OpenRead(lease);
+        using var cancellation = new CancellationTokenSource();
+
+        Task<int> read =
+            opened.ReadAsync(
+                    new byte[1],
+                    cancellation.Token)
+                .AsTask();
+        await entered.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        cancellation.Cancel();
+
+        OperationCanceledException exception =
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                async () => await read);
+        await cancellationObserved.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        Assert.Equal(
+            cancellation.Token,
+            exception.CancellationToken);
+        using ArtifactContributionScope stillActive =
+            owner.BeginContribution(admission);
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_ReturnedStreamKeepsGenerationAliveUntilDisposed()
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("snapshot"),
+                _ => StreamFor([1, 2]));
+        }
+        RetainedArtifactContent retained =
+            owner.CreateRetainedContent(
+                contribution.Registration,
+                _ => StreamFor([1, 2]));
+        owner.CompleteAdmission(admission);
+        ArtifactQueryAuthorization query =
+            owner.CreateQueryAuthorization();
+        using ArtifactQueryLease lease = owner.IssueLease(query);
+        Stream opened = retained.OpenRead(lease);
+
+        Task ending = owner.EndGenerationAsync().AsTask();
+
+        Assert.False(ending.IsCompleted);
+        Assert.Equal(1, opened.ReadByte());
+        Assert.Throws<UnauthorizedAccessException>(
+            () => retained.OpenRead(lease));
+
+        opened.Dispose();
+        await ending;
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_StreamDisposalFailureStillReportsQuiescence()
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("throwing-dispose"),
+                _ => StreamFor([1]));
+        }
+        RetainedArtifactContent retained =
+            owner.CreateRetainedContent(
+                contribution.Registration,
+                _ => new ThrowingDisposeReadStream());
+        owner.CompleteAdmission(admission);
+        ArtifactQueryAuthorization query =
+            owner.CreateQueryAuthorization();
+        using ArtifactQueryLease lease = owner.IssueLease(query);
+        Stream opened = retained.OpenRead(lease);
+        Task ending = owner.EndGenerationAsync().AsTask();
+
+        Assert.Throws<IOException>(opened.Dispose);
+        await ending;
+    }
+
+    [Fact]
+    public async Task ArtifactAccess_LeaseDisposalIsAtomicWithOpenRegistration()
+    {
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission =
+            owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope =
+            owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance("admitted-opener"),
+                _ =>
+                {
+                    entered.TrySetResult();
+                    release.Task.GetAwaiter().GetResult();
+                    return StreamFor([1]);
+                });
+        }
+        ArtifactAdmissionLease lease = owner.IssueLease(admission);
+
+        Task<Stream> opening =
+            Task.Run(() => contribution.OpenRead(lease));
+        await entered.Task.WaitAsync(
+            TestContext.Current.CancellationToken);
+        lease.Dispose();
+        release.SetResult();
+
+        using Stream opened = await opening;
+        Assert.Equal(1, opened.ReadByte());
+        Assert.Throws<ObjectDisposedException>(
+            () => contribution.OpenRead(lease));
+    }
+
+    [Fact]
     public void DisposedLease_RejectsNewOpen()
     {
         var owner = new ArtifactGenerationAuthority();
@@ -238,13 +515,13 @@ public sealed class ArtifactContractTests
         {
             contribution = scope.Register(
                 new Provenance("snapshot"),
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
         }
 
         RetainedArtifactContent retained =
             owner.CreateRetainedContent(
                 contribution.Registration,
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
         owner.CompleteAdmission(admission);
         ArtifactQueryAuthorization query =
             owner.CreateQueryAuthorization();
@@ -300,7 +577,7 @@ public sealed class ArtifactContractTests
         {
             contribution = scope.Register(
                 new Provenance("package"),
-                () => StreamFor([1]));
+                _ => StreamFor([1]));
         }
 
         List<ArtifactContribution> source = [contribution];
@@ -387,6 +664,80 @@ public sealed class ArtifactContractTests
 
     private static MemoryStream StreamFor(byte[] content) =>
         new(content, writable: false);
+
+    private sealed class ThrowingDisposeReadStream :
+        MemoryStream
+    {
+        public ThrowingDisposeReadStream()
+            : base([1], writable: false)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            throw new IOException("stream cleanup failed");
+        }
+    }
+
+    private sealed class CancellationCaptureReadStream(
+        TaskCompletionSource entered,
+        TaskCompletionSource cancellationObserved) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length =>
+            throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            entered.TrySetResult();
+            try
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationObserved.TrySetResult();
+                throw;
+            }
+
+            throw new InvalidOperationException(
+                "Caller cancellation was not observed.");
+        }
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+
+        public override void Flush() =>
+            throw new NotSupportedException();
+
+        public override long Seek(
+            long offset,
+            SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+    }
 
     private sealed record Provenance(string Source) :
         IArtifactProvenance;

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
@@ -145,23 +145,26 @@ public sealed class ArtifactSetSessionTests
     {
         CancellationToken cancellationToken =
             TestContext.Current.CancellationToken;
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
         var acquisitionLease = new TrackingLease();
         var session = new ArtifactSetSession();
         await session.AddRequiredAcquisitionAsync(
-            (scope, acquisitionCancellation) =>
+            (scope, _) =>
             {
-                _ = acquisitionCancellation;
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("throwing-cancellation"),
                     ownerCancellation =>
                     {
-                        _ = ownerCancellation.Register(
+                        ownerCancellation.Register(
                             static () =>
                                 throw new IOException(
                                     "owner cancellation failed"));
-                        return new MemoryStream(
-                            [1],
-                            writable: false);
+                        entered.TrySetResult();
+                        ownerCancellation.WaitHandle.WaitOne();
+                        ownerCancellation.ThrowIfCancellationRequested();
+                        throw new InvalidOperationException(
+                            "The owner did not cancel the opener.");
                     });
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
@@ -169,29 +172,33 @@ public sealed class ArtifactSetSessionTests
                         acquisitionLease));
             },
             cancellationToken: cancellationToken);
-        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
-            await session.SealAsync(cancellationToken));
-        ArtifactQueryAuthorization authorization =
-            session.CreateQueryAuthorization();
-        using ArtifactQueryLease lease =
-            session.IssueLease(authorization);
-        ArtifactIdentity identity =
-            Assert.Single(session.GetCatalog(lease)).Identity;
-        Stream opened = session.OpenRead(identity, lease);
 
+        Task<ArtifactSetPublicationOutcome> publication =
+            Task.Run(
+                async () =>
+                    await session.SealAsync(cancellationToken),
+                cancellationToken);
+        await entered.Task.WaitAsync(cancellationToken);
         Task firstDisposal = session.DisposeAsync().AsTask();
 
-        Assert.False(firstDisposal.IsCompleted);
-        Assert.Equal(0, acquisitionLease.DisposeCount);
-        opened.Dispose();
         await firstDisposal;
-
         Assert.Equal(1, acquisitionLease.DisposeCount);
         AggregateException failure =
             Assert.IsType<AggregateException>(
                 Assert.Single(session.CleanupFailures));
         Assert.IsType<IOException>(
-            Assert.Single(failure.InnerExceptions));
+            Assert.Single(
+                failure.Flatten().InnerExceptions));
+        ObjectDisposedException disposed =
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                async () => await publication);
+        IReadOnlyList<Exception> attached =
+            Assert.IsAssignableFrom<IReadOnlyList<Exception>>(
+                disposed.Data[
+                    "DotnetInspector.Artifacts.Workspaces.CleanupFailures"]);
+        Assert.Same(
+            failure,
+            Assert.Single(attached));
 
         await session.DisposeAsync();
         Assert.Equal(1, acquisitionLease.DisposeCount);

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
@@ -50,16 +50,20 @@ public sealed class ArtifactSetSessionTests
                         session.GetProvenance(
                             descriptor.Identity,
                             lease)).Source));
+            using Stream firstContent =
+                session.OpenRead(
+                    catalog[0].Identity,
+                    lease);
             Assert.Equal(
                 [1, 2],
-                ReadAll(session.OpenRead(
-                    catalog[0].Identity,
-                    lease)));
+                ReadAll(firstContent));
+            using Stream secondContent =
+                session.OpenRead(
+                    catalog[1].Identity,
+                    lease);
             Assert.Equal(
                 [3, 4],
-                ReadAll(session.OpenRead(
-                    catalog[1].Identity,
-                    lease)));
+                ReadAll(secondContent));
         }
         finally
         {
@@ -99,6 +103,136 @@ public sealed class ArtifactSetSessionTests
 
         Assert.Equal(1, first.DisposeCount);
         Assert.Equal(1, second.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var acquisitionLease = new TrackingLease();
+        var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) => Acquired(
+                scope,
+                new Provenance("query-stream"),
+                [1, 2],
+                acquisitionLease),
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        using ArtifactQueryLease lease =
+            session.IssueLease(authorization);
+        ArtifactIdentity identity =
+            Assert.Single(session.GetCatalog(lease)).Identity;
+        Stream opened = session.OpenRead(identity, lease);
+
+        Task disposal = session.DisposeAsync().AsTask();
+
+        Assert.False(disposal.IsCompleted);
+        Assert.Equal(0, acquisitionLease.DisposeCount);
+        Assert.Equal(1, opened.ReadByte());
+
+        opened.Dispose();
+        await disposal;
+        Assert.Equal(1, acquisitionLease.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ArtifactSetSession_CancellationCallbackFailureDoesNotSkipLeaseCleanup()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var acquisitionLease = new TrackingLease();
+        var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, acquisitionCancellation) =>
+            {
+                _ = acquisitionCancellation;
+                ArtifactContribution contribution = scope.Register(
+                    new Provenance("throwing-cancellation"),
+                    ownerCancellation =>
+                    {
+                        _ = ownerCancellation.Register(
+                            static () =>
+                                throw new IOException(
+                                    "owner cancellation failed"));
+                        return new MemoryStream(
+                            [1],
+                            writable: false);
+                    });
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(
+                        [contribution],
+                        acquisitionLease));
+            },
+            cancellationToken: cancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(cancellationToken));
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        using ArtifactQueryLease lease =
+            session.IssueLease(authorization);
+        ArtifactIdentity identity =
+            Assert.Single(session.GetCatalog(lease)).Identity;
+        Stream opened = session.OpenRead(identity, lease);
+
+        Task firstDisposal = session.DisposeAsync().AsTask();
+
+        Assert.False(firstDisposal.IsCompleted);
+        Assert.Equal(0, acquisitionLease.DisposeCount);
+        opened.Dispose();
+        await firstDisposal;
+
+        Assert.Equal(1, acquisitionLease.DisposeCount);
+        AggregateException failure =
+            Assert.IsType<AggregateException>(
+                Assert.Single(session.CleanupFailures));
+        Assert.IsType<IOException>(
+            Assert.Single(failure.InnerExceptions));
+
+        await session.DisposeAsync();
+        Assert.Equal(1, acquisitionLease.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ArtifactSetSession_DisposalCancelsInFlightMaterialization()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var cancellationObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var acquisitionLease = new TrackingLease();
+        var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) =>
+            {
+                ArtifactContribution contribution = scope.Register(
+                    new Provenance("owner-cancelled-read"),
+                    _ => new OwnerCancellationReadStream(
+                        entered,
+                        cancellationObserved));
+                return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired(
+                        [contribution],
+                        acquisitionLease));
+            },
+            cancellationToken: cancellationToken);
+
+        Task<ArtifactSetPublicationOutcome> publication =
+            session.SealAsync(cancellationToken).AsTask();
+        await entered.Task.WaitAsync(cancellationToken);
+        Task disposal = session.DisposeAsync().AsTask();
+
+        await cancellationObserved.Task.WaitAsync(cancellationToken);
+        await disposal;
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            async () => await publication);
+        Assert.Equal(1, acquisitionLease.DisposeCount);
     }
 
     [Fact]
@@ -206,7 +340,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("late"),
-                    () => new MemoryStream(
+                    _ => new MemoryStream(
                         [1],
                         writable: false));
                 entered.SetResult();
@@ -289,13 +423,13 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution gated = scope.Register(
                     new Provenance("gated"),
-                    () => new GatedReadStream(
+                    _ => new GatedReadStream(
                         [1],
                         entered,
                         release));
                 ArtifactContribution unopened = scope.Register(
                     new Provenance("unopened"),
-                    () => new MemoryStream(
+                    _ => new MemoryStream(
                         [2],
                         writable: false));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
@@ -393,7 +527,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("disposed-source"),
-                    () => throw new ObjectDisposedException(
+                    _ => throw new ObjectDisposedException(
                         "source stream"));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
@@ -492,10 +626,10 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution first = scope.Register(
                     new Provenance("first"),
-                    () => new MemoryStream([1], writable: false));
+                    _ => new MemoryStream([1], writable: false));
                 ArtifactContribution second = scope.Register(
                     new Provenance("second"),
-                    () => new MemoryStream([2], writable: false));
+                    _ => new MemoryStream([2], writable: false));
                 return new ArtifactAcquisitionOutcome.Acquired(
                     [first, second],
                     ArtifactAcquisitionLeases.None);
@@ -518,7 +652,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution duplicate = scope.Register(
                     new Provenance("duplicate"),
-                    () => new MemoryStream([1], writable: false));
+                    _ => new MemoryStream([1], writable: false));
                 return new ArtifactAcquisitionOutcome.Acquired(
                     [duplicate, duplicate],
                     ArtifactAcquisitionLeases.None);
@@ -634,7 +768,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("required"),
-                    () =>
+                    _ =>
                     {
                         openCount++;
                         return new MemoryStream(
@@ -667,9 +801,11 @@ public sealed class ArtifactSetSessionTests
             session.IssueLease(authorization);
         ArtifactDescriptor artifact =
             Assert.Single(session.GetCatalog(lease));
+        using Stream opened =
+            session.OpenRead(artifact.Identity, lease);
         Assert.Equal(
             [1, 2, 3],
-            ReadAll(session.OpenRead(artifact.Identity, lease)));
+            ReadAll(opened));
     }
 
     [Fact]
@@ -791,14 +927,14 @@ public sealed class ArtifactSetSessionTests
                 Assert.Equal(1, capacity.MaxArtifacts);
                 ArtifactContribution first = scope.Register(
                     new Provenance("first"),
-                    () =>
+                    _ =>
                     {
                         opened++;
                         return new MemoryStream([2], writable: false);
                     });
                 ArtifactContribution second = scope.Register(
                     new Provenance("second"),
-                    () =>
+                    _ =>
                     {
                         opened++;
                         return new MemoryStream([3], writable: false);
@@ -853,10 +989,10 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution first = scope.Register(
                     new Provenance("first"),
-                    () => new MemoryStream([1, 2], writable: false));
+                    _ => new MemoryStream([1, 2], writable: false));
                 ArtifactContribution second = scope.Register(
                     new Provenance("second"),
-                    () => new MemoryStream([3, 4], writable: false));
+                    _ => new MemoryStream([3, 4], writable: false));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
                         [first, second],
@@ -1009,7 +1145,7 @@ public sealed class ArtifactSetSessionTests
             {
                 foreign = scope.Register(
                     new Provenance("foreign"),
-                    () => new MemoryStream([4], writable: false));
+                    _ => new MemoryStream([4], writable: false));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
                         [foreign],
@@ -1057,7 +1193,7 @@ public sealed class ArtifactSetSessionTests
                     ArtifactContribution contribution =
                         scope.Register(
                             new Provenance("first"),
-                            () => new MemoryStream(
+                            _ => new MemoryStream(
                                 [1],
                                 writable: false));
                     entered.SetResult();
@@ -1102,7 +1238,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution duplicate = scope.Register(
                     new Provenance("duplicate"),
-                    () =>
+                    _ =>
                     {
                         collisionOpens++;
                         return new MemoryStream([1], writable: false);
@@ -1131,14 +1267,14 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution first = scope.Register(
                     new Provenance("first"),
-                    () =>
+                    _ =>
                     {
                         firstOpens++;
                         return new MemoryStream([1], writable: false);
                     });
                 ArtifactContribution second = scope.Register(
                     new Provenance("second"),
-                    () => throw new IOException("read failed"));
+                    _ => throw new IOException("read failed"));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
                         [first, second],
@@ -1169,7 +1305,7 @@ public sealed class ArtifactSetSessionTests
                                 ArtifactContribution contribution =
                                     scope.Register(
                                         new Provenance("unexpected"),
-                                        () => throw
+                                        _ => throw
                                             new FormatException(
                                                 "unexpected"));
                                 return ValueTask.FromResult<
@@ -1200,10 +1336,10 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution first = scope.Register(
                     new Provenance("first"),
-                    () => new MemoryStream([1], writable: false));
+                    _ => new MemoryStream([1], writable: false));
                 ArtifactContribution second = scope.Register(
                     new Provenance("second"),
-                    () => new MemoryStream([2], writable: false));
+                    _ => new MemoryStream([2], writable: false));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
                     new ArtifactAcquisitionOutcome.Acquired(
                         [first, second],
@@ -1248,7 +1384,7 @@ public sealed class ArtifactSetSessionTests
                     capacity.MaxArtifacts);
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("late"),
-                    () => new MemoryStream([1], writable: false));
+                    _ => new MemoryStream([1], writable: false));
                 entered.SetResult();
                 await release.Task.WaitAsync(token);
                 return new ArtifactAcquisitionOutcome.Acquired(
@@ -1357,7 +1493,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("supplemental"),
-                    () => new GatedReadStream(
+                    _ => new GatedReadStream(
                         [2],
                         entered,
                         never));
@@ -1390,7 +1526,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("required"),
-                    () => new GatedReadStream(
+                    _ => new GatedReadStream(
                         [1],
                         checkpointEntered,
                         checkpointNever));
@@ -1502,7 +1638,7 @@ public sealed class ArtifactSetSessionTests
             {
                 ArtifactContribution contribution = scope.Register(
                     new Provenance("mutable"),
-                    () => new MemoryStream(
+                    _ => new MemoryStream(
                         source,
                         writable: false));
                 return ValueTask.FromResult<ArtifactAcquisitionOutcome>(
@@ -1524,9 +1660,7 @@ public sealed class ArtifactSetSessionTests
         using Stream first = session.OpenRead(identity, lease);
 
         Assert.False(first.CanWrite);
-        Assert.False(
-            Assert.IsType<MemoryStream>(first)
-                .TryGetBuffer(out _));
+        Assert.IsNotType<MemoryStream>(first);
         Assert.Throws<NotSupportedException>(
             () => first.WriteByte(7));
         Assert.Equal([1, 2, 3], ReadAll(first));
@@ -1740,7 +1874,7 @@ public sealed class ArtifactSetSessionTests
     {
         ArtifactContribution contribution = scope.Register(
             provenance,
-            () => new MemoryStream(
+            _ => new MemoryStream(
                 content,
                 writable: false));
         return new ArtifactAcquisitionOutcome.Acquired(
@@ -1849,5 +1983,65 @@ public sealed class ArtifactSetSessionTests
                 buffer,
                 cancellationToken);
         }
+    }
+
+    private sealed class OwnerCancellationReadStream(
+        TaskCompletionSource entered,
+        TaskCompletionSource cancellationObserved) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length =>
+            throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            entered.TrySetResult();
+            try
+            {
+                await Task.Delay(
+                    Timeout.InfiniteTimeSpan,
+                    cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationObserved.TrySetResult();
+                throw;
+            }
+
+            throw new InvalidOperationException(
+                "The owner did not cancel the materialization read.");
+        }
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
+
+        public override void Flush() =>
+            throw new NotSupportedException();
+
+        public override long Seek(
+            long offset,
+            SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            throw new NotSupportedException();
     }
 }

--- a/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -98,8 +98,7 @@ public abstract class ArtifactSetPublicationOutcome
 /// The session invokes source adapters sequentially, materializes every
 /// contribution into owner-private bounded memory, and retains successful
 /// acquisition leases until disposal. This slice does not yet implement
-/// workspace-wide reservation, single-flight admission, or dependent-group
-/// quiescence.
+/// workspace-wide reservation or single-flight admission.
 /// Materialization, publication, mutation, open, and lease-lifetime behavior
 /// are gated by <c>ArtifactSetSession_SealingRequiresMaterializedBoundedContent</c>,
 /// <c>ArtifactSetSession_SealedGenerationCannotMutate</c>,
@@ -115,6 +114,9 @@ public abstract class ArtifactSetPublicationOutcome
 /// termination completion is gated by
 /// <c>ArtifactSetSession_ConcurrentTerminationWaitsForCleanup</c> and
 /// <c>ArtifactSetSession_ConcurrentAbortAndDisposalShareCleanup</c>.
+/// Content-access quiescence is gated by
+/// <c>ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce</c>
+/// and <c>ArtifactSetSession_DisposalCancelsInFlightMaterialization</c>.
 /// </remarks>
 public sealed class ArtifactSetSession : IAsyncDisposable
 {
@@ -852,6 +854,16 @@ public sealed class ArtifactSetSession : IAsyncDisposable
 
             return new ArtifactSetPublicationOutcome.Published();
         }
+        catch (OperationCanceledException) when (IsDisposed())
+        {
+            IReadOnlyList<Exception> cleanupFailures =
+                await AbortAsync().ConfigureAwait(false);
+            var disposed = new ObjectDisposedException(
+                nameof(ArtifactSetSession),
+                "The artifact session was disposed while sealing was in progress.");
+            AttachCleanupFailures(disposed, cleanupFailures);
+            throw disposed;
+        }
         catch (OperationCanceledException ex)
         {
             IReadOnlyList<Exception> cleanupFailures =
@@ -1255,7 +1267,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         RetainedArtifactContent retained =
             _authority.CreateRetainedContent(
                 contribution.Registration,
-                () => OpenSnapshot(snapshot));
+                _ => OpenSnapshot(snapshot));
         return new PublishedArtifact(
             contribution.Descriptor,
             contribution.Registration,
@@ -1476,12 +1488,27 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         {
             try
             {
-                _authority.EndGeneration();
+                var failures = new List<Exception>();
+                try
+                {
+                    await _authority.EndGenerationAsync()
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(ex);
+                }
                 _admissionLease.Dispose();
-                IReadOnlyList<Exception> failures =
+                IReadOnlyList<Exception> leaseFailures =
                     await DisposeLeasesAsync().ConfigureAwait(false);
-                RecordCleanupFailures(failures);
-                starter.SetResult(failures);
+                failures.AddRange(leaseFailures);
+                IReadOnlyList<Exception> cleanupFailures =
+                    failures.Count == 0
+                        ? []
+                        : new ReadOnlyCollection<Exception>(
+                            failures);
+                RecordCleanupFailures(cleanupFailures);
+                starter.SetResult(cleanupFailures);
             }
             catch (Exception ex)
             {

--- a/src/DotnetInspector.Artifacts/ArtifactAccess.cs
+++ b/src/DotnetInspector.Artifacts/ArtifactAccess.cs
@@ -66,9 +66,14 @@ public sealed class ArtifactContributionScope : IDisposable
     }
 
     /// <summary>Registers one source contribution in the owning generation.</summary>
+    /// <remarks>
+    /// The opener runs only after its access is registered. A potentially
+    /// blocking opener must promptly observe the supplied generation-end
+    /// cancellation token without depending on a worker thread.
+    /// </remarks>
     public ArtifactContribution Register(
         IArtifactProvenance provenance,
-        Func<Stream> openRead,
+        Func<CancellationToken, Stream> openRead,
         string? mediaType = null,
         string? kind = null)
     {
@@ -116,7 +121,7 @@ public sealed class ArtifactContribution
 {
     private readonly ArtifactGenerationAuthority _authority;
     private readonly ArtifactAdmissionAuthorization _authorization;
-    private readonly Func<Stream> _openRead;
+    private readonly Func<CancellationToken, Stream> _openRead;
 
     internal ArtifactContribution(
         ArtifactGenerationAuthority authority,
@@ -124,7 +129,7 @@ public sealed class ArtifactContribution
         ArtifactContributionScope scope,
         ArtifactDescriptor descriptor,
         ArtifactAcquisitionRegistration registration,
-        Func<Stream> openRead)
+        Func<CancellationToken, Stream> openRead)
     {
         _authority = authority;
         _authorization = authorization;
@@ -142,19 +147,10 @@ public sealed class ArtifactContribution
     public Stream OpenRead(ArtifactAdmissionLease lease)
     {
         ArgumentNullException.ThrowIfNull(lease);
-        lease.EnsureAccess(_authority, _authorization);
-        return OpenReadable(_openRead);
-    }
-
-    internal static Stream OpenReadable(Func<Stream> openRead)
-    {
-        Stream? stream = openRead();
-        if (stream is not null && stream.CanRead)
-            return stream;
-
-        stream?.Dispose();
-        throw new IOException(
-            "The artifact opener did not return a readable stream.");
+        return _authority.OpenContribution(
+            lease,
+            _authorization,
+            _openRead);
     }
 }
 
@@ -168,17 +164,18 @@ public sealed class ArtifactContribution
 /// Lease disposal or authorization revocation rejects new opens; a stream
 /// already returned remains valid until its consumer disposes it. This access
 /// behavior is gated by
-/// <c>RetainedContent_RejectsRevokedOrForeignAuthorizationWithoutRevokingOpenStream</c>.
+/// <c>RetainedContent_RejectsRevokedOrForeignAuthorizationWithoutRevokingOpenStream</c>
+/// and <c>ArtifactAccess_ReturnedStreamKeepsGenerationAliveUntilDisposed</c>.
 /// </remarks>
 public sealed class RetainedArtifactContent
 {
     private readonly ArtifactGenerationAuthority _authority;
-    private readonly Func<Stream> _openRead;
+    private readonly Func<CancellationToken, Stream> _openRead;
 
     internal RetainedArtifactContent(
         ArtifactGenerationAuthority authority,
         ArtifactAcquisitionRegistration registration,
-        Func<Stream> openRead)
+        Func<CancellationToken, Stream> openRead)
     {
         _authority = authority;
         Registration = registration;
@@ -196,8 +193,9 @@ public sealed class RetainedArtifactContent
                 "The artifact access lease was not issued by this owner.");
         }
 
-        access.EnsureAccess(_authority);
-        return ArtifactContribution.OpenReadable(_openRead);
+        return _authority.OpenRetained(
+            access,
+            _openRead);
     }
 }
 
@@ -218,8 +216,14 @@ public sealed class ArtifactGenerationAuthority
     private readonly Dictionary<ArtifactAcquisitionRegistration, bool>
         _registrations =
             new(ReferenceEqualityComparer.Instance);
+    private readonly CancellationTokenSource _endCancellation = new();
+    private readonly TaskCompletionSource<Exception?>
+        _endCancellationCompletion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private TaskCompletionSource? _accessQuiescence;
     private ArtifactAdmissionAuthorization? _admission;
     private long _nextOrdinal;
+    private int _activeAccesses;
     private int _activeContributionScopes;
     private bool _admissionCompleted;
     private int _ended;
@@ -271,9 +275,17 @@ public sealed class ArtifactGenerationAuthority
         }
     }
 
+    /// <summary>
+    /// Registers owner-retained content for one admitted artifact.
+    /// </summary>
+    /// <remarks>
+    /// The opener runs only after its access is registered. A potentially
+    /// blocking opener must promptly observe the supplied generation-end
+    /// cancellation token without depending on a worker thread.
+    /// </remarks>
     public RetainedArtifactContent CreateRetainedContent(
         ArtifactAcquisitionRegistration registration,
-        Func<Stream> openRead)
+        Func<CancellationToken, Stream> openRead)
     {
         ArgumentNullException.ThrowIfNull(registration);
         ArgumentNullException.ThrowIfNull(openRead);
@@ -398,17 +410,76 @@ public sealed class ArtifactGenerationAuthority
     /// <summary>Ends the generation and rejects every future open or mint.</summary>
     public void EndGeneration()
     {
+        BeginEndGeneration(out bool started);
+        if (!started)
+            return;
+        Exception? cancellationFailure =
+            _endCancellationCompletion.Task
+                .GetAwaiter()
+                .GetResult();
+        if (cancellationFailure is not null)
+            throw cancellationFailure;
+    }
+
+    /// <summary>
+    /// Ends the generation and waits until every admitted content access
+    /// completes.
+    /// </summary>
+    /// <remarks>
+    /// Already-returned query streams remain valid and keep this operation
+    /// incomplete until their consumers dispose them.
+    /// </remarks>
+    public async ValueTask EndGenerationAsync()
+    {
+        Task quiescence = BeginEndGeneration(out _);
+        Exception? cancellationFailure =
+            await _endCancellationCompletion.Task
+                .ConfigureAwait(false);
+        await quiescence.ConfigureAwait(false);
+        if (cancellationFailure is not null)
+            throw cancellationFailure;
+    }
+
+    private Task BeginEndGeneration(out bool started)
+    {
+        bool cancel = false;
+        Task quiescence;
         lock (_gate)
         {
-            if (Volatile.Read(ref _ended) != 0)
-                return;
+            if (Volatile.Read(ref _ended) == 0)
+            {
+                Volatile.Write(ref _ended, 1);
+                foreach (ArtifactAuthorization authorization
+                    in _authorizations)
+                {
+                    authorization.Revoke();
+                }
+                _authorizations.Clear();
+                _registrations.Clear();
+                cancel = true;
+            }
 
-            Volatile.Write(ref _ended, 1);
-            foreach (ArtifactAuthorization authorization in _authorizations)
-                authorization.Revoke();
-            _authorizations.Clear();
-            _registrations.Clear();
+            quiescence =
+                _accessQuiescence?.Task
+                ?? Task.CompletedTask;
         }
+
+        if (cancel)
+        {
+            Exception? cancellationFailure = null;
+            try
+            {
+                _endCancellation.Cancel();
+            }
+            catch (Exception ex)
+            {
+                cancellationFailure = ex;
+            }
+            _endCancellationCompletion.TrySetResult(
+                cancellationFailure);
+        }
+        started = cancel;
+        return quiescence;
     }
 
     /// <summary>
@@ -420,7 +491,9 @@ public sealed class ArtifactGenerationAuthority
         lock (_gate)
         {
             EnsureQueryPhase();
-            lease.EnsureAccess(this);
+            lease.EnsureAccess(
+                this,
+                expectedAuthorization: null);
         }
     }
 
@@ -428,7 +501,7 @@ public sealed class ArtifactGenerationAuthority
         ArtifactContributionScope scope,
         ArtifactAdmissionAuthorization authorization,
         IArtifactProvenance provenance,
-        Func<Stream> openRead,
+        Func<CancellationToken, Stream> openRead,
         string? mediaType,
         string? kind)
     {
@@ -463,6 +536,111 @@ public sealed class ArtifactGenerationAuthority
             if (_activeContributionScopes > 0)
                 _activeContributionScopes--;
         }
+    }
+
+    internal Stream OpenContribution(
+        ArtifactAdmissionLease lease,
+        ArtifactAdmissionAuthorization authorization,
+        Func<CancellationToken, Stream> openRead)
+    {
+        ArtifactContentAccess access =
+            BeginAccess(
+                lease,
+                authorization,
+                cancelReads: true);
+        return OpenReadable(openRead, access);
+    }
+
+    internal Stream OpenRetained(
+        ArtifactAccessLease lease,
+        Func<CancellationToken, Stream> openRead)
+    {
+        ArtifactContentAccess access =
+            BeginAccess(
+                lease,
+                expectedAuthorization: null,
+                cancelReads: false);
+        return OpenReadable(openRead, access);
+    }
+
+    private ArtifactContentAccess BeginAccess(
+        ArtifactAccessLease lease,
+        ArtifactAuthorization? expectedAuthorization,
+        bool cancelReads)
+    {
+        lock (_gate)
+        {
+            lease.EnsureAccess(this, expectedAuthorization);
+            if (_activeAccesses == 0)
+            {
+                _accessQuiescence =
+                    new(
+                        TaskCreationOptions
+                            .RunContinuationsAsynchronously);
+            }
+            _activeAccesses =
+                checked(_activeAccesses + 1);
+            return new ArtifactContentAccess(
+                this,
+                _endCancellation.Token,
+                cancelReads);
+        }
+    }
+
+    private static Stream OpenReadable(
+        Func<CancellationToken, Stream> openRead,
+        ArtifactContentAccess access)
+    {
+        Stream? stream = null;
+        try
+        {
+            stream = openRead(access.CancellationToken);
+            if (stream is null || !stream.CanRead)
+            {
+                throw new IOException(
+                    "The artifact opener did not return a readable stream.");
+            }
+
+            access.CancellationToken.ThrowIfCancellationRequested();
+            return new ArtifactAccessStream(stream, access);
+        }
+        catch
+        {
+            try
+            {
+                stream?.Dispose();
+            }
+            finally
+            {
+                access.Dispose();
+            }
+            throw;
+        }
+    }
+
+    internal void CompleteAccess()
+    {
+        TaskCompletionSource? completion = null;
+        lock (_gate)
+        {
+            if (_activeAccesses <= 0)
+            {
+                throw new InvalidOperationException(
+                    "Artifact content access completion was unbalanced.");
+            }
+
+            _activeAccesses--;
+            if (_activeAccesses == 0)
+                completion = _accessQuiescence;
+        }
+
+        completion?.TrySetResult();
+    }
+
+    internal void DisposeLease(ArtifactAccessLease lease)
+    {
+        lock (_gate)
+            lease.MarkDisposed();
     }
 
     private void EnsureAdmissionActive(
@@ -524,6 +702,202 @@ public sealed class ArtifactGenerationAuthority
                 "The artifact generation has ended.");
         }
     }
+
+    internal sealed class ArtifactContentAccess : IDisposable
+    {
+        private readonly ArtifactGenerationAuthority _authority;
+        private int _disposed;
+
+        internal ArtifactContentAccess(
+            ArtifactGenerationAuthority authority,
+            CancellationToken cancellationToken,
+            bool cancelReads)
+        {
+            _authority = authority;
+            CancellationToken = cancellationToken;
+            CancelReads = cancelReads;
+        }
+
+        internal CancellationToken CancellationToken { get; }
+        internal bool CancelReads { get; }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+                _authority.CompleteAccess();
+        }
+    }
+
+    internal sealed class ArtifactAccessStream(
+        Stream inner,
+        ArtifactContentAccess access) : Stream
+    {
+        private int _disposeStarted;
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanTimeout => inner.CanTimeout;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+        public override int ReadTimeout
+        {
+            get => inner.ReadTimeout;
+            set => inner.ReadTimeout = value;
+        }
+        public override int WriteTimeout
+        {
+            get => inner.WriteTimeout;
+            set => inner.WriteTimeout = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override Task FlushAsync(
+            CancellationToken cancellationToken) =>
+            inner.FlushAsync(cancellationToken);
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            inner.Read(buffer, offset, count);
+
+        public override int Read(Span<byte> buffer) =>
+            inner.Read(buffer);
+
+        public override int ReadByte() => inner.ReadByte();
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) =>
+            ReadAsync(
+                buffer.AsMemory(offset, count),
+                cancellationToken).AsTask();
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            if (!access.CancelReads)
+                return inner.ReadAsync(buffer, cancellationToken);
+            return ReadWithOwnerCancellationAsync(
+                buffer,
+                cancellationToken);
+        }
+
+        private async ValueTask<int> ReadWithOwnerCancellationAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            CancellationToken ownerToken = access.CancellationToken;
+            if (!cancellationToken.CanBeCanceled)
+            {
+                int read = await inner.ReadAsync(buffer, ownerToken)
+                    .ConfigureAwait(false);
+                ownerToken.ThrowIfCancellationRequested();
+                return read;
+            }
+
+            using CancellationTokenSource linked =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    ownerToken);
+            try
+            {
+                int read = await inner.ReadAsync(buffer, linked.Token)
+                    .ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                ownerToken.ThrowIfCancellationRequested();
+                return read;
+            }
+            catch (OperationCanceledException)
+                when (cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(cancellationToken);
+            }
+            catch (OperationCanceledException)
+                when (ownerToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(ownerToken);
+            }
+        }
+
+        public override long Seek(
+            long offset,
+            SeekOrigin origin) =>
+            inner.Seek(offset, origin);
+
+        public override void SetLength(long value) =>
+            inner.SetLength(value);
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count) =>
+            inner.Write(buffer, offset, count);
+
+        public override void Write(
+            ReadOnlySpan<byte> buffer) =>
+            inner.Write(buffer);
+
+        public override Task WriteAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken) =>
+            inner.WriteAsync(
+                buffer,
+                offset,
+                count,
+                cancellationToken);
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            inner.WriteAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing
+                && Interlocked.Exchange(ref _disposeStarted, 1) == 0)
+            {
+                try
+                {
+                    inner.Dispose();
+                }
+                finally
+                {
+                    access.Dispose();
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposeStarted, 1) == 0)
+            {
+                try
+                {
+                    await inner.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    access.Dispose();
+                }
+            }
+
+            GC.SuppressFinalize(this);
+        }
+    }
 }
 
 public abstract class ArtifactAuthorization
@@ -566,7 +940,8 @@ public abstract class ArtifactAccessLease : IArtifactAccessLease
     private ArtifactAuthorization Authorization { get; }
 
     internal void EnsureAccess(
-        ArtifactGenerationAuthority authority)
+        ArtifactGenerationAuthority authority,
+        ArtifactAuthorization? expectedAuthorization)
     {
         if (!ReferenceEquals(Authorization.Authority, authority))
         {
@@ -579,20 +954,19 @@ public abstract class ArtifactAccessLease : IArtifactAccessLease
             Volatile.Read(ref _disposed) != 0,
             this);
         Authorization.ThrowIfRevoked();
-    }
-
-    internal void EnsureAccess(
-        ArtifactGenerationAuthority authority,
-        ArtifactAuthorization authorization)
-    {
-        EnsureAccess(authority);
-        if (!ReferenceEquals(Authorization, authorization))
+        if (expectedAuthorization is not null
+            && !ReferenceEquals(
+                Authorization,
+                expectedAuthorization))
         {
             throw new UnauthorizedAccessException(
                 "The artifact access lease belongs to another authorization.");
         }
     }
 
-    public void Dispose() =>
+    internal void MarkDisposed() =>
         Interlocked.Exchange(ref _disposed, 1);
+
+    public void Dispose() =>
+        Authorization.Authority.DisposeLease(this);
 }

--- a/src/DotnetInspector.Artifacts/ArtifactAccess.cs
+++ b/src/DotnetInspector.Artifacts/ArtifactAccess.cs
@@ -69,7 +69,9 @@ public sealed class ArtifactContributionScope : IDisposable
     /// <remarks>
     /// The opener runs only after its access is registered. A potentially
     /// blocking opener must promptly observe the supplied generation-end
-    /// cancellation token without depending on a worker thread.
+    /// cancellation token without depending on a worker thread. The token is
+    /// scoped to the callback and is detached before a returned stream escapes;
+    /// it does not represent the returned stream's lifetime.
     /// </remarks>
     public ArtifactContribution Register(
         IArtifactProvenance provenance,
@@ -281,7 +283,9 @@ public sealed class ArtifactGenerationAuthority
     /// <remarks>
     /// The opener runs only after its access is registered. A potentially
     /// blocking opener must promptly observe the supplied generation-end
-    /// cancellation token without depending on a worker thread.
+    /// cancellation token without depending on a worker thread. The token is
+    /// scoped to the callback and is detached before a returned stream escapes;
+    /// it does not represent the returned stream's lifetime.
     /// </remarks>
     public RetainedArtifactContent CreateRetainedContent(
         ArtifactAcquisitionRegistration registration,
@@ -587,25 +591,37 @@ public sealed class ArtifactGenerationAuthority
         }
     }
 
-    private static Stream OpenReadable(
+    private Stream OpenReadable(
         Func<CancellationToken, Stream> openRead,
         ArtifactContentAccess access)
     {
+        CancellationTokenSource openerCancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                access.CancellationToken);
+        bool openingFinished = false;
         Stream? stream = null;
         try
         {
-            stream = openRead(access.CancellationToken);
+            stream = openRead(openerCancellation.Token);
             if (stream is null || !stream.CanRead)
             {
                 throw new IOException(
                     "The artifact opener did not return a readable stream.");
             }
 
-            access.CancellationToken.ThrowIfCancellationRequested();
+            if (!TryCompleteOpening(openerCancellation))
+            {
+                openingFinished = true;
+                throw new OperationCanceledException(
+                    access.CancellationToken);
+            }
+            openingFinished = true;
             return new ArtifactAccessStream(stream, access);
         }
         catch
         {
+            if (!openingFinished)
+                AbandonOpening(openerCancellation);
             try
             {
                 stream?.Dispose();
@@ -615,6 +631,32 @@ public sealed class ArtifactGenerationAuthority
                 access.Dispose();
             }
             throw;
+        }
+    }
+
+    private bool TryCompleteOpening(
+        CancellationTokenSource openerCancellation)
+    {
+        lock (_gate)
+        {
+            if (Volatile.Read(ref _ended) != 0)
+                return false;
+
+            openerCancellation.Dispose();
+            return true;
+        }
+    }
+
+    private void AbandonOpening(
+        CancellationTokenSource openerCancellation)
+    {
+        lock (_gate)
+        {
+            if (Volatile.Read(ref _ended) == 0
+                || _endCancellationCompletion.Task.IsCompleted)
+            {
+                openerCancellation.Dispose();
+            }
         }
     }
 

--- a/src/ILInspector.Research.Tests/ResearchTargetResolverTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchTargetResolverTests.cs
@@ -2030,12 +2030,12 @@ public class ResearchTargetResolverTests
         {
             contribution = scope.Register(
                 TestArtifactProvenance.Instance,
-                openRead);
+                _ => openRead());
         }
 
         authority.CreateRetainedContent(
             contribution.Registration,
-            openRead);
+            _ => openRead());
         authority.CompleteAdmission(admission);
         return contribution.Registration;
     }

--- a/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
+++ b/tests/ILInspector.Metadata.Tests/InspectionAcquisitionPlanTests.cs
@@ -1444,12 +1444,12 @@ public class InspectionAcquisitionPlanTests
         {
             contribution = scope.Register(
                 TestArtifactProvenance.Instance,
-                openRead);
+                _ => openRead());
         }
 
         authority.CreateRetainedContent(
             contribution.Registration,
-            openRead);
+            _ => openRead());
         authority.CompleteAdmission(admission);
         return contribution.Registration;
     }


### PR DESCRIPTION
## Summary

Implements artifact content-access quiescence: open admission is now atomic
with generation end, authorization replacement, and lease disposal; admitted
openers and streams remain registered until failure or disposal; and
`ArtifactSetSession` releases acquisition leases only after registered content
access drains.

Potentially blocking openers receive the generation cancellation token, while
admission stream reads combine caller and owner cancellation without relying
on `Task.Run`. Opener cancellation is detached under the authority gate before
a successful stream escapes, so it cannot become an accidental
returned-stream lifetime signal. Returned query streams deliberately remain
valid after generation end and pin release until consumer disposal. There is
no timeout or invisible invalidation: abandoning a returned stream leaves
`DisposeAsync` incomplete.

Cancellation-callback failures are retained as cleanup failures after
quiescence and do not skip admission-lease or acquisition-lease cleanup.

Closes #5032.

## Demo

Before this change, the committed `CurrentReleaseDuringOpenStream.cfg`
counterexample reaches acquisition-lease release while a returned query stream
is still open.

A file-based app using the public `ArtifactSetSession` APIs now starts disposal
with a query stream open, reads from that stream after generation end, attempts
a neighboring late open, then closes the original stream:

```bash
dotnet run /tmp/artifact-quiescence-demo.cs
```

```text
before close: disposal=False, leases=0
existing stream after end: 1
later open: rejected
after close: disposal=True, leases=1
```

Notice that generation end rejects the later open immediately, but neither
invalidates the admitted stream nor releases its backing lease. Closing the
stream is the quiescence event that completes disposal and releases the lease.
A neighboring retained-opener probe registers stream cleanup against the
opener token and confirms that successful callback return detaches it:

```text
retained opener token: detached
content quiescence: supported
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
  - 0 warnings, 0 errors
- `dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release --no-build`
  - 66 total, 0 failed, 6 Windows-only skips on Linux
- 20 consecutive Release runs of the replacement artifact test executable
- NativeAOT `linux-x64` publish and execution of the public-API demo
- Browser/Wasm publish and Node execution of the same quiescence contract
  - `artifact-content-quiescence: supported`
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md docs/design/models/artifact-generation-access/README.md`

## Compatibility

Repository callers now provide `Func<CancellationToken, Stream>` openers.
Immediate immutable-snapshot openers remain synchronous; potentially blocking
openers must observe owner cancellation. The implementation uses no inspected
assembly loading, Roslyn, worker-thread assumption, or platform-specific
resource primitive.
