### PR TITLE
Add bounded package-content query facets

### DIFF
--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -21,16 +21,19 @@ backs the browser's single-package dependency view
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
 for what shipped and what did not.
 
-The current sources also implement the host-neutral L1 nuspec facet contract
-as `PackageQuery`: product-owned ordered descriptors, typed request planning,
-ANDed predicate evaluation over `PackageProfileQuery`, non-empty inert
-evidence, separate candidate and match bounds, visible failures, and typed
-completion. `PackageQueryTests` is its Release gate;
+The current sources also implement the host-neutral L1 facet contract as
+`PackageQuery`: product-owned ordered descriptors, typed request planning,
+ANDed predicate evaluation over `PackageProfileQuery`, an explicit
+package-content provider for archive-derived facets, non-empty inert evidence,
+separate candidate and match bounds, visible failures, and typed completion.
+Package-content evaluation is product-gated to at most 20 candidates.
+`PackageQueryTests` is its Release gate;
 `PackageQueryPlanner_IsReachableFromBrowserConsumer` is the Browser consumer
 canary.
 
-Still proposal-only: CLI `--where` wiring, the tier capability gate, and the
-promoted IL tier. Despite the Sections migration landing,
+Still proposal-only: CLI `--where` wiring, CLI capability spelling for
+package-content facets, and the promoted IL tier. Despite the Sections
+migration landing,
 `find --package-prefix`'s corpus limit is also still spelled `-t`, not the
 historical #4677 `-n` target. [Item and line
 limits](item-and-line-limits.md) records that CLI syntax ownership remains
@@ -72,13 +75,13 @@ and partial-source failure, rendered through the shared Sections registry
 just as `library`/`member`/`package` are. Its corpus-limit spelling is still
 `-t`; the historical #4677 target proposed `-n` instead — see
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
-The L1 nuspec facet engine now provides a host-neutral way to ask "and does
-each package satisfy *this*" over facts already available from the source and
-exact manifest. The CLI does not expose it yet, and the explicit promoted tier
-for facts that require opening IL remains unimplemented. This document defines
-where those pieces belong across the existing L1/L2/L3 split, rather than
-treating the CLI project as a place to accumulate new bespoke logic the way it
-did before that split existed.
+The L1 facet engine now provides a host-neutral way to ask "and does each
+package satisfy *this*" over facts available from the source, exact manifest,
+or an explicitly supplied package archive. The CLI does not expose it yet, and
+the promoted tier for facts that require opening IL remains unimplemented.
+This document defines where those pieces belong across the existing L1/L2/L3
+split, rather than treating the CLI project as a place to accumulate new
+bespoke logic the way it did before that split existed.
 
 ## Is this CLI-side or core?
 
@@ -87,12 +90,13 @@ Core. Concretely:
 - **L1 — `DotnetInspector.Queries`.** The facet-matching engine belongs here,
   next to `PackageProfileQuery` and `PackageDependencyGroupsQuery`, which
   #4551 places in this layer rather than in the CLI project. A typed
-  query that evaluates nuspec-tier facets over a streamed manifest, and a
-  second typed query that evaluates promoted-tier (IL) facets over an
-  explicitly bounded package/version set, both return typed results and
-  choose no renderer — the existing L1 contract. This is what makes the
-  facet engine reachable from a second consumer (the browser/Wasm engine)
-  without re-deriving it, the exact failure mode
+  query that evaluates nuspec-tier facets over a streamed manifest and
+  package-content facets through an explicit host capability returns typed
+  results and chooses no renderer — the existing L1 contract. A future query
+  that evaluates promoted IL facets over an explicitly bounded
+  package/version set follows the same ownership. This is what makes the facet
+  engine reachable from a second consumer (the browser/Wasm engine) without
+  re-deriving it, the exact failure mode
   [inspection-layers.md](inspection-layers.md) exists to prevent.
 - **L2 — `Sections` (currently `src/dotnet-inspect/Sections`).** Row
   declaration, `--where` predicate evaluation, and the shape-ladder
@@ -101,7 +105,7 @@ Core. Concretely:
   at L2 ("row query — field predicates within a section... L2."), pointing
   at [row-query-order.md](row-query-order.md) for the model; nothing about
   package rows changes that. This is also where the tier capability gate is
-  enforced — see [Tier gating](#tier-gating-nuspec-vs-promoted) below — since
+  enforced — see [Tier gating](#tier-gating) below — since
   L2 is where a request is checked against what the selected section actually
   offers before L1 is asked to compute anything.
 - **L3 — `dotnet-inspect` (the `find` command).** Argument parsing,
@@ -195,11 +199,10 @@ now declared sections, yet the corpus limit is still `-t`, not `-n`. See
 [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing)
 for the resulting follow-up.
 
-## Two-tier facets, one product vocabulary
+## Current tiers and future IL promotion
 
-The web design's nuspec/promoted split maps directly onto capability. L1 owns
-the vocabulary and predicate semantics; front ends submit product-issued
-opaque facet IDs and do not reconstruct those predicates:
+L1 owns the vocabulary and predicate semantics; front ends submit
+product-issued opaque facet IDs and do not reconstruct those predicates:
 
 - **`nuspec` tier.** Available over the bounded package profile produced from
   source metadata and exact manifests. `PackageQuery.Facets` is the finite,
@@ -209,13 +212,19 @@ opaque facet IDs and do not reconstruct those predicates:
   production envelope in which it is available, not the narrowest individual
   field its predicate reads; the common nuspec result row still carries exact
   manifest facts.
-- **`promoted` tier.** Requires opening IL for a bounded set of candidates —
-  never for the whole corpus. This must be capability-gated the same way the
-  repository already gates other exhaustive/expensive work (`--all`,
-  README.md:474, 535). The exact CLI spelling remains for its implementation
-  slice, but the adapter must resolve that spelling through product-owned
-  descriptors or bindings and submit opaque IDs. It must not hard-code a
-  second predicate vocabulary in L2 or L3.
+- **`package-content` tier.** Requires an explicit
+  `IPackageQueryContentProvider` and accepts at most 20 candidates.
+  `PackageQuery` still applies manifest predicates first, so a tool-format
+  facet does not acquire non-tool packages. The current archive-derived
+  facets inspect `DotnetToolSettings.xml` for tool v1/v2 and package paths for
+  `skills/SKILL.md` or `skills/**/SKILL.md`.
+- **Future promoted IL tier.** Requires opening IL for a bounded set of
+  candidates — never for the whole corpus. It must be capability-gated the
+  same way the repository already gates other exhaustive/expensive work
+  (`--all`, README.md:474, 535). The exact CLI spelling remains for its
+  implementation slice, but the adapter must resolve that spelling through
+  product-owned descriptors or bindings and submit opaque IDs. It must not
+  hard-code a second predicate vocabulary in L2 or L3.
 
 The future CLI may reuse `RowPredicateSyntaxParser` and repeated `--where`
 syntax as an input grammar, but this document no longer defines package facets
@@ -223,12 +232,19 @@ as arbitrary section-field predicates. If `--where` is retained, the
 implementation slice must add product-owned CLI bindings for the finite facet
 set so the CLI and browser continue to invoke the same L1 definitions.
 
-### Tier gating: nuspec vs. promoted
+### Tier gating
 
-The gate is enforced at L2, before L1 is asked to evaluate anything: a
-`--where` clause naming a promoted-tier field is rejected up front unless the
-capability flag is present, exactly mirroring how a coordinate-scoped section
-is discoverable only when its carrier flag is present
+The current L1 planner rejects package-content requests above 20 candidates,
+and execution rejects a package-content plan unless its host supplies the
+explicit content-provider capability. Selecting a package-content facet is the
+Browser's explicit cost gesture; the Browser request state lowers its
+candidate bound from 200 to 20 before dispatch.
+
+For the future CLI and promoted IL tier, the gate is enforced at L2 before L1
+is asked to evaluate anything: a `--where` clause naming a capability-bearing
+field is rejected up front unless the capability flag is present, exactly
+mirroring how a coordinate-scoped section is discoverable only when its
+carrier flag is present
 ([output-shapes.md](output-shapes.md), "Coordinate carriers sit before the
 ladder"). The bound itself — how many candidates promoted-tier evaluation
 may run against — is not the whole corpus scanned so far; it is whatever
@@ -237,15 +253,16 @@ both), mirroring the browser experience's Deepen action, which is
 "an explicit, checkbox-gated escalation... bounded to a selection so a
 thousand-row funnel doesn't silently trigger a thousand package downloads."
 
-This document does not fix `--deepen`'s exact spelling or bound shape; that is
-an open question for the implementation slice that adds it (see
+This document does not fix the CLI gesture for package-content facets or
+`--deepen`'s exact spelling and bound shape for promoted IL. Those remain open
+questions for their CLI implementation slices (see
 [Landing sequence](#landing-sequence)).
 
 ## Row declaration: coercing a wide per-package fact set into a Table
 
 A facet-matched package is not naturally one flat row: it may match zero or
-more facets, each with its own evidence, and evaluating a promoted-tier facet
-may add fields a nuspec-only row never had. Before this can be a Table,
+more facets, each with its own evidence, and evaluating a capability-bearing
+facet may add fields a nuspec-only row never had. Before this can be a Table,
 something has to decide the row grain — the same "declared row unit"
 decision #4551 already makes once for package/dependency pairs. This
 document proposes:
@@ -306,11 +323,12 @@ because a predicate can shrink what the bound counts:
   fewer matches than its candidate bound is a true, bounded-complete result
   over that candidate set, not a truncated one.
 
-The implementation must preserve both distinct orderings: nuspec predicates
-run before the semantic `-n` result limit, while `--deepen` bounds candidates
-before promoted IL evaluation. Help text and rendered completion state must
-name the candidate bound, and the asserted ordering must name its enforcing
-gate.
+The implementation must preserve the orderings: nuspec predicates run before
+the semantic `-n` result limit; the package-content candidate cap applies
+before archive evaluation, with manifest prefilters running before acquisition;
+and `--deepen` bounds candidates before future promoted IL evaluation. Help
+text and rendered completion state must name the candidate bound, and the
+asserted ordering must name its enforcing gate.
 
 `PackageQuery.ExecuteAsync` now implements the nuspec half with separate
 `MaximumCandidates` and `MaximumMatches` bounds.
@@ -321,8 +339,9 @@ candidate-bound completion. Reaching the semantic match limit is deliberately
 conservative: execution stops without acquiring another manifest, so
 `MatchLimitReached` means more matches may exist even when the last emitted row
 also happened to exhaust the source. This behavior is gated by
-`ExecuteAsync_ExactExhaustionAtMatchLimitIsConservative`. Promoted-tier
-ordering remains proposal-only.
+`ExecuteAsync_ExactExhaustionAtMatchLimitIsConservative`. Package-content
+candidate limits and manifest prefiltering are gated by `PackageQueryTests`;
+promoted IL ordering remains proposal-only.
 
 ## Shared request/outcome shape with the browser
 
@@ -350,8 +369,10 @@ the CLI's named facets as canonical for the browser's facet rail.
 - No relational query surface here. Package-to-capability or
   package-to-integration questions route through the existing inspection
   graph, not through a new edge concept invented for this document.
-- No unbounded promoted-tier evaluation. Every IL-tier facet requires an
-  explicit, bounded `--deepen` (or equivalent) — never a corpus-wide default.
+- No unbounded package-content or promoted-tier evaluation. Package-content
+  facets retain their product-owned 20-candidate maximum. Every future IL-tier
+  facet requires an explicit, bounded `--deepen` (or equivalent) — never a
+  corpus-wide default.
 - No decision here on `--deepen`'s exact spelling, bound shape, or the saved
   query/result file's exact fields — those are implementation-slice
   decisions, not settled by this document.
@@ -369,11 +390,12 @@ the CLI's named facets as canonical for the browser's facet rail.
    `-t`-as-package-limit for the historical #4677 `-n` proposal, and `-S`/`--where`
    remain unwired. See
    [Sections migration: already landed, ahead of this document's sequencing](#sections-migration-already-landed-ahead-of-this-documents-sequencing).
-3. **Product-owned nuspec facet contract — implemented in the current
-   sources.** `PackageQuery` composes `PackageProfileQuery` without package
-   payload acquisition, publishes stable ordered facet descriptors, validates
-   opaque selections, and streams matched package rows with product-authored
-   evidence and honest completion. `PackageQueryTests` and
+3. **Product-owned facet contract — implemented in the current sources.**
+   `PackageQuery` composes `PackageProfileQuery`, publishes stable ordered
+   facet descriptors, validates opaque selections, and streams matched package
+   rows with product-authored evidence and honest completion. Nuspec facets
+   need no package payload. Package-content facets require an explicit host
+   provider and at most 20 candidates. `PackageQueryTests` and
    `PackageQueryPlanner_IsReachableFromBrowserConsumer` are the named Release
    gates.
 4. **Resolve the corpus-limit spelling under a focused CLI item-limit
@@ -384,10 +406,12 @@ the CLI's named facets as canonical for the browser's facet rail.
    make its own CLI decision and settle any product-owned bindings needed to
    lower the chosen spelling to opaque facet IDs without duplicating
    predicates. Neither sub-goal has landed yet.
-5. **Add the promoted-tier capability gate and `--deepen`-bounded IL
+5. **Define and wire the CLI capability gesture for package-content
+   facets**, preserving the product-owned candidate cap and visible failures.
+6. **Add the promoted-tier capability gate and `--deepen`-bounded IL
    evaluation**, including the L2 tier-gating error for an ungated
    promoted-tier field.
-6. **Define the shared save/resume file shape**, coordinated with whatever
+7. **Define the shared save/resume file shape**, coordinated with whatever
    the browser experience's local-storage record settles on when it is
    implemented.
 

--- a/docs/design/package-query-experience.md
+++ b/docs/design/package-query-experience.md
@@ -1,9 +1,10 @@
 # The package query experience
 
 This document defines the UX for a full-bleed inspect-web surface: a
-grep.app-style wide query over nuget.org, built on the nuspec-only streaming
-profile introduced by [#4551](https://github.com/richlander/dotnet-inspect/pull/4551)
-and the product-owned package-query contract introduced by
+grep.app-style wide query over nuget.org, built on the streaming package
+profile introduced by
+[#4551](https://github.com/richlander/dotnet-inspect/pull/4551) and the
+product-owned package-query contract introduced by
 [#5020](https://github.com/richlander/dotnet-inspect/pull/5020). It extends
 [browser-package-sources.md](browser-package-sources.md) (source clients) and
 [progressive-disclosure.md](progressive-disclosure.md) (explicit, capability-
@@ -14,12 +15,13 @@ counterpart — where the facet engine and its layering actually live — is
 browser front end for that one product surface.
 
 **What is enforced.** The production integration supplies the `/query` page,
-prefix form, product-issued nuspec facet catalog, streaming Browser engine
-source, cancellation, honest partial and bounded completion states, and typed
-Workspace handoff. The controller, adapter, route, renderer, and engine
-projection are enforced by the package-query frontend and Browser engine test
-suites. Visualization, persistence, sharing, outcome caching, and deeper
-artifact evaluation are future scope and are unverified.
+prefix form, product-issued facet catalog, streaming Browser engine source,
+explicitly bounded package-content acquisition, cancellation, honest partial
+and bounded completion states, and typed Workspace handoff. The controller,
+adapter, route, renderer, and engine projection are enforced by the
+package-query frontend and Browser engine test suites. Visualization,
+persistence, sharing, outcome caching, and assembly/IL evaluation are future
+scope and are unverified.
 
 ## Shell placement boundary
 
@@ -62,8 +64,8 @@ QueryRequest       — scope + predicate + declared bound (top N / all-bounded)
 QueryOutcome       — streamed QueryResultRow[] + partial failures + completion state
     |
     v
-QueryResultRow     — one package's nuspec-derived projection + which predicate
-                      terms matched + why (the evidence, not just a checkmark)
+QueryResultRow     — one package's manifest/content-derived projection + which
+                      predicate terms matched + why
 ```
 
 This mirrors the existing `NuGetSearchOutcome` shape (`Results` + `Failures`,
@@ -72,11 +74,15 @@ convention. The runtime `QueryRequest` carries the package-ID prefix, selected
 opaque product facet descriptors, and independent candidate and match limits.
 Facet descriptors come from `PackageQuery.Facets`; the browser does not own an
 independent predicate table. It preserves the product-issued ID, label,
-summary, weight, tier, and optional exclusive-selection group.
+summary, weight, tier, optional exclusive-selection group, and optional
+display group.
 
-Every current row carries the `nuspec` tier tag because the query uses only
-search and manifest evidence. No promoted tier or archive/assembly evaluation
-is exposed by this contract.
+Rows carry the highest evidence tier used by the request: `nuspec` for search
+and manifest evidence, or `package-content` when a selected facet opens the
+package archive. Package-content requests are accepted only with at most 20
+candidates. The Browser supplies that capability through its existing
+admitted package store and shared operation deadline; acquisition or
+evaluation failures remain visible per-package failures.
 
 ## Layout
 
@@ -93,11 +99,12 @@ its Search entry is owned by
 │ Facets         │  Microsoft.Extensions.Hosting           nuspec              │
 │                │    Verified source · Has dependencies                       │
 │ Verified source│    1,234,567 downloads · nuget.org                           │
-│ .NET tool      │                           [ Open in workspace ]               │
+│ [.NET Tool|v1|v2]                           [ Open in workspace ]              │
 │ Has dependencies                                                             │
 │ No dependencies│  … 99 more (bounded: first 100 matches)                     │
 │ 1M+ downloads  │                                                             │
 │ Embedded README│                                                             │
+│ embedded SKILL.md                                                            │
 └───────────────┴────────────────────────────────────────────────────────────--┘
 ```
 
@@ -108,10 +115,16 @@ its Search entry is owned by
   vocabulary or open grammar. Selecting a facet restarts source work; it never
   client-side-filters stale rows. Product-issued selection groups make
   mutually exclusive facets, such as has-dependencies and no-dependencies,
-  replace one another.
+  replace one another. Product-issued display groups render `.NET Tool`, `v1`,
+  and `v2` as one segmented control while retaining three independently
+  focusable buttons and opaque facet IDs. `.NET Tool` matches any tool from
+  manifest evidence; `v1` and `v2` inspect `DotnetToolSettings.xml`.
+  `embedded SKILL.md` matches package entries at `skills/SKILL.md` or
+  `skills/**/SKILL.md`, case-insensitively. The rail persistently discloses
+  that content facets may download up to 20 candidate archives.
 - **Result stream**: rows append incrementally. Each row is a compact
-  nuspec-derived summary plus the product-authored evidence for *why* it
-  matched — never a bare name.
+  package summary plus the product-authored evidence for *why* it matched —
+  never a bare name.
 - **Handoff, not duplication**: `Open in workspace` submits the row's
   product-issued package ID and exact version once through the standard typed
   Workspace transition, without inferring a framework, source, or fallback
@@ -286,10 +299,10 @@ preset never needs to "contain" its own history.
   with two front ends, not two designs to keep in sync.
 - No client-side re-filtering of a fetched result set — every facet change is
   a new request, keeping displayed counts honest.
-- No archive, assembly, metadata, or IL evaluation. This surface is
-  nuspec-only: it renders exactly the product-issued nuspec facet catalog and
-  does not render promoted facets, selection checkboxes, or `Deepen`. Those
-  controls require a separately owned product operation and UI change.
+- No unbounded archive evaluation. Package-content facets are an explicit
+  gesture and are product-gated to 20 candidates.
+- No assembly, metadata, or IL evaluation. A future promoted tier still
+  requires a separately owned product operation and UI change.
 - No persistence, sharing, or outcome cache in the current slice.
 - No chart or aggregation surface in the current slice.
 
@@ -305,7 +318,7 @@ and browser-history and focus-return outcomes are proved by
 1. Load `/query` directly and on refresh and confirm that the route starts
    without a persisted request, selected facets, or inferred package
    coordinate.
-2. Toggle two product-issued nuspec facets and confirm that each change starts
+2. Toggle two product-issued facets and confirm that each change starts
    a fresh engine request with opaque IDs, cancels the prior request, and
    suppresses its late rows and failures.
 3. Confirm that product rows, evidence, partial failures, and exhausted,
@@ -320,8 +333,15 @@ and browser-history and focus-return outcomes are proved by
    exact product-issued ID and version, without inferring a framework, source,
    or fallback from display text. Confirm that a typed failure retains
    `/query`, the result set, and the request.
-7. Confirm that no promoted facet, selection checkbox, or `Deepen` control is
-   rendered in this nuspec-only slice.
+7. Confirm that `.NET Tool`, `v1`, and `v2` form one segmented control with
+   independent focus and pressed state, and that selecting one replaces the
+   others.
+8. Select `v1`, `v2`, or `embedded SKILL.md`; confirm the request bound drops
+   to 20 candidates, archive acquisition uses the Browser package store and
+   deadline, and acquisition/evaluation failures remain visible. Remove the
+   final package-content facet and confirm the default returns to 200.
+9. Confirm that no assembly/IL promoted facet, selection checkbox, or `Deepen`
+   control is rendered.
 
 ## Landing sequence
 
@@ -330,13 +350,15 @@ and browser-history and focus-return outcomes are proved by
 2. **#5020** supplied the product-owned facet catalog, planning, rows,
    evidence, failures, cancellation, and completion.
 3. **Inspect Web integration** supplies the `/query` route, query bar, Browser
-   event adapter, product-issued nuspec facet rail, and typed Workspace handoff.
-4. Deeper artifact evaluation requires a separate product-owned query and UX
-   design; this nuspec contract does not reserve controls for it.
+   event adapter, product-issued facet rail, and typed Workspace handoff.
+4. **#5464** adds the bounded package-content tier, the embedded `SKILL.md`
+   facet, and the segmented .NET tool format control.
+5. Assembly/IL evaluation requires a separate product-owned query and UX
+   design; this contract does not reserve controls for it.
 
 The TypeScript state and renderer (`src/package-query.ts` and
 `src/package-query-view.ts`) retain their source-independent controller seam.
 The production Browser adapter satisfies it with product events; inline fake
 sources remain focused tests of race and rendering behavior. Visualization and
 the future features above remain additive work rather than implied behavior of
-the nuspec integration.
+the package query integration.

--- a/docs/design/progressive-disclosure.md
+++ b/docs/design/progressive-disclosure.md
@@ -149,6 +149,12 @@ work should follow the reference model rather than copy a legacy command.
 
 Package acquisition and symbol/source acquisition are separate.
 
+In the Browser package query, selecting a product-issued package-content facet
+is the explicit package-acquisition gesture. The product planner caps that
+request at 20 candidates, and execution requires the host to supply an
+`IPackageQueryContentProvider`; merely discovering that an archive is
+available grants no authority to open it.
+
 Capability-bearing gestures carry **request provenance**, not authority.
 Argument parsing retains the user's original verbosity, explicit
 section/category/glob selection, discovery mode, and explicit policy flags.

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -645,16 +645,26 @@ internal static class BrowserPackageWorkspace
         PackageSourceCoordinate coordinate = PackageSourceCoordinate.Create(
             package.PackageId,
             package.Version);
-        PackageSourcePayloadResult result =
-            await PackagePayloadAcquisition.AcquireAsync(
-                source,
-                coordinate,
-                Store,
-                limits: PayloadLimits,
-                cancellationToken: deadline.Token,
-                transferPolicy: new BrowserPackageOperationTransferPolicy(
+        PackageSourcePayloadResult result;
+        try
+        {
+            result = await PackagePayloadAcquisition.AcquireAsync(
+                    source,
+                    coordinate,
                     Store,
-                    deadline)).ConfigureAwait(false);
+                    limits: PayloadLimits,
+                    cancellationToken: deadline.Token,
+                    transferPolicy: new BrowserPackageQueryTransferPolicy(
+                        new BrowserPackageOperationTransferPolicy(
+                            Store,
+                            deadline)))
+                .ConfigureAwait(false);
+        }
+        catch (BrowserPackagePayloadPolicyException exception)
+        {
+            return new PackageQueryContentResult.Unavailable(
+                exception.Message);
+        }
         return result switch
         {
             PackageSourcePayloadResult.Acquired acquired =>
@@ -1019,6 +1029,31 @@ internal static class BrowserPackageWorkspace
             public void Dispose() => inner.Dispose();
         }
     }
+
+    internal sealed class BrowserPackageQueryTransferPolicy(
+        IPackagePayloadTransferPolicy inner)
+        : IPackagePayloadTransferPolicy
+    {
+        public IPackagePayloadReservation Reserve(
+            PackagePayloadTransfer transfer)
+        {
+            try
+            {
+                return inner.Reserve(transfer);
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new BrowserPackagePayloadPolicyException(
+                    exception.Message,
+                    exception);
+            }
+        }
+    }
+
+    internal sealed class BrowserPackagePayloadPolicyException(
+        string message,
+        Exception innerException)
+        : InvalidOperationException(message, innerException);
 
     internal static string? SelectDependencyVersion(
         string[] versions,

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -633,6 +633,44 @@ internal static class BrowserPackageWorkspace
         };
     }
 
+    internal static async ValueTask<PackageQueryContentResult>
+        AcquirePackageQueryContentAsync(
+            PackageProfileMatch package,
+            IPackageSourceClient source,
+            BrowserPackageOperationDeadline deadline)
+    {
+        ArgumentNullException.ThrowIfNull(package);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(deadline);
+        PackageSourceCoordinate coordinate = PackageSourceCoordinate.Create(
+            package.PackageId,
+            package.Version);
+        PackageSourcePayloadResult result =
+            await PackagePayloadAcquisition.AcquireAsync(
+                source,
+                coordinate,
+                Store,
+                limits: PayloadLimits,
+                cancellationToken: deadline.Token,
+                transferPolicy: new BrowserPackageOperationTransferPolicy(
+                    Store,
+                    deadline)).ConfigureAwait(false);
+        return result switch
+        {
+            PackageSourcePayloadResult.Acquired acquired =>
+                new PackageQueryContentResult.Available(
+                    acquired.Payload.Content),
+            PackageSourcePayloadResult.Unavailable unavailable =>
+                new PackageQueryContentResult.Unavailable(
+                    unavailable.Message),
+            PackageSourcePayloadResult.Failed failed =>
+                new PackageQueryContentResult.Unavailable(
+                    failed.Failure.Message),
+            _ => throw new InvalidOperationException(
+                "Package payload acquisition returned an unknown outcome."),
+        };
+    }
+
     internal static Task<T> WaitForSharedAcquisitionAsync<T>(
         Task<T> acquisition,
         CancellationToken cancellationToken)

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -4922,6 +4922,53 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageQueryContent_AcquiresThroughBrowserPackagePolicy()
+    {
+        string packageId = $"gallery.query.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        byte[] archive = PackageWithSkill(packageId, version);
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            archive);
+        using IPackageSourceClient source = Gallery(handler);
+        PackageManifestFacts manifest = Assert.IsType<
+            PackageManifestFactsResult.Available>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(
+                        Nuspec(packageId, version)),
+                    PackageSourceCoordinate.Create(packageId, version))).Value;
+        var package = new PackageProfileMatch(
+            packageId,
+            version,
+            [],
+            TotalDownloads: 0,
+            Verified: false,
+            PackageSourceIdentity.NuGetOrg,
+            manifest);
+        using var deadline =
+            new BrowserPackageWorkspace.BrowserPackageOperationDeadline(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+        PackageQueryContentResult result =
+            await BrowserPackageWorkspace.AcquirePackageQueryContentAsync(
+                package,
+                source,
+                deadline);
+
+        IPackageContent content = Assert.IsType<
+            PackageQueryContentResult.Available>(result).Content;
+        Assert.Contains(
+            "skills/SKILL.md",
+            content.EnumerateEntries(),
+            StringComparer.Ordinal);
+        Assert.Equal(
+            [$"https://globalcdn.nuget.org/packages/{packageId}.{version}.nupkg"],
+            handler.Requested);
+    }
+
+    [Fact]
     public async Task BrowserPackageRealization_ReceivesAcquisitionIssuedCoordinate()
     {
         string packageId = $"Gallery.Binding.{Guid.NewGuid():N}";
@@ -5911,6 +5958,41 @@ public sealed class BrowserEngineBoundaryTests
 
         return content.ToArray();
     }
+
+    static byte[] PackageWithSkill(string packageId, string version)
+    {
+        using var content = new MemoryStream();
+        using (var archive = new ZipArchive(
+            content,
+            ZipArchiveMode.Create,
+            leaveOpen: true))
+        {
+            using (StreamWriter manifest = new(
+                archive.CreateEntry(
+                    $"{packageId}.nuspec",
+                    CompressionLevel.NoCompression).Open(),
+                Encoding.UTF8,
+                leaveOpen: false))
+            {
+                manifest.Write(Nuspec(packageId, version));
+            }
+            archive.CreateEntry(
+                "skills/SKILL.md",
+                CompressionLevel.NoCompression);
+        }
+
+        return content.ToArray();
+    }
+
+    static string Nuspec(string packageId, string version) =>
+        $"""
+         <package>
+           <metadata>
+             <id>{packageId}</id>
+             <version>{version}</version>
+           </metadata>
+         </package>
+         """;
 
     static IPackageSourceClient Gallery(HttpMessageHandler handler) =>
         PackageSourceClientFactory.CreateGallery(

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -4969,6 +4969,51 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
+    public async Task PackageQueryContent_PolicyRejectionRemainsVisible()
+    {
+        string packageId = $"gallery.query.no-length.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            PackageWithSkill(packageId, version),
+            omitContentLength: true);
+        using IPackageSourceClient source = Gallery(handler);
+        PackageManifestFacts manifest = Assert.IsType<
+            PackageManifestFactsResult.Available>(
+                PackageManifestFactsQuery.Execute(
+                    Encoding.UTF8.GetBytes(
+                        Nuspec(packageId, version)),
+                    PackageSourceCoordinate.Create(packageId, version))).Value;
+        var package = new PackageProfileMatch(
+            packageId,
+            version,
+            [],
+            TotalDownloads: 0,
+            Verified: false,
+            PackageSourceIdentity.NuGetOrg,
+            manifest);
+        using var deadline =
+            new BrowserPackageWorkspace.BrowserPackageOperationDeadline(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+        PackageQueryContentResult result =
+            await BrowserPackageWorkspace.AcquirePackageQueryContentAsync(
+                package,
+                source,
+                deadline);
+
+        string message = Assert.IsType<
+            PackageQueryContentResult.Unavailable>(result).Message;
+        Assert.Contains(
+            "did not declare its byte length",
+            message,
+            StringComparison.Ordinal);
+        Assert.True(handler.PayloadDisposed);
+    }
+
+    [Fact]
     public async Task BrowserPackageRealization_ReceivesAcquisitionIssuedCoordinate()
     {
         string packageId = $"Gallery.Binding.{Guid.NewGuid():N}";

--- a/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserPackageQueryOperationsTests.cs
@@ -25,18 +25,24 @@ public sealed class BrowserPackageQueryOperationsTests
             Assert.Equal(expected.Summary, actual.Summary);
             Assert.Equal(expected.Weight, actual.Weight);
             Assert.Equal(expected.SelectionGroupId, actual.SelectionGroupId);
-            Assert.Equal(BrowserPackageQueryFacetTier.Nuspec, actual.Tier);
+            Assert.Equal(expected.DisplayGroupId, actual.DisplayGroupId);
+            Assert.Equal(expected.DisplayGroupLabel, actual.DisplayGroupLabel);
+            Assert.Equal(
+                expected.Tier == PackageQueryFacetTier.Nuspec
+                    ? BrowserPackageQueryFacetTier.Nuspec
+                    : BrowserPackageQueryFacetTier.PackageContent,
+                actual.Tier);
         }
     }
 
     [Fact]
     public void Project_PreservesFailureAndCompletionEvidence()
     {
-        var failure = new PackageProfileFailure(
+        var failure = new PackageQueryFailure(
             "Contoso.Bad",
             "1.0.0",
             PackageSourceIdentity.NuGetOrg,
-            PackageProfileFailureKind.ManifestAcquisition,
+            PackageQueryFailureKind.ManifestAcquisition,
             "manifest unavailable");
         var summary = new PackageQuerySummary(
             new InertString(TextPolicy.Field, "Contoso."),
@@ -68,6 +74,52 @@ public sealed class BrowserPackageQueryOperationsTests
             projectedCompletion.Completion!.Kind);
         Assert.Equal(200, projectedCompletion.Completion.CandidateLimit);
         Assert.Equal(100, projectedCompletion.Completion.MatchLimit);
+    }
+
+    [Fact]
+    public void Project_PreservesPackageContentTierAndFailure()
+    {
+        PackageProfileMatch package = new(
+            "Contoso.Tool",
+            "1.0.0",
+            [],
+            TotalDownloads: 42,
+            Verified: false,
+            PackageSourceIdentity.NuGetOrg,
+            Manifest(
+                "Contoso.Tool",
+                "1.0.0",
+                isToolPackage: true));
+        var match = new PackageQueryMatch(
+            package,
+            PackageQueryFacetTier.PackageContent,
+            [
+                new PackageQueryEvidence(
+                    PackageQuery.ToolV2FacetId,
+                    new InertString(
+                        TextPolicy.Prose,
+                        "DotnetToolSettings.xml declares v2.")),
+            ]);
+        var failure = new PackageQueryFailure(
+            "Contoso.Bad",
+            "1.0.0",
+            PackageSourceIdentity.NuGetOrg,
+            PackageQueryFailureKind.PackageContentAcquisition,
+            "package payload unavailable");
+
+        BrowserPackageQueryEvent projectedMatch =
+            BrowserPackageQueryOperations.Project(
+                new PackageQueryEvent.Match(match));
+        BrowserPackageQueryEvent projectedFailure =
+            BrowserPackageQueryOperations.Project(
+                new PackageQueryEvent.Failure(failure));
+
+        Assert.Equal(
+            BrowserPackageQueryFacetTier.PackageContent,
+            projectedMatch.Row!.Tier);
+        Assert.Equal(
+            BrowserPackageQueryFailureKind.PackageContentAcquisition,
+            projectedFailure.Failure!.Kind);
     }
 
     [Fact]
@@ -128,4 +180,23 @@ public sealed class BrowserPackageQueryOperationsTests
 
         Assert.Contains("facet IDs are unknown", error.Message);
     }
+
+    static PackageManifestFacts Manifest(
+        string packageId,
+        string version,
+        bool isToolPackage) =>
+        new(
+            PackageSourceCoordinate.Create(packageId, version),
+            "nuspec",
+            Description: null,
+            Authors: null,
+            Repository: null,
+            RepositoryType: null,
+            RepositoryCommit: null,
+            License: null,
+            LicenseUrl: null,
+            PackageTypes: isToolPackage ? ["DotnetTool"] : [],
+            IsToolPackage: isToolPackage,
+            ReadmeFile: null,
+            DependencyGroups: []);
 }

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -206,6 +206,7 @@ public sealed record BrowserBuildIdentity(
 public enum BrowserPackageQueryFacetTier
 {
     Nuspec,
+    PackageContent,
 }
 
 public sealed record BrowserPackageQueryFacetDescriptor(
@@ -214,7 +215,9 @@ public sealed record BrowserPackageQueryFacetDescriptor(
     string Summary,
     int Weight,
     BrowserPackageQueryFacetTier Tier,
-    string? SelectionGroupId);
+    string? SelectionGroupId,
+    string? DisplayGroupId,
+    string? DisplayGroupLabel);
 
 public sealed record BrowserPackageQueryFacetCatalog(
     BrowserPackageQueryFacetDescriptor[] Facets);
@@ -240,6 +243,8 @@ public enum BrowserPackageQueryFailureKind
     ManifestAcquisition,
     ManifestContract,
     InvalidManifest,
+    PackageContentAcquisition,
+    PackageContentEvaluation,
 }
 
 public sealed record BrowserPackageQueryFailure(

--- a/prototypes/inspect-web/engine/BrowserPackageQueryOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserPackageQueryOperations.cs
@@ -22,10 +22,14 @@ namespace InspectWeb.Engine
                             {
                                 PackageQueryFacetTier.Nuspec =>
                                     BrowserPackageQueryFacetTier.Nuspec,
+                                PackageQueryFacetTier.PackageContent =>
+                                    BrowserPackageQueryFacetTier.PackageContent,
                                 _ => throw new InvalidOperationException(
                                     "Unknown package-query facet tier."),
                             },
-                            facet.SelectionGroupId)),
+                            facet.SelectionGroupId,
+                            facet.DisplayGroupId,
+                            facet.DisplayGroupLabel)),
                 ]);
 
         internal static async Task<BrowserPackageQueryEvent> ExecuteAsync(
@@ -34,6 +38,25 @@ namespace InspectWeb.Engine
             int maximumCandidates,
             int maximumMatches,
             bool includePrerelease,
+            Action<BrowserPackageQueryEvent> emit,
+            CancellationToken cancellationToken)
+            => await ExecuteAsync(
+                prefix,
+                facetIds,
+                maximumCandidates,
+                maximumMatches,
+                includePrerelease,
+                contentProvider: null,
+                emit,
+                cancellationToken).ConfigureAwait(false);
+
+        internal static async Task<BrowserPackageQueryEvent> ExecuteAsync(
+            string prefix,
+            string[] facetIds,
+            int maximumCandidates,
+            int maximumMatches,
+            bool includePrerelease,
+            IPackageQueryContentProvider? contentProvider,
             Action<BrowserPackageQueryEvent> emit,
             CancellationToken cancellationToken)
         {
@@ -56,6 +79,7 @@ namespace InspectWeb.Engine
             await foreach (PackageQueryEvent queryEvent in PackageQuery.ExecuteAsync(
                 BrowserPackageWorkspace.Gallery,
                 plan,
+                contentProvider,
                 cancellationToken).ConfigureAwait(false))
             {
                 BrowserPackageQueryEvent projected = Project(queryEvent);
@@ -83,6 +107,8 @@ namespace InspectWeb.Engine
                         {
                             PackageQueryFacetTier.Nuspec =>
                                 BrowserPackageQueryFacetTier.Nuspec,
+                            PackageQueryFacetTier.PackageContent =>
+                                BrowserPackageQueryFacetTier.PackageContent,
                             _ => throw new InvalidOperationException(
                                 "Unknown package-query match tier."),
                         },
@@ -107,16 +133,20 @@ namespace InspectWeb.Engine
                         failure.Value.Producer.Value,
                         failure.Value.Kind switch
                         {
-                            PackageProfileFailureKind.Search =>
+                            PackageQueryFailureKind.Search =>
                                 BrowserPackageQueryFailureKind.Search,
-                            PackageProfileFailureKind.SearchContract =>
+                            PackageQueryFailureKind.SearchContract =>
                                 BrowserPackageQueryFailureKind.SearchContract,
-                            PackageProfileFailureKind.ManifestAcquisition =>
+                            PackageQueryFailureKind.ManifestAcquisition =>
                                 BrowserPackageQueryFailureKind.ManifestAcquisition,
-                            PackageProfileFailureKind.ManifestContract =>
+                            PackageQueryFailureKind.ManifestContract =>
                                 BrowserPackageQueryFailureKind.ManifestContract,
-                            PackageProfileFailureKind.InvalidManifest =>
+                            PackageQueryFailureKind.InvalidManifest =>
                                 BrowserPackageQueryFailureKind.InvalidManifest,
+                            PackageQueryFailureKind.PackageContentAcquisition =>
+                                BrowserPackageQueryFailureKind.PackageContentAcquisition,
+                            PackageQueryFailureKind.PackageContentEvaluation =>
+                                BrowserPackageQueryFailureKind.PackageContentEvaluation,
                             _ => throw new InvalidOperationException(
                                 "Unknown package-query failure kind."),
                         },
@@ -196,12 +226,15 @@ public static partial class InspectionEngine
             await BrowserPackageWorkspace.RunPackageOperationAsync(
             async deadline =>
             {
+                var contentProvider =
+                    new BrowserPackageQueryContentProvider(deadline);
                 return await BrowserPackageQueryOperations.ExecuteAsync(
                     prefix,
                     facetIds,
                     maximumCandidates,
                     maximumMatches,
                     includePrerelease,
+                    contentProvider,
                     queryEvent => eventSink.SetProperty(
                         "event",
                         BrowserPackageQueryOperations.Serialize(queryEvent)),
@@ -212,5 +245,25 @@ public static partial class InspectionEngine
         return JsonSerializer.Serialize(
             completed,
             BrowserJsonContext.Default.BrowserPackageQueryEvent);
+    }
+}
+
+namespace InspectWeb.Engine
+{
+    [SupportedOSPlatform("browser")]
+    internal sealed class BrowserPackageQueryContentProvider(
+        BrowserPackageWorkspace.BrowserPackageOperationDeadline deadline)
+        : IPackageQueryContentProvider
+    {
+        public ValueTask<PackageQueryContentResult> GetContentAsync(
+            PackageProfileMatch package,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return BrowserPackageWorkspace.AcquirePackageQueryContentAsync(
+                package,
+                BrowserPackageWorkspace.Gallery,
+                deadline);
+        }
     }
 }

--- a/prototypes/inspect-web/engine/inspect-web-engine.ts
+++ b/prototypes/inspect-web/engine/inspect-web-engine.ts
@@ -20,9 +20,9 @@ export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached
 
 export type BrowserPackageQueryEventKind = "Match" | "Failure" | "Completed" | number;
 
-export type BrowserPackageQueryFacetTier = "Nuspec" | number;
+export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | number;
 
-export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | number;
+export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
 
 export interface BrowserAccessibilityDescriptor {
   readonly id: string;
@@ -564,6 +564,8 @@ export interface BrowserPackageQueryFacetDescriptor {
   readonly weight: number;
   readonly tier: BrowserPackageQueryFacetTier;
   readonly selectionGroupId: string | null;
+  readonly displayGroupId: string | null;
+  readonly displayGroupLabel: string | null;
 }
 
 export interface BrowserPackageQueryFailure {

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -5,8 +5,8 @@ export type BrowserDependencyCoordinateMatchOutcome = "NoMatch" | "Unique" | "Am
 export type BrowserDependencyCoordinateProvenance = "NuGetPackage" | "PlatformRuntime" | number;
 export type BrowserPackageQueryCompletionKind = "Exhausted" | "MatchLimitReached" | "CandidateLimitReached" | "SourcePageLimitReached" | "ClientPageLimitReached" | "Failed" | number;
 export type BrowserPackageQueryEventKind = "Match" | "Failure" | "Completed" | number;
-export type BrowserPackageQueryFacetTier = "Nuspec" | number;
-export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | number;
+export type BrowserPackageQueryFacetTier = "Nuspec" | "PackageContent" | number;
+export type BrowserPackageQueryFailureKind = "Search" | "SearchContract" | "ManifestAcquisition" | "ManifestContract" | "InvalidManifest" | "PackageContentAcquisition" | "PackageContentEvaluation" | number;
 export interface BrowserAccessibilityDescriptor {
     readonly id: string;
     readonly label: string;
@@ -485,6 +485,8 @@ export interface BrowserPackageQueryFacetDescriptor {
     readonly weight: number;
     readonly tier: BrowserPackageQueryFacetTier;
     readonly selectionGroupId: string | null;
+    readonly displayGroupId: string | null;
+    readonly displayGroupLabel: string | null;
 }
 export interface BrowserPackageQueryFailure {
     readonly packageId: string | null;

--- a/prototypes/inspect-web/src/package-query-source.ts
+++ b/prototypes/inspect-web/src/package-query-source.ts
@@ -34,17 +34,15 @@ export function packageQueryFacets(
 function toQueryFacet(
   descriptor: BrowserPackageQueryFacetDescriptor,
 ): QueryFacetTerm {
-  if (descriptor.tier !== "Nuspec") {
-    throw new Error(
-      `Unsupported package-query facet tier '${String(descriptor.tier)}'.`);
-  }
   return {
     key: descriptor.id,
     label: descriptor.label,
     summary: descriptor.summary,
     weight: descriptor.weight,
-    tier: "nuspec",
+    tier: toQueryTier(descriptor.tier),
     selectionGroupId: descriptor.selectionGroupId,
+    displayGroupId: descriptor.displayGroupId,
+    displayGroupLabel: descriptor.displayGroupLabel,
   };
 }
 
@@ -239,7 +237,7 @@ function parseCompletion(value: unknown): BrowserPackageQueryCompletion {
 function facetTierValue(
   value: unknown,
 ): BrowserPackageQueryRow["tier"] {
-  if (value === "Nuspec") return value;
+  if (value === "Nuspec" || value === "PackageContent") return value;
   throw new TypeError(
     `Unsupported package-query row tier '${String(value)}'.`);
 }
@@ -253,6 +251,8 @@ function failureKindValue(
     case "ManifestAcquisition":
     case "ManifestContract":
     case "InvalidManifest":
+    case "PackageContentAcquisition":
+    case "PackageContentEvaluation":
       return value;
     default:
       throw new TypeError(
@@ -313,10 +313,6 @@ function dispatchEvent(
 function toQueryRow(
   row: NonNullable<BrowserPackageQueryEvent["row"]>,
 ): QueryResultRow {
-  if (row.tier !== "Nuspec") {
-    throw new TypeError(
-      `Unsupported package-query row tier '${String(row.tier)}'.`);
-  }
   const evidence = row.evidence.map(item => item.text);
   if (!evidence.length) {
     throw new TypeError("A package-query row contained no evidence.");
@@ -324,11 +320,25 @@ function toQueryRow(
   return {
     packageId: row.packageId,
     version: row.version,
-    tier: "nuspec",
+    tier: toQueryTier(row.tier),
     evidence: [evidence[0]!, ...evidence.slice(1)],
     totalDownloads: row.totalDownloads,
     producer: row.producer,
   };
+}
+
+function toQueryTier(
+  tier: BrowserPackageQueryRow["tier"],
+): QueryResultRow["tier"] {
+  switch (tier) {
+    case "Nuspec":
+      return "nuspec";
+    case "PackageContent":
+      return "package-content";
+    default:
+      throw new TypeError(
+        `Unsupported package-query tier '${String(tier)}'.`);
+  }
 }
 
 function formatFailure(failure: BrowserPackageQueryFailure): string {

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -206,7 +206,7 @@ function renderRow(
           <h2>${escapeHtml(row.packageId)}</h2>
           <span class="query-row-version">${escapeHtml(row.version)}</span>
         </div>
-        <span class="query-tier query-tier-nuspec">nuspec</span>
+        <span class="query-tier query-tier-${escapeHtml(row.tier)}">${escapeHtml(row.tier)}</span>
       </div>
       <ul class="query-evidence">${evidence}</ul>
       <div class="query-row-meta">
@@ -234,6 +234,36 @@ function renderFacet(
       title="${escapeHtml(facet.summary ?? facet.label)}">
       ${escapeHtml(facet.label)}
     </button>`;
+}
+
+function renderFacets(
+  facets: readonly QueryFacetTerm[],
+  activeKeys: ReadonlySet<string>,
+  escapeHtml: (value: unknown) => string,
+): string {
+  const renderedGroups = new Set<string>();
+  return facets.map(facet => {
+    if (!facet.displayGroupId) {
+      return renderFacet(facet, activeKeys, escapeHtml);
+    }
+    if (renderedGroups.has(facet.displayGroupId)) return "";
+    renderedGroups.add(facet.displayGroupId);
+    const groupFacets = facets.filter(candidate =>
+      candidate.displayGroupId === facet.displayGroupId);
+    return `
+      <div
+        class="query-facet-group"
+        role="group"
+        aria-label="${escapeHtml(
+          facet.displayGroupLabel ?? facet.label)}">
+        ${groupFacets
+          .map(groupFacet => renderFacet(
+            groupFacet,
+            activeKeys,
+            escapeHtml))
+          .join("")}
+      </div>`;
+  }).join("");
 }
 
 function renderCompletionFooter(
@@ -273,7 +303,7 @@ function renderEmptyState(
       <section class="query-empty">
         <span class="large-glyph">⌕</span>
         <h2>Query nuget.org</h2>
-        <p>Enter a package ID prefix, then narrow the live result stream with nuspec facets. No package archive is downloaded.</p>
+        <p>Enter a package ID prefix, then narrow the live result stream with product facets.</p>
       </section>`;
   }
   if (completion.kind === "cancelled") {
@@ -337,9 +367,7 @@ export function renderPackageQueryView(
     escapeHtml,
   } = options;
   const activeKeys = new Set(state.request?.facets.map(facet => facet.key) ?? []);
-  const facets = availableFacets
-    .map(facet => renderFacet(facet, activeKeys, escapeHtml))
-    .join("");
+  const facets = renderFacets(availableFacets, activeKeys, escapeHtml);
   const failures = state.outcome.failures.length
     ? `
       <section class="query-failures">
@@ -355,7 +383,7 @@ export function renderPackageQueryView(
   const results = rows
     ? `<div class="query-list">${rows}</div>${renderCompletionFooter(state.outcome, escapeHtml)}`
     : state.outcome.completion.kind === "streaming" && state.request
-      ? `<section class="query-empty query-running"><span class="loader" aria-hidden="true"></span><h2>Searching nuget.org</h2><p>Matches will appear as their manifests are evaluated.</p></section>${renderCompletionFooter(state.outcome, escapeHtml)}`
+      ? `<section class="query-empty query-running"><span class="loader" aria-hidden="true"></span><h2>Searching nuget.org</h2><p>Matches will appear as package candidates are evaluated.</p></section>${renderCompletionFooter(state.outcome, escapeHtml)}`
       : renderEmptyState(state, escapeHtml);
 
   return `
@@ -366,9 +394,9 @@ export function renderPackageQueryView(
       </header>
       <main class="query-main">
         <div class="query-heading">
-          <p class="query-kicker">nuspec-only · nuget.org</p>
+          <p class="query-kicker">manifest + bounded package content · nuget.org</p>
           <h1 id="package-query-heading" tabindex="-1">Package query</h1>
-          <p>Find packages by product-owned manifest and source facets without downloading package archives.</p>
+          <p>Find packages by product-owned source, manifest, and package-content facets.</p>
         </div>
         <form id="package-query-form" class="query-bar" role="search">
           <label for="package-query-prefix">Package ID prefix</label>
@@ -387,6 +415,7 @@ export function renderPackageQueryView(
             <h2>Facets</h2>
             <p>Every change starts a fresh request.</p>
             <div class="query-facets">${facets}</div>
+            <p class="query-facet-disclosure">Content facets download up to 20 candidate package archives.</p>
           </aside>
           <section class="query-results" aria-label="Package query results">
             ${results}

--- a/prototypes/inspect-web/src/package-query.ts
+++ b/prototypes/inspect-web/src/package-query.ts
@@ -20,8 +20,8 @@ export interface QueryFacetTerm {
   displayGroupLabel?: string | null;
 }
 
-export const DEFAULT_QUERY_CANDIDATE_LIMIT = 200;
-export const PACKAGE_CONTENT_QUERY_CANDIDATE_LIMIT = 20;
+const DEFAULT_QUERY_CANDIDATE_LIMIT = 200;
+const PACKAGE_CONTENT_QUERY_CANDIDATE_LIMIT = 20;
 
 /** One rerunnable in-memory request. Never encodes a resolved outcome. */
 export interface QueryRequest {

--- a/prototypes/inspect-web/src/package-query.ts
+++ b/prototypes/inspect-web/src/package-query.ts
@@ -2,7 +2,7 @@
 //
 // This module owns the request/outcome contract and pure state transitions for a
 // wide, streaming query over a package source (nuget.org today; other feeds
-// possible later), narrowed by product-issued nuspec facets.
+// possible later), narrowed by product-issued package facets.
 //
 // It is deliberately data-source-agnostic: `PackageQueryDataSource` is supplied
 // by the caller so this module can be built and tested against fake sources
@@ -14,9 +14,14 @@ export interface QueryFacetTerm {
   label: string;
   summary?: string;
   weight?: number;
-  tier: "nuspec";
+  tier: "nuspec" | "package-content";
   selectionGroupId?: string | null;
+  displayGroupId?: string | null;
+  displayGroupLabel?: string | null;
 }
+
+export const DEFAULT_QUERY_CANDIDATE_LIMIT = 200;
+export const PACKAGE_CONTENT_QUERY_CANDIDATE_LIMIT = 20;
 
 /** One rerunnable in-memory request. Never encodes a resolved outcome. */
 export interface QueryRequest {
@@ -37,7 +42,7 @@ export function createQueryRequest(
   return {
     scopeQuery,
     facets: [],
-    requestedLimit: 200,
+    requestedLimit: DEFAULT_QUERY_CANDIDATE_LIMIT,
     requestedMatchLimit: 100,
   };
 }
@@ -57,14 +62,29 @@ export function withFacet(
   facet: QueryFacetTerm,
 ): QueryRequest {
   if (request.facets.some(existing => existing.key === facet.key)) return request;
-  return { ...request, facets: [...request.facets, facet] };
+  return withFacets(request, [...request.facets, facet]);
 }
 
 export function withoutFacet(
   request: QueryRequest,
   facetKey: string,
 ): QueryRequest {
-  return { ...request, facets: request.facets.filter(f => f.key !== facetKey) };
+  return withFacets(
+    request,
+    request.facets.filter(facet => facet.key !== facetKey));
+}
+
+function withFacets(
+  request: QueryRequest,
+  facets: readonly QueryFacetTerm[],
+): QueryRequest {
+  return {
+    ...request,
+    facets,
+    requestedLimit: facets.some(facet => facet.tier === "package-content")
+      ? PACKAGE_CONTENT_QUERY_CANDIDATE_LIMIT
+      : DEFAULT_QUERY_CANDIDATE_LIMIT,
+  };
 }
 
 export function toggleFacet(
@@ -79,7 +99,7 @@ export function toggleFacet(
     ? request.facets.filter(existing =>
         existing.selectionGroupId !== facet.selectionGroupId)
     : request.facets;
-  return withFacet({ ...request, facets: compatible }, facet);
+  return withFacet(withFacets(request, compatible), facet);
 }
 
 /** One package's projection plus which predicate terms matched and why. Never
@@ -91,7 +111,7 @@ export function toggleFacet(
 export interface QueryResultRow {
   packageId: string;
   version: string;
-  tier: "nuspec";
+  tier: "nuspec" | "package-content";
   evidence: readonly [string, ...string[]];
   totalDownloads: number;
   producer?: string;

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -2098,7 +2098,14 @@ kbd {
   color: var(--dim);
   font: 10px/1.4 var(--mono);
 }
+.query-facet-rail .query-facet-disclosure {
+  margin: 12px 0 0;
+}
 .query-facets { display: flex; flex-direction: column; gap: 7px; }
+.query-facet-group {
+  display: flex;
+  width: 100%;
+}
 .query-facet {
   width: 100%;
   min-height: 34px;
@@ -2113,10 +2120,32 @@ kbd {
 }
 .query-facet:hover { color: var(--text); border-color: var(--text); }
 .query-facet.active {
-  border: 2px solid var(--accent);
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
   background: var(--panel-active);
   color: var(--accent);
-  padding: 5px 9px;
+}
+.query-facet-group .query-facet {
+  position: relative;
+  width: auto;
+  flex: 0 0 auto;
+  margin-left: -1px;
+  border-radius: 0;
+  text-align: center;
+}
+.query-facet-group .query-facet:first-child {
+  flex: 1 1 auto;
+  margin-left: 0;
+  border-radius: 999px 0 0 999px;
+  text-align: left;
+}
+.query-facet-group .query-facet:last-child {
+  border-radius: 0 999px 999px 0;
+}
+.query-facet-group .query-facet:hover,
+.query-facet-group .query-facet:focus-visible,
+.query-facet-group .query-facet.active {
+  z-index: 1;
 }
 .query-results { min-width: 0; }
 .query-list { display: grid; gap: 10px; }
@@ -2198,6 +2227,7 @@ kbd {
   .query-facet-rail { position: static; }
   .query-facets { flex-flow: row wrap; }
   .query-facet { width: auto; text-align: center; }
+  .query-facet-group { width: auto; }
   .query-row-meta { flex-wrap: wrap; }
   .query-row-meta button { flex-basis: 100%; margin-left: 0; }
 }

--- a/prototypes/inspect-web/test/package-query-source.test.ts
+++ b/prototypes/inspect-web/test/package-query-source.test.ts
@@ -38,6 +38,8 @@ test("packageQueryFacets preserves product descriptors and producer ordering", (
         weight: 20,
         tier: "Nuspec",
         selectionGroupId: "package.query.dependencies",
+        displayGroupId: null,
+        displayGroupLabel: null,
       },
       {
         id: "package.query.source-verified",
@@ -46,6 +48,18 @@ test("packageQueryFacets preserves product descriptors and producer ordering", (
         weight: 10,
         tier: "Nuspec",
         selectionGroupId: null,
+        displayGroupId: null,
+        displayGroupLabel: null,
+      },
+      {
+        id: "package.query.dotnet-tool-v2",
+        label: "v2",
+        summary: "RID-specific .NET tool format.",
+        weight: 30,
+        tier: "PackageContent",
+        selectionGroupId: "package.query.dotnet-tool-format",
+        displayGroupId: "package.query.display.dotnet-tool",
+        displayGroupLabel: ".NET tool format",
       },
     ],
   };
@@ -58,6 +72,8 @@ test("packageQueryFacets preserves product descriptors and producer ordering", (
       weight: 20,
       tier: "nuspec",
       selectionGroupId: "package.query.dependencies",
+      displayGroupId: null,
+      displayGroupLabel: null,
     },
     {
       key: "package.query.source-verified",
@@ -66,8 +82,88 @@ test("packageQueryFacets preserves product descriptors and producer ordering", (
       weight: 10,
       tier: "nuspec",
       selectionGroupId: null,
+      displayGroupId: null,
+      displayGroupLabel: null,
+    },
+    {
+      key: "package.query.dotnet-tool-v2",
+      label: "v2",
+      summary: "RID-specific .NET tool format.",
+      weight: 30,
+      tier: "package-content",
+      selectionGroupId: "package.query.dotnet-tool-format",
+      displayGroupId: "package.query.display.dotnet-tool",
+      displayGroupLabel: ".NET tool format",
     },
   ]);
+});
+
+test("Browser data source maps package-content rows and visible failures", async () => {
+  const matchEvent: BrowserPackageQueryEvent = {
+    kind: "Match",
+    failure: null,
+    completion: null,
+    row: {
+      packageId: "Contoso.Tool",
+      version: "2.0.0",
+      tier: "PackageContent",
+      evidence: [{
+        id: "package.query.dotnet-tool-v2",
+        text: "DotnetToolSettings.xml declares v2.",
+      }],
+      totalDownloads: 12,
+      verified: false,
+      producer: "nuget.org",
+    },
+  };
+  const failureEvent: BrowserPackageQueryEvent = {
+    kind: "Failure",
+    row: null,
+    completion: null,
+    failure: {
+      packageId: "Contoso.Bad",
+      version: "1.0.0",
+      producer: "nuget.org",
+      kind: "PackageContentEvaluation",
+      message: "package content could not be evaluated",
+    },
+  };
+  let candidateLimit = 0;
+  const engine: BrowserPackageQueryEngine = {
+    cancel() {},
+    async run(_prefix, _facets, candidates, _matches, _prerelease, sink) {
+      candidateLimit = candidates;
+      assert.ok(typeof sink === "object" && sink !== null);
+      Reflect.set(sink, "event", JSON.stringify(matchEvent));
+      Reflect.set(sink, "event", JSON.stringify(failureEvent));
+      return completionEvent;
+    },
+  };
+  const rows: { packageId: string; tier: string }[] = [];
+  const failures: string[] = [];
+  const request = withFacet(createQueryRequest("Contoso."), {
+    key: "package.query.dotnet-tool-v2",
+    label: "v2",
+    tier: "package-content",
+  });
+
+  await createBrowserPackageQueryDataSource(engine).run(
+    request,
+    page => rows.push(...page.map(row => ({
+      packageId: row.packageId,
+      tier: row.tier,
+    }))),
+    failure => failures.push(failure),
+    new AbortController().signal);
+
+  assert.equal(candidateLimit, 20);
+  assert.deepEqual(rows, [{
+    packageId: "Contoso.Tool",
+    tier: "package-content",
+  }]);
+  assert.deepEqual(
+    failures,
+    ["Contoso.Bad@1.0.0: package content could not be evaluated"]);
 });
 
 test("Browser data source streams matches and failures before terminal completion", async () => {

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -32,7 +32,43 @@ const escapeHtml = (value: unknown) => String(value)
 
 const NUSPEC_FACET: QueryFacetTerm = { key: "tfm-out-of-support", label: "out-of-support only", tier: "nuspec" };
 const DOWNLOAD_FACET: QueryFacetTerm = { key: "downloads-1m", label: "1M+ downloads", tier: "nuspec" };
-const FACETS: readonly QueryFacetTerm[] = [NUSPEC_FACET, DOWNLOAD_FACET];
+const TOOL_FACETS: readonly QueryFacetTerm[] = [
+  {
+    key: "package.query.dotnet-tool",
+    label: ".NET Tool",
+    tier: "nuspec",
+    selectionGroupId: "package.query.dotnet-tool-format",
+    displayGroupId: "package.query.display.dotnet-tool",
+    displayGroupLabel: ".NET tool format",
+  },
+  {
+    key: "package.query.dotnet-tool-v1",
+    label: "v1",
+    tier: "package-content",
+    selectionGroupId: "package.query.dotnet-tool-format",
+    displayGroupId: "package.query.display.dotnet-tool",
+    displayGroupLabel: ".NET tool format",
+  },
+  {
+    key: "package.query.dotnet-tool-v2",
+    label: "v2",
+    tier: "package-content",
+    selectionGroupId: "package.query.dotnet-tool-format",
+    displayGroupId: "package.query.display.dotnet-tool",
+    displayGroupLabel: ".NET tool format",
+  },
+];
+const SKILL_FACET: QueryFacetTerm = {
+  key: "package.query.embedded-skill",
+  label: "embedded SKILL.md",
+  tier: "package-content",
+};
+const FACETS: readonly QueryFacetTerm[] = [
+  NUSPEC_FACET,
+  ...TOOL_FACETS,
+  DOWNLOAD_FACET,
+  SKILL_FACET,
+];
 
 function row(packageId: string): QueryResultRow {
   return {
@@ -131,6 +167,50 @@ test("facet buttons expose pressed state without shipping promoted placeholders"
     html,
     /data-query-facet="downloads-1m"[\s\S]*aria-pressed="false"/);
   assert.doesNotMatch(html, /promoted|Deepen/);
+});
+
+test("tool format facets render as one independently selectable segmented control", () => {
+  const state: PackageQueryState = {
+    request: withFacet(
+      createQueryRequest("Microsoft."),
+      TOOL_FACETS[2]!),
+    outcome: appendRows(emptyOutcome(), [row("A")]),
+  };
+
+  const html = renderPackageQueryView({
+    state,
+    availableFacets: FACETS,
+    escapeHtml,
+  });
+
+  assert.match(
+    html,
+    /class="query-facet-group"[\s\S]*role="group"[\s\S]*aria-label="\.NET tool format"/);
+  assert.match(
+    html,
+    /data-query-facet="package\.query\.dotnet-tool"[\s\S]*>\s*\.NET Tool\s*<\/button>[\s\S]*data-query-facet="package\.query\.dotnet-tool-v1"[\s\S]*>\s*v1\s*<\/button>[\s\S]*data-query-facet="package\.query\.dotnet-tool-v2"[\s\S]*aria-pressed="true"[\s\S]*>\s*v2\s*<\/button>/);
+  assert.match(html, />\s*embedded SKILL\.md\s*<\/button>/);
+  assert.match(
+    html,
+    /Content facets download up to 20 candidate package archives/);
+});
+
+test("package-content results disclose their evidence tier", () => {
+  const state: PackageQueryState = {
+    request: withFacet(createQueryRequest("Contoso."), SKILL_FACET),
+    outcome: appendRows(emptyOutcome(), [{
+      ...row("Contoso.Skill"),
+      tier: "package-content",
+    }]),
+  };
+
+  const html = renderPackageQueryView({
+    state,
+    availableFacets: FACETS,
+    escapeHtml,
+  });
+
+  assert.match(html, /query-tier-package-content">package-content</);
 });
 
 test("a facet catalog failure remains visible beside an empty facet rail", () => {

--- a/prototypes/inspect-web/test/package-query.test.ts
+++ b/prototypes/inspect-web/test/package-query.test.ts
@@ -40,6 +40,12 @@ const NO_DEPENDENCIES_FACET: QueryFacetTerm = {
   selectionGroupId: "package.query.dependencies",
 };
 
+const SKILL_FACET: QueryFacetTerm = {
+  key: "package.query.embedded-skill",
+  label: "embedded SKILL.md",
+  tier: "package-content",
+};
+
 function row(packageId: string): QueryResultRow {
   return {
     packageId,
@@ -66,6 +72,19 @@ test("createQueryRequest gives candidate and match limits independent defaults",
   assert.equal(defaults.requestedLimit, 200);
   assert.equal(defaults.requestedMatchLimit, 100);
   assert.notEqual(defaults.requestedLimit, defaults.requestedMatchLimit);
+});
+
+test("package-content facets lower the candidate bound until the last one is removed", () => {
+  const base = createQueryRequest("Microsoft.");
+  const withSkill = withFacet(base, SKILL_FACET);
+  const withSkillAndManifest = withFacet(withSkill, TFM_FACET);
+  const manifestOnly = withoutFacet(
+    withSkillAndManifest,
+    SKILL_FACET.key);
+
+  assert.equal(withSkill.requestedLimit, 20);
+  assert.equal(withSkillAndManifest.requestedLimit, 20);
+  assert.equal(manifestOnly.requestedLimit, 200);
 });
 
 test("withScopeQuery preserves facets and bounds while changing the prefix", () => {

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using DotnetInspector.Packages;
 using InertText;
 using NuGetFetch;
 
@@ -13,18 +15,29 @@ public sealed class PackageQueryTests
             [
                 ("package.query.source-verified", 100),
                 ("package.query.dotnet-tool", 200),
+                ("package.query.dotnet-tool-v1", 210),
+                ("package.query.dotnet-tool-v2", 220),
                 ("package.query.has-dependencies", 300),
                 ("package.query.no-dependencies", 400),
                 ("package.query.downloads-1m", 500),
                 ("package.query.embedded-readme", 600),
+                ("package.query.embedded-skill", 700),
             ],
             PackageQuery.Facets.Select(facet =>
                 (facet.Id, facet.Weight)));
-        Assert.All(
-            PackageQuery.Facets,
-            facet => Assert.Equal(
+        Assert.Equal(
+            [
                 PackageQueryFacetTier.Nuspec,
-                facet.Tier));
+                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.PackageContent,
+                PackageQueryFacetTier.PackageContent,
+                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.Nuspec,
+                PackageQueryFacetTier.PackageContent,
+            ],
+            PackageQuery.Facets.Select(facet => facet.Tier));
         Assert.Equal(
             PackageQuery.DependencySelectionGroupId,
             PackageQuery.Facets.Single(facet =>
@@ -35,6 +48,29 @@ public sealed class PackageQueryTests
             PackageQuery.Facets.Single(facet =>
                 facet.Id == PackageQuery.NoDependenciesFacetId)
                 .SelectionGroupId);
+        Assert.Equal(
+            ".NET Tool",
+            PackageQuery.Facets.Single(facet =>
+                facet.Id == PackageQuery.ToolFacetId).Label);
+        Assert.Equal(
+            "embedded SKILL.md",
+            PackageQuery.Facets.Single(facet =>
+                facet.Id == PackageQuery.EmbeddedSkillFacetId).Label);
+        Assert.All(
+            PackageQuery.Facets.Where(facet =>
+                facet.Id is PackageQuery.ToolFacetId
+                    or PackageQuery.ToolV1FacetId
+                    or PackageQuery.ToolV2FacetId),
+            facet =>
+            {
+                Assert.Equal(
+                    PackageQuery.ToolSelectionGroupId,
+                    facet.SelectionGroupId);
+                Assert.Equal(
+                    PackageQuery.ToolDisplayGroupId,
+                    facet.DisplayGroupId);
+                Assert.Equal(".NET tool format", facet.DisplayGroupLabel);
+            });
     }
 
     [Theory]
@@ -104,6 +140,37 @@ public sealed class PackageQueryTests
         Assert.Equal(
             PackageProfileQuery.MaximumPackageLimit,
             plan.MaximumMatches);
+    }
+
+    [Fact]
+    public void Plan_RequiresThePackageContentCandidateBound()
+    {
+        PackageQueryRequestFailure rejected = Rejected(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.EmbeddedSkillFacetId],
+                    MaximumCandidates:
+                        PackageQuery.MaximumPackageContentCandidates + 1)));
+
+        Assert.Equal(
+            PackageQueryRequestFailureReason
+                .PackageContentCandidateLimitExceeded,
+            rejected.Reason);
+        Assert.Equal(
+            PackageQuery.MaximumPackageContentCandidates + 1,
+            rejected.Value);
+
+        PackageQueryPlan accepted = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.EmbeddedSkillFacetId],
+                    MaximumCandidates:
+                        PackageQuery.MaximumPackageContentCandidates)));
+        Assert.Equal(
+            PackageQueryFacetTier.PackageContent,
+            Assert.Single(accepted.Facets).Tier);
     }
 
     [Fact]
@@ -384,6 +451,169 @@ public sealed class PackageQueryTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_PackageContentFacetsMatchSkillsAndToolFormats()
+    {
+        PackageSearchMatch[] candidates =
+        [
+            Match("Contoso.V1"),
+            Match("Contoso.V2"),
+            Match("Contoso.Library"),
+        ];
+        var source = new FakePackageSource(
+            candidates,
+            candidates.ToDictionary(
+                candidate =>
+                    $"{candidate.Metadata.Id.ToLowerInvariant()}@1.0.0",
+                candidate => Manifest(
+                    candidate.Metadata.Id,
+                    packageTypes: candidate.Metadata.Id == "Contoso.Library"
+                        ? ""
+                        : """
+                          <packageTypes>
+                            <packageType name="DotnetTool" />
+                          </packageTypes>
+                          """)));
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>
+            {
+                ["Contoso.V1"] = new FakePackageContent(
+                    ("tools/net8.0/any/DotnetToolSettings.xml",
+                        "<DotNetCliTool><Commands /></DotNetCliTool>"),
+                    ("SKILLS/demo/skill.MD", "# Demo")),
+                ["Contoso.V2"] = new FakePackageContent(
+                    ("tools/any/any/DotnetToolSettings.xml",
+                        "<DotNetCliTool Version=\"2\"><Commands /></DotNetCliTool>")),
+                ["Contoso.Library"] = new FakePackageContent(
+                    ("skills/SKILL.md", "# Library")),
+            });
+
+        PackageQueryPlan v1Plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolV1FacetId],
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+        List<PackageQueryEvent> v1Events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                v1Plan,
+                content,
+                TestContext.Current.CancellationToken));
+        PackageQueryMatch v1 = Assert.Single(
+            v1Events.OfType<PackageQueryEvent.Match>()).Value;
+        Assert.Equal("Contoso.V1", v1.Package.PackageId);
+        Assert.Equal(PackageQueryFacetTier.PackageContent, v1.Tier);
+        Assert.Equal(
+            [PackageQuery.PrefixEvidenceId, PackageQuery.ToolV1FacetId],
+            v1.Evidence.Select(evidence => evidence.Id));
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.V2"],
+            content.Requests);
+
+        content.Requests.Clear();
+        PackageQueryPlan v2Plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolV2FacetId],
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+        List<PackageQueryEvent> v2Events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                v2Plan,
+                content,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "Contoso.V2",
+            Assert.Single(v2Events.OfType<PackageQueryEvent.Match>())
+                .Value.Package.PackageId);
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.V2"],
+            content.Requests);
+
+        content.Requests.Clear();
+        PackageQueryPlan skillPlan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.EmbeddedSkillFacetId],
+                    MaximumCandidates: 3,
+                    MaximumMatches: 3)));
+        List<PackageQueryEvent> skillEvents = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                skillPlan,
+                content,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.Library"],
+            skillEvents.OfType<PackageQueryEvent.Match>()
+                .Select(item => item.Value.Package.PackageId));
+        Assert.Equal(
+            ["Contoso.V1", "Contoso.V2", "Contoso.Library"],
+            content.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PackageContentAcquisitionFailureRemainsVisible()
+    {
+        var source = SourceFor(Manifest("Contoso.Package"));
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>(),
+            "package payload unavailable");
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.EmbeddedSkillFacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                content,
+                TestContext.Current.CancellationToken));
+
+        PackageQueryFailure failure =
+            Assert.IsType<PackageQueryEvent.Failure>(events[0]).Value;
+        Assert.Equal(
+            PackageQueryFailureKind.PackageContentAcquisition,
+            failure.Kind);
+        Assert.Equal("package payload unavailable", failure.Message);
+        PackageQuerySummary summary =
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
+        Assert.Equal(1, summary.Failures);
+        Assert.Equal(0, summary.Matches);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PackageContentFacetRequiresProviderBeforeSourceWork()
+    {
+        var source = SourceFor(Manifest("Contoso.Package"));
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.EmbeddedSkillFacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CollectAsync(
+                PackageQuery.ExecuteAsync(
+                    source,
+                    plan,
+                    TestContext.Current.CancellationToken)));
+
+        Assert.Empty(source.ManifestRequests);
+        Assert.Equal(0, source.LastSearchTake);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_RejectsCloseFacetNegatives()
     {
         await AssertNoMatchesAsync(
@@ -621,9 +851,9 @@ public sealed class PackageQueryTests
                 plan,
                 TestContext.Current.CancellationToken));
 
-        PackageProfileFailure failure =
+        PackageQueryFailure failure =
             Assert.IsType<PackageQueryEvent.Failure>(events[0]).Value;
-        Assert.Equal(PackageProfileFailureKind.SearchContract, failure.Kind);
+        Assert.Equal(PackageQueryFailureKind.SearchContract, failure.Kind);
         PackageQuerySummary summary =
             Assert.IsType<PackageQueryEvent.Completed>(events[^1]).Value;
         Assert.Equal(PackageQueryCompletionKind.Failed, summary.Completion);
@@ -1043,5 +1273,83 @@ public sealed class PackageQueryTests
         public void Dispose()
         {
         }
+    }
+
+    private sealed class FakePackageQueryContentProvider(
+        IReadOnlyDictionary<string, IPackageContent> content,
+        string unavailableMessage = "package content unavailable")
+        : IPackageQueryContentProvider
+    {
+        public List<string> Requests { get; } = [];
+
+        public ValueTask<PackageQueryContentResult> GetContentAsync(
+            PackageProfileMatch package,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(package.PackageId);
+            return ValueTask.FromResult<PackageQueryContentResult>(
+                content.TryGetValue(
+                    package.PackageId,
+                    out IPackageContent? packageContent)
+                    ? new PackageQueryContentResult.Available(packageContent)
+                    : new PackageQueryContentResult.Unavailable(
+                        unavailableMessage));
+        }
+    }
+
+    private sealed class FakePackageContent(
+        params (string Path, string Content)[] entries)
+        : IPackageContent
+    {
+        readonly IReadOnlyDictionary<string, byte[]> _entries =
+            entries.ToDictionary(
+                entry => entry.Path,
+                entry => Encoding.UTF8.GetBytes(entry.Content),
+                StringComparer.Ordinal);
+
+        public string? RootPath => null;
+        public string? NupkgPath => null;
+        public bool FromCache => false;
+        public string ProducerKey => "nuget.org";
+        public bool RequiresArchiveTreeMatch => false;
+
+        public bool TryOpenArchive([NotNullWhen(true)] out Stream? stream)
+        {
+            stream = null;
+            return false;
+        }
+
+        public bool TryOpenEntry(
+            string relativePath,
+            [NotNullWhen(true)] out Stream? stream)
+        {
+            if (_entries.TryGetValue(relativePath, out byte[]? content))
+            {
+                stream = new MemoryStream(content, writable: false);
+                return true;
+            }
+
+            stream = null;
+            return false;
+        }
+
+        public bool TryOpenEntry(
+            string relativePath,
+            long maxExpandedBytes,
+            [NotNullWhen(true)] out Stream? stream)
+        {
+            if (!_entries.TryGetValue(relativePath, out byte[]? content)
+                || content.LongLength > maxExpandedBytes)
+            {
+                stream = null;
+                return false;
+            }
+
+            stream = new MemoryStream(content, writable: false);
+            return true;
+        }
+
+        public IEnumerable<string> EnumerateEntries() => _entries.Keys;
     }
 }

--- a/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageQueryTests.cs
@@ -482,7 +482,8 @@ public sealed class PackageQueryTests
                     ("SKILLS/demo/skill.MD", "# Demo")),
                 ["Contoso.V2"] = new FakePackageContent(
                     ("tools/any/any/DotnetToolSettings.xml",
-                        "<DotNetCliTool Version=\"2\"><Commands /></DotNetCliTool>")),
+                        "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                        + "<DotNetCliTool Version=\"2\"><Commands /></DotNetCliTool>")),
                 ["Contoso.Library"] = new FakePackageContent(
                     ("skills/SKILL.md", "# Library")),
             });
@@ -554,6 +555,52 @@ public sealed class PackageQueryTests
         Assert.Equal(
             ["Contoso.V1", "Contoso.V2", "Contoso.Library"],
             content.Requests);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidToolSettingsRemainVisible()
+    {
+        var source = SourceFor(
+            Manifest(
+                "Contoso.Tool",
+                packageTypes:
+                """
+                <packageTypes>
+                  <packageType name="DotnetTool" />
+                </packageTypes>
+                """),
+            "Contoso.Tool");
+        var content = new FakePackageQueryContentProvider(
+            new Dictionary<string, IPackageContent>
+            {
+                ["Contoso.Tool"] = new FakePackageContent(
+                    ("tools/net8.0/any/DotnetToolSettings.xml",
+                        "<DotNetCliTool Version=\"2\"><Commands>")),
+            });
+        PackageQueryPlan plan = Accepted(
+            PackageQuery.Plan(
+                new PackageQueryRequest(
+                    "Contoso.",
+                    [PackageQuery.ToolV2FacetId],
+                    MaximumCandidates: 1,
+                    MaximumMatches: 1)));
+
+        List<PackageQueryEvent> events = await CollectAsync(
+            PackageQuery.ExecuteAsync(
+                source,
+                plan,
+                content,
+                TestContext.Current.CancellationToken));
+
+        PackageQueryFailure failure =
+            Assert.IsType<PackageQueryEvent.Failure>(events[0]).Value;
+        Assert.Equal(
+            PackageQueryFailureKind.PackageContentEvaluation,
+            failure.Kind);
+        Assert.Equal(
+            1,
+            Assert.IsType<PackageQueryEvent.Completed>(events[^1])
+                .Value.Failures);
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Xml;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using InertText;
@@ -652,7 +653,8 @@ public static class PackageQuery
                                 or InvalidDataException
                                 or DecoderFallbackException
                                 or NotSupportedException
-                                or UnauthorizedAccessException)
+                                or UnauthorizedAccessException
+                                or XmlException)
                         {
                             // Iterator catch clauses cannot yield; null is
                             // projected below as a typed item failure.
@@ -847,8 +849,10 @@ public static class PackageQuery
                 string xml = new UTF8Encoding(
                     encoderShouldEmitUTF8Identifier: false,
                     throwOnInvalidBytes: true).GetString(bytes);
+                if (xml.Length > 0 && xml[0] == '\uFEFF')
+                    xml = xml[1..];
                 DotnetToolSettingsData? settings =
-                    DotnetToolSettingsParser.ParseContent(xml);
+                    DotnetToolSettingsParser.ParseContentOrThrow(xml);
                 if (settings is null)
                     return null;
                 string version = settings.Version ?? "1";

--- a/src/DotnetInspector.Queries/PackageQuery.cs
+++ b/src/DotnetInspector.Queries/PackageQuery.cs
@@ -1,6 +1,9 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
 using InertText;
 using NuGetFetch;
 
@@ -10,6 +13,7 @@ namespace DotnetInspector.Queries;
 public enum PackageQueryFacetTier
 {
     Nuspec,
+    PackageContent,
 }
 
 /// <summary>One product-owned package-query facet.</summary>
@@ -21,13 +25,19 @@ public enum PackageQueryFacetTier
 /// <param name="SelectionGroupId">
 /// Optional opaque identity shared by facets that cannot be selected together.
 /// </param>
+/// <param name="DisplayGroupId">
+/// Optional opaque identity shared by facets rendered as one grouped control.
+/// </param>
+/// <param name="DisplayGroupLabel">Accessible label for the grouped control.</param>
 public sealed record PackageQueryFacetDescriptor(
     string Id,
     string Label,
     string Summary,
     int Weight,
     PackageQueryFacetTier Tier,
-    string? SelectionGroupId = null);
+    string? SelectionGroupId = null,
+    string? DisplayGroupId = null,
+    string? DisplayGroupLabel = null);
 
 /// <summary>A bounded package-query request over one package-ID prefix.</summary>
 public sealed record PackageQueryRequest(
@@ -48,6 +58,7 @@ public enum PackageQueryRequestFailureReason
     UnknownFacet,
     DuplicateFacet,
     IncompatibleFacets,
+    PackageContentCandidateLimitExceeded,
 }
 
 /// <summary>
@@ -88,6 +99,8 @@ public sealed record PackageQueryRequestFailure
             "A package-query facet ID was selected more than once.",
         PackageQueryRequestFailureReason.IncompatibleFacets =>
             "The selected package-query facets cannot be combined.",
+        PackageQueryRequestFailureReason.PackageContentCandidateLimitExceeded =>
+            $"Package-content facets accept at most {PackageQuery.MaximumPackageContentCandidates} candidates.",
         _ => "The package-query request is invalid.",
     };
 }
@@ -150,6 +163,27 @@ public sealed record PackageQueryMatch(
     PackageQueryFacetTier Tier,
     ImmutableArray<PackageQueryEvidence> Evidence);
 
+/// <summary>The stage at which one package-query item failed.</summary>
+public enum PackageQueryFailureKind
+{
+    Search,
+    SearchContract,
+    ManifestAcquisition,
+    ManifestContract,
+    InvalidManifest,
+    PackageContentAcquisition,
+    PackageContentEvaluation,
+}
+
+/// <summary>One visible package-query failure.</summary>
+public sealed record PackageQueryFailure(
+    string? PackageId,
+    string? Version,
+    PackageSourceIdentity Producer,
+    PackageQueryFailureKind Kind,
+    string Message,
+    PackageManifestFailureReason? ManifestFailureReason = null);
+
 /// <summary>Why one package-query stream stopped.</summary>
 public enum PackageQueryCompletionKind
 {
@@ -180,33 +214,69 @@ public abstract record PackageQueryEvent
     }
 
     public sealed record Match(PackageQueryMatch Value) : PackageQueryEvent;
-    public sealed record Failure(PackageProfileFailure Value) : PackageQueryEvent;
+    public sealed record Failure(PackageQueryFailure Value) : PackageQueryEvent;
     public sealed record Completed(PackageQuerySummary Value) : PackageQueryEvent;
+}
+
+/// <summary>The result of acquiring admitted package content for one query candidate.</summary>
+public abstract record PackageQueryContentResult
+{
+    private PackageQueryContentResult()
+    {
+    }
+
+    public sealed record Available(IPackageContent Content)
+        : PackageQueryContentResult;
+
+    public sealed record Unavailable(string Message)
+        : PackageQueryContentResult;
+}
+
+/// <summary>
+/// Host capability for acquiring one exact candidate's admitted package content.
+/// </summary>
+public interface IPackageQueryContentProvider
+{
+    ValueTask<PackageQueryContentResult> GetContentAsync(
+        PackageProfileMatch package,
+        CancellationToken cancellationToken);
 }
 
 internal sealed record PackageQueryFacetDefinition(
     PackageQueryFacetDescriptor Descriptor,
-    Func<PackageProfileMatch, bool> Matches,
-    Func<PackageProfileMatch, InertString> Evidence);
+    Func<PackageProfileMatch, bool> MatchesManifest,
+    Func<PackageProfileMatch, InertString> Evidence,
+    Func<PackageContentFacts, bool>? MatchesPackageContent = null);
+
+internal sealed record PackageContentFacts(
+    bool HasSkillDocument,
+    string? ToolSettingsVersion);
 
 /// <summary>
-/// Plans and executes product-owned nuspec-tier facets over a bounded package
-/// profile without acquiring package archives or assemblies.
+/// Plans and executes product-owned manifest and package-content facets over a
+/// bounded package profile without loading inspected assemblies.
 /// </summary>
 public static class PackageQuery
 {
     public const int DefaultMaximumCandidates = 200;
     public const int DefaultMaximumMatches = 100;
+    public const int MaximumPackageContentCandidates = 20;
     public const int MaximumFacetIdLength = 100;
+    public const int MaximumToolSettingsBytes = 64 * 1024;
 
     public const string PrefixEvidenceId = "package.query.scope.prefix";
     public const string VerifiedFacetId = "package.query.source-verified";
     public const string ToolFacetId = "package.query.dotnet-tool";
+    public const string ToolV1FacetId = "package.query.dotnet-tool-v1";
+    public const string ToolV2FacetId = "package.query.dotnet-tool-v2";
     public const string HasDependenciesFacetId = "package.query.has-dependencies";
     public const string NoDependenciesFacetId = "package.query.no-dependencies";
     public const string MillionDownloadsFacetId = "package.query.downloads-1m";
     public const string EmbeddedReadmeFacetId = "package.query.embedded-readme";
+    public const string EmbeddedSkillFacetId = "package.query.embedded-skill";
     public const string DependencySelectionGroupId = "package.query.dependencies";
+    public const string ToolSelectionGroupId = "package.query.dotnet-tool-format";
+    public const string ToolDisplayGroupId = "package.query.display.dotnet-tool";
 
     static readonly ImmutableArray<PackageQueryFacetDefinition> Definitions =
     [
@@ -223,13 +293,44 @@ public static class PackageQuery
         new(
             new PackageQueryFacetDescriptor(
                 ToolFacetId,
-                ".NET tool",
+                ".NET Tool",
                 "The package manifest declares the .NET tool package type.",
                 200,
-                PackageQueryFacetTier.Nuspec),
+                PackageQueryFacetTier.Nuspec,
+                ToolSelectionGroupId,
+                ToolDisplayGroupId,
+                ".NET tool format"),
             static match => match.Manifest.IsToolPackage,
             static _ => Evidence(
                 "The package manifest declares a .NET tool package.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                ToolV1FacetId,
+                "v1",
+                "Downloads the package and matches the portable .NET tool format.",
+                210,
+                PackageQueryFacetTier.PackageContent,
+                ToolSelectionGroupId,
+                ToolDisplayGroupId,
+                ".NET tool format"),
+            static match => match.Manifest.IsToolPackage,
+            static _ => Evidence(
+                "DotnetToolSettings.xml declares the portable .NET tool v1 format."),
+            static content => content.ToolSettingsVersion == "1"),
+        new(
+            new PackageQueryFacetDescriptor(
+                ToolV2FacetId,
+                "v2",
+                "Downloads the package and matches the RID-specific .NET tool format.",
+                220,
+                PackageQueryFacetTier.PackageContent,
+                ToolSelectionGroupId,
+                ToolDisplayGroupId,
+                ".NET tool format"),
+            static match => match.Manifest.IsToolPackage,
+            static _ => Evidence(
+                "DotnetToolSettings.xml declares the RID-specific .NET tool v2 format."),
+            static content => content.ToolSettingsVersion == "2"),
         new(
             new PackageQueryFacetDescriptor(
                 HasDependenciesFacetId,
@@ -281,6 +382,17 @@ public static class PackageQuery
                 match.Manifest.ReadmeFile),
             static _ => Evidence(
                 "The package manifest declares an embedded README file.")),
+        new(
+            new PackageQueryFacetDescriptor(
+                EmbeddedSkillFacetId,
+                "embedded SKILL.md",
+                "Downloads the package and matches a skills/SKILL.md or skills/**/SKILL.md file.",
+                700,
+                PackageQueryFacetTier.PackageContent),
+            static _ => true,
+            static _ => Evidence(
+                "The package contains a skills/SKILL.md document."),
+            static content => content.HasSkillDocument),
     ];
 
     static readonly IReadOnlyDictionary<string, PackageQueryFacetDefinition>
@@ -385,6 +497,16 @@ public static class PackageQuery
                 incompatible.Select(definition =>
                     definition.Descriptor.Id));
         }
+        if (request.MaximumCandidates > MaximumPackageContentCandidates
+            && selected.Any(definition =>
+                definition.Descriptor.Tier
+                    == PackageQueryFacetTier.PackageContent))
+        {
+            return Rejected(
+                PackageQueryRequestFailureReason
+                    .PackageContentCandidateLimitExceeded,
+                value: request.MaximumCandidates);
+        }
 
         return new PackageQueryPlanResult.Accepted(
             new PackageQueryPlan(
@@ -402,11 +524,28 @@ public static class PackageQuery
             IPackageSourceClient source,
             PackageQueryPlan plan,
             CancellationToken cancellationToken = default)
+        => await ExecuteToArrayAsync(
+            source,
+            plan,
+            contentProvider: null,
+            cancellationToken).ConfigureAwait(false);
+
+    /// <summary>
+    /// Executes and materializes one validated package query with the explicit
+    /// package-content capability required by package-content facets.
+    /// </summary>
+    public static async ValueTask<ImmutableArray<PackageQueryEvent>>
+        ExecuteToArrayAsync(
+            IPackageSourceClient source,
+            PackageQueryPlan plan,
+            IPackageQueryContentProvider? contentProvider,
+            CancellationToken cancellationToken = default)
     {
         var events = ImmutableArray.CreateBuilder<PackageQueryEvent>();
         await foreach (PackageQueryEvent queryEvent in ExecuteAsync(
             source,
             plan,
+            contentProvider,
             cancellationToken).ConfigureAwait(false))
         {
             events.Add(queryEvent);
@@ -420,8 +559,36 @@ public static class PackageQuery
         PackageQueryPlan plan,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        await foreach (PackageQueryEvent queryEvent in ExecuteAsync(
+            source,
+            plan,
+            contentProvider: null,
+            cancellationToken).ConfigureAwait(false))
+        {
+            yield return queryEvent;
+        }
+    }
+
+    /// <summary>
+    /// Executes a package query with the explicit host capability required to
+    /// acquire admitted package content.
+    /// </summary>
+    public static async IAsyncEnumerable<PackageQueryEvent> ExecuteAsync(
+        IPackageSourceClient source,
+        PackageQueryPlan plan,
+        IPackageQueryContentProvider? contentProvider,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(plan);
+        bool requiresPackageContent = plan.Definitions.Any(definition =>
+            definition.Descriptor.Tier
+                == PackageQueryFacetTier.PackageContent);
+        if (requiresPackageContent && contentProvider is null)
+        {
+            throw new InvalidOperationException(
+                "Package-content facets require an explicit package-content provider.");
+        }
 
         int candidates = 0;
         int matches = 0;
@@ -441,15 +608,87 @@ public static class PackageQuery
             {
                 case PackageProfileEvent.Match match:
                     candidates++;
-                    if (!TryMatch(plan, match.Value, out var evidence))
+                    if (!TryMatchManifest(
+                        plan,
+                        match.Value,
+                        out ImmutableArray<PackageQueryEvidence>.Builder
+                            evidence))
                         continue;
+
+                    if (requiresPackageContent)
+                    {
+                        PackageQueryContentResult contentResult =
+                            await contentProvider!.GetContentAsync(
+                                match.Value,
+                                cancellationToken).ConfigureAwait(false);
+                        if (contentResult
+                            is PackageQueryContentResult.Unavailable unavailable)
+                        {
+                            failures++;
+                            yield return new PackageQueryEvent.Failure(
+                                new PackageQueryFailure(
+                                    match.Value.PackageId,
+                                    match.Value.Version,
+                                    match.Value.Producer,
+                                    PackageQueryFailureKind
+                                        .PackageContentAcquisition,
+                                    unavailable.Message));
+                            continue;
+                        }
+
+                        IPackageContent content =
+                            ((PackageQueryContentResult.Available)contentResult)
+                                .Content;
+                        PackageContentFacts? facts = null;
+                        try
+                        {
+                            facts = await ReadPackageContentFactsAsync(
+                                content,
+                                plan.Definitions,
+                                cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex) when (
+                            ex is IOException
+                                or InvalidDataException
+                                or DecoderFallbackException
+                                or NotSupportedException
+                                or UnauthorizedAccessException)
+                        {
+                            // Iterator catch clauses cannot yield; null is
+                            // projected below as a typed item failure.
+                        }
+                        if (facts is null)
+                        {
+                            failures++;
+                            yield return new PackageQueryEvent.Failure(
+                                new PackageQueryFailure(
+                                    match.Value.PackageId,
+                                    match.Value.Version,
+                                    match.Value.Producer,
+                                    PackageQueryFailureKind
+                                        .PackageContentEvaluation,
+                                    "The package content could not be evaluated."));
+                            continue;
+                        }
+
+                        if (!TryMatchPackageContent(
+                            plan,
+                            match.Value,
+                            facts,
+                            evidence))
+                        {
+                            continue;
+                        }
+                    }
 
                     matches++;
                     yield return new PackageQueryEvent.Match(
                         new PackageQueryMatch(
                             match.Value,
-                            PackageQueryFacetTier.Nuspec,
-                            evidence));
+                            requiresPackageContent
+                                ? PackageQueryFacetTier.PackageContent
+                                : PackageQueryFacetTier.Nuspec,
+                            evidence.MoveToImmutable()));
                     cancellationToken.ThrowIfCancellationRequested();
                     if (matches >= plan.MaximumMatches)
                     {
@@ -472,7 +711,8 @@ public static class PackageQuery
                         candidates++;
                     }
 
-                    yield return new PackageQueryEvent.Failure(failure.Value);
+                    yield return new PackageQueryEvent.Failure(
+                        FromProfileFailure(failure.Value));
                     break;
 
                 case PackageProfileEvent.Completed completed:
@@ -481,7 +721,7 @@ public static class PackageQuery
                         completed.Value.Producer,
                         completed.Value.Candidates,
                         matches,
-                        completed.Value.Failures,
+                        failures,
                         completed.Value.Candidates == 0
                             && completed.Value.Failures > 0
                             ? PackageQueryCompletionKind.Failed
@@ -495,34 +735,186 @@ public static class PackageQuery
             "The package profile stream ended without a completion event.");
     }
 
-    static bool TryMatch(
+    static bool TryMatchManifest(
         PackageQueryPlan plan,
         PackageProfileMatch match,
-        out ImmutableArray<PackageQueryEvidence> evidence)
+        out ImmutableArray<PackageQueryEvidence>.Builder evidence)
     {
-        var builder = ImmutableArray.CreateBuilder<PackageQueryEvidence>(
+        evidence = ImmutableArray.CreateBuilder<PackageQueryEvidence>(
             plan.Definitions.Length + 1);
-        builder.Add(
+        evidence.Add(
             new PackageQueryEvidence(
                 PrefixEvidenceId,
                 plan.PrefixEvidence));
         foreach (PackageQueryFacetDefinition definition in plan.Definitions)
         {
-            if (!definition.Matches(match))
+            if (!definition.MatchesManifest(match))
             {
-                evidence = [];
+                evidence.Clear();
                 return false;
             }
 
-            builder.Add(
+            if (definition.Descriptor.Tier == PackageQueryFacetTier.Nuspec)
+            {
+                evidence.Add(
+                    new PackageQueryEvidence(
+                        definition.Descriptor.Id,
+                        definition.Evidence(match)));
+            }
+        }
+
+        return true;
+    }
+
+    static bool TryMatchPackageContent(
+        PackageQueryPlan plan,
+        PackageProfileMatch match,
+        PackageContentFacts content,
+        ImmutableArray<PackageQueryEvidence>.Builder evidence)
+    {
+        foreach (PackageQueryFacetDefinition definition in plan.Definitions)
+        {
+            if (definition.Descriptor.Tier
+                    != PackageQueryFacetTier.PackageContent)
+            {
+                continue;
+            }
+            if (definition.MatchesPackageContent is null
+                || !definition.MatchesPackageContent(content))
+            {
+                return false;
+            }
+
+            evidence.Add(
                 new PackageQueryEvidence(
                     definition.Descriptor.Id,
                     definition.Evidence(match)));
         }
 
-        evidence = builder.MoveToImmutable();
         return true;
     }
+
+    static async ValueTask<PackageContentFacts> ReadPackageContentFactsAsync(
+        IPackageContent content,
+        ImmutableArray<PackageQueryFacetDefinition> definitions,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        string[] entries = [.. content.EnumerateEntries()];
+        bool needsSkills = definitions.Any(definition =>
+            definition.Descriptor.Id == EmbeddedSkillFacetId);
+        bool needsToolSettings = definitions.Any(definition =>
+            definition.Descriptor.Id is ToolV1FacetId or ToolV2FacetId);
+        bool hasSkill = needsSkills && entries.Any(IsSkillDocument);
+        string? toolVersion = needsToolSettings
+            ? await ReadToolSettingsVersionAsync(
+                content,
+                entries,
+                cancellationToken).ConfigureAwait(false)
+            : null;
+        return new PackageContentFacts(hasSkill, toolVersion);
+    }
+
+    static async ValueTask<string?> ReadToolSettingsVersionAsync(
+        IPackageContent content,
+        IEnumerable<string> entries,
+        CancellationToken cancellationToken)
+    {
+        string[] settingsPaths =
+        [
+            .. entries
+                .Where(IsToolSettings)
+                .Order(StringComparer.OrdinalIgnoreCase),
+        ];
+        string? packageVersion = null;
+        foreach (string path in settingsPaths)
+        {
+            if (!content.TryOpenEntry(
+                path,
+                MaximumToolSettingsBytes,
+                out Stream? stream))
+            {
+                throw new IOException(
+                    "The selected tool settings entry is unavailable.");
+            }
+
+            await using (stream.ConfigureAwait(false))
+            {
+                byte[] bytes = await BoundedContentReader.ReadAllBytesAsync(
+                    stream,
+                    MaximumToolSettingsBytes,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                string xml = new UTF8Encoding(
+                    encoderShouldEmitUTF8Identifier: false,
+                    throwOnInvalidBytes: true).GetString(bytes);
+                DotnetToolSettingsData? settings =
+                    DotnetToolSettingsParser.ParseContent(xml);
+                if (settings is null)
+                    return null;
+                string version = settings.Version ?? "1";
+                if (packageVersion is null)
+                {
+                    packageVersion = version;
+                }
+                else if (!packageVersion.Equals(
+                    version,
+                    StringComparison.Ordinal))
+                {
+                    return null;
+                }
+            }
+        }
+
+        return packageVersion;
+    }
+
+    static bool IsSkillDocument(string path)
+    {
+        string[] segments = path.Split('/');
+        return segments.Length >= 2
+            && segments[0].Equals(
+                "skills",
+                StringComparison.OrdinalIgnoreCase)
+            && segments[^1].Equals(
+                "SKILL.md",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool IsToolSettings(string path)
+    {
+        string[] segments = path.Split('/');
+        return segments.Length is >= 2 and <= 4
+            && segments[0].Equals(
+                "tools",
+                StringComparison.OrdinalIgnoreCase)
+            && segments[^1].Equals(
+                "DotnetToolSettings.xml",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    static PackageQueryFailure FromProfileFailure(
+        PackageProfileFailure failure) =>
+        new(
+            failure.PackageId,
+            failure.Version,
+            failure.Producer,
+            failure.Kind switch
+            {
+                PackageProfileFailureKind.Search =>
+                    PackageQueryFailureKind.Search,
+                PackageProfileFailureKind.SearchContract =>
+                    PackageQueryFailureKind.SearchContract,
+                PackageProfileFailureKind.ManifestAcquisition =>
+                    PackageQueryFailureKind.ManifestAcquisition,
+                PackageProfileFailureKind.ManifestContract =>
+                    PackageQueryFailureKind.ManifestContract,
+                PackageProfileFailureKind.InvalidManifest =>
+                    PackageQueryFailureKind.InvalidManifest,
+                _ => throw new InvalidOperationException(
+                    "Unknown package-profile failure kind."),
+            },
+            failure.Message,
+            failure.ManifestFailureReason);
 
     static int DependencyCount(PackageProfileMatch match) =>
         match.Manifest.DependencyGroups.Sum(group =>

--- a/src/DotnetInspector.Services.Tests/DotnetToolSettingsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/DotnetToolSettingsParserTests.cs
@@ -77,6 +77,14 @@ public class DotnetToolSettingsParserTests
     }
 
     [Fact]
+    public void ParseContent_UnrelatedRoot_ReturnsNull()
+    {
+        Assert.Null(
+            DotnetToolSettingsParser.ParseContent(
+                """<NotDotNetTool Version="2" />"""));
+    }
+
+    [Fact]
     public void ParseContent_MalformedXml_ReturnsNullWithoutThrowing()
     {
         Assert.Null(DotnetToolSettingsParser.ParseContent("<DotNetCliTool Version=\"2\"><Commands>"));

--- a/src/DotnetInspector.Services/DotnetToolSettingsParser.cs
+++ b/src/DotnetInspector.Services/DotnetToolSettingsParser.cs
@@ -74,7 +74,7 @@ public static class DotnetToolSettingsParser
     {
         try
         {
-            return ParseDocument(HardenedXml.ParseXDocument(xml));
+            return ParseContentOrThrow(xml);
         }
         catch
         {
@@ -82,9 +82,25 @@ public static class DotnetToolSettingsParser
         }
     }
 
+    /// <summary>
+    /// Parses <c>DotnetToolSettings.xml</c> from raw XML content, or
+    /// <see langword="null"/> for an unsupported document.
+    /// </summary>
+    /// <exception cref="System.Xml.XmlException">
+    /// The content is not a well-formed XML document.
+    /// </exception>
+    public static DotnetToolSettingsData? ParseContentOrThrow(string xml)
+    {
+        ArgumentNullException.ThrowIfNull(xml);
+        return ParseDocument(HardenedXml.ParseXDocument(xml));
+    }
+
     private static DotnetToolSettingsData? ParseDocument(XDocument doc)
     {
         var root = doc.Root;
+        if (root?.Name != "DotNetCliTool")
+            return null;
+
         var version = root?.Attribute("Version")?.Value;
 
         return version switch


### PR DESCRIPTION
Build robust, capable package discovery that combines conventionally sound
bounded acquisition with a compact, distinctive query experience.

## Demo

The package-query facet rail now renders the product-issued tool family as one
segmented control:

```text
[ .NET Tool | v1 | v2 ]

embedded README
embedded SKILL.md

Content facets download up to 20 candidate package archives.
```

- `.NET Tool` remains a manifest-only query for any .NET tool package.
- `v1` and `v2` select the portable or RID-specific tool format from
  `DotnetToolSettings.xml`.
- `embedded SKILL.md` finds `skills/SKILL.md` and nested
  `skills/**/SKILL.md` package entries.

Each segment remains an independently focusable pressed-state button. Selecting
a package-content facet automatically lowers the candidate limit from 200 to
20; removing the final content facet restores the manifest-only limit.

## Summary

- Add a product-owned `PackageContent` facet tier with explicit host
  capability, bounded evaluation, manifest prefiltering, typed evidence, and
  visible per-package acquisition/evaluation failures.
- Reuse the Browser package store, payload admission, transfer reservations,
  cancellation, and shared operation deadline instead of introducing another
  archive path.
- Project grouping and tier metadata through generated Browser contracts and
  render `.NET Tool | v1 | v2` without browser-owned predicate logic.
- Update the package-query and progressive-disclosure designs while keeping
  assembly/IL promoted evaluation out of scope.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- 35 focused `PackageQueryTests`
- 8 focused Browser package-query tests
- 51 focused TypeScript package-query tests
- Inspect Web typecheck, lint, production build, generated-facade check
- markdownlint for all changed design documents

Closes #5464
