### PR TITLE
Activate expanded source oracle assembly pool

### DIFF
--- a/eng/prepare-authored-source-oracles.sh
+++ b/eng/prepare-authored-source-oracles.sh
@@ -4,44 +4,62 @@
 set -euo pipefail
 
 VERSION="10.0.10"
-TFM="net10.0"
-ASSEMBLY_SHA256="91f4b016890cfd5468d46d32c451931cac34096f869cc1c8077c902d9a7f5ccd"
+
+# package ID | NuGet cache directory | package asset | assembly SHA-256
+declare -a oracle_specs=(
+  "System.Text.Encodings.Web|system.text.encodings.web|lib/net10.0/System.Text.Encodings.Web.dll|91f4b016890cfd5468d46d32c451931cac34096f869cc1c8077c902d9a7f5ccd"
+  "System.Runtime.Serialization.Formatters|system.runtime.serialization.formatters|lib/net8.0/System.Runtime.Serialization.Formatters.dll|33693c0971e95d158efc64307e6ef379a9dc322f1642178e3c29c8e1d4db255e"
+  "System.Reflection.Context|system.reflection.context|lib/net10.0/System.Reflection.Context.dll|94da27080f9aaa03e3719828976838ba39b0d8d7299fe9bd6130b1c822014f3b"
+  "System.Reflection.Metadata|system.reflection.metadata|lib/net10.0/System.Reflection.Metadata.dll|2a8c49aa47e910f4e690bce79be3986d3cfb0df8d8e978bbdf51b76d594a378d"
+)
 
 out="${1:-}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-cat > "$tmp/oracles.csproj" <<EOF
+{
+  cat <<EOF
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net11.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Encodings.Web" Version="$VERSION" />
+EOF
+  for spec in "${oracle_specs[@]}"; do
+    package_id="${spec%%|*}"
+    printf '    <PackageReference Include="%s" Version="%s" />\n' "$package_id" "$VERSION"
+  done
+  cat <<'EOF'
   </ItemGroup>
 </Project>
 EOF
+} > "$tmp/oracles.csproj"
 
 dotnet restore "$tmp/oracles.csproj" --verbosity quiet >&2
 
 packages="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
-assembly="$packages/system.text.encodings.web/$VERSION/lib/$TFM/System.Text.Encodings.Web.dll"
-if [ ! -f "$assembly" ]; then
-  echo "Missing source-oracle assembly: $assembly" >&2
-  exit 1
-fi
+declare -a assemblies=()
+for spec in "${oracle_specs[@]}"; do
+  IFS='|' read -r package_id package_directory asset_path expected_sha256 <<< "$spec"
+  assembly="$packages/$package_directory/$VERSION/$asset_path"
+  if [ ! -f "$assembly" ]; then
+    echo "Missing source-oracle assembly for $package_id: $assembly" >&2
+    exit 1
+  fi
 
-actual_sha256="$(sha256sum "$assembly" | awk '{print $1}')"
-if [ "$actual_sha256" != "$ASSEMBLY_SHA256" ]; then
-  echo "Source-oracle assembly SHA-256 mismatch: $assembly" >&2
-  echo "Expected: $ASSEMBLY_SHA256" >&2
-  echo "Actual:   $actual_sha256" >&2
-  exit 1
-fi
+  actual_sha256="$(sha256sum "$assembly" | awk '{print $1}')"
+  if [ "$actual_sha256" != "$expected_sha256" ]; then
+    echo "Source-oracle assembly SHA-256 mismatch for $package_id: $assembly" >&2
+    echo "Expected: $expected_sha256" >&2
+    echo "Actual:   $actual_sha256" >&2
+    exit 1
+  fi
+  assemblies+=("$assembly")
+done
 
 if [ -n "$out" ]; then
-  printf '%s\n' "$assembly" > "$out"
+  printf '%s\n' "${assemblies[@]}" > "$out"
 else
-  printf '%s\n' "$assembly"
+  printf '%s\n' "${assemblies[@]}"
 fi

--- a/src/ILInspector.Decompiler.Tests/AuthoredCorpusRatchetTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredCorpusRatchetTests.cs
@@ -1533,19 +1533,33 @@ public class AuthoredCorpusRatchetTests
             workflow,
             StringComparison.Ordinal);
         Assert.Contains(
-            "<PackageReference Include=\"System.Text.Encodings.Web\" Version=\"$VERSION\" />",
-            poolScript,
-            StringComparison.Ordinal);
-        Assert.Contains(
             "VERSION=\"10.0.10\"",
             poolScript,
             StringComparison.Ordinal);
+        string[] expectedSpecs =
+        [
+            "System.Text.Encodings.Web|system.text.encodings.web|lib/net10.0/System.Text.Encodings.Web.dll|91f4b016890cfd5468d46d32c451931cac34096f869cc1c8077c902d9a7f5ccd",
+            "System.Runtime.Serialization.Formatters|system.runtime.serialization.formatters|lib/net8.0/System.Runtime.Serialization.Formatters.dll|33693c0971e95d158efc64307e6ef379a9dc322f1642178e3c29c8e1d4db255e",
+            "System.Reflection.Context|system.reflection.context|lib/net10.0/System.Reflection.Context.dll|94da27080f9aaa03e3719828976838ba39b0d8d7299fe9bd6130b1c822014f3b",
+            "System.Reflection.Metadata|system.reflection.metadata|lib/net10.0/System.Reflection.Metadata.dll|2a8c49aa47e910f4e690bce79be3986d3cfb0df8d8e978bbdf51b76d594a378d",
+        ];
+        Assert.Equal(
+            expectedSpecs,
+            poolScript
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Trim())
+                .Where(line => line.StartsWith("\"System.", StringComparison.Ordinal))
+                .Select(line => line.Trim('"')));
         Assert.Contains(
-            "TFM=\"net10.0\"",
+            "printf '    <PackageReference Include=\"%s\" Version=\"%s\" />\\n' \"$package_id\" \"$VERSION\"",
             poolScript,
             StringComparison.Ordinal);
         Assert.Contains(
-            "ASSEMBLY_SHA256=\"91f4b016890cfd5468d46d32c451931cac34096f869cc1c8077c902d9a7f5ccd\"",
+            "if [ \"$actual_sha256\" != \"$expected_sha256\" ]; then",
+            poolScript,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "printf '%s\\n' \"${assemblies[@]}\" > \"$out\"",
             poolScript,
             StringComparison.Ordinal);
         Assert.Contains(

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -444,7 +444,7 @@ sets, the Valid/Correct prerequisites, and Printer-exact opt-in.
 The enrolled third-party rows and manifest live on the
 `vendor/authored-source-corpus` orphan branch under `oracle/`, beside CIVIL and
 EVIL but independently gated. Restore that branch, prepare the pinned oracle
-assembly, and run the gate with:
+assemblies, and run the gate with:
 
 ```bash
 bash eng/restore-authored-source-corpus.sh
@@ -455,6 +455,12 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
   --source-oracle-manifest external/authored-source-corpus/oracle/manifest.json \
   "${oracle_assemblies[@]}"
 ```
+
+The preparation script restores version 10.0.10 of
+`System.Text.Encodings.Web`, `System.Runtime.Serialization.Formatters`,
+`System.Reflection.Context`, and `System.Reflection.Metadata`. It selects the
+exact enrolled package assets, verifies every assembly SHA-256, and emits all
+four paths for the benchmark.
 
 The periodic authored-corpus Deep Inspect lane runs this perfection gate before
 the separate EVIL regression ratchet. `DeepInspect_RunsTheWholeFileSourceOracleGate`


### PR DESCRIPTION
dotnet-inspect's whole-file oracle now exercises robust, conventionally sound printer behavior across the complete four-file enrolled corpus instead of leaving three files outside the periodic consumer.

This is the main-branch consumer slice of #5001. The immutable corpus remains on `vendor/authored-source-corpus`; this PR only materializes and gates the exact assembly set it requires.

## Demo

Before, `eng/prepare-authored-source-oracles.sh` emitted only:

```text
System.Text.Encodings.Web.dll
```

After, the same workflow handoff emits, in deterministic order:

```text
System.Text.Encodings.Web.dll
System.Runtime.Serialization.Formatters.dll
System.Reflection.Context.dll
System.Reflection.Metadata.dll
```

The real periodic invocation now reports:

| Evidence | Result |
| --- | ---: |
| Whole files Valid | 4/4 |
| Whole files Correct | 4/4 |
| Whole files Printer exact | 4/4 |
| Files with tracked inventory | 4/4 |
| Eligible member rows | 5/5 |
| Observed printer syntax features | 13 |

The neighboring stdout mode emits the same four-path sequence as output-file mode.

## Changes

- Replace the single-assembly preparation variables with one auditable four-row specification containing package ID, NuGet directory, exact asset, and SHA-256.
- Generate explicit 10.0.10 package references from that table, fail on any missing or mismatched asset, and emit all verified paths only after the complete pool succeeds.
- Strengthen `DeepInspect_RunsTheWholeFileSourceOracleGate` so deleting or changing any enrolled input, hash, package-reference loop, hash check, or complete-array handoff fails.
- Document the four-package pool consumed by the periodic Deep Inspect perfection gate.

## Compatibility

`System.Runtime.Serialization.Formatters` intentionally uses its shipped `lib/net8.0` implementation asset; the other packages use `lib/net10.0`. Network-bound package acquisition remains confined to the existing explicit preparation step, and both script output modes are preserved.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method '*DeepInspect_RunsTheWholeFileSourceOracleGate*'`
- Exact periodic `--benchmark-authored-corpus` command against `vendor/authored-source-corpus@47c2484aa1906204822c37a85c82f9e22d8ef37e`
- Four emitted assembly SHA-256 checks
- `npx markdownlint-cli tools/DecompilerHarness/README.md`
- `bash -n eng/prepare-authored-source-oracles.sh`
