### PR TITLE
Classify bounded navigation subject inventory

### DIFF
--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -20,15 +20,17 @@ retained evaluation bases, and pure lens recommendation are implemented by
 `NavigationLensRecommendation` and gated at their claims below. Pure initial
 subject ranking over already trustworthy Type candidates and already available
 Library candidates is implemented by `NavigationInitialSubjectRecommendation`
-and gated at its claim below. Pure standalone exact-lens activation is
+and gated at its claim below. Generation-free classification of bounded Type
+and Member inventory evidence is implemented by
+`NavigationSubjectInventoryClassification` and gated at its claim below. Pure
+standalone exact-lens activation is
 implemented by `NavigationLensActivation` and gated by
 `StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`,
 `ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`, and
-`ExplicitLensResolution_RetainsExactRegistryEvidence`. Candidate availability
-and failure classification, subject activation, snapshot installation,
-reconciliation, revision behavior, retained sessions, synchronization, and
-restoration remain unverified until their implementation gates in
-[Verification](#verification) land.
+`ExplicitLensResolution_RetainsExactRegistryEvidence`. Descriptor composition,
+subject activation, snapshot installation, reconciliation, revision behavior,
+retained sessions, synchronization, and restoration remain unverified until
+their implementation gates in [Verification](#verification) land.
 
 The concurrency claims are specified separately as executable TLA+ models under
 [`models/inspection-subject-navigation/`](models/inspection-subject-navigation/).
@@ -325,14 +327,60 @@ subject is selected.
 When no Library is available, Root is selected. This allows root-only package
 coordinates, including the tools-v2 pointer-package case tracked by #4829.
 
+### Bounded subject inventory classification
+
+Navigation classifies one bounded API-surface result over the admitted Library
+participants before snapshot-relative descriptors are composed. Participant
+outcomes exact-join the admitted Library prefix by owner-issued acquisition
+registration; a foreign, reordered, duplicated, or unexplained missing outcome
+is invalid input rather than evidence about subject availability.
+
+The generation-free classification follows this table:
+
+| Producer evidence | Type inventory outcome |
+| --- | --- |
+| One or more returned Types with exact definition identity | `Available`; retain every exact Type and Member row in producer order plus all peer evidence |
+| Complete successful production with zero Types and no inspection failures | `Unavailable` |
+| No exact Type plus participant rejection, participant failure, inspection failure, missing exact Type or projected-Member declaring-Type identity, or projection omission | `Failed` with the original typed evidence |
+| Exact Types plus any of those failures | `Available` and partial; retain the exact rows and original typed evidence |
+
+Projection truncation never proves that an omitted Library is empty. A returned
+Type without exact `MetadataTypeDefinitionName` is retained as identity-failure
+evidence and is not reconstructed from display text, metadata token, or list
+position. A Member projected onto another Type currently carries canonical
+declaring text but not the typed declaring-Type definition identity required by
+`StructuralSubjectIdentity.MemberSubject`; classification retains that complete
+producer row as typed identity-failure evidence rather than rewriting it as a
+declaration on the containing Type. The typed producer identity is tracked by
+issue #5437. Returned exact rows remain trustworthy when another row or
+participant fails; failure does not erase positive evidence.
+
+Every admitted Library remains an available Library candidate for initial
+subject recommendation. Only exact returned Type rows become Type candidates.
+Classification does not commit the recommendation, choose an active subject,
+compose `Current` or `Selection required`, mint generation-scoped actions, or
+produce a navigation snapshot.
+
+This classification is gated by
+`NavigationSubjectInventoryTests.EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`,
+`ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed`,
+`SuccessfulProducerRows_AreTrustworthyDespitePeerFailure`,
+`CompleteSuccessfulEmptyInventory_IsUnavailable`,
+`NoCandidateWithIndeterminateProducer_IsFailed`,
+`ProjectionTruncation_NeverProvesUnavailability`,
+`ProducerEvidence_IsRetainedWithoutTranslation`,
+`InitialCandidates_ContainOnlyTrustworthyExactRows`, and
+`InventoryJoin_RequiresExactParticipantRegistration`.
+
 The pure ranking over already trustworthy Type candidates and already
 available Library candidates is gated by
 `NavigationInitialSubjectRecommendationTests.InitialRecommendation_PrefersTypeThenLibraryThenRoot`,
 `TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder`, and
 `InitialRecommendation_NeverChoosesMember`. Candidate coordinate, Library,
 Type, primary-role, and accessibility consistency is gated by
-`CandidateConstruction_RejectsInconsistentOwnerIssuedEvidence`. Producer
-trust, availability, and failure classification remain unverified.
+`CandidateConstruction_RejectsInconsistentOwnerIssuedEvidence`. The bounded
+classification above supplies the trustworthy Type candidates and retains
+availability and failure evidence.
 
 ### Lens recommendation
 
@@ -739,6 +787,15 @@ The eventual subject-navigation implementation must include named gates for:
 - `InitialRecommendation_PrefersTypeThenLibraryThenRoot`
 - `TypeRecommendation_UsesPrimaryLibraryAccessibilityAndProducerOrder`
 - `InitialRecommendation_NeverChoosesMember`
+- `EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`
+- `ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed`
+- `SuccessfulProducerRows_AreTrustworthyDespitePeerFailure`
+- `CompleteSuccessfulEmptyInventory_IsUnavailable`
+- `NoCandidateWithIndeterminateProducer_IsFailed`
+- `ProjectionTruncation_NeverProvesUnavailability`
+- `ProducerEvidence_IsRetainedWithoutTranslation`
+- `InitialCandidates_ContainOnlyTrustworthyExactRows`
+- `InventoryJoin_RequiresExactParticipantRegistration`
 - `LensIdentity_BindsExactStructuralSubjectAndFacet`
 - `LensOutcome_RetainsRecommendationOrExactRequestBasis`
 - `LensRecommendation_UsesPreferredRoleBeforeRegistryOrder`
@@ -759,7 +816,6 @@ The eventual subject-navigation implementation must include named gates for:
 - `RecommendationBasis_RefreshRerunsRecommendation`
 - `ExactNonSuccessLens_RefreshReresolvesExactIdentityWithoutFallback`
 - `ExactNonSuccessDuringSubjectReconciliation_InstallsReplacementSubjectRecommendationBasis`
-- `EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`
 - `UnavailableDescriptor_HasNoTargetOrActionId`
 - `ExplicitUnavailableTransition_DoesNotApplyFallback`
 - `UnavailableReplacement_AdvancesStateRevision`

--- a/src/DotnetInspector.Queries.Tests/NavigationSubjectInventoryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/NavigationSubjectInventoryTests.cs
@@ -1,0 +1,582 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries.Tests;
+
+public sealed class NavigationSubjectInventoryTests
+{
+    [Fact]
+    public void EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember first = Library(coordinate, "First");
+        WorkspaceContextMember second = Library(coordinate, "Second");
+        ApiType firstType = Type(
+            "FirstType",
+            "public",
+            Member("First"),
+            Member("Second"));
+        ApiType secondType = Type("SecondType", "private", Member("Third"));
+        ApiType thirdType = Type("ThirdType", "protected");
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [first, second],
+            first,
+            Surface(
+                Available(first, firstType, secondType),
+                Available(second, thirdType)));
+
+        Assert.Equal(
+            [
+                StructuralSubjectIdentity.ForLibrary(first),
+                StructuralSubjectIdentity.ForLibrary(second),
+            ],
+            inventory.Libraries.Select(library => library.Subject));
+        Assert.True(inventory.Libraries[0].IsPrimary);
+        Assert.False(inventory.Libraries[1].IsPrimary);
+        NavigationTypeInventoryOutcome.Available aggregate =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                inventory.Types);
+        Assert.Equal(
+            [firstType, secondType, thirdType],
+            aggregate.Rows.Select(row => row.ProducerRow));
+        Assert.Equal(
+            ["Sample.FirstType", "Sample.SecondType", "Sample.ThirdType"],
+            aggregate.Rows.Select(
+                row => row.Subject.Identity.Type.ToEscapedFullName()));
+        Assert.Equal(
+            firstType.Members,
+            aggregate.Rows[0].Members.Select(member => member.ProducerRow));
+        Assert.Equal(
+            firstType.Members.Select(member =>
+                ApiMemberIdentity.GetMemberAnchor(firstType, member)),
+            aggregate.Rows[0].Members.Select(member => member.Subject.Identity.Member));
+        Assert.All(
+            aggregate.Rows[0].Members,
+            member => Assert.Same(
+                aggregate.Rows[0].Subject,
+                member.Subject.DeclaringType));
+    }
+
+    [Fact]
+    public void ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed()
+    {
+        var participant = new AssemblyContextParticipant(
+            ResolvedAssemblyReference.CreateFromPath(
+                typeof(NavigationSubjectInventoryTests).Assembly.Location,
+                AssemblyResolutionProvenance.Local("inventory gate")),
+            NoResolverAssemblyBindingPolicy.Instance);
+        using var workspace = new InspectionWorkspace();
+        using AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup([participant]);
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        var library = new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            coordinate,
+            participant);
+        AssemblyContextApiSurfaceResult surface =
+            AssemblyContextApiSurfaceQuery.ExecuteBounded(
+                group,
+                ApiSurfaceScope.Public,
+                new ApiSurfaceProjectionLimits(
+                    int.MaxValue,
+                    int.MaxValue,
+                    int.MaxValue,
+                    int.MaxValue,
+                    int.MaxValue,
+                    int.MaxValue,
+                    int.MaxValue));
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [library],
+            library,
+            surface);
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                inventory.Types);
+        NavigationTypeInventoryRow receiver = Assert.Single(
+            types.Rows,
+            row => row.ProducerRow.FullName == typeof(InventoryFixture).FullName);
+        Assert.DoesNotContain(
+            receiver.Members,
+            row => row.ProducerRow.Name == nameof(InventoryExtensions.Extend));
+        NavigationInventoryEvidence.MemberIdentityMissing extension =
+            Assert.Single(
+                types.Evidence
+                    .OfType<
+                        NavigationInventoryEvidence.MemberIdentityMissing>(),
+                evidence =>
+                    evidence.ProducerRow.Name
+                        == nameof(InventoryExtensions.Extend)
+                    && ReferenceEquals(
+                        evidence.ContainingType,
+                        receiver.ProducerRow));
+        Assert.NotNull(extension.ProducerRow.DeclaringTypeCanonicalName);
+        NavigationTypeInventoryRow declaring = Assert.Single(
+            types.Rows,
+            row => row.ProducerRow.FullName
+                == typeof(InventoryExtensions).FullName);
+        Assert.Contains(
+            declaring.Members,
+            row => row.ProducerRow.Name
+                    == nameof(InventoryExtensions.Extend)
+                && row.ProducerRow.DeclaringTypeCanonicalName is null
+                && row.Subject.DeclaringType == declaring.Subject);
+    }
+
+    [Fact]
+    public void SuccessfulProducerRows_AreTrustworthyDespitePeerFailure()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember healthy = Library(coordinate, "Healthy");
+        WorkspaceContextMember failed = Library(coordinate, "Failed");
+        ApiType returned = Type("Widget", "public");
+        var error = new InvalidOperationException("inspection failed");
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [healthy, failed],
+            healthy,
+            Surface(
+                Available(healthy, returned),
+                Failed(failed, error)));
+
+        NavigationTypeInventoryOutcome.Available aggregate =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                inventory.Types);
+        Assert.Same(returned, Assert.Single(aggregate.Rows).ProducerRow);
+        NavigationInventoryEvidence.ParticipantFailed retained =
+            Assert.IsType<NavigationInventoryEvidence.ParticipantFailed>(
+                Assert.Single(aggregate.Evidence));
+        Assert.Same(error, retained.Error);
+        Assert.Single(inventory.InitialCandidates[0].Types);
+        Assert.Empty(inventory.InitialCandidates[1].Types);
+        Assert.Equal(
+            inventory.InitialCandidates[0].Types[0].Subject,
+            NavigationInitialSubjectRecommendation.Recommend(
+                inventory.Root,
+                allLibraries: null,
+                inventory.InitialCandidates).Subject);
+    }
+
+    [Fact]
+    public void CompleteSuccessfulEmptyInventory_IsUnavailable()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember first = Library(coordinate, "First");
+        WorkspaceContextMember second = Library(coordinate, "Second");
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [first, second],
+            primary: null,
+            Surface(Available(first), Available(second)));
+
+        Assert.IsType<NavigationTypeInventoryOutcome.Unavailable>(
+            inventory.Types);
+        Assert.All(
+            inventory.Libraries,
+            library => Assert.IsType<NavigationTypeInventoryOutcome.Unavailable>(
+                library.Types));
+        Assert.All(
+            inventory.InitialCandidates,
+            candidate => Assert.Empty(candidate.Types));
+    }
+
+    [Fact]
+    public void NoCandidateWithIndeterminateProducer_IsFailed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember rejected = Library(coordinate, "Rejected");
+        WorkspaceContextMember incomplete = Library(coordinate, "Incomplete");
+        var openFailure = new CandidateOpenFailure(
+            CandidateOpenFailureKind.InvalidImage,
+            "invalid image");
+        var inspectionFailure = InspectionFailure("read type");
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [rejected, incomplete],
+            primary: null,
+            Surface(
+                Rejected(rejected, openFailure),
+                AvailableWithFailures(incomplete, [inspectionFailure])));
+
+        NavigationTypeInventoryOutcome.Failed aggregate =
+            Assert.IsType<NavigationTypeInventoryOutcome.Failed>(
+                inventory.Types);
+        Assert.Empty(aggregate.Rows);
+        Assert.Collection(
+            aggregate.Evidence,
+            evidence => Assert.Same(
+                openFailure,
+                Assert.IsType<
+                    NavigationInventoryEvidence.ParticipantRejected>(
+                        evidence).Failure),
+            evidence => Assert.Same(
+                inspectionFailure,
+                Assert.IsType<
+                    NavigationInventoryEvidence.InspectionFailed>(
+                        evidence).Failure));
+        Assert.All(
+            inventory.Libraries,
+            library => Assert.IsType<NavigationTypeInventoryOutcome.Failed>(
+                library.Types));
+    }
+
+    [Fact]
+    public void ProjectionTruncation_NeverProvesUnavailability()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember projected = Library(coordinate, "Projected");
+        WorkspaceContextMember omitted = Library(coordinate, "Omitted");
+        ApiSurfaceProjectionTruncation truncation = Truncation(
+            projectedParticipants: 1,
+            omittedParticipants: 1);
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [projected, omitted],
+            primary: null,
+            Surface(truncation, Available(projected)));
+
+        Assert.IsType<NavigationTypeInventoryOutcome.Unavailable>(
+            inventory.Libraries[0].Types);
+        NavigationTypeInventoryOutcome.Failed omittedTypes =
+            Assert.IsType<NavigationTypeInventoryOutcome.Failed>(
+                inventory.Libraries[1].Types);
+        NavigationInventoryEvidence.ProjectionOmitted evidence =
+            Assert.IsType<NavigationInventoryEvidence.ProjectionOmitted>(
+                Assert.Single(omittedTypes.Evidence));
+        Assert.Same(truncation, evidence.Truncation);
+        Assert.Equal(
+            StructuralSubjectIdentity.ForLibrary(omitted),
+            evidence.Library);
+        Assert.IsType<NavigationTypeInventoryOutcome.Failed>(inventory.Types);
+
+        ApiType returned = Type("Widget", "public");
+        NavigationSubjectInventory partial = Classify(
+            coordinate,
+            [projected, omitted],
+            primary: null,
+            Surface(truncation, Available(projected, returned)));
+        NavigationTypeInventoryOutcome.Available partialTypes =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                partial.Types);
+        Assert.Same(returned, Assert.Single(partialTypes.Rows).ProducerRow);
+        Assert.IsType<NavigationInventoryEvidence.ProjectionOmitted>(
+            Assert.Single(partialTypes.Evidence));
+    }
+
+    [Fact]
+    public void ProducerEvidence_IsRetainedWithoutTranslation()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        ApiType returned = Type("Widget", "public");
+        ApiSurfaceInspectionFailure failure =
+            InspectionFailure("decode signature");
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [library],
+            library,
+            Surface(AvailableWithFailures(library, [failure], returned)));
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                inventory.Types);
+        NavigationInventoryEvidence.InspectionFailed retained =
+            Assert.IsType<NavigationInventoryEvidence.InspectionFailed>(
+                Assert.Single(types.Evidence));
+        Assert.Same(failure, retained.Failure);
+        Assert.Same(returned, Assert.Single(types.Rows).ProducerRow);
+    }
+
+    [Fact]
+    public void InitialCandidates_ContainOnlyTrustworthyExactRows()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        ApiType exact = Type("Exact", "public");
+        ApiType missingIdentity = Type("Legacy", "private");
+        missingIdentity.DefinitionName = null;
+
+        NavigationSubjectInventory inventory = Classify(
+            coordinate,
+            [library],
+            library,
+            Surface(Available(library, exact, missingIdentity)));
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                inventory.Types);
+        Assert.Same(exact, Assert.Single(types.Rows).ProducerRow);
+        NavigationInventoryEvidence.TypeIdentityMissing missing =
+            Assert.IsType<NavigationInventoryEvidence.TypeIdentityMissing>(
+                Assert.Single(types.Evidence));
+        Assert.Same(missingIdentity, missing.ProducerRow);
+        NavigationInitialTypeCandidate candidate =
+            Assert.Single(Assert.Single(inventory.InitialCandidates).Types);
+        Assert.Equal(types.Rows[0].Subject, candidate.Subject);
+        Assert.Equal("public", candidate.Accessibility.Id);
+
+        NavigationSubjectInventory onlyMissing = Classify(
+            coordinate,
+            [library],
+            library,
+            Surface(Available(library, missingIdentity)));
+        Assert.IsType<NavigationTypeInventoryOutcome.Failed>(
+            onlyMissing.Types);
+    }
+
+    [Fact]
+    public void InventoryJoin_RequiresExactParticipantRegistration()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember expected = Library(coordinate, "Expected");
+        WorkspaceContextMember foreign = Library(coordinate, "Foreign");
+
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected],
+                primary: null,
+                Surface(Available(foreign, Type("Widget", "public")))));
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected],
+                primary: null,
+                Surface()));
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected],
+                foreign,
+                Surface(Available(expected))));
+
+        WorkspaceContextMember second = Library(coordinate, "Second");
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected, second],
+                primary: null,
+                Surface(Available(second), Available(expected))));
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected, expected],
+                primary: null,
+                Surface(Available(expected), Available(expected))));
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected, second],
+                primary: null,
+                Surface(
+                    Truncation(
+                        projectedParticipants: 1,
+                        omittedParticipants: 2),
+                    Available(expected))));
+
+        var foreignCoordinatePrimary = new WorkspaceContextMember(
+            expected.Declared,
+            new RealizedMemberCoordinate.Package(
+                coordinate.PackageId,
+                "2.0.0",
+                coordinate.Producer,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            expected.Participant);
+        Assert.Throws<ArgumentException>(
+            () => Classify(
+                coordinate,
+                [expected],
+                foreignCoordinatePrimary,
+                Surface(Available(expected))));
+    }
+
+    [Fact]
+    public void InventoryModels_UseSequenceValueEquality()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        ApiType type = Type("Widget", "public", Member("Run"));
+        AssemblyContextApiSurfaceResult surface =
+            Surface(Available(library, type));
+        var equalLibrary = new WorkspaceContextMember(
+            library.Declared,
+            Coordinate(),
+            library.Participant);
+
+        NavigationSubjectInventory first = Classify(
+            coordinate,
+            [library],
+            library,
+            surface);
+        NavigationSubjectInventory second = Classify(
+            Coordinate(),
+            [equalLibrary],
+            equalLibrary,
+            surface);
+
+        Assert.Equal(first, second);
+        Assert.Equal(first.GetHashCode(), second.GetHashCode());
+    }
+
+    static NavigationSubjectInventory Classify(
+        RealizedMemberCoordinate.Package coordinate,
+        ImmutableArray<WorkspaceContextMember> libraries,
+        WorkspaceContextMember? primary,
+        AssemblyContextApiSurfaceResult surface) =>
+        NavigationSubjectInventoryClassification.Classify(
+            StructuralSubjectIdentity.ForRoot(coordinate),
+            libraries,
+            primary,
+            surface);
+
+    static AssemblyContextApiSurfaceResult Surface(
+        params AssemblyContextEntry<AssemblyApiSurface>[] entries) =>
+        Surface(truncation: null, entries);
+
+    static AssemblyContextApiSurfaceResult Surface(
+        ApiSurfaceProjectionTruncation? truncation,
+        params AssemblyContextEntry<AssemblyApiSurface>[] entries) =>
+        new(
+            new AssemblyContextResult<AssemblyApiSurface>([.. entries]),
+            [],
+            truncation);
+
+    static AssemblyContextEntry<AssemblyApiSurface> Available(
+        WorkspaceContextMember library,
+        params ApiType[] types) =>
+        AvailableWithFailures(library, [], types);
+
+    static AssemblyContextEntry<AssemblyApiSurface> AvailableWithFailures(
+        WorkspaceContextMember library,
+        ImmutableArray<ApiSurfaceInspectionFailure> failures,
+        params ApiType[] types)
+    {
+        var surface = new ApiSurface
+        {
+            Types = [.. types],
+            InspectionFailures = [.. failures],
+        };
+        return new AssemblyContextEntry<AssemblyApiSurface>.Available(
+            new AssemblyContextSubject(library.Participant.Assembly),
+            new AssemblyApiSurface(surface, failures));
+    }
+
+    static AssemblyContextEntry<AssemblyApiSurface> Rejected(
+        WorkspaceContextMember library,
+        CandidateOpenFailure failure) =>
+        new AssemblyContextEntry<AssemblyApiSurface>.Rejected(
+            new AssemblyContextSubject(library.Participant.Assembly),
+            failure);
+
+    static AssemblyContextEntry<AssemblyApiSurface> Failed(
+        WorkspaceContextMember library,
+        Exception error) =>
+        new AssemblyContextEntry<AssemblyApiSurface>.Failed(
+            new AssemblyContextSubject(library.Participant.Assembly),
+            error);
+
+    static ApiType Type(
+        string name,
+        string accessibility,
+        params ApiMember[] members) =>
+        new()
+        {
+            Namespace = "Sample",
+            Name = name,
+            DefinitionName = TypeName("Sample", name),
+            Accessibility = accessibility,
+            Members = [.. members],
+        };
+
+    static ApiMember Member(string name) =>
+        new()
+        {
+            Name = name,
+            Kind = "method",
+            Signature = $"void {name}()",
+        };
+
+    static ApiSurfaceInspectionFailure InspectionFailure(string operation) =>
+        new(
+            operation,
+            SubjectToken: 1,
+            MetadataTypeNameFailureMechanism.Metadata,
+            Kind: "TypeDef",
+            Detail: "failed");
+
+    static ApiSurfaceProjectionTruncation Truncation(
+        int projectedParticipants,
+        int omittedParticipants) =>
+        new(
+            ApiSurfaceProjectionLimit.Types,
+            Bound: 1,
+            projectedParticipants,
+            omittedParticipants,
+            ProjectedTypes: 0,
+            ProjectedMembers: 0,
+            ProjectedInspectionFailures: 0,
+            ProjectedTypeForwarders: 0,
+            InspectedMetadataRows: 0,
+            ProjectedRetainedTextCharacters: 0);
+
+    static RealizedMemberCoordinate.Package Coordinate() =>
+        new(
+            "sample.package",
+            "1.0.0",
+            "nuget-org",
+            "net11.0",
+            runtimeIdentifier: null);
+
+    static WorkspaceContextMember Library(
+        RealizedMemberCoordinate.Package coordinate,
+        string name)
+    {
+        ResolvedAssemblyReference assembly = ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(
+                name,
+                new Version(1, 0, 0, 0),
+                Culture: null,
+                PublicKeyToken: null),
+            path: null,
+            () => new MemoryStream([0], writable: false),
+            AssemblyResolutionProvenance.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier));
+        return new WorkspaceContextMember(
+            WorkspaceMemberCoordinate.Package(
+                coordinate.PackageId,
+                coordinate.Version,
+                coordinate.Framework,
+                coordinate.RuntimeIdentifier),
+            coordinate,
+            new AssemblyContextParticipant(
+                assembly,
+                NoResolverAssemblyBindingPolicy.Instance));
+    }
+
+    static MetadataTypeDefinitionName TypeName(
+        string @namespace,
+        string name) =>
+        Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+            MetadataTypeDefinitionName.Create(
+                @namespace,
+                [name])).Name;
+}

--- a/src/DotnetInspector.Queries/NavigationSubjectInventory.cs
+++ b/src/DotnetInspector.Queries/NavigationSubjectInventory.cs
@@ -1,0 +1,753 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Typed evidence that prevented one complete Type inventory.</summary>
+public abstract record NavigationInventoryEvidence
+{
+    private protected NavigationInventoryEvidence(
+        StructuralSubjectIdentity.LibrarySubject library)
+    {
+        ArgumentNullException.ThrowIfNull(library);
+        Library = library;
+    }
+
+    public StructuralSubjectIdentity.LibrarySubject Library { get; }
+
+    /// <summary>The Library participant could not be opened.</summary>
+    public sealed record ParticipantRejected : NavigationInventoryEvidence
+    {
+        internal ParticipantRejected(
+            StructuralSubjectIdentity.LibrarySubject library,
+            AssemblyContextSubject producerSubject,
+            CandidateOpenFailure failure)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(producerSubject);
+            ArgumentNullException.ThrowIfNull(failure);
+            ProducerSubject = producerSubject;
+            Failure = failure;
+        }
+
+        public AssemblyContextSubject ProducerSubject { get; }
+        public CandidateOpenFailure Failure { get; }
+    }
+
+    /// <summary>The Library participant failed during inspection.</summary>
+    public sealed record ParticipantFailed : NavigationInventoryEvidence
+    {
+        internal ParticipantFailed(
+            StructuralSubjectIdentity.LibrarySubject library,
+            AssemblyContextSubject producerSubject,
+            Exception error)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(producerSubject);
+            ArgumentNullException.ThrowIfNull(error);
+            ProducerSubject = producerSubject;
+            Error = error;
+        }
+
+        public AssemblyContextSubject ProducerSubject { get; }
+        public Exception Error { get; }
+    }
+
+    /// <summary>A metadata row failed while the Library surface was produced.</summary>
+    public sealed record InspectionFailed : NavigationInventoryEvidence
+    {
+        internal InspectionFailed(
+            StructuralSubjectIdentity.LibrarySubject library,
+            ApiSurfaceInspectionFailure failure)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            Failure = failure;
+        }
+
+        public ApiSurfaceInspectionFailure Failure { get; }
+    }
+
+    /// <summary>A returned Type row lacked exact definition identity.</summary>
+    public sealed record TypeIdentityMissing : NavigationInventoryEvidence
+    {
+        internal TypeIdentityMissing(
+            StructuralSubjectIdentity.LibrarySubject library,
+            ApiType producerRow)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(producerRow);
+            ProducerRow = producerRow;
+        }
+
+        public ApiType ProducerRow { get; }
+    }
+
+    /// <summary>A projected Member lacked an exact local declaring Type.</summary>
+    public sealed record MemberIdentityMissing : NavigationInventoryEvidence
+    {
+        internal MemberIdentityMissing(
+            StructuralSubjectIdentity.LibrarySubject library,
+            ApiType containingType,
+            ApiMember producerRow)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(containingType);
+            ArgumentNullException.ThrowIfNull(producerRow);
+            ContainingType = containingType;
+            ProducerRow = producerRow;
+        }
+
+        public ApiType ContainingType { get; }
+        public ApiMember ProducerRow { get; }
+    }
+
+    /// <summary>A projection bound omitted this Library and every later row.</summary>
+    public sealed record ProjectionOmitted : NavigationInventoryEvidence
+    {
+        internal ProjectionOmitted(
+            StructuralSubjectIdentity.LibrarySubject library,
+            ApiSurfaceProjectionTruncation truncation)
+            : base(library)
+        {
+            ArgumentNullException.ThrowIfNull(truncation);
+            Truncation = truncation;
+        }
+
+        public ApiSurfaceProjectionTruncation Truncation { get; }
+    }
+}
+
+/// <summary>One exact Member row in producer-issued order.</summary>
+public sealed record NavigationMemberInventoryRow
+{
+    internal NavigationMemberInventoryRow(
+        ApiMember producerRow,
+        StructuralSubjectIdentity.MemberSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(producerRow);
+        ArgumentNullException.ThrowIfNull(subject);
+        ProducerRow = producerRow;
+        Subject = subject;
+    }
+
+    public ApiMember ProducerRow { get; }
+    public StructuralSubjectIdentity.MemberSubject Subject { get; }
+}
+
+/// <summary>One exact Type row and its Members in producer-issued order.</summary>
+public sealed record NavigationTypeInventoryRow
+{
+    internal NavigationTypeInventoryRow(
+        ApiType producerRow,
+        StructuralSubjectIdentity.TypeSubject subject,
+        ApiAccessibilityBucket accessibility,
+        ImmutableArray<NavigationMemberInventoryRow> members)
+    {
+        ArgumentNullException.ThrowIfNull(producerRow);
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(accessibility);
+        if (members.IsDefault)
+        {
+            throw new ArgumentException(
+                "Member rows must be an initialized immutable array.",
+                nameof(members));
+        }
+        foreach (NavigationMemberInventoryRow? member in members)
+        {
+            if (member is null
+                || member.Subject.DeclaringType != subject)
+            {
+                throw new ArgumentException(
+                    "Every exact Member row must belong to its containing Type.",
+                    nameof(members));
+            }
+        }
+
+        ProducerRow = producerRow;
+        Subject = subject;
+        Accessibility = accessibility;
+        Members = members;
+    }
+
+    public ApiType ProducerRow { get; }
+    public StructuralSubjectIdentity.TypeSubject Subject { get; }
+    public ApiAccessibilityBucket Accessibility { get; }
+    public ImmutableArray<NavigationMemberInventoryRow> Members { get; }
+
+    public bool Equals(NavigationTypeInventoryRow? other) =>
+        ReferenceEquals(this, other)
+        || other is not null
+        && ReferenceEquals(ProducerRow, other.ProducerRow)
+        && Subject == other.Subject
+        && Accessibility == other.Accessibility
+        && Members.SequenceEqual(other.Members);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(ProducerRow);
+        hash.Add(Subject);
+        hash.Add(Accessibility);
+        foreach (NavigationMemberInventoryRow member in Members)
+            hash.Add(member);
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>The classified Type inventory for one scope.</summary>
+public abstract record NavigationTypeInventoryOutcome
+{
+    private protected NavigationTypeInventoryOutcome(
+        ImmutableArray<NavigationTypeInventoryRow> rows,
+        ImmutableArray<NavigationInventoryEvidence> evidence)
+    {
+        if (rows.IsDefault)
+        {
+            throw new ArgumentException(
+                "Type rows must be an initialized immutable array.",
+                nameof(rows));
+        }
+        if (evidence.IsDefault)
+        {
+            throw new ArgumentException(
+                "Inventory evidence must be an initialized immutable array.",
+                nameof(evidence));
+        }
+        if (rows.Any(static row => row is null)
+            || evidence.Any(static item => item is null))
+        {
+            throw new ArgumentException(
+                "Inventory rows and evidence cannot contain null values.");
+        }
+
+        Rows = rows;
+        Evidence = evidence;
+    }
+
+    public ImmutableArray<NavigationTypeInventoryRow> Rows { get; }
+    public ImmutableArray<NavigationInventoryEvidence> Evidence { get; }
+
+    /// <summary>At least one trustworthy exact Type row is available.</summary>
+    public sealed record Available : NavigationTypeInventoryOutcome
+    {
+        internal Available(
+            ImmutableArray<NavigationTypeInventoryRow> rows,
+            ImmutableArray<NavigationInventoryEvidence> evidence)
+            : base(rows, evidence)
+        {
+            if (rows.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "An available inventory requires at least one Type row.",
+                    nameof(rows));
+            }
+        }
+
+        public bool Equals(Available? other) =>
+            ReferenceEquals(this, other)
+            || other is not null
+            && Rows.SequenceEqual(other.Rows)
+            && Evidence.SequenceEqual(other.Evidence);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (NavigationTypeInventoryRow row in Rows)
+                hash.Add(row);
+            foreach (NavigationInventoryEvidence item in Evidence)
+                hash.Add(item);
+            return hash.ToHashCode();
+        }
+    }
+
+    /// <summary>Complete successful production proved the Type inventory empty.</summary>
+    public sealed record Unavailable : NavigationTypeInventoryOutcome
+    {
+        internal Unavailable()
+            : base([], [])
+        {
+        }
+    }
+
+    /// <summary>No trustworthy Type row exists and completeness was not established.</summary>
+    public sealed record Failed : NavigationTypeInventoryOutcome
+    {
+        internal Failed(ImmutableArray<NavigationInventoryEvidence> evidence)
+            : base([], evidence)
+        {
+            if (evidence.IsEmpty)
+            {
+                throw new ArgumentException(
+                    "A failed inventory requires typed failure evidence.",
+                    nameof(evidence));
+            }
+        }
+
+        public bool Equals(Failed? other) =>
+            ReferenceEquals(this, other)
+            || other is not null
+            && Evidence.SequenceEqual(other.Evidence);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (NavigationInventoryEvidence item in Evidence)
+                hash.Add(item);
+            return hash.ToHashCode();
+        }
+    }
+}
+
+/// <summary>One admitted Library and its generation-free Type inventory.</summary>
+public sealed record NavigationLibraryInventory
+{
+    internal NavigationLibraryInventory(
+        StructuralSubjectIdentity.LibrarySubject subject,
+        bool isPrimary,
+        NavigationTypeInventoryOutcome types)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(types);
+        if (types.Rows.Any(row => row.Subject.Library != subject)
+            || types.Evidence.Any(item => item.Library != subject))
+        {
+            throw new ArgumentException(
+                "Library inventory rows and evidence must retain the exact Library.",
+                nameof(types));
+        }
+
+        Subject = subject;
+        IsPrimary = isPrimary;
+        Types = types;
+    }
+
+    public StructuralSubjectIdentity.LibrarySubject Subject { get; }
+    public bool IsPrimary { get; }
+    public NavigationTypeInventoryOutcome Types { get; }
+}
+
+/// <summary>
+/// Generation-free classified subject inventory over one realized coordinate.
+/// </summary>
+public sealed record NavigationSubjectInventory
+{
+    internal NavigationSubjectInventory(
+        StructuralSubjectIdentity.RootSubject root,
+        ImmutableArray<NavigationLibraryInventory> libraries,
+        NavigationTypeInventoryOutcome types,
+        ImmutableArray<NavigationInitialLibraryCandidate> initialCandidates)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(types);
+        if (libraries.IsDefault || initialCandidates.IsDefault)
+        {
+            throw new ArgumentException(
+                "Inventory collections must be initialized.");
+        }
+        if (libraries.Length != initialCandidates.Length)
+        {
+            throw new ArgumentException(
+                "Inventory collections must retain every exact Library.");
+        }
+        for (int index = 0; index < libraries.Length; index++)
+        {
+            NavigationLibraryInventory? library = libraries[index];
+            NavigationInitialLibraryCandidate? candidate =
+                initialCandidates[index];
+            if (library is null
+                || candidate is null
+                || library.Subject.Coordinate != root.Coordinate
+                || candidate.Subject != library.Subject
+                || candidate.IsPrimary != library.IsPrimary
+                || !candidate.Types.Select(static item => item.Subject)
+                    .SequenceEqual(
+                        library.Types.Rows.Select(static row => row.Subject))
+                || !candidate.Types.Select(static item => item.Accessibility)
+                    .SequenceEqual(
+                        library.Types.Rows.Select(
+                            static row => row.Accessibility)))
+            {
+                throw new ArgumentException(
+                    "Initial candidates must exactly project each Library inventory.",
+                    nameof(initialCandidates));
+            }
+        }
+        if (!types.Rows.SequenceEqual(
+                libraries.SelectMany(static library => library.Types.Rows))
+            || !types.Evidence.SequenceEqual(
+                libraries.SelectMany(
+                    static library => library.Types.Evidence)))
+        {
+            throw new ArgumentException(
+                "The aggregate inventory must equal the ordered Library rollup.",
+                nameof(types));
+        }
+
+        Root = root;
+        Libraries = libraries;
+        Types = types;
+        InitialCandidates = initialCandidates;
+    }
+
+    public StructuralSubjectIdentity.RootSubject Root { get; }
+    public ImmutableArray<NavigationLibraryInventory> Libraries { get; }
+    public NavigationTypeInventoryOutcome Types { get; }
+    public ImmutableArray<NavigationInitialLibraryCandidate> InitialCandidates
+    {
+        get;
+    }
+
+    public bool Equals(NavigationSubjectInventory? other) =>
+        ReferenceEquals(this, other)
+        || other is not null
+        && Root == other.Root
+        && Libraries.SequenceEqual(other.Libraries)
+        && Types == other.Types
+        && InitialCandidates.SequenceEqual(other.InitialCandidates);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(Root);
+        foreach (NavigationLibraryInventory library in Libraries)
+            hash.Add(library);
+        hash.Add(Types);
+        foreach (NavigationInitialLibraryCandidate candidate
+            in InitialCandidates)
+        {
+            hash.Add(candidate);
+        }
+        return hash.ToHashCode();
+    }
+}
+
+/// <summary>
+/// Classifies bounded API-surface evidence without committing navigation state.
+/// </summary>
+public static class NavigationSubjectInventoryClassification
+{
+    public static NavigationSubjectInventory Classify(
+        StructuralSubjectIdentity.RootSubject root,
+        ImmutableArray<WorkspaceContextMember> libraries,
+        WorkspaceContextMember? primaryLibrary,
+        AssemblyContextApiSurfaceResult surface)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(surface);
+        if (libraries.IsDefault)
+        {
+            throw new ArgumentException(
+                "Libraries must be an initialized immutable array.",
+                nameof(libraries));
+        }
+
+        int primaryIndex = ValidateLibraries(root, libraries, primaryLibrary);
+        ImmutableArray<AssemblyContextEntry<AssemblyApiSurface>> entries =
+            surface.Assemblies?.Assemblies
+            ?? throw new ArgumentException(
+                "The API-surface result must retain participant outcomes.",
+                nameof(surface));
+        ValidateJoin(libraries, entries, surface.Truncation);
+
+        var classified = ImmutableArray.CreateBuilder<NavigationLibraryInventory>(
+            libraries.Length);
+        for (int index = 0; index < entries.Length; index++)
+        {
+            StructuralSubjectIdentity.LibrarySubject library =
+                StructuralSubjectIdentity.ForLibrary(libraries[index]);
+            classified.Add(
+                new NavigationLibraryInventory(
+                    library,
+                    index == primaryIndex,
+                    ClassifyEntry(library, entries[index])));
+        }
+
+        for (int index = entries.Length; index < libraries.Length; index++)
+        {
+            StructuralSubjectIdentity.LibrarySubject library =
+                StructuralSubjectIdentity.ForLibrary(libraries[index]);
+            var omission = new NavigationInventoryEvidence.ProjectionOmitted(
+                library,
+                surface.Truncation!);
+            classified.Add(
+                new NavigationLibraryInventory(
+                    library,
+                    index == primaryIndex,
+                    new NavigationTypeInventoryOutcome.Failed([omission])));
+        }
+
+        ImmutableArray<NavigationLibraryInventory> libraryInventory =
+            classified.ToImmutable();
+        var rows = libraryInventory
+            .SelectMany(static library => library.Types.Rows)
+            .ToImmutableArray();
+        var evidence = libraryInventory
+            .SelectMany(static library => library.Types.Evidence)
+            .ToImmutableArray();
+        NavigationTypeInventoryOutcome types =
+            Outcome(rows, evidence);
+        ImmutableArray<NavigationInitialLibraryCandidate> initialCandidates =
+            [
+                .. libraryInventory.Select(
+                    static library =>
+                        new NavigationInitialLibraryCandidate(
+                            library.Subject,
+                            library.IsPrimary,
+                            [
+                                .. library.Types.Rows.Select(
+                                    static row =>
+                                        new NavigationInitialTypeCandidate(
+                                            row.Subject,
+                                            row.Accessibility)),
+                            ])),
+            ];
+        return new NavigationSubjectInventory(
+            root,
+            libraryInventory,
+            types,
+            initialCandidates);
+    }
+
+    static int ValidateLibraries(
+        StructuralSubjectIdentity.RootSubject root,
+        ImmutableArray<WorkspaceContextMember> libraries,
+        WorkspaceContextMember? primaryLibrary)
+    {
+        var registrations = new HashSet<AssemblyAcquisitionRegistration>(
+            ReferenceEqualityComparer.Instance);
+        StructuralSubjectIdentity.LibrarySubject? primarySubject =
+            primaryLibrary is null
+                ? null
+                : StructuralSubjectIdentity.ForLibrary(primaryLibrary);
+        int primaryIndex = -1;
+        for (int index = 0; index < libraries.Length; index++)
+        {
+            WorkspaceContextMember? library = libraries[index];
+            if (library is null || library.Realized != root.Coordinate)
+            {
+                throw new ArgumentException(
+                    "Every Library must belong to the Root coordinate.",
+                    nameof(libraries));
+            }
+
+            AssemblyAcquisitionRegistration registration =
+                library.Participant.Assembly.Registration;
+            if (!registrations.Add(registration))
+            {
+                throw new ArgumentException(
+                    "Libraries must have distinct exact registrations.",
+                    nameof(libraries));
+            }
+            if (primaryLibrary is not null
+                && StructuralSubjectIdentity.ForLibrary(library)
+                    == primarySubject)
+            {
+                primaryIndex = index;
+            }
+        }
+
+        if (primaryLibrary is not null && primaryIndex < 0)
+        {
+            throw new ArgumentException(
+                "The primary Library must be one of the admitted Libraries.",
+                nameof(primaryLibrary));
+        }
+
+        return primaryIndex;
+    }
+
+    static void ValidateJoin(
+        ImmutableArray<WorkspaceContextMember> libraries,
+        ImmutableArray<AssemblyContextEntry<AssemblyApiSurface>> entries,
+        ApiSurfaceProjectionTruncation? truncation)
+    {
+        if (entries.IsDefault || entries.Length > libraries.Length)
+        {
+            throw new ArgumentException(
+                "Participant outcomes must be an initialized Library prefix.",
+                nameof(entries));
+        }
+        for (int index = 0; index < entries.Length; index++)
+        {
+            AssemblyContextEntry<AssemblyApiSurface>? entry = entries[index];
+            if (entry?.Subject is null
+                || !ReferenceEquals(
+                    entry.Subject.Registration,
+                    libraries[index].Participant.Assembly.Registration))
+            {
+                throw new ArgumentException(
+                    "Participant outcomes must exact-join the Library prefix by registration.",
+                    nameof(entries));
+            }
+        }
+
+        int omitted = libraries.Length - entries.Length;
+        if (truncation is null)
+        {
+            if (omitted != 0)
+            {
+                throw new ArgumentException(
+                    "A complete projection must contain every admitted Library.",
+                    nameof(entries));
+            }
+            return;
+        }
+
+        if (omitted == 0
+            || truncation.OmittedParticipants != omitted
+            || truncation.ProjectedParticipants != entries.Length)
+        {
+            throw new ArgumentException(
+                "Projection truncation must account for the exact omitted Library suffix.",
+                nameof(truncation));
+        }
+    }
+
+    static NavigationTypeInventoryOutcome ClassifyEntry(
+        StructuralSubjectIdentity.LibrarySubject library,
+        AssemblyContextEntry<AssemblyApiSurface> entry)
+        => entry switch
+        {
+            AssemblyContextEntry<AssemblyApiSurface>.Available available =>
+                ClassifyAvailable(library, available.Value),
+            AssemblyContextEntry<AssemblyApiSurface>.Rejected rejected =>
+                new NavigationTypeInventoryOutcome.Failed(
+                    [
+                        new NavigationInventoryEvidence.ParticipantRejected(
+                            library,
+                            rejected.Subject,
+                            rejected.Failure),
+                    ]),
+            AssemblyContextEntry<AssemblyApiSurface>.Failed failed =>
+                new NavigationTypeInventoryOutcome.Failed(
+                    [
+                        new NavigationInventoryEvidence.ParticipantFailed(
+                            library,
+                            failed.Subject,
+                            failed.Error),
+                    ]),
+            _ => throw new InvalidOperationException(
+                "Unknown assembly-context API-surface outcome."),
+        };
+
+    static NavigationTypeInventoryOutcome ClassifyAvailable(
+        StructuralSubjectIdentity.LibrarySubject library,
+        AssemblyApiSurface? available)
+    {
+        if (available?.Surface?.Types is null
+            || available.InspectionFailures.IsDefault)
+        {
+            throw new ArgumentException(
+                "An available API surface must retain rows and inspection evidence.",
+                nameof(available));
+        }
+
+        var rows = ImmutableArray.CreateBuilder<NavigationTypeInventoryRow>();
+        var evidence =
+            ImmutableArray.CreateBuilder<NavigationInventoryEvidence>();
+        foreach (ApiSurfaceInspectionFailure? failure
+            in available.InspectionFailures)
+        {
+            if (failure is null)
+            {
+                throw new ArgumentException(
+                    "Inspection evidence cannot contain null values.",
+                    nameof(available));
+            }
+            evidence.Add(
+                new NavigationInventoryEvidence.InspectionFailed(
+                    library,
+                    failure));
+        }
+
+        var subjectByType =
+            new Dictionary<
+                ApiType,
+                StructuralSubjectIdentity.TypeSubject>(
+                    ReferenceEqualityComparer.Instance);
+        foreach (ApiType? type in available.Surface.Types)
+        {
+            if (type is null)
+            {
+                throw new ArgumentException(
+                    "API surfaces cannot contain null Type rows.",
+                    nameof(available));
+            }
+            if (type.DefinitionName is not { } definition)
+            {
+                evidence.Add(
+                    new NavigationInventoryEvidence.TypeIdentityMissing(
+                        library,
+                        type));
+                continue;
+            }
+            StructuralSubjectIdentity.TypeSubject subject =
+                StructuralSubjectIdentity.ForType(library, definition);
+            subjectByType.Add(type, subject);
+        }
+
+        foreach (ApiType? type in available.Surface.Types)
+        {
+            if (type is null || !subjectByType.TryGetValue(
+                type,
+                out StructuralSubjectIdentity.TypeSubject? typeSubject))
+            {
+                continue;
+            }
+            if (type.Members is null)
+            {
+                throw new ArgumentException(
+                    "API Type rows must retain their Member rows.",
+                    nameof(available));
+            }
+
+            var members =
+                ImmutableArray.CreateBuilder<NavigationMemberInventoryRow>(
+                    type.Members.Count);
+            foreach (ApiMember? member in type.Members)
+            {
+                if (member is null)
+                {
+                    throw new ArgumentException(
+                        "API Type rows cannot contain null Member rows.",
+                        nameof(available));
+                }
+                if (member.DeclaringTypeCanonicalName is not null)
+                {
+                    evidence.Add(
+                        new NavigationInventoryEvidence.MemberIdentityMissing(
+                            library,
+                            type,
+                            member));
+                    continue;
+                }
+                members.Add(
+                    new NavigationMemberInventoryRow(
+                        member,
+                        StructuralSubjectIdentity.ForMember(
+                            typeSubject,
+                            ApiMemberIdentity.GetMemberAnchor(type, member))));
+            }
+
+            rows.Add(
+                new NavigationTypeInventoryRow(
+                    type,
+                    typeSubject,
+                    ApiAccessibility.Classify(type.Accessibility),
+                    members.ToImmutable()));
+        }
+
+        return Outcome(rows.ToImmutable(), evidence.ToImmutable());
+    }
+
+    static NavigationTypeInventoryOutcome Outcome(
+        ImmutableArray<NavigationTypeInventoryRow> rows,
+        ImmutableArray<NavigationInventoryEvidence> evidence) =>
+        !rows.IsEmpty
+            ? new NavigationTypeInventoryOutcome.Available(rows, evidence)
+            : evidence.IsEmpty
+                ? new NavigationTypeInventoryOutcome.Unavailable()
+                : new NavigationTypeInventoryOutcome.Failed(evidence);
+}


### PR DESCRIPTION
## Summary

Implement generation-free Inspection Subject Navigation classification over one
bounded API-surface result.

- exact-join participant outcomes to admitted Libraries by acquisition
  registration;
- preserve trustworthy exact Type and declaration-side Member rows in producer
  order;
- retain typed rejection, failure, inspection, missing-identity, and truncation
  evidence;
- distinguish complete successful emptiness from indeterminate emptiness; and
- supply only trustworthy exact Types to the existing initial-subject
  recommendation.

## Design basis

Normative owner:
`docs/design/inspection-subject-navigation.md#bounded-subject-inventory-classification`.

`AssemblyContextApiSurfaceQuery` supplies bounded producer rows and typed
partial/failure evidence. `StructuralSubjectIdentity` supplies exact Navigation
identity. `NavigationInitialSubjectRecommendation` consumes the classified
Library and Type candidates without owning their trust classification.

## Demo

The contract gates classify three neighboring cases:

1. One Library returns ordered exact Types and Members while a peer participant
   fails. The aggregate remains available and partial, the healthy Type remains
   eligible for recommendation, and the exact peer failure is retained.
2. Every producer completes successfully with zero Types. The aggregate and
   each Library Type inventory are unavailable.
3. A bounded projection returns zero rows for one Library and omits the next.
   The projected Library is unavailable, the omitted Library is failed with the
   exact truncation, and the aggregate is failed rather than false emptiness.

A real bounded projection over the query-test assembly also demonstrates the
identity boundary for extension methods: the declaration-side Member remains
an exact row, while its attached receiver-side copy remains typed
`MemberIdentityMissing` evidence because the producer does not yet expose a
typed declaring-Type definition. That producer currency is tracked by #5437.

## Compatibility and boundaries

This is a host-neutral Queries-layer contract with no CLI or browser behavior
change. It deliberately does not create navigation snapshots, descriptors,
`Current` or `Selection required` state, generations, action IDs, transitions,
revisions, reconciliation, retained sessions, synchronization, restoration, or
browser effects.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
  - 1,014 passed
- `npx markdownlint-cli docs/design/inspection-subject-navigation.md`
- `git diff --check`

Closes #5436.
