### PR TITLE
Certify classic async identity when trimming removes support roles

### DIFF
--- a/docs/design/classic-async-reconstruction.md
+++ b/docs/design/classic-async-reconstruction.md
@@ -238,7 +238,7 @@ The resulting matrix separates artifact availability from reconstruction:
 | --- | --- | --- |
 | Implementation | Kickoff, `MoveNext`, and `SetStateMachine` retain compiler IL. | Authenticated request; the neighboring accepted recipe reconstructs. |
 | SDK reference | The same MethodDefs retain synthesized `ldnull; throw` bodies. | Authenticated request; `ClassicInverseBodyReplacingReferenceAssembliesDecline` remains the core gate. |
-| Ordinary trim, reachable method | Kickoff and `MoveNext` remain, but ILLink removes `SetStateMachine`. | Target contract: authenticated request with `SetStateMachine: AbsentFromArtifact`; the inverse proves or declines the retained bodies. Current Metadata still rejects pending #5307 implementation. |
+| Ordinary trim, reachable method | Kickoff and `MoveNext` remain, but ILLink removes `SetStateMachine`. | Metadata authenticates the relationship with `SetStateMachine: AbsentFromArtifact`; #5277 must form the request so the inverse can prove or decline the retained bodies. |
 | Ordinary trim, unused method | The kickoff and generated state machine are removed. | No core request forms. |
 | Role-preserved trim | All required MethodDefs retain post-trim IL. | Authenticated request; the accepted recipe reconstructs from the trimmed artifact. |
 | Default-interface implementation | The kickoff and execution MethodDefs carry managed IL. | Authenticated request without a declaring-type category exclusion. |
@@ -262,13 +262,12 @@ inverse-core decision gates below.
 Before #5277 supplies the authenticated request boundary, the legacy
 `ClassicAsyncReconstructionPass` still reports `Full` for both trimmed
 variants: it discovers the generated execution sibling directly and therefore
-bypasses Metadata's rejection in the ordinary-trim case. That measured
-pre-implementation behavior is not a valid core request. Under the target
-Metadata contract, #5277 must attach the resolved relationship and explicit
-support-role disposition rather than preserve that sibling inference. The
-eventual end-to-end demo must reconstruct both retained-body trim variants
-through authenticated requests, while the unused and body-replacing cases
-continue to decline:
+bypasses Metadata's certificate in the ordinary-trim case. That measured
+behavior is not yet a valid core request. #5277 must attach the resolved
+relationship and explicit support-role disposition rather than preserve that
+sibling inference. The eventual end-to-end demo must reconstruct both
+retained-body trim variants through authenticated requests, while the unused
+and body-replacing cases continue to decline:
 
 ```csharp
 int left = await first;

--- a/docs/design/state-machine-relationship-index.md
+++ b/docs/design/state-machine-relationship-index.md
@@ -241,7 +241,8 @@ Release gates enforce the certificate:
   invalid or missing `MoveNext` to reject and prevents malformed, bodyless,
   ambiguous, or contradictory `SetStateMachine` candidates from becoming
   absence. Its explicit wrong-signature arm uses a body name that cannot enter
-  implicit matching.
+  implicit matching, and its malformed-interface arm rejects a self-cyclic
+  declaration parent rather than certifying absence.
 - `AsyncLoweringFixtureMatrixTests.IdenticalSource_ProducesClassicAndRuntimeAsyncPhysicalShapes`
   preserves runtime async as `Absent` while the identical classic source
   produces a resolved relationship with every role present.

--- a/docs/design/state-machine-relationship-index.md
+++ b/docs/design/state-machine-relationship-index.md
@@ -18,7 +18,7 @@ should receive a recommendation.
 
 ## Status and decision
 
-Design target, advancing
+Implemented, advancing
 [#5307](https://github.com/richlander/dotnet-inspect/issues/5307).
 This document is the normative owner for relationship certificate issuance and
 role dispositions. The exact claim is that classic async identity remains
@@ -26,9 +26,6 @@ resolvable when `SetStateMachine` alone is absent, with that absence carried
 explicitly rather than converted to rejection. The
 [classic async inverse design](classic-async-reconstruction.md#immediate-boundary)
 is a consumer map; #5277 and #5276 own adapter and inverse implementation.
-
-The current implementation still requires every role to be present. The target
-contract below is unimplemented unless a section names an existing gate.
 
 ## Contract
 
@@ -193,13 +190,8 @@ execution identity.
 
 ## Contract demonstration
 
-This target mockup uses the ordinary full-trim artifact from
-`ClassicAsyncArtifactMatrixTests`. The current gate records a retained claimed
-state-machine type with a MethodDef named `MoveNext`, no MethodDef named
-`SetStateMachine`, and the current `Rejected(Unresolved)` result. Before the
-target result is implemented, its gate must additionally establish the direct
-`IAsyncStateMachine` declaration, exact body-bearing `MoveNext` role, and
-absence of both explicit and implicit `SetStateMachine` candidates:
+The ordinary full-trim artifact from `ClassicAsyncArtifactMatrixTests`
+produces this certificate:
 
 ```text
 Relationship: Resolved(ClassicAsync)
@@ -229,29 +221,34 @@ success-shaped absence.
 
 ## Validation status
 
-This design changes no product behavior. The new certificate and classic
-support-role disposition are **unverified** until implementation supplies
-Release gates for:
+Release gates enforce the certificate:
 
-- a real ordinary full-trim artifact resolving with body-bearing `MoveNext` and
-  `SetStateMachine: AbsentFromArtifact`;
-- the role-preserved and SDK-reference artifacts resolving with both roles
-  present;
-- complete role-disposition publication with no omitted classic role;
-- rejection when `MoveNext` is missing or invalid; and
-- rejection, rather than absence, for malformed, bodyless, ambiguous, or
-  contradictory `SetStateMachine` candidates, including a wrong-signature
-  explicit declaration whose body does not have the implicit role name.
+- `ClassicAsyncArtifactMatrixTests.TrimmedArtifactWithoutRolePreservation_AuthenticatesAbsentSupport`
+  independently establishes the ordinary full-trim artifact's direct
+  `IAsyncStateMachine` declaration, exact body-bearing `MoveNext`, and absence
+  of both explicit and implicit `SetStateMachine` candidates before requiring
+  `Resolved(ClassicAsync)` with `SetStateMachine: AbsentFromArtifact`.
+- `ClassicAsyncArtifactMatrixTests.ImplementationAndRolePreservedTrim_AuthenticateRecoverableClassicRecipe`
+  and
+  `ClassicAsyncArtifactMatrixTests.ReferenceArtifact_AuthenticatesRelationshipsOverBodyReplacingIl`
+  require both roles to remain `Present` in the role-preserved and SDK
+  reference artifacts.
+- `StateMachineRelationshipIndex_ResolvesClassicAsyncWithAbsentSupportRole`
+  requires one closed disposition for each classic role, retains
+  implementation lookup for `MoveNext`, and exposes no support MethodDef
+  through `TryGetMethod`.
+- `StateMachineRelationshipIndex_RejectsInvalidImplementationShapes` requires
+  invalid or missing `MoveNext` to reject and prevents malformed, bodyless,
+  ambiguous, or contradictory `SetStateMachine` candidates from becoming
+  absence. Its explicit wrong-signature arm uses a body name that cannot enter
+  implicit matching.
+- `AsyncLoweringFixtureMatrixTests.IdenticalSource_ProducesClassicAndRuntimeAsyncPhysicalShapes`
+  preserves runtime async as `Absent` while the identical classic source
+  produces a resolved relationship with every role present.
 
-`ClassicAsyncArtifactMatrixTests.TrimmedArtifactWithoutRolePreservation_RetainsKickoffButCannotFormRequest`
-currently gates the old rejection, retained `MoveNext` MethodDef name, and
-absent `SetStateMachine` MethodDef name. It does not independently gate the
-direct interface, exact `MoveNext` role and body, or absence of an explicit
-support-role candidate whose body has another name; those target artifact
-premises remain **unverified**.
 `StateMachineRelationshipIndex_RejectsInvalidImplementationShapes` gates
-several present-but-invalid role shapes. Neither gate enforces the target
-certificate.
+several present-but-invalid role shapes in addition to the classic-specific
+arms above.
 
 ## Non-claims
 

--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -96,7 +96,7 @@ binding is unverified pending
 | `ApiTypeShape` | One identity-sensitive API signature or serializer root | Primitive code, array kind and rank, exact named definition, and constructed generic arguments | Display spelling, assembly resolution, or universal type correspondence |
 | `MemberTargetSelector` | One member-selection request | The user's member question, including overload and digest syntax | Evidence that selection succeeded |
 | `MetadataNamedTypeReference` | One decoded signature detached from its reader | Which exact named type definition and metadata scope the signature denotes | Resolution to an acquired assembly, constructed-type shape, or display spelling |
-| `StateMachineRelationship` and `StateMachineRelationshipResult` | One physical metadata module | Which kickoff, same-module state-machine type, and exact interface implementation methods form an authenticated compiler-state-machine relationship, or why structural authentication failed | Analysis attribution, decompiler reconstruction eligibility, source ownership, or presentation policy |
+| `StateMachineRelationship` and `StateMachineRelationshipResult` | One physical metadata module | Which kickoff, same-module state-machine type, and closed interface-role dispositions form an authenticated compiler-state-machine relationship, or why structural authentication failed | Analysis attribution, decompiler reconstruction eligibility, source ownership, or presentation policy |
 
 #### `DotnetInspector.Queries`
 

--- a/src/ILInspector.Decompiler.Tests/AsyncLoweringFixtureMatrixTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AsyncLoweringFixtureMatrixTests.cs
@@ -51,6 +51,10 @@ public sealed class AsyncLoweringFixtureMatrixTests
         Assert.Equal(
             StateMachineClaimKind.ClassicAsync,
             relationship.Relationship.Kind);
+        Assert.All(
+            relationship.Relationship.Roles,
+            role => Assert.IsType<
+                StateMachineRoleDisposition.Present>(role));
 
         Assert.True(HasRuntimeAsyncFlag(
             runtimeArtifact.Reader.GetMethodDefinition(runtimeMethod)));

--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncArtifactMatrixTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncArtifactMatrixTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
@@ -27,38 +28,55 @@ public sealed class ClassicAsyncArtifactMatrixTests
 
     [Fact]
     public async Task
-        TrimmedArtifactWithoutRolePreservation_RetainsKickoffButCannotFormRequest()
+        TrimmedArtifactWithoutRolePreservation_AuthenticatesAbsentSupport()
     {
         ArtifactMatrix matrix = await s_matrix.Value;
 
         using ArtifactEvidence artifact = ArtifactEvidence.Open(matrix.Trimmed);
-        StateMachineRelationshipResult result =
-            artifact.Relationship(FixtureType, RecoverableMethod);
-
-        var rejected =
-            Assert.IsType<StateMachineRelationshipResult.Rejected>(result);
-        Assert.Equal(
-            StateMachineRelationshipFailureKind.Unresolved,
-            rejected.Failure.Kind);
-        Assert.Contains(
-            "required state-machine interface role",
-            rejected.Failure.Detail,
-            StringComparison.Ordinal);
-
-        var stateMachine = Assert.Single(
-            rejected.Failure.StateMachineCandidates);
+        var resolved = AssertClassicRelationship(
+            artifact.Relationship(FixtureType, RecoverableMethod),
+            expectSetStateMachine: false);
+        MetadataTypeDefinitionAddress stateMachine =
+            resolved.Relationship.StateMachineType;
         Assert.True(
             stateMachine.TryResolve(
                 artifact.Reader,
                 out TypeDefinitionHandle stateMachineHandle));
         TypeDefinition definition = artifact.Reader.GetTypeDefinition(
             stateMachineHandle);
-        string[] methods = definition.GetMethods()
-            .Select(handle => artifact.Reader.GetString(
-                artifact.Reader.GetMethodDefinition(handle).Name))
-            .ToArray();
-        Assert.Contains("MoveNext", methods);
-        Assert.DoesNotContain("SetStateMachine", methods);
+        AssertDirectAsyncStateMachineInterface(
+            artifact.Reader,
+            definition);
+        Assert.DoesNotContain(
+            definition.GetMethodImplementations(),
+            handle => IsMethodDeclaration(
+                artifact.Reader,
+                artifact.Reader.GetMethodImplementation(handle)
+                    .MethodDeclaration,
+                "System.Runtime.CompilerServices",
+                "IAsyncStateMachine",
+                "SetStateMachine"));
+
+        var moveNext = Assert.IsType<
+            StateMachineRoleDisposition.Present>(
+                resolved.Relationship.GetRole(
+                    StateMachineMethodRole.MoveNext));
+        MethodDefinition moveNextDefinition =
+            artifact.Reader.GetMethodDefinition(moveNext.Method.Handle);
+        Assert.Equal(
+            stateMachineHandle,
+            moveNextDefinition.GetDeclaringType());
+        Assert.True(
+            artifact.Reader.StringComparer.Equals(
+                moveNextDefinition.Name,
+                "MoveNext"));
+        AssertManagedIlBody(moveNextDefinition);
+
+        Assert.DoesNotContain(
+            definition.GetMethods(),
+            handle => artifact.Reader.StringComparer.Equals(
+                artifact.Reader.GetMethodDefinition(handle).Name,
+                "SetStateMachine"));
     }
 
     [Fact]
@@ -119,8 +137,13 @@ public sealed class ClassicAsyncArtifactMatrixTests
 
         AssertBodyReplacing(artifact, resolved.Relationship.Kickoff.Handle);
         Assert.All(
-            resolved.Relationship.Methods,
-            method => AssertBodyReplacing(artifact, method.Method.Handle));
+            resolved.Relationship.Roles,
+            disposition =>
+            {
+                var present = Assert.IsType<
+                    StateMachineRoleDisposition.Present>(disposition);
+                AssertBodyReplacing(artifact, present.Method.Handle);
+            });
     }
 
     [Fact]
@@ -138,22 +161,142 @@ public sealed class ClassicAsyncArtifactMatrixTests
     }
 
     static StateMachineRelationshipResult.Resolved AssertClassicRelationship(
-        StateMachineRelationshipResult result)
+        StateMachineRelationshipResult result,
+        bool expectSetStateMachine = true)
     {
         var resolved =
             Assert.IsType<StateMachineRelationshipResult.Resolved>(result);
         Assert.Equal(
             StateMachineClaimKind.ClassicAsync,
             resolved.Relationship.Kind);
-        Assert.Collection(
-            resolved.Relationship.Methods.OrderBy(method => method.Role),
-            method => Assert.Equal(
-                StateMachineMethodRole.MoveNext,
-                method.Role),
-            method => Assert.Equal(
-                StateMachineMethodRole.SetStateMachine,
-                method.Role));
+        var moveNext = Assert.IsType<
+            StateMachineRoleDisposition.Present>(
+                resolved.Relationship.GetRole(
+                    StateMachineMethodRole.MoveNext));
+        Assert.Equal(StateMachineMethodRole.MoveNext, moveNext.Role);
+        StateMachineRoleDisposition setStateMachine =
+            resolved.Relationship.GetRole(
+                StateMachineMethodRole.SetStateMachine);
+        if (expectSetStateMachine)
+        {
+            Assert.IsType<StateMachineRoleDisposition.Present>(
+                setStateMachine);
+        }
+        else
+        {
+            Assert.IsType<
+                StateMachineRoleDisposition.AbsentFromArtifact>(
+                    setStateMachine);
+            Assert.False(
+                resolved.Relationship.TryGetMethod(
+                    StateMachineMethodRole.SetStateMachine,
+                    out _));
+        }
+
+        Assert.Equal(2, resolved.Relationship.Roles.Length);
         return resolved;
+    }
+
+    static void AssertDirectAsyncStateMachineInterface(
+        MetadataReader reader,
+        TypeDefinition definition)
+    {
+        Assert.Contains(
+            definition.GetInterfaceImplementations(),
+            handle =>
+            {
+                InterfaceImplementation implementation =
+                    reader.GetInterfaceImplementation(handle);
+                return IsNamedType(
+                    reader,
+                    implementation.Interface,
+                    "System.Runtime.CompilerServices",
+                    "IAsyncStateMachine");
+            });
+    }
+
+    static bool IsNamedType(
+        MetadataReader reader,
+        EntityHandle handle,
+        string @namespace,
+        string name)
+    {
+        StringHandle namespaceHandle;
+        StringHandle nameHandle;
+        if (handle.Kind == HandleKind.TypeReference)
+        {
+            TypeReference type =
+                reader.GetTypeReference((TypeReferenceHandle)handle);
+            namespaceHandle = type.Namespace;
+            nameHandle = type.Name;
+        }
+        else if (handle.Kind == HandleKind.TypeDefinition)
+        {
+            TypeDefinition type =
+                reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+            namespaceHandle = type.Namespace;
+            nameHandle = type.Name;
+        }
+        else
+        {
+            return false;
+        }
+
+        return reader.StringComparer.Equals(namespaceHandle, @namespace)
+            && reader.StringComparer.Equals(nameHandle, name);
+    }
+
+    static bool IsMethodDeclaration(
+        MetadataReader reader,
+        EntityHandle handle,
+        string @namespace,
+        string typeName,
+        string methodName)
+    {
+        EntityHandle declaringType;
+        StringHandle name;
+        if (handle.Kind == HandleKind.MemberReference)
+        {
+            MemberReference member =
+                reader.GetMemberReference((MemberReferenceHandle)handle);
+            declaringType = member.Parent;
+            name = member.Name;
+        }
+        else if (handle.Kind == HandleKind.MethodDefinition)
+        {
+            MethodDefinition method =
+                reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+            declaringType = method.GetDeclaringType();
+            name = method.Name;
+        }
+        else
+        {
+            return false;
+        }
+
+        return reader.StringComparer.Equals(name, methodName)
+            && IsNamedType(
+                reader,
+                declaringType,
+                @namespace,
+                typeName);
+    }
+
+    static void AssertManagedIlBody(MethodDefinition method)
+    {
+        Assert.NotEqual(0, method.RelativeVirtualAddress);
+        Assert.Equal(
+            MethodImplAttributes.IL,
+            method.ImplAttributes & MethodImplAttributes.CodeTypeMask);
+        Assert.Equal(
+            MethodImplAttributes.Managed,
+            method.ImplAttributes & MethodImplAttributes.ManagedMask);
+        Assert.False(
+            (method.Attributes & MethodAttributes.PinvokeImpl) != 0);
+        Assert.False(
+            (method.ImplAttributes
+                & (MethodImplAttributes.Runtime
+                    | MethodImplAttributes.InternalCall)) != 0);
     }
 
     static void AssertBodyReplacing(

--- a/src/ILInspector.Metadata/StateMachineRelationship.cs
+++ b/src/ILInspector.Metadata/StateMachineRelationship.cs
@@ -22,10 +22,40 @@ public enum StateMachineMethodRole
     DisposeAsync,
 }
 
-/// <summary>One exact MethodDef implementing a required state-machine role.</summary>
-public sealed record StateMachineMethodRelationship(
-    StateMachineMethodRole Role,
-    MetadataMethodAddress Method);
+/// <summary>
+/// The closed physical disposition of one state-machine interface role.
+/// </summary>
+public abstract record StateMachineRoleDisposition
+{
+    private protected StateMachineRoleDisposition(
+        StateMachineMethodRole role) =>
+        Role = role;
+
+    public StateMachineMethodRole Role { get; }
+
+    /// <summary>An exact MethodDef implements the role.</summary>
+    public sealed record Present : StateMachineRoleDisposition
+    {
+        internal Present(
+            StateMachineMethodRole role,
+            MetadataMethodAddress method)
+            : base(role) =>
+            Method = method;
+
+        public MetadataMethodAddress Method { get; }
+    }
+
+    /// <summary>
+    /// A bounded scan found no candidate for an explicitly optional role.
+    /// </summary>
+    public sealed record AbsentFromArtifact : StateMachineRoleDisposition
+    {
+        internal AbsentFromArtifact(StateMachineMethodRole role)
+            : base(role)
+        {
+        }
+    }
+}
 
 /// <summary>
 /// A structurally authenticated same-module state-machine relationship.
@@ -37,37 +67,82 @@ public sealed record StateMachineRelationship
         MetadataTypeDefinitionAddress stateMachineType,
         MetadataTypeDefinitionName stateMachineName,
         StateMachineClaimKind kind,
-        ImmutableArray<StateMachineMethodRelationship> methods)
+        ImmutableArray<StateMachineRoleDisposition> roles)
     {
-        if (methods.IsDefaultOrEmpty)
+        ReadOnlySpan<StateMachineMethodRole> expected = RolesFor(kind);
+        if (roles.IsDefault || roles.Length != expected.Length)
         {
             throw new ArgumentException(
-                "A state-machine relationship must contain an execution method.",
-                nameof(methods));
+                "A state-machine relationship must account for every role.",
+                nameof(roles));
+        }
+
+        foreach (StateMachineMethodRole expectedRole in expected)
+        {
+            StateMachineRoleDisposition? disposition = null;
+            foreach (StateMachineRoleDisposition candidate in roles)
+            {
+                if (candidate.Role != expectedRole)
+                    continue;
+                if (disposition is not null)
+                {
+                    throw new ArgumentException(
+                        "A state-machine relationship cannot contain duplicate roles.",
+                        nameof(roles));
+                }
+
+                disposition = candidate;
+            }
+
+            if (disposition is null
+                || disposition is
+                    StateMachineRoleDisposition.AbsentFromArtifact
+                    && !CanBeAbsent(kind, expectedRole))
+            {
+                throw new ArgumentException(
+                    "A state-machine relationship contains an invalid role disposition.",
+                    nameof(roles));
+            }
         }
 
         Kickoff = kickoff;
         StateMachineType = stateMachineType;
         StateMachineName = stateMachineName;
         Kind = kind;
-        Methods = methods;
+        Roles = roles;
     }
 
     public MetadataMethodAddress Kickoff { get; }
     public MetadataTypeDefinitionAddress StateMachineType { get; }
     public MetadataTypeDefinitionName StateMachineName { get; }
     public StateMachineClaimKind Kind { get; }
-    public ImmutableArray<StateMachineMethodRelationship> Methods { get; }
+    public ImmutableArray<StateMachineRoleDisposition> Roles { get; }
+
+    public StateMachineRoleDisposition GetRole(
+        StateMachineMethodRole role)
+    {
+        foreach (StateMachineRoleDisposition candidate in Roles)
+        {
+            if (candidate.Role == role)
+                return candidate;
+        }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(role),
+            role,
+            "The role does not belong to this state-machine claim kind.");
+    }
 
     public bool TryGetMethod(
         StateMachineMethodRole role,
         out MetadataMethodAddress method)
     {
-        foreach (StateMachineMethodRelationship candidate in Methods)
+        foreach (StateMachineRoleDisposition candidate in Roles)
         {
-            if (candidate.Role == role)
+            if (candidate is StateMachineRoleDisposition.Present present
+                && candidate.Role == role)
             {
-                method = candidate.Method;
+                method = present.Method;
                 return true;
             }
         }
@@ -75,6 +150,36 @@ public sealed record StateMachineRelationship
         method = default;
         return false;
     }
+
+    internal static ReadOnlySpan<StateMachineMethodRole> RolesFor(
+        StateMachineClaimKind kind) =>
+        kind switch
+        {
+            StateMachineClaimKind.ClassicAsync =>
+            [
+                StateMachineMethodRole.MoveNext,
+                StateMachineMethodRole.SetStateMachine,
+            ],
+            StateMachineClaimKind.AsyncIterator =>
+            [
+                StateMachineMethodRole.MoveNext,
+                StateMachineMethodRole.SetStateMachine,
+                StateMachineMethodRole.MoveNextAsync,
+                StateMachineMethodRole.DisposeAsync,
+            ],
+            StateMachineClaimKind.Iterator =>
+            [
+                StateMachineMethodRole.MoveNext,
+                StateMachineMethodRole.Dispose,
+            ],
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+
+    internal static bool CanBeAbsent(
+        StateMachineClaimKind kind,
+        StateMachineMethodRole role) =>
+        kind == StateMachineClaimKind.ClassicAsync
+        && role == StateMachineMethodRole.SetStateMachine;
 }
 
 /// <summary>Why a state-machine relationship could not be authenticated.</summary>

--- a/src/ILInspector.Metadata/StateMachineRelationshipIndex.cs
+++ b/src/ILInspector.Metadata/StateMachineRelationshipIndex.cs
@@ -14,7 +14,9 @@ namespace ILInspector.Metadata;
 /// </summary>
 /// <remarks>
 /// <c>StateMachineRelationshipIndex_ResolvesExactInterfaceImplementations</c>
-/// gates exact role selection and
+/// gates exact role selection,
+/// <c>StateMachineRelationshipIndex_ResolvesClassicAsyncWithAbsentSupportRole</c>
+/// gates the admitted classic support-role absence, and
 /// <c>StateMachineRelationshipIndex_PropagatesTypedBudgetFailure</c>,
 /// <c>StateMachineRelationshipIndex_MergesEveryOverlappingRejection</c>, and
 /// <c>StateMachineRelationshipIndex_RejectsInvalidImplementationShapes</c>
@@ -945,7 +947,7 @@ public sealed class StateMachineRelationshipIndex
                         previous.StateMachineType.Definition.Value,
                         stateMachineAddress.Definition.Value,
                     ],
-                    [.. previous.Methods.Select(
+                    [.. PresentRoles(previous).Select(
                         method => method.Method.Token)]);
                 return;
             }
@@ -964,38 +966,22 @@ public sealed class StateMachineRelationshipIndex
                 return;
             }
 
-            RoleSpec[] roles = claim.Kind switch
-            {
-                StateMachineClaimKind.ClassicAsync =>
-                [
-                    RoleSpec.AsyncMoveNext,
-                    RoleSpec.SetStateMachine,
-                ],
-                StateMachineClaimKind.AsyncIterator =>
-                [
-                    RoleSpec.AsyncMoveNext,
-                    RoleSpec.SetStateMachine,
-                    RoleSpec.MoveNextAsync,
-                    RoleSpec.DisposeAsync,
-                ],
-                StateMachineClaimKind.Iterator =>
-                [
-                    RoleSpec.IteratorMoveNext,
-                    RoleSpec.Dispose,
-                ],
-                _ => throw new InvalidOperationException(
-                    "Unknown state-machine claim kind."),
-            };
-
-            var methods =
+            ReadOnlySpan<StateMachineMethodRole> roles =
+                StateMachineRelationship.RolesFor(claim.Kind);
+            var dispositions =
                 ImmutableArray.CreateBuilder<
-                    StateMachineMethodRelationship>(
-                        roles.Length);
-            foreach (RoleSpec role in roles)
+                    StateMachineRoleDisposition>(roles.Length);
+            foreach (StateMachineMethodRole roleKind in roles)
             {
+                RoleSpec role = RoleSpec.For(claim.Kind, roleKind);
                 RoleResolution resolution =
-                    ResolveRole(stateMachine, role);
-                if (resolution.Method.IsNil)
+                    ResolveRole(
+                        stateMachine,
+                        role,
+                        StateMachineRelationship.CanBeAbsent(
+                            claim.Kind,
+                            roleKind));
+                if (resolution.Kind == RoleResolutionKind.Rejected)
                 {
                     PublishRejection(
                         resolution.Failure,
@@ -1009,10 +995,13 @@ public sealed class StateMachineRelationshipIndex
                     return;
                 }
 
-                methods.Add(
-                    new(
+                dispositions.Add(
+                    resolution.Kind == RoleResolutionKind.Present
+                    ? new StateMachineRoleDisposition.Present(
                         role.Role,
-                        Address(resolution.Method)));
+                        Address(resolution.Method))
+                    : new StateMachineRoleDisposition.AbsentFromArtifact(
+                        role.Role));
             }
 
             var relationship =
@@ -1021,14 +1010,14 @@ public sealed class StateMachineRelationshipIndex
                     stateMachineAddress,
                     claim.StateMachineName,
                     claim.Kind,
-                    methods.ToImmutable());
+                    dispositions.ToImmutable());
             var resolved =
                 new StateMachineRelationshipResult.Resolved(
                     relationship);
 
             var implementationTokens = new HashSet<int>();
-            foreach (StateMachineMethodRelationship method
-                in relationship.Methods)
+            foreach (StateMachineRoleDisposition.Present method
+                in PresentRoles(relationship))
             {
                 if (!implementationTokens.Add(method.Method.Token))
                 {
@@ -1064,8 +1053,8 @@ public sealed class StateMachineRelationshipIndex
                 resolvedEntry;
             _byStateMachine[MetadataTokens.GetToken(stateMachine)] =
                 resolvedEntry;
-            foreach (StateMachineMethodRelationship method
-                in relationship.Methods)
+            foreach (StateMachineRoleDisposition.Present method
+                in PresentRoles(relationship))
             {
                 int token = method.Method.Token;
                 _byImplementation[token] = resolvedEntry;
@@ -1078,7 +1067,7 @@ public sealed class StateMachineRelationshipIndex
             int implementationToken)
         {
             ImmutableArray<int> currentImplementations =
-                [.. relationship.Methods.Select(
+                [.. PresentRoles(relationship).Select(
                     method => method.Method.Token)];
             if (existing.Rejection is not null)
             {
@@ -1114,7 +1103,7 @@ public sealed class StateMachineRelationshipIndex
                     previous.StateMachineType.Definition.Value,
                     relationship.StateMachineType.Definition.Value,
                 ],
-                [.. previous.Methods
+                [.. PresentRoles(previous)
                     .Select(method => method.Method.Token)
                     .Concat(currentImplementations)
                     .Append(implementationToken)
@@ -1127,16 +1116,22 @@ public sealed class StateMachineRelationshipIndex
             _byKickoff.Remove(relationship.Kickoff.Token);
             _byStateMachine.Remove(
                 relationship.StateMachineType.Definition.Value);
-            foreach (StateMachineMethodRelationship method
-                in relationship.Methods)
+            foreach (StateMachineRoleDisposition.Present method
+                in PresentRoles(relationship))
             {
                 _byImplementation.Remove(method.Method.Token);
             }
         }
 
+        static IEnumerable<StateMachineRoleDisposition.Present> PresentRoles(
+            StateMachineRelationship relationship) =>
+            relationship.Roles.OfType<
+                StateMachineRoleDisposition.Present>();
+
         RoleResolution ResolveRole(
             TypeDefinitionHandle stateMachine,
-            RoleSpec role)
+            RoleSpec role,
+            bool allowAbsent)
         {
             TypeDefinition type =
                 _reader.GetTypeDefinition(stateMachine);
@@ -1156,6 +1151,10 @@ public sealed class StateMachineRelationshipIndex
                 Charge();
                 MethodImplementation implementation =
                     _reader.GetMethodImplementation(handle);
+                bool isCandidate = allowAbsent
+                    && _signatures.IsDeclarationCandidate(
+                        implementation.MethodDeclaration,
+                        role);
                 if (!_signatures.MatchesDeclaration(
                         implementation.MethodDeclaration,
                         role,
@@ -1166,6 +1165,13 @@ public sealed class StateMachineRelationshipIndex
                             implementedInterface,
                             declaredInterface))
                 {
+                    if (isCandidate)
+                    {
+                        return RoleResolution.Rejected(
+                            StateMachineRelationshipFailureKind.Unresolved,
+                            "A state-machine MethodImpl declaration names an optional role but does not match its signature.");
+                    }
+
                     continue;
                 }
                 if (!explicitMethod.IsNil
@@ -1192,7 +1198,7 @@ public sealed class StateMachineRelationshipIndex
                 explicitMethod = body;
             }
             if (!explicitMethod.IsNil)
-                return RoleResolution.Resolved(explicitMethod);
+                return RoleResolution.Present(explicitMethod);
 
             MethodDefinitionHandle implicitMethod = default;
             foreach (MethodDefinitionHandle handle in type.GetMethods())
@@ -1200,15 +1206,21 @@ public sealed class StateMachineRelationshipIndex
                 Charge();
                 MethodDefinition method =
                     _reader.GetMethodDefinition(handle);
-                if (!_reader.StringComparer.Equals(
-                        method.Name,
-                        role.Name)
-                    || !IsImplementationCandidate(
+                if (!_reader.StringComparer.Equals(method.Name, role.Name))
+                    continue;
+                if (!IsImplementationCandidate(
                         handle,
                         stateMachine,
                         role,
                         requireImplicitVisibility: true))
                 {
+                    if (allowAbsent)
+                    {
+                        return RoleResolution.Rejected(
+                            StateMachineRelationshipFailureKind.Unresolved,
+                            "A state-machine MethodDef names an optional role but does not match its required shape.");
+                    }
+
                     continue;
                 }
                 if (!implicitMethod.IsNil)
@@ -1220,11 +1232,14 @@ public sealed class StateMachineRelationshipIndex
                 implicitMethod = handle;
             }
 
-            return implicitMethod.IsNil
-                ? RoleResolution.Rejected(
-                    StateMachineRelationshipFailureKind.Unresolved,
-                    "A required state-machine interface role could not be resolved.")
-                : RoleResolution.Resolved(implicitMethod);
+            if (!implicitMethod.IsNil)
+                return RoleResolution.Present(implicitMethod);
+            if (allowAbsent)
+                return RoleResolution.AbsentFromArtifact();
+
+            return RoleResolution.Rejected(
+                StateMachineRelationshipFailureKind.Unresolved,
+                "A required state-machine interface role could not be resolved.");
         }
 
         EntityHandle FindImplementedInterface(
@@ -1843,6 +1858,38 @@ public sealed class StateMachineRelationshipIndex
                 && Matches(value, role);
         }
 
+        internal bool IsDeclarationCandidate(
+            EntityHandle declaration,
+            RoleSpec role)
+        {
+            StringHandle name;
+            EntityHandle declaringType;
+            if (declaration.Kind == HandleKind.MemberReference)
+            {
+                MemberReference member =
+                    _reader.GetMemberReference(
+                        (MemberReferenceHandle)declaration);
+                declaringType = member.Parent;
+                name = member.Name;
+            }
+            else if (declaration.Kind
+                == HandleKind.MethodDefinition)
+            {
+                MethodDefinition method =
+                    _reader.GetMethodDefinition(
+                        (MethodDefinitionHandle)declaration);
+                declaringType = method.GetDeclaringType();
+                name = method.Name;
+            }
+            else
+            {
+                return false;
+            }
+
+            return _reader.StringComparer.Equals(name, role.Name)
+                && IsKnownType(declaringType, role.Interface);
+        }
+
         internal bool MatchesMethod(
             MethodDefinition method,
             RoleSpec role)
@@ -2371,6 +2418,39 @@ public sealed class StateMachineRelationshipIndex
         KnownStateMachineType Return,
         ImmutableArray<KnownStateMachineType> Parameters)
     {
+        internal static RoleSpec For(
+            StateMachineClaimKind kind,
+            StateMachineMethodRole role) =>
+            (kind, role) switch
+            {
+                (
+                    StateMachineClaimKind.ClassicAsync,
+                    StateMachineMethodRole.MoveNext) => AsyncMoveNext,
+                (
+                    StateMachineClaimKind.ClassicAsync,
+                    StateMachineMethodRole.SetStateMachine) => SetStateMachine,
+                (
+                    StateMachineClaimKind.AsyncIterator,
+                    StateMachineMethodRole.MoveNext) => AsyncMoveNext,
+                (
+                    StateMachineClaimKind.AsyncIterator,
+                    StateMachineMethodRole.SetStateMachine) => SetStateMachine,
+                (
+                    StateMachineClaimKind.AsyncIterator,
+                    StateMachineMethodRole.MoveNextAsync) => MoveNextAsync,
+                (
+                    StateMachineClaimKind.AsyncIterator,
+                    StateMachineMethodRole.DisposeAsync) => DisposeAsync,
+                (
+                    StateMachineClaimKind.Iterator,
+                    StateMachineMethodRole.MoveNext) => IteratorMoveNext,
+                (
+                    StateMachineClaimKind.Iterator,
+                    StateMachineMethodRole.Dispose) => Dispose,
+                _ => throw new InvalidOperationException(
+                    "Unknown state-machine role."),
+            };
+
         internal static RoleSpec AsyncMoveNext { get; } =
             new(
                 StateMachineMethodRole.MoveNext,
@@ -2452,22 +2532,42 @@ public sealed class StateMachineRelationshipIndex
                 detail);
     }
 
+    enum RoleResolutionKind
+    {
+        Present,
+        AbsentFromArtifact,
+        Rejected,
+    }
+
     readonly record struct RoleResolution(
+        RoleResolutionKind Kind,
         MethodDefinitionHandle Method,
         StateMachineRelationshipFailureKind Failure,
         string Detail)
     {
-        internal static RoleResolution Resolved(
+        internal static RoleResolution Present(
             MethodDefinitionHandle method) =>
             new(
+                RoleResolutionKind.Present,
                 method,
+                StateMachineRelationshipFailureKind.Unresolved,
+                "");
+
+        internal static RoleResolution AbsentFromArtifact() =>
+            new(
+                RoleResolutionKind.AbsentFromArtifact,
+                default,
                 StateMachineRelationshipFailureKind.Unresolved,
                 "");
 
         internal static RoleResolution Rejected(
             StateMachineRelationshipFailureKind failure,
             string detail) =>
-            new(default, failure, detail);
+            new(
+                RoleResolutionKind.Rejected,
+                default,
+                failure,
+                detail);
     }
 
     sealed class RelationshipBudgetException : Exception;

--- a/src/ILInspector.Metadata/StateMachineRelationshipIndex.cs
+++ b/src/ILInspector.Metadata/StateMachineRelationshipIndex.cs
@@ -1151,10 +1151,20 @@ public sealed class StateMachineRelationshipIndex
                 Charge();
                 MethodImplementation implementation =
                     _reader.GetMethodImplementation(handle);
-                bool isCandidate = allowAbsent
-                    && _signatures.IsDeclarationCandidate(
-                        implementation.MethodDeclaration,
-                        role);
+                DeclarationCandidateKind candidateKind =
+                    allowAbsent
+                        ? _signatures.ClassifyDeclarationCandidate(
+                            implementation.MethodDeclaration,
+                            role)
+                        : DeclarationCandidateKind.NotCandidate;
+                if (candidateKind
+                    == DeclarationCandidateKind.Rejected)
+                {
+                    return RoleResolution.Rejected(
+                        StateMachineRelationshipFailureKind.Malformed,
+                        "A state-machine MethodImpl declaration type could not be read.");
+                }
+
                 if (!_signatures.MatchesDeclaration(
                         implementation.MethodDeclaration,
                         role,
@@ -1165,7 +1175,8 @@ public sealed class StateMachineRelationshipIndex
                             implementedInterface,
                             declaredInterface))
                 {
-                    if (isCandidate)
+                    if (candidateKind
+                        == DeclarationCandidateKind.Candidate)
                     {
                         return RoleResolution.Rejected(
                             StateMachineRelationshipFailureKind.Unresolved,
@@ -1858,7 +1869,7 @@ public sealed class StateMachineRelationshipIndex
                 && Matches(value, role);
         }
 
-        internal bool IsDeclarationCandidate(
+        internal DeclarationCandidateKind ClassifyDeclarationCandidate(
             EntityHandle declaration,
             RoleSpec role)
         {
@@ -1883,11 +1894,20 @@ public sealed class StateMachineRelationshipIndex
             }
             else
             {
-                return false;
+                return DeclarationCandidateKind.NotCandidate;
             }
 
-            return _reader.StringComparer.Equals(name, role.Name)
-                && IsKnownType(declaringType, role.Interface);
+            if (!_reader.StringComparer.Equals(name, role.Name))
+                return DeclarationCandidateKind.NotCandidate;
+
+            SignatureType type =
+                DecodeType(declaringType, ClassTypeCode);
+            if (type.TypeNameFailure is not null)
+                return DeclarationCandidateKind.Rejected;
+
+            return type.Type == role.Interface
+                ? DeclarationCandidateKind.Candidate
+                : DeclarationCandidateKind.NotCandidate;
         }
 
         internal bool MatchesMethod(
@@ -2376,6 +2396,13 @@ public sealed class StateMachineRelationshipIndex
         Primitive,
         Class,
         ValueType,
+    }
+
+    enum DeclarationCandidateKind
+    {
+        NotCandidate,
+        Candidate,
+        Rejected,
     }
 
     enum KnownStateMachineType

--- a/tests/ILInspector.Metadata.Tests/StateMachineCompletenessTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StateMachineCompletenessTests.cs
@@ -403,11 +403,10 @@ public sealed class StateMachineCompletenessTests
                 it reports Rejected regardless of whether anything claimed it
                 (see #4833).
 
-                A known cause of the first is trimming: ILLink removes
-                SetStateMachine, which both ClassicAsync and AsyncIterator require,
-                so every async claim in a trimmed assembly is refused (see #4827).
-                If this corpus contains trimmed output, that is expected rather than
-                a regression.
+                A known cause of the first is trimming a must-be-present role.
+                ClassicAsync admits an absent SetStateMachine support role, but
+                AsyncIterator still requires it. A trimmed async iterator may
+                therefore be refused when that role is removed.
 
                 {Truncated(offenders)}
                 """);
@@ -677,21 +676,21 @@ public sealed class StateMachineCompletenessTests
     }
 
     /// <summary>
-    /// Renames <c>SetStateMachine</c> in place so claims remain decodable but
-    /// fail role authentication.
+    /// Renames <c>MoveNext</c> in place so claims remain decodable but fail
+    /// required execution-role authentication.
     /// </summary>
     static byte[] Unauthenticatable(byte[] image)
     {
         byte[] copy = (byte[])image.Clone();
-        ReadOnlySpan<byte> role = "SetStateMachine"u8;
+        ReadOnlySpan<byte> role = "MoveNext\0"u8;
         int at = copy.AsSpan().IndexOf(role);
         Assert.True(
             at >= 0,
-            "The specimen carries no SetStateMachine to rename, so it cannot "
+            "The specimen carries no MoveNext to rename, so it cannot "
                 + "produce a refused claim.");
 
         // The heap deduplicates strings, so one edit reaches every reference.
-        copy[at + role.Length - 1] = (byte)'Z';
+        copy[at + role.Length - 2] = (byte)'Z';
         return copy;
     }
 

--- a/tests/ILInspector.Metadata.Tests/StateMachineRelationshipIndexTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StateMachineRelationshipIndexTests.cs
@@ -981,6 +981,9 @@ public sealed class StateMachineRelationshipIndexTests
         ClassicRelationshipMutation.ExplicitWrongSignatureSetStateMachine,
         StateMachineRelationshipFailureKind.Unresolved)]
     [InlineData(
+        ClassicRelationshipMutation.ExplicitMalformedInterfaceSetStateMachine,
+        StateMachineRelationshipFailureKind.Malformed)]
+    [InlineData(
         ClassicRelationshipMutation.DuplicateSetStateMachine,
         StateMachineRelationshipFailureKind.Ambiguous)]
     [InlineData(
@@ -2949,6 +2952,18 @@ public sealed class StateMachineRelationshipIndexTests
                 metadata.GetOrAddString(
                     "System.Runtime.CompilerServices"),
                 metadata.GetOrAddString("IsReadOnlyAttribute"));
+        TypeReferenceHandle malformedAsyncStateMachine = default;
+        if (mutation
+            == ClassicRelationshipMutation
+                .ExplicitMalformedInterfaceSetStateMachine)
+        {
+            malformedAsyncStateMachine =
+                metadata.AddTypeReference(
+                    MetadataTokens.TypeReferenceHandle(5),
+                    metadata.GetOrAddString(
+                        "System.Runtime.CompilerServices"),
+                    metadata.GetOrAddString("IAsyncStateMachine"));
+        }
 
         var staticVoidSignature = new BlobBuilder();
         new BlobEncoder(staticVoidSignature)
@@ -3066,6 +3081,12 @@ public sealed class StateMachineRelationshipIndexTests
             mutation
                 == ClassicRelationshipMutation
                     .ExplicitWrongSignatureSetStateMachine;
+        bool explicitMalformedInterface =
+            mutation
+                == ClassicRelationshipMutation
+                    .ExplicitMalformedInterfaceSetStateMachine;
+        bool explicitSetStateMachine =
+            explicitWrongSignature || explicitMalformedInterface;
         MethodDefinitionHandle setStateMachine = default;
         if (!omitSetStateMachine)
         {
@@ -3079,7 +3100,7 @@ public sealed class StateMachineRelationshipIndexTests
                         ? MethodImplAttributes.Runtime
                         : MethodImplAttributes.IL,
                     metadata.GetOrAddString(
-                        explicitWrongSignature
+                        explicitSetStateMachine
                             ? "IAsyncStateMachine.SetStateMachine"
                             : "SetStateMachine"),
                     metadata.GetOrAddBlob(
@@ -3134,13 +3155,18 @@ public sealed class StateMachineRelationshipIndexTests
                 moveNext,
                 declaration);
         }
-        if (explicitWrongSignature)
+        if (explicitSetStateMachine)
         {
             MemberReferenceHandle declaration =
                 metadata.AddMemberReference(
-                    asyncStateMachine,
+                    explicitMalformedInterface
+                        ? malformedAsyncStateMachine
+                        : asyncStateMachine,
                     metadata.GetOrAddString("SetStateMachine"),
-                    metadata.GetOrAddBlob(instanceVoidSignature));
+                    metadata.GetOrAddBlob(
+                        explicitWrongSignature
+                            ? instanceVoidSignature
+                            : setStateMachineSignature));
             metadata.AddMethodImplementation(
                 machine,
                 setStateMachine,
@@ -3674,6 +3700,7 @@ public sealed class StateMachineRelationshipIndexTests
         ValueTypeSetStateMachine,
         NonIlSetStateMachine,
         ExplicitWrongSignatureSetStateMachine,
+        ExplicitMalformedInterfaceSetStateMachine,
         DuplicateSetStateMachine,
         StaticMoveNext,
         NonIlMoveNext,

--- a/tests/ILInspector.Metadata.Tests/StateMachineRelationshipIndexTests.cs
+++ b/tests/ILInspector.Metadata.Tests/StateMachineRelationshipIndexTests.cs
@@ -53,8 +53,11 @@ public sealed class StateMachineRelationshipIndexTests
         Assert.Equal(expectedKind, result.Relationship.Kind);
         Assert.Equal(
             expectedRoles,
-            result.Relationship.Methods
-                .Select(method => method.Role));
+            result.Relationship.Roles.Select(role => role.Role));
+        Assert.All(
+            result.Relationship.Roles,
+            role => Assert.IsType<
+                StateMachineRoleDisposition.Present>(role));
         Assert.Equal(
             MetadataTokens.GetToken(kickoff),
             result.Relationship.Kickoff.Token);
@@ -72,8 +75,9 @@ public sealed class StateMachineRelationshipIndexTests
             result.Relationship.StateMachineName);
         Assert.IsType<StateMachineRelationshipResult.Resolved>(
             index.GetByStateMachine(stateMachineType));
-        foreach (StateMachineMethodRelationship method
-            in result.Relationship.Methods)
+        foreach (StateMachineRoleDisposition.Present method
+            in result.Relationship.Roles.OfType<
+                StateMachineRoleDisposition.Present>())
         {
             Assert.IsType<StateMachineRelationshipResult.Resolved>(
                 index.GetByImplementation(method.Method.Handle));
@@ -106,12 +110,65 @@ public sealed class StateMachineRelationshipIndexTests
             reader.GetMethodDefinition(moveNext.Handle);
         Assert.NotEqual("MoveNext", reader.GetString(method.Name));
         Assert.DoesNotContain(
-            result.Relationship.Methods,
+            result.Relationship.Roles.OfType<
+                StateMachineRoleDisposition.Present>(),
             candidate =>
                 reader.StringComparer.Equals(
                     reader.GetMethodDefinition(
                         candidate.Method.Handle).Name,
                     "MoveNext"));
+    }
+
+    [Fact]
+    public void
+        StateMachineRelationshipIndex_ResolvesClassicAsyncWithAbsentSupportRole()
+    {
+        using var image = new LoadedImage(
+            BuildClassicRelationshipImage(
+                ClassicRelationshipMutation.MissingSetStateMachine));
+
+        StateMachineRelationshipIndex index =
+            StateMachineRelationshipIndex.Create(image.Reader);
+        var result =
+            Assert.IsType<StateMachineRelationshipResult.Resolved>(
+                index.GetByKickoff(
+                    MetadataTokens.MethodDefinitionHandle(1)));
+
+        Assert.Collection(
+            result.Relationship.Roles.OrderBy(role => role.Role),
+            role =>
+            {
+                var present = Assert.IsType<
+                    StateMachineRoleDisposition.Present>(role);
+                Assert.Equal(
+                    StateMachineMethodRole.MoveNext,
+                    present.Role);
+            },
+            role =>
+            {
+                var absent = Assert.IsType<
+                    StateMachineRoleDisposition.AbsentFromArtifact>(role);
+                Assert.Equal(
+                    StateMachineMethodRole.SetStateMachine,
+                    absent.Role);
+            });
+        Assert.True(
+            result.Relationship.TryGetMethod(
+                StateMachineMethodRole.MoveNext,
+                out var moveNext));
+        Assert.False(
+            result.Relationship.TryGetMethod(
+                StateMachineMethodRole.SetStateMachine,
+                out _));
+        Assert.IsType<
+            StateMachineRoleDisposition.AbsentFromArtifact>(
+                result.Relationship.GetRole(
+                    StateMachineMethodRole.SetStateMachine));
+        Assert.IsType<StateMachineRelationshipResult.Resolved>(
+            index.GetByImplementation(moveNext.Handle));
+        Assert.IsType<StateMachineRelationshipResult.Resolved>(
+            index.GetByStateMachine(
+                MetadataTokens.TypeDefinitionHandle(3)));
     }
 
     [Theory]
@@ -159,8 +216,7 @@ public sealed class StateMachineRelationshipIndexTests
                     StateMachineMethodRole.MoveNext,
                     StateMachineMethodRole.SetStateMachine,
                 ],
-            result.Relationship.Methods.Select(
-                method => method.Role));
+            result.Relationship.Roles.Select(role => role.Role));
     }
 
     [Fact]
@@ -918,6 +974,15 @@ public sealed class StateMachineRelationshipIndexTests
     [InlineData(
         ClassicRelationshipMutation.ValueTypeSetStateMachine,
         StateMachineRelationshipFailureKind.Unresolved)]
+    [InlineData(
+        ClassicRelationshipMutation.NonIlSetStateMachine,
+        StateMachineRelationshipFailureKind.Unresolved)]
+    [InlineData(
+        ClassicRelationshipMutation.ExplicitWrongSignatureSetStateMachine,
+        StateMachineRelationshipFailureKind.Unresolved)]
+    [InlineData(
+        ClassicRelationshipMutation.DuplicateSetStateMachine,
+        StateMachineRelationshipFailureKind.Ambiguous)]
     [InlineData(
         ClassicRelationshipMutation.StaticMoveNext,
         StateMachineRelationshipFailureKind.Unresolved)]
@@ -2994,14 +3059,48 @@ public sealed class StateMachineRelationshipIndexTests
                             : instanceVoidSignature),
                 bodyOffset,
                 MetadataTokens.ParameterHandle(1));
-        metadata.AddMethodDefinition(
-            MethodAttributes.Public
-                | MethodAttributes.Virtual,
-            MethodImplAttributes.IL,
-            metadata.GetOrAddString("SetStateMachine"),
-            metadata.GetOrAddBlob(setStateMachineSignature),
-            bodyOffset,
-            MetadataTokens.ParameterHandle(1));
+        bool omitSetStateMachine =
+            mutation
+                == ClassicRelationshipMutation.MissingSetStateMachine;
+        bool explicitWrongSignature =
+            mutation
+                == ClassicRelationshipMutation
+                    .ExplicitWrongSignatureSetStateMachine;
+        MethodDefinitionHandle setStateMachine = default;
+        if (!omitSetStateMachine)
+        {
+            setStateMachine =
+                metadata.AddMethodDefinition(
+                    MethodAttributes.Public
+                        | MethodAttributes.Virtual,
+                    mutation
+                        == ClassicRelationshipMutation
+                            .NonIlSetStateMachine
+                        ? MethodImplAttributes.Runtime
+                        : MethodImplAttributes.IL,
+                    metadata.GetOrAddString(
+                        explicitWrongSignature
+                            ? "IAsyncStateMachine.SetStateMachine"
+                            : "SetStateMachine"),
+                    metadata.GetOrAddBlob(
+                        explicitWrongSignature
+                            ? instanceVoidSignature
+                            : setStateMachineSignature),
+                    bodyOffset,
+                    MetadataTokens.ParameterHandle(1));
+            if (mutation
+                == ClassicRelationshipMutation.DuplicateSetStateMachine)
+            {
+                metadata.AddMethodDefinition(
+                    MethodAttributes.Public
+                        | MethodAttributes.Virtual,
+                    MethodImplAttributes.IL,
+                    metadata.GetOrAddString("SetStateMachine"),
+                    metadata.GetOrAddBlob(setStateMachineSignature),
+                    bodyOffset,
+                    MetadataTokens.ParameterHandle(1));
+            }
+        }
         MethodDefinitionHandle damagedKickoff = default;
         if ((addMalformedConstructorRow
                 || rejectedConstructorTypeName
@@ -3033,6 +3132,18 @@ public sealed class StateMachineRelationshipIndexTests
             metadata.AddMethodImplementation(
                 machine,
                 moveNext,
+                declaration);
+        }
+        if (explicitWrongSignature)
+        {
+            MemberReferenceHandle declaration =
+                metadata.AddMemberReference(
+                    asyncStateMachine,
+                    metadata.GetOrAddString("SetStateMachine"),
+                    metadata.GetOrAddBlob(instanceVoidSignature));
+            metadata.AddMethodImplementation(
+                machine,
+                setStateMachine,
                 declaration);
         }
 
@@ -3558,8 +3669,12 @@ public sealed class StateMachineRelationshipIndexTests
     public enum ClassicRelationshipMutation
     {
         None,
+        MissingSetStateMachine,
         CustomModifiedSetStateMachine,
         ValueTypeSetStateMachine,
+        NonIlSetStateMachine,
+        ExplicitWrongSignatureSetStateMachine,
+        DuplicateSetStateMachine,
         StaticMoveNext,
         NonIlMoveNext,
         MethodImplBodyOnOtherType,


### PR DESCRIPTION
Builds the robust, evidence-carrying Metadata foundation needed for classic
async reconstruction across real post-build artifacts.

Closes #5307.

## Demo

Run the real Release artifact matrix:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class '*ClassicAsyncArtifactMatrixTests*' \
  -class '*AsyncLoweringFixtureMatrixTests*'
```

The same `StateMachineRelationshipIndex.GetByKickoff` probe over the ordinary
full-trim artifact changed from base `ed0122843`:

```text
Relationship: Rejected(Unresolved)
Evidence:     A required state-machine interface role could not be resolved.
```

to replacement head `ff6b20882`:

```text
Relationship: Resolved(ClassicAsync)
  MoveNext: Present
  SetStateMachine: AbsentFromArtifact
```

Notice that the relationship remains closed: both classic roles have one typed
disposition. The neighboring role-preserved trim and SDK reference artifacts
still resolve with both roles `Present`, while the identical-source
runtime-async lowering remains `Absent`.

## Summary

- Replace the method-only relationship array with one authoritative closed
  role-disposition collection: `Present(Method)` or
  `AbsentFromArtifact`.
- Admit absence only for classic `IAsyncStateMachine.SetStateMachine`, and only
  after bounded explicit and implicit scans find no candidate.
- Reject wrong-signature, bodyless, custom-modified, duplicate, or otherwise
  invalid support-role candidates instead of turning damaged evidence into
  success-shaped absence. Unreadable declaration parents are preserved as
  `Rejected(Malformed)`.
- Keep implementation reverse lookup limited to `Present` MethodDefs and retain
  `TryGetMethod` as a present-method projection.
- Update the normative Metadata certificate contract and the Decompiler
  consumer map without implementing #5277 request attachment or #5276 inverse
  reconstruction.

## Evidence

- The ordinary full-trim gate independently verifies the direct
  `IAsyncStateMachine` declaration, exact managed-IL `MoveNext`, and absence of
  both explicit and implicit `SetStateMachine` candidates.
- Synthetic Metadata gates cover closed role publication, absent support,
  invalid required `MoveNext`, non-IL and malformed implicit support,
  duplicate support, a wrong-signature explicit declaration whose body cannot
  enter implicit matching, and an exact-name explicit declaration with a
  self-cyclic interface `TypeRef`.
- The role-preserved, SDK-reference, and runtime-async matrix arms protect the
  adjacent positive and negative boundaries.

## Validation

```text
ILInspector.Metadata.Tests
  focused baseline: 9 passed
  focused head:     16 passed

ILInspector.Decompiler.Tests
  artifact/lowering matrix baseline: 6 passed
  artifact/lowering matrix head:     6 passed

markdownlint: 3 changed design documents passed

full Release solution build: 0 warnings, 0 errors
full ILInspector.Metadata.Tests: 2408 total, 0 failed, 1 skipped
full ILInspector.Decompiler.Tests: 6217 total, 0 failed
```

The change remains SRM-only and does not load inspected assemblies. It changes
Metadata structural identity evidence only; body semantics, kickoff-body
correlation, request attachment, and reconstruction eligibility remain with
their owning layers.
