### PR TITLE
Use MTP for xUnit zero-test failure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Architecture](architecture.md) | Current host-neutral composition, logical layers, project regions, currencies, and code-navigation map. |
 | [CLI Host Architecture](cli-architecture.md) | CLI command-host responsibilities, request lifetime, selection, and presentation composition. |
 | [CLI Change Classification and Obsolete Inputs](design/cli-change-classification.md) | Published CLI surfaces, observable change classification, disclosure, invalid-input guards, and routing reservations. |
-| [Repository xUnit Test Host](design/xunit-test-host.md) | Explicit-selection non-vacuity for the delegated xUnit argument vector while preserving xUnit-owned discovery, execution, reporting, and server dispatch. |
+| [Repository xUnit Test Host](design/xunit-test-host.md) | Microsoft Testing Platform execution and aggregate non-vacuity for repository xUnit executables. |
 | [Repository CI Change Plan](design/ci-change-plan.md) | Typed candidate provenance, exact changed-path interpretation, immutable CI validation selection, scoped evidence, and visible planner refusal. |
 | [LLM Design](llm-design.md) | Current agent-facing output and workflow design. |
 | [Progressive Disclosure](design/progressive-disclosure.md) | Current model for base/domain scope, discovery budgets, `-D`/`-S`, capabilities, counts, and row limits. |

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -157,16 +157,20 @@ entry gate invalidates every later result, so run it first and report it.
    [The repository xUnit test host](design/xunit-test-host.md) selects
    Microsoft Testing Platform (MTP) as the owner of aggregate non-vacuity.
    The decompiler host owns `--gate` preset expansion and the stronger
-   per-class execution receipt for `--gate pre-merge`: the preset names
-   independent correctness claims, so the CI checker requires report evidence
-   for every expected class rather than relying only on MTP's aggregate
-   minimum.
+   `--gate pre-merge` receipt: the preset names independent correctness claims,
+   so the CI checker requires report evidence for every expected class and
+   compares independent pre-enumerated discovery identities with execution
+   identities to prove every selected case executes exactly once. MTP's
+   aggregate minimum cannot replace either property.
 
    Until the MTP adoption tracked by #5379, the decompiler executable retains
    its transitional `ExplicitFilterGuard` preflight. That preflight is not the
    repository contract and is removed by adoption rather than generalized.
    The MTP migration must preserve `--gate` expansion and the per-class receipt
-   while replacing native xUnit selector syntax with MTP filters.
+   and discovery-to-execution completeness receipt while replacing native
+   xUnit selector syntax with MTP filters. If the selected MTP version cannot
+   expose the required independent identities, this suite remains on its
+   transitional host until an equally strong MTP-backed receipt exists.
 
 3. **IR invariant checks.** Every pass must leave a structurally valid tree.
    `IrPasses.Run` calls `function.CheckInvariant()` after each pass — armed by

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -154,27 +154,19 @@ entry gate invalidates every later result, so run it first and report it.
 
    Filter to a class while iterating, e.g.
    `… -c Release -- -filter "/*/*/IteratorAcknowledgmentPassTests/*"`.
-   [The repository xUnit test host](design/xunit-test-host.md) owns
-   explicit-selection non-vacuity. The decompiler host owns `--gate` preset
-   expansion and applies its current preflight to the expanded xUnit argument
-   vector. It rejects an explicit `-class`, `-method`, or `-filter` selector
-   that matches no discovered test. Every requested `-id` must resolve after
-   the other filters, even when another ID is valid. The host also rejects
-   standalone or combined direct selections that resolve to no runnable test,
-   including through explicit-test mode, and reports stale or malformed
-   `-run` serializations directly. Namespace, trait, and partially disjoint
-   final-witness coverage remain unverified until adoption of the repository
-   host contract tracked by #5379.
-   Preflight discovery runs in a short-lived child process so its serializer
-   registration and disposable theory data cannot alter the real runner process.
-   `ExplicitFilterGuardTests.TestHost_RejectsEveryUnmatchedExplicitFilter` is
-   the subprocess gate for both the rejection and isolation contracts.
-   `ExplicitFilterGuardTests.AppHostAlias_ConcurrentProcessesAreIsolated`
-   protects its renamed-apphost regression from concurrent test processes by
-   holding isolated aliases live in independent workers while another host
-   starts through the real muxer.
-   `ExplicitFilterGuardTests.AppHostAlias_CancellationCleansParentOwnedDirectories`
-   protects worker cleanup when the parent cancels those processes.
+   [The repository xUnit test host](design/xunit-test-host.md) selects
+   Microsoft Testing Platform (MTP) as the owner of aggregate non-vacuity.
+   The decompiler host owns `--gate` preset expansion and the stronger
+   per-class execution receipt for `--gate pre-merge`: the preset names
+   independent correctness claims, so the CI checker requires report evidence
+   for every expected class rather than relying only on MTP's aggregate
+   minimum.
+
+   Until the MTP adoption tracked by #5379, the decompiler executable retains
+   its transitional `ExplicitFilterGuard` preflight. That preflight is not the
+   repository contract and is removed by adoption rather than generalized.
+   The MTP migration must preserve `--gate` expansion and the per-class receipt
+   while replacing native xUnit selector syntax with MTP filters.
 
 3. **IR invariant checks.** Every pass must leave a structurally valid tree.
    `IrPasses.Run` calls `function.CheckInvariant()` after each pass — armed by

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -36,7 +36,8 @@ building another test host.
 The repository host consumes:
 
 - one xUnit test executable configured to use MTP;
-- the MTP argument vector, after any suite-owned expansion; and
+- an MTP argument vector in the repository evidence profile, after any
+  suite-owned expansion; and
 - the MTP integration supplied by the repository's pinned `xunit.v3` package.
 
 It produces MTP's execution or non-execution result without a repository
@@ -60,13 +61,21 @@ execution through `dotnet run`. For a test-execution invocation:
 5. Parse, discovery, filter, execution, and reporting failures remain visible
    through MTP's exit result.
 
+The repository evidence profile excludes an explicit MTP opt-out that ignores
+exit code `8` or lowers the minimum expected test count below one. Such an
+invocation deliberately declines the non-vacuity contract and is not supported
+as repository evidence. The host does not add an argument parser to police
+trusted callers; reviewed call sites and suite-owned expansion are responsible
+for selecting the evidence profile.
+
 The minimum applies to every test execution, including unfiltered and
 exclusion-filtered runs. This is MTP's conventional behavior and is useful for
 repository test executables: a supported test suite that executes nothing is
 not successful evidence.
 
 Help, test listing, runner information, and server operation are non-execution
-modes and do not acquire a test-count requirement.
+modes. MTP owns their result as well; the repository does not weaken a nonzero
+result when an empty filtered listing is rejected by the packaged MTP version.
 
 ## Aggregate and per-selection evidence
 
@@ -89,10 +98,12 @@ repository host does not reproduce xUnit filtering to infer contribution.
 Existing result checks may remain where they prove per-selection execution,
 not merely that the overall run was nonzero.
 
-The decompiler pre-merge gate is such a scenario: its preset names independent
+The decompiler pre-merge gate is such a scenario. Its preset names independent
 correctness classes, and its report checker requires execution evidence for
-every expected class. The decompiler suite owns that inventory, preset
-expansion, and receipt check.
+every expected class. It also compares an independent pre-enumerated discovery
+reference with execution identities so every discovered case executes exactly
+once. The decompiler suite owns that inventory, preset expansion, and complete
+discovery-to-execution receipt.
 
 ## Convention and dependencies
 
@@ -121,14 +132,27 @@ The implementation gate must cover:
 - an unfiltered suite reaching normal xUnit execution;
 - an exclusion filter that leaves tests reaching normal execution;
 - suite-owned argument expansion producing valid MTP filters;
+- the decompiler's custom entry point dispatching ordinary execution to MTP;
 - report production needed by domain-level per-selection receipts;
 - removal of the decompiler's repository-owned semantic preflight;
-- preservation of the decompiler's per-class execution receipt; and
+- preservation of the decompiler's per-class and per-case completeness
+  receipts, including exactly-once execution; and
 - migration of supported repository invocations and examples to MTP syntax.
 
 The same probe must show that one valid and one stale filter value can still
 produce a successful aggregate run. This negative control pins the boundary:
 MTP enforces the aggregate minimum, not per-selection contribution.
+
+Another boundary probe must show that explicitly ignoring exit code `8` can
+turn zero execution into success. This pins why that opt-out is outside the
+repository evidence profile rather than motivating a second command-line
+parser.
+
+If the selected MTP version cannot produce the independent discovery and
+execution identities required by the decompiler completeness receipt, that
+suite remains on its transitional host until its owner has an equally strong
+MTP-backed receipt. Aggregate MTP adoption elsewhere does not authorize
+weakening or removing that gate.
 
 Until a repository adoption names and runs these outcome-level gates, the MTP
 host contract is **unverified**.
@@ -144,6 +168,7 @@ The host does not:
 - infer which tests a workflow ought to select;
 - own or define suite-specific argument expansion or execution receipts;
 - promise that every value in a multi-value filter contributes a test;
+- police trusted callers that deliberately opt out of MTP's zero-test result;
 - parse workflow files, source text, prose, console output, or result XML;
 - replace MTP or xUnit discovery, filtering, execution, or reporting;
 - require `dotnet test` as the repository's supported correctness command; or

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -2,190 +2,136 @@
 
 ## Status and owner
 
-This document owns the repository xUnit executable host: the boundary between
-the argument vector ready for xUnit and xUnit-owned runner dispatch.
+This document owns the repository choice of command-line host for xUnit test
+executables and the aggregate non-vacuity contract for test execution.
 Issue [#5379](https://github.com/richlander/dotnet-inspect/issues/5379) tracks
-the first implementation.
+adoption.
 
-The host owns explicit-selection non-vacuity. It does not own test discovery,
-test-case identity, filtering semantics, execution, reporting, or Microsoft
-Testing Platform protocol behavior; xUnit retains those responsibilities.
-Suite-specific argument expansion, such as the decompiler's `--gate` presets,
-also remains with that suite and runs before this boundary.
+Microsoft Testing Platform (MTP) owns command-line parsing, filtering,
+discovery, execution, reporting, and the zero-test exit result. xUnit owns its
+adapter from MTP filters to xUnit test cases. Suite-specific argument expansion,
+such as the decompiler's `--gate` presets, remains with that suite and runs
+before the MTP boundary.
 
 ## Problem
 
 The repository uses focused xUnit invocations as evidence for narrow changes.
-With the pinned xUnit v3 console runner, an explicit include selector that
-matches no tests can complete successfully after reporting `Total: 0`. A
-renamed, deleted, misspelled, or wholly or partially disjoint selection can
-therefore preserve a green command while removing evidence the caller intended
-to run.
+With the xUnit v3 native console runner, a selector that matches no tests can
+complete successfully after reporting `Total: 0`. A renamed, deleted, or
+misspelled selection can therefore preserve a green command while removing all
+of the intended evidence.
 
-Post-run XML checks cover only the invocation paths that remember to request
-and parse that report. They do not establish the executable's contract and
-cannot distinguish all selection failures without reproducing xUnit's model.
+A repository-owned semantic preflight would need to consume xUnit's parser,
+discovery, filter, identity, serialization, and explicit-test behavior. That
+duplicates runner policy and couples repository infrastructure to libraries
+whose semantics xUnit already adapts for MTP.
+
+The `xunit.v3` package already includes MTP support. MTP's conventional
+execution contract expects at least one test and returns exit code `8` when a
+run executes none. The repository uses that existing contract instead of
+building another test host.
 
 ## Boundary
 
-The host consumes:
+The repository host consumes:
 
-- one repository xUnit test assembly;
-- the exact argument vector that will be delegated to xUnit, after any
-  suite-owned expansion; and
-- xUnit's discovery and selection model for that assembly.
+- one xUnit test executable configured to use MTP;
+- the MTP argument vector, after any suite-owned expansion; and
+- the MTP integration supplied by the repository's pinned `xunit.v3` package.
 
-It produces exactly one of these outcomes:
+It produces MTP's execution or non-execution result without a repository
+preflight. MTP and xUnit remain responsible for interpreting selectors and
+deciding which test cases run.
 
-- **delegate** — transfer that vector to xUnit-owned runner dispatch without
-  changing runner behavior; or
-- **refuse** — return a nonzero result with a diagnostic identifying an
-  explicit selection that cannot select the requested evidence.
+Repository call sites use the MTP command-line grammar directly. The host does
+not carry a compatibility layer that translates native xUnit options at
+runtime.
 
-xUnit remains the execution owner. Delegation must preserve its console-runner
-and Microsoft Testing Platform dispatch behavior.
+## Execution contract
 
-## Explicit-selection contract
+Every repository xUnit executable uses the MTP command-line host for direct
+execution through `dotnet run`. For a test-execution invocation:
 
-The host first classifies whether xUnit will execute tests or perform a
-non-execution operation such as help, listing, assembly information, or
-Microsoft Testing Platform server dispatch. The contract applies only to a
-test-execution invocation whose delegated console argument vector contains an
-explicit inclusion by namespace, class, method, trait, query filter, test-case
-identity, or serialized test case.
+1. The effective minimum expected test count is at least one.
+2. Exit code `8` is not ignored.
+3. Focused invocations use xUnit's MTP filter options rather than the native
+   xUnit console options.
+4. Suite-owned presets expand to MTP arguments before runner dispatch.
+5. Parse, discovery, filter, execution, and reporting failures remain visible
+   through MTP's exit result.
 
-The **witness set** is the set of test cases xUnit would submit to its execution
-path after filter, direct-selection, identity-resolution, and explicit-test
-policy. Static or dynamic skips, cancellation, stop-on-failure, and test
-outcomes do not change preflight membership in that set.
+The minimum applies to every test execution, including unfiltered and
+exclusion-filtered runs. This is MTP's conventional behavior and is useful for
+repository test executables: a supported test suite that executes nothing is
+not successful evidence.
 
-Before delegation:
+Help, test listing, runner information, and server operation are non-execution
+modes and do not acquire a test-count requirement.
 
-1. Every named namespace, class, method, or trait inclusion, and every query
-   selection, must retain at least one matching case in the witness set.
-2. Every requested test-case identity must identify a discovered case selected
-   by the active filters and admitted to the witness set, matching xUnit's
-   filtered identity resolution.
-3. Every serialized test-case selection must decode as a test case admitted to
-   the witness set under xUnit's direct-selection explicit policy. Filters do
-   not apply to a serialized selection when xUnit does not apply them.
-4. The witness set must contain at least one test case.
+## Aggregate and per-selection evidence
 
-These are semantic discovery obligations. The host must use xUnit's parser,
-discovery, filter, identity, serialization, and explicit-test semantics rather
-than infer selection from argument spelling, source text, test names, console
-output, or result XML.
+MTP's minimum count establishes **aggregate non-vacuity**: at least one test
+ran. It does not establish that every value in a multi-value filter contributed
+a test. A command combining one valid class with one stale class can still run
+the valid class and satisfy the aggregate minimum.
 
-A query argument is one atomic explicit selection, including a query composed
-only of negation. The host does not parse a query into positive and negative
-subclaims or reproduce xUnit's query grammar. The exclusion-only category below
-is limited to xUnit's simple negative namespace, class, method, and trait
-switches.
+The meaning of a multi-selection command follows the evidence claim made by
+its owner:
 
-## Delegation and failure
+- If the values describe one aggregate selection, MTP's nonzero execution is
+  the complete host-level contract.
+- If the command claims that each named class, method, or other selection
+  contributed evidence, the owning suite or workflow must provide a
+  domain-level receipt for each named claim.
 
-Help, discovery listings, assembly information, and Microsoft Testing Platform
-server operation are non-execution modes and delegate before selection
-preflight. Unfiltered test execution and runs containing only simple negative
-namespace, class, method, or trait switches also delegate without acquiring a
-minimum-test-count requirement from this design. Suite-owned argument expansion
-occurs before this partition, so an expansion that produces an explicit xUnit
-selection is subject to the same contract as a directly supplied selection.
+That stronger receipt remains local to the scenario that needs it. The
+repository host does not reproduce xUnit filtering to infer contribution.
+Existing result checks may remain where they prove per-selection execution,
+not merely that the overall run was nonzero.
 
-Direct selection changes the set xUnit executes. Serialized `-run` cases bypass
-the ordinary filters, while `-id` cases resolve through them. The host preserves
-that asymmetry:
+The decompiler pre-merge gate is such a scenario: its preset names independent
+correctness classes, and its report checker requires execution evidence for
+every expected class. The decompiler suite owns that inventory, preset
+expansion, and receipt check.
 
-- without `-run` or `-id`, the witness set contains the filter-selected
-  discovered cases admitted by xUnit's explicit-test policy;
-- with either direct selector, the witness set contains only valid deserialized
-  `-run` cases plus filter-selected discovered cases named by `-id`, after
-  xUnit's direct-selection explicit policy; ordinary discovered cases are not
-  added; and
-- every separately named simple inclusion or query selection must match a case
-  in that final witness set.
+## Convention and dependencies
 
-A direct case does not make an unrelated named inclusion non-vacuous merely
-because some other test will run.
+xUnit v3 conventionally supports MTP as a built-in command-line host. With the
+pinned xUnit v3.2.2 package, MTP v1 is already present; selecting it does not
+require a new direct package reference or repository test-host library.
+`dotnet run` remains the canonical repository command because the test project
+is still an executable.
 
-Selection preflight must not consume or mutate the runner's execution state.
-When discovery can materialize disposable theory data, preflight uses an
-isolated process and releases that data before the real runner starts.
-
-For an applicable explicit selection:
-
-- a semantic mismatch is a visible refusal;
-- failure to start or complete the isolated preflight is a visible refusal;
-  and
-- an argument or discovery failure already owned and reported by xUnit may
-  delegate only when xUnit's resulting runner path fails visibly.
-
-An adoption must gate that delegated xUnit-owned failures return nonzero. The
-host does not turn an indeterminate applicable preflight into successful
-zero-test execution.
-
-## Convention and divergence
-
-xUnit v3 conventionally owns its command-line grammar, discovery, execution,
-and console and Microsoft Testing Platform dispatch. The repository preserves
-that owner and delegates successful selections without changing those paths.
-
-The pinned xUnit v3.2.2 in-process console runner has no exposed option that
-makes an unmatched explicit selector fail; the repository probe for #5379
-observed `Total: 0` with exit code `0`. Microsoft Testing Platform has a
-separate zero-test exit contract, but repository correctness suites use direct
-`dotnet run` console execution, and server dispatch must remain transparent.
-
-The repository deliberately adds a stricter pre-delegation rule only for
-explicit inclusions because those commands claim named evidence. It does not
-make the stronger and different claim that every unfiltered or
-exclusion-filtered run must execute a test.
-
-The repository also treats each query argument as one atomic selection, even
-when the query is wholly negative. This is deliberately stricter than the
-equivalent simple negative switches: the xUnit runner exposes the query as one
-selection expression, and classifying its internal polarity would require the
-host to reproduce query-language semantics it does not own.
-
-The existing decompiler test host demonstrates the compatible process-isolated
-preflight and xUnit-semantic approach. Its current selector coverage is only a
-partial precedent; the repository contract also closes namespace, trait, and
-partially disjoint inclusion paths.
+The repository does not depend directly on xUnit runner implementation
+libraries to enforce selection non-vacuity. A future xUnit package update may
+change the packaged MTP major version, but it must preserve this document's
+minimum-count and visible-failure contract before adoption.
 
 ## Evidence
 
-The pathological fixture is an ordinary test executable invoked with a method
-selector that names no test. Before adoption it reports zero tests and exits
-successfully. An adoption must make that invocation fail and must also
-demonstrate a neighboring valid selector that reaches normal xUnit execution.
+The pathological fixture is an ordinary test executable invoked through MTP
+with a method filter that names no test. With the pinned xUnit v3.2.2 package,
+it reports `Zero tests ran` and exits `8`. A neighboring valid fully qualified
+method filter runs one test and exits `0`.
 
-The implementation gate for an adoption must cover:
+The implementation gate must cover:
 
-- unmatched class and method inclusions and query selections;
-- unmatched namespace and trait inclusions;
-- a wholly negated query that contributes no case to the witness set;
-- simple negative switches that intentionally select no test and still
-  delegate;
-- individually valid inclusions whose full intersection is empty;
-- a nonempty combined selection in which any named inclusion has no final
-  witness;
-- missing and filter-disjoint test-case identities;
-- invalid serialized test cases and serialized cases excluded by xUnit's
-  direct-selection explicit policy;
-- a serialized test case that xUnit runs without applying an otherwise active
-  filter;
-- a direct selection that leaves a separately named inclusion without a case
-  in the witness set;
-- explicit-only selection with an empty witness set;
-- isolated-preflight startup or protocol failure;
-- delegated xUnit-owned parse or discovery failure;
-- a valid explicit selection;
-- an exclusion-only run; and
-- unchanged xUnit console and Microsoft Testing Platform dispatch.
+- an unmatched focused filter returning exit code `8`;
+- a valid focused filter reaching normal xUnit execution;
+- an unfiltered suite reaching normal xUnit execution;
+- an exclusion filter that leaves tests reaching normal execution;
+- suite-owned argument expansion producing valid MTP filters;
+- report production needed by domain-level per-selection receipts;
+- removal of the decompiler's repository-owned semantic preflight;
+- preservation of the decompiler's per-class execution receipt; and
+- migration of supported repository invocations and examples to MTP syntax.
 
-The decompiler's current `ExplicitFilterGuardTests` enforce most semantic and
-process-isolation cases. Until a repository-host adoption names its own
-outcome-level integration gate, that adoption is **unverified**.
+The same probe must show that one valid and one stale filter value can still
+produce a successful aggregate run. This negative control pins the boundary:
+MTP enforces the aggregate minimum, not per-selection contribution.
+
+Until a repository adoption names and runs these outcome-level gates, the MTP
+host contract is **unverified**.
 
 ## Non-claims
 
@@ -196,9 +142,9 @@ The host does not:
 
 - validate that a test proves its stated property;
 - infer which tests a workflow ought to select;
-- own or define suite-specific argument expansion;
-- require a minimum count for unfiltered or exclusion-only runs;
-- parse workflow files, source text, prose, console formatting, or result XML;
-- replace xUnit discovery, filtering, execution, or reporting;
-- define Browser/Wasm product compatibility; or
-- make `dotnet test` the repository's supported correctness command.
+- own or define suite-specific argument expansion or execution receipts;
+- promise that every value in a multi-value filter contributes a test;
+- parse workflow files, source text, prose, console output, or result XML;
+- replace MTP or xUnit discovery, filtering, execution, or reporting;
+- require `dotnet test` as the repository's supported correctness command; or
+- add product dependencies or alter product platform compatibility.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -109,11 +109,10 @@ substrates, and inspection producers that will extend that space.
   owner-issued artifact, fragment, and correspondence evidence;
   `ILInspector.CSharp`, `ILInspector.Decompiler`, and `ILInspector.ILDiff`
   retain ownership of producing that evidence.
-- [Repository xUnit test host](design/xunit-test-host.md) owns explicit test
-  selection non-vacuity for the argument vector handed to xUnit after any
-  suite-owned expansion. xUnit retains command-line parsing, discovery,
-  filtering, execution, reporting, and Microsoft Testing Platform protocol
-  behavior.
+- [Repository xUnit test host](design/xunit-test-host.md) owns the repository's
+  use of Microsoft Testing Platform for aggregate non-vacuity of xUnit test
+  execution. MTP and xUnit retain runner semantics; suite owners retain
+  argument expansion and any stronger per-selection evidence receipts.
 - [Repository CI change plan](design/ci-change-plan.md) owns candidate
   provenance, exact changed-path interpretation, path and event routing
   implications, and one immutable validation plan with bounded scoped evidence.
@@ -179,10 +178,9 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   inputs](design/cli-change-classification.md): published surfaces, change
   disclosure, routing-collision analysis, invalid-input guards, and
   reservations.
-- [Repository xUnit test host](design/xunit-test-host.md): semantic
-  non-vacuity for explicit test selections after suite-owned argument
-  expansion, while preserving xUnit-owned discovery, execution, reporting, and
-  server dispatch.
+- [Repository xUnit test host](design/xunit-test-host.md): MTP-owned aggregate
+  non-vacuity for xUnit execution, with stronger per-selection evidence left
+  to the suite that makes that claim.
 - [Find type-search service](design/find-search-service.md): CLI-scoped
   candidate collection, classification precedence, source ordering, limits,
   failure visibility, and typed result boundary for `find`.


### PR DESCRIPTION
Replaces the proposed repository semantic selector preflight with Microsoft Testing Platform’s built-in aggregate non-vacuity contract. The existing `xunit.v3` 3.2.2 package already supplies MTP, so adoption needs no direct dependency on xUnit runner internals or new repository test-host library.

Refs #5379.

## Design basis

Normative owner: `docs/design/xunit-test-host.md` — repository command-line host selection and aggregate non-vacuity for xUnit test execution.

Supporting roles:

- MTP owns command-line parsing, test discovery and execution, reporting, and its minimum-expected-test exit result.
- xUnit owns adaptation from MTP filters to xUnit test cases.
- Suite owners retain argument expansion and any stronger receipt when one command claims that each of several named selections contributed evidence.
- `docs/decompiler-correctness-pipeline.md` retains decompiler ownership of `--gate` expansion and its per-class plus independent discovery-to-execution completeness receipt.

## Demo

The filter deliberately names a test that does not exist. MTP reports that zero tests ran and returns a nonzero process exit code, so a shell or CI job treats the command as failed:

```console
$ dotnet run --project src/dotnet-inspect.Tests -c Release \
    -p:UseMicrosoftTestingPlatformRunner=true -- \
    --filter-method "*DefinitelyNoSuchTest5099*"
...
Test run summary: Zero tests ran
$ status=$?
$ echo "dotnet exit code: $status"
dotnet exit code: 8
```

Here, `8` is MTP’s process exit code for zero executed tests. It is not the number of tests. Process exit code `0` means success; any nonzero value makes an ordinary shell or CI step fail.

A neighboring valid fully qualified method filter runs one test and returns process exit code `0`.

Two negative controls bound the contract. One valid plus one stale filter value still exits `0` after running the valid test, because MTP proves aggregate rather than per-selection non-vacuity. Explicitly passing `--ignore-exit-code 8` also turns zero execution into exit `0`; that deliberate opt-out is outside the supported repository evidence profile rather than motivation for another repository argument parser.

## Validation

- `npx markdownlint-cli docs/design/xunit-test-host.md docs/overview.md docs/README.md docs/decompiler-correctness-pipeline.md`
- `git diff --check`
- Pinned xUnit v3.2.2 MTP probe: unmatched method filter exits `8`.
- Pinned xUnit v3.2.2 MTP probe: valid method filter runs one test and exits `0`.
- Pinned xUnit v3.2.2 MTP negative controls: mixed valid/stale values run one test; explicit exit-8 suppression returns `0`.

## Compatibility and non-action boundary

This PR changes documentation only. It does not yet enable MTP, translate repository invocations, or remove `ExplicitFilterGuard`. `dotnet run` remains the canonical test command. The subsequent adoption will use MTP already carried by `xunit.v3`; it will not add a shared selector library or parse trusted arguments.

Decompiler migration is conditional on preserving its complete existing receipt: expected-class coverage plus independent pre-enumerated discovery identities matched to exactly-once execution identities. If the selected MTP version cannot expose equivalent evidence, that suite remains on its transitional host while ordinary suites adopt MTP.