### PR TITLE
Adopt typed endpoint topology for IL body comparison

### DIFF
--- a/docs/design/finding-producers.md
+++ b/docs/design/finding-producers.md
@@ -99,8 +99,9 @@ census. Human diagnostic messages are not occurrence identity.
 **Status:** the shared Findings topology is implemented and verified by the
 gates named in
 [Finding Nomenclature](finding-nomenclature.md#typed-inspection-topology).
-The adjacent producer obligations below remain unverified pending focused
-migrations in each native owner.
+`ILInspector.ILDiff` has adopted the obligations below through
+`IlAssemblyDiff.CompareMemberEndpoints`. The adjacent C# producer obligations
+remain unverified pending their focused migration.
 
 Body differs use the shared
 [typed inspection topology](finding-nomenclature.md#typed-inspection-topology)
@@ -148,12 +149,20 @@ supplies exact endpoints or typed absence evidence; the producer decides
 whether it can inspect them and owns its native observations, pair algorithm,
 and result.
 
-These adoption properties are **unverified** in #4796. Each producer migration
-must name owner-specific gates for explicit endpoint evidence, null rejection,
-skipping native comparison for non-`Complete` endpoints, retaining the topology
-transition, and retiring bespoke missing-body failures. The Findings gates
-prove the shared state and transition contract; they do not prove adjacent
-producer wiring.
+The ILDiff adoption is gated by
+`CompareMemberEndpoints_BodyfulPair_RetainsFindingAndNativeResults`,
+`CompareMemberEndpoints_BodyfulAndBodyless_UsesNoApplicableInputWithoutPairDiff`,
+`CompareMemberEndpoints_BodyfulAndSubjectAbsent_RetainsExplicitAbsenceWithoutPairDiff`,
+`CompareMemberEndpoints_BothSubjectAbsent_IsExactWithoutPairDiff`,
+`CompareMemberEndpoints_DecodeFailure_RetainsFailedInspectionWithoutPairDiff`,
+and `PresentEndpoint_RejectsNullAndNilEvidence`. Together they verify explicit
+endpoint evidence, null rejection, retained topology, pair suppression outside
+`Complete`/`Complete`, and the absence of bespoke missing-body failures on the
+adopted path. Legacy assembly-wide and `CompareMembers` paths retain their
+existing compatibility result until their consumers migrate; they are not the
+typed endpoint path. Each remaining producer migration must name equivalent
+owner-specific gates. The Findings gates prove the shared state and transition
+contract; they do not prove adjacent producer wiring.
 
 ## 5. Choose identity and ordering semantics
 

--- a/docs/design/il-diff-canonicalization.md
+++ b/docs/design/il-diff-canonicalization.md
@@ -26,6 +26,31 @@ resolved exact `MethodDefinitionHandle` values. It returns old/new
 so RTS, Research, and diagnostics can attach IL diff evidence to their own
 member identity without running an assembly-wide card.
 
+`CompareMemberEndpoints` is the total endpoint-topology entry point. Its caller
+supplies an `IlMemberDiffEndpoint.Present` with an exact method definition or an
+explicit `IlMemberDiffEndpoint.SubjectAbsent`; the adapter performs no selector
+resolution or cross-version correspondence. Each present endpoint becomes a
+`Complete`, `NoApplicableInput`, or `Failed` Finding inspection. The resulting
+`IlMemberEndpointComparison` always retains both endpoint subjects and the
+exact `FindingComparison<CanonicalIlOperation>`. It contains an
+`IlMemberDiffResult` only for `Complete`/`Complete`, which is the only topology
+that invokes `IlBodyDiff`.
+
+This path does not infer absence from a null reader, handle, or body. RVA-zero
+methods are present but `NoApplicableInput`; only the explicit endpoint arm is
+`SubjectAbsent`. The producer gates are
+`CompareMemberEndpoints_BodyfulPair_RetainsFindingAndNativeResults`,
+`CompareMemberEndpoints_BodyfulAndBodyless_UsesNoApplicableInputWithoutPairDiff`,
+`CompareMemberEndpoints_BodyfulAndSubjectAbsent_RetainsExplicitAbsenceWithoutPairDiff`,
+`CompareMemberEndpoints_BothSubjectAbsent_IsExactWithoutPairDiff`,
+`CompareMemberEndpoints_DecodeFailure_RetainsFailedInspectionWithoutPairDiff`,
+and `PresentEndpoint_RejectsNullAndNilEvidence`.
+
+The older assembly-wide and `CompareMembers` paths retain old/new-body-missing
+failure rows for source compatibility while their existing consumers migrate.
+Those compatibility failures are not emitted by `CompareMemberEndpoints`,
+where endpoint topology owns the state.
+
 `IlBodyDiffNormalization` exposes independent, domain-neutral normalization
 mechanics without defining a consumer's equality policy:
 

--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -867,11 +867,14 @@ This boundary does not define:
 **Status:** target design for
 [#5441](https://github.com/richlander/dotnet-inspect/issues/5441). No runtime
 type implements this contract, and every named gate below is **unverified**.
-The C# and ILDiff owners must first supply their focused typed-inspection
-adapters under
+The ILDiff owner now supplies its focused typed-inspection adapter through
+`IlAssemblyDiff.CompareMemberEndpoints`, gated by the owner-specific tests named
+in [IL diff canonicalization boundary](il-diff-canonicalization.md). The C#
+owner must still supply its focused adapter under
 [Finding producer guidance](finding-producers.md#admit-body-topology-before-native-comparison).
-Those prerequisites are tracked by
-[#5443](https://github.com/richlander/dotnet-inspect/issues/5443) and
+The remaining prerequisite is
+[#5443](https://github.com/richlander/dotnet-inspect/issues/5443); the delivered
+ILDiff prerequisite was tracked by
 [#5444](https://github.com/richlander/dotnet-inspect/issues/5444).
 
 This boundary is owned by `ILInspector.Research`. It turns one complete target
@@ -1137,10 +1140,11 @@ is required for this design.
 
 Implementation proceeds in focused owner order:
 
-1. C# and ILDiff separately adopt the shared Findings endpoint topology and
-   expose typed adapters and native results that retain the transition under
-   [#5443](https://github.com/richlander/dotnet-inspect/issues/5443) and
-   [#5444](https://github.com/richlander/dotnet-inspect/issues/5444).
+1. ILDiff has adopted the shared Findings endpoint topology and exposed its
+   typed adapter and native result under
+   [#5444](https://github.com/richlander/dotnet-inspect/issues/5444). C# must
+   adopt the same owner-specific obligations under
+   [#5443](https://github.com/richlander/dotnet-inspect/issues/5443).
 2. Research implements its catalog, exact work derivation, sequential session,
    input access, cleanup, and completion validator.
 3. The Research completion becomes available to the separately owned rank-5

--- a/src/ILInspector.ILDiff.Tests/IlMemberEndpointComparisonTests.cs
+++ b/src/ILInspector.ILDiff.Tests/IlMemberEndpointComparisonTests.cs
@@ -1,0 +1,263 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.ILDiff.Tests;
+
+public class IlMemberEndpointComparisonTests
+{
+    [Fact]
+    public void CompareMemberEndpoints_BodyfulPair_RetainsFindingAndNativeResults()
+    {
+        using var image = OpenCurrentAssembly();
+        var method = image.FindMethod(nameof(MemberA));
+        var legacy = IlAssemblyDiff.CompareMembers(
+            image.Pe,
+            image.Reader,
+            method,
+            image.Pe,
+            image.Reader,
+            method);
+
+        var result = IlAssemblyDiff.CompareMemberEndpoints(
+            Present(legacy.Old, image, method),
+            Present(legacy.New, image, method));
+
+        var comparison = Assert.IsType<FindingComparison<CanonicalIlOperation>.Complete>(
+            result.Findings.Value);
+        Assert.Equal(FindingInspectionState.Complete, comparison.Transition.Old);
+        Assert.Equal(FindingInspectionState.Complete, comparison.Transition.New);
+        Assert.Equal(legacy.Old, result.Old);
+        Assert.Equal(legacy.New, result.New);
+        Assert.NotNull(result.MemberDiff);
+        Assert.Equal(legacy.Old, result.MemberDiff.Old);
+        Assert.Equal(legacy.New, result.MemberDiff.New);
+        Assert.Equal(legacy.Diff, result.MemberDiff.Diff);
+        Assert.Empty(result.MemberDiff.IdentityFailures);
+    }
+
+    [Fact]
+    public void CompareMemberEndpoints_BodyfulAndBodyless_UsesNoApplicableInputWithoutPairDiff()
+    {
+        using var image = OpenCurrentAssembly();
+        var bodyful = image.FindMethod(nameof(MemberA));
+        var bodyless = image.FindMethod(nameof(Bodyless.Missing));
+
+        var result = IlAssemblyDiff.CompareMemberEndpoints(
+            Present(Subject("old"), image, bodyful),
+            Present(Subject("new"), image, bodyless));
+
+        var comparison = Assert.IsType<FindingComparison<CanonicalIlOperation>.Complete>(
+            result.Findings.Value);
+        Assert.Equal(FindingInspectionState.Complete, comparison.Transition.Old);
+        Assert.Equal(FindingInspectionState.NoApplicableInput, comparison.Transition.New);
+        Assert.Null(result.MemberDiff);
+    }
+
+    [Fact]
+    public void CompareMemberEndpoints_BodyfulAndSubjectAbsent_RetainsExplicitAbsenceWithoutPairDiff()
+    {
+        using var image = OpenCurrentAssembly();
+        var bodyful = image.FindMethod(nameof(MemberA));
+        var absentSubject = Subject("new");
+
+        var result = IlAssemblyDiff.CompareMemberEndpoints(
+            Present(Subject("old"), image, bodyful),
+            new IlMemberDiffEndpoint.SubjectAbsent(absentSubject, "Exact subject is absent."));
+
+        var comparison = Assert.IsType<FindingComparison<CanonicalIlOperation>.Complete>(
+            result.Findings.Value);
+        Assert.Equal(FindingInspectionState.Complete, comparison.Transition.Old);
+        Assert.Equal(FindingInspectionState.SubjectAbsent, comparison.Transition.New);
+        var absent = Assert.IsType<FindingInspection<CanonicalIlOperation>.Absent>(
+            result.Findings.NewInspection.Value);
+        Assert.Equal(FindingInspectionAbsenceKind.SubjectAbsent, absent.Kind);
+        Assert.Equal("Exact subject is absent.", absent.Detail);
+        Assert.Equal(absentSubject, result.New);
+        Assert.Null(result.MemberDiff);
+    }
+
+    [Fact]
+    public void CompareMemberEndpoints_BothSubjectAbsent_IsExactWithoutPairDiff()
+    {
+        var oldSubject = Subject("old");
+        var newSubject = Subject("new");
+
+        var result = IlAssemblyDiff.CompareMemberEndpoints(
+            new IlMemberDiffEndpoint.SubjectAbsent(oldSubject),
+            new IlMemberDiffEndpoint.SubjectAbsent(newSubject));
+
+        var comparison = Assert.IsType<FindingComparison<CanonicalIlOperation>.Complete>(
+            result.Findings.Value);
+        Assert.Equal(FindingInspectionState.SubjectAbsent, comparison.Transition.Old);
+        Assert.Equal(FindingInspectionState.SubjectAbsent, comparison.Transition.New);
+        Assert.True(result.Findings.IsExact);
+        Assert.Equal(oldSubject, result.Old);
+        Assert.Equal(newSubject, result.New);
+        Assert.Null(result.MemberDiff);
+    }
+
+    [Fact]
+    public void CompareMemberEndpoints_DecodeFailure_RetainsFailedInspectionWithoutPairDiff()
+    {
+        using var failedImage = new AssemblyImage(BuildDecodeFailureImage());
+        using var validImage = OpenCurrentAssembly();
+
+        var result = IlAssemblyDiff.CompareMemberEndpoints(
+            Present(Subject("old"), failedImage, failedImage.FindMethod("M")),
+            Present(Subject("new"), validImage, validImage.FindMethod(nameof(MemberA))));
+
+        Assert.IsType<FindingComparison<CanonicalIlOperation>.Failed>(result.Findings.Value);
+        var failed = Assert.IsType<FindingInspection<CanonicalIlOperation>.Failed>(
+            result.Findings.OldInspection.Value);
+        Assert.NotEmpty(failed.Error.Reason);
+        Assert.IsType<FindingInspection<CanonicalIlOperation>.Complete>(
+            result.Findings.NewInspection.Value);
+        Assert.Null(result.MemberDiff);
+    }
+
+    [Fact]
+    public void PresentEndpoint_RejectsNullAndNilEvidence()
+    {
+        using var image = OpenCurrentAssembly();
+        var subject = Subject("member");
+        var method = image.FindMethod(nameof(MemberA));
+
+        Assert.Throws<ArgumentNullException>(
+            () => new IlMemberDiffEndpoint.Present(null!, image.Pe, image.Reader, method));
+        Assert.Throws<ArgumentNullException>(
+            () => new IlMemberDiffEndpoint.Present(subject, null!, image.Reader, method));
+        Assert.Throws<ArgumentNullException>(
+            () => new IlMemberDiffEndpoint.Present(subject, image.Pe, null!, method));
+        Assert.Throws<ArgumentException>(
+            () => new IlMemberDiffEndpoint.Present(subject, image.Pe, image.Reader, default));
+        Assert.Throws<ArgumentNullException>(
+            () => new IlMemberDiffEndpoint.SubjectAbsent(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => IlAssemblyDiff.CompareMemberEndpoints(
+                null!,
+                new IlMemberDiffEndpoint.SubjectAbsent(subject)));
+        Assert.Throws<ArgumentNullException>(
+            () => IlAssemblyDiff.CompareMemberEndpoints(
+                new IlMemberDiffEndpoint.SubjectAbsent(subject),
+                null!));
+    }
+
+    static IlMemberDiffEndpoint.Present Present(
+        IlMemberDiffSubject subject,
+        AssemblyImage image,
+        MethodDefinitionHandle method)
+        => new(subject, image.Pe, image.Reader, method);
+
+    static IlMemberDiffSubject Subject(string identity)
+        => new(identity, identity);
+
+    static AssemblyImage OpenCurrentAssembly()
+        => new(File.ReadAllBytes(typeof(IlMemberEndpointComparisonTests).Assembly.Location));
+
+    static int MemberA() => 1;
+
+    abstract class Bodyless
+    {
+        public abstract void Missing();
+    }
+
+    static byte[] BuildDecodeFailureImage()
+    {
+        var metadata = new MetadataBuilder();
+        metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Synthetic.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Synthetic"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public,
+            default,
+            metadata.GetOrAddString("C"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var instructions = new BlobBuilder();
+        var encoder = new InstructionEncoder(instructions, new ControlFlowBuilder());
+        instructions.WriteByte(0xff);
+        var methodBodies = new BlobBuilder();
+        int bodyOffset = new MethodBodyStreamEncoder(methodBodies)
+            .AddMethodBody(encoder, maxStack: 1);
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Static,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            VoidMethodSignature(metadata),
+            bodyOffset,
+            MetadataTokens.ParameterHandle(1));
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            methodBodies,
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+
+    static BlobHandle VoidMethodSignature(MetadataBuilder metadata)
+    {
+        var signature = new BlobBuilder();
+        signature.WriteByte(0x00);
+        signature.WriteCompressedInteger(0);
+        signature.WriteByte(0x01);
+        return metadata.GetOrAddBlob(signature);
+    }
+
+    sealed class AssemblyImage : IDisposable
+    {
+        readonly MemoryStream _stream;
+
+        public AssemblyImage(byte[] bytes)
+        {
+            _stream = new MemoryStream(bytes);
+            Pe = new PEReader(_stream);
+            Reader = Pe.GetMetadataReader();
+        }
+
+        public PEReader Pe { get; }
+        public MetadataReader Reader { get; }
+
+        public MethodDefinitionHandle FindMethod(string name)
+        {
+            foreach (var handle in Reader.MethodDefinitions)
+            {
+                if (Reader.GetString(Reader.GetMethodDefinition(handle).Name) == name)
+                    return handle;
+            }
+
+            throw new InvalidOperationException($"Method {name} was not found.");
+        }
+
+        public void Dispose()
+        {
+            Pe.Dispose();
+            _stream.Dispose();
+        }
+    }
+}

--- a/src/ILInspector.ILDiff/IlAssemblyDiff.cs
+++ b/src/ILInspector.ILDiff/IlAssemblyDiff.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 
 namespace ILInspector.Instructions;
@@ -50,6 +51,109 @@ public sealed record IlMemberDiffResult(
     ImmutableArray<IlIdentityResolutionFailure> IdentityFailures = default);
 
 /// <summary>
+/// One explicitly admitted endpoint for an IL member comparison. A present endpoint identifies an
+/// exact method definition; subject absence is separate evidence and is never inferred from a null
+/// reader, handle, or body.
+/// </summary>
+public abstract record IlMemberDiffEndpoint
+{
+    IlMemberDiffEndpoint()
+    {
+    }
+
+    public sealed record Present : IlMemberDiffEndpoint
+    {
+        public Present(
+            IlMemberDiffSubject subject,
+            PEReader pe,
+            MetadataReader reader,
+            MethodDefinitionHandle method)
+        {
+            Subject = ValidateSubject(subject);
+            Pe = pe ?? throw new ArgumentNullException(nameof(pe));
+            Reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            if (method.IsNil)
+                throw new ArgumentException("Method handle must not be nil.", nameof(method));
+            Method = method;
+        }
+
+        public IlMemberDiffSubject Subject { get; }
+        public PEReader Pe { get; }
+        public MetadataReader Reader { get; }
+        public MethodDefinitionHandle Method { get; }
+    }
+
+    public sealed record SubjectAbsent : IlMemberDiffEndpoint
+    {
+        public SubjectAbsent(IlMemberDiffSubject subject, string? detail = null)
+        {
+            Subject = ValidateSubject(subject);
+            Detail = detail;
+        }
+
+        public IlMemberDiffSubject Subject { get; }
+        public string? Detail { get; }
+    }
+
+    static IlMemberDiffSubject ValidateSubject(IlMemberDiffSubject subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject.Identity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject.Label);
+        return subject;
+    }
+}
+
+/// <summary>
+/// The total IL-owned result for two explicitly admitted endpoints. <see cref="MemberDiff"/> is
+/// present exactly when both endpoint inspections completed and the pair-dependent IL differ ran.
+/// </summary>
+public sealed record IlMemberEndpointComparison
+{
+    internal IlMemberEndpointComparison(
+        IlMemberDiffSubject old,
+        IlMemberDiffSubject @new,
+        FindingComparison<CanonicalIlOperation> findings,
+        IlMemberDiffResult? memberDiff)
+    {
+        Old = old ?? throw new ArgumentNullException(nameof(old));
+        New = @new ?? throw new ArgumentNullException(nameof(@new));
+        Findings = findings ?? throw new ArgumentNullException(nameof(findings));
+
+        bool isCompletePair = findings.Value
+            is FindingComparison<CanonicalIlOperation>.Complete
+            {
+                Transition:
+                {
+                    Old: FindingInspectionState.Complete,
+                    New: FindingInspectionState.Complete,
+                },
+            };
+        if (isCompletePair != (memberDiff is not null))
+        {
+            throw new ArgumentException(
+                "A native member diff must be present exactly for a complete/complete endpoint pair.",
+                nameof(memberDiff));
+        }
+
+        if (memberDiff is not null
+            && (memberDiff.Old != old || memberDiff.New != @new))
+        {
+            throw new ArgumentException(
+                "The native member diff must retain the admitted endpoint subjects.",
+                nameof(memberDiff));
+        }
+
+        MemberDiff = memberDiff;
+    }
+
+    public IlMemberDiffSubject Old { get; }
+    public IlMemberDiffSubject New { get; }
+    public FindingComparison<CanonicalIlOperation> Findings { get; }
+    public IlMemberDiffResult? MemberDiff { get; }
+}
+
+/// <summary>
 /// Product-owned IL/body diff producer over two metadata-backed assemblies.
 /// </summary>
 public static class IlAssemblyDiff
@@ -66,6 +170,95 @@ public static class IlAssemblyDiff
     readonly record struct MethodIdentityResult(
         string? Identity,
         MetadataTypeNameFailure? Failure);
+
+    readonly record struct InspectedEndpoint(
+        IlMemberDiffSubject Subject,
+        FindingInspection<CanonicalIlOperation> Inspection,
+        MethodInstructions? Body,
+        MethodBodyBlock? MethodBody);
+
+    /// <summary>
+    /// Compares two explicitly admitted endpoints without performing selector resolution or
+    /// cross-version correspondence. The pair-dependent IL body differ runs only when both
+    /// endpoint inspections complete.
+    /// </summary>
+    public static IlMemberEndpointComparison CompareMemberEndpoints(
+        IlMemberDiffEndpoint oldEndpoint,
+        IlMemberDiffEndpoint newEndpoint,
+        IlBodyDiffNormalization normalization = IlBodyDiffNormalization.None)
+    {
+        ArgumentNullException.ThrowIfNull(oldEndpoint);
+        ArgumentNullException.ThrowIfNull(newEndpoint);
+
+        var old = InspectEndpoint(oldEndpoint);
+        var @new = InspectEndpoint(newEndpoint);
+        var findings = IlFindings.CompareInspections(
+            old.Inspection,
+            @new.Inspection,
+            old.Body,
+            @new.Body,
+            acceptanceThreshold: 100);
+
+        IlMemberDiffResult? memberDiff = null;
+        if (old.MethodBody is not null
+            && @new.MethodBody is not null
+            && findings.Value
+                is FindingComparison<CanonicalIlOperation>.Complete
+                {
+                    Transition:
+                    {
+                        Old: FindingInspectionState.Complete,
+                        New: FindingInspectionState.Complete,
+                    },
+                })
+        {
+            var oldPresent = (IlMemberDiffEndpoint.Present)oldEndpoint;
+            var newPresent = (IlMemberDiffEndpoint.Present)newEndpoint;
+            memberDiff = new IlMemberDiffResult(
+                old.Subject,
+                @new.Subject,
+                IlBodyDiff.Compare(
+                    oldPresent.Reader,
+                    old.MethodBody,
+                    newPresent.Reader,
+                    @new.MethodBody,
+                    normalization),
+                []);
+        }
+
+        return new IlMemberEndpointComparison(
+            old.Subject,
+            @new.Subject,
+            findings,
+            memberDiff);
+    }
+
+    static InspectedEndpoint InspectEndpoint(IlMemberDiffEndpoint endpoint)
+        => endpoint switch
+        {
+            IlMemberDiffEndpoint.Present present => InspectPresentEndpoint(present),
+            IlMemberDiffEndpoint.SubjectAbsent absent => new(
+                absent.Subject,
+                new FindingInspection<CanonicalIlOperation>.Absent(
+                    FindingInspectionAbsenceKind.SubjectAbsent,
+                    absent.Detail),
+                Body: null,
+                MethodBody: null),
+            _ => throw new ArgumentOutOfRangeException(nameof(endpoint)),
+        };
+
+    static InspectedEndpoint InspectPresentEndpoint(IlMemberDiffEndpoint.Present endpoint)
+    {
+        var subject = new FindingSubject(endpoint.Subject.Identity, endpoint.Subject.Label);
+        var inspection = IlFindings.InspectMethod(
+            endpoint.Pe,
+            endpoint.Reader,
+            endpoint.Method,
+            subject,
+            out var body,
+            out var methodBody);
+        return new InspectedEndpoint(endpoint.Subject, inspection, body, methodBody);
+    }
 
     public static IlAssemblyDiffPairResult CompareFiles(
         string oldPath,

--- a/src/ILInspector.ILDiff/IlFindings.cs
+++ b/src/ILInspector.ILDiff/IlFindings.cs
@@ -104,7 +104,7 @@ public static class IlFindings
         if (method.IsNil)
             throw new ArgumentException("Method handle must not be nil.", nameof(method));
 
-        return InspectMethod(pe, reader, method, subject, out _);
+        return InspectMethod(pe, reader, method, subject, out _, out _);
     }
 
     /// <summary>
@@ -151,13 +151,15 @@ public static class IlFindings
             oldReader,
             oldMethod,
             subject,
-            out var oldBody);
+            out var oldBody,
+            out _);
         var newInspection = InspectMethod(
             newPe,
             newReader,
             newMethod,
             subject,
-            out var newBody);
+            out var newBody,
+            out _);
         return CompareInspections(
             oldInspection,
             newInspection,
@@ -166,7 +168,7 @@ public static class IlFindings
             acceptanceThreshold);
     }
 
-    static FindingComparison<CanonicalIlOperation> CompareInspections(
+    internal static FindingComparison<CanonicalIlOperation> CompareInspections(
         FindingInspection<CanonicalIlOperation> oldInspection,
         FindingInspection<CanonicalIlOperation> newInspection,
         MethodInstructions? oldBody,
@@ -195,21 +197,24 @@ public static class IlFindings
             [.. complete.NewAtoms.Select(static atom => atom.Payload)]));
     }
 
-    static FindingInspection<CanonicalIlOperation> InspectMethod(
+    internal static FindingInspection<CanonicalIlOperation> InspectMethod(
         PEReader pe,
         MetadataReader reader,
         MethodDefinitionHandle methodHandle,
         FindingSubject subject,
-        out MethodInstructions? body)
+        out MethodInstructions? body,
+        out MethodBodyBlock? methodBody)
     {
         body = null;
+        methodBody = null;
         try
         {
             var method = reader.GetMethodDefinition(methodHandle);
             if (method.RelativeVirtualAddress == 0)
                 return Inspect(null, reader, subject);
 
-            body = MethodInstructions.Decode(pe.GetMethodBody(method.RelativeVirtualAddress));
+            methodBody = pe.GetMethodBody(method.RelativeVirtualAddress);
+            body = MethodInstructions.Decode(methodBody);
             return Inspect(body, reader, subject);
         }
         catch (Exception ex) when (ex is BadImageFormatException


### PR DESCRIPTION
Build robust, capable features that are foundational or compelling user
experiences: conventionally sound where the platform has precedent, and
delightfully new where dotnet-inspect can make .NET evidence easier to use.

## Summary

Adopt the shared Findings endpoint topology in `ILInspector.ILDiff` through one
total, producer-owned member adapter.

- add explicit `Present` and `SubjectAbsent` endpoint evidence;
- classify present endpoints as `Complete`, `NoApplicableInput`, or `Failed`;
- retain the endpoint subjects and exact
  `FindingComparison<CanonicalIlOperation>` in every result;
- run `IlBodyDiff` and retain `IlMemberDiffResult` only for
  `Complete`/`Complete`; and
- keep old/new-body-missing failures only on legacy compatibility paths while
  typed topology owns those states on the new path.

The adapter performs no selector resolution or cross-version correspondence,
accepts no Research type, and leaves C# and Research adoption to their focused
owners.

## Demo

The same native API now distinguishes a present body from an explicitly absent
subject without manufacturing a pair-comparison failure:

```csharp
var result = IlAssemblyDiff.CompareMemberEndpoints(
    new IlMemberDiffEndpoint.Present(oldSubject, oldPe, oldReader, oldMethod),
    new IlMemberDiffEndpoint.SubjectAbsent(
        newSubject,
        "Exact subject is absent."));

var comparison =
    (FindingComparison<CanonicalIlOperation>.Complete)result.Findings.Value;

comparison.Transition.Old // Complete
comparison.Transition.New // SubjectAbsent
result.MemberDiff         // null: IlBodyDiff did not run
```

With two bodyful present endpoints, the transition is
`Complete`/`Complete` and `MemberDiff` contains the native IL body result.
Bodyless methods instead produce `NoApplicableInput`; decode failures retain a
failed endpoint inspection.

## Validation

- `dotnet run --project src/ILInspector.ILDiff.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `npx markdownlint-cli docs/design/finding-producers.md docs/design/il-diff-canonicalization.md docs/design/implementation-diff.md`

Closes #5444.
