### PR TITLE
Validate platform summary forwarder descriptors

### DIFF
--- a/docs/design/platform-composition-and-overlays.md
+++ b/docs/design/platform-composition-and-overlays.md
@@ -29,6 +29,34 @@ can establish it. A genuine, Microsoft-signed .NET 6 `System.Runtime.dll` is
 authentic and, sitting beside a .NET 10 library, wrong. Authenticity is not
 coherence.
 
+## Compact platform-summary forwarding
+
+Compact API summaries may follow a platform type forwarder only through the
+structured type-resolution path. A neighboring file whose name matches the
+forwarder's assembly reference is a candidate, not proof that it supplies the
+target: its canonical assembly identity must satisfy that reference before any
+of its definitions contribute to the summary.
+
+Structured resolution first validates the neighboring candidate's canonical
+identity. When that candidate is the adjacent sibling of a platform root, the
+platform-summary owner mints one `ResolvedAssemblyReference` with platform
+provenance from the validated identity and opener. Summary extraction opens
+that descriptor, and every copied forwarded `ApiType` retains the same
+descriptor through the CLI inspection lifetime. Downstream consumers therefore
+receive the validated physical supplier rather than reconstructing one from
+`SourceAssemblyPath`.
+
+An unavailable, malformed, ambiguous, or identity-incompatible candidate
+contributes no forwarded type. Resolution remains bounded by the shared
+type-forwarding contract; this owner does not redefine hop semantics, general
+artifact acquisition, PDB policy, API rendering, platform precedence, or
+closure coherence.
+
+`PlatformSummary_RejectsFilenameMatchWithIncompatibleManifestIdentity` is the
+Release gate for the filename-match boundary.
+`PlatformSummary_RetainsValidatedForwardedSupplierDescriptor` is the neighboring
+positive and descriptor-retention gate.
+
 ## Installed implementation-platform realization
 
 Issue [#5139](https://github.com/richlander/dotnet-inspect/issues/5139)

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1336,6 +1336,99 @@ public class SourceForwarderResolutionTests
         }
     }
 
+    [Fact]
+    public void PlatformSummary_RejectsFilenameMatchWithIncompatibleManifestIdentity()
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            string targetPath = Path.Combine(directory, "Target.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly(
+                    "Facade",
+                    new AssemblyReferenceIdentity(
+                        "Target",
+                        new Version(1, 0, 0, 0),
+                        null,
+                        null)));
+            File.WriteAllBytes(
+                targetPath,
+                BuildAssembly(
+                    "DifferentTarget",
+                    definesType: true));
+
+            ApiServices.LoadedApiSurface loaded =
+                Assert.IsType<ApiServices.LoadedApiSurface>(
+                    ApiServices.LoadPlatformApiSummary(
+                        facadePath,
+                        facadePath,
+                        SourceKind.Platform,
+                        "1.0.0",
+                        "net11.0",
+                        new VerboseLogger(enabled: false)));
+
+            Assert.Empty(loaded.Api.Types);
+            Assert.Empty(loaded.SourceAssemblies);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PlatformSummary_RetainsValidatedForwardedSupplierDescriptor()
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            string targetPath = Path.Combine(directory, "Target.dll");
+            File.WriteAllBytes(
+                facadePath,
+                BuildAssembly(
+                    "Facade",
+                    new AssemblyReferenceIdentity(
+                        "Target",
+                        new Version(1, 0, 0, 0),
+                        null,
+                        null)));
+            File.WriteAllBytes(
+                targetPath,
+                BuildAssembly(
+                    "Target",
+                    definesType: true));
+
+            ApiServices.LoadedApiSurface loaded =
+                Assert.IsType<ApiServices.LoadedApiSurface>(
+                    ApiServices.LoadPlatformApiSummary(
+                        facadePath,
+                        facadePath,
+                        SourceKind.Platform,
+                        "1.0.0",
+                        "net11.0",
+                        new VerboseLogger(enabled: false)));
+
+            ApiType type = Assert.Single(loaded.Api.Types);
+            Assert.True(type.IsForwarded);
+            ResolvedAssemblyReference supplier =
+                loaded.GetSourceAssembly(type);
+            Assert.Equal(
+                Path.GetFullPath(targetPath),
+                supplier.Path);
+            Assert.Equal("Target", supplier.Identity.Name);
+            Assert.IsType<
+                AssemblyResolutionProvenance.PlatformAsset>(
+                    supplier.Provenance);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     static MetadataTypeDefinitionName TypeName() =>
         Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
             MetadataTypeDefinitionName.Create("N", ["Type"])).Name;

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -243,20 +243,6 @@ internal static class ApiServices
         if (api == null)
             return null;
 
-        ResolveForwardedTypes(
-            api,
-            searchPath,
-            logger,
-            includeAll: false,
-            isPlatformAssembly: true,
-            targetFramework: selectedTfm,
-            summaryOnly: true);
-
-        api.Name = Path.GetFileNameWithoutExtension(searchPath);
-        api.Tfm = selectedTfm;
-        api.Source = apiSource;
-        api.Version = apiVersion;
-        api.Library = Path.GetFileName(searchPath);
         ResolvedAssemblyReference rootAssembly =
             ResolvedAssemblyReference.CreateFromPath(
                 searchPath,
@@ -267,11 +253,25 @@ internal static class ApiServices
         var sourceAssemblies =
             new Dictionary<ApiType, ResolvedAssemblyReference>(
                 ReferenceEqualityComparer.Instance);
-        foreach (ApiType type in api.Types.Where(
-            static type => !type.IsForwarded))
-        {
+        foreach (ApiType type in api.Types)
             sourceAssemblies.Add(type, rootAssembly);
-        }
+
+        ResolveForwardedTypes(
+            api,
+            searchPath,
+            logger,
+            includeAll: false,
+            isPlatformAssembly: true,
+            targetFramework: selectedTfm,
+            summaryOnly: true,
+            summaryRootAssembly: rootAssembly,
+            sourceAssemblies: sourceAssemblies);
+
+        api.Name = Path.GetFileNameWithoutExtension(searchPath);
+        api.Tfm = selectedTfm;
+        api.Source = apiSource;
+        api.Version = apiVersion;
+        api.Library = Path.GetFileName(searchPath);
         return new LoadedApiSurface(
             api,
             searchPath,
@@ -383,7 +383,10 @@ internal static class ApiServices
         bool isPlatformAssembly = false,
         ApiOptions? options = null,
         string? targetFramework = null,
-        bool summaryOnly = false)
+        bool summaryOnly = false,
+        ResolvedAssemblyReference? summaryRootAssembly = null,
+        IDictionary<ApiType, ResolvedAssemblyReference>?
+            sourceAssemblies = null)
     {
         if (api.TypeForwarders.Count == 0)
             return;
@@ -396,7 +399,9 @@ internal static class ApiServices
                 logger,
                 isPlatformAssembly,
                 options,
-                targetFramework);
+                targetFramework,
+                summaryRootAssembly,
+                sourceAssemblies);
             return;
         }
 
@@ -723,23 +728,19 @@ internal static class ApiServices
         VerboseLogger logger,
         bool isPlatformAssembly,
         ApiOptions? options,
-        string? targetFramework)
+        string? targetFramework,
+        ResolvedAssemblyReference? rootAssembly,
+        IDictionary<ApiType, ResolvedAssemblyReference>?
+            sourceAssemblies)
     {
         TypeDefinitionResolutionSession? resolution = null;
-        var adjacentSummaries =
-            new Dictionary<string, ApiSurface?>(
-                StringComparer.OrdinalIgnoreCase);
-        HashSet<MetadataTypeDefinitionName> adjacentEligibleTypes =
-            api.TypeForwarders
-                .Where(forwarder => forwarder.DefinitionName is not null)
-                .GroupBy(forwarder => forwarder.DefinitionName!)
-                .Where(group => group.Count() == 1)
-                .Select(group => group.Key)
-                .ToHashSet();
         Dictionary<
             AssemblyAcquisitionRegistration,
             (ResolvedAssemblyReference Assembly,
                 HashSet<MetadataTypeDefinitionName> Types)> byAssembly = [];
+        Dictionary<
+            AssemblyAcquisitionRegistration,
+            ResolvedAssemblyReference> retainedAssemblies = [];
         int resolvedCount = 0;
 
         try
@@ -753,29 +754,20 @@ internal static class ApiServices
                     continue;
                 }
 
-                bool added = false;
-                bool handledAdjacent =
-                    adjacentEligibleTypes.Contains(forwarder.DefinitionName)
-                    && TryResolveAdjacentSummaryForwarder(
-                        api,
-                        dllPath,
-                        forwarder,
-                        adjacentSummaries,
-                        [],
-                        out added);
-                if (handledAdjacent)
-                {
-                    if (added)
-                        resolvedCount++;
-                    continue;
-                }
-
-                resolution ??= new TypeDefinitionResolutionSession(
-                    dllPath,
-                    isPlatformAssembly,
-                    options?.ProjectAssetsPath,
-                    options?.Tfm ?? targetFramework,
-                    options?.PlatformFramework);
+                resolution ??=
+                    rootAssembly is null
+                        ? new TypeDefinitionResolutionSession(
+                            dllPath,
+                            isPlatformAssembly,
+                            options?.ProjectAssetsPath,
+                            options?.Tfm ?? targetFramework,
+                            options?.PlatformFramework)
+                        : new TypeDefinitionResolutionSession(
+                            rootAssembly,
+                            isPlatformAssembly,
+                            options?.ProjectAssetsPath,
+                            options?.Tfm ?? targetFramework,
+                            options?.PlatformFramework);
                 TypeResolutionOutcome outcome =
                     resolution.Resolve(forwarder.DefinitionName);
                 if (outcome is not TypeResolutionOutcome.Resolved resolved
@@ -786,8 +778,20 @@ internal static class ApiServices
                     continue;
                 }
 
-                ResolvedAssemblyReference assembly =
+                ResolvedAssemblyReference resolvedAssembly =
                     resolved.Definition.Assembly.Assembly;
+                if (!retainedAssemblies.TryGetValue(
+                        resolvedAssembly.Registration,
+                        out ResolvedAssemblyReference? assembly))
+                {
+                    assembly =
+                        CreatePlatformSummarySupplierDescriptor(
+                            resolvedAssembly,
+                            rootAssembly);
+                    retainedAssemblies.Add(
+                        resolvedAssembly.Registration,
+                        assembly);
+                }
                 if (!byAssembly.TryGetValue(
                         assembly.Registration,
                         out var group))
@@ -819,6 +823,9 @@ internal static class ApiServices
                                 api,
                                 type,
                                 group.Assembly.Path);
+                            sourceAssemblies?.Add(
+                                type,
+                                group.Assembly);
                             resolvedCount++;
                         }
                     }
@@ -875,81 +882,31 @@ internal static class ApiServices
         }
     }
 
-    private static bool TryResolveAdjacentSummaryForwarder(
-        ApiSurface api,
-        string dllPath,
-        TypeForwarder forwarder,
-        Dictionary<string, ApiSurface?> adjacentSummaries,
-        HashSet<string> visitedPaths,
-        out bool added)
+    static ResolvedAssemblyReference
+        CreatePlatformSummarySupplierDescriptor(
+            ResolvedAssemblyReference assembly,
+            ResolvedAssemblyReference? rootAssembly)
     {
-        added = false;
-        if (!IsSafeAdjacentAssemblyName(forwarder.TargetAssembly))
-            return false;
-
-        string? directory = Path.GetDirectoryName(dllPath);
-        if (directory is null)
-            return false;
-
-        string targetPath = Path.Combine(directory, forwarder.TargetAssembly + ".dll");
-        if (!File.Exists(targetPath) || !visitedPaths.Add(targetPath))
-            return false;
-
-        if (!adjacentSummaries.TryGetValue(targetPath, out var targetApi))
+        if (rootAssembly?.Provenance
+                is not AssemblyResolutionProvenance.PlatformAsset
+                    platform
+            || assembly.Provenance
+                is not AssemblyResolutionProvenance.LocalAsset local
+            || !local.ResolverSource.Equals(
+                nameof(
+                    AssemblyDependencyProvenance.SiblingAssembly),
+                StringComparison.Ordinal))
         {
-            targetApi = AssemblyReader.ExtractApiSummarySurface(targetPath);
-            adjacentSummaries.Add(targetPath, targetApi);
+            return assembly;
         }
 
-        if (targetApi is null)
-            return false;
-
-        var matchingTypes = targetApi.Types
-            .Where(candidate => candidate.DefinitionName == forwarder.DefinitionName)
-            .Take(2)
-            .ToArray();
-        if (matchingTypes.Length == 1)
-        {
-            if (api.Types.Any(
-                candidate => candidate.DefinitionName == forwarder.DefinitionName))
-            {
-                return true;
-            }
-
-            AddForwardedType(api, matchingTypes[0], targetPath);
-            added = true;
-            return true;
-        }
-        if (matchingTypes.Length > 1)
-            return false;
-
-        var matchingForwarders = targetApi.TypeForwarders
-            .Where(candidate => candidate.DefinitionName == forwarder.DefinitionName)
-            .Take(2)
-            .ToArray();
-        if (matchingForwarders.Length == 1)
-        {
-            return TryResolveAdjacentSummaryForwarder(
-                api,
-                targetPath,
-                matchingForwarders[0],
-                adjacentSummaries,
-                visitedPaths,
-                out added);
-        }
-        if (matchingForwarders.Length > 1)
-            return false;
-
-        // The adjacent target was readable and contains neither a visible definition nor another
-        // hop. The full extractor would not add this forwarded type to the public surface either.
-        return true;
+        return ResolvedAssemblyReference.Create(
+            assembly.Identity,
+            assembly.Path,
+            assembly.OpenRead,
+            platform,
+            assembly.LastWriteTimeUtc);
     }
-
-    private static bool IsSafeAdjacentAssemblyName(string assemblyName) =>
-        !string.IsNullOrEmpty(assemblyName)
-        && assemblyName is not "." and not ".."
-        && assemblyName.IndexOfAny(['/', '\\']) < 0
-        && !Path.IsPathRooted(assemblyName);
 
     private static void AddForwardedType(
         ApiSurface api,


### PR DESCRIPTION
## Purpose

Build robust platform API summaries that cannot silently import types from a
filename-matching but identity-incompatible sibling. The result keeps the fast
quiet platform experience while making its forwarding path conventionally
sound: validate the physical supplier, carry its typed descriptor, and never
reconstruct authority from a path.

Closes #4869.

**Normative owner:** platform composition and forwarding —
`docs/design/platform-composition-and-overlays.md#compact-platform-summary-forwarding`.

**Owned claim:** a compact platform summary follows a forwarder only through
structured resolution; an adjacent candidate's canonical assembly identity
must satisfy the forwarder's assembly reference before its types contribute,
and every copied type retains the platform descriptor minted from that
validated supplier.

## Demo

The boundary fixture creates this ordinary platform-summary layout:

```text
Facade.dll
  AssemblyRef: Target, Version=1.0.0.0
  forwards: N.Type

Target.dll
  AssemblyDef: DifferentTarget, Version=1.0.0.0
  defines: N.Type
```

Before:

```text
compact summary -> N.Type is accepted from Target.dll
source assembly -> inferred path only
```

After:

```text
compact summary -> no forwarded type
reason -> Target.dll's manifest identity does not satisfy AssemblyRef Target
```

The neighboring valid platform case remains the normal quiet experience:

```console
$ dotnet run --project src/dotnet-inspect -c Release --no-build -- \
    type System.Runtime -v:q --verbose --tips q
Extracting compact API summary from: System.Runtime.dll
Resolving 918 forwarded types from 2 acquired libraries...
Resolved 869 types from forwarded libraries.
# System.Runtime

Library: System.Runtime.dll | Types: 869 | Methods: 10845 |
Properties: 1495 | Source: Platform |
Version: 11.0.0-preview.7.26381.103 | TFM: net11.0
```

What to notice: valid platform forwarders still resolve at the same scale; the
new negative case differs only in the supplier's manifest identity.

## Implementation

- Remove the raw recursive adjacent-summary shortcut.
- Resolve every compact-summary forwarder through
  `TypeDefinitionResolutionSession`, which validates the selected candidate
  against the structured assembly reference.
- For a validated adjacent sibling of a platform root, mint one platform
  `ResolvedAssemblyReference` from the selected identity and opener.
- Open that descriptor for summary extraction and retain it on every copied
  `ApiType` through `LoadedApiSurface.SourceAssemblies`.
- Reuse the minted descriptor for all forwarded types supplied by the same
  acquisition registration.

## Development basis

- **Convention/best-practice baseline:** assembly selection validates the
  candidate manifest against the requested identity, then carries typed
  provenance across layers. A filename is discovery evidence, not identity.
- **Intentional divergence:** `ApiType` remains unchanged; the CLI retains
  descriptors by selected object identity in its existing inspection-lifetime
  map. This avoids expanding the public API model for one internal handoff.
- **Analogous implementation evidence:** the transferable loader convention is
  identity matching before binding. No external implementation shares this
  repository's SRM-only compact-summary object model, so repository
  outcome-level gates define the exact behavior.
- **Pathological case:** a `Target.dll` whose manifest says
  `DifferentTarget` must contribute nothing even when it defines the requested
  type.
- **Neighboring case:** a `Target.dll` whose manifest satisfies the reference
  still contributes the type and retains platform provenance.

## Boundaries

Supporting `docs/design/type-forwarding-resolution.md` owns hop semantics and
validated terminal outcomes. Assembly inspection supplies canonical identities.
This slice does not redefine artifact acquisition, core-library entitlement,
platform precedence/coherence, PDB policy, API rendering, or WinMD support.

## Validation

- `SourceForwarderResolutionTests`: 25 passed, including:
  - `PlatformSummary_RejectsFilenameMatchWithIncompatibleManifestIdentity`;
  - `PlatformSummary_RetainsValidatedForwardedSupplierDescriptor`.
- `npx markdownlint-cli
  docs/design/platform-composition-and-overlays.md`.
- `git diff --check`.
- Same SDK and exact-base compact-summary timing, five warm samples:
  candidate median 1.11s; base median 1.16s.
