### PR TITLE
Narrow the caret to the moved token in qualifier<->argument invocation rows

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -979,6 +979,81 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void CompareStructure_NarrowsInvocationQualifierArgumentCaretToMovedToken()
+    {
+        // Issue #5486 (corpus follow-up to #5022's item 2): once item 1
+        // collapses #4942's stacked rows to the single most-specific
+        // InvocationExpression row, the caret should narrow to just the
+        // `receiver` token that moved between qualifier and argument
+        // position, not the entire `receiver.Values(typeof(Attribute),
+        // true)` call -- matching the #4952 agreed mockup exactly. Item 2's
+        // `NarrowToChangedHeader` never covered `InvocationExpression` (it
+        // only narrows a closed set of statement kinds with their own
+        // printer `Header` region), so this is a distinct narrowing pass.
+        const string beforeText =
+            "return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();";
+        const string afterText =
+            "return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();";
+
+        var before = Document(
+            beforeText,
+            ("Return", beforeText),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "receiver.Values(typeof(Attribute), true)"));
+        var after = Document(
+            afterText,
+            ("Return", afterText),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>()"),
+            ("InvocationExpression", "Values(receiver, typeof(Attribute), true)"));
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            before,
+            after,
+            [0, 1, 2],
+            [0, 1, 2],
+            [
+                new CSharpNodeCorrespondence(0, 0),
+                new CSharpNodeCorrespondence(1, 1),
+                new CSharpNodeCorrespondence(2, 2),
+            ]));
+
+        var row = Assert.Single(comparison.Rows);
+        Assert.Equal(2, row.BeforeNodeId);
+        Assert.Equal(2, row.AfterNodeId);
+
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+        Assert.Equal("receiver", beforeText.Substring(beforeSpan.Start, beforeSpan.Length));
+        Assert.Equal("receiver", afterText.Substring(afterSpan.Start, afterSpan.Length));
+        Assert.Equal(beforeText.IndexOf("receiver", StringComparison.Ordinal), beforeSpan.Start);
+        Assert.Equal(afterText.IndexOf("receiver", StringComparison.Ordinal), afterSpan.Start);
+
+        // The caption still recognizes the shape -- and stays honest -- even
+        // though the caret text itself ("receiver" on both sides) no longer
+        // carries the "changed" signal that item 3's caption logic used to
+        // rely on; the caption must be derived from the full matched node
+        // text, not the narrowed caret spans.
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(comparison, CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(comparison, CSharpStructuralSide.After);
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: used as extension-call qualifier",
+            beforeBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "raise: InvocationExpression; receiver: moved to argument 1 (static call)",
+            afterBody,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("changed to", beforeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("changed from", afterBody, StringComparison.Ordinal);
+
+        var display = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal(
+            "receiver: qualifier -> argument 1 (extension -> static call)",
+            display.Detail);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_FallsBackToTextDumpWhenQualifierRoleShapeIsNotRecognized()
     {
         // A callee rename is not the narrow "receiver becomes an argument"

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1054,6 +1054,65 @@ public class CSharpStructuralComparisonTests
     }
 
     [Fact]
+    public void CompareStructure_DoesNotNarrowInvocationQualifierArgumentCaretWhenCallExceedsInlineRenderLimit()
+    {
+        // Regression for round-1 review (GPT-5.6 Sol and Claude Opus 5,
+        // independently): the qualifier/argument shape is recognized, but
+        // the full call text exceeds the printer's inline-render length
+        // limit (MaximumInlineTransitionLength, 120 chars) on both sides. If
+        // the row's caret were narrowed anyway, the caption/detail logic's
+        // FullNodeText lookup would fail (same length gate), fall back to
+        // the row's own (narrowed, now textually-identical-on-both-sides,
+        // and therefore short enough to pass the length gate) spans, and
+        // print a misleading self-transition like "changed to receiver"
+        // instead of the honest, pre-existing "text changed" fallback that
+        // already applies to any row too long to render inline. Narrowing
+        // must stay gated on the same length/inline-renderability check the
+        // caption logic uses, so it never narrows a row the caption can't
+        // also describe.
+        const string beforeText =
+            "receiver.Values(argumentOne, argumentTwo, argumentThree, argumentFour, "
+            + "argumentFive, argumentSix, argumentSeven, argumentEight)";
+        const string afterText =
+            "Values(receiver, argumentOne, argumentTwo, argumentThree, argumentFour, "
+            + "argumentFive, argumentSix, argumentSeven, argumentEight)";
+        Assert.True(beforeText.Length > 120);
+        Assert.True(afterText.Length > 120);
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        var narrowedBeforeSpan = Assert.Single(row.BeforeSpans);
+        var narrowedAfterSpan = Assert.Single(row.AfterSpans);
+
+        // The row must keep its original, un-narrowed full-call span.
+        Assert.Equal(0, narrowedBeforeSpan.Start);
+        Assert.Equal(beforeText.Length, narrowedBeforeSpan.Length);
+        Assert.Equal(0, narrowedAfterSpan.Start);
+        Assert.Equal(afterText.Length, narrowedAfterSpan.Length);
+
+        // And the fallback must be the honest, generic "text changed" (the
+        // same fallback already used for any overlong row, unrelated to this
+        // shape) -- never a self-referential "changed to receiver".
+        string overlongBeforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(comparison, CSharpStructuralSide.Before);
+        Assert.Contains(
+            "raise: InvocationExpression; text changed",
+            overlongBeforeBody,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("changed to receiver", overlongBeforeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("changed from receiver", overlongBeforeBody, StringComparison.Ordinal);
+
+        var overlongDisplay = Assert.Single(CSharpStructuralDiffPrinter.ToDisplayRows(comparison));
+        Assert.Equal("", overlongDisplay.Detail);
+    }
+
+    [Fact]
     public void RenderAnnotatedBody_FallsBackToTextDumpWhenQualifierRoleShapeIsNotRecognized()
     {
         // A callee rename is not the narrow "receiver becomes an argument"

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -1263,9 +1263,19 @@ public static partial class CSharpBodyDiff
 
             var beforeNode = before.Nodes[beforeNodeId];
             var afterNode = after.Nodes[afterNodeId];
+
+            // Only narrow when the printer's own caption/detail derivation
+            // will later be able to recognize and render the full call
+            // shape (same length/inline-renderability gate as
+            // CSharpStructuralDiffPrinter.FullNodeText). Otherwise the
+            // caption logic falls back to comparing the narrowed, now
+            // textually-identical-on-both-sides caret spans and produces a
+            // misleading self-transition such as "changed to receiver".
             if (beforeNode.Spans.Count != 1 || afterNode.Spans.Count != 1
                 || row.BeforeSpans[0] != beforeNode.Spans[0]
                 || row.AfterSpans[0] != afterNode.Spans[0]
+                || CSharpStructuralDiffPrinter.FullNodeText(before, beforeNodeId) is null
+                || CSharpStructuralDiffPrinter.FullNodeText(after, afterNodeId) is null
                 || NarrowInvocationQualifierArgumentSpan(
                     before, beforeNode.Spans[0],
                     after, afterNode.Spans[0]) is not { } narrowed)

--- a/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralComparison.cs
@@ -749,8 +749,11 @@ public static partial class CSharpBodyDiff
         }
 
         var rows = ImmutableArray.CreateBuilder<CSharpStructuralDiffRow>();
-        rows.AddRange(RefineUsingResourceDeclarationRows(
-            SuppressSubsumedAncestorRows(matchedRows, input.Before, input.After),
+        rows.AddRange(RefineInvocationQualifierArgumentRows(
+            RefineUsingResourceDeclarationRows(
+                SuppressSubsumedAncestorRows(matchedRows, input.Before, input.After),
+                input.Before,
+                input.After),
             input.Before,
             input.After));
 
@@ -1213,6 +1216,130 @@ public static partial class CSharpBodyDiff
                 AfterRegion = EnclosingRegion(after, narrowed.AfterSpans),
             };
         }
+    }
+
+    // Issue #5486 (corpus follow-up to #5022's item 2): item 2's
+    // `NarrowToChangedHeader` only narrows a closed set of statement kinds
+    // with their own printer `Header` region (see `KindsWithOwnHeaderRegion`
+    // above); `InvocationExpression` was never in that set, so a matched
+    // invocation pair's row always carries the entire call's span as its
+    // caret -- even for the #4942 corpus example item 3's own
+    // `TryDescribeQualifierArgumentRoleTransition` caption already
+    // recognizes: a receiver identifier moving between call-qualifier
+    // position (`receiver.Values(...)`) and first-argument position
+    // (`Values(receiver, ...)`). This pass narrows exactly that one
+    // well-evidenced shape's caret to the `receiver` token itself, on each
+    // side, reusing the printer's own shape recognizer
+    // (`CSharpStructuralDiffPrinter.TryParseQualifiedCall`/
+    // `TryFindInsertedArgumentIndex`) so the caret and the caption can never
+    // disagree about what shape they are describing. It does not attempt
+    // any other expression-level narrowing; an unrecognized shape keeps the
+    // full-node-span caret as before.
+    //
+    // Runs after `RefineUsingResourceDeclarationRows` (order does not matter
+    // in practice, since the two passes target disjoint node kinds) and only
+    // touches rows still carrying their original, unnarrowed full-node
+    // spans -- nothing else narrows an `InvocationExpression` row today, but
+    // the guard keeps this pass honestly scoped to its own precondition
+    // rather than assuming it.
+    static IEnumerable<CSharpStructuralDiffRow> RefineInvocationQualifierArgumentRows(
+        IEnumerable<CSharpStructuralDiffRow> rows,
+        AnnotatedSourceDocument before,
+        AnnotatedSourceDocument after)
+    {
+        foreach (var row in rows)
+        {
+            if (row.Change != CSharpStructuralChangeKind.Changed
+                || row.BeforeNodeId is not int beforeNodeId
+                || row.AfterNodeId is not int afterNodeId
+                || !string.Equals(row.BeforeKind, "InvocationExpression", StringComparison.Ordinal)
+                || !string.Equals(row.AfterKind, "InvocationExpression", StringComparison.Ordinal)
+                || row.BeforeSpans.Length != 1
+                || row.AfterSpans.Length != 1)
+            {
+                yield return row;
+                continue;
+            }
+
+            var beforeNode = before.Nodes[beforeNodeId];
+            var afterNode = after.Nodes[afterNodeId];
+            if (beforeNode.Spans.Count != 1 || afterNode.Spans.Count != 1
+                || row.BeforeSpans[0] != beforeNode.Spans[0]
+                || row.AfterSpans[0] != afterNode.Spans[0]
+                || NarrowInvocationQualifierArgumentSpan(
+                    before, beforeNode.Spans[0],
+                    after, afterNode.Spans[0]) is not { } narrowed)
+            {
+                yield return row;
+                continue;
+            }
+
+            yield return row with
+            {
+                BeforeSpans = narrowed.BeforeSpans,
+                AfterSpans = narrowed.AfterSpans,
+                BeforeRegion = EnclosingRegion(before, narrowed.BeforeSpans),
+                AfterRegion = EnclosingRegion(after, narrowed.AfterSpans),
+            };
+        }
+    }
+
+    static (ImmutableArray<AnnotatedSourceSpan> BeforeSpans, ImmutableArray<AnnotatedSourceSpan> AfterSpans)?
+        NarrowInvocationQualifierArgumentSpan(
+            AnnotatedSourceDocument beforeDocument,
+            AnnotatedSourceSpan beforeNodeSpan,
+            AnnotatedSourceDocument afterDocument,
+            AnnotatedSourceSpan afterNodeSpan)
+    {
+        string beforeText = beforeDocument.Text.Substring(beforeNodeSpan.Start, beforeNodeSpan.Length);
+        string afterText = afterDocument.Text.Substring(afterNodeSpan.Start, afterNodeSpan.Length);
+
+        if (!CSharpStructuralDiffPrinter.TryParseQualifiedCall(
+                beforeText, out string? beforeQualifier, out string beforeCallee, out var beforeArgs)
+            || !CSharpStructuralDiffPrinter.TryParseQualifiedCall(
+                afterText, out string? afterQualifier, out string afterCallee, out var afterArgs))
+        {
+            return null;
+        }
+
+        if (beforeCallee.Length == 0
+            || !string.Equals(beforeCallee, afterCallee, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // The qualifier candidate is always parsed as an exact prefix of its
+        // own side's text (`text[..dotIndex]`), so its absolute span is
+        // simply the node's own start, spanning the qualifier's length.
+        if (beforeQualifier is { } qualifier && afterQualifier is null)
+        {
+            if (!CSharpStructuralDiffPrinter.TryFindInsertedArgumentIndex(
+                    beforeArgs, afterArgs, qualifier, out int argIndex)
+                || !CSharpStructuralDiffPrinter.TryFindArgumentSpan(afterText, argIndex, out int argStart, out int argLength))
+            {
+                return null;
+            }
+
+            AnnotatedSourceSpan beforeQualifierSpan = new(beforeNodeSpan.Start, qualifier.Length);
+            AnnotatedSourceSpan afterArgumentSpan = new(afterNodeSpan.Start + argStart, argLength);
+            return ([beforeQualifierSpan], [afterArgumentSpan]);
+        }
+
+        if (afterQualifier is { } movedQualifier && beforeQualifier is null)
+        {
+            if (!CSharpStructuralDiffPrinter.TryFindInsertedArgumentIndex(
+                    afterArgs, beforeArgs, movedQualifier, out int argIndex)
+                || !CSharpStructuralDiffPrinter.TryFindArgumentSpan(beforeText, argIndex, out int argStart, out int argLength))
+            {
+                return null;
+            }
+
+            AnnotatedSourceSpan beforeArgumentSpan = new(beforeNodeSpan.Start + argStart, argLength);
+            AnnotatedSourceSpan afterQualifierSpan = new(afterNodeSpan.Start, movedQualifier.Length);
+            return ([beforeArgumentSpan], [afterQualifierSpan]);
+        }
+
+        return null;
     }
 
     // Item 10 (issue #5022): the header-narrowing above (items 2/7) still

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -308,8 +308,15 @@ public static class CSharpStructuralDiffPrinter
     /// when the row's caret has been narrowed to just the moved sub-token
     /// (issue #5486) -- the caret position and the caption derivation are
     /// separate concerns.
+    ///
+    /// Also used (as <c>internal</c>) by <c>RefineInvocationQualifierArgumentRows</c>
+    /// to gate narrowing itself: a row must only be narrowed when this same
+    /// method would later be able to recognize and render its full call
+    /// shape, otherwise the caption/detail logic falls back to the (now
+    /// narrowed, textually-identical-on-both-sides) caret spans and produces
+    /// a misleading self-transition such as "changed to receiver".
     /// </summary>
-    static string? FullNodeText(AnnotatedSourceDocument document, int? nodeId)
+    internal static string? FullNodeText(AnnotatedSourceDocument document, int? nodeId)
     {
         if (nodeId is not int id)
             return null;

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -216,12 +216,7 @@ public static class CSharpStructuralDiffPrinter
     /// </summary>
     static string FormatDetail(CSharpStructuralComparison comparison, CSharpStructuralDiffRow row)
     {
-        bool textChanged = row.Change.HasFlag(CSharpStructuralChangeKind.Changed)
-            && !CSharpBodyDiff.SelectedTextEqual(
-                comparison.Before,
-                row.BeforeSpans,
-                comparison.After,
-                row.AfterSpans);
+        bool textChanged = RowTextChanged(comparison, row);
         bool added = row.Change.HasFlag(CSharpStructuralChangeKind.Added);
         bool removed = row.Change.HasFlag(CSharpStructuralChangeKind.Removed);
         if (!textChanged && !added && !removed)
@@ -229,15 +224,20 @@ public static class CSharpStructuralDiffPrinter
 
         string? beforeText = InlineText(comparison.Before, row.BeforeSpans);
         string? afterText = InlineText(comparison.After, row.AfterSpans);
-        if (textChanged
-            && IsInvocationRoleCandidate(row)
-            && beforeText is not null
-            && afterText is not null)
+        if (textChanged && IsInvocationRoleCandidate(row))
         {
-            if (TryDescribeQualifierArgumentRoleTransition(beforeText, afterText, out var qualifierTransition))
-                return qualifierTransition.DetailSummary;
-            if (TryDescribeCalleeRenamedRoleTransition(comparison, beforeText, afterText, out var calleeTransition))
-                return calleeTransition.DetailSummary;
+            // Use the full matched node's text, not the (possibly narrowed,
+            // issue #5486) caret spans -- these captions need to see the
+            // whole call shape to recognize it.
+            string? beforeCallText = FullNodeText(comparison.Before, row.BeforeNodeId) ?? beforeText;
+            string? afterCallText = FullNodeText(comparison.After, row.AfterNodeId) ?? afterText;
+            if (beforeCallText is not null && afterCallText is not null)
+            {
+                if (TryDescribeQualifierArgumentRoleTransition(beforeCallText, afterCallText, out var qualifierTransition))
+                    return qualifierTransition.DetailSummary;
+                if (TryDescribeCalleeRenamedRoleTransition(comparison, beforeCallText, afterCallText, out var calleeTransition))
+                    return calleeTransition.DetailSummary;
+            }
         }
 
         if (textChanged
@@ -254,6 +254,43 @@ public static class CSharpStructuralDiffPrinter
             : FormatTransition(beforeText, afterText);
     }
 
+    /// <summary>
+    /// Whether a row's text meaningfully changed. For most rows this is the
+    /// (possibly narrowed) caret spans' own text equality -- narrowing
+    /// preserves the property that the narrowed span still differs whenever
+    /// the row does (items 2/7/10 only narrow when the surrounding text is
+    /// identical, so the difference necessarily survives inside the narrowed
+    /// span). The one shape that does not preserve this property is issue
+    /// #5486's qualifier/argument narrowing: `receiver` narrows to the exact
+    /// same identifier text on both sides, even though its role (qualifier
+    /// vs. argument) genuinely changed. For that shape, compare the full
+    /// matched nodes' text instead of the narrowed caret spans.
+    /// </summary>
+    static bool RowTextChanged(CSharpStructuralComparison comparison, CSharpStructuralDiffRow row)
+    {
+        if (!row.Change.HasFlag(CSharpStructuralChangeKind.Changed))
+            return false;
+
+        if (IsInvocationRoleCandidate(row)
+            && row.BeforeNodeId is int beforeId
+            && row.AfterNodeId is int afterId)
+        {
+            var beforeNode = comparison.Before.Nodes[beforeId];
+            var afterNode = comparison.After.Nodes[afterId];
+            return !CSharpBodyDiff.SelectedTextEqual(
+                comparison.Before,
+                beforeNode.Spans,
+                comparison.After,
+                afterNode.Spans);
+        }
+
+        return !CSharpBodyDiff.SelectedTextEqual(
+            comparison.Before,
+            row.BeforeSpans,
+            comparison.After,
+            row.AfterSpans);
+    }
+
     static string? InlineText(AnnotatedSourceDocument document, ImmutableArray<AnnotatedSourceSpan> spans)
     {
         if (spans.Length != 1 || spans[0].Length > MaximumInlineTransitionLength)
@@ -263,18 +300,63 @@ public static class CSharpStructuralDiffPrinter
         return CanRenderExactInline(text) ? Contain(text) : null;
     }
 
+    /// <summary>
+    /// The full text of a matched node's own span, independent of whatever
+    /// (possibly narrowed) caret spans its row carries. Invocation-role
+    /// captions (item 3's qualifier/argument transition, item 9's
+    /// callee-rename) need to see the whole call shape to recognize it, even
+    /// when the row's caret has been narrowed to just the moved sub-token
+    /// (issue #5486) -- the caret position and the caption derivation are
+    /// separate concerns.
+    /// </summary>
+    static string? FullNodeText(AnnotatedSourceDocument document, int? nodeId)
+    {
+        if (nodeId is not int id)
+            return null;
+
+        var node = document.Nodes[id];
+        if (node.Spans.Count != 1 || node.Spans[0].Length > MaximumInlineTransitionLength)
+            return null;
+
+        string text = SelectText(document, node.Spans[0]);
+        return CanRenderExactInline(text) ? Contain(text) : null;
+    }
+
     static string TextTransitionSuffix(
         CSharpStructuralComparison comparison,
         CSharpStructuralDiffRow row,
         CSharpStructuralSide side)
     {
-        if (!row.Change.HasFlag(CSharpStructuralChangeKind.Changed)
-            || CSharpBodyDiff.SelectedTextEqual(
-                comparison.Before,
-                row.BeforeSpans,
-                comparison.After,
-                row.AfterSpans))
+        if (!RowTextChanged(comparison, row))
             return "";
+
+        // Invocation-role captions need the whole call shape, not the
+        // (possibly narrowed, issue #5486) caret spans -- try this first,
+        // independent of the caret's own span count/length, and fall back to
+        // the caret-derived text below when the shape isn't recognized.
+        if (IsInvocationRoleCandidate(row))
+        {
+            string? beforeCallText = FullNodeText(comparison.Before, row.BeforeNodeId);
+            string? afterCallText = FullNodeText(comparison.After, row.AfterNodeId);
+            if (beforeCallText is not null && afterCallText is not null)
+            {
+                if (TryDescribeQualifierArgumentRoleTransition(
+                        beforeCallText, afterCallText, out var qualifierTransition))
+                {
+                    return side == CSharpStructuralSide.Before
+                        ? $"; {qualifierTransition.BeforeDescription}"
+                        : $"; {qualifierTransition.AfterDescription}";
+                }
+
+                if (TryDescribeCalleeRenamedRoleTransition(
+                        comparison, beforeCallText, afterCallText, out var calleeTransition))
+                {
+                    return side == CSharpStructuralSide.Before
+                        ? $"; {calleeTransition.BeforeDescription}"
+                        : $"; {calleeTransition.AfterDescription}";
+                }
+            }
+        }
 
         if (row.BeforeSpans.Length != 1 || row.AfterSpans.Length != 1)
             return "; text changed";
@@ -291,30 +373,6 @@ public static class CSharpStructuralDiffPrinter
         string afterText = SelectText(comparison.After, afterSpan);
         if (!CanRenderExactInline(beforeText) || !CanRenderExactInline(afterText))
             return "; text changed";
-
-        if (IsInvocationRoleCandidate(row))
-        {
-            if (TryDescribeQualifierArgumentRoleTransition(
-                    Contain(beforeText)!,
-                    Contain(afterText)!,
-                    out var qualifierTransition))
-            {
-                return side == CSharpStructuralSide.Before
-                    ? $"; {qualifierTransition.BeforeDescription}"
-                    : $"; {qualifierTransition.AfterDescription}";
-            }
-
-            if (TryDescribeCalleeRenamedRoleTransition(
-                    comparison,
-                    Contain(beforeText)!,
-                    Contain(afterText)!,
-                    out var calleeTransition))
-            {
-                return side == CSharpStructuralSide.Before
-                    ? $"; {calleeTransition.BeforeDescription}"
-                    : $"; {calleeTransition.AfterDescription}";
-            }
-        }
 
         if (IsUsingDeclarationRoleCandidate(row)
             && TryDescribeUsingDeclarationRoleTransition(
@@ -418,7 +476,7 @@ public static class CSharpStructuralDiffPrinter
     /// exactly, or when more than one position does (an ambiguous match is
     /// not an honest one).
     /// </summary>
-    static bool TryFindInsertedArgumentIndex(
+    internal static bool TryFindInsertedArgumentIndex(
         ImmutableArray<string> smaller,
         ImmutableArray<string> larger,
         string value,
@@ -1105,7 +1163,7 @@ public static class CSharpStructuralDiffPrinter
     /// narrow heuristic does not recognize -- callers must treat that as "no
     /// opinion", not as evidence the shape does not exist.
     /// </summary>
-    static bool TryParseQualifiedCall(
+    internal static bool TryParseQualifiedCall(
         string text,
         out string? qualifier,
         out string callee,
@@ -1265,6 +1323,94 @@ public static class CSharpStructuralDiffPrinter
         }
         results.Add(argsText[start..].Trim());
         return results.ToImmutable();
+    }
+
+    /// <summary>
+    /// Locates the trimmed span of the <paramref name="argumentIndex"/>-th
+    /// top-level argument in <paramref name="text"/>'s own call-expression
+    /// argument list (the same shape <see cref="TryParseQualifiedCall"/> and
+    /// <see cref="SplitTopLevelArguments"/> recognize), as an offset and
+    /// length relative to <paramref name="text"/> itself. Used to narrow a
+    /// structural-diff caret to the exact argument a qualifier moved into or
+    /// out of, rather than the call's entire span (issue #5486).
+    /// </summary>
+    internal static bool TryFindArgumentSpan(string text, int argumentIndex, out int start, out int length)
+    {
+        start = 0;
+        length = 0;
+        if (argumentIndex < 0)
+            return false;
+
+        int openParen = FindUnquotedIndexOf(text, '(', 0);
+        if (openParen < 0)
+            return false;
+        int closeParen = FindMatchingClose(text, openParen);
+        if (closeParen < 0)
+            return false;
+
+        int argsStart = openParen + 1;
+        string argsText = text[argsStart..closeParen];
+        if (argsText.Trim().Length == 0)
+            return false;
+
+        int depth = 0;
+        bool inString = false;
+        bool inChar = false;
+        int segmentStart = 0;
+        int currentIndex = 0;
+        for (int index = 0; index < argsText.Length; index++)
+        {
+            char character = argsText[index];
+            if (inString)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '"') inString = false;
+                continue;
+            }
+            if (inChar)
+            {
+                if (character == '\\') { index++; continue; }
+                if (character == '\'') inChar = false;
+                continue;
+            }
+            if (character == '"') { inString = true; continue; }
+            if (character == '\'') { inChar = true; continue; }
+            if (character is '(' or '[' or '{') { depth++; continue; }
+            if (character is ')' or ']' or '}') { depth--; continue; }
+            if (character != ',' || depth != 0)
+                continue;
+
+            if (currentIndex == argumentIndex)
+                return TryTrimArgumentSegment(argsText, argsStart, segmentStart, index, out start, out length);
+
+            currentIndex++;
+            segmentStart = index + 1;
+        }
+
+        return currentIndex == argumentIndex
+            && TryTrimArgumentSegment(argsText, argsStart, segmentStart, argsText.Length, out start, out length);
+    }
+
+    static bool TryTrimArgumentSegment(
+        string argsText,
+        int argsStart,
+        int segmentStart,
+        int segmentEnd,
+        out int start,
+        out int length)
+    {
+        start = 0;
+        length = 0;
+        string raw = argsText[segmentStart..segmentEnd];
+        string leftTrimmed = raw.TrimStart();
+        int leadingWhitespace = raw.Length - leftTrimmed.Length;
+        string trimmed = leftTrimmed.TrimEnd();
+        if (trimmed.Length == 0)
+            return false;
+
+        start = argsStart + segmentStart + leadingWhitespace;
+        length = trimmed.Length;
+        return true;
     }
 
     static bool CanRenderExactInline(string text)


### PR DESCRIPTION
Closes #5486.

## Demo

Real captured output for the exact #4942 shape (a receiver-qualification rewrite, instance-call syntax -> static-call syntax), reproduced via `CompareStructure_CollapsesSubsumedAncestorRowsToMostSpecificNode`'s fixture:

**Before this PR** (item 1's row-collapsing and item 3's captions already worked; the caret still spanned the entire 40-char call):

```
return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();
//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//     raise: InvocationExpression; receiver: used as extension-call qualifier

return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();
//     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//     raise: InvocationExpression; receiver: moved to argument 1 (static call)
```

**After this PR** (caret narrows to just the 8-char moved token, matching #4952's agreed corpus mockup exactly):

```
return receiver.Values(typeof(Attribute), true).FirstOrDefault<Attribute>();
//     ^^^^^^^^
//     raise: InvocationExpression; receiver: used as extension-call qualifier

return Values(receiver, typeof(Attribute), true).FirstOrDefault<Attribute>();
//            ^^^^^^^^
//            raise: InvocationExpression; receiver: moved to argument 1 (static call)
```

Notice: the caption text is unchanged (item 3 already got this right); only the caret width/position changed, so the reader's eye now lands on exactly what moved instead of scanning the whole call.

## What changed

Adds a new comparison pass, `RefineInvocationQualifierArgumentRows`, that narrows a matched `InvocationExpression` row's caret to just the token that moved between extension-call qualifier and static-call argument position (item 3's existing recognized shape), instead of spanning the entire call expression. Item 2's `NarrowToChangedHeader`/`KindsWithOwnHeaderRegion` never covered `InvocationExpression` (it only narrows a closed set of statement kinds with their own printer `Header` region), so this closes a distinct, previously-untracked gap surfaced while re-validating #4952's corpus against the fully-merged #5022 printer.

- Reuses `TryParseQualifiedCall`/`TryFindInsertedArgumentIndex` (now `internal`, was `private`) as the single source of truth for shape recognition -- the narrowing pass and the existing caption logic agree by construction on which shapes are recognized.
- Adds `TryFindArgumentSpan` to locate the argument's absolute text offset within the call (the qualifier side is always at offset 0 of its own node's text, so only the argument side needs position tracking).
- Adds `FullNodeText` (fetches a matched node's own, un-narrowed span) and `RowTextChanged` (compares full node text for invocation-role rows, falling back to the prior row-span comparison for every other row kind) to fix two assumptions the existing caption logic baked in that a narrowed-but-textually-identical token breaks:
  - `TryDescribeQualifierArgumentRoleTransition` expected the *entire call expression* as input text, not a narrowed sub-token.
  - `SelectedTextEqual(row.BeforeSpans, row.AfterSpans)` was used as a "did this row meaningfully change" proxy, which only holds for narrowing where the row's `Changed` state guarantees the difference survives inside the narrowed span (items 2/7/10). It doesn't hold here: the moved token (`receiver`) is textually identical on both sides -- only its *role* changed.

Both fixes only special-case invocation-role-candidate rows; every other row kind's behavior is unchanged.

## Validation

- `ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests`: 93/93 passing (92 existing + 1 new end-to-end test asserting narrowed span position/text, per-side captions, absence of the generic "changed to/from" fallback, and the `Detail` column value).
- Existing tests already guard the two boundary cases without new tests needed:
  - `RenderAnnotatedBody_FallsBackToTextDumpWhenQualifierRoleShapeIsNotRecognized` (a callee rename, not this shape) and `RenderAnnotatedBody_FallsBackToTextDumpWhenArgumentChangeAccompaniesQualifierMove` (an ambiguous shape) both assert the full, un-narrowed text still appears -- confirming the new pass only narrows the exact recognized shape and falls back safely otherwise.
  - `IssueCorrespondence_InfersAddedLocalFunctionDeclarationAlongsideMatchedCallSite` (item 9's callee-rename shape, no qualifier on either side) continues to pass unmodified, confirming no interaction with the new pass.
- `dotnet build dotnet-inspect.slnx -c Release`: 0 errors/warnings.
