### PR TITLE
Clarify the CSharpText validation endpoint

### DIFF
--- a/docs/design/csharp-declared-type-self-name.md
+++ b/docs/design/csharp-declared-type-self-name.md
@@ -3,7 +3,8 @@
 ## Status
 
 Implemented for issue #5367. The admission, shared-use, and atomic-refusal
-properties are enforced by the named Release gates below.
+properties are enforced by the named Release gates below. The composed
+product-output compile/SRM endpoint is specified below and remains unverified.
 
 This is the focused successor to superseded PR #5110. It does not inherit that
 PR's proposed declaration-result, receipt, composition, or retention protocol.
@@ -237,6 +238,39 @@ uses
 An exact generated leaf remains on the legacy compatibility path. Its current
 substitute may enter legacy shell output, but it is not an admitted identifier
 and makes no exact identity claim.
+
+## Validation endpoint
+
+The terminal observation for this adopter is the public
+`CSharpTypePrintOutcome`, not the intermediate CSharpText admission result.
+CSharpText proves that one admitted leaf token compiles and preserves its
+TypeDef leaf identity; this component owns whether that token was composed into
+the requested model-bound artifact correctly.
+
+The complete validation goal has two outcome arms:
+
+- `NotRendered` carries the exact self-name failures and exposes no source,
+  units, source artifact, or replacement range.
+- `Printed` carries source produced by `CSharpTypePrinter`. A tools-only gate
+  compiles that source unchanged, reads the emitted TypeDefs through SRM, and
+  requires the complete namespace, nesting, leaf name, and canonical generic
+  arity of every exact admitted declaration to equal the requested Metadata
+  identity. Successful compilation also proves that constructor and
+  destructor-spelled finalizer heads bind to their containing declarations.
+
+The compiler harness may supply references and compilation options, but it must
+not construct, normalize, or repair the source under test. Compilation success
+is distinct from identity agreement, following
+[C# assembly round-trip testing](csharp-member-recompilation.md#proof-levels).
+Roslyn remains tools/test-only; this validation goal adds no compiler dependency
+to `CSharpText` or `ILInspector.CSharp`.
+
+The named gates below currently prove lexical admission, model-bound handoff,
+shared use, hostile-metadata refusal, and atomic publication separately. A
+retained gate that compiles actual `CSharpTypePrinter` output and compares all
+exact emitted TypeDef identities through SRM is **unverified**. That gate is the
+next evidence endpoint; it strengthens evidence without broadening this
+component into member, namespace, generated-name, or whole-assembly policy.
 
 ## Required implementation gates
 

--- a/docs/design/csharp-type-declaration-identifier-admission.md
+++ b/docs/design/csharp-type-declaration-identifier-admission.md
@@ -72,6 +72,39 @@ oracle. It:
 Product code remains dependency-free, Roslyn-free, and compatible with
 NativeAOT and Browser/Wasm.
 
+## Validation endpoint and handoff
+
+CSharpText's validation endpoint is deliberately lexical and exact. For an
+`Admitted` result, the gate places the owner-issued spelling in one minimal
+type-declaration position, compiles it with the repository's current language
+version, and requires SRM to read the original input identity as the emitted
+TypeDef leaf. For a `Refused` result, the gate requires the closed reason to
+match whether the compiler rejects the spelling or emits a different identity.
+
+That observation proves only the CSharpText result. It does not prove that a
+model-bound consumer correctly composed namespace, nesting, generic arity,
+headers, constructors, finalizers, members, or a complete source artifact.
+Consumers must not cite the CSharpText gate alone for those claims.
+
+When a consumer claims that product-generated C# is compilable and
+identity-preserving, its terminal validation point is the unchanged product
+artifact and outcome, not the admitted token. The consumer-owned gate must:
+
+1. obtain the source or typed refusal from product code;
+2. compile published source without harness repair using the tools-only compiler
+   boundary;
+3. read the emitted artifact through SRM and compare the identities owned by
+   that consumer; and
+4. preserve typed artifact, compile, and comparison outcomes rather than
+   collapsing them into one success value.
+
+[C# assembly round-trip testing](csharp-member-recompilation.md#proof-levels)
+owns the general tools-side compilation and comparison levels. The first
+model-bound handoff is
+[C# declared-type self-name admission](csharp-declared-type-self-name.md#validation-endpoint),
+which owns its exact product outcome and identity comparison. Neither handoff
+adds Roslyn to CSharpText or another shipped product path.
+
 ## Non-claims
 
 This boundary does not define:


### PR DESCRIPTION
Clarifies where CSharpText’s compiler-backed proof ends and what model-bound consumers must validate before claiming compilable, identity-preserving source. It also records the missing CSharpTypePrinter artifact-level compile/SRM gate as unverified rather than implying that lexical admission proves the composed output.

## Demo

Before, the focused admission designs established compiler and metadata evidence for one identifier token but did not state the handoff to complete product-source validation. After this change, the documents explicitly distinguish the lexical endpoint from the terminal CSharpTypePrintOutcome and define the positive and negative evidence required at that boundary.

## Validation

- `npx markdownlint-cli docs/design/csharp-type-declaration-identifier-admission.md docs/design/csharp-declared-type-self-name.md`