### PR TITLE
Wait for forced plugin process exit

### DIFF
--- a/src/NuGetFetch/Plugins/PluginConnection.cs
+++ b/src/NuGetFetch/Plugins/PluginConnection.cs
@@ -1003,6 +1003,7 @@ internal sealed class PluginConnection : IAsyncDisposable
             if (!_process.HasExited && !_process.WaitForExit((int)ExitWaitAfterClose.TotalMilliseconds))
             {
                 _process.Kill(entireProcessTree: true);
+                await _process.WaitForExitAsync().ConfigureAwait(false);
             }
         }
         catch


### PR DESCRIPTION
Closes #5456 by keeping `PluginConnection.DisposeAsync` inside its process
ownership boundary until a forcibly terminated plugin has actually exited.

Here, **plugin** means a
[NuGet credential provider](https://learn.microsoft.com/nuget/reference/extensibility/nuget-cross-platform-plugins):
a separate executable that answers package-feed credential requests through
NuGet's JSON protocol over stdin/stdout. It is not a generic dotnet-inspect
extension or necessarily a credential manager or secret store; the provider
may acquire credentials from an underlying identity or token system.

**Owner:** `NuGetFetch` plugin connection lifecycle.
**Owning document:** `docs/design/nuget-authentication.md`, concurrent
conversation and shutdown rules.
**Claim:** successful forced disposal does not return while the owned plugin
process can still hold its executable image open.

## Demo

Scheduled Windows run
[33498278278](https://github.com/richlander/dotnet-inspect/actions/runs/33498278278)
exercised a real copied plugin while its inbound response writer was stalled:

```text
Before
  wait 1 second for graceful process exit
  Process.Kill(entireProcessTree: true)
  return from PluginConnection.DisposeAsync
  test fixture deletes copied plugin
  UnauthorizedAccessException: nuget-plugin-quiesce-inbound-response.dll

After
  wait 1 second for graceful process exit
  Process.Kill(entireProcessTree: true)
  await Process.WaitForExitAsync()
  return from PluginConnection.DisposeAsync
  test fixture deletes copied plugin
```

What to notice: connection quiescence was already correct. The gap was after
forced termination: `Process.Kill` requests termination but does not establish
that Windows has released the executing image before disposal returns.

The neighboring graceful-exit path is unchanged and still returns without
forcing termination.

## Change

Await the owned process after a successful forced tree termination. The existing
real-process
`ConnectionResourcesWaitForInboundResponseWritersToQuiesce` gate remains the
pathological regression test; it is the test that exposed the Windows file
lock.

This follows existing repository process-management precedent in
`eng/CiChangeDetection/EvaluatedProjectGraph.cs` and
`eng/CiChangeDetection/DetectionHarness.cs`, which pair forced tree termination
with `WaitForExit`.

The request-versus-operation timeout behavior addressed separately by #5454 is
unrelated and unchanged.

## Validation

- `ConnectionResourcesWaitForInboundResponseWritersToQuiesce`: 50/50 repeated
  runs.
- Complete `NuGetFetch.Tests`: 870 total, 0 failed, 11 skipped.
- SDK: `11.0.100-preview.7.26381.103`.
