### PR TITLE
Narrow using-declaration caret to Type identifier = with liveness captions (#5022 item 10)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -461,19 +461,17 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
-    public void CompareStructure_NarrowsUsingStatementSpanToHeaderAndStopsAnnotatingUnchangedBody()
+    public void CompareStructure_NarrowsUsingStatementDeclarationDroppedToTypeIdentifierEquals()
     {
-        // Reproduces the #4113 shape recorded in #4952 (issue #5022, items 2
-        // and 7): a disposed-only `using` resource is raised to the
-        // variable-less form. Only the header line's variable declaration
-        // changes; the body (`{`, `n = 1;`, `}`) is untouched. Previously the
-        // matched UsingStatement row's spans covered the whole construct, so
-        // RenderAnnotatedBody repeated a "construct; text changed"
-        // annotation on all four lines. Narrowing the row's spans to the
-        // printer's own recorded Header sub-region (a) confines the caret to
-        // the header line (item 2) and (b) stops annotating the unchanged
-        // body lines as a side effect, with no separate propagation step to
-        // suppress (item 7).
+        // Reproduces the #4113 shape recorded in #4952 (issue #5022, items 2,
+        // 7, and 10): a disposed-only `using` resource is raised to the
+        // variable-less form. The body (`{`, `n = 1;`, `}`) is untouched and
+        // never reads `iDisposable`, so item 10 narrows the row's spans
+        // further than items 2/7's header-only narrowing: to exactly
+        // `IDisposable iDisposable =` on the declaring side, and to the bare
+        // resource expression on the variable-less side -- matching #4952's
+        // "agreed-better mockup" for #4113 exactly, including its side-local
+        // "never read" captions.
         const string beforeText = """
             int n = 0;
             using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
@@ -507,17 +505,16 @@ public class CSharpStructuralComparisonTests
         var beforeSpan = Assert.Single(row.BeforeSpans);
         var afterSpan = Assert.Single(row.AfterSpans);
         Assert.Equal(
-            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            "IDisposable iDisposable =",
             before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
         Assert.Equal(
-            "using (DisposableFromObjectSpan([a, b]))",
+            "DisposableFromObjectSpan([a, b])",
             after.Text.Substring(afterSpan.Start, afterSpan.Length));
 
-        // Round-2 review: the row's reported region role must reflect the
-        // narrowed spans it actually renders (Header), not the full
-        // statement's Construct region the node used to span before
-        // narrowing -- otherwise the caret narrows but the label still says
-        // "construct", contradicting itself.
+        // The narrowed span is still contained within the printer's own
+        // Header region, so the row's reported region role stays Header --
+        // matching items 2/7's own invariant that the reported region must
+        // reflect what the caret actually covers.
         Assert.Equal(PrintedRegionRole.Header, row.BeforeRegion);
         Assert.Equal(PrintedRegionRole.Header, row.AfterRegion);
 
@@ -530,12 +527,18 @@ public class CSharpStructuralComparisonTests
 
         AssertCaret(
             beforeBody,
-            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
-            "raise: UsingStatement header;");
+            "IDisposable iDisposable =",
+            "raise: UsingStatement header; declares variable `iDisposable` (never read)");
         AssertCaret(
             afterBody,
-            "using (DisposableFromObjectSpan([a, b]))",
-            "raise: UsingStatement header;");
+            "DisposableFromObjectSpan([a, b])",
+            "raise: UsingStatement header; variable-less resource (declaration dropped; never read)");
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal(
+            "header: variable declaration dropped (`iDisposable` never read)",
+            display.Detail);
+
         Assert.DoesNotContain("raise: UsingStatement construct", beforeBody, StringComparison.Ordinal);
         Assert.DoesNotContain("raise: UsingStatement construct", afterBody, StringComparison.Ordinal);
         foreach (string unchangedLine in new[] { "{", "n = 1;", "}" })
@@ -543,6 +546,126 @@ public class CSharpStructuralComparisonTests
             Assert.DoesNotContain($"raise: {unchangedLine}", beforeBody, StringComparison.Ordinal);
             Assert.DoesNotContain($"raise: {unchangedLine}", afterBody, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public void CompareStructure_DoesNotNarrowUsingDeclarationWhenVariableIsRead()
+    {
+        // Close negative for item 10: same declaration-dropped header shape
+        // as the previous test, but the body now reads `iDisposable` (via
+        // `iDisposable.Dispose()`), so item 10's liveness check must refuse
+        // to narrow further or caption "never read" -- that claim would be
+        // false, and dropping a variable that is actually read is not an
+        // equivalent rewrite in the first place. The row falls back to
+        // items 2/7's header-only narrowing and generic caption.
+        const string beforeText = """
+            int n = 0;
+            using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+            {
+                iDisposable.Dispose();
+            }
+            return n;
+            """;
+        const string afterText = """
+            int n = 0;
+            using (DisposableFromObjectSpan([a, b]))
+            {
+                iDisposable.Dispose();
+            }
+            return n;
+            """;
+
+        var before = UsingStatementDocument(beforeText);
+        var after = UsingStatementDocument(afterText);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal(
+            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.Equal(
+            "using (DisposableFromObjectSpan([a, b]))",
+            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.DoesNotContain("never read", display.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareStructure_NarrowsUsingStatementDeclarationAddedToTypeIdentifierEquals()
+    {
+        // Mirror direction of item 10: a variable-less resource gains a
+        // declaration (before has none, after declares `iDisposable`, never
+        // read in the untouched body). The row narrows symmetrically: the
+        // bare expression on the before side, `Type identifier =` on the
+        // after side, with captions swapped to match.
+        const string beforeText = """
+            int n = 0;
+            using (DisposableFromObjectSpan([a, b]))
+            {
+                n = 1;
+            }
+            return n;
+            """;
+        const string afterText = """
+            int n = 0;
+            using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+            {
+                n = 1;
+            }
+            return n;
+            """;
+
+        var before = UsingStatementDocument(beforeText);
+        var after = UsingStatementDocument(afterText);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal(
+            "DisposableFromObjectSpan([a, b])",
+            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.Equal(
+            "IDisposable iDisposable =",
+            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(
+            comparison,
+            CSharpStructuralSide.After);
+
+        AssertCaret(
+            beforeBody,
+            "DisposableFromObjectSpan([a, b])",
+            "raise: UsingStatement header; variable-less resource (declaration added; never read)");
+        AssertCaret(
+            afterBody,
+            "IDisposable iDisposable =",
+            "raise: UsingStatement header; declares variable `iDisposable` (never read)");
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal(
+            "header: variable declaration added (`iDisposable` never read)",
+            display.Detail);
     }
 
     [Fact]
@@ -640,17 +763,21 @@ public class CSharpStructuralComparisonTests
 
         // Item 1 (ancestor collapsing) recognizes the nested UsingStatement's
         // narrowed header row as the sole explanation for the TryStatement's
-        // text change and suppresses the redundant ancestor row.
+        // text change and suppresses the redundant ancestor row, using the
+        // items-2/7 header-level span (before item 10's further declaration
+        // narrowing runs -- see RefineUsingResourceDeclarationRows). The
+        // surviving row is then refined by item 10 same as any other, since
+        // `iDisposable` is never read in the nested using's own body.
         var row = Assert.Single(comparison.Rows);
         Assert.Equal(1, row.BeforeNodeId);
         Assert.Equal(1, row.AfterNodeId);
         var beforeSpan = Assert.Single(row.BeforeSpans);
         var afterSpan = Assert.Single(row.AfterSpans);
         Assert.Equal(
-            "using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))",
+            "IDisposable iDisposable =",
             before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
         Assert.Equal(
-            "using (DisposableFromObjectSpan([a, b]))",
+            "DisposableFromObjectSpan([a, b])",
             after.Text.Substring(afterSpan.Start, afterSpan.Length));
     }
 

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -601,6 +601,70 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void CompareStructure_DoesNotRefineUsingDeclarationWhenBodyAlsoChanged()
+    {
+        // Close negative for item 10: the declaration is dropped (as in the
+        // narrowing test above), but the body also gains a statement, so
+        // items 2/7's own header-narrowing (`NarrowToChangedHeader`) falls
+        // back to the full node span instead of the Header region -- the
+        // text outside a naive header span would then differ between before
+        // and after. Item 10 must refuse to refine that fallback span: its
+        // `using (` prefix would otherwise fool `UsingHeaderInnerSpan` into
+        // scanning for a closing paren across the whole (differing) body,
+        // narrowing to a bogus, mid-token substring instead of an honest
+        // full-construct span.
+        const string beforeText = """
+            int n = 0;
+            using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
+            {
+                Bar();
+            }
+            return n;
+            """;
+        const string afterText = """
+            int n = 0;
+            using (DisposableFromObjectSpan([a, b]))
+            {
+                Bar();
+                n = 1;
+            }
+            return n;
+            """;
+
+        var before = UsingStatementDocument(beforeText);
+        var after = UsingStatementDocument(afterText);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+
+        // Not narrowed to `IDisposable iDisposable =` / the bare resource
+        // expression -- since the body also changed, items 2/7's own
+        // header-narrowing already fell back to the full node span, and
+        // item 10 must leave that fallback alone rather than reaching past
+        // its own side's matching closing paren into the (differing) body.
+        Assert.NotEqual(
+            "IDisposable iDisposable =",
+            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.NotEqual(
+            "DisposableFromObjectSpan([a, b])",
+            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+        Assert.NotEqual(PrintedRegionRole.Header, row.BeforeRegion);
+        Assert.NotEqual(PrintedRegionRole.Header, row.AfterRegion);
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.DoesNotContain("never read", display.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareStructure_NarrowsUsingStatementDeclarationAddedToTypeIdentifierEquals()
     {
         // Mirror direction of item 10: a variable-less resource gains a

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -646,17 +646,14 @@ public class CSharpStructuralComparisonTests
         var beforeSpan = Assert.Single(row.BeforeSpans);
         var afterSpan = Assert.Single(row.AfterSpans);
 
-        // Not narrowed to `IDisposable iDisposable =` / the bare resource
-        // expression -- since the body also changed, items 2/7's own
-        // header-narrowing already fell back to the full node span, and
-        // item 10 must leave that fallback alone rather than reaching past
-        // its own side's matching closing paren into the (differing) body.
-        Assert.NotEqual(
-            "IDisposable iDisposable =",
-            before.Text.Substring(beforeSpan.Start, beforeSpan.Length));
-        Assert.NotEqual(
-            "DisposableFromObjectSpan([a, b])",
-            after.Text.Substring(afterSpan.Start, afterSpan.Length));
+        // Falls all the way back to the full `UsingStatement` node spans --
+        // not narrowed to `IDisposable iDisposable =` / the bare resource
+        // expression, nor to any other erroneous substring reaching into
+        // the (differing) body. Since the body also changed, items 2/7's
+        // own header-narrowing already fell back to the full node span, and
+        // item 10 must leave that fallback exactly alone.
+        Assert.Equal(before.Nodes[0].Spans[0], beforeSpan);
+        Assert.Equal(after.Nodes[0].Spans[0], afterSpan);
         Assert.NotEqual(PrintedRegionRole.Header, row.BeforeRegion);
         Assert.NotEqual(PrintedRegionRole.Header, row.AfterRegion);
 

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -1177,7 +1177,18 @@ public static partial class CSharpBodyDiff
                 || !string.Equals(row.BeforeKind, "UsingStatement", StringComparison.Ordinal)
                 || !string.Equals(row.AfterKind, "UsingStatement", StringComparison.Ordinal)
                 || row.BeforeSpans.Length != 1
-                || row.AfterSpans.Length != 1)
+                || row.AfterSpans.Length != 1
+                // Only refine a row whose span is actually the printer's
+                // Header region (items 2/7's successful narrowing). When
+                // that narrowing instead fell back to the full node span --
+                // e.g. because the body also changed -- the span still
+                // starts with `using (`, but its closing paren is not the
+                // header's; scanning for one via `UsingHeaderInnerSpan`
+                // would then reach into the body and narrow to a bogus,
+                // mid-token substring. Requiring Header here keeps this pass
+                // strictly a refinement of items 2/7's own result.
+                || row.BeforeRegion != PrintedRegionRole.Header
+                || row.AfterRegion != PrintedRegionRole.Header)
             {
                 yield return row;
                 continue;

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -749,7 +749,10 @@ public static partial class CSharpBodyDiff
         }
 
         var rows = ImmutableArray.CreateBuilder<CSharpStructuralDiffRow>();
-        rows.AddRange(SuppressSubsumedAncestorRows(matchedRows, input.Before, input.After));
+        rows.AddRange(RefineUsingResourceDeclarationRows(
+            SuppressSubsumedAncestorRows(matchedRows, input.Before, input.After),
+            input.Before,
+            input.After));
 
         foreach (int nodeId in beforeSelection)
         {
@@ -1154,21 +1157,261 @@ public static partial class CSharpBodyDiff
         return ([beforeHeaderSpan], [afterHeaderSpan]);
     }
 
+    // Item 10 (issue #5022): applies `NarrowUsingResourceDeclaration` to
+    // surviving matched rows, after `SuppressSubsumedAncestorRows` (item 1)
+    // has already run against the coarser, items-2/7 header-level spans --
+    // see that method's own comment for why the ordering matters. Recomputes
+    // each refined row's region role, since a further-narrowed span could in
+    // principle no longer resolve to the same recorded region (in practice
+    // it stays Header here, as the narrowed span remains a subset of it).
+    static IEnumerable<CSharpStructuralDiffRow> RefineUsingResourceDeclarationRows(
+        IEnumerable<CSharpStructuralDiffRow> rows,
+        AnnotatedSourceDocument before,
+        AnnotatedSourceDocument after)
+    {
+        foreach (var row in rows)
+        {
+            if (row.Change != CSharpStructuralChangeKind.Changed
+                || row.BeforeNodeId is not int beforeNodeId
+                || row.AfterNodeId is not int afterNodeId
+                || !string.Equals(row.BeforeKind, "UsingStatement", StringComparison.Ordinal)
+                || !string.Equals(row.AfterKind, "UsingStatement", StringComparison.Ordinal)
+                || row.BeforeSpans.Length != 1
+                || row.AfterSpans.Length != 1)
+            {
+                yield return row;
+                continue;
+            }
+
+            var beforeNode = before.Nodes[beforeNodeId];
+            var afterNode = after.Nodes[afterNodeId];
+            if (beforeNode.Spans.Count != 1 || afterNode.Spans.Count != 1
+                || NarrowUsingResourceDeclaration(
+                    before, beforeNode.Spans[0], row.BeforeSpans[0],
+                    after, afterNode.Spans[0], row.AfterSpans[0]) is not { } narrowed)
+            {
+                yield return row;
+                continue;
+            }
+
+            yield return row with
+            {
+                BeforeSpans = narrowed.BeforeSpans,
+                AfterSpans = narrowed.AfterSpans,
+                BeforeRegion = EnclosingRegion(before, narrowed.BeforeSpans),
+                AfterRegion = EnclosingRegion(after, narrowed.AfterSpans),
+            };
+        }
+    }
+
+    // Item 10 (issue #5022): the header-narrowing above (items 2/7) still
+    // over-attributes the caret to the entire `using (...)` clause even when
+    // only the optional resource-variable declaration was added or dropped,
+    // e.g. `using (IDisposable iDisposable = Expr())` raised to the
+    // variable-less `using (Expr())`. Per the exact "agreed-better mockup" in
+    // #4952 (#4113), the caret should narrow further: to just `Type
+    // identifier =` on the side that declares a variable, and to the bare
+    // resource expression on the side that does not. This is licensed only
+    // when (a) the header's inner content (between `using (`/`await using (`
+    // and the closing `)`) differs by exactly that declaration-prefix shape,
+    // and (b) the declared identifier is never referenced elsewhere in the
+    // statement's own body -- confirmed here, not assumed, via a narrow
+    // single-identifier scan of the printer's own recorded Body region.
+    // Dropping a variable that *is* read elsewhere would be a materially
+    // different, non-equivalent rewrite, so this must not narrow (or
+    // caption) in that case; the coarser header-only narrowing above remains
+    // the honest fallback.
+    //
+    // This runs as a distinct pass over surviving rows (see
+    // `RefineUsingResourceDeclarationRows`), strictly after
+    // `SuppressSubsumedAncestorRows` (item 1) rather than inline in
+    // `NarrowToChangedHeader`. Item 1's ancestor-suppression compares the
+    // text immediately outside a descendant row's own span on both sides,
+    // which relies on that span identifying the *same* header boundary on
+    // both sides; this narrowing's before/after spans intentionally cover
+    // different-length, differently-positioned substrings of the header
+    // (the declaration prefix vs. the bare expression), which would make an
+    // enclosing ancestor's "outside text" spuriously differ and wrongly
+    // block item 1's suppression if applied any earlier.
+    static (ImmutableArray<AnnotatedSourceSpan> BeforeSpans, ImmutableArray<AnnotatedSourceSpan> AfterSpans)?
+        NarrowUsingResourceDeclaration(
+            AnnotatedSourceDocument beforeDocument,
+            AnnotatedSourceSpan beforeNodeSpan,
+            AnnotatedSourceSpan beforeHeaderSpan,
+            AnnotatedSourceDocument afterDocument,
+            AnnotatedSourceSpan afterNodeSpan,
+            AnnotatedSourceSpan afterHeaderSpan)
+    {
+        var beforeInner = UsingHeaderInnerSpan(beforeDocument, beforeHeaderSpan);
+        var afterInner = UsingHeaderInnerSpan(afterDocument, afterHeaderSpan);
+        if (beforeInner is not { } beforeInnerSpan || afterInner is not { } afterInnerSpan)
+            return null;
+
+        string beforeInnerText = beforeDocument.Text.Substring(beforeInnerSpan.Start, beforeInnerSpan.Length);
+        string afterInnerText = afterDocument.Text.Substring(afterInnerSpan.Start, afterInnerSpan.Length);
+
+        if (TryParseDeclarationPrefix(beforeInnerText, beforeInnerSpan, afterInnerText, out var declSpan, out string droppedIdentifier)
+            && IdentifierNeverReferencedInBody(beforeDocument, beforeNodeSpan, droppedIdentifier))
+        {
+            return ([declSpan], [afterInnerSpan]);
+        }
+
+        if (TryParseDeclarationPrefix(afterInnerText, afterInnerSpan, beforeInnerText, out var addedDeclSpan, out string addedIdentifier)
+            && IdentifierNeverReferencedInBody(afterDocument, afterNodeSpan, addedIdentifier))
+        {
+            return ([beforeInnerSpan], [addedDeclSpan]);
+        }
+
+        return null;
+    }
+
+    // The header always begins with `using (` or `await using (` and ends at
+    // the matching closing parenthesis (see CSharpPrinter.cs), so locating
+    // the last `)` in the header text -- rather than trusting the header
+    // span's own end, which may or may not include a trailing newline --
+    // gives the exact inner content regardless of that formatting detail.
+    static AnnotatedSourceSpan? UsingHeaderInnerSpan(
+        AnnotatedSourceDocument document,
+        AnnotatedSourceSpan headerSpan)
+    {
+        string headerText = document.Text.Substring(headerSpan.Start, headerSpan.Length);
+        const string AwaitPrefix = "await using (";
+        const string Prefix = "using (";
+        int prefixLength = headerText.StartsWith(AwaitPrefix, StringComparison.Ordinal)
+            ? AwaitPrefix.Length
+            : headerText.StartsWith(Prefix, StringComparison.Ordinal)
+                ? Prefix.Length
+                : -1;
+        if (prefixLength < 0)
+            return null;
+
+        int closeParen = headerText.LastIndexOf(')');
+        if (closeParen < prefixLength)
+            return null;
+
+        int innerLength = closeParen - prefixLength;
+        return innerLength <= 0 ? null : new AnnotatedSourceSpan(headerSpan.Start + prefixLength, innerLength);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="declText"/> is exactly a
+    /// `Type identifier =` prefix (the C# grammar for a using-resource
+    /// declarator, which allows no modifiers) followed by
+    /// <paramref name="exprText"/> verbatim, and returns the exact span of
+    /// that prefix (through the `=`, excluding trailing whitespace) plus the
+    /// declared identifier. Requires exactly two whitespace-separated tokens
+    /// before the `=` -- a generic type containing its own internal space
+    /// (e.g. `Dictionary&lt;string, int&gt;`) does not match and correctly
+    /// falls back to the coarser header-only narrowing rather than risk a
+    /// wrong split. Also rejects a compound/relational operator ending in
+    /// `=` (`==`, `!=`, `&lt;=`, `&gt;=`, `+=`, ...), which is never valid in
+    /// this position but would otherwise misparse as a plain assignment.
+    /// </summary>
+    static bool TryParseDeclarationPrefix(
+        string declText,
+        AnnotatedSourceSpan declSpan,
+        string exprText,
+        out AnnotatedSourceSpan declarationSpan,
+        out string identifier)
+    {
+        declarationSpan = default;
+        identifier = "";
+
+        if (exprText.Length == 0
+            || declText.Length <= exprText.Length
+            || !declText.EndsWith(exprText, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string prefix = declText[..(declText.Length - exprText.Length)];
+        string trimmedPrefix = prefix.TrimEnd();
+        if (trimmedPrefix.Length < 2 || trimmedPrefix[^1] != '='
+            || IsCompoundEqualsPrefixChar(trimmedPrefix[^2]))
+        {
+            return false;
+        }
+
+        string beforeEquals = trimmedPrefix[..^1].TrimEnd();
+        string[] tokens = beforeEquals.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length != 2 || !IsSimpleIdentifier(tokens[1]))
+            return false;
+
+        declarationSpan = new AnnotatedSourceSpan(declSpan.Start, trimmedPrefix.Length);
+        identifier = tokens[1];
+        return true;
+    }
+
+    static bool IsCompoundEqualsPrefixChar(char character)
+        => character is '=' or '!' or '<' or '>' or '+' or '-' or '*' or '/' or '%' or '&' or '|' or '^';
+
+    static bool IsSimpleIdentifier(string text)
+    {
+        if (text.Length == 0)
+            return false;
+        char first = text[0];
+        if (!char.IsLetter(first) && first != '_' && first != '@')
+            return false;
+        for (int index = 1; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (!char.IsLetterOrDigit(character) && character != '_')
+                return false;
+        }
+        return true;
+    }
+
+    static bool IdentifierNeverReferencedInBody(
+        AnnotatedSourceDocument document,
+        AnnotatedSourceSpan nodeSpan,
+        string identifier)
+    {
+        var body = FindSoleContainedRegion(document, [nodeSpan], PrintedRegionRole.Body);
+        if (body is not { } bodySpan)
+            return false; // Unknown body shape: never assert an unverifiable claim.
+
+        string bodyText = document.Text.Substring(bodySpan.Start, bodySpan.Length);
+        return !ContainsWholeWord(bodyText, identifier);
+    }
+
+    static bool ContainsWholeWord(string text, string word)
+    {
+        int index = 0;
+        while ((index = text.IndexOf(word, index, StringComparison.Ordinal)) >= 0)
+        {
+            bool leftBoundary = index == 0 || !IsIdentifierChar(text[index - 1]);
+            int endIndex = index + word.Length;
+            bool rightBoundary = endIndex == text.Length || !IsIdentifierChar(text[endIndex]);
+            if (leftBoundary && rightBoundary)
+                return true;
+            index++;
+        }
+        return false;
+    }
+
+    static bool IsIdentifierChar(char character) => char.IsLetterOrDigit(character) || character == '_';
+
     static AnnotatedSourceSpan? FindSoleContainedHeaderRegion(
         AnnotatedSourceDocument document,
         AnnotatedSourceNode node)
+        => FindSoleContainedRegion(document, node.Spans, PrintedRegionRole.Header);
+
+    static AnnotatedSourceSpan? FindSoleContainedRegion(
+        AnnotatedSourceDocument document,
+        IReadOnlyList<AnnotatedSourceSpan> containerSpans,
+        PrintedRegionRole role)
     {
         AnnotatedSourceSpan? found = null;
         foreach (var region in document.Regions)
         {
-            if (region.Role != PrintedRegionRole.Header
+            if (region.Role != role
                 || region.Spans.Count != 1
-                || !ContainsAll(node.Spans, region.Spans))
+                || !ContainsAll(containerSpans, region.Spans))
             {
                 continue;
             }
             if (found is not null)
-                return null; // Ambiguous: more than one contained header region.
+                return null; // Ambiguous: more than one contained region of this role.
             found = region.Spans[0];
         }
         return found;

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -240,6 +240,15 @@ public static class CSharpStructuralDiffPrinter
                 return calleeTransition.DetailSummary;
         }
 
+        if (textChanged
+            && IsUsingDeclarationRoleCandidate(row)
+            && beforeText is not null
+            && afterText is not null
+            && TryDescribeUsingDeclarationRoleTransition(beforeText, afterText, out var usingTransition))
+        {
+            return usingTransition.DetailSummary;
+        }
+
         return beforeText is null && afterText is null
             ? ""
             : FormatTransition(beforeText, afterText);
@@ -307,6 +316,17 @@ public static class CSharpStructuralDiffPrinter
             }
         }
 
+        if (IsUsingDeclarationRoleCandidate(row)
+            && TryDescribeUsingDeclarationRoleTransition(
+                Contain(beforeText)!,
+                Contain(afterText)!,
+                out var usingTransition))
+        {
+            return side == CSharpStructuralSide.Before
+                ? $"; {usingTransition.BeforeDescription}"
+                : $"; {usingTransition.AfterDescription}";
+        }
+
         string counterpart = side == CSharpStructuralSide.Before
             ? afterText
             : beforeText;
@@ -319,6 +339,10 @@ public static class CSharpStructuralDiffPrinter
     static bool IsInvocationRoleCandidate(CSharpStructuralDiffRow row)
         => string.Equals(row.BeforeKind, "InvocationExpression", StringComparison.Ordinal)
             && string.Equals(row.AfterKind, "InvocationExpression", StringComparison.Ordinal);
+
+    static bool IsUsingDeclarationRoleCandidate(CSharpStructuralDiffRow row)
+        => string.Equals(row.BeforeKind, "UsingStatement", StringComparison.Ordinal)
+            && string.Equals(row.AfterKind, "UsingStatement", StringComparison.Ordinal);
 
     /// <summary>
     /// Item 3 (issue #5022): a side-local role description for the narrow,
@@ -509,6 +533,95 @@ public static class CSharpStructuralDiffPrinter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Item 10 (issue #5022): a side-local role description for the
+    /// #4113 "using-resource declaration dropped/added" shape licensed by
+    /// <c>NarrowUsingResourceDeclaration</c> in <c>CSharpStructuralComparison.cs</c>
+    /// -- once that narrowing has already confirmed the declared identifier
+    /// is never read elsewhere in the statement's own body, this purely
+    /// re-derives which side is the declaring one from each side's own
+    /// already-narrowed text, so a "declares variable" / "variable-less
+    /// resource" caption is only ever produced for that one verified shape.
+    /// </summary>
+    readonly record struct UsingDeclarationRoleTransition(
+        string BeforeDescription,
+        string AfterDescription,
+        string DetailSummary);
+
+    static bool TryDescribeUsingDeclarationRoleTransition(
+        string beforeText,
+        string afterText,
+        out UsingDeclarationRoleTransition transition)
+    {
+        transition = default;
+
+        if (TryParseTrailingDeclarationEquals(beforeText, out string droppedName)
+            && !TryParseTrailingDeclarationEquals(afterText, out _))
+        {
+            transition = new UsingDeclarationRoleTransition(
+                $"declares variable `{droppedName}` (never read)",
+                "variable-less resource (declaration dropped; never read)",
+                $"header: variable declaration dropped (`{droppedName}` never read)");
+            return true;
+        }
+
+        if (TryParseTrailingDeclarationEquals(afterText, out string addedName)
+            && !TryParseTrailingDeclarationEquals(beforeText, out _))
+        {
+            transition = new UsingDeclarationRoleTransition(
+                "variable-less resource (declaration added; never read)",
+                $"declares variable `{addedName}` (never read)",
+                $"header: variable declaration added (`{addedName}` never read)");
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Recognizes exactly the `Type identifier =` shape (the C# grammar for
+    /// a using-resource declarator, which allows no modifiers) that
+    /// <c>TryParseDeclarationPrefix</c> in <c>CSharpStructuralComparison.cs</c>
+    /// narrows a row's span to. This is an independent textual re-check, not
+    /// a shared call, matching this file's existing pattern (e.g.
+    /// <see cref="TryParseQualifiedCall"/>) of recognizing nothing beyond
+    /// what each side's own selected text shows.
+    /// </summary>
+    static bool TryParseTrailingDeclarationEquals(string text, out string identifier)
+    {
+        identifier = "";
+        string trimmed = text.TrimEnd();
+        if (trimmed.Length < 2 || trimmed[^1] != '=' || IsCompoundEqualsPrefixChar(trimmed[^2]))
+            return false;
+
+        string beforeEquals = trimmed[..^1].TrimEnd();
+        string[] tokens = beforeEquals.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length != 2 || !IsSimpleIdentifier(tokens[1]))
+            return false;
+
+        identifier = tokens[1];
+        return true;
+    }
+
+    static bool IsCompoundEqualsPrefixChar(char character)
+        => character is '=' or '!' or '<' or '>' or '+' or '-' or '*' or '/' or '%' or '&' or '|' or '^';
+
+    static bool IsSimpleIdentifier(string text)
+    {
+        if (text.Length == 0)
+            return false;
+        char first = text[0];
+        if (!char.IsLetter(first) && first != '_' && first != '@')
+            return false;
+        for (int index = 1; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (!char.IsLetterOrDigit(character) && character != '_')
+                return false;
+        }
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements item 10 (the final remaining item) from tracking issue #5022:
narrows the `using`-declaration caret to exactly `Type identifier =` (rather
than the whole header) and adds side-local "never read" liveness captions,
matching the exact mockup recorded in issue #4952's `#4113` section.

Items 2 and 7 already narrow a changed `UsingStatement` row's spans to the
printer's `Header` region (`using (...)`). When the only textual difference
inside that header is a declared-but-never-read resource variable being
dropped (or added), the header-level span is wider than the actual change:
it still includes the unchanged resource expression on both sides. Item 10
narrows further, in a new pass (`RefineUsingResourceDeclarationRows`) that
runs strictly after item 1's ancestor-suppression pass, so that pass still
reasons about the coarser header-level spans it depends on.

## Demo

Real fixture: `CfgSampleClass.InlineArraySpanUsingResource(object a, object b)`
(`src/ILInspector.Decompiler.Tests/CfgSampleClass.cs`), the compiled witness
for the disposed-only variable-less `using` raise (#3346/#4113). Its resource
(`DisposableFromObjectSpan([a, b])`) is disposed-only — the body never reads
it — so the raise pass elides the declared variable entirely. The **after**
text below is the tool's real, current output for this method, confirmed by
the existing passing test `IrImporterTests.InlineArraySpanUsingResource_RaisesToVariableLessUsing`.
The **before** text is the pre-raise declared-variable shape recorded as the
agreed-better mockup in issue #4952's `#4113` section, using this same real
resource expression.

Running the tool's actual `CSharpBodyDiff.CompareStructure` +
`CSharpStructuralDiffPrinter.RenderAnnotatedBody` pipeline against this real
before/after pair (`CSharpStructuralComparisonTests.CompareStructure_NarrowsUsingStatementDeclarationDroppedToTypeIdentifierEquals`)
produces this genuine annotated output:

**Before** (declared variable, never read):

```text
int n = 0;
using (IDisposable iDisposable = DisposableFromObjectSpan([a, b]))
//     ^^^^^^^^^^^^^^^^^^^^^^^^^
//     raise: UsingStatement header; declares variable `iDisposable` (never read)
{
    n = 1;
}
return n;
```

**After** (variable elided):

```text
int n = 0;
using (DisposableFromObjectSpan([a, b]))
//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//     raise: UsingStatement header; variable-less resource (declaration dropped; never read)
{
    n = 1;
}
return n;
```

Notice: the caret on the before side covers exactly `IDisposable iDisposable =`
(not the whole `using (...)` header), and the after side's caret covers
exactly the bare resource expression `DisposableFromObjectSpan([a, b])`. Prior
to this change, both carets would have spanned the entire header text
`IDisposable iDisposable = DisposableFromObjectSpan([a, b])` /
`DisposableFromObjectSpan([a, b])` respectively — item 10 narrows the
declaring side down to just the part that actually changed, and adds the
"never read" liveness caption that trusts the narrowing already proved.

The row's Detail column also narrows accordingly:
`header: variable declaration dropped (\`iDisposable\` never read)`.

A close negative (`CompareStructure_DoesNotNarrowUsingDeclarationWhenVariableIsRead`)
confirms the narrowing and caption are correctly suppressed when the
resource variable is actually read in the body — in that case, dropping the
declaration would not be an equivalent rewrite, so the row falls back to
items 2/7's header-only narrowing and generic caption.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — 0 warnings, 0 errors.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests` — 91/91 pass.

## Non-action boundary

This closes tracking issue #5022 (all 10 items now implemented). No CLI
command currently surfaces `CSharpStructuralDiffPrinter`/`CSharpBodyDiff`
directly; these remain library-only APIs exercised via tests and demos.
