### PR TITLE
State join-currency rule for TLA+ models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,11 @@ over-broad-design recovery procedure live in
   normative changes need focused efforts joined by a thin composition map.
 - State boundaries and contracts as simply as possible. Never translate current
   or planned implementation into prose; code implements the contract.
+- When product correctness joins facts across components, model the same
+  owner-issued join currency — version, generation, identity, receipt, handle,
+  or composite key — and preserve the association, freshness, and replacement
+  semantics that make the product join sound. The model may abstract the
+  currency's concrete representation.
 - Let TLA+ module dependencies mirror product dependencies: consume stable
   owner-issued definitions and behaviors through named instances instead of
   copying them, and recheck the imported properties in each composition. A

--- a/docs/tla-plus-methodology.md
+++ b/docs/tla-plus-methodology.md
@@ -21,6 +21,32 @@ certificate transferred to another instance. A consumer gains confidence by
 rechecking the owner's properties under the consumer's additional states,
 actions, schedules, and fairness assumptions.
 
+Start a composition model from the product's join boundary. When the product
+combines facts by an owner-issued version, generation, identity, receipt,
+handle, or composite key, the model must represent and reason about that same
+conceptual **join currency**. The TLA+ value need not reproduce the concrete
+implementation type or spelling, but it must preserve every distinction that
+makes the modeled join sound:
+
+- which owner or operation issued the currency;
+- which evidence was captured under it;
+- which values may match and which must remain distinct;
+- when replacement creates a fresh value; and
+- what mismatch, staleness, or retirement prevents.
+
+A join currency may be a tuple when the product join requires several
+owner-issued dimensions. Do not collapse such a tuple to one nominal identity
+when that would admit combinations the product rejects. Conversely, do not
+copy representation details that cannot affect the modeled association.
+Replacing a product join currency with unrelated consumer-local atoms removes
+the very cross-component behavior the composition is meant to check.
+
+The owner model defines the currency's lifecycle. A consumer binds that
+lifecycle to its local state, uses the owner action instead of duplicating the
+transition, and rechecks the imported behavior under its additional actions and
+schedules. Import only this smallest stable boundary; modeling the join
+currency does not require importing the owner's entire state machine.
+
 Keep reusable modules with the component that owns the corresponding product
 contract. Give every repository module a globally unique, owner-specific name,
 and keep the import graph acyclic and pointed in the same direction as product
@@ -51,6 +77,13 @@ BindingVersionAdvanceIsFresh ==
 BindingVersionBehaviorRefinesOwner ==
     BindingVersion!SafetySpec
 ```
+
+Here `AssemblyBindingPolicyVersion` is the product join currency represented by
+`liveVersion`: the binding owner defines how it advances, and both the
+composite-binding and workspace consumers check that evidence from
+incompatible generations cannot be combined. The abstract `VersionOne` and
+`VersionTwo` values preserve freshness and association without reproducing the
+implementation type.
 
 The owner module keeps its own finite harness and configurations. A consumer
 then:


### PR DESCRIPTION
This makes owner-aligned TLA+ composition actionable: when product correctness
depends on joining facts across components, the models must preserve the same
owner-issued join currency and its association semantics.

## Summary

- state the join-currency rule concisely in `AGENTS.md`;
- define versions, generations, identities, receipts, handles, and composite
  keys as possible conceptual currencies;
- require models to preserve ownership, captured-evidence association,
  equality distinctions, freshness, replacement, staleness, and retirement
  where those semantics affect the join; and
- keep concrete implementation representation and whole lower-layer state
  machines out of the modeling requirement.

## Demo

Before, repository guidance said model dependencies should mirror product
dependencies, but it did not explain what product-level fact makes that
composition necessary.

After, the guidance starts from the product join:

> When product correctness joins facts across components, model the same
> owner-issued join currency.

The binding pilot supplies the concrete example:
`AssemblyBindingPolicyVersion` is represented by abstract `VersionOne` and
`VersionTwo` values. The abstraction retains freshness and evidence association
without reproducing the implementation type.

The neighboring composite-key case is also explicit: when the product requires
several owner-issued dimensions, the model must preserve the tuple rather than
collapse it to nominal identity.

## Ownership and scope

`docs/tla-plus-methodology.md#compose-models-along-product-boundaries` is the
single normative owner. `AGENTS.md` carries only its concise binding rule.

This changes no product behavior or contract, adds no model, requires no
concrete .NET type representation in TLA+, and does not initiate a corpus-wide
currency inventory or migration.

## Validation

- `npx markdownlint-cli --fix AGENTS.md docs/tla-plus-methodology.md`
- `npx markdownlint-cli AGENTS.md docs/tla-plus-methodology.md`
- `git diff --check`

Closes #5452.
