### PR TITLE
Add Integration Inventory row projection

### DIFF
--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -861,11 +861,25 @@ candidate attempt and retains:
 - `In` or `Out` plus the typed `Out` reason; and
 - admitted relationship identity when `In`.
 
+The admitted relationship identity is the exact context-addressed candidate
+attempt. It is not a graph-local occurrence or edge id. A later graph
+projection must retain correspondence from this identity to the graph-owned
+occurrence and logical edge it admits.
+
+`IntegrationCensusProjectionResult` retains the independently validated plan
+and the exact compatible snapshot. `IntegrationInventoryProjectionResult`
+adds the immutable rows in the snapshot's canonical classified-attempt order.
+An incomplete snapshot may therefore retain healthy rows beside its original
+typed failures without projecting failed attempts as `Out` or successful empty
+rows.
+
 The Section is `Verbose`, `NetworkFree`, and `ExplicitOnly`. It does not enter
 the existing Library `@Integrations` catalog, so selecting that category keeps
 its current focused-section meaning and bounded output. A workspace host may
 assign the Section to an authored workspace category under the
 [Section model](section-model.md) contract.
+The reusable L2 catalog and schema exist independently of host registration;
+this slice does not add a CLI route or Library pipeline binding.
 Those declarations describe the Integration-produced row set;
 [Section model](section-model.md) remains authoritative for discovery,
 selection, effectiveness, category expansion, count, and empty-section
@@ -980,7 +994,9 @@ Implementation should land as focused slices:
    and the projection-neutral Census snapshot (implemented core model);
 3. sequential Workspace-backed execution over exact typed capability bindings
    (implemented);
-4. `Integration Inventory` row Section and structured row output;
+4. `Integration Inventory` row Section and structured row output
+   (implemented as a host-neutral row projection plus an unregistered reusable
+   L2 catalog and schema);
 5. graph correspondence from `In` candidates without changing graph semantics;
 6. sparse matrix projection and WASM demo; and
 7. separately owned #4979 `find` prerequisite or optional enrichment for
@@ -1115,6 +1131,23 @@ The projection-neutral core-model slice is verified by:
 - `IntegrationCensusExecutor_ResolvedFulfillmentSourcesExactlyCoverDeclaredLookups`
 - `IntegrationCensusExecutor_FulfillmentResolutionCannotRepeatLookup`
 
+The Integration Inventory row-projection slice is verified by:
+
+- `IntegrationInventory_RowsRetainTypedSourcePeerAndProvenance`
+- `IntegrationInventory_PeerLookupRetainsEveryTypeReferenceScopeArm`
+- `IntegrationInventory_ForwardedInAndOutRetainTerminalDefinitionProvenanceAndHops`
+- `IntegrationInventory_ForwardedOutUsesTerminalParentForHandoff`
+- `IntegrationInventory_KnownParentUsesAuthoritativeCoordinate`
+- `IntegrationInventory_UnknownParentNeverGuessesFromAssemblyName`
+- `IntegrationInventory_FindPatternUsesTypeLookupGrammarUnchanged`
+- `IntegrationInventory_SameCandidateAcrossContextsProducesDistinctRows`
+- `IntegrationInventory_IncompleteCensusRetainsHealthyRowsWithoutManufacturingFailureRows`
+- `IntegrationInventory_IncompleteEmptyCensusRetainsFailureState`
+- `IntegrationInventory_IsExplicitNetworkFreeVerboseSection`
+- `IntegrationInventory_DoesNotWidenLibraryIntegrationsCategory`
+- `IntegrationProjection_EachResponseRetainsItsExactValidatedRequest`
+- `IntegrationProjection_ReuseRequiresCompatibleCensusSnapshot`
+
 The remaining target implementation is unverified until these named gates
 land:
 
@@ -1125,15 +1158,6 @@ land:
 - `IntegrationCandidate_UnavailableAmbiguousOrMissingSelectedPeerIsFailure`
 - `IntegrationCandidate_UnresolvedForwardingIsFailure`
 - `IntegrationCandidate_RemovingSoleSourceRemovesCandidate`
-- `IntegrationInventory_RowsRetainTypedSourcePeerAndProvenance`
-- `IntegrationInventory_PeerLookupRetainsEveryTypeReferenceScopeArm`
-- `IntegrationInventory_ForwardedInAndOutRetainTerminalDefinitionProvenanceAndHops`
-- `IntegrationInventory_ForwardedOutUsesTerminalParentForHandoff`
-- `IntegrationInventory_KnownParentUsesAuthoritativeCoordinate`
-- `IntegrationInventory_UnknownParentNeverGuessesFromAssemblyName`
-- `IntegrationInventory_FindPatternUsesTypeLookupGrammarUnchanged`
-- `IntegrationInventory_IsExplicitNetworkFreeVerboseSection`
-- `IntegrationInventory_DoesNotWidenLibraryIntegrationsCategory`
 - `IntegrationMatrix_RetainsCandidateIdentityAndDispositionCounts`
 - `IntegrationMatrix_RepeatedLibraryAcrossContextsRemainsDistinct`
 - `IntegrationMatrix_IncompleteLibraryDoesNotRenderAsZero`
@@ -1146,8 +1170,6 @@ land:
 - `IntegrationGraph_CandidateInventoryPrecedesInducedSetProjection`
 - `IntegrationGraph_RetainsCandidateAttemptOccurrenceAndEdgeCorrespondence`
 - `IntegrationGraph_MultipleCandidatesMayCorrespondToOneLogicalEdge`
-- `IntegrationProjection_EachResponseRetainsItsExactValidatedRequest`
-- `IntegrationProjection_ReuseRequiresCompatibleCensusSnapshot`
 - `IntegrationProjection_RowsMatrixAndGraphShareOneAnalysisAndSnapshot`
 - `IntegrationWasmDemo_RendersSharedProjectionWithoutDetectionPolicy`
 

--- a/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
+++ b/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
@@ -1813,6 +1813,570 @@ public sealed class IntegrationCensusTests
             snapshot.CatalogRevision);
     }
 
+    // ---- Inventory projection ------------------------------------------
+
+    [Fact]
+    public void IntegrationInventory_RowsRetainTypedSourcePeerAndProvenance()
+    {
+        RealizedMemberCoordinate.Package sourceCoordinate = new(
+            "contoso.adapters",
+            "1.0.0",
+            "fixture",
+            "net11.0",
+            null);
+        IntegrationSourceParticipantIdentity participant =
+            IntegrationSourceParticipantIdentity.Portable(
+                sourceCoordinate,
+                Assembly("Adapters"));
+        MetadataTypeDefinitionName sourceType =
+            TypeName("Adapters", "ClientAdapter");
+        IntegrationCandidateSourceElement.Member sourceMember = new(
+            sourceType,
+            Anchor(sourceType.ToMetadataFullName()));
+        IntegrationCandidatePeerIdentity peer = AssemblyPeer(
+            Assembly("Peer.Contracts"),
+            TypeName("Peer", "Client"));
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            peer,
+            sourceMember);
+        RealizedMemberCoordinate.Platform terminalCoordinate = new(
+            "runtime",
+            "11.0.0",
+            "fixture",
+            "net11.0",
+            assembly: null);
+        IntegrationTypeIdentity terminal = new(
+            IntegrationSourceParticipantIdentity.Portable(
+                terminalCoordinate,
+                Assembly("Peer.Runtime")),
+            peer.Type);
+        var context = new Context();
+        IntegrationCandidateAttemptAddress address = new(candidate, context);
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(
+                    participant,
+                    Ecosystem,
+                    candidate,
+                    candidate)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                new IntegrationCandidateAttempt.Classified(
+                    address,
+                    new IntegrationCandidateDisposition.In(
+                        Resolved(candidate, terminal))),
+            ],
+            plan: plan);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(plan, snapshot);
+        IntegrationInventoryRow row = Assert.Single(result.Rows);
+
+        Assert.Same(plan, result.Plan);
+        Assert.Same(snapshot, result.Snapshot);
+        Assert.Same(candidate.Relationship, row.Relationship);
+        Assert.Same(candidate.Concept, row.Concept);
+        Assert.Same(candidate.Source, row.Source);
+        Assert.Same(sourceMember, row.Source.Element);
+        Assert.Same(sourceCoordinate, row.SourceProvenance);
+        Assert.Same(sourceCoordinate, row.SourceParent);
+        Assert.Same(peer, row.PeerLookup.Identity);
+        Assert.Same(
+            Assert.IsType<
+                IntegrationCandidatePeerIdentity.NamedType>(peer)
+                .Reference.Scope,
+            row.PeerLookup.Scope);
+        Assert.Equal("Peer.Client", row.PeerLookup.FindPattern);
+        Assert.Same(
+            terminalCoordinate,
+            row.PeerLookup.AuthoritativeProvenance);
+        Assert.Same(
+            terminalCoordinate,
+            row.PeerLookup.AuthoritativeParent);
+        Assert.Same(terminal, row.TerminalDefinition);
+        Assert.Same(terminalCoordinate, row.TerminalProvenance);
+        Assert.Same(terminalCoordinate, row.TerminalParent);
+        Assert.Same(context, row.BindingContext);
+        Assert.Equal(address, row.AdmittedRelationshipIdentity);
+        Assert.Null(row.OutReason);
+        Assert.Same(
+            Ecosystem,
+            Assert.Single(row.ProducerPolicyAttempts).Policy);
+    }
+
+    [Fact]
+    public void IntegrationInventory_PeerLookupRetainsEveryTypeReferenceScopeArm()
+    {
+        MetadataTypeDefinitionName type = TypeName("Peer", "Client");
+        MetadataTypeReferenceScope[] scopes =
+        [
+            new MetadataTypeReferenceScope.CurrentAssembly(),
+            new MetadataTypeReferenceScope.IntrinsicCoreLibrary(),
+            new MetadataTypeReferenceScope.AssemblyReference(
+                Assembly("Peer.Contracts")),
+            new MetadataTypeReferenceScope.ModuleReference(
+                "peer.contracts.netmodule"),
+        ];
+
+        foreach (MetadataTypeReferenceScope scope in scopes)
+        {
+            IntegrationCandidatePeerIdentity identity =
+                NamedPeer(scope, type);
+            var lookup = new IntegrationPeerLookup(identity);
+
+            Assert.Same(identity, lookup.Identity);
+            Assert.Same(scope, lookup.Scope);
+            Assert.Same(type, lookup.Type);
+            Assert.Null(lookup.PolicyTarget);
+            Assert.Null(lookup.AuthoritativeProvenance);
+            Assert.Null(lookup.AuthoritativeParent);
+        }
+
+        IntegrationOpportunityTarget target = new(
+            "Peer.Contracts",
+            type);
+        var policyLookup = new IntegrationPeerLookup(
+            new IntegrationCandidatePeerIdentity.PolicyTarget(target));
+        Assert.Same(target, policyLookup.PolicyTarget);
+        Assert.Null(policyLookup.Scope);
+        Assert.Null(policyLookup.AuthoritativeProvenance);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void
+        IntegrationInventory_ForwardedInAndOutRetainTerminalDefinitionProvenanceAndHops(
+            bool inside)
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Facade"),
+                TypeName("Peer", "Client")));
+        IntegrationTypeIdentity facade = new(
+            ParticipantForAssembly(Assembly("Peer.Facade")),
+            candidate.Peer.Type);
+        RealizedMemberCoordinate.Package terminalCoordinate = new(
+            "contoso.peer.runtime",
+            "2.0.0",
+            "fixture",
+            "net11.0",
+            null);
+        IntegrationTypeIdentity terminal = new(
+            IntegrationSourceParticipantIdentity.Portable(
+                terminalCoordinate,
+                Assembly("Peer.Runtime")),
+            candidate.Peer.Type);
+        IntegrationResolvedPeer resolved = new(
+            candidate.Peer,
+            [facade, terminal]);
+        IntegrationCandidateDisposition disposition = inside
+            ? new IntegrationCandidateDisposition.In(resolved)
+            : new IntegrationCandidateDisposition.Out(resolved);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            selectedTypes: inside ? [terminal] : [],
+            contexts: [context],
+            candidateAttempts:
+            [
+                new IntegrationCandidateAttempt.Classified(
+                    new IntegrationCandidateAttemptAddress(
+                        candidate,
+                        context),
+                    disposition),
+            ],
+            plan: plan);
+
+        IntegrationInventoryRow row = Assert.Single(
+            IntegrationInventoryProjection.Project(plan, snapshot).Rows);
+
+        Assert.Equal([facade, terminal], row.ResolutionPath);
+        Assert.Equal([facade], row.ForwardingHops);
+        Assert.Same(terminal, row.TerminalDefinition);
+        Assert.Same(terminalCoordinate, row.TerminalProvenance);
+        Assert.Same(terminalCoordinate, row.TerminalParent);
+        if (inside)
+        {
+            Assert.NotNull(row.AdmittedRelationshipIdentity);
+            Assert.Null(row.OutReason);
+        }
+        else
+        {
+            Assert.Null(row.AdmittedRelationshipIdentity);
+            Assert.Equal(
+                IntegrationCandidateOutReason.PeerOutsideUniverse,
+                row.OutReason);
+        }
+    }
+
+    [Fact]
+    public void IntegrationInventory_ForwardedOutUsesTerminalParentForHandoff()
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Facade"),
+                TypeName("Peer", "Client")));
+        RealizedMemberCoordinate.Package facadeCoordinate = new(
+            "contoso.peer.facade",
+            "1.0.0",
+            "fixture",
+            "net11.0",
+            null);
+        RealizedMemberCoordinate.Package terminalCoordinate = new(
+            "contoso.peer.runtime",
+            "2.0.0",
+            "fixture",
+            "net11.0",
+            null);
+        IntegrationTypeIdentity facade = new(
+            IntegrationSourceParticipantIdentity.Portable(
+                facadeCoordinate,
+                Assembly("Peer.Facade")),
+            candidate.Peer.Type);
+        IntegrationTypeIdentity terminal = new(
+            IntegrationSourceParticipantIdentity.Portable(
+                terminalCoordinate,
+                Assembly("Peer.Runtime")),
+            candidate.Peer.Type);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            contexts: [context],
+            candidateAttempts:
+            [
+                new IntegrationCandidateAttempt.Classified(
+                    new IntegrationCandidateAttemptAddress(
+                        candidate,
+                        context),
+                    new IntegrationCandidateDisposition.Out(
+                        new IntegrationResolvedPeer(
+                            candidate.Peer,
+                            [facade, terminal]))),
+            ],
+            plan: plan);
+
+        IntegrationInventoryRow row = Assert.Single(
+            IntegrationInventoryProjection.Project(plan, snapshot).Rows);
+
+        Assert.Same(terminalCoordinate, row.TerminalParent);
+        Assert.Same(
+            terminalCoordinate,
+            row.PeerLookup.AuthoritativeParent);
+        Assert.NotSame(facadeCoordinate, row.TerminalParent);
+    }
+
+    [Fact]
+    public void IntegrationInventory_KnownParentUsesAuthoritativeCoordinate()
+    {
+        RealizedMemberCoordinate.Platform sourceCoordinate = new(
+            "runtime",
+            "11.0.0",
+            "fixture",
+            "net11.0",
+            assembly: "Adapters");
+        IntegrationSourceParticipantIdentity participant =
+            IntegrationSourceParticipantIdentity.Portable(
+                sourceCoordinate,
+                Assembly("Adapters"));
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Contracts"),
+                TypeName("Peer", "Client")));
+        RealizedMemberCoordinate.Package terminalCoordinate = new(
+            "contoso.peer",
+            "3.0.0",
+            "fixture",
+            "net11.0",
+            null);
+        IntegrationTypeIdentity terminal = new(
+            IntegrationSourceParticipantIdentity.Portable(
+                terminalCoordinate,
+                Assembly("Peer.Contracts")),
+            candidate.Peer.Type);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                new IntegrationCandidateAttempt.Classified(
+                    new IntegrationCandidateAttemptAddress(
+                        candidate,
+                        context),
+                    new IntegrationCandidateDisposition.In(
+                        Resolved(candidate, terminal))),
+            ],
+            plan: plan);
+
+        IntegrationInventoryRow row = Assert.Single(
+            IntegrationInventoryProjection.Project(plan, snapshot).Rows);
+
+        Assert.Same(sourceCoordinate, row.SourceParent);
+        Assert.Same(terminalCoordinate, row.TerminalParent);
+    }
+
+    [Fact]
+    public void IntegrationInventory_UnknownParentNeverGuessesFromAssemblyName()
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        AssemblyReferenceIdentity terminalAssembly =
+            Assembly("Looks.Like.A.Package");
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                terminalAssembly,
+                TypeName("Peer", "Client")));
+        IntegrationTypeIdentity terminal = new(
+            IntegrationSourceParticipantIdentity.Workspace(
+                Registration(),
+                terminalAssembly),
+            candidate.Peer.Type);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                new IntegrationCandidateAttempt.Classified(
+                    new IntegrationCandidateAttemptAddress(
+                        candidate,
+                        context),
+                    new IntegrationCandidateDisposition.In(
+                        Resolved(candidate, terminal))),
+            ],
+            plan: plan);
+
+        IntegrationInventoryRow row = Assert.Single(
+            IntegrationInventoryProjection.Project(plan, snapshot).Rows);
+
+        Assert.Same(terminalAssembly, row.TerminalAssembly);
+        Assert.Null(row.TerminalProvenance);
+        Assert.Null(row.TerminalParent);
+        Assert.Null(row.PeerLookup.AuthoritativeProvenance);
+        Assert.Null(row.PeerLookup.AuthoritativeParent);
+        Assert.Same(
+            terminalAssembly,
+            Assert.IsType<MetadataTypeReferenceScope.AssemblyReference>(
+                row.PeerLookup.Scope).Assembly);
+    }
+
+    [Fact]
+    public void IntegrationInventory_FindPatternUsesTypeLookupGrammarUnchanged()
+    {
+        MetadataTypeDefinitionName type =
+            Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Peer.Namespace",
+                    ["Outer", "Inner"])).Name;
+        var lookup = new IntegrationPeerLookup(
+            AssemblyPeer(Assembly("Peer.Contracts"), type));
+
+        Assert.Equal(type.ToMetadataFullName(), lookup.FindPattern);
+        Assert.Equal("Peer.Namespace.Outer.Inner", lookup.FindPattern);
+    }
+
+    [Fact]
+    public void IntegrationInventory_SameCandidateAcrossContextsProducesDistinctRows()
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            DefaultPeer);
+        var first = new Context();
+        var second = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            contexts: [first, second],
+            candidateAttempts:
+            [
+                ClassifiedOut(candidate, second),
+                ClassifiedOut(candidate, first),
+            ],
+            plan: plan);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(plan, snapshot);
+
+        Assert.Equal(2, result.Rows.Length);
+        Assert.Same(candidate, result.Rows[0].Candidate);
+        Assert.Same(candidate, result.Rows[1].Candidate);
+        Assert.Same(first, result.Rows[0].BindingContext);
+        Assert.Same(second, result.Rows[1].BindingContext);
+        Assert.NotEqual(
+            result.Rows[0].Attempt,
+            result.Rows[1].Attempt);
+    }
+
+    [Fact]
+    public void
+        IntegrationInventory_IncompleteCensusRetainsHealthyRowsWithoutManufacturingFailureRows()
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        IntegrationCandidateIdentity healthy = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Healthy.Peer"),
+                TypeName("Peer", "Healthy")));
+        IntegrationCandidateIdentity failed = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Failed.Peer"),
+                TypeName("Peer", "Failed")));
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(
+                    participant,
+                    Ecosystem,
+                    healthy,
+                    failed)),
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedOut(healthy, context),
+                new IntegrationCandidateAttempt.Failed(
+                    new IntegrationCandidateAttemptAddress(
+                        failed,
+                        context),
+                    new CandidateFailure()),
+            ],
+            plan: plan);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(plan, snapshot);
+        IntegrationInventoryRow row = Assert.Single(result.Rows);
+
+        Assert.False(result.IsComplete);
+        Assert.Same(healthy, row.Candidate);
+        Assert.DoesNotContain(
+            result.Rows,
+            candidate => candidate.Candidate.Equals(failed));
+        Assert.Single(result.Snapshot.FailedCandidateAttempts);
+    }
+
+    [Fact]
+    public void IntegrationProjection_EachResponseRetainsItsExactValidatedRequest()
+    {
+        AnalysisReportSurface surface = Surface();
+        AnalysisUniverseDescription universe = FullUniverse();
+        AnalysisRequestPlan rows =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Rows);
+        IntegrationCensusSnapshot snapshot = Snapshot([], plan: rows);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(rows, snapshot);
+
+        Assert.Same(rows, result.Plan);
+        Assert.Same(snapshot, result.Snapshot);
+        Assert.Same(rows.Analysis, result.Analysis);
+        Assert.Same(rows.ReportSurface, result.ReportSurface);
+        Assert.Same(rows.Universe, result.Universe);
+        Assert.Equal(rows.Mode, result.Mode);
+        Assert.Same(rows.Projection, result.Projection);
+        Assert.True(result.IsComplete);
+        Assert.Empty(result.Rows);
+    }
+
+    [Fact]
+    public void IntegrationProjection_ReuseRequiresCompatibleCensusSnapshot()
+    {
+        AnalysisReportSurface surface = Surface();
+        AnalysisUniverseDescription universe = FullUniverse();
+        AnalysisRequestPlan graph =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Graph);
+        AnalysisRequestPlan rows =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Rows);
+        IntegrationCensusSnapshot snapshot = Snapshot([], plan: graph);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(rows, snapshot);
+
+        Assert.Same(rows, result.Plan);
+        Assert.Same(snapshot, result.Snapshot);
+        Assert.Throws<ArgumentException>(() =>
+            IntegrationInventoryProjection.Project(
+                Plan(surface, universe, IntegrationAnalysisCatalog.Matrix),
+                snapshot));
+        Assert.Throws<ArgumentException>(() =>
+            IntegrationInventoryProjection.Project(
+                Plan(surface, FullUniverse(), IntegrationAnalysisCatalog.Rows),
+                snapshot));
+    }
+
+    [Fact]
+    public void IntegrationInventory_IncompleteEmptyCensusRetainsFailureState()
+    {
+        IntegrationSourceParticipantIdentity participant = Portable();
+        AnalysisRequestPlan plan = Plan();
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            sourceAttempts:
+            [
+                new IntegrationSourceParticipantAttempt.Failed(
+                    participant,
+                    new ParticipantFailure()),
+            ],
+            producerAttempts:
+            [
+                Unavailable(participant, Ecosystem),
+                Unavailable(participant, OpenTelemetry),
+                Unavailable(participant, Opportunity),
+            ],
+            plan: plan);
+
+        IntegrationInventoryProjectionResult result =
+            IntegrationInventoryProjection.Project(plan, snapshot);
+
+        Assert.False(result.IsComplete);
+        Assert.Empty(result.Rows);
+        Assert.Same(snapshot, result.Snapshot);
+    }
+
     // =====================================================================
     // Fixture / helper layer
     // =====================================================================

--- a/src/DotnetInspector.Queries/IntegrationInventoryProjection.cs
+++ b/src/DotnetInspector.Queries/IntegrationInventoryProjection.cs
@@ -1,0 +1,224 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One independently validated projection over a compatible Integration
+/// Census snapshot.
+/// </summary>
+public abstract class IntegrationCensusProjectionResult
+{
+    private protected IntegrationCensusProjectionResult(
+        AnalysisRequestPlan plan,
+        IntegrationCensusSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (!snapshot.IsCompatibleWith(plan))
+        {
+            throw new ArgumentException(
+                "The Integration projection request is not compatible with the Census snapshot.",
+                nameof(plan));
+        }
+
+        Plan = plan;
+        Snapshot = snapshot;
+    }
+
+    public AnalysisRequestPlan Plan { get; }
+    public IntegrationCensusSnapshot Snapshot { get; }
+    public AnalysisDescriptor Analysis => Plan.Analysis;
+    public AnalysisReportSurface ReportSurface => Plan.ReportSurface;
+    public AnalysisUniverseDescription Universe => Plan.Universe;
+    public AnalysisQuestionMode Mode => Plan.Mode;
+    public AnalysisProjectionDescriptor Projection => Plan.Projection;
+    public ImmutableArray<AnalysisUniverseRequirementDescriptor>
+        UniverseRequirements => Plan.UniverseRequirements;
+    public IntegrationConceptCatalogRevision CatalogRevision =>
+        Snapshot.CatalogRevision;
+    public bool IsComplete => Snapshot.IsComplete;
+}
+
+/// <summary>
+/// The exact structured peer handoff retained by an Integration Inventory row.
+/// </summary>
+public sealed class IntegrationPeerLookup
+{
+    public IntegrationPeerLookup(IntegrationCandidatePeerIdentity identity)
+        : this(identity, authoritativeProvenance: null)
+    {
+    }
+
+    internal IntegrationPeerLookup(
+        IntegrationCandidatePeerIdentity identity,
+        RealizedMemberCoordinate? authoritativeProvenance)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        Identity = identity;
+        Type = identity.Type;
+        FindPattern = Type.ToMetadataFullName();
+        Scope = identity is IntegrationCandidatePeerIdentity.NamedType named
+            ? named.Reference.Scope
+            : null;
+        PolicyTarget =
+            (identity as IntegrationCandidatePeerIdentity.PolicyTarget)?.Target;
+        AuthoritativeProvenance = authoritativeProvenance;
+        AuthoritativeParent = IntegrationInventoryProjection.ParentOf(
+            authoritativeProvenance);
+    }
+
+    public IntegrationCandidatePeerIdentity Identity { get; }
+    public MetadataTypeDefinitionName Type { get; }
+    public MetadataTypeReferenceScope? Scope { get; }
+    public IntegrationOpportunityTarget? PolicyTarget { get; }
+    public RealizedMemberCoordinate? AuthoritativeProvenance { get; }
+    public RealizedMemberCoordinate? AuthoritativeParent { get; }
+    public string FindPattern { get; }
+}
+
+/// <summary>
+/// One classified candidate attempt in the Integration Inventory.
+/// </summary>
+public sealed class IntegrationInventoryRow
+{
+    internal IntegrationInventoryRow(
+        IntegrationCandidateAttempt.Classified attempt,
+        ImmutableArray<IntegrationProducerPolicyAttemptAddress>
+            producerPolicyAttempts)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        Attempt = attempt.Address;
+        ProducerPolicyAttempts = producerPolicyAttempts;
+        Candidate = Attempt.Candidate;
+        BindingContext = Attempt.BindingContext;
+        Relationship = Candidate.Relationship;
+        Concept = Candidate.Concept;
+        Source = Candidate.Source;
+        SourceAssembly = Source.Participant.Assembly;
+        SourceProvenance = Source.Participant.Coordinate;
+        SourceParent = IntegrationInventoryProjection.ParentOf(
+            SourceProvenance);
+        ResolvedPeer = attempt.Disposition.Peer;
+        ResolutionPath = ResolvedPeer.ResolutionPath;
+        ForwardingHops =
+        [
+            .. ResolutionPath.Take(ResolutionPath.Length - 1),
+        ];
+        TerminalDefinition = ResolvedPeer.Terminal;
+        TerminalAssembly = TerminalDefinition.Participant.Assembly;
+        TerminalProvenance = TerminalDefinition.Participant.Coordinate;
+        TerminalParent = IntegrationInventoryProjection.ParentOf(
+            TerminalProvenance);
+        PeerLookup = new IntegrationPeerLookup(
+            Candidate.Peer,
+            TerminalProvenance);
+        Disposition = attempt.Disposition;
+        OutReason = attempt.Disposition
+            is IntegrationCandidateDisposition.Out outside
+                ? outside.Reason
+                : null;
+        AdmittedRelationshipIdentity = attempt.Disposition
+            is IntegrationCandidateDisposition.In
+                ? Attempt
+                : null;
+    }
+
+    public IntegrationCandidateAttemptAddress Attempt { get; }
+    public IntegrationCandidateIdentity Candidate { get; }
+    public IIntegrationBindingContextIdentity BindingContext { get; }
+    public ImmutableArray<IntegrationProducerPolicyAttemptAddress>
+        ProducerPolicyAttempts { get; }
+    public InspectionGraphRelationshipDescriptor Relationship { get; }
+    public IntegrationConceptDescriptor Concept { get; }
+    public IntegrationCandidateSourceIdentity Source { get; }
+    public AssemblyReferenceIdentity SourceAssembly { get; }
+    public RealizedMemberCoordinate? SourceProvenance { get; }
+    public RealizedMemberCoordinate? SourceParent { get; }
+    public IntegrationPeerLookup PeerLookup { get; }
+    public IntegrationResolvedPeer ResolvedPeer { get; }
+    public ImmutableArray<IntegrationTypeIdentity> ResolutionPath { get; }
+    public ImmutableArray<IntegrationTypeIdentity> ForwardingHops { get; }
+    public IntegrationTypeIdentity TerminalDefinition { get; }
+    public AssemblyReferenceIdentity TerminalAssembly { get; }
+    public RealizedMemberCoordinate? TerminalProvenance { get; }
+    public RealizedMemberCoordinate? TerminalParent { get; }
+    public IntegrationCandidateDisposition Disposition { get; }
+    public IntegrationCandidateOutReason? OutReason { get; }
+
+    /// <summary>
+    /// The context-addressed candidate identity admitted as a relationship, or
+    /// <c>null</c> when the terminal peer is outside the selected universe.
+    /// </summary>
+    public IntegrationCandidateAttemptAddress? AdmittedRelationshipIdentity
+        { get; }
+
+}
+
+/// <summary>The typed row payload for the Integration Inventory section.</summary>
+public sealed class IntegrationInventoryProjectionResult
+    : IntegrationCensusProjectionResult
+{
+    internal IntegrationInventoryProjectionResult(
+        AnalysisRequestPlan plan,
+        IntegrationCensusSnapshot snapshot,
+        ImmutableArray<IntegrationInventoryRow> rows)
+        : base(RequireRowsPlan(plan), snapshot)
+    {
+        Rows = rows;
+    }
+
+    public ImmutableArray<IntegrationInventoryRow> Rows { get; }
+
+    static AnalysisRequestPlan RequireRowsPlan(AnalysisRequestPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        if (!ReferenceEquals(
+                plan.Projection,
+                IntegrationAnalysisCatalog.Rows))
+        {
+            throw new ArgumentException(
+                "Integration Inventory requires the configured rows projection.",
+                nameof(plan));
+        }
+
+        return plan;
+    }
+}
+
+/// <summary>Projects classified Census attempts into canonical inventory rows.</summary>
+public static class IntegrationInventoryProjection
+{
+    public static IntegrationInventoryProjectionResult Project(
+        AnalysisRequestPlan plan,
+        IntegrationCensusSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        Dictionary<IntegrationCandidateIdentity, IntegrationCensusCandidate>
+            candidates = snapshot.Candidates.ToDictionary(
+                static candidate => candidate.Identity);
+        ImmutableArray<IntegrationInventoryRow> rows =
+        [
+            .. snapshot.ClassifiedAttempts.Select(attempt =>
+                new IntegrationInventoryRow(
+                    attempt,
+                    candidates[attempt.Address.Candidate]
+                        .ProducerAttempts)),
+        ];
+        return new IntegrationInventoryProjectionResult(
+            plan,
+            snapshot,
+            rows);
+    }
+
+    internal static RealizedMemberCoordinate? ParentOf(
+        RealizedMemberCoordinate? provenance) =>
+        provenance is RealizedMemberCoordinate.Package
+            or RealizedMemberCoordinate.Platform
+                ? provenance
+                : null;
+}

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -315,6 +315,74 @@ public class SectionPipelineTests
     // ===== Library pipeline integration tests =====
 
     [Fact]
+    public void IntegrationInventory_IsExplicitNetworkFreeVerboseSection()
+    {
+        DocumentSchema schema = IntegrationInventorySections.CreateSchema();
+        SectionCatalog<IntegrationInventoryProjectionResult> catalog =
+            IntegrationInventorySections.CreateCatalog();
+
+        Assert.Equal(
+            IntegrationInventorySections.Inventory,
+            IntegrationInventorySections.InventoryRows.Name);
+        Assert.False(
+            IntegrationInventorySections.InventoryRows.IsExpensive);
+        Assert.True(
+            IntegrationInventorySections.InventoryRows.ExplicitOnly);
+        Assert.Equal(
+            SectionSizeClass.Verbose,
+            IntegrationInventorySections.InventoryRows.SizeClass);
+        Assert.Equal(
+            SectionCost.NetworkFree,
+            IntegrationInventorySections.InventoryRows.Cost);
+        Assert.Equal(
+            [
+                "Concept",
+                "Relationship",
+                "Source",
+                "Source Assembly",
+                "Source Provenance",
+                "Source Parent",
+                "Binding Context",
+                "Peer",
+                "Peer Scope",
+                "Terminal",
+                "Terminal Assembly",
+                "Terminal Provenance",
+                "Terminal Parent",
+                "Forwarding Hops",
+                "Disposition",
+                "Out Reason",
+                "Producer Policies",
+            ],
+            schema.GetSection(IntegrationInventorySections.Inventory)!
+                .Items.Select(static item => item.Name));
+        Assert.Equal(
+            [IntegrationInventorySections.Inventory],
+            catalog.AllSectionNames);
+        Assert.Empty(
+            catalog.Pipeline.GetCandidateSections(Verbosity.Detailed));
+        Assert.Equal(
+            [IntegrationInventorySections.Inventory],
+            catalog.Pipeline.GetCandidateSections(
+                Verbosity.Normal,
+                [IntegrationInventorySections.Inventory]));
+    }
+
+    [Fact]
+    public void IntegrationInventory_DoesNotWidenLibraryIntegrationsCategory()
+    {
+        SectionCatalog<LibraryInspection> catalog =
+            LibrarySections.CreateCatalog().Sections;
+
+        Assert.DoesNotContain(
+            IntegrationInventorySections.Inventory,
+            catalog.AllSectionNames);
+        Assert.DoesNotContain(
+            IntegrationInventorySections.Inventory,
+            catalog.CategoryMap[SectionCategoryNames.Integrations]);
+    }
+
+    [Fact]
     public void LibraryPipeline_HasExpectedSectionCount()
     {
         var pipeline = LibrarySections.CreatePipeline();

--- a/src/dotnet-inspect/Sections/IntegrationInventorySections.cs
+++ b/src/dotnet-inspect/Sections/IntegrationInventorySections.cs
@@ -1,0 +1,63 @@
+using DotnetInspector.Queries;
+using Markout;
+
+namespace DotnetInspector.Sections;
+
+/// <summary>
+/// Reusable L2 declaration for the Workspace Integration Inventory.
+/// </summary>
+public static class IntegrationInventorySections
+{
+    public const string Inventory = "Integration Inventory";
+
+    public static SectionCatalog<IntegrationInventoryProjectionResult>
+        SectionCatalog { get; } =
+        CreatePipeline().Compile();
+
+    public static SectionCatalog<IntegrationInventoryProjectionResult>
+        CreateCatalog() =>
+        SectionCatalog;
+
+    public static SectionPipeline<IntegrationInventoryProjectionResult>
+        CreatePipeline() =>
+        new SectionPipeline<IntegrationInventoryProjectionResult>()
+            .UseCuratedCatalog()
+            .WithoutComputedPoles()
+            .Add<InventoryRows>();
+
+    public static DocumentSchema CreateSchema() =>
+        new DocumentSchema().Add(
+            Inventory,
+            "column",
+            "Concept",
+            "Relationship",
+            "Source",
+            "Source Assembly",
+            "Source Provenance",
+            "Source Parent",
+            "Binding Context",
+            "Peer",
+            "Peer Scope",
+            "Terminal",
+            "Terminal Assembly",
+            "Terminal Provenance",
+            "Terminal Parent",
+            "Forwarding Hops",
+            "Disposition",
+            "Out Reason",
+            "Producer Policies");
+
+    public sealed class InventoryRows
+        : ISectionDescriptor<IntegrationInventoryProjectionResult>
+    {
+        public static string Name => Inventory;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static SectionSizeClass SizeClass => SectionSizeClass.Verbose;
+        public static SectionCost Cost => SectionCost.NetworkFree;
+
+        public static bool CanRender(
+            IntegrationInventoryProjectionResult model) =>
+            model.Rows.Length != 0;
+    }
+}


### PR DESCRIPTION
## Summary

Add the typed `Integration Inventory` row projection over the immutable
Workspace Integration Census.

- Projects one row per classified candidate attempt in canonical Census order,
  retaining candidate, binding-context, producer-policy, concept, relationship,
  source, peer lookup, terminal definition, forwarding, provenance, and
  disposition identity.
- Retains the exact independently validated rows request beside the compatible
  Census snapshot, including incomplete snapshots with healthy rows and typed
  failures.
- Introduces the reusable explicit, `Verbose`, `NetworkFree` L2 Section catalog
  and schema without adding a CLI route or widening the Library
  `@Integrations` category.
- Uses the context-addressed candidate attempt as the admitted relationship
  identity for `In`; graph-local occurrence and edge correspondence remain the
  next separately owned slice.

The projection is synchronous, SRM-only, renderer-free at L1, and compatible
with the Browser/Wasm sequential baseline. It performs no acquisition, network
lookup, package-name inference, or graph projection.

Part of #3629.

## Demo

The contract fixtures project direct and forwarded candidates through the same
typed row shape:

| Candidate attempt | Resolution path | Disposition | Authoritative handoff |
| --- | --- | --- | --- |
| `Adapters.ClientAdapter -> Peer.Client @ context A` | terminal definition | `In` | terminal platform coordinate |
| `Source.Type -> Peer.Client @ context A` | facade -> terminal definition | `Out(PeerOutsideUniverse)` | terminal package coordinate |
| same candidate @ context B | terminal definition | independent row | same candidate identity, distinct attempt identity |

The neighboring incomplete fixtures retain healthy classified rows while
failed attempts remain failures, and distinguish a complete empty result from
an incomplete empty result. Unknown parent provenance stays null even when the
assembly name looks package-like.

Run the executable demo with:

```bash
dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- \
  -method '*IntegrationInventory_*' \
  -method '*IntegrationProjection_*' \
  -reporter quiet
```

## Design

`docs/design/integrations.md#candidate-row-projection` owns row identity,
projection compatibility, peer handoff, provenance, and completeness.
`docs/design/section-model.md` owns the L2 Section declaration and
`docs/design/output-shapes.md` owns later shaping and rendering.

The L1 result keeps typed identities and authoritative coordinates rather than
presentation labels. The standalone L2 catalog declares the Section and schema
but remains unregistered until a Workspace host composes it.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -method '*IntegrationInventory_IsExplicitNetworkFreeVerboseSection' -method '*IntegrationInventory_DoesNotWidenLibraryIntegrationsCategory'`
- `npx markdownlint-cli docs/design/integrations.md`
- `git diff --check`
