### PR TITLE
Implement exact inspection lens activation outcomes

### DIFF
--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -20,10 +20,15 @@ retained evaluation bases, and pure lens recommendation are implemented by
 `NavigationLensRecommendation` and gated at their claims below. Pure initial
 subject ranking over already trustworthy Type candidates and already available
 Library candidates is implemented by `NavigationInitialSubjectRecommendation`
-and gated at its claim below. Candidate availability and failure
-classification, activation, reconciliation, revision behavior, retained
-sessions, synchronization, and restoration remain unverified until their
-implementation gates in [Verification](#verification) land.
+and gated at its claim below. Pure standalone exact-lens activation is
+implemented by `NavigationLensActivation` and gated by
+`StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`,
+`ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`, and
+`ExplicitLensResolution_RetainsExactRegistryEvidence`. Candidate availability
+and failure classification, subject activation, snapshot installation,
+reconciliation, revision behavior, retained sessions, synchronization, and
+restoration remain unverified until their implementation gates in
+[Verification](#verification) land.
 
 The concurrency claims are specified separately as executable TLA+ models under
 [`models/inspection-subject-navigation/`](models/inspection-subject-navigation/).
@@ -464,6 +469,14 @@ Every outcome retains the exact registry result and request identity, including
 the absent descriptor in `Unknown`. A Navigation-owned preparation failure
 after an available registry result remains distinguishable from a
 Registry-owned failed result. Neither failure is rewritten as unavailable.
+
+The pure exact-request boundary is gated by
+`StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`,
+`ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`, and
+`ExplicitLensResolution_RetainsExactRegistryEvidence`. Snapshot replacement,
+revision advancement, and installation of an exact-request basis remain
+unverified until their separately named gates land.
+
 A valid exact request that completes as Registry `Unavailable` or `Failed`
 installs its exact-request basis and evidence whenever that replacement differs
 from the prior snapshot and its bound subject remains active. It does not

--- a/src/DotnetInspector.Queries.Tests/NavigationLensActivationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/NavigationLensActivationTests.cs
@@ -1,0 +1,417 @@
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class NavigationLensActivationTests
+{
+    [Fact]
+    public void StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution()
+    {
+        AssemblyContextParticipant participant = Participant();
+        StructuralSubjectIdentity.TypeSubject active =
+            TypeSubject("Active", participant);
+        StructuralSubjectIdentity.TypeSubject equal =
+            TypeSubject("Active", participant);
+        StructuralSubjectIdentity.TypeSubject requested =
+            TypeSubject("Requested", participant);
+        Assert.NotSame(active, equal);
+        Assert.Equal(active, equal);
+
+        ViewFacetDescriptor availableDescriptor = Descriptor(
+            "type.api",
+            StructuralSubjectKind.Type);
+        ViewFacetRegistry availableRegistry = Registry(availableDescriptor);
+        var availableFacts = new ViewFacetAvailabilitySnapshot(
+        [
+            new ViewFacetAvailabilityFact(
+                availableDescriptor.Id,
+                ViewFacetAvailability.Available.Instance),
+        ]);
+        NavigationLensActivationResult.Applied equalResult =
+            Assert.IsType<NavigationLensActivationResult.Applied>(
+                NavigationLensActivation.Activate(
+                    active,
+                    new NavigationLensIdentity(
+                        equal,
+                        availableDescriptor.Id),
+                    availableRegistry,
+                    availableFacts));
+        Assert.Same(equal, equalResult.Request.Subject);
+
+        var request = new NavigationLensIdentity(
+            requested,
+            new ViewFacetId("type.api"));
+        ViewFacetRegistry registry = Registry(
+            availableDescriptor,
+            _ => throw new InvalidOperationException(
+                "Registry applicability must not run."));
+
+        NavigationLensActivationResult.Rejected result =
+            Assert.IsType<NavigationLensActivationResult.Rejected>(
+                NavigationLensActivation.Activate(
+                    active,
+                    request,
+                    registry,
+                    ThrowingFacts.Instance));
+        NavigationLensRejection.SubjectMismatch rejection =
+            Assert.IsType<NavigationLensRejection.SubjectMismatch>(
+                result.Rejection);
+
+        Assert.Same(request, result.Request);
+        Assert.Same(active, rejection.ActiveSubject);
+    }
+
+    [Fact]
+    public void ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback()
+    {
+        ActivationFixture fixture = CreateFixture();
+
+        NavigationLensActivationResult.Applied available =
+            Assert.IsType<NavigationLensActivationResult.Applied>(
+                fixture.Activate("type.available"));
+        Assert.Equal(
+            "type.available",
+            available.Outcome.EffectiveLens!.Facet.Value);
+
+        NavigationLensActivationResult.Unavailable unavailable =
+            Assert.IsType<NavigationLensActivationResult.Unavailable>(
+                fixture.Activate("type.unavailable"));
+        Assert.Null(unavailable.Outcome.EffectiveLens);
+        Assert.Equal(
+            "type.unavailable",
+            Assert.IsType<NavigationLensEvaluationBasis.ExactRequest>(
+                unavailable.Outcome.Basis).Request.Facet.Value);
+
+        NavigationLensActivationResult.Failed failed =
+            Assert.IsType<NavigationLensActivationResult.Failed>(
+                fixture.Activate("type.failed"));
+        Assert.Null(failed.Outcome.EffectiveLens);
+        Assert.Equal(
+            "type.failed",
+            Assert.IsType<NavigationLensEvaluationBasis.ExactRequest>(
+                failed.Outcome.Basis).Request.Facet.Value);
+        Assert.IsType<NavigationLensFailure.RegistryEvaluation>(
+            failed.Outcome.Failure);
+
+        NavigationLensActivationResult.Rejected inapplicable =
+            Assert.IsType<NavigationLensActivationResult.Rejected>(
+                fixture.Activate("root.inapplicable"));
+        Assert.IsType<ViewFacetResolution.Inapplicable>(
+            Assert.IsType<NavigationLensRejection.Registry>(
+                inapplicable.Rejection).Result);
+
+        NavigationLensActivationResult.Rejected unknown =
+            Assert.IsType<NavigationLensActivationResult.Rejected>(
+                fixture.Activate("type.unknown"));
+        Assert.IsType<ViewFacetResolution.Unknown>(
+            Assert.IsType<NavigationLensRejection.Registry>(
+                unknown.Rejection).Result);
+
+        StructuralSubjectIdentity.RootSubject root =
+            StructuralSubjectIdentity.ForRoot(PackageCoordinate());
+        ViewFacetDescriptor rootDescriptor = Descriptor(
+            "root.overview",
+            StructuralSubjectKind.Root);
+        ViewFacetRegistry rootRegistry = Registry(
+            rootDescriptor,
+            target =>
+                target.RootKind == ViewFacetRootKind.PackageCapable);
+        var rootFacts = new ViewFacetAvailabilitySnapshot(
+        [
+            new ViewFacetAvailabilityFact(
+                rootDescriptor.Id,
+                ViewFacetAvailability.Available.Instance),
+        ]);
+        NavigationLensActivationResult.Applied rootResult =
+            Assert.IsType<NavigationLensActivationResult.Applied>(
+                NavigationLensActivation.Activate(
+                    root,
+                    new NavigationLensIdentity(root, rootDescriptor.Id),
+                    rootRegistry,
+                    rootFacts));
+        Assert.Same(root, rootResult.Outcome.EffectiveLens!.Subject);
+    }
+
+    [Fact]
+    public void ExplicitLensResolution_RetainsExactRegistryEvidence()
+    {
+        ActivationFixture fixture = CreateFixture();
+
+        NavigationLensActivationResult.Applied available =
+            Assert.IsType<NavigationLensActivationResult.Applied>(
+                fixture.Activate("type.available"));
+        AssertExactBasis(
+            fixture,
+            available.Request,
+            available.Outcome.Basis,
+            fixture.Available);
+
+        NavigationLensActivationResult.Unavailable unavailable =
+            Assert.IsType<NavigationLensActivationResult.Unavailable>(
+                fixture.Activate("type.unavailable"));
+        NavigationLensEvaluationBasis.ExactRequest unavailableBasis =
+            AssertExactBasis(
+                fixture,
+                unavailable.Request,
+                unavailable.Outcome.Basis,
+                fixture.Unavailable);
+        Assert.Same(
+            fixture.UnavailableReason,
+            Assert.IsType<ViewFacetResolution.Unavailable>(
+                unavailableBasis.Result).Reason);
+
+        NavigationLensActivationResult.Failed failed =
+            Assert.IsType<NavigationLensActivationResult.Failed>(
+                fixture.Activate("type.failed"));
+        NavigationLensEvaluationBasis.ExactRequest failedBasis =
+            AssertExactBasis(
+                fixture,
+                failed.Request,
+                failed.Outcome.Basis,
+                fixture.Failed);
+        Assert.Same(
+            fixture.Diagnostic,
+            Assert.IsType<ViewFacetResolution.Failed>(
+                failedBasis.Result).Evidence);
+
+        foreach ((string Id, ViewFacetDescriptor? Descriptor) rejected in
+            new[]
+            {
+                ("root.inapplicable", fixture.Inapplicable),
+                ("type.unknown", null),
+            })
+        {
+            NavigationLensActivationResult.Rejected result =
+                Assert.IsType<NavigationLensActivationResult.Rejected>(
+                    fixture.Activate(rejected.Id));
+            ViewFacetResolution resolution =
+                Assert.IsType<NavigationLensRejection.Registry>(
+                    result.Rejection).Basis.Result;
+
+            Assert.Same(fixture.Subject, result.Request.Subject);
+            Assert.Equal(rejected.Id, result.Request.Facet.Value);
+            if (rejected.Descriptor is null)
+            {
+                Assert.IsType<ViewFacetResolution.Unknown>(resolution);
+            }
+            else
+            {
+                Assert.Same(
+                    rejected.Descriptor,
+                    Assert.IsType<ViewFacetResolution.Inapplicable>(
+                        resolution).Descriptor);
+            }
+        }
+    }
+
+    static NavigationLensEvaluationBasis.ExactRequest AssertExactBasis(
+        ActivationFixture fixture,
+        NavigationLensIdentity request,
+        NavigationLensEvaluationBasis basis,
+        ViewFacetDescriptor descriptor)
+    {
+        var exact =
+            Assert.IsType<NavigationLensEvaluationBasis.ExactRequest>(basis);
+        Assert.Same(request, exact.Request);
+        ViewFacetDescriptor actual = exact.Result switch
+        {
+            ViewFacetResolution.Available available =>
+                available.Descriptor,
+            ViewFacetResolution.Unavailable unavailable =>
+                unavailable.Descriptor,
+            ViewFacetResolution.Failed failed =>
+                failed.Descriptor,
+            _ => throw new Xunit.Sdk.XunitException(
+                "Expected an applicable Registry result."),
+        };
+        Assert.Same(descriptor, actual);
+        Assert.Same(fixture.Subject, exact.Subject);
+        return exact;
+    }
+
+    static ActivationFixture CreateFixture()
+    {
+        StructuralSubjectIdentity.TypeSubject subject = TypeSubject("Widget");
+        ViewFacetDescriptor available = Descriptor(
+            "type.available",
+            StructuralSubjectKind.Type,
+            order: 100);
+        ViewFacetDescriptor unavailable = Descriptor(
+            "type.unavailable",
+            StructuralSubjectKind.Type,
+            order: 200);
+        ViewFacetDescriptor failed = Descriptor(
+            "type.failed",
+            StructuralSubjectKind.Type,
+            order: 300);
+        ViewFacetDescriptor fallback = Descriptor(
+            "type.fallback",
+            StructuralSubjectKind.Type,
+            order: 400);
+        ViewFacetDescriptor inapplicable = Descriptor(
+            "root.inapplicable",
+            StructuralSubjectKind.Root,
+            order: 100);
+        ViewFacetUnavailableReason unavailableReason =
+            ViewFacetUnavailableReason.CapabilityAbsent(
+                "The requested view is unavailable.");
+        var diagnostic = new TestDiagnosticEvidence("failed");
+        ViewFacetRegistry registry = Registry(
+        [
+            Registration(available),
+            Registration(unavailable),
+            Registration(failed),
+            Registration(fallback),
+            Registration(inapplicable),
+        ]);
+        var facts = new ViewFacetAvailabilitySnapshot(
+        [
+            new ViewFacetAvailabilityFact(
+                available.Id,
+                ViewFacetAvailability.Available.Instance),
+            new ViewFacetAvailabilityFact(
+                unavailable.Id,
+                new ViewFacetAvailability.Unavailable(unavailableReason)),
+            new ViewFacetAvailabilityFact(
+                failed.Id,
+                new ViewFacetAvailability.Failed(
+                    "The requested view failed.",
+                    diagnostic)),
+            new ViewFacetAvailabilityFact(
+                fallback.Id,
+                ViewFacetAvailability.Available.Instance),
+        ]);
+        return new(
+            subject,
+            registry,
+            facts,
+            available,
+            unavailable,
+            failed,
+            inapplicable,
+            unavailableReason,
+            diagnostic);
+    }
+
+    static ViewFacetRegistry Registry(
+        ViewFacetDescriptor descriptor,
+        Func<ViewFacetTarget, bool>? applies = null) =>
+        Registry([Registration(descriptor, applies)]);
+
+    static ViewFacetRegistry Registry(
+        IEnumerable<ViewFacetRegistration> registrations)
+    {
+        ViewFacetRegistration[] values = [.. registrations];
+        return new(
+            values,
+            values.Select(registration =>
+                Assert.IsType<ViewFacetRegistration.Active>(
+                    registration).Binding));
+    }
+
+    static ViewFacetRegistration.Active Registration(
+        ViewFacetDescriptor descriptor,
+        Func<ViewFacetTarget, bool>? applies = null) =>
+        new(
+            descriptor,
+            descriptor.Summary,
+            applies ?? (target => target.Subject.Kind == descriptor.Kind),
+            new ViewFacetExecutionBinding(descriptor.Id, descriptor),
+            (_, facts) => facts.Get(descriptor.Id));
+
+    static ViewFacetDescriptor Descriptor(
+        string id,
+        StructuralSubjectKind kind,
+        int order = 100) =>
+        new(
+            new ViewFacetId(id),
+            kind,
+            id,
+            $"Summary for {id}.",
+            order);
+
+    static RealizedMemberCoordinate.Package PackageCoordinate() =>
+        new(
+            "sample.package",
+            "1.0.0",
+            "nuget-org",
+            "net11.0",
+            runtimeIdentifier: null);
+
+    static AssemblyContextParticipant Participant()
+    {
+        ResolvedAssemblyReference assembly = ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                "Library",
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            path: null,
+            () => new MemoryStream([0], writable: false),
+            AssemblyResolutionProvenance.Package(
+                "sample.package",
+                "1.0.0",
+                "net11.0",
+                rid: null));
+        return new AssemblyContextParticipant(
+            assembly,
+            NoResolverAssemblyBindingPolicy.Instance);
+    }
+
+    static StructuralSubjectIdentity.TypeSubject TypeSubject(
+        string name,
+        AssemblyContextParticipant? participant = null)
+    {
+        RealizedMemberCoordinate.Package coordinate = PackageCoordinate();
+        var library = new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            coordinate,
+            participant ?? Participant());
+        MetadataTypeDefinitionName type =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Sample",
+                    [name])).Name;
+        return StructuralSubjectIdentity.ForType(
+            StructuralSubjectIdentity.ForLibrary(library),
+            type);
+    }
+
+    sealed record ActivationFixture(
+        StructuralSubjectIdentity.TypeSubject Subject,
+        ViewFacetRegistry Registry,
+        IViewFacetAvailabilityFacts Facts,
+        ViewFacetDescriptor Available,
+        ViewFacetDescriptor Unavailable,
+        ViewFacetDescriptor Failed,
+        ViewFacetDescriptor Inapplicable,
+        ViewFacetUnavailableReason UnavailableReason,
+        TestDiagnosticEvidence Diagnostic)
+    {
+        public NavigationLensActivationResult Activate(string facet) =>
+            NavigationLensActivation.Activate(
+                Subject,
+                new NavigationLensIdentity(
+                    Subject,
+                    new ViewFacetId(facet)),
+                Registry,
+                Facts);
+    }
+
+    sealed record TestDiagnosticEvidence(string Value)
+        : IViewFacetDiagnosticEvidence;
+
+    sealed class ThrowingFacts : IViewFacetAvailabilityFacts
+    {
+        public static ThrowingFacts Instance { get; } = new();
+
+        public ViewFacetAvailability Get(ViewFacetId id) =>
+            throw new InvalidOperationException(
+                $"Facts must not be read for '{id.Value}'.");
+    }
+}

--- a/src/DotnetInspector.Queries/NavigationLensActivation.cs
+++ b/src/DotnetInspector.Queries/NavigationLensActivation.cs
@@ -1,0 +1,282 @@
+namespace DotnetInspector.Queries;
+
+/// <summary>A typed rejection of one exact navigation-lens request.</summary>
+public abstract record NavigationLensRejection
+{
+    private protected NavigationLensRejection()
+    {
+    }
+
+    /// <summary>The request was bound to a subject other than the active subject.</summary>
+    public sealed record SubjectMismatch : NavigationLensRejection
+    {
+        internal SubjectMismatch(StructuralSubjectIdentity activeSubject)
+        {
+            ArgumentNullException.ThrowIfNull(activeSubject);
+            ActiveSubject = activeSubject;
+        }
+
+        public StructuralSubjectIdentity ActiveSubject { get; }
+    }
+
+    /// <summary>The registry rejected the exact requested facet.</summary>
+    public sealed record Registry : NavigationLensRejection
+    {
+        internal Registry(
+            NavigationLensIdentity request,
+            ViewFacetResolution result)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            ArgumentNullException.ThrowIfNull(result);
+            if (result is not ViewFacetResolution.Inapplicable
+                and not ViewFacetResolution.Unknown)
+            {
+                throw new ArgumentException(
+                    "A registry rejection must be inapplicable or unknown.",
+                    nameof(result));
+            }
+
+            Basis = new NavigationLensEvaluationBasis.ExactRequest(
+                request,
+                result);
+        }
+
+        public NavigationLensEvaluationBasis.ExactRequest Basis { get; }
+
+        public ViewFacetResolution Result => Basis.Result;
+    }
+}
+
+/// <summary>The semantic result of activating one exact navigation lens.</summary>
+public abstract record NavigationLensActivationResult
+{
+    private protected NavigationLensActivationResult(
+        NavigationLensIdentity request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        Request = request;
+    }
+
+    /// <summary>The complete exact request correlated with this result.</summary>
+    public NavigationLensIdentity Request { get; }
+
+    /// <summary>The exact requested lens is available.</summary>
+    public sealed record Applied : NavigationLensActivationResult
+    {
+        internal Applied(
+            NavigationLensIdentity request,
+            NavigationLensOutcome.Effective outcome)
+            : base(request)
+        {
+            ArgumentNullException.ThrowIfNull(outcome);
+            NavigationLensEvaluationBasis.ExactRequest exact =
+                ValidateExactOutcome(request, outcome);
+            if (exact.Result is not ViewFacetResolution.Available)
+            {
+                throw new ArgumentException(
+                    "An applied activation requires an available Registry result.",
+                    nameof(outcome));
+            }
+            if (outcome.EffectiveLens != request)
+            {
+                throw new ArgumentException(
+                    "An applied activation must produce the exact requested lens.",
+                    nameof(outcome));
+            }
+            Outcome = outcome;
+        }
+
+        public NavigationLensOutcome.Effective Outcome { get; }
+    }
+
+    /// <summary>The exact requested lens is currently unavailable.</summary>
+    public sealed record Unavailable : NavigationLensActivationResult
+    {
+        internal Unavailable(
+            NavigationLensIdentity request,
+            NavigationLensOutcome.Unavailable outcome)
+            : base(request)
+        {
+            ArgumentNullException.ThrowIfNull(outcome);
+            NavigationLensEvaluationBasis.ExactRequest exact =
+                ValidateExactOutcome(request, outcome);
+            if (exact.Result is not ViewFacetResolution.Unavailable)
+            {
+                throw new ArgumentException(
+                    "An unavailable activation requires an unavailable Registry result.",
+                    nameof(outcome));
+            }
+            Outcome = outcome;
+        }
+
+        public NavigationLensOutcome.Unavailable Outcome { get; }
+    }
+
+    /// <summary>The exact request is invalid for the active subject or registry.</summary>
+    public sealed record Rejected : NavigationLensActivationResult
+    {
+        internal Rejected(
+            NavigationLensIdentity request,
+            NavigationLensRejection rejection)
+            : base(request)
+        {
+            ArgumentNullException.ThrowIfNull(rejection);
+            switch (rejection)
+            {
+                case NavigationLensRejection.SubjectMismatch mismatch
+                    when mismatch.ActiveSubject == request.Subject:
+                    throw new ArgumentException(
+                        "A subject-mismatch rejection requires different exact subjects.",
+                        nameof(rejection));
+                case NavigationLensRejection.Registry registry:
+                    if (registry.Basis.Request != request)
+                    {
+                        throw new ArgumentException(
+                            "A Registry rejection must retain the exact request.",
+                            nameof(rejection));
+                    }
+                    break;
+            }
+            Rejection = rejection;
+        }
+
+        public NavigationLensRejection Rejection { get; }
+    }
+
+    /// <summary>The registry failed while evaluating the exact requested lens.</summary>
+    public sealed record Failed : NavigationLensActivationResult
+    {
+        internal Failed(
+            NavigationLensIdentity request,
+            NavigationLensOutcome.Failed outcome)
+            : base(request)
+        {
+            ArgumentNullException.ThrowIfNull(outcome);
+            NavigationLensEvaluationBasis.ExactRequest exact =
+                ValidateExactOutcome(request, outcome);
+            if (exact.Result is not ViewFacetResolution.Failed
+                || outcome.Failure
+                    is not NavigationLensFailure.RegistryEvaluation)
+            {
+                throw new ArgumentException(
+                    "A failed activation requires the exact failed Registry result.",
+                    nameof(outcome));
+            }
+            Outcome = outcome;
+        }
+
+        public NavigationLensOutcome.Failed Outcome { get; }
+    }
+
+    static NavigationLensEvaluationBasis.ExactRequest ValidateExactOutcome(
+        NavigationLensIdentity request,
+        NavigationLensOutcome outcome)
+    {
+        if (outcome.Basis
+                is not NavigationLensEvaluationBasis.ExactRequest exact
+            || exact.Request != request)
+        {
+            throw new ArgumentException(
+                "An activation outcome must retain the exact request.",
+                nameof(outcome));
+        }
+
+        return exact;
+    }
+}
+
+/// <summary>Pure product mapping for one exact navigation-lens request.</summary>
+public static class NavigationLensActivation
+{
+    public static NavigationLensActivationResult Activate(
+        StructuralSubjectIdentity activeSubject,
+        NavigationLensIdentity request,
+        ViewFacetRegistry registry,
+        IViewFacetAvailabilityFacts facts)
+    {
+        ArgumentNullException.ThrowIfNull(activeSubject);
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(facts);
+
+        if (request.Subject != activeSubject)
+        {
+            return new NavigationLensActivationResult.Rejected(
+                request,
+                new NavigationLensRejection.SubjectMismatch(activeSubject));
+        }
+
+        ViewFacetResolution result = registry.Resolve(
+            request.Facet.Value,
+            Target(activeSubject),
+            facts);
+        return result switch
+        {
+            ViewFacetResolution.Available =>
+                Applied(request, result),
+            ViewFacetResolution.Unavailable =>
+                Unavailable(request, result),
+            ViewFacetResolution.Failed =>
+                Failed(request, result),
+            ViewFacetResolution.Inapplicable
+                or ViewFacetResolution.Unknown =>
+                new NavigationLensActivationResult.Rejected(
+                    request,
+                    new NavigationLensRejection.Registry(request, result)),
+            _ => throw new InvalidOperationException(
+                "Unknown view-facet resolution result."),
+        };
+    }
+
+    static NavigationLensActivationResult Applied(
+        NavigationLensIdentity request,
+        ViewFacetResolution result)
+    {
+        var basis = new NavigationLensEvaluationBasis.ExactRequest(
+            request,
+            result);
+        return new NavigationLensActivationResult.Applied(
+            request,
+            new NavigationLensOutcome.Effective(basis, request));
+    }
+
+    static NavigationLensActivationResult Unavailable(
+        NavigationLensIdentity request,
+        ViewFacetResolution result)
+    {
+        var basis = new NavigationLensEvaluationBasis.ExactRequest(
+            request,
+            result);
+        return new NavigationLensActivationResult.Unavailable(
+            request,
+            new NavigationLensOutcome.Unavailable(basis));
+    }
+
+    static NavigationLensActivationResult Failed(
+        NavigationLensIdentity request,
+        ViewFacetResolution result)
+    {
+        var basis = new NavigationLensEvaluationBasis.ExactRequest(
+            request,
+            result);
+        return new NavigationLensActivationResult.Failed(
+            request,
+            new NavigationLensOutcome.Failed(
+                basis,
+                NavigationLensFailure.RegistryEvaluation.Instance));
+    }
+
+    static ViewFacetTarget Target(StructuralSubjectIdentity subject) =>
+        subject switch
+        {
+            StructuralSubjectIdentity.RootSubject root =>
+                ViewFacetTarget.ForRoot(root),
+            StructuralSubjectIdentity.AllLibrariesSubject
+                or StructuralSubjectIdentity.LibrarySubject
+                or StructuralSubjectIdentity.TypeSubject
+                or StructuralSubjectIdentity.MemberSubject =>
+                ViewFacetTarget.ForSubject(subject),
+            _ => throw new InvalidOperationException(
+                "Unknown structural subject kind."),
+        };
+}


### PR DESCRIPTION
## Summary

Implement the product-owned exact navigation-lens activation boundary. A
standalone request must bind the active exact subject before View Facet
Registry resolution, maps all five Registry outcomes without fallback, and
retains the complete request and Registry evidence.

This is the first implementation prerequisite for the focused Inspect Web
Navigation Consumer. It deliberately does not introduce browser-local
navigation result types.

## Demo

The focused gate submits the same `type.api` facet ID against two exact Type
subjects:

```text
active Type + differently bound request
  -> Rejected.SubjectMismatch
  -> Registry applicability and availability are not evaluated

active Type + matching exact request
  Available    -> Applied(exact lens)
  Unavailable  -> Unavailable(exact request + reason)
  Failed       -> Failed(exact request + diagnostic evidence)
  Inapplicable -> Rejected(exact Registry result)
  Unknown      -> Rejected(exact Registry result)
```

What to notice: an available sibling facet is present throughout the fixture,
but unavailable and failed requests never fall back to it. A separately
constructed value-equal subject is accepted, while a differently bound subject
is rejected before the Registry seam runs.

## Design basis

- Normative owner:
  `docs/design/inspection-subject-navigation.md#explicit-activation` - exact
  subject equality is checked before Registry resolution, and every exact
  Registry result maps without fallback while retaining its evidence.
- Supporting contract: `docs/design/view-facet-registry.md` owns exact facet
  identity and the five Registry resolution variants.
- Existing foundation: `StructuralSubjectIdentity`,
  `NavigationLensIdentity`, and `NavigationLensEvaluationBasis.ExactRequest`.
- Consumer boundary:
  `docs/design/inspect-web-navigation-consumer.md` will consume later
  session-issued results; it does not own this mapping.

## Compatibility and non-claims

- Adds a host-neutral product API in `DotnetInspector.Queries`.
- Does not implement snapshot installation or revision, subject activation,
  reconciliation, retained sessions, synchronization, canonical restoration,
  Browser DTO projection, history, focus, or rendering.
- `ExactNonSuccess_InstallsExactRequestBasis` remains for the later
  snapshot/session integration slice.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  - 988 passed
- `npx markdownlint-cli docs/design/inspection-subject-navigation.md`
- `git diff --check`

Closes #5430
