### PR TITLE
Add Integration Census graph projection

### DIFF
--- a/docs/design/inspection-graph-document.md
+++ b/docs/design/inspection-graph-document.md
@@ -355,6 +355,15 @@ actually used rather than accepting a caller assertion. Acquisition-aware call
 receipts make the document session-bound even when their logical endpoint
 subjects have portable detached identities.
 
+The Integration Census adapter uses graph subject variants that wrap its exact
+candidate-source, resolved-Type, and participant identities. Those variants
+remain session-bound even when the participant carries a realized coordinate:
+the admitted occurrence retains an
+`IntegrationCandidateAttemptAddress`, whose binding-context identity has no
+portable contract. This bridge preserves the Integration owner's currency
+without inventing an acquisition registration or treating display text as
+identity; it does not settle the deferred general portable Type-subject design.
+
 ### Nodes and groups
 
 Package and type are both subject kinds and grouping lenses.

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -935,6 +935,36 @@ candidate inventory is produced before
 never reconstructed from the projection's surviving edges or filtered
 `BindingMissing` details.
 
+`IntegrationGraphProjectionResult` retains the exact Graph plan, compatible
+snapshot, explicit induced-set request, projected graph document, and candidate
+inventory in canonical classified-attempt order. An `Out` inventory entry has
+no admitted occurrence. Every `In` entry retains its pre-induction edge and
+occurrence subjects plus a closed projection state: `Retained` names the final
+dense occurrence and logical-edge ids, while `FilteredByRequest` records that
+the existing induced-set projection removed it. A missing `In` occurrence is
+therefore not representable as an ordinary result.
+
+Census graph occurrence evidence retains the exact classified attempt, and its
+relationship-specific occurrence identity is the
+`IntegrationCandidateAttemptAddress`. Distinct context attempts can therefore
+remain distinct occurrences while normal graph collapse maps them to one
+logical edge. `integration.observed` admits the candidate's source member or
+Type; this widens the descriptor's admitted source currency without changing
+the legacy workspace query's existing member occurrences. Opportunity
+projection preserves its existing assembly-to-Type logical edge and
+Type-to-Type occurrence semantics.
+
+Graph subjects wrap the exact Integration-issued candidate source, resolved
+Type, or participant identity. They never invent an acquisition registration
+or derive identity from display text. Coordinate-backed package participants
+join their realized package group on both source and terminal sides.
+Integration-backed member, Type, and assembly subjects remain graph
+session-bound because `IIntegrationBindingContextIdentity` has no portable
+contract. An incomplete snapshot retains healthy admitted occurrences beside a
+global graph failure containing the exact unhealthy source, producer-policy,
+and candidate receipts; the graph document cannot look successfully complete
+when the projection result is incomplete.
+
 ### Peer lookup and parent provenance
 
 `IntegrationPeerLookup` is the candidate's handoff currency. It retains the
@@ -997,7 +1027,8 @@ Implementation should land as focused slices:
 4. `Integration Inventory` row Section and structured row output
    (implemented as a host-neutral row projection plus an unregistered reusable
    L2 catalog and schema);
-5. graph correspondence from `In` candidates without changing graph semantics;
+5. graph correspondence from `In` candidates without changing graph semantics
+   (implemented);
 6. sparse matrix projection and WASM demo; and
 7. separately owned #4979 `find` prerequisite or optional enrichment for
    discovering an unknown parent.
@@ -1148,6 +1179,18 @@ The Integration Inventory row-projection slice is verified by:
 - `IntegrationProjection_EachResponseRetainsItsExactValidatedRequest`
 - `IntegrationProjection_ReuseRequiresCompatibleCensusSnapshot`
 
+The Integration graph-correspondence slice is verified by:
+
+- `IntegrationGraph_OnlyInCandidatesContributeOccurrences`
+- `IntegrationGraph_OutCandidatesAreNeitherEdgesNorFailures`
+- `IntegrationGraph_CandidateInventoryPrecedesInducedSetProjection`
+- `IntegrationGraph_RetainsCandidateAttemptOccurrenceAndEdgeCorrespondence`
+- `IntegrationGraph_MultipleCandidatesMayCorrespondToOneLogicalEdge`
+- `IntegrationGraph_OpportunityPreservesAssemblyEdgeAndTypeOccurrence`
+- `IntegrationGraph_IncompleteCensusRetainsHealthyGraphAndFailure`
+- `IntegrationGraph_RequiresGraphPlanAndCensusBackedRequest`
+- `IntegrationProjection_RowsAndGraphShareOneAnalysisAndSnapshot`
+
 The remaining target implementation is unverified until these named gates
 land:
 
@@ -1165,11 +1208,6 @@ land:
 - `IntegrationMatrix_ProducerPolicyFailureIncompletesEveryBindingContextForItsConcept`
 - `IntegrationMatrix_CandidateFailureDoesNotContaminateOtherBindingContexts`
 - `IntegrationMatrix_OrdersByDeclaredParticipantContextAndConceptOrder`
-- `IntegrationGraph_OnlyInCandidatesContributeOccurrences`
-- `IntegrationGraph_OutCandidatesAreNeitherEdgesNorFailures`
-- `IntegrationGraph_CandidateInventoryPrecedesInducedSetProjection`
-- `IntegrationGraph_RetainsCandidateAttemptOccurrenceAndEdgeCorrespondence`
-- `IntegrationGraph_MultipleCandidatesMayCorrespondToOneLogicalEdge`
 - `IntegrationProjection_RowsMatrixAndGraphShareOneAnalysisAndSnapshot`
 - `IntegrationWasmDemo_RendersSharedProjectionWithoutDetectionPolicy`
 

--- a/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
+++ b/src/DotnetInspector.Queries.Tests/IntegrationCensusTests.cs
@@ -2377,6 +2377,544 @@ public sealed class IntegrationCensusTests
         Assert.Same(snapshot, result.Snapshot);
     }
 
+    // ---- Graph projection ----------------------------------------------
+
+    [Fact]
+    public void IntegrationGraph_OnlyInCandidatesContributeOccurrences()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-in-out");
+        IntegrationCandidateIdentity inside = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.In"),
+                TypeName("Peer", "Inside")),
+            TypeElement("Source", "Observed"));
+        IntegrationCandidateIdentity outside = new(
+            OpportunityRel,
+            IntegrationConceptCatalog.Aspire,
+            new IntegrationCandidateSourceIdentity(
+                participant,
+                TypeElement("Source", "Opportunity")),
+            PolicyTargetPeer(
+                "Peer.Out",
+                TypeName("Peer", "Outside")));
+        IntegrationTypeIdentity terminal = PeerTerminal(inside);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, inside),
+                Completed(participant, Opportunity, outside)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedIn(inside, context, terminal),
+                ClassifiedOut(outside, context),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(participant),
+                        PackageSubject(terminal.Participant),
+                    ],
+                    Observed,
+                    OpportunityRel));
+
+        InspectionGraphOccurrence occurrence =
+            Assert.Single(result.Document.Occurrences);
+        var evidence = Assert.IsType<
+            InspectionGraphIntegrationCensusCandidateEvidence>(
+                occurrence.Evidence);
+        Assert.Same(
+            inside,
+            evidence.Attempt.Address.Candidate);
+        Assert.Equal(2, result.CandidateInventory.Length);
+        Assert.NotNull(
+            Assert.Single(
+                result.CandidateInventory,
+                item => ReferenceEquals(item.Candidate, inside))
+                .Occurrence);
+        Assert.Null(
+            Assert.Single(
+                result.CandidateInventory,
+                item => ReferenceEquals(item.Candidate, outside))
+                .Occurrence);
+    }
+
+    [Fact]
+    public void IntegrationGraph_OutCandidatesAreNeitherEdgesNorFailures()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-out");
+        IntegrationCandidateIdentity candidate = new(
+            OpportunityRel,
+            IntegrationConceptCatalog.AI,
+            new IntegrationCandidateSourceIdentity(
+                participant,
+                TypeElement("Source", "Opportunity")),
+            PolicyTargetPeer(
+                "Peer.Out",
+                TypeName("Peer", "Outside")));
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Opportunity, candidate)),
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedOut(candidate, context),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [PackageSubject(participant)],
+                    OpportunityRel));
+
+        Assert.Empty(result.Document.Nodes);
+        Assert.Empty(result.Document.Edges);
+        Assert.Empty(result.Document.Occurrences);
+        Assert.Empty(result.Document.Failures);
+        Assert.Single(result.Document.Groups);
+        Assert.Null(Assert.Single(result.CandidateInventory).Occurrence);
+    }
+
+    [Fact]
+    public void IntegrationGraph_CandidateInventoryPrecedesInducedSetProjection()
+    {
+        IntegrationSourceParticipantIdentity firstSource =
+            Portable("graph-first");
+        IntegrationSourceParticipantIdentity secondSource =
+            Portable("graph-second");
+        IntegrationCandidateIdentity first = ObservedCandidate(
+            firstSource,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.First"),
+                TypeName("Peer", "First")),
+            TypeElement("Source", "First"));
+        IntegrationCandidateIdentity second = ObservedCandidate(
+            secondSource,
+            IntegrationConceptCatalog.Aspire,
+            AssemblyPeer(
+                Assembly("Peer.Second"),
+                TypeName("Peer", "Second")),
+            TypeElement("Source", "Second"));
+        IntegrationTypeIdentity firstTerminal = PeerTerminal(first);
+        IntegrationTypeIdentity secondTerminal = PeerTerminal(second);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [firstSource, secondSource],
+            producerAttempts: Producers(
+                [firstSource, secondSource],
+                Completed(firstSource, Ecosystem, first),
+                Completed(secondSource, Ecosystem, second)),
+            selectedTypes: [firstTerminal, secondTerminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedIn(second, context, secondTerminal),
+                ClassifiedIn(first, context, firstTerminal),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(firstSource),
+                        PackageSubject(firstTerminal.Participant),
+                    ],
+                    Observed));
+
+        Assert.Equal(2, result.CandidateInventory.Length);
+        Assert.Equal(
+            snapshot.ClassifiedAttempts,
+            result.CandidateInventory.Select(
+                static item => item.Attempt));
+        IntegrationGraphCandidateProjection retained = Assert.Single(
+            result.CandidateInventory,
+            item => ReferenceEquals(item.Candidate, first));
+        IntegrationGraphCandidateProjection filtered = Assert.Single(
+            result.CandidateInventory,
+            item => ReferenceEquals(item.Candidate, second));
+        Assert.IsType<IntegrationGraphOccurrenceProjection.Retained>(
+            Assert.IsType<IntegrationGraphCandidateOccurrence>(
+                retained.Occurrence).Projection);
+        Assert.IsType<IntegrationGraphOccurrenceProjection.FilteredByRequest>(
+            Assert.IsType<IntegrationGraphCandidateOccurrence>(
+                filtered.Occurrence).Projection);
+        Assert.Single(result.Document.Occurrences);
+    }
+
+    [Fact]
+    public void IntegrationGraph_RetainsCandidateAttemptOccurrenceAndEdgeCorrespondence()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-correspondence");
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Correspondence"),
+                TypeName("Peer", "Client")),
+            TypeElement("Source", "TypeEvidence"));
+        IntegrationTypeIdentity terminal = PeerTerminal(candidate);
+        var context = new Context();
+        IntegrationCandidateAttempt.Classified attempt =
+            ClassifiedIn(candidate, context, terminal);
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts: [attempt],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(participant),
+                        PackageSubject(terminal.Participant),
+                    ],
+                    Observed));
+
+        IntegrationGraphCandidateProjection projected =
+            Assert.Single(result.CandidateInventory);
+        IntegrationGraphCandidateOccurrence admitted =
+            Assert.IsType<IntegrationGraphCandidateOccurrence>(
+                projected.Occurrence);
+        var retained = Assert.IsType<
+            IntegrationGraphOccurrenceProjection.Retained>(
+                admitted.Projection);
+        InspectionGraphOccurrence occurrence =
+            result.Document.Occurrences[retained.OccurrenceId];
+        InspectionGraphEdge edge =
+            result.Document.Edges[retained.EdgeId];
+        var evidence = Assert.IsType<
+            InspectionGraphIntegrationCensusCandidateEvidence>(
+                occurrence.Evidence);
+
+        Assert.Same(attempt, projected.Attempt);
+        Assert.Same(attempt, evidence.Attempt);
+        Assert.Equal(admitted.OccurrenceSource, occurrence.SourceSubject);
+        Assert.Equal(admitted.OccurrenceTarget, occurrence.TargetSubject);
+        Assert.Contains(retained.OccurrenceId, edge.OccurrenceIds);
+        Assert.Equal(admitted.EdgeSource,
+            result.Document.Nodes[edge.FromNodeId].Subject);
+        Assert.Equal(admitted.EdgeTarget,
+            result.Document.Nodes[edge.ToNodeId].Subject);
+        var source = Assert.IsType<
+            InspectionGraphTypeIdentity.CensusType>(
+                Assert.IsType<InspectionGraphSubject.TypeSubject>(
+                    occurrence.SourceSubject).Identity);
+        var target = Assert.IsType<
+            InspectionGraphTypeIdentity.CensusType>(
+                Assert.IsType<InspectionGraphSubject.TypeSubject>(
+                    occurrence.TargetSubject).Identity);
+        Assert.Same(participant, source.Identity.Participant);
+        Assert.Same(terminal, target.Identity);
+        Assert.Null(source.Identity.Participant.Registration);
+        Assert.NotNull(source.Identity.Participant.Coordinate);
+        Assert.Equal(
+            InspectionGraphDocumentScope.SessionBound,
+            result.Document.Scope);
+        Assert.Same(result.GraphRequest, result.Document.InducedSetRequest);
+    }
+
+    [Fact]
+    public void IntegrationGraph_OpportunityPreservesAssemblyEdgeAndTypeOccurrence()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-opportunity");
+        IntegrationCandidateIdentity candidate = OpportunityCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            PolicyTargetPeer(
+                "Peer.Opportunity",
+                TypeName("Peer", "Client")));
+        IntegrationTypeIdentity terminal = PeerTerminal(candidate);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Opportunity, candidate)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedIn(candidate, context, terminal),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(participant),
+                        PackageSubject(terminal.Participant),
+                    ],
+                    OpportunityRel));
+
+        InspectionGraphEdge edge = Assert.Single(result.Document.Edges);
+        InspectionGraphOccurrence occurrence =
+            Assert.Single(result.Document.Occurrences);
+        Assert.IsType<
+            InspectionGraphAssemblyIdentity.CensusParticipant>(
+                Assert.IsType<InspectionGraphSubject.AssemblySubject>(
+                    result.Document.Nodes[edge.FromNodeId].Subject).Identity);
+        Assert.IsType<InspectionGraphSubject.TypeSubject>(
+            occurrence.SourceSubject);
+        Assert.Equal(
+            occurrence.TargetSubject,
+            result.Document.Nodes[edge.ToNodeId].Subject);
+    }
+
+    [Fact]
+    public void IntegrationGraph_MultipleCandidatesMayCorrespondToOneLogicalEdge()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-many");
+        IntegrationCandidateIdentity candidate = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Many"),
+                TypeName("Peer", "Client")),
+            new IntegrationCandidateSourceElement.Member(
+                TypeName("Source", "Adapter"),
+                Anchor("Source.Adapter")));
+        IntegrationTypeIdentity terminal = PeerTerminal(candidate);
+        var first = new Context();
+        var second = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(participant, Ecosystem, candidate)),
+            selectedTypes: [terminal],
+            contexts: [first, second],
+            candidateAttempts:
+            [
+                ClassifiedIn(candidate, second, terminal),
+                ClassifiedIn(candidate, first, terminal),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(participant),
+                        PackageSubject(terminal.Participant),
+                    ],
+                    Observed));
+
+        IntegrationGraphOccurrenceProjection.Retained[] retained =
+        [
+            .. result.CandidateInventory.Select(item =>
+                Assert.IsType<
+                    IntegrationGraphOccurrenceProjection.Retained>(
+                        Assert.IsType<IntegrationGraphCandidateOccurrence>(
+                            item.Occurrence).Projection)),
+        ];
+        Assert.Equal(2, retained.Length);
+        Assert.NotEqual(
+            retained[0].OccurrenceId,
+            retained[1].OccurrenceId);
+        Assert.Equal(retained[0].EdgeId, retained[1].EdgeId);
+        Assert.Single(result.Document.Edges);
+        Assert.Equal(2, Assert.Single(result.Document.Edges).OccurrenceIds.Length);
+    }
+
+    [Fact]
+    public void IntegrationGraph_IncompleteCensusRetainsHealthyGraphAndFailure()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-incomplete");
+        IntegrationCandidateIdentity healthy = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.AI,
+            AssemblyPeer(
+                Assembly("Peer.Healthy"),
+                TypeName("Peer", "Healthy")),
+            TypeElement("Source", "Healthy"));
+        IntegrationCandidateIdentity failed = ObservedCandidate(
+            participant,
+            IntegrationConceptCatalog.Aspire,
+            AssemblyPeer(
+                Assembly("Peer.Failed"),
+                TypeName("Peer", "Failed")),
+            TypeElement("Source", "Failed"));
+        IntegrationTypeIdentity terminal = PeerTerminal(healthy);
+        var context = new Context();
+        AnalysisRequestPlan plan = Plan(
+            projection: IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            producerAttempts: Producers(
+                [participant],
+                Completed(
+                    participant,
+                    Ecosystem,
+                    healthy,
+                    failed)),
+            selectedTypes: [terminal],
+            contexts: [context],
+            candidateAttempts:
+            [
+                ClassifiedIn(healthy, context, terminal),
+                new IntegrationCandidateAttempt.Failed(
+                    new IntegrationCandidateAttemptAddress(
+                        failed,
+                        context),
+                    new CandidateFailure()),
+            ],
+            plan: plan);
+
+        IntegrationGraphProjectionResult result =
+            IntegrationGraphProjection.Project(
+                plan,
+                snapshot,
+                GraphRequest(
+                    [
+                        PackageSubject(participant),
+                        PackageSubject(terminal.Participant),
+                    ],
+                    Observed));
+
+        Assert.False(result.IsComplete);
+        Assert.Single(result.Document.Occurrences);
+        InspectionGraphFailure failure =
+            Assert.Single(result.Document.Failures);
+        Assert.Same(
+            InspectionGraphIntegrationsCatalog.ProjectionFailure,
+            failure.Descriptor);
+        var evidence = Assert.IsType<
+            InspectionGraphIntegrationCensusFailureEvidence>(
+                failure.Evidence);
+        Assert.Single(evidence.CandidateAttempts);
+        Assert.Empty(evidence.SourceAttempts);
+        Assert.Empty(evidence.ProducerPolicyAttempts);
+    }
+
+    [Fact]
+    public void IntegrationProjection_RowsAndGraphShareOneAnalysisAndSnapshot()
+    {
+        AnalysisReportSurface surface = Surface();
+        AnalysisUniverseDescription universe = FullUniverse();
+        AnalysisRequestPlan rows =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Rows);
+        AnalysisRequestPlan graph =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Graph);
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-shared");
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            plan: rows);
+
+        IntegrationInventoryProjectionResult rowResult =
+            IntegrationInventoryProjection.Project(rows, snapshot);
+        IntegrationGraphProjectionResult graphResult =
+            IntegrationGraphProjection.Project(
+                graph,
+                snapshot,
+                GraphRequest(
+                    [PackageSubject(participant)],
+                    Observed));
+
+        Assert.Same(snapshot, rowResult.Snapshot);
+        Assert.Same(snapshot, graphResult.Snapshot);
+        Assert.Same(rowResult.Analysis, graphResult.Analysis);
+        Assert.Same(rowResult.ReportSurface, graphResult.ReportSurface);
+        Assert.Same(rowResult.Universe, graphResult.Universe);
+        Assert.Empty(rowResult.Rows);
+        Assert.Empty(graphResult.CandidateInventory);
+        Assert.Empty(graphResult.Document.Occurrences);
+    }
+
+    [Fact]
+    public void IntegrationGraph_RequiresGraphPlanAndCensusBackedRequest()
+    {
+        IntegrationSourceParticipantIdentity participant =
+            Portable("graph-request");
+        AnalysisReportSurface surface = Surface();
+        AnalysisUniverseDescription universe = FullUniverse();
+        AnalysisRequestPlan rows =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Rows);
+        AnalysisRequestPlan graph =
+            Plan(surface, universe, IntegrationAnalysisCatalog.Graph);
+        IntegrationCensusSnapshot snapshot = Snapshot(
+            [participant],
+            plan: rows);
+        InspectionGraphInducedSetRequest request = GraphRequest(
+            [PackageSubject(participant)],
+            Observed);
+
+        Assert.Throws<ArgumentException>(() =>
+            IntegrationGraphProjection.Project(rows, snapshot, request));
+        Assert.Throws<ArgumentException>(() =>
+            IntegrationGraphProjection.Project(
+                graph,
+                snapshot,
+                GraphRequest(
+                    [PackageSubject(participant)],
+                    InspectionGraphIntegrationsCatalog.Extension)));
+        Assert.Throws<ArgumentException>(() =>
+            IntegrationGraphProjection.Project(
+                graph,
+                snapshot,
+                GraphRequest(
+                    [
+                        InspectionGraphSubject.ForRealizedPackage(
+                            new RealizedMemberCoordinate.Package(
+                                "contoso.foreign",
+                                "1.0.0",
+                                "fixture",
+                                "net11.0",
+                                null)),
+                    ],
+                    Observed)));
+    }
+
     // =====================================================================
     // Fixture / helper layer
     // =====================================================================
@@ -2584,6 +3122,30 @@ public sealed class IntegrationCensusTests
             new IntegrationCandidateAttemptAddress(candidate, context),
             new IntegrationCandidateDisposition.Out(
                 Resolved(candidate, PeerTerminal(candidate))));
+
+    static IntegrationCandidateAttempt.Classified ClassifiedIn(
+        IntegrationCandidateIdentity candidate,
+        IIntegrationBindingContextIdentity context,
+        IntegrationTypeIdentity terminal) =>
+        new(
+            new IntegrationCandidateAttemptAddress(candidate, context),
+            new IntegrationCandidateDisposition.In(
+                Resolved(candidate, terminal)));
+
+    static InspectionGraphSubject PackageSubject(
+        IntegrationSourceParticipantIdentity participant) =>
+        InspectionGraphSubject.ForRealizedPackage(
+            Assert.IsType<RealizedMemberCoordinate.Package>(
+                participant.Coordinate));
+
+    static InspectionGraphInducedSetRequest GraphRequest(
+        IEnumerable<InspectionGraphSubject> subjects,
+        params InspectionGraphRelationshipDescriptor[] relationships) =>
+        new(
+            subjects,
+            relationships,
+            InspectionGraphInducedSetAdmissionRule
+                .BothEndpointsWithinSubjectClosure);
 
     // The exact selected-universe Type identity backing one candidate's source
     // element, admitted so completed producer evidence stays live.

--- a/src/DotnetInspector.Queries/InspectionGraphDocument.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphDocument.cs
@@ -69,6 +69,29 @@ public abstract record InspectionGraphMemberIdentity
         public MemberAnchor Member { get; }
         public override bool IsPortable => false;
     }
+
+    /// <summary>
+    /// One Integration candidate member interpreted within its Census
+    /// participant.
+    /// </summary>
+    public sealed record CensusMember : InspectionGraphMemberIdentity
+    {
+        public CensusMember(IntegrationCandidateSourceIdentity source)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            if (source.Element is not IntegrationCandidateSourceElement.Member)
+            {
+                throw new ArgumentException(
+                    "An Integration member subject requires a member source element.",
+                    nameof(source));
+            }
+
+            Source = source;
+        }
+
+        public IntegrationCandidateSourceIdentity Source { get; }
+        public override bool IsPortable => false;
+    }
 }
 
 /// <summary>Owner-issued identity for one type subject.</summary>
@@ -109,6 +132,21 @@ public abstract record InspectionGraphTypeIdentity
 
         public AssemblyAcquisitionRegistration Registration { get; }
         public MetadataTypeDefinitionName Type { get; }
+        public override bool IsPortable => false;
+    }
+
+    /// <summary>
+    /// One Integration Census Type interpreted within its exact participant.
+    /// </summary>
+    public sealed record CensusType : InspectionGraphTypeIdentity
+    {
+        public CensusType(IntegrationTypeIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+            Identity = identity;
+        }
+
+        public IntegrationTypeIdentity Identity { get; }
         public override bool IsPortable => false;
     }
 }
@@ -156,6 +194,23 @@ public abstract record InspectionGraphAssemblyIdentity
 
         public AssemblyReferenceIdentity Assembly { get; }
         public override bool IsPortable => true;
+    }
+
+    /// <summary>
+    /// One assembly participant addressed by an Integration Census.
+    /// </summary>
+    public sealed record CensusParticipant :
+        InspectionGraphAssemblyIdentity
+    {
+        public CensusParticipant(
+            IntegrationSourceParticipantIdentity participant)
+        {
+            ArgumentNullException.ThrowIfNull(participant);
+            Participant = participant;
+        }
+
+        public IntegrationSourceParticipantIdentity Participant { get; }
+        public override bool IsPortable => false;
     }
 }
 
@@ -215,6 +270,10 @@ public abstract record InspectionGraphSubject
                 declaringType,
                 member));
 
+    public static InspectionGraphSubject ForIntegrationMember(
+        IntegrationCandidateSourceIdentity source) =>
+        ForMember(new InspectionGraphMemberIdentity.CensusMember(source));
+
     public static InspectionGraphSubject ForType(
         InspectionGraphTypeIdentity identity) =>
         new TypeSubject(identity);
@@ -230,6 +289,10 @@ public abstract record InspectionGraphSubject
                 registration,
                 type));
 
+    public static InspectionGraphSubject ForIntegrationType(
+        IntegrationTypeIdentity identity) =>
+        ForType(new InspectionGraphTypeIdentity.CensusType(identity));
+
     public static InspectionGraphSubject ForAssembly(
         InspectionGraphAssemblyIdentity identity) =>
         new AssemblySubject(identity);
@@ -242,6 +305,12 @@ public abstract record InspectionGraphSubject
         AssemblyReferenceIdentity assembly) =>
         ForAssembly(
             new InspectionGraphAssemblyIdentity.Metadata(assembly));
+
+    public static InspectionGraphSubject ForIntegrationAssembly(
+        IntegrationSourceParticipantIdentity participant) =>
+        ForAssembly(
+            new InspectionGraphAssemblyIdentity.CensusParticipant(
+                participant));
 
     public static InspectionGraphSubject ForPackage(
         InspectionGraphPackageIdentity identity) =>

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -31,8 +31,26 @@ public static class InspectionGraphIntegrationsCatalog
         { get; } =
         new("metadata.integration-opportunity", InspectionGraphOwner.Metadata);
 
+    public static InspectionGraphEvidenceDescriptor CensusObservedEvidence
+        { get; } =
+        new(
+            "queries.integration-census-observed",
+            InspectionGraphOwner.Queries);
+
+    public static InspectionGraphEvidenceDescriptor CensusOpportunityEvidence
+        { get; } =
+        new(
+            "queries.integration-census-opportunity",
+            InspectionGraphOwner.Queries);
+
     public static InspectionGraphEvidenceDescriptor FailureEvidence { get; } =
         new("queries.integration-graph-failure", InspectionGraphOwner.Queries);
+
+    public static InspectionGraphEvidenceDescriptor CensusFailureEvidence
+        { get; } =
+        new(
+            "queries.integration-census-incomplete",
+            InspectionGraphOwner.Queries);
 
     public static InspectionGraphRelationshipDescriptor Extension { get; } =
         new(
@@ -71,9 +89,15 @@ public static class InspectionGraphIntegrationsCatalog
             "integration.observed",
             InspectionGraphOwner.Metadata,
             InspectionGraphRelationshipSemantics.Observed,
-            [InspectionGraphSubjectKind.Member],
+            [
+                InspectionGraphSubjectKind.Member,
+                InspectionGraphSubjectKind.Type,
+            ],
             [InspectionGraphSubjectKind.Type],
-            [InspectionGraphSubjectKind.Member],
+            [
+                InspectionGraphSubjectKind.Member,
+                InspectionGraphSubjectKind.Type,
+            ],
             [InspectionGraphSubjectKind.Type],
             [
                 new(
@@ -95,7 +119,10 @@ public static class InspectionGraphIntegrationsCatalog
             ],
             InspectionGraphEndpointProjection.Exact,
             OccurrenceIdentity,
-            [IntegrationEvidence]);
+            [
+                IntegrationEvidence,
+                CensusObservedEvidence,
+            ]);
 
     public static InspectionGraphRelationshipDescriptor MetadataReference
         { get; } =
@@ -159,13 +186,19 @@ public static class InspectionGraphIntegrationsCatalog
             ],
             OpportunityEndpointProjection,
             OccurrenceIdentity,
-            [OpportunityEvidence]);
+            [
+                OpportunityEvidence,
+                CensusOpportunityEvidence,
+            ]);
 
     public static InspectionGraphFailureDescriptor ProjectionFailure { get; } =
         new(
             "queries.integration-graph-incomplete",
             InspectionGraphOwner.Queries,
-            [FailureEvidence]);
+            [
+                FailureEvidence,
+                CensusFailureEvidence,
+            ]);
 
     public static ImmutableArray<InspectionGraphRelationshipDescriptor>
         Relationships { get; } =
@@ -209,6 +242,8 @@ public static class InspectionGraphIntegrationsCatalog
                             opportunity.Integration,
                             opportunity.GetConcept()),
                         opportunity.Target),
+                InspectionGraphIntegrationCensusCandidateEvidence census =>
+                    census.Attempt.Address,
                 _ => throw new ArgumentException(
                     "Unsupported Integration graph occurrence evidence.",
                     nameof(occurrence)),
@@ -314,6 +349,24 @@ public static class InspectionGraphIntegrationsCatalog
 
             if (occurrence.SourceSubject == endpoint)
                 return true;
+            if (occurrence.SourceSubject
+                    is InspectionGraphSubject.TypeSubject
+                    {
+                        Identity:
+                            InspectionGraphTypeIdentity.CensusType
+                            sourceType,
+                    }
+                && endpoint
+                    is InspectionGraphSubject.AssemblySubject
+                    {
+                        Identity:
+                            InspectionGraphAssemblyIdentity
+                                .CensusParticipant sourceAssembly,
+                    })
+            {
+                return sourceType.Identity.Participant.Equals(
+                    sourceAssembly.Participant);
+            }
             return occurrence.SourceSubject
                     is InspectionGraphSubject.TypeSubject
                     {
@@ -513,6 +566,49 @@ public sealed record InspectionGraphOpportunityEvidence(
                 : null;
 }
 
+/// <summary>
+/// Exact Census candidate-attempt evidence retained by one admitted
+/// Integration occurrence.
+/// </summary>
+public sealed record InspectionGraphIntegrationCensusCandidateEvidence :
+    IInspectionGraphOccurrenceEvidence
+{
+    public InspectionGraphIntegrationCensusCandidateEvidence(
+        IntegrationCandidateAttempt.Classified attempt)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        if (attempt.Disposition is not IntegrationCandidateDisposition.In)
+        {
+            throw new ArgumentException(
+                "Only an In candidate attempt can contribute graph evidence.",
+                nameof(attempt));
+        }
+        if (!ReferenceEquals(
+                attempt.Address.Candidate.Relationship,
+                InspectionGraphIntegrationsCatalog.IntegrationObserved)
+            && !ReferenceEquals(
+                attempt.Address.Candidate.Relationship,
+                InspectionGraphIntegrationsCatalog.IntegrationOpportunity))
+        {
+            throw new ArgumentException(
+                "The candidate relationship is not supported by the Integration Census graph.",
+                nameof(attempt));
+        }
+
+        Attempt = attempt;
+    }
+
+    public IntegrationCandidateAttempt.Classified Attempt { get; }
+
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        ReferenceEquals(
+            Attempt.Address.Candidate.Relationship,
+            InspectionGraphIntegrationsCatalog.IntegrationObserved)
+                ? InspectionGraphIntegrationsCatalog.CensusObservedEvidence
+                : InspectionGraphIntegrationsCatalog
+                    .CensusOpportunityEvidence;
+}
+
 /// <summary>Why available workspace evidence could not enter the graph.</summary>
 public enum InspectionGraphIntegrationFailureKind
 {
@@ -530,6 +626,48 @@ public enum InspectionGraphIntegrationFailureKind
     TargetTypeRejected,
     OpportunityTargetMissing,
     OpportunityTargetAmbiguous,
+}
+
+/// <summary>
+/// Typed incomplete Census receipts retained by a graph projection.
+/// </summary>
+public sealed record InspectionGraphIntegrationCensusFailureEvidence :
+    IInspectionGraphDiagnosticEvidence
+{
+    public InspectionGraphIntegrationCensusFailureEvidence(
+        IntegrationCensusSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        SourceAttempts =
+        [
+            .. snapshot.SourceAttempts.Where(static attempt =>
+                attempt is not IntegrationSourceParticipantAttempt.Available),
+        ];
+        ProducerPolicyAttempts =
+        [
+            .. snapshot.ProducerPolicyAttempts.Where(static attempt =>
+                attempt is not IntegrationProducerPolicyAttempt.Completed),
+        ];
+        CandidateAttempts = snapshot.FailedCandidateAttempts;
+        if (SourceAttempts.IsEmpty
+            && ProducerPolicyAttempts.IsEmpty
+            && CandidateAttempts.IsEmpty)
+        {
+            throw new ArgumentException(
+                "Integration Census graph failure evidence requires an incomplete snapshot.",
+                nameof(snapshot));
+        }
+    }
+
+    public ImmutableArray<IntegrationSourceParticipantAttempt> SourceAttempts
+        { get; }
+    public ImmutableArray<IntegrationProducerPolicyAttempt>
+        ProducerPolicyAttempts { get; }
+    public ImmutableArray<IntegrationCandidateAttempt.Failed> CandidateAttempts
+        { get; }
+
+    public InspectionGraphEvidenceDescriptor Descriptor =>
+        InspectionGraphIntegrationsCatalog.CensusFailureEvidence;
 }
 
 /// <summary>One incomplete Integration graph contribution.</summary>

--- a/src/DotnetInspector.Queries/InspectionGraphProjectionUtilities.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphProjectionUtilities.cs
@@ -60,6 +60,51 @@ internal static class InspectionGraphProjectionUtilities
                 && node.GroupIds.Any(groupId =>
                     source.Groups[groupId].Subject == package);
         }
+        if (owner is InspectionGraphSubject.AssemblySubject
+            {
+                Identity:
+                    InspectionGraphAssemblyIdentity.CensusParticipant
+                    assembly,
+            })
+        {
+            return subject switch
+            {
+                InspectionGraphSubject.TypeSubject
+                {
+                    Identity:
+                        InspectionGraphTypeIdentity.CensusType type,
+                } =>
+                    assembly.Participant.Equals(
+                        type.Identity.Participant),
+                InspectionGraphSubject.MemberSubject
+                {
+                    Identity:
+                        InspectionGraphMemberIdentity.CensusMember
+                        assemblyMember,
+                } =>
+                    assembly.Participant.Equals(
+                        assemblyMember.Source.Participant),
+                _ => false,
+            };
+        }
+        if (owner is InspectionGraphSubject.TypeSubject
+            {
+                Identity:
+                    InspectionGraphTypeIdentity.CensusType
+                    integrationOwnerType,
+            }
+            && subject is InspectionGraphSubject.MemberSubject
+            {
+                Identity:
+                    InspectionGraphMemberIdentity.CensusMember
+                    integrationMember,
+            })
+        {
+            return integrationOwnerType.Identity.Participant.Equals(
+                    integrationMember.Source.Participant)
+                && integrationOwnerType.Identity.Type.Equals(
+                    integrationMember.Source.SourceType);
+        }
         if (!TryGetRegistration(owner, out var ownerRegistration)
             || !TryGetRegistration(subject, out var subjectRegistration)
             || !ReferenceEquals(

--- a/src/DotnetInspector.Queries/IntegrationGraphProjection.cs
+++ b/src/DotnetInspector.Queries/IntegrationGraphProjection.cs
@@ -1,0 +1,575 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// Whether one admitted Census occurrence survived the requested graph
+/// induction.
+/// </summary>
+public abstract record IntegrationGraphOccurrenceProjection
+{
+    private protected IntegrationGraphOccurrenceProjection()
+    {
+    }
+
+    public sealed record FilteredByRequest :
+        IntegrationGraphOccurrenceProjection;
+
+    public sealed record Retained :
+        IntegrationGraphOccurrenceProjection
+    {
+        public Retained(int occurrenceId, int edgeId)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(occurrenceId);
+            ArgumentOutOfRangeException.ThrowIfNegative(edgeId);
+            OccurrenceId = occurrenceId;
+            EdgeId = edgeId;
+        }
+
+        public int OccurrenceId { get; }
+        public int EdgeId { get; }
+    }
+}
+
+/// <summary>
+/// The pre-induction graph occurrence admitted by one <c>In</c> candidate.
+/// </summary>
+public sealed class IntegrationGraphCandidateOccurrence
+{
+    internal IntegrationGraphCandidateOccurrence(
+        InspectionGraphSubject edgeSource,
+        InspectionGraphSubject edgeTarget,
+        InspectionGraphSubject occurrenceSource,
+        InspectionGraphSubject occurrenceTarget,
+        IntegrationGraphOccurrenceProjection projection)
+    {
+        EdgeSource = edgeSource;
+        EdgeTarget = edgeTarget;
+        OccurrenceSource = occurrenceSource;
+        OccurrenceTarget = occurrenceTarget;
+        Projection = projection;
+    }
+
+    public InspectionGraphSubject EdgeSource { get; }
+    public InspectionGraphSubject EdgeTarget { get; }
+    public InspectionGraphSubject OccurrenceSource { get; }
+    public InspectionGraphSubject OccurrenceTarget { get; }
+    public IntegrationGraphOccurrenceProjection Projection { get; }
+}
+
+/// <summary>
+/// One classified candidate retained before explicit induced-set filtering.
+/// </summary>
+public sealed class IntegrationGraphCandidateProjection
+{
+    internal IntegrationGraphCandidateProjection(
+        IntegrationCandidateAttempt.Classified attempt,
+        IntegrationGraphCandidateOccurrence? occurrence)
+    {
+        ArgumentNullException.ThrowIfNull(attempt);
+        if ((attempt.Disposition is IntegrationCandidateDisposition.In)
+            != (occurrence is not null))
+        {
+            throw new ArgumentException(
+                "Exactly the In candidate attempts require an admitted graph occurrence.",
+                nameof(occurrence));
+        }
+
+        Attempt = attempt;
+        Occurrence = occurrence;
+    }
+
+    public IntegrationCandidateAttempt.Classified Attempt { get; }
+    public IntegrationCandidateAttemptAddress Address => Attempt.Address;
+    public IntegrationCandidateIdentity Candidate => Address.Candidate;
+    public IntegrationCandidateDisposition Disposition => Attempt.Disposition;
+    public IntegrationGraphCandidateOccurrence? Occurrence { get; }
+}
+
+/// <summary>
+/// The typed graph payload for one independently validated Integration
+/// projection.
+/// </summary>
+public sealed class IntegrationGraphProjectionResult :
+    IntegrationCensusProjectionResult
+{
+    internal IntegrationGraphProjectionResult(
+        AnalysisRequestPlan plan,
+        IntegrationCensusSnapshot snapshot,
+        InspectionGraphInducedSetRequest graphRequest,
+        InspectionGraphDocument document,
+        ImmutableArray<IntegrationGraphCandidateProjection>
+            candidateInventory)
+        : base(RequireGraphPlan(plan), snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(graphRequest);
+        ArgumentNullException.ThrowIfNull(document);
+        GraphRequest = graphRequest;
+        Document = document;
+        CandidateInventory = candidateInventory;
+    }
+
+    public InspectionGraphInducedSetRequest GraphRequest { get; }
+    public InspectionGraphDocument Document { get; }
+    public ImmutableArray<IntegrationGraphCandidateProjection>
+        CandidateInventory { get; }
+
+    internal static AnalysisRequestPlan RequireGraphPlan(
+        AnalysisRequestPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        if (!ReferenceEquals(
+                plan.Projection,
+                IntegrationAnalysisCatalog.Graph))
+        {
+            throw new ArgumentException(
+                "Integration graph projection requires the configured graph projection.",
+                nameof(plan));
+        }
+
+        return plan;
+    }
+}
+
+/// <summary>
+/// Projects <c>In</c> Census candidates through the existing Integration
+/// relationship and induced-set contracts.
+/// </summary>
+public static class IntegrationGraphProjection
+{
+    public static IntegrationGraphProjectionResult Project(
+        AnalysisRequestPlan plan,
+        IntegrationCensusSnapshot snapshot,
+        InspectionGraphInducedSetRequest graphRequest)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(graphRequest);
+        IntegrationGraphProjectionResult.RequireGraphPlan(plan);
+        if (!snapshot.IsCompatibleWith(plan))
+        {
+            throw new ArgumentException(
+                "The Integration graph request is not compatible with the Census snapshot.",
+                nameof(plan));
+        }
+        ValidateRelationships(graphRequest.Relationships);
+
+        var builder = new SourceBuilder(snapshot);
+        Dictionary<
+            IntegrationCandidateAttemptAddress,
+            CandidateOccurrenceShape> shapes =
+            builder.AddCandidates();
+        foreach (InspectionGraphSubject subject in graphRequest.Subjects)
+            builder.AddRequestedSubject(subject);
+
+        InspectionGraphDocument source = builder.Build();
+        InspectionGraphDocument document =
+            InspectionGraphInducedSetProjection.Project(
+                source,
+                graphRequest);
+        Dictionary<IntegrationCandidateAttemptAddress, int> occurrenceIds =
+            RetainedOccurrenceIds(document);
+        Dictionary<int, int> edgeIds = RetainedEdgeIds(document);
+
+        ImmutableArray<IntegrationGraphCandidateProjection> inventory =
+        [
+            .. snapshot.ClassifiedAttempts.Select(attempt =>
+            {
+                if (attempt.Disposition
+                    is not IntegrationCandidateDisposition.In)
+                {
+                    return new IntegrationGraphCandidateProjection(
+                        attempt,
+                        occurrence: null);
+                }
+
+                CandidateOccurrenceShape shape =
+                    shapes[attempt.Address];
+                IntegrationGraphOccurrenceProjection projection =
+                    occurrenceIds.TryGetValue(
+                        attempt.Address,
+                        out int occurrenceId)
+                        ? new IntegrationGraphOccurrenceProjection.Retained(
+                            occurrenceId,
+                            edgeIds[occurrenceId])
+                        : new IntegrationGraphOccurrenceProjection
+                            .FilteredByRequest();
+                return new IntegrationGraphCandidateProjection(
+                    attempt,
+                    new IntegrationGraphCandidateOccurrence(
+                        shape.EdgeSource,
+                        shape.EdgeTarget,
+                        shape.OccurrenceSource,
+                        shape.OccurrenceTarget,
+                        projection));
+            }),
+        ];
+        return new IntegrationGraphProjectionResult(
+            plan,
+            snapshot,
+            graphRequest,
+            document,
+            inventory);
+    }
+
+    static void ValidateRelationships(
+        IEnumerable<InspectionGraphRelationshipDescriptor> relationships)
+    {
+        HashSet<InspectionGraphRelationshipDescriptor> configured =
+        [
+            .. IntegrationAnalysisCatalog.ProducerPolicies.Select(
+                static policy => policy.Relationship),
+        ];
+        foreach (InspectionGraphRelationshipDescriptor relationship
+            in relationships)
+        {
+            if (!configured.Contains(relationship))
+            {
+                throw new ArgumentException(
+                    $"Relationship '{relationship.Id}' is not produced by the Integration Census.",
+                    nameof(relationships));
+            }
+        }
+    }
+
+    static Dictionary<IntegrationCandidateAttemptAddress, int>
+        RetainedOccurrenceIds(InspectionGraphDocument document)
+    {
+        var ids =
+            new Dictionary<IntegrationCandidateAttemptAddress, int>();
+        foreach (InspectionGraphOccurrence occurrence in document.Occurrences)
+        {
+            if (occurrence.Evidence
+                is not InspectionGraphIntegrationCensusCandidateEvidence
+                    evidence)
+            {
+                throw new InspectionQueryException(
+                    "An Integration Census graph retained unsupported occurrence evidence.");
+            }
+            if (!ids.TryAdd(evidence.Attempt.Address, occurrence.Id))
+            {
+                throw new InspectionQueryException(
+                    "An Integration candidate attempt contributed more than one graph occurrence.");
+            }
+        }
+
+        return ids;
+    }
+
+    static Dictionary<int, int> RetainedEdgeIds(
+        InspectionGraphDocument document)
+    {
+        var ids = new Dictionary<int, int>();
+        foreach (InspectionGraphEdge edge in document.Edges)
+        {
+            foreach (int occurrenceId in edge.OccurrenceIds)
+            {
+                if (!ids.TryAdd(occurrenceId, edge.Id))
+                {
+                    throw new InspectionQueryException(
+                        "An Integration occurrence contributed to more than one logical edge.");
+                }
+            }
+        }
+
+        return ids;
+    }
+
+    sealed class SourceBuilder
+    {
+        readonly IntegrationCensusSnapshot _snapshot;
+        readonly HashSet<IntegrationSourceParticipantIdentity>
+            _participants;
+        readonly HashSet<IntegrationTypeIdentity> _selectedTypes;
+        readonly HashSet<IntegrationCandidateSourceIdentity>
+            _candidateSources;
+        readonly HashSet<RealizedMemberCoordinate.Package> _packages;
+        readonly List<InspectionGraphNode> _nodes = [];
+        readonly Dictionary<InspectionGraphSubject, int> _nodeIds = [];
+        readonly List<InspectionGraphGroup> _groups = [];
+        readonly Dictionary<RealizedMemberCoordinate.Package, int>
+            _packageGroupIds = [];
+        readonly List<InspectionGraphOccurrence> _occurrences = [];
+        readonly List<EdgeBuilder> _edges = [];
+        readonly Dictionary<EdgeKey, EdgeBuilder> _edgeByKey = [];
+
+        internal SourceBuilder(IntegrationCensusSnapshot snapshot)
+        {
+            _snapshot = snapshot;
+            _participants =
+            [
+                .. snapshot.SourceParticipants.Concat(
+                    snapshot.SelectedTypes.Select(
+                        static type => type.Participant)),
+            ];
+            _selectedTypes = snapshot.SelectedTypes.ToHashSet();
+            _candidateSources =
+            [
+                .. snapshot.Candidates.Select(
+                    static candidate => candidate.Identity.Source),
+            ];
+            _packages =
+            [
+                .. _participants.Select(
+                    static participant => participant.Coordinate)
+                    .OfType<RealizedMemberCoordinate.Package>(),
+            ];
+        }
+
+        internal Dictionary<
+            IntegrationCandidateAttemptAddress,
+            CandidateOccurrenceShape> AddCandidates()
+        {
+            var shapes =
+                new Dictionary<
+                    IntegrationCandidateAttemptAddress,
+                    CandidateOccurrenceShape>();
+            foreach (IntegrationCandidateAttempt.Classified attempt
+                in _snapshot.ClassifiedAttempts)
+            {
+                if (attempt.Disposition
+                    is not IntegrationCandidateDisposition.In inside)
+                {
+                    continue;
+                }
+
+                IntegrationCandidateIdentity candidate =
+                    attempt.Address.Candidate;
+                InspectionGraphSubject occurrenceSource =
+                    SourceSubject(candidate.Source);
+                InspectionGraphSubject occurrenceTarget =
+                    InspectionGraphSubject.ForIntegrationType(
+                        inside.Peer.Terminal);
+                InspectionGraphSubject edgeSource = ReferenceEquals(
+                    candidate.Relationship,
+                    InspectionGraphIntegrationsCatalog
+                        .IntegrationOpportunity)
+                            ? InspectionGraphSubject.ForIntegrationAssembly(
+                                candidate.Source.Participant)
+                            : occurrenceSource;
+                InspectionGraphSubject edgeTarget = occurrenceTarget;
+
+                int sourceNodeId = AddNode(edgeSource);
+                int targetNodeId = AddNode(edgeTarget);
+                AddNode(occurrenceSource);
+                AddNode(occurrenceTarget);
+                int occurrenceId = _occurrences.Count;
+                _occurrences.Add(
+                    new InspectionGraphOccurrence(
+                        occurrenceId,
+                        candidate.Relationship,
+                        occurrenceSource,
+                        occurrenceTarget,
+                        new InspectionGraphIntegrationCensusCandidateEvidence(
+                            attempt),
+                        []));
+
+                var key = new EdgeKey(
+                    sourceNodeId,
+                    targetNodeId,
+                    candidate.Relationship);
+                if (!_edgeByKey.TryGetValue(key, out EdgeBuilder? edge))
+                {
+                    edge = new EdgeBuilder(
+                        sourceNodeId,
+                        targetNodeId,
+                        candidate.Relationship);
+                    _edgeByKey.Add(key, edge);
+                    _edges.Add(edge);
+                }
+                edge.OccurrenceIds.Add(occurrenceId);
+                shapes.Add(
+                    attempt.Address,
+                    new CandidateOccurrenceShape(
+                        edgeSource,
+                        edgeTarget,
+                        occurrenceSource,
+                        occurrenceTarget));
+            }
+
+            return shapes;
+        }
+
+        internal void AddRequestedSubject(InspectionGraphSubject subject)
+        {
+            ArgumentNullException.ThrowIfNull(subject);
+            switch (subject)
+            {
+                case InspectionGraphSubject.PackageSubject
+                {
+                    Identity:
+                        InspectionGraphPackageIdentity.Realized package,
+                } when _packages.Contains(package.Package):
+                    AddPackageGroup(package.Package);
+                    return;
+                case InspectionGraphSubject.AssemblySubject
+                {
+                    Identity:
+                        InspectionGraphAssemblyIdentity.CensusParticipant
+                        assembly,
+                } when _participants.Contains(assembly.Participant):
+                    AddNode(subject);
+                    return;
+                case InspectionGraphSubject.TypeSubject
+                {
+                    Identity:
+                        InspectionGraphTypeIdentity.CensusType type,
+                } when _selectedTypes.Contains(type.Identity):
+                    AddNode(subject);
+                    return;
+                case InspectionGraphSubject.MemberSubject
+                {
+                    Identity:
+                        InspectionGraphMemberIdentity.CensusMember
+                        member,
+                } when _candidateSources.Contains(member.Source):
+                    AddNode(subject);
+                    return;
+                default:
+                    throw new ArgumentException(
+                        "An explicit Integration graph subject must be backed by the Census participant, selected-Type, or candidate-source roster.",
+                        nameof(subject));
+            }
+        }
+
+        internal InspectionGraphDocument Build()
+        {
+            InspectionGraphEdge[] edges =
+            [
+                .. _edges.Select((edge, id) =>
+                    new InspectionGraphEdge(
+                        id,
+                        edge.FromNodeId,
+                        edge.ToNodeId,
+                        edge.Relationship,
+                        edge.OccurrenceIds)),
+            ];
+            InspectionGraphFailure[] failures = _snapshot.IsComplete
+                ? []
+                :
+                [
+                    new InspectionGraphFailure(
+                        InspectionGraphIntegrationsCatalog.ProjectionFailure,
+                        Evidence:
+                            new InspectionGraphIntegrationCensusFailureEvidence(
+                                _snapshot)),
+                ];
+            InspectionGraphDocumentScope scope =
+                _occurrences.Count == 0
+                && failures.Length == 0
+                && _nodes.All(static node => node.Subject.IsPortable)
+                && _groups.All(static group => group.Subject.IsPortable)
+                    ? InspectionGraphDocumentScope.Portable
+                    : InspectionGraphDocumentScope.SessionBound;
+            return new InspectionGraphDocument(
+                scope,
+                InspectionGraphModeRequest.InducedSet(
+                    InspectionGraphInducedSetRule.DocumentSubjects),
+                _nodes,
+                _groups,
+                edges,
+                _occurrences,
+                [],
+                [],
+                [],
+                failures);
+        }
+
+        int AddNode(InspectionGraphSubject subject)
+        {
+            if (_nodeIds.TryGetValue(subject, out int existing))
+                return existing;
+
+            int[] groupIds = ParticipantOf(subject) is { } participant
+                && participant.Coordinate
+                    is RealizedMemberCoordinate.Package package
+                        ? [AddPackageGroup(package)]
+                        : [];
+            int id = _nodes.Count;
+            _nodes.Add(
+                new InspectionGraphNode(
+                    id,
+                    subject,
+                    InspectionGraphNodeRole.Ordinary,
+                    groupIds));
+            _nodeIds.Add(subject, id);
+            return id;
+        }
+
+        int AddPackageGroup(RealizedMemberCoordinate.Package package)
+        {
+            if (_packageGroupIds.TryGetValue(package, out int existing))
+                return existing;
+
+            int id = _groups.Count;
+            _groups.Add(
+                new InspectionGraphGroup(
+                    id,
+                    InspectionGraphSubject.ForRealizedPackage(package),
+                    parentId: null));
+            _packageGroupIds.Add(package, id);
+            return id;
+        }
+
+        static InspectionGraphSubject SourceSubject(
+            IntegrationCandidateSourceIdentity source) =>
+            source.Element switch
+            {
+                IntegrationCandidateSourceElement.Member =>
+                    InspectionGraphSubject.ForIntegrationMember(source),
+                IntegrationCandidateSourceElement.Type =>
+                    InspectionGraphSubject.ForIntegrationType(
+                        new IntegrationTypeIdentity(
+                            source.Participant,
+                            source.SourceType)),
+                _ => throw new InvalidOperationException(
+                    "Unknown Integration candidate source element."),
+            };
+
+        static IntegrationSourceParticipantIdentity? ParticipantOf(
+            InspectionGraphSubject subject) =>
+            subject switch
+            {
+                InspectionGraphSubject.MemberSubject
+                {
+                    Identity:
+                        InspectionGraphMemberIdentity.CensusMember member,
+                } => member.Source.Participant,
+                InspectionGraphSubject.TypeSubject
+                {
+                    Identity:
+                        InspectionGraphTypeIdentity.CensusType type,
+                } => type.Identity.Participant,
+                InspectionGraphSubject.AssemblySubject
+                {
+                    Identity:
+                        InspectionGraphAssemblyIdentity.CensusParticipant
+                        assembly,
+                } => assembly.Participant,
+                _ => null,
+            };
+    }
+
+    sealed record CandidateOccurrenceShape(
+        InspectionGraphSubject EdgeSource,
+        InspectionGraphSubject EdgeTarget,
+        InspectionGraphSubject OccurrenceSource,
+        InspectionGraphSubject OccurrenceTarget);
+
+    readonly record struct EdgeKey(
+        int FromNodeId,
+        int ToNodeId,
+        InspectionGraphRelationshipDescriptor Relationship);
+
+    sealed class EdgeBuilder(
+        int fromNodeId,
+        int toNodeId,
+        InspectionGraphRelationshipDescriptor relationship)
+    {
+        internal int FromNodeId { get; } = fromNodeId;
+        internal int ToNodeId { get; } = toNodeId;
+        internal InspectionGraphRelationshipDescriptor Relationship
+            { get; } = relationship;
+        internal List<int> OccurrenceIds { get; } = [];
+    }
+}


### PR DESCRIPTION
Projects the shared Integration Census into the existing Inspection Graph
envelope without rerunning Integration producers. Every classified `In`
attempt receives exact candidate-attempt-to-occurrence-to-logical-edge
correspondence; `Out` remains inventory-only, and explicit induced-set
filtering cannot erase the pre-projection candidate inventory.

The adapter preserves portable Census identity without inventing acquisition
registrations, retains incomplete Census receipts as a visible graph failure,
and allows distinct binding-context attempts to collapse onto one logical edge.
The existing `InspectionGraphIntegrationsQuery` execution and command behavior
are unchanged.

## Demo

```console
$ dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build -- \
    -method '*IntegrationGraph_MultipleCandidatesMayCorrespondToOneLogicalEdge*' \
    -method '*IntegrationGraph_CandidateInventoryPrecedesInducedSetProjection*'
=== TEST EXECUTION SUMMARY ===
   DotnetInspector.Queries.Tests  Total: 2, Errors: 0, Failed: 0, Skipped: 0
```

The first scenario projects two context-addressed attempts with the same
semantic endpoints into two physical occurrences on one logical edge. The
neighboring scenario induces only one package pair while retaining both `In`
candidates: one is `Retained` with final dense occurrence/edge ids and one is
`FilteredByRequest`.

## Design

- `docs/design/integrations.md#graph-projection` owns candidate admission and
  correspondence.
- `docs/design/inspection-graph-document.md` owns subject identity, graph-local
  ids, occurrences, logical edges, failures, and scope.
- `docs/design/inspection-graph-modes.md#induced-set-mode` owns explicit
  both-endpoint induction.

The graph identity union gains session-bound Census member, Type, and assembly
participant currencies. `integration.observed` admits its existing member
source plus the Type source already permitted by the Census contract; the
legacy workspace graph producer continues to emit the same member
occurrences.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
  — 1,049 tests
- focused Census and graph contract classes — 149 tests
- focused graph projection gates — 9 tests
- `npx markdownlint-cli docs/design/integrations.md
  docs/design/inspection-graph-document.md`
- `git diff --check`

Part of #3629.
