### PR TITLE
Clarify row selection capability boundaries

### DIFF
--- a/docs/design/section-row-shaping.md
+++ b/docs/design/section-row-shaping.md
@@ -496,7 +496,7 @@ planning, the delegated result contract, completion-evidence binding, and the
 non-vacuous optimized-execution gates. L2 accepts an optimized result only
 when it is observationally equivalent to the complete reference contracts in
 [Row query and ordering](row-query-order.md#logical-composition) and
-[Semantic row selection](semantic-row-selection.md#reference-semantics-and-optimized-execution).
+[Semantic row selection](semantic-row-selection.md#reference-evaluator-and-alternative-interpretation).
 That includes their predicate, baseline-order, callback, exception-identity,
 resolver-cardinality, caching, and failure-precedence observations. Comparer
 call count and pair order remain excluded exactly where the semantic owner

--- a/docs/design/semantic-row-selection.md
+++ b/docs/design/semantic-row-selection.md
@@ -28,20 +28,26 @@ Related designs:
   [#5162](https://github.com/richlander/dotnet-inspect/issues/5162).
 - [Output shapes](output-shapes.md) owns declared row units and the
   Document-to-Scalar shape ladder.
-- [Source delegation](source-delegation.md) owns delegation planning and
-  completion-evidence binding for any permitted optimized execution.
+- [Source delegation](source-delegation.md) owns one specialized optional
+  protocol for source-executed prefixes and completion-evidence binding. It is
+  not required to consume the typed language or its reference evaluator.
 - [Semantic row-selection interaction model](../models/semantic-row-selection/SemanticRowSelection.tla)
   checks bounded stage, failure, publication, and resolver interactions.
 
 ## Authority and scope
 
-The proposed dependency-free `DotnetInspector.RowSelection` library, through
-`RowSelectionPlan` and `RowSelectionExecutor`, is the authority that evaluates
-ordered row-selection stages over complete logical sequences.
+The proposed dependency-free `DotnetInspector.RowSelection` library is the
+authority for two distinct capabilities:
+
+- the typed declaration language expressed by `RowSelectionStage` and
+  `RowSelectionPlan`; and
+- the generic complete-sequence reference evaluator expressed by
+  `RowSelectionExecutor`.
 
 This design owns:
 
-- the normalized, renderer-independent row-selection stages;
+- construction, validation, and runtime inspection of the normalized,
+  renderer-independent row-selection language;
 - sequential stage evaluation;
 - lenient and strict stage behavior;
 - stage-local positions and reindexing;
@@ -62,15 +68,51 @@ This design does not own:
 Those excluded concerns consume this contract or provide its inputs; they do
 not redefine its semantics.
 
+## Three-part architecture and adoption
+
+The broader row-selection system has three separately adoptable parts:
+
+| Part | Contract | Dependency |
+| --- | --- | --- |
+| Typed selection language | An immutable, runtime-inspectable declaration of ordered `Head`, `Tail`, `Window`, and `Top` stages with validated operands and an opaque resolved-order identity. | No row values, evaluator, source protocol, Sections, CLI, or presentation concepts are required to construct or inspect it. |
+| Generic reference evaluator | The canonical implementation of that language over complete finite `IReadOnlyList<T>` sequences, including named inputs, ordering callbacks, snapshots, and structured strict-window failures. | Depends on the typed language but not on source execution, Sections, CLI, or presentation. |
+| Optional delegated interpretation | A separately owned component may accept the typed declaration and perform an equivalent interpretation, or decline so its caller can use another strategy such as the reference evaluator. | Depends on the language's meaning. It need not invoke the reference evaluator in production, but its supported interpretations require equivalence evidence against that oracle. |
+
+These are capability boundaries, not three required assemblies. The initial
+implementation places the language and reference evaluator in the same
+dependency-free leaf library. A language-only consumer can construct, retain,
+inspect, and transport a plan without supplying row values or invoking
+`RowSelectionExecutor`; this design does not claim that the language ships as a
+separate package or assembly. The independent-adoption and physical-closure
+proof is tracked by
+[#5235](https://github.com/richlander/dotnet-inspect/issues/5235).
+
+The declaration carries meaning, not an execution strategy. A component that
+receives it may:
+
+1. provide a complete logical sequence to the reference evaluator; or
+2. use a separately designed interpreter that preserves the reference
+   evaluator's observable semantics for every stage it accepts.
+
+This design owns the equivalence target but not a universal delegation API.
+Each delegation protocol owns its own capability negotiation, acceptance,
+decline, commitment, result transport, and failure boundary. The
+[source-delegation](source-delegation.md) design is one narrower protocol for
+source-owned execution and completion evidence; it must not become a
+dependency of applications that only need the language or evaluator, and it
+must not be mistaken for permission to reinterpret unsupported stages.
+
 ## Purpose and review boundary
 
 This component gives dotnet-inspect and other applications one reusable,
-presentation-independent implementation of ordered row selection. Its supported
-caller is cooperating in-process code that supplies complete logical sequences,
-an already validated plan, and deterministic comparers for resolved `Top`
-orders. The variable inputs are the sequence values, stage order and operands,
-named-sequence keys, and comparer results. The observable contract is the
-selected values in order or one structured strict-window failure.
+presentation-independent language and reference implementation of ordered row
+selection. Its supported caller is cooperating in-process code. A
+language-only caller supplies stage operands and resolved `Top` order
+identities. An evaluator caller additionally supplies complete logical
+sequences and deterministic comparers for those resolved orders. The variable
+inputs are the sequence values, stage order and operands, named-sequence keys,
+and comparer results. The observable evaluator contract is the selected values
+in order or one structured strict-window failure.
 
 The caller, its row objects, its resolved order identities, and its comparer
 implementation are trusted. This is not a security boundary and does not defend
@@ -83,7 +125,20 @@ Repository-wide platform policy applies to this code as it does to other simple
 product libraries; this design defines no component-specific platform behavior
 or evidence.
 
-## Immediate boundary contract
+## Typed declaration boundary
+
+`RowSelectionPlan<TOrder>` is an inert ordered declaration. It contains stage
+kinds, validated operands, and opaque caller-resolved `TOrder` values; it
+contains no row values, comparer, callback, source, result, or execution state.
+A consumer can inspect every stage and choose an execution component at
+runtime without parsing CLI tokens, rendered text, or field names.
+
+Constructing or inspecting a plan does not invoke selection behavior. The plan
+does not choose the reference evaluator, advertise a source capability, or
+assert that an alternative interpreter supports its stages. Those decisions
+belong to the adopting component and any separately owned delegation protocol.
+
+## Reference evaluator boundary
 
 The generic executor receives:
 
@@ -108,12 +163,11 @@ available current count. When several sequences would fail, input sequence
 order and then stage order determine the one returned. The failure contains no
 presentation text.
 
-The reference executor evaluates a complete logical input sequence. A source
-optimizer may avoid acquiring that complete sequence only when it can prove the
-same selected values, order, and strict-window outcome. The
-[source delegation](source-delegation.md) design owns how that
-proof is represented, bound, and accepted. Each adopting source owns how it
-obtains and constructs the proof.
+The reference executor evaluates a complete logical input sequence. An
+alternative interpreter may avoid using that complete sequence only under its
+own protocol and only when its accepted interpretation preserves the
+observable equivalence contract in
+[Reference evaluator and alternative interpretation](#reference-evaluator-and-alternative-interpretation).
 
 The evaluated Release compile/runtime closure contains only framework
 references and this component. The project has no product `PackageReference`,
@@ -188,7 +242,7 @@ resolver at entry even when no sequence would reach that stage.
 
 ## Public surface and immutability
 
-The supported product surface is:
+The supported typed-language surface is:
 
 ```csharp
 namespace DotnetInspector.RowSelection;
@@ -226,6 +280,12 @@ public sealed class RowSelectionPlan<TOrder>
         IReadOnlyList<RowSelectionStage<TOrder>> stages);
     public RowSelectionPlan<TOrder> Append(RowSelectionStage<TOrder> stage);
 }
+```
+
+The supported reference-evaluator surface is:
+
+```csharp
+namespace DotnetInspector.RowSelection;
 
 public sealed class RowSequenceKey : IEquatable<RowSequenceKey>
 {
@@ -331,13 +391,17 @@ named-input creation. Callers must not mutate a source collection concurrently
 with the synchronous boundary call.
 
 A fixture project outside the component compiles against the supported surface
-above and executes every entry point. This proves that an ordinary non-friend
-consumer can use the leaf without importing Sections, source execution, CLI, or
-presentation concepts.
+above. One language-only scenario constructs and inspects every declaration
+entry point without row values or executor use. A second scenario executes
+every reference-evaluator entry point. Together they prove that an ordinary
+non-friend consumer can use either capability without importing Sections,
+source execution, CLI, or presentation concepts.
 
 ## Mock component demo
 
-The first implementation demonstrates the public leaf directly:
+The first implementation demonstrates both logical surfaces of the public leaf
+directly. A component can construct and inspect the declaration before it has
+row values or chooses an execution strategy:
 
 ```csharp
 var plan = RowSelectionPlan<string>.Create(
@@ -346,6 +410,12 @@ var plan = RowSelectionPlan<string>.Create(
     RowSelectionStage<string>.Tail(2)
 ]);
 
+// plan.Stages reports [Window, Tail]
+```
+
+The same component may then choose the generic reference evaluator:
+
+```csharp
 var result = RowSelectionExecutor.Apply(
     new[] { 1, 2, 3, 4, 5, 6, 7, 8 },
     plan);
@@ -354,9 +424,12 @@ var result = RowSelectionExecutor.Apply(
 ```
 
 What to notice: the second stage consumes and reindexes the first stage's
-output. The neighboring pathological plan `Head(2)` then `Window(2,3)` returns
-a structured stage-2 failure requiring position 3 from an input of 2; it does
-not intersect both stages against the original sequence and return row 2.
+output. An alternative interpreter receives the same typed plan rather than a
+different source-specific spelling and must produce the same observation for
+every stage it accepts. The neighboring pathological plan `Head(2)` then
+`Window(2,3)` returns a structured stage-2 failure requiring position 3 from an
+input of 2; it does not intersect both stages against the original sequence and
+return row 2.
 
 ## Stage semantics
 
@@ -542,11 +615,12 @@ Invalid plan construction and a missing resolved comparer are caller misuse,
 not `RowWindowFailure` outcomes. They reject before a selected result is
 returned.
 
-## Reference semantics and optimized execution
+## Reference evaluator and alternative interpretation
 
-The stage definitions over a complete sequence are the semantic oracle.
-Implementations may stream, buffer, sort, or push work into a provider, but
-those choices are observationally equivalent only when they preserve:
+The reference evaluator's stage definitions over a complete sequence are the
+semantic oracle. An alternative interpreter may stream, buffer, sort, or push
+work into a provider, but it is conforming only for the stages it accepts and
+only when it preserves:
 
 - the same surviving caller-owned values;
 - the same output order;
@@ -558,8 +632,10 @@ those choices are observationally equivalent only when they preserve:
 - the same semantic-failure, resolver-failure, and comparer-failure precedence.
 
 Comparer call count and pair order are not equivalence dimensions for a valid
-deterministic comparer. The
-[source delegation](source-delegation.md) contract applies its
+deterministic comparer. A delegation protocol may decline a plan or supported
+subset according to its own contract; decline is not a semantic result and
+does not change this language. The
+[source delegation](source-delegation.md) protocol applies its
 [source-closed boundary](source-delegation.md#source-closed-operations);
 operations this design does not declare source-closed remain in the reference
 or row-handoff residual path. A later observation-transport extension must
@@ -674,14 +750,14 @@ The implementation must add these proportional outcome-level Release gates:
 | `SelectionCallbacksFollowStageOrder` | Resolver presence is validated at entry without eager invocation; each reached Top resolves once per stage and is cached across named sequences; earlier strict failures stop later callbacks; resolver and comparer exceptions propagate unchanged. |
 | `NamedSelectionIsAtomicAndDeterministic` | Named success preserves input order; a strict miss returns no selected sequence collection; the first failure follows sequence then stage order; equal key values reject before execution and keys use stable value equality. |
 | `RowSelectionSnapshotsAreImmutable` | Plans, named inputs, and returned collections snapshot membership and order; Append leaves the prior plan unchanged; exposed collections cannot mutate snapshots; selected row objects remain the caller's original values. |
-| `RowSelectionExternalConsumerExercisesSurface` | A non-friend fixture constructs every stage, plan, and named input through the supported factories, invokes both executor methods with omitted and named optional arguments, and observes accessor, success, and failure behavior using only the leaf reference. |
+| `RowSelectionLanguageConsumerExercisesDeclaration` | A non-friend fixture constructs and inspects every stage and plan entry point without row values, executor invocation, or references to Sections, source execution, CLI, or presentation. |
+| `RowSelectionReferenceEvaluatorExercisesSurface` | A non-friend fixture consumes the typed plan, constructs named input through the supported factories, invokes both executor methods with omitted and named optional arguments, and observes accessor, success, and failure behavior using only the leaf reference. |
 | `RowSelectionHasOnlyFrameworkRuntimeDependencies` | Evaluated Release references and resolved compile/runtime/native assets contain only framework references and this component; build-only tooling is allowed only when it contributes no product asset. |
 
-The
-[source delegation](source-delegation.md) contract owns the
-required equivalence gate comparing every optimized delegation it supports
-with this complete-sequence reference executor. Delegation follows that
-owner's
+Every optional interpreter must name an equivalence gate for the stages it
+accepts, using this complete-sequence reference evaluator as the oracle. The
+[source delegation](source-delegation.md) contract owns that gate for its
+specialized source protocol. Its delegation follows that owner's
 [source-closed boundary](source-delegation.md#source-closed-operations):
 operations this design does not declare source-closed remain in the reference
 or row-handoff residual path. Any later extension that transports those


### PR DESCRIPTION
The semantic row-selection contract now explicitly separates the typed
declaration language, generic reference evaluator, and optional delegated
interpretation model.

- The language is an inert, runtime-inspectable `RowSelectionPlan<TOrder>`.
- The reference evaluator is the canonical generic implementation over
  complete `IReadOnlyList<T>` sequences.
- Alternative interpreters consume the same language and prove supported
  behavior against the reference oracle.
- Source delegation remains one specialized optional protocol rather than a
  dependency of the language or evaluator.

The first two capabilities remain logical surfaces in one dependency-free leaf
assembly. This change does not require a premature package split.

## Demo

A component can construct and inspect a typed plan before it has row values or
chooses an execution strategy:

```csharp
var plan = RowSelectionPlan<string>.Create(
[
    RowSelectionStage<string>.Window(3, 6),
    RowSelectionStage<string>.Tail(2)
]);

// plan.Stages reports [Window, Tail]
```

It can then pass a complete sequence to `RowSelectionExecutor`, or a separately
owned interpreter can accept the same plan and prove equivalent observations.
The pathological `Head(2)` then `Window(2,3)` case must remain a structured
stage-2 failure under either interpretation.

## Scope

`docs/design/semantic-row-selection.md` remains the sole normative owner changed
by this PR. The PR does not define a universal delegation API, modify the
source-delegation protocol, choose package boundaries, or implement product
code.

## Validation

- `npx markdownlint-cli docs/design/semantic-row-selection.md docs/design/section-row-shaping.md`
- `git diff --check`

Related to #4677 and #5235.
