### PR TITLE
Stabilize request-timeout attribution gates

### DIFF
--- a/src/DotnetInspector.Services.Tests/PackagePayloadAcquisitionTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackagePayloadAcquisitionTests.cs
@@ -2153,7 +2153,8 @@ public sealed class PackagePayloadAcquisitionTests
         var options = new NuGetFetchOptions
         {
             RequestTimeout = TimeSpan.FromMilliseconds(40),
-            OperationTimeout = TimeSpan.FromSeconds(1),
+            // If both bounds elapse, Operation correctly wins.
+            OperationTimeout = TimeSpan.FromSeconds(30),
         };
         var store = new InMemoryPackageStore();
         using IPackageSourceClient source =

--- a/src/NuGetFetch.Tests/PackageSourceClientTests.cs
+++ b/src/NuGetFetch.Tests/PackageSourceClientTests.cs
@@ -4359,7 +4359,8 @@ public sealed class PackageSourceClientTests
                 new NuGetFetchOptions
                 {
                     RequestTimeout = TimeSpan.FromMilliseconds(50),
-                    OperationTimeout = TimeSpan.FromSeconds(1),
+                    // If both bounds elapse, Operation correctly wins.
+                    OperationTimeout = TimeSpan.FromSeconds(30),
                 });
 
         PackageSourceFailure failure = payload


### PR DESCRIPTION
Stabilizes the request-timeout attribution gates that failed scheduled Deep
Inspect on macOS and Windows. Product timeout semantics are unchanged.

Relates to #5287. This does not close that issue because its independent Windows
plugin-file access failure remains under investigation.

**Owner:** `NuGetFetch`.
**Owning document:** `docs/design/browser-package-sources.md`, Timeout ownership
and Operation-context handoff.
**Claim:** request-focused integration tests keep the operation ceiling live
long enough to observe the request deadline they intend to gate.

## Demo

A controlled probe constrained the ThreadPool to one worker, occupied that
worker for 1.2 seconds, and then ran the same stalled Gallery request used by
the failing test.

```text
Before: request=50ms, operation=1s
Elapsed: 00:00:01.2014924
Timeout: PackageSourceTimeout { Kind = Operation, Duration = 00:00:01 }

After: request=50ms, operation=30s
Elapsed: 00:00:02.0644480
Timeout: PackageSourceTimeout { Kind = Request, Duration = 00:00:00.0500000 }
```

What to notice: the before result is correct, not a product defect. Once both
deadlines have elapsed, the documented precedence intentionally reports the
operation ceiling. Keeping that outer ceiling at 30 seconds lets these tests
exercise request attribution even when a shared macOS or Windows runner delays
timer callbacks beyond one second.

The neighboring delayed-callback owner gates already use a 30-second operation
ceiling when asserting a 40 ms request deadline.

## Changes

- Keep `GalleryRequestsUseLibraryDeadlines` outside its operation ceiling while
  it waits for the 50 ms request deadline.
- Apply the same separation to
  `TypedAcquisition_PreservesPayloadStreamTimeout` for its 40 ms stream request
  deadline.
- Preserve the production rule that caller cancellation outranks operation,
  which outranks request when multiple deadlines have elapsed.

## Validation

- `GalleryRequestsUseLibraryDeadlines`: 50/50 runs, 100 theory cases.
- `TypedAcquisition_PreservesPayloadStreamTimeout`: 50/50 runs.
- Complete `NuGetFetch.Tests`: 870 total, 0 failed, 11 skipped.
- Complete `DotnetInspector.Services.Tests`: 1,051 total, 0 failed.
- SDK: `11.0.100-preview.7.26381.103`.
