### PR TITLE
Specify PackageIndexCache semantic reuse

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Package Source Model](design/package-source-model.md) | Configured package authority, mapping, source-result adoption, aggregation, selection, and cache authorization. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Cache concurrency and publication](design/cache-concurrency.md) | Process-local single-flight, cross-process atomic publication, dependency overlap, and filesystem guarantees. |
+| [Package Index Cache](design/package-index-cache.md) | Persistent filesystem-derived package inspection identity, completeness, freshness, validation, and reuse. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the typed inspection result (why the CLI should not hold a `PEReader`). |
 | [Find Type-Search Service](design/find-search-service.md) | CLI-scoped candidate collection and exact, glob, namespace-prefix, partial, and miss classification into typed results. |
 | [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,13 +188,13 @@ without referencing the CLI assembly.
 | `tools/DecompilerHarness` | Correctness harness | Decompiler correctness, compile-back, corpus, and independent-oracle orchestration. | [Decompiler correctness pipeline](decompiler-correctness-pipeline.md) |
 | Focused apps and fixtures | Boundary canary | Narrow executable consumers that prove a reusable boundary without becoming product owners. | Their local README or owning design |
 
+Harnesses and fixtures may prove product behavior, but they do not manufacture
+or repair the product evidence they measure.
+
 Within the CLI host, `PackageIndexCache` is a focused derived-result owner. Its
 [package index cache](design/package-index-cache.md) contract defines when a
 persistent filesystem-derived package projection may replace cold inspection;
 `CoreCache` remains only its storage mechanism.
-
-Harnesses and fixtures may prove product behavior, but they do not manufacture
-or repair the product evidence they measure.
 
 ## Core currencies
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,11 @@ without referencing the CLI assembly.
 | `tools/DecompilerHarness` | Correctness harness | Decompiler correctness, compile-back, corpus, and independent-oracle orchestration. | [Decompiler correctness pipeline](decompiler-correctness-pipeline.md) |
 | Focused apps and fixtures | Boundary canary | Narrow executable consumers that prove a reusable boundary without becoming product owners. | Their local README or owning design |
 
+Within the CLI host, `PackageIndexCache` is a focused derived-result owner. Its
+[package index cache](design/package-index-cache.md) contract defines when a
+persistent filesystem-derived package projection may replace cold inspection;
+`CoreCache` remains only its storage mechanism.
+
 Harnesses and fixtures may prove product behavior, but they do not manufacture
 or repair the product evidence they measure.
 

--- a/docs/design/nuget.md
+++ b/docs/design/nuget.md
@@ -18,8 +18,11 @@ package version is absent; an unreadable or metadata-incapable higher source pro
 rather than borrowing another feed's answer.
 
 Metadata cache entries include the canonical source identity, so equal package coordinates from
-different feeds cannot share aggregate metadata. The filesystem-derived package inspection cache
-uses the same producer identity for the same reason.
+different feeds cannot share aggregate metadata. The
+[package index cache](package-index-cache.md) separately owns persistent
+filesystem-derived inspection results. Its current producer-scoped key is a
+legacy boundary; the target consumes package-owned authority and retained
+content identity rather than treating producer identity as authorization.
 
 Endpoints on the explicitly configured feed origin use the feed client and its scoped credentials.
 That exact host and port may resolve to private addresses; redirects and cross-origin connections

--- a/docs/design/package-index-cache.md
+++ b/docs/design/package-index-cache.md
@@ -44,8 +44,9 @@ It consumes:
   that cold inspection consumes;
 - an acquisition-owned durable package-content identity covering the retained
   archive and its admitted matching product-owned inspection tree;
-- the complete filesystem-derived package projection produced from that
-  content; and
+- a typed package-inspection production outcome whose success case carries the
+  complete canonical filesystem-derived projection and whose incomplete case
+  carries the producer's diagnostics; and
 - `CoreCache` storage under one versioned package-index contract.
 
 It returns either:
@@ -170,12 +171,8 @@ The target projection is the following closed inventory:
 - manifest and deps-file relationships: `DependencyGroups`,
   `RuntimeDependencies`, and each `RuntimeIdentifierPackages` member's
   `RuntimeIdentifier` and `PackageId`, but not its request-current `Exists`;
-- `BuiltDate` from the retained archive in the identified archive/tree
-  generation; and
 - local binary facts: `TotalBinaries`, `EmbeddedPdbs`, `InPackagePdbs`,
-  `EmbeddedSourceLinkPdbs`, and `InPackageSourceLinkPdbs`, with
-  `SymbolsAvailable` and `SourceLinkAvailable` derived only from those local
-  counts.
+  `EmbeddedSourceLinkPdbs`, and `InPackageSourceLinkPdbs`.
 
 Every `InspectionResult` field not listed is outside the projection. Adding,
 removing, or changing the semantics of an inventory member changes the
@@ -206,7 +203,10 @@ Binary-signal production for this projection does not acquire or observe
 external PDBs. `SnupkgPdbs`, `MsdlPdbs`, `OtherPdbs`, their SourceLink
 counterparts, and aggregate availability that includes them remain
 request-current. Their absence from the projection is not persistent zero
-evidence.
+evidence. Reconstruction derives `SymbolsAvailable` exactly as `EmbeddedPdbs +
+InPackagePdbs` and `SourceLinkAvailable` exactly as
+`EmbeddedSourceLinkPdbs + InPackageSourceLinkPdbs`; it does not accept stored
+aggregate or external-source counts.
 
 The following facts remain outside the persistent projection:
 
@@ -214,12 +214,34 @@ The following facts remain outside the persistent projection:
   deprecation, and vulnerabilities;
 - whether a RID companion is available under the current source policy;
 - whether network or symbol acquisition is currently authorized or succeeds;
+- `BuiltDate`, because ZIP DOS time has no offset and `ZipArchiveEntry` binds
+  it to the observing process's current time zone;
 - tool-wrapper traversal and the requested package's relationship to the final
   payload; and
 - current host capability, cancellation, deadlines, and presentation choices.
 
 The caller may compose those facts after a hit. Their absence from the entry is
 not evidence that they are false or unavailable.
+
+## Production completion
+
+Serialized completeness and production completeness are separate claims. The
+entry completion record proves that every persistent member state reached the
+stored payload. It cannot prove that every cold producer completed before those
+states were formed.
+
+`PackageIndexCache` therefore accepts publication only from the success case of
+a typed package-inspection production outcome bound to the frozen cache subject.
+Success means every producer needed for the closed inventory completed and the
+result passed canonical-shape validation. A per-file decode or scan failure
+that can make any member partial produces an incomplete outcome with its
+diagnostics and cannot mint a publishable value. Missing values, default
+counters, and the absence of logged warnings cannot reconstruct success.
+
+[#3738](https://github.com/richlander/dotnet-inspect/issues/3738) owns
+construction of that outcome in `PackageInspector`. The same cold operation
+returns its ordinary result and diagnostics even when the outcome is
+incomplete; only the optional persistent publication is declined.
 
 ## Hit, miss, and failure semantics
 
@@ -247,17 +269,18 @@ are misses. A miss runs the ordinary authorized cold path. Cache corruption is
 not reported as package corruption because the entry is optional derived data,
 not the acquired package payload.
 
-An invalid cold result, failed package inspection, or incomplete projection is
-not published. A value that this cache cannot represent, including one whose
-treated-text provenance cannot be persisted, declines publication rather than
-invalidating an otherwise successful package inspection. A storage write
-failure likewise leaves the cold result usable and visible. The current
-`pkg-index-v16` truncated-description exception is a known mismatch with this
-target behavior. Target adoption supersedes that exception's effect on the
-package operation: [#3787](https://github.com/richlander/dotnet-inspect/issues/3787)
-continues to own whether richer provenance can make a truncated description
-persistable, while this owner makes an unpersistable optional value a cache
-nonpublication rather than a package failure.
+An invalid cold result, unsuccessful production outcome, or incomplete
+projection is not published. A value that this cache cannot represent,
+including one whose treated-text provenance cannot be persisted, declines
+publication rather than invalidating an otherwise successful package
+inspection. A storage write failure likewise leaves the cold result usable and
+visible. The current `pkg-index-v16` truncated-description exception is a known
+mismatch with this target behavior. Target adoption supersedes that exception's
+effect on the package operation:
+[#3787](https://github.com/richlander/dotnet-inspect/issues/3787) continues to
+own whether richer provenance can make a truncated description persistable,
+while this owner makes an unpersistable optional value a cache nonpublication
+rather than a package failure.
 
 ## Freshness and replacement
 
@@ -362,10 +385,13 @@ and version. `PackageExtractionResult` does not carry a package-owned durable
 authority key, `PackageContentGenerationIdentity`, or durable identity for the
 exact inspected tree into `PackageInspector`. It also permits a global-packages
 foreign tree to seed or consume the cache, persists `Snupkg`, `Msdl`, and
-`Other` PDB observations plus aggregates that can include them, and has no
-explicit complete-entry record. The current namespace therefore cannot satisfy
-the target subject or projection and must be fenced rather than relabeled when
-adoption lands.
+`Other` PDB observations plus aggregates that can include them, omits
+`RuntimeDependencies` entirely, persists the process-time-zone interpretation
+of `BuiltDate`, and has neither an explicit complete-entry record nor a
+production-success receipt. A per-DLL binary scan failure can therefore publish
+partial counters, while a warm hit can silently lose the complete Runtime
+Dependencies section. The current namespace cannot satisfy the target subject
+or projection and must be fenced rather than relabeled when adoption lands.
 
 Adoption depends on #3738 carrying package authority and provenance through
 derived inspection and #5484 issuing exact durable package-content identity.
@@ -405,9 +431,9 @@ The target remains unverified until Release tests establish:
   proving the first entry cannot answer the second;
 - `PackageIndexCache_AuthorityWithoutDurableKeySkipsPersistentReuse`, proving
   there is no producer-keyed fallback;
-- `PackageIndexCache_HitUsesTheExactColdProductionSubject`, proving acquisition,
-  inspection, and publication consume one retained content generation and
-  durable identity;
+- `PackageIndexCache_PublicationRequiresFrozenSubjectAndSuccessfulProduction`,
+  proving lookup and publication use one immutable subject and a missing,
+  incomplete, failed, or differently bound production outcome cannot publish;
 - `PackageIndexCache_ForeignTreeCannotSeedPersistentReuse`, covering
   global-packages entries with and without retained archives;
 - `PackageIndexCache_RejectsNoncanonicalOrAmbiguousProjection`, covering
@@ -417,10 +443,13 @@ The target remains unverified until Release tests establish:
   positive entry and missing, predecessor, malformed, truncated,
   missing-completion, deleted-member, duplicate-member, unknown-member, and
   semantically incomplete entries; and
-- `PackageIndexCache_ProjectionExcludesRequestCurrentFacts`, proving RID
-  availability, metadata enrichment, wrapper routing, current authorization,
-  and externally acquired symbol availability cannot enter the persistent
-  value.
+- `PackageIndexCache_ProjectionExcludesRequestCurrentFactsAndBuildDate`, proving
+  RID availability, metadata enrichment, wrapper routing, current
+  authorization, externally acquired symbol availability, and `BuiltDate`
+  cannot enter the persistent value; and
+- `PackageIndexCache_LocalBinaryAggregatesAreDerived`, proving reconstruction
+  derives aggregate symbol and SourceLink availability only from the four
+  persisted local-source counters.
 
 The existing inert-description and producer-separation tests remain evidence
 for their narrower current properties. They do not count as the target gates
@@ -429,7 +458,10 @@ under different names. Acquisition's
 its process-local generation owner; #5484 owns the durable identity and
 W-to-S-to-W retained-content evidence. End-to-end `PackageInspector` adoption
 and current-fact recomposition remain integration work under #3738 rather than
-gates assigned to this cache owner.
+gates assigned to this cache owner. That adoption must gate
+`PackageInspector_PartialProjectionCannotPublish`,
+`PackageInspector_WarmHitRecomputesBuildDate`, and
+`PackageInspector_ColdAndWarmRuntimeDependenciesAgree`.
 
 ## Non-claims
 
@@ -443,6 +475,7 @@ This design does not:
 - detect source-side replacement behind an acquisition cache hit;
 - persist results derived from a foreign or unretained inspection tree;
 - reuse an entry across hosts with different filesystem semantics;
+- persist the process-time-zone interpretation of a ZIP build timestamp;
 - persist package payloads, source credentials, untreated display text, or
   request-current policy;
 - guarantee a cache hit, durable write, cross-process single-flight, or

--- a/docs/design/package-index-cache.md
+++ b/docs/design/package-index-cache.md
@@ -31,6 +31,40 @@ authorities may contain different bytes. It is also stricter than
 content-addressing alone: equal bytes do not grant a caller authority to use an
 entry derived under another configured package authority.
 
+## Change classification and complexity
+
+This design corrects an existing CLI-host optimization; it does not add or
+expand a product capability, shared substrate, host path, information domain,
+or rendering path. Its named consumer is the existing `PackageInspector`, and
+[#3738](https://github.com/richlander/dotnet-inspect/issues/3738) is the
+end-to-end tracker for that consumer's adoption. The browser/Wasm host does not
+participate in the changed surface: both the owner and consumer are existing
+types under `src/dotnet-inspect`, and the target changes that existing call
+path without introducing a shared API. No browser enablement plan or
+single-host substrate exception is therefore created here. Any shared
+acquisition capability proposed by #5484 must make its own consumer and host
+classification before implementation.
+
+Rendering is unchanged. The cache continues to return the existing typed
+`InspectionResult` data consumed by the existing Markout-backed package
+presentation; it neither formats data nor introduces another lowering.
+
+The design adds only complexity required by observed correctness failures:
+
+- authority plus retained-content identity prevents one authorized cold
+  subject from reusing another's result;
+- a production-success outcome prevents per-file scan failures from becoming
+  complete-looking warm entries;
+- a closed inventory and completion record prevent omitted or truncated fields
+  from becoming defaults; and
+- canonical projection rules prevent filesystem enumeration order from
+  selecting a durable winner.
+
+The pathological case and the reproduced `BuiltDate`, partial-scan, and
+`RuntimeDependencies` divergences are the evidence that requires those
+mechanisms. The four outcome-level gates below are the required evidence
+without restating inherited platform or `CoreCache` properties.
+
 ## Owner and boundaries
 
 The owner is `PackageIndexCache`, currently in
@@ -423,32 +457,21 @@ the current exception that target adoption must replace with nonpublication.
 
 The target remains unverified until Release tests establish:
 
-- `PackageIndexCache_DistinctAuthoritiesWithEqualProducerDoNotShare`,
-  using two authorities that deliberately share producer identity and publish
-  different bytes for one coordinate;
-- `PackageIndexCache_DifferentRetainedContentIdentityCannotHit`, presenting two
-  acquisition-issued content identities under one authority and coordinate and
-  proving the first entry cannot answer the second;
-- `PackageIndexCache_AuthorityWithoutDurableKeySkipsPersistentReuse`, proving
-  there is no producer-keyed fallback;
-- `PackageIndexCache_PublicationRequiresFrozenSubjectAndSuccessfulProduction`,
-  proving lookup and publication use one immutable subject and a missing,
-  incomplete, failed, or differently bound production outcome cannot publish;
-- `PackageIndexCache_ForeignTreeCannotSeedPersistentReuse`, covering
-  global-packages entries with and without retained archives;
-- `PackageIndexCache_RejectsNoncanonicalOrAmbiguousProjection`, covering
-  shuffled filesystem-derived lists and multiple distinct deps-file runtime
+- `PackageIndexCache_SubjectControlsPersistentReuse`, covering distinct
+  authorities with equal producer identity, distinct retained-content
+  identities at one coordinate, an authority without a durable key, and
+  global-packages trees with and without retained archives;
+- `PackageIndexCache_PublicationRequiresOneSuccessfulFrozenSubject`, covering
+  missing, incomplete, failed, or differently bound production outcomes,
+  shuffled filesystem-derived lists, and multiple distinct deps-file runtime
   targets;
-- `PackageIndexCache_CompleteProjectionRoundTripsOrMisses`, covering a complete
-  positive entry and missing, predecessor, malformed, truncated,
-  missing-completion, deleted-member, duplicate-member, unknown-member, and
-  semantically incomplete entries; and
-- `PackageIndexCache_ProjectionExcludesRequestCurrentFactsAndBuildDate`, proving
+- `PackageIndexCache_EntryIsCompleteAndCurrent`, covering complete round-trip
+  plus predecessor, malformed, truncated, missing-completion, deleted-member,
+  duplicate-member, unknown-member, and semantically incomplete entries; and
+- `PackageIndexCache_ProjectionContainsOnlyStableFacts`, covering exclusion of
   RID availability, metadata enrichment, wrapper routing, current
-  authorization, externally acquired symbol availability, and `BuiltDate`
-  cannot enter the persistent value; and
-- `PackageIndexCache_LocalBinaryAggregatesAreDerived`, proving reconstruction
-  derives aggregate symbol and SourceLink availability only from the four
+  authorization, externally acquired symbol availability, and `BuiltDate`,
+  plus derivation of aggregate symbol and SourceLink availability from the four
   persisted local-source counters.
 
 The existing inert-description and producer-separation tests remain evidence
@@ -458,10 +481,10 @@ under different names. Acquisition's
 its process-local generation owner; #5484 owns the durable identity and
 W-to-S-to-W retained-content evidence. End-to-end `PackageInspector` adoption
 and current-fact recomposition remain integration work under #3738 rather than
-gates assigned to this cache owner. That adoption must gate
-`PackageInspector_PartialProjectionCannotPublish`,
-`PackageInspector_WarmHitRecomputesBuildDate`, and
-`PackageInspector_ColdAndWarmRuntimeDependenciesAgree`.
+gates assigned to this cache owner. The outcome-level
+`PackageInspector_ColdAndWarmCacheableProjectionAgree` gate covers partial
+production refusal, warm `BuiltDate` recomputation, and cold/warm
+`RuntimeDependencies` agreement.
 
 ## Non-claims
 

--- a/docs/design/package-index-cache.md
+++ b/docs/design/package-index-cache.md
@@ -1,0 +1,450 @@
+# Package index cache
+
+## Status
+
+Target design for the `PackageIndexCache` slice of
+[#3738](https://github.com/richlander/dotnet-inspect/issues/3738).
+The current `pkg-index-v16` implementation supplies format fencing, source
+producer separation, inert-description persistence, malformed-entry rejection,
+and request-time RID reverification. It does not yet carry the package-owned
+authority and retained-content identity required by this contract.
+[Issue #5484](https://github.com/richlander/dotnet-inspect/issues/5484) tracks
+the acquisition-owned durable content prerequisite. The complete contract is
+therefore **unverified**.
+
+## Decision
+
+`PackageIndexCache` owns one decision: whether a persistent
+filesystem-derived package inspection result may replace cold inspection of one
+exact authorized package payload.
+
+A hit is valid only for the same package-owned durable authority, normalized
+package coordinate, exact retained package content, and package-inspection
+projection contract that produced the entry. A hit supplies stable
+content-derived facts only. It carries no claim about current authorization,
+availability, network, metadata enrichment, or wrapper routing.
+
+This is stricter than treating package ID and version as immutable identity.
+nuget.org prevents replacement of one published coordinate, but custom and
+local sources need not make that promise, and equal coordinates from different
+authorities may contain different bytes. It is also stricter than
+content-addressing alone: equal bytes do not grant a caller authority to use an
+entry derived under another configured package authority.
+
+## Owner and boundaries
+
+The owner is `PackageIndexCache`, currently in
+`src/dotnet-inspect/Inspectors/PackageIndexCache.cs`.
+
+It consumes:
+
+- a package-owned durable configured-authority cache key, when one exists;
+- an exact normalized package ID and version;
+- the process-local `PackageContentGenerationIdentity` for the retained content
+  that cold inspection consumes;
+- an acquisition-owned durable package-content identity covering the retained
+  archive and its admitted matching product-owned inspection tree;
+- the complete filesystem-derived package projection produced from that
+  content; and
+- `CoreCache` storage under one versioned package-index contract.
+
+It returns either:
+
+- a complete filesystem-derived package projection bound to the requested
+  cache subject; or
+- a cache miss.
+
+It does not own:
+
+- configured package authority, source mapping, producer identity, or payload
+  authorization;
+- package download, extraction, admission, retention, or digest construction;
+- `CoreCache` paths, hashing, atomic file replacement, maintenance, or
+  telemetry;
+- NuGet metadata enrichment, RID companion availability, symbol acquisition,
+  tool-wrapper routing, or other request-current observations;
+- package inspection algorithms or the meaning of individual
+  `InspectionResult` fields; or
+- package command selection, disclosure, rendering, or output containment.
+
+[Package source model](package-source-model.md) owns configured authority and
+whether it has a credential-safe durable key.
+[Cache concurrency and publication](cache-concurrency.md) owns admitted package
+payload publication.
+[Artifact acquisition and workspaces](artifact-acquisition-and-workspaces.md)
+owns `PackageContentGenerationIdentity`, `PackageRootBinding`, and the
+owner-mediated digest pattern. The durable package-content identity needed by
+this CLI path is the focused acquisition prerequisite tracked by
+[#5484](https://github.com/richlander/dotnet-inspect/issues/5484).
+[InertText](inert-text.md) owns persisted treated-text semantics.
+[Inspection space](../inspection-space.md#corecache) owns the repository-wide
+derived-cache rule, and `CoreCache` supplies only the storage mechanism.
+
+## Cache subject
+
+The logical subject is:
+
+```text
+PackageIndexCacheSubject
+  durable configured-authority cache key
+  normalized package ID
+  normalized package version
+  retained archive/tree content digest
+  package-index projection contract
+```
+
+Every dimension is load-bearing:
+
+- **Configured authority** preserves current package authorization semantics.
+  NuGetFetch producer identity remains provenance and cannot substitute for
+  package-owned authority. If the authority has no credential-safe durable key,
+  this owner does not persist or reuse an entry for it.
+- **Coordinate** preserves the package identity the result describes. Package
+  ID comparison is case-insensitive and version spelling uses the package
+  owner's normalized version; this owner does not define another normalization.
+- **Content digest** identifies one retained package-content generation: the
+  retained archive plus the product-owned inspection tree that admission proved
+  matches that archive. The acquisition owner binds it to the same
+  `PackageContentGenerationIdentity` that cold inspection consumes. This cache
+  does not reopen a path, hash an extracted tree after inspection, or infer
+  content identity from a producer key, timestamp, package manifest, or
+  completion marker. The process-local generation token proves same-snapshot
+  use while the digest supplies the durable key; neither substitutes for the
+  other.
+- **Projection contract** identifies the closed set and semantics of persistent
+  fields. It is represented by the versioned cache category and an explicit
+  completion record in the payload, not by accepting whatever fields an entry
+  happens to contain.
+
+The subject is frozen before lookup or cold production. Cold inspection,
+serialization, and publication consume that same subject and process-local
+content generation. If acquisition cannot retain that generation through cold
+inspection and publication, the operation cannot publish.
+
+## Persistent-cache eligibility
+
+Persistent reuse is available only when the package-content owner issues both:
+
+- a durable configured-authority key; and
+- durable content identity for the exact tree cold inspection reads.
+
+A product-owned package-content slot can qualify because its retained archive
+and extracted tree are admitted as one matching content generation. The
+acquisition owner establishes that relationship; this cache does not infer it
+from `RequiresArchiveTreeMatch` or a completion marker.
+
+NuGet's global-packages folder is a foreign tree rather than a product-owned
+one-to-one extraction. It can be archive-less, its retained archive does not
+necessarily identify the tree that inspection reads, and other tools may
+change it between operations. Such a tree remains inspectable, but it is
+ineligible for this persistent derived cache unless a future acquisition owner
+retains and identifies the exact inspected snapshot.
+
+A directly named local `.nupkg` likewise remains outside persistent reuse. Its
+current inspection path is explicitly local rather than a configured package
+authority. A future owner may admit it only by supplying both required
+identities; the shared `explicit-local-input` producer spelling is not enough.
+
+If either identity is unavailable, the package operation uses the ordinary
+cold inspection path. Disabling this optimization is the conservative adoption
+state, not a package failure.
+
+## Persistent projection
+
+The persistent projection contains only facts that are deterministic functions
+of the admitted package payload under one host filesystem's semantics and the
+projection contract. It is complete: publication cannot encode a
+request-selected subset and later return it as the full projection.
+
+The target projection is the following closed inventory:
+
+- package and manifest facts: `PackageName`, `ManifestVersion`, `Version`,
+  `Description`, `Authors`, `License`, `LicenseUrl`, `Repository`,
+  `RepositoryType`, and `RepositoryCommit`;
+- package-tree facts: `ReadmeFile`, `PackageReadmeFile`, `HasReadme`,
+  `HasAgentDocumentation`, `IsToolPackage`, `PackageTypes`,
+  `ContentDirectories`, `TargetFrameworks`, `SupportedRids`, `AssemblyCount`,
+  `IsFrameworkDependent`, `HasRidSpecificAssets`, `HasNativeDependencies`,
+  `ToolFormat`, `IsRidSpecificPointerPackage`, `ToolCommands`,
+  `RuntimeTargetRid`, `NativeFiles`, and `LibraryFiles`;
+- manifest and deps-file relationships: `DependencyGroups`,
+  `RuntimeDependencies`, and each `RuntimeIdentifierPackages` member's
+  `RuntimeIdentifier` and `PackageId`, but not its request-current `Exists`;
+- `BuiltDate` from the retained archive in the identified archive/tree
+  generation; and
+- local binary facts: `TotalBinaries`, `EmbeddedPdbs`, `InPackagePdbs`,
+  `EmbeddedSourceLinkPdbs`, and `InPackageSourceLinkPdbs`, with
+  `SymbolsAvailable` and `SourceLinkAvailable` derived only from those local
+  counts.
+
+Every `InspectionResult` field not listed is outside the projection. Adding,
+removing, or changing the semantics of an inventory member changes the
+projection contract and cache category. A field that depends on another
+artifact, authority, capability, clock, or cache either adds that dependency's
+owner-issued identity to the subject or remains outside this cache.
+
+The producer supplies one canonical projection. Package-tree paths and
+filesystem-derived string lists use normalized relative paths and ordinal
+ordering. RID package references order by runtime identifier and package ID.
+Dependency groups order by target framework, and their dependencies and
+`RuntimeDependencies` order by package ID and version; equal members retain
+their multiplicity. Package-authored scalar and list order that comes directly
+from the manifest remains payload-defined. More than one distinct deps-file
+runtime target makes `RuntimeTargetRid` ambiguous and the result ineligible for
+publication rather than selecting whichever file the filesystem enumerated
+last.
+
+`PackageIndexCache` validates this canonical shape and declines publication for
+a noncanonical or ambiguous value; it does not sort or repair the result after
+cold inspection. #3738 owns adoption in `PackageInspector`, including
+canonical production before the same result is returned cold or offered for
+publication. Its producer-side evidence must seed a multi-RID tool package,
+vary deps-file and directory enumeration order, and prove equal canonical
+results or visible cache ineligibility.
+
+Binary-signal production for this projection does not acquire or observe
+external PDBs. `SnupkgPdbs`, `MsdlPdbs`, `OtherPdbs`, their SourceLink
+counterparts, and aggregate availability that includes them remain
+request-current. Their absence from the projection is not persistent zero
+evidence.
+
+The following facts remain outside the persistent projection:
+
+- package metadata enrichment such as downloads, publication state,
+  deprecation, and vulnerabilities;
+- whether a RID companion is available under the current source policy;
+- whether network or symbol acquisition is currently authorized or succeeds;
+- tool-wrapper traversal and the requested package's relationship to the final
+  payload; and
+- current host capability, cancellation, deadlines, and presentation choices.
+
+The caller may compose those facts after a hit. Their absence from the entry is
+not evidence that they are false or unavailable.
+
+## Hit, miss, and failure semantics
+
+Lookup first requires a complete `PackageIndexCacheSubject`. Missing durable
+authority or retained-content identity is a miss and does not fall back to a
+producer-keyed persistent entry.
+
+An entry is a hit only when:
+
+1. it is read from the exact current contract category;
+2. its subject equals the requested subject;
+3. its framing and every required value decode successfully;
+4. its contained text reconstructs only through the owning text policy; and
+5. its explicit completion record proves the complete current projection was
+   published.
+
+The completion record represents every inventory member's state, including
+null and default states, and closes the framed payload. A decoder rejects a
+missing, duplicate, unknown, or unaccounted-for member. It does not infer that
+a deleted field had its default value merely because a line-oriented encoding
+omits defaults.
+
+Missing, predecessor, truncated, malformed, or semantically incomplete entries
+are misses. A miss runs the ordinary authorized cold path. Cache corruption is
+not reported as package corruption because the entry is optional derived data,
+not the acquired package payload.
+
+An invalid cold result, failed package inspection, or incomplete projection is
+not published. A value that this cache cannot represent, including one whose
+treated-text provenance cannot be persisted, declines publication rather than
+invalidating an otherwise successful package inspection. A storage write
+failure likewise leaves the cold result usable and visible. The current
+`pkg-index-v16` truncated-description exception is a known mismatch with this
+target behavior. Target adoption supersedes that exception's effect on the
+package operation: [#3787](https://github.com/richlander/dotnet-inspect/issues/3787)
+continues to own whether richer provenance can make a truncated description
+persistable, while this owner makes an unpersistable optional value a cache
+nonpublication rather than a package failure.
+
+## Freshness and replacement
+
+An entry has no time-based expiry. Its reusable facts are functions of exact
+retained content. When acquisition supplies a different durable content
+identity, the earlier entry cannot answer even when authority and coordinate
+are unchanged.
+
+This owner does not promise that acquisition will detect a source-side
+replacement behind an already-committed package-content slot. It describes only
+the retained payload acquisition supplied. Source replacement, reacquisition,
+and package-content-store freshness remain acquisition-owner decisions.
+
+Current authorization is still checked before cache lookup. Removing a source,
+changing package-source mapping, rotating to an authority without the same
+owner-issued durable identity, or otherwise revoking eligibility makes the
+entry unreachable even when its bytes remain on disk.
+
+A projection-contract change selects a successor category. Older categories
+are never reinterpreted under the new contract. `CoreCache` may retire older
+numeric categories after the successor registers; that cleanup has no bearing
+on whether a current entry is semantically valid.
+
+## Publication and concurrency
+
+`PackageIndexCache` delegates atomic file replacement and best-effort storage to
+`CoreCache`. It adds no lock, single-flight registry, or mutable publication
+protocol.
+
+Within one host-local `CoreCache` root, concurrent producers may publish the
+same subject only when the subject proves that both consumed the same retained
+payload and projection contract. They observe the same host filesystem
+semantics, and the cache accepts only canonical projections, so their encodings
+are semantically equal. An atomic winner or later equal replacement is
+sufficient; readers observe an old complete entry, a new complete entry, or a
+miss, never a partially written entry. Moving or sharing a cache root across
+hosts with different filesystem semantics is unsupported.
+
+No TLA+ model is required for this focused owner. Scheduling and filesystem
+publication are delegated to the existing `CoreCache` mechanism, while this
+contract's correctness rests on immutable subject equality and complete-value
+validation rather than a new stateful interaction. A future mutable
+coordination protocol would require its own design and interaction model.
+
+## Pathological case
+
+Two configured authorities intentionally receive one credential-free NuGetFetch
+producer identity, and both expose `Example@1.0.0`:
+
+```text
+authority A -> payload digest aaa... -> Authors: "A"
+authority B -> payload digest bbb... -> Authors: "B"
+```
+
+The current key:
+
+```text
+producer-key:example@1.0.0
+```
+
+allows A's warm result to answer B. A source-policy change can therefore report
+facts from bytes the current request did not authorize.
+
+The target subjects differ in both authority and content identity:
+
+```text
+authority-A/example/1.0.0/aaa...
+authority-B/example/1.0.0/bbb...
+```
+
+Neither entry can answer the other request. Replacing B's package while keeping
+its coordinate cannot reuse the old entry when acquisition supplies the
+replacement as a different retained content identity.
+
+The neighboring positive case is one authority reacquiring the same retained
+payload under the same normalized coordinate. Its authority and digest are
+equal, so the persistent result remains reusable across processes.
+
+## Precedents and deliberate choices
+
+- NuGet package stores scope payload reuse by an exact coordinate and authorized
+  source. This owner consumes that decision rather than reconstructing source
+  authorization.
+- Git-style content addressing demonstrates that derived data can name immutable
+  bytes rather than a mutable location. This owner additionally retains
+  authority because digest equality does not grant package access.
+- The repository's library effective-catalog cache includes a content hash, and
+  `AnalysisIndexCache` records why a path coordinate alone cannot establish
+  derived-result identity. Package inspection follows the same principle using
+  the acquisition owner's digest instead of reopening a path.
+
+The deliberate divergence from NuGet's ordinary exact-coordinate reuse is the
+required content digest. NuGet.org's immutable-coordinate policy is an external
+service guarantee, while this cache can consume packages from authorities that
+make no such promise and can bypass the complete inspection stage. The digest
+keeps that broader reuse honest without turning the cache into an authority.
+
+## Current implementation gap
+
+`pkg-index-v16` keys entries by NuGetFetch producer key, lowercased package ID,
+and version. `PackageExtractionResult` does not carry a package-owned durable
+authority key, `PackageContentGenerationIdentity`, or durable identity for the
+exact inspected tree into `PackageInspector`. It also permits a global-packages
+foreign tree to seed or consume the cache, persists `Snupkg`, `Msdl`, and
+`Other` PDB observations plus aggregates that can include them, and has no
+explicit complete-entry record. The current namespace therefore cannot satisfy
+the target subject or projection and must be fenced rather than relabeled when
+adoption lands.
+
+Adoption depends on #3738 carrying package authority and provenance through
+derived inspection and #5484 issuing exact durable package-content identity.
+Until both inputs exist, the correct successor behavior is cold-path-only
+rather than fallback to `pkg-index-v16`.
+
+The existing `pkg-index-v16` behavior ships unchanged until that implementation
+slice. It remains a legacy producer-scoped namespace, and no existing Release
+gate proves configured-authority separation. The package source model's target
+`LegacyProducerScopedCache_IsNotReinterpretedAsAuthorityScoped` gate is not
+implemented, so interim authority containment is **unverified**. Existing tests
+prove only predecessor-category fencing and separation between distinct
+producer keys; neither makes producer identity an authority.
+
+Existing tests establish useful partial properties:
+
+- `EqualCoordinatesFromDifferentProducersDoNotShareInspectionResults`;
+- `RidAvailability_IsNotPersisted`;
+- `Description_RoundTripsAsContainedProse`;
+- `Description_MalformedEnvelopeRejectsTheWholeCacheEntry`;
+- `Description_NullAndEmptyRemainDistinct`.
+
+They do not prove package authority, retained-content identity, projection
+completeness, or current-subject wiring.
+`Description_TruncatedValueRequiresHigherProvenancePersistence` instead records
+the current exception that target adoption must replace with nonpublication.
+
+## Required gates
+
+The target remains unverified until Release tests establish:
+
+- `PackageIndexCache_DistinctAuthoritiesWithEqualProducerDoNotShare`,
+  using two authorities that deliberately share producer identity and publish
+  different bytes for one coordinate;
+- `PackageIndexCache_DifferentRetainedContentIdentityCannotHit`, presenting two
+  acquisition-issued content identities under one authority and coordinate and
+  proving the first entry cannot answer the second;
+- `PackageIndexCache_AuthorityWithoutDurableKeySkipsPersistentReuse`, proving
+  there is no producer-keyed fallback;
+- `PackageIndexCache_HitUsesTheExactColdProductionSubject`, proving acquisition,
+  inspection, and publication consume one retained content generation and
+  durable identity;
+- `PackageIndexCache_ForeignTreeCannotSeedPersistentReuse`, covering
+  global-packages entries with and without retained archives;
+- `PackageIndexCache_RejectsNoncanonicalOrAmbiguousProjection`, covering
+  shuffled filesystem-derived lists and multiple distinct deps-file runtime
+  targets;
+- `PackageIndexCache_CompleteProjectionRoundTripsOrMisses`, covering a complete
+  positive entry and missing, predecessor, malformed, truncated,
+  missing-completion, deleted-member, duplicate-member, unknown-member, and
+  semantically incomplete entries; and
+- `PackageIndexCache_ProjectionExcludesRequestCurrentFacts`, proving RID
+  availability, metadata enrichment, wrapper routing, current authorization,
+  and externally acquired symbol availability cannot enter the persistent
+  value.
+
+The existing inert-description and producer-separation tests remain evidence
+for their narrower current properties. They do not count as the target gates
+under different names. Acquisition's
+`PackageRootGenerationIdentity_ReplacementChangesIdentity` remains evidence for
+its process-local generation owner; #5484 owns the durable identity and
+W-to-S-to-W retained-content evidence. End-to-end `PackageInspector` adoption
+and current-fact recomposition remain integration work under #3738 rather than
+gates assigned to this cache owner.
+
+## Non-claims
+
+This design does not:
+
+- make a package coordinate immutable;
+- make `CoreCache` a semantic cache owner;
+- define a universal derived-cache abstraction or migrate another cache;
+- authorize sharing merely because two authorities produce equal bytes;
+- require persistent caching for an authority without a safe durable identity;
+- detect source-side replacement behind an acquisition cache hit;
+- persist results derived from a foreign or unretained inspection tree;
+- reuse an entry across hosts with different filesystem semantics;
+- persist package payloads, source credentials, untreated display text, or
+  request-current policy;
+- guarantee a cache hit, durable write, cross-process single-flight, or
+  power-loss transaction; or
+- change current package output or command behavior.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,6 +37,9 @@ substrates, and inspection producers that will extend that space.
   CLI-scoped boundary from host-authorized candidate collection through typed
   exact, glob, namespace-prefix, partial, and miss classification; Metadata
   retains candidate facts and the command retains presentation.
+  The [package index cache](design/package-index-cache.md) separately owns
+  whether a persistent filesystem-derived package result may replace cold
+  inspection of one exact authorized retained payload.
 - `src/DotnetInspector.Queries/` contains host-neutral typed query definitions,
   deterministic synchronous/asynchronous execution, prerequisite-aware cost,
   and content-shaped metadata, reference, package dependency-group,


### PR DESCRIPTION
This work serves dotnet-inspect’s mission to build robust, capable features that provide foundational capabilities or compelling user experiences and are conventionally sound, delightfully new or unique, or both.

## Summary

Establish `PackageIndexCache` as the focused semantic owner for deciding when a persistent filesystem-derived package projection may replace cold inspection. `CoreCache` remains only the generic storage mechanism.

The contract requires package-owned configured authority, owner-issued identity for the exact retained archive/tree generation, and a typed successful-production outcome. It excludes foreign global-packages trees, request-current authorization and enrichment, externally acquired symbols, time-zone-bound `BuiltDate`, and incomplete or noncanonical projections. Until #3738 and #5484 supply those inputs, the conservative successor behavior is cold inspection rather than reinterpretation of `pkg-index-v16`.

## Demo

Two configured authorities can intentionally share one credential-free NuGetFetch producer identity while serving different bytes for the same coordinate:

```text
authority A -> producer P -> Example@1.0.0 -> digest aaa -> Authors: A
authority B -> producer P -> Example@1.0.0 -> digest bbb -> Authors: B
```

The current cache collapses both to one subject:

```text
P:example@1.0.0
```

The target keeps authorization and content continuity distinct:

```text
authority-A/example/1.0.0/aaa
authority-B/example/1.0.0/bbb
```

Notice that equal producer provenance no longer grants cross-authority reuse, a replacement payload cannot hit the earlier content identity, and a foreign global-packages tree remains a cold-path input because an archive digest does not identify the tree actually inspected.

## Simplest-sufficient design basis

This corrects an existing CLI-host cache path rather than adding a product capability, shared substrate, host path, information domain, or renderer. The existing consumer is `PackageInspector`; #3738 is its end-to-end adoption tracker. Both owner and consumer remain existing `src/dotnet-inspect` types, no shared API is introduced, and existing typed `InspectionResult`/Markout presentation is unchanged. #5484 is a separate acquisition prerequisite and is not implementation-ready until it records a shared CLI plus browser/Wasm plan or explicit approved narrower scope.

Each added mechanism answers reproduced correctness evidence: authority plus content identity prevents cross-authority or replaced-content reuse; a successful-production outcome prevents partial scans from becoming complete warm entries; a closed inventory/receipt prevents omission and truncation from becoming defaults; and canonical projection prevents filesystem enumeration from selecting a durable winner. Four outcome-level cache gates cover those claims without restating inherited platform or `CoreCache` properties.

## Design boundaries

- `PackageIndexCache` owns subject equality, the closed persistent projection, canonical and complete-entry validation, successful-production admission, miss behavior, and publication eligibility.
- Package-source ownership supplies durable configured authority; #3738 carries that provenance through derived inspection, creates the production outcome, and recomposes nonpersistent facts after hits.
- Package acquisition supplies process-local retained-generation continuity and the durable exact archive/tree prerequisite tracked by #5484.
- `CoreCache` owns paths, key hashing, atomic replacement, maintenance, and telemetry only.
- No TLA+ model is needed because this owner introduces no mutable coordination protocol.

## Review-driven corrections

Round 1 exact-head probes established that `pkg-index-v16` loses `RuntimeDependencies` on warm hits, persists the producing process time-zone interpretation of ZIP build time, and can publish partial binary counters after a per-DLL scan failure. The target discloses those current gaps, keeps `BuiltDate` outside persistence, derives local symbol aggregates, and requires a typed successful-production outcome before publication.

Current-main guidance then required a significant-interaction update: the design now records its complexity and consumer/host/rendering classification, #3738/#5484 carry the corresponding tracker state, and the evidence plan is consolidated from nine gates to four outcome-level gates.

## Compatibility and non-action

This is a design-only change. It does not alter current commands, output, cache files, or package acquisition. It records current `pkg-index-v16` authority containment and projection completeness as unverified and requires a successor namespace rather than relabeling legacy entries.

Related to #3738. Prerequisite: #5484. Text-provenance follow-up: #3787.

## Validation

- `npx --yes markdownlint-cli docs/design/package-index-cache.md docs/design/nuget.md docs/overview.md docs/architecture.md docs/README.md`