### PR TITLE
Expose projected member declaring Type identity

### DIFF
--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -114,6 +114,35 @@ item into one product-owned kind facet and accepts the returned opaque IDs for
 filtering. Unknown IDs and unclassified producer values fail visibly rather
 than becoming an empty inventory.
 
+### Projected Member declaring identity
+
+When an `ApiMember` is projected beneath a Type other than its metadata
+declaration, `DeclaringTypeDefinitionName` retains the declaration's exact
+`MetadataTypeDefinitionName`. It is the lookup-name currency for consumers that
+must distinguish the declaration from the containing or receiver Type;
+`DeclaringType` remains display text and `DeclaringTypeCanonicalName` remains
+the separate canonical-anchor spelling consumed by `ApiMemberIdentity`.
+
+The typed lookup name and canonical `MemberAnchor` projection originate from
+the same declaring Type, but neither substitutes for the other. A projected
+Member is emitted only when the producer retains the typed declaration name.
+The field is serialized as a structured namespace-plus-segments value and is
+charged to the bounded API-surface retained-text budget. Null remains the
+compatibility shape for a Member declared on its containing Type and for an
+older serialized projection; consumers requiring exact projected declaration
+identity must fail visibly rather than parse either declaring-Type string.
+`DeclaringTypeCanonicalName` identifies a projected row: both declaring
+currencies are absent on a declaration-side Member, while canonical text
+present with typed identity absent is an older or incomplete projection that
+cannot support exact lookup.
+
+This contract is gated by
+`ExtensionAttachmentNameBoundaryTests.AttachedExtension_PreservesTypedDeclaringTypeAndAnchor`,
+`ApiSurfaceExtractorBoundsTests.ProjectedDeclaringTypeIdentityContributesItsOwnRetainedText`,
+`ApiSurfaceRelationshipFailureTests.ExtractSummary_CyclicTypePreservesValidSiblingAndFailure`,
+and
+`ApiOutputFormatterTests.ApiTypeJson_RoundTripsProjectedMemberDeclaringTypeIdentity`.
+
 `ApiTypeShape` is also the currency for a serialized
 `[JsonSerializable(typeof(T))]` root. Its parser accepts only complete
 structural generic argument lists: leading, doubled, and trailing delimiters

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -1340,6 +1340,18 @@ public class ApiMember
     public string? DeclaringTypeCanonicalName { get; set; }
 
     /// <summary>
+    /// Exact metadata lookup name of the declaring Type when this Member is
+    /// projected beneath another <see cref="ApiType"/>.
+    /// </summary>
+    /// <remarks>
+    /// Null for Members declared on their containing Type and for older
+    /// serialized surfaces. Consumers that require exact declaration identity
+    /// must not reconstruct this value from declaring-Type display text.
+    /// </remarks>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public MetadataTypeDefinitionName? DeclaringTypeDefinitionName { get; set; }
+
+    /// <summary>
     /// 1-based overload index in <see cref="DeclaringType"/> for projected members.
     /// </summary>
     public int? DeclaringOverloadIndex { get; set; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -200,16 +200,27 @@ public static class ApiSurfaceExtractor
                     continue;
 
                 var (typeNamespace, typeName) = GetApiTypeNameParts(reader, typeDefHandle);
+                MetadataTypeDefinitionName definitionName =
+                    MetadataTypeDefinitionNameReader.Read(
+                        reader,
+                        typeDefHandle)
+                    switch
+                    {
+                        MetadataTypeDefinitionNameReadResult.Read read =>
+                            read.Name,
+                        MetadataTypeDefinitionNameReadResult.Rejected rejected =>
+                            throw new MetadataRowRejectedException(
+                                "type identity",
+                                rejected.Failure),
+                        _ => throw new InvalidOperationException(
+                            "Unknown type-definition name result.")
+                    };
                 var apiType = new ApiType
                 {
                     Namespace = typeNamespace,
                     Name = typeName,
                     MetadataName = GetMetadataName(reader, typeDefHandle),
-                    DefinitionName =
-                        MetadataTypeDefinitionNameReader.Read(reader, typeDefHandle)
-                        is MetadataTypeDefinitionNameReadResult.Read read
-                            ? read.Name
-                            : null,
+                    DefinitionName = definitionName,
                     IntroducedTypeParameterCounts =
                         MetadataDeclarationQuery.GetIntroducedTypeParameterCounts(
                             reader,
@@ -2893,6 +2904,10 @@ public static class ApiSurfaceExtractor
                 }
                 if (ReferenceEquals(targetType, declaringType))
                     continue;
+                MetadataTypeDefinitionName declaringTypeDefinitionName =
+                    declaringType.DefinitionName
+                    ?? throw new InvalidOperationException(
+                        "An extension declaration must retain exact Type identity before projection.");
                 string declaringTypeCanonicalName =
                     ApiMemberIdentity.FormatTypeAnchorName(declaringType);
                 if (targetType.Members.Any(member =>
@@ -2928,6 +2943,8 @@ public static class ApiSurfaceExtractor
                     DeclaringType = declaringType.FullName,
                     DeclaringTypeCanonicalName =
                         declaringTypeCanonicalName,
+                    DeclaringTypeDefinitionName =
+                        declaringTypeDefinitionName,
                     DeclaringOverloadIndex = declaringOverloadIndex,
                     IsObsolete = extension.IsObsolete,
                     ObsoleteMessage = extension.ObsoleteMessage,
@@ -5104,6 +5121,7 @@ public static class ApiSurfaceExtractor
         AddText(ref count, member.ExtendedType);
         AddText(ref count, member.DeclaringType);
         AddText(ref count, member.DeclaringTypeCanonicalName);
+        AddText(ref count, member.DeclaringTypeDefinitionName);
         AddText(ref count, member.EnumValueLiteral);
         AddText(ref count, member.JsonPropertyName);
         AddText(ref count, member.GetterAccessibility);

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -2338,6 +2338,64 @@ public class ApiOutputFormatterTests
         Assert.Equal([0, 0], restored.IntroducedTypeParameterCounts);
     }
 
+    [Fact]
+    public void ApiTypeJson_RoundTripsProjectedMemberDeclaringTypeIdentity()
+    {
+        MetadataTypeDefinitionName receiver = Assert
+            .IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "N",
+                    ["Widget"]))
+            .Name;
+        MetadataTypeDefinitionName declaring = Assert
+            .IsType<MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "N`1",
+                    [
+                        "Outer+Literal`1",
+                        "Extensions.WithDot`2",
+                    ]))
+            .Name;
+        var type = new ApiType
+        {
+            Namespace = receiver.Namespace,
+            Name = receiver.Segments[0],
+            DefinitionName = receiver,
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Extend",
+                    Kind = "extension-method",
+                    DeclaringType =
+                        "N`1.Outer+Literal<T>.Extensions.WithDot<T1, T2>",
+                    DeclaringTypeCanonicalName =
+                        @"N`1.Outer\+Literal`1.Extensions\.WithDot`2",
+                    DeclaringTypeDefinitionName = declaring,
+                },
+            ],
+        };
+
+        string json = JsonSerializer.Serialize(
+            type,
+            ApiTypeJsonContext.Default.ApiType);
+        ApiType restored = JsonSerializer.Deserialize(
+            json,
+            ApiTypeJsonContext.Default.ApiType)!;
+
+        ApiMember member = Assert.Single(restored.Members);
+        Assert.Equal(
+            declaring,
+            member.DeclaringTypeDefinitionName);
+        Assert.NotEqual(
+            restored.DefinitionName,
+            member.DeclaringTypeDefinitionName);
+        Assert.Contains(
+            "\"declaring_type_definition_name\"",
+            json,
+            StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// The production API-type JSON context persists the directional
     /// <c>JsonIgnore</c> evidence instead of relying on the legacy derived

--- a/src/dotnet-inspect.Tests/UntrustedLibraryViewContainmentTests.cs
+++ b/src/dotnet-inspect.Tests/UntrustedLibraryViewContainmentTests.cs
@@ -1493,6 +1493,7 @@ public class LibraryViewShapeDerivedContainmentTests
     private static readonly string[] OutOfReach =
     [
         "ApiJsonSerializableRoot.Type (ApiTypeShape): no public constructor",
+        "ApiMember.DeclaringTypeDefinitionName (MetadataTypeDefinitionName): no public constructor",
         "ApiSignature.PublicAccessorsSummary (String): string with no setter",
         "ApiSignature.ReturnTypeShape (ApiTypeShape): no public constructor",
         "ApiSurfaceInspectionFailure.OwningTypeDefinition (MetadataTypeDefinitionName): no public constructor",

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceExtractorBoundsTests.cs
@@ -302,10 +302,16 @@ public sealed class ApiSurfaceExtractorBoundsTests
     }
 
     [Fact]
-    public void ExtensionReceiverIdentityContributesItsOwnRetainedText()
+    public void ProjectedDeclaringTypeIdentityContributesItsOwnRetainedText()
     {
         const string receiver = "System.Collections.Generic.IEnumerable<T>";
         const string declaringType = "Samples.Extensions";
+        MetadataTypeDefinitionName declaringTypeDefinition = Assert.IsType<
+            MetadataTypeDefinitionNameResult.Valid>(
+                MetadataTypeDefinitionName.Create(
+                    "Samples",
+                    ["Extensions"]))
+            .Name;
         var withoutReceiver = new ApiMember
         {
             Name = "M",
@@ -321,10 +327,15 @@ public sealed class ApiSurfaceExtractorBoundsTests
                 ExtensionReceiverType = receiver,
             },
             DeclaringTypeCanonicalName = declaringType,
+            DeclaringTypeDefinitionName = declaringTypeDefinition,
         };
 
         Assert.Equal(
-            receiver.Length + declaringType.Length,
+            receiver.Length
+                + declaringType.Length
+                + declaringTypeDefinition.Namespace.Length
+                + declaringTypeDefinition.Segments.Sum(
+                    static segment => segment.Length),
             ApiSurfaceExtractor.CountRetainedText(withReceiver)
                 - ApiSurfaceExtractor.CountRetainedText(withoutReceiver));
     }

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceRelationshipFailureTests.cs
@@ -112,6 +112,30 @@ public class ApiSurfaceRelationshipFailureTests
     }
 
     [Fact]
+    public void ExtractSummary_CyclicTypePreservesValidSiblingAndFailure()
+    {
+        using var stream = new MemoryStream(BuildImage(
+            cyclicTypeName: "Rejected",
+            validTypeNames: ["Sibling"]));
+        using var peReader = new PEReader(stream);
+
+        ApiSurface surface = ApiSurfaceExtractor.ExtractSummary(peReader);
+
+        ApiType sibling = Assert.Single(surface.Types);
+        Assert.Equal("Sibling", sibling.Name);
+        Assert.NotNull(sibling.DefinitionName);
+        Assert.Equal(1, surface.PublicTypeCount);
+        ApiSurfaceInspectionFailure failure =
+            Assert.Single(surface.InspectionFailures);
+        Assert.Equal("type identity", failure.Operation);
+        Assert.Equal(0x02000002, failure.SubjectToken);
+        Assert.Equal(
+            MetadataTypeNameFailureMechanism.Relationship,
+            failure.Mechanism);
+        Assert.Equal("Cycle", failure.Kind);
+    }
+
+    [Fact]
     public void BoundedApiSurface_RejectedIdentityDoesNotSpendTheTypeBudget()
     {
         using var stream = new MemoryStream(BuildImage(

--- a/tests/ILInspector.Metadata.Tests/ExtensionAttachmentNameBoundaryTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtensionAttachmentNameBoundaryTests.cs
@@ -80,7 +80,7 @@ public sealed class ExtensionAttachmentNameBoundaryTests
     }
 
     [Fact]
-    public void AttachedExtension_PreservesItsExactDeclaringTypeAnchor()
+    public void AttachedExtension_PreservesTypedDeclaringTypeAndAnchor()
     {
         using var peReader = new PEReader(ImmutableArray.Create(BuildImage()));
         ApiSurface surface = ApiSurfaceExtractor.Extract(
@@ -101,6 +101,25 @@ public sealed class ExtensionAttachmentNameBoundaryTests
             member => member.Kind == "extension-method"
                 && member.Name == "Extend");
 
+        MetadataTypeDefinitionName attachedDeclaringType = Assert.IsType<
+            MetadataTypeDefinitionName>(
+                attached.DeclaringTypeDefinitionName);
+        Assert.Equal(
+            extensions.DefinitionName,
+            attachedDeclaringType);
+        Assert.Null(original.DeclaringTypeDefinitionName);
+        Assert.NotNull(attached.DeclaringTypeCanonicalName);
+        Assert.Null(original.DeclaringTypeCanonicalName);
+        Assert.NotEqual(
+            widget.DefinitionName,
+            attachedDeclaringType);
+        Assert.Equal("", attachedDeclaringType.Namespace);
+        Assert.Equal(
+            ["Extensions.WithDot"],
+            attachedDeclaringType.Segments);
+        Assert.Equal(
+            ApiMemberIdentity.FormatTypeAnchorName(extensions),
+            attached.DeclaringTypeCanonicalName);
         Assert.Equal(
             ApiMemberIdentity.GetMemberAnchor(
                 extensions,


### PR DESCRIPTION
## Summary

Projected API members now retain their exact typed declaring-Type lookup name
separately from display text and canonical anchor spelling. This gives
downstream consumers the producer-issued identity needed to distinguish an
extension declaration from the receiver Type without parsing strings.

- Add nullable `ApiMember.DeclaringTypeDefinitionName` JSON currency.
- Populate it only on attached extension-member projections while leaving the
  declaration-side row unchanged.
- Preserve `DeclaringTypeCanonicalName` for exact `MemberAnchor` projection.
- Charge the structured namespace and segments to retained-text bounds.
- Reject malformed summary Type identities visibly rather than constructing a
  projection without exact identity.

## Demo

```bash
dotnet run --project src/dotnet-inspect -c Release -- \
  type DotnetInspector.Fixtures.BodyShapeFixture \
  --library ./artifacts/bin/dotnet-inspect.Tests/release/DotnetInspector.Fixtures.dll \
  -S "Extension Methods" --json -T q
```

```json
{
  "name": "ProjectedCreation",
  "kind": "extension-method",
  "extended_type": "DotnetInspector.Fixtures.BodyShapeFixture",
  "declaring_type": "DotnetInspector.Fixtures.BodyShapeFixtureExtensions",
  "declaring_type_canonical_name": "DotnetInspector.Fixtures.BodyShapeFixtureExtensions",
  "declaring_type_definition_name": {
    "namespace": "DotnetInspector.Fixtures",
    "segments": [
      "BodyShapeFixtureExtensions"
    ]
  }
}
```

Notice that the projected row is shown beneath `BodyShapeFixture`, while its
typed declaration identity remains `BodyShapeFixtureExtensions`.

## Compatibility and boundaries

The new property is nullable and omitted when null, preserving older serialized
surfaces and ordinary members declared on their containing Type. This PR does
not change Navigation classification, snapshot semantics, subject descriptors,
action IDs, browser rendering, or cross-assembly correspondence.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- 2,409 Metadata tests passed; 2 environment-dependent tests skipped
- 5,256 CLI/product-output tests passed; 23 environment-dependent tests skipped
- Post-integration focused gates: 120 Metadata tests and 80 CLI tests passed;
  1 `ilasm`-dependent test skipped
- `npx markdownlint-cli docs/design/type-member-api-representation.md`
- `git diff --check`

Closes #5437
