### PR TITLE
Implement reusable SlideStrip navigation

### DIFF
--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -141,7 +141,8 @@ The subject strip maps each subject descriptor to:
 The inspector strip maps each inspector descriptor to:
 
 - its owner-issued label as Label;
-- an optional owner-issued Short Label such as `CG`;
+- a Short Label derived by uppercasing the first character of each displayed
+  label word, such as `O`, `CG`, or `AS`;
 - an optional owner-issued Unicode Icon;
 - its boxed one-based owner-order number as Index; and
 - preferred-to-minimum modes Label, Short Label, Icon, and Index, skipping
@@ -186,12 +187,14 @@ of Label or Index content.
    minimum. For each inspector result, it reserves exactly that result's normal
    inline width, gives all remaining width to subjects, and records the
    resulting subject mode and window.
-3. The composite deduplicates identical result pairs and removes every
-   dominated pair for which another allocation shows at least as rich a
-   subject result and at least as rich an inspector result, with one strict
-   improvement. The remaining Pareto levels are ordered from inspector-rich to
-   subject-rich; each successive level strictly increases the visible subject
-   result and strictly decreases the inspector result.
+3. The composite collapses result pairs with equal richness — the same visible
+   subject count plus the same inspector mode and visible count — to the
+   representative window nearest the strips' current continuity state. It then
+   removes every dominated pair for which another allocation shows at least as
+   rich a subject result and at least as rich an inspector result, with one
+   strict improvement. The remaining Pareto levels are ordered from
+   inspector-rich to subject-rich; each successive level strictly increases
+   the visible subject result and strictly decreases the inspector result.
    SlideStrip's policy and adjacent capacity thresholds define inspector
    richness; the Label-only subject result is richer when it contains more
    visible subjects.

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -1,8 +1,10 @@
 import {
   bindScopeBar,
   captureScopeBarFocus,
+  createScopeBarState,
   renderScopeBar,
   restoreScopeBarFocus,
+  type ScopeBarBinding,
 } from "../src/scope-bar.ts";
 import { renderAnnotatedSourcePageActions } from "../src/annotated-source.ts";
 import type {
@@ -20,6 +22,7 @@ import { renderWorkspaceSubject } from "../src/workspace-subject.ts";
 declare global {
   interface Window {
     focusWorkbenchSearchProbe: () => boolean;
+    renderPackageScopeProbe: () => void;
     rerenderScopeBarProbe: () => void;
   }
 }
@@ -34,10 +37,14 @@ function escapeHtml(value: unknown): string {
 
 const app = document.querySelector<HTMLElement>("#app");
 if (!app) throw new Error("The workspace-titlebar harness root is unavailable.");
+const appRoot: HTMLElement = app;
+const scopeBarState = createScopeBarState();
+let scopeBarBinding: ScopeBarBinding | null = null;
 const params = new URL(location.href).searchParams;
 const workspaceMode = params.has("workspace");
 const packageMode = params.has("package");
 const memberMode = params.has("member");
+const emptyMode = params.has("empty");
 const annotatedMode = params.has("annotated");
 const longMode = params.has("long");
 const defaultPackageIcon =
@@ -117,21 +124,27 @@ let activeScope: WorkspaceScope = workspaceMode
 let activePackageLens: PackageLens = "overview";
 let activeTypeLens: TypeLens = "api";
 let activeMemberSection: MemberSection = "overview";
-const packageStrip: readonly (readonly [PackageLens, string])[] = [
-  ["overview", "Overview"],
-  ["dependencies", "Dependencies"],
+const packageStrip: readonly (
+  readonly [PackageLens, string, string, string]
+)[] = [
+  ["overview", "Overview", "OV", "◫"],
+  ["dependencies", "Dependencies", "DEP", "⇄"],
 ];
-const typeStrip: readonly (readonly [TypeLens, string])[] = [
-  ["api", "API"],
-  ["metadata", "Metadata"],
-  ["source", "Source"],
+const typeStrip: readonly (
+  readonly [TypeLens, string, string, string]
+)[] = [
+  ["api", "API", "API", "⌘"],
+  ["metadata", "Metadata", "META", "≡"],
+  ["source", "Source", "SRC", "⌑"],
 ];
-const memberStrip: readonly (readonly [MemberSection, string])[] = [
-  ["overview", "Overview"],
-  ["call-graph", "Call graph"],
-  ["facts", "Facts"],
-  ["source", "Source"],
-  ["annotated", "Annotated source"],
+const memberStrip: readonly (
+  readonly [MemberSection, string, string, string]
+)[] = [
+  ["overview", "Overview", "OV", "◫"],
+  ["call-graph", "Call graph", "CG", "⑂"],
+  ["facts", "Facts", "FX", "·"],
+  ["source", "Source", "SRC", "⌑"],
+  ["annotated", "Annotated source", "ANN", "✎"],
 ];
 
 function scopeBarHtml() {
@@ -140,12 +153,13 @@ function scopeBarHtml() {
     : activeScope === "package"
       ? packageStrip
       : activeScope === "member"
-        ? memberStrip
+        ? (emptyMode ? [] : memberStrip)
         : typeStrip;
   return renderScopeBar({
     scope: activeScope,
     strip,
     activeStripId: activeScope === "workspace"
+      || (activeScope === "member" && emptyMode)
       ? null
       : activeScope === "package"
         ? activePackageLens
@@ -159,6 +173,7 @@ function scopeBarHtml() {
         : "data-lens",
     panelId: "inspector-panel",
     showMemberScope: memberMode,
+    emptyStripLabel: emptyMode ? "Filtered member list" : "",
     escapeHtml,
   });
 }
@@ -258,18 +273,39 @@ document.querySelectorAll<HTMLElement>("[data-subject-copy]").forEach(button =>
   }));
 
 function renderHarnessScopeBar() {
-  const focusTarget = document.activeElement instanceof HTMLElement
-    ? captureScopeBarFocus(document.activeElement)
+  const focusedElement = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
+  const scopeBarOwnsFocus = focusedElement
+    ?.closest("[data-scope-bar]") !== null;
+  const focusTarget = focusedElement
+    ? captureScopeBarFocus(focusedElement)
     : null;
   const scopeBar = document.querySelector<HTMLElement>(".lensbar");
   if (!scopeBar) throw new Error("The scope bar is unavailable.");
+  if (scopeBarOwnsFocus) {
+    appRoot.tabIndex = -1;
+    appRoot.focus({ preventScroll: true });
+  }
+  scopeBarBinding?.disconnect();
   scopeBar.outerHTML = scopeBarHtml();
   bindHarnessScopeBar();
-  if (focusTarget) restoreScopeBarFocus(document, focusTarget);
+  if (scopeBarOwnsFocus) {
+    let restored = false;
+    if (focusTarget) {
+      scopeBarBinding?.revealFocusTarget(focusTarget);
+      restored = restoreScopeBarFocus(document, focusTarget);
+    }
+    if (!restored) {
+      document.querySelector<HTMLElement>(".brand")
+        ?.focus({ preventScroll: true });
+    }
+    appRoot.removeAttribute("tabindex");
+  }
 }
 
 function bindHarnessScopeBar() {
-  bindScopeBar(document, {
+  scopeBarBinding = bindScopeBar(document, {
     onMemberSectionSelect: section => {
       activeMemberSection = section;
       renderHarnessScopeBar();
@@ -286,10 +322,15 @@ function bindHarnessScopeBar() {
       activeTypeLens = lens;
       renderHarnessScopeBar();
     },
-  });
+  }, scopeBarState);
 }
 
 bindHarnessScopeBar();
 
 window.focusWorkbenchSearchProbe = () => focusWorkbenchSearch(document);
+window.renderPackageScopeProbe = () => {
+  activeScope = "package";
+  activePackageLens = "overview";
+  renderHarnessScopeBar();
+};
 window.rerenderScopeBarProbe = renderHarnessScopeBar;

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -4,6 +4,7 @@ import {
   createScopeBarState,
   renderScopeBar,
   restoreScopeBarFocus,
+  scopeBarShortLabel,
   type ScopeBarBinding,
 } from "../src/scope-bar.ts";
 import { renderAnnotatedSourcePageActions } from "../src/annotated-source.ts";
@@ -127,24 +128,24 @@ let activeMemberSection: MemberSection = "overview";
 const packageStrip: readonly (
   readonly [PackageLens, string, string, string]
 )[] = [
-  ["overview", "Overview", "OV", "◫"],
-  ["dependencies", "Dependencies", "DEP", "⇄"],
+  ["overview", "Overview", scopeBarShortLabel("Overview"), "◫"],
+  ["dependencies", "Dependencies", scopeBarShortLabel("Dependencies"), "⇄"],
 ];
 const typeStrip: readonly (
   readonly [TypeLens, string, string, string]
 )[] = [
-  ["api", "API", "API", "⌘"],
-  ["metadata", "Metadata", "META", "≡"],
-  ["source", "Source", "SRC", "⌑"],
+  ["api", "API", scopeBarShortLabel("API"), "⌘"],
+  ["metadata", "Metadata", scopeBarShortLabel("Metadata"), "≡"],
+  ["source", "Source", scopeBarShortLabel("Source"), "⌑"],
 ];
 const memberStrip: readonly (
   readonly [MemberSection, string, string, string]
 )[] = [
-  ["overview", "Overview", "OV", "◫"],
-  ["call-graph", "Call graph", "CG", "⑂"],
-  ["facts", "Facts", "FX", "·"],
-  ["source", "Source", "SRC", "⌑"],
-  ["annotated", "Annotated source", "ANN", "✎"],
+  ["overview", "Overview", scopeBarShortLabel("Overview"), "◫"],
+  ["call-graph", "Call graph", scopeBarShortLabel("Call graph"), "⑂"],
+  ["facts", "Facts", scopeBarShortLabel("Facts"), "·"],
+  ["source", "Source", scopeBarShortLabel("Source"), "⌑"],
+  ["annotated", "Annotated source", scopeBarShortLabel("Annotated source"), "✎"],
 ];
 
 function scopeBarHtml() {
@@ -277,7 +278,7 @@ function renderHarnessScopeBar() {
     ? document.activeElement
     : null;
   const scopeBarOwnsFocus = focusedElement
-    ?.closest("[data-scope-bar]") !== null;
+    ?.closest("[data-scope-bar]") != null;
   const focusTarget = focusedElement
     ? captureScopeBarFocus(focusedElement)
     : null;

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -516,22 +516,21 @@ test("edge indicators do not replace an item hit target", async ({ page }) => {
     });
 
   expect(target).toBe("call-graph");
-  const triangles = await page.locator(".slide-strip-inspector").evaluate(
+  const indicators = await page.locator(".slide-strip-inspector").evaluate(
     element => {
       const before = getComputedStyle(
         element.querySelector<HTMLElement>("[data-slide-strip-before]")!);
       const after = getComputedStyle(
         element.querySelector<HTMLElement>("[data-slide-strip-after]")!);
       return {
-        before: before.borderRightWidth,
-        after: after.borderLeftWidth,
-        height: Number.parseFloat(after.borderTopWidth)
-          + Number.parseFloat(after.borderBottomWidth),
+        before: before.borderLeftWidth,
+        after: after.borderRightWidth,
+        width: after.width,
       };
     });
-  expect(triangles.before).toBe("4px");
-  expect(triangles.after).toBe("4px");
-  expect(triangles.height).toBe(28);
+  expect(indicators.before).toBe("2px");
+  expect(indicators.after).toBe("2px");
+  expect(indicators.width).toBe("8px");
 });
 
 test("a mounted empty SlideStrip applies its empty state", async ({ page }) => {

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -473,6 +473,56 @@ test("allocation controls move between adjacent stable result pairs", async ({
   ).toHaveText(["Overview", "Call graph", "Facts"]);
 });
 
+test("allocation preserves a manually slid inspector window", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const help = page.locator("#help");
+  await help.focus();
+  await slideAfter(page, ".slide-strip-inspector");
+  await expect(help).toBeFocused();
+  expect(await page.locator(
+      ".slide-strip-inspector [data-inspector-tab]:not([hidden])",
+    ).evaluateAll(items => items.map(item => item.dataset.slideStripId)),
+  ).toEqual(["facts", "source", "annotated"]);
+
+  await page.locator("[data-more-subjects]").click();
+  await expect(
+    page.locator(
+      ".slide-strip-inspector [data-inspector-tab]:not([hidden])",
+    ).first(),
+  ).toHaveAttribute("data-slide-strip-id", "facts");
+});
+
+test("focus navigation refreshes allocation action candidates", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const moreSubjects = page.locator("[data-more-subjects]");
+  await moreSubjects.click();
+  await page.locator('[data-member-section="overview"]').focus();
+  await page.keyboard.press("ArrowLeft");
+
+  await expect(page.locator('[data-member-section="annotated"]')).toBeFocused();
+  expect(await page.locator(
+      ".slide-strip-inspector [data-inspector-tab]:not([hidden])",
+    ).evaluateAll(items => items.map(item => item.dataset.slideStripId)),
+  ).toEqual(["source", "annotated"]);
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "false");
+  const priorSubjectCount = await page.locator(
+    ".slide-strip-subject [data-subject-tab]:not([hidden])",
+  ).count();
+  await moreSubjects.click();
+  await expect.poll(() => page.locator(
+    ".slide-strip-subject [data-subject-tab]:not([hidden])",
+  ).count()).toBeGreaterThan(priorSubjectCount);
+  await expect(page.locator('[data-member-section="annotated"]')).toBeVisible();
+});
+
 test("every allocation level strictly trades subject for inspector richness", async ({
   page,
 }) => {

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -327,6 +327,95 @@ test("SlideStrip slides one uniform window without stealing external focus", asy
   await expect(inspector).toHaveAttribute("data-fallback", "false");
 });
 
+test("width-only changes retain the initially applied window", async ({
+  page,
+}) => {
+  await page.goto("/browser/workspace-titlebar.html");
+
+  const state = await page.evaluate(async () => {
+    const { SlideStripDomController } = await import(
+      "../src/slide-strip-dom.ts");
+    document.head.insertAdjacentHTML(
+      "beforeend",
+      `<style>
+        .resize-continuity-probe .slide-strip-items {
+          display: flex;
+          gap: 0;
+        }
+        .resize-continuity-probe button {
+          padding: 0;
+          border: 0;
+        }
+        .resize-continuity-probe [data-slide-strip-id="a"] {
+          width: 60px;
+        }
+        .resize-continuity-probe [data-slide-strip-id="b"] {
+          width: 40px;
+        }
+        .resize-continuity-probe [data-slide-strip-id="c"] {
+          width: 70px;
+        }
+      </style>`);
+    const element = document.createElement("div");
+    element.className = "slide-strip resize-continuity-probe";
+    element.innerHTML = `
+      <div class="slide-strip-items">
+        <button data-slide-strip-id="a">
+          <span data-slide-strip-representation="label">A</span>
+        </button>
+        <button data-slide-strip-id="b">
+          <span data-slide-strip-representation="label">B</span>
+        </button>
+        <button data-slide-strip-id="c">
+          <span data-slide-strip-representation="label">C</span>
+        </button>
+      </div>
+      <span data-slide-strip-before></span>
+      <span data-slide-strip-after></span>`;
+    document.body.append(element);
+    const continuity: { key: string; leadingId?: string } = {
+      key: "resize-continuity",
+    };
+    const controller = new SlideStripDomController(
+      element,
+      [
+        { id: "a", label: "A" },
+        { id: "b", label: "B" },
+        { id: "c", label: "C" },
+      ],
+      {
+        modes: [{ kind: "label", minimumVisible: 1, gap: 0 }],
+        initialAnchor: "b",
+        preferredDirection: "after",
+        continuityKey: "resize-continuity",
+        fallbackVisibilityFloor: 20,
+        oversizedAlignment: "start",
+      },
+      continuity);
+    const snapshot = () => ({
+      visible: [...element.querySelectorAll<HTMLElement>(
+        "[data-slide-strip-id]:not([hidden])")]
+        .map(item => item.dataset.slideStripId),
+      leading: continuity.leadingId,
+    });
+
+    controller.apply(controller.resolve(100));
+    const initial = snapshot();
+    controller.apply(controller.resolve(110));
+    const wider = snapshot();
+    controller.apply(controller.resolve(170));
+    const complete = snapshot();
+
+    return { initial, wider, complete };
+  });
+
+  expect(state).toEqual({
+    initial: { visible: ["a", "b"], leading: "a" },
+    wider: { visible: ["a", "b"], leading: "a" },
+    complete: { visible: ["a", "b", "c"], leading: "a" },
+  });
+});
+
 test("allocation controls move between adjacent stable result pairs", async ({
   page,
 }) => {
@@ -484,7 +573,7 @@ test("removing a focused allocation control transfers focus before removal", asy
   const moreSubjects = page.locator("[data-more-subjects]");
   await moreSubjects.focus();
   await expect(moreSubjects).toBeFocused();
-  await page.setViewportSize({ width: 400, height: 900 });
+  await page.setViewportSize({ width: 360, height: 900 });
 
   await expect(page.locator("[data-slide-strip-allocation]")).toBeHidden();
   await expect(page.locator('[data-scope="member"]')).toBeFocused();
@@ -499,6 +588,100 @@ test("removing a focused allocation control transfers focus before removal", asy
   await expect(page.locator('[data-scope="member"]')).toBeFocused();
   await expect(page.locator(".slide-strip-subject [tabindex='0']"))
     .toHaveCount(1);
+});
+
+test("allocation focus transfer participates in pressure selection", async ({
+  page,
+}) => {
+  await page.goto("/browser/workspace-titlebar.html");
+
+  const state = await page.evaluate(async () => {
+    const scopeBar = await import("../src/scope-bar.ts");
+    document.head.insertAdjacentHTML(
+      "beforeend",
+      `<style>
+        .focus-pressure-probe .lensbar {
+          width: 400px;
+          flex: none;
+        }
+        .focus-pressure-probe
+          [data-slide-strip="subject"] .slide-strip-item {
+          width: 40px;
+          padding: 0;
+        }
+        .focus-pressure-probe
+          [data-slide-strip="inspector"] .slide-strip-item {
+          width: 30px;
+          padding: 0;
+        }
+        .focus-pressure-probe
+          [data-slide-strip="inspector"]
+          [data-slide-strip-id="a"] {
+          width: 220px;
+        }
+      </style>`);
+    document.body.innerHTML = `
+      <div class="focus-pressure-probe">
+        ${scopeBar.renderScopeBar({
+          scope: "member",
+          strip: [
+            ["a", "Alpha", "A", "x"],
+            ["b", "Beta", "B", "x"],
+            ["c", "Charlie", "C", "x"],
+            ["d", "Delta", "D", "x"],
+            ["e", "Echo", "E", "x"],
+          ],
+          activeStripId: "a",
+          stripAttribute: "data-member-section",
+          showMemberScope: true,
+          escapeHtml: String,
+        })}
+      </div>`;
+    const binding = scopeBar.bindScopeBar(
+      document,
+      {
+        onMemberSectionSelect() {},
+        onPackageLensSelect() {},
+        onScopeSelect() {},
+        onTypeLensSelect() {},
+      },
+      scopeBar.createScopeBarState());
+    await new Promise(resolve => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
+
+    const navigation = document.querySelector<HTMLElement>(".lensbar")!;
+    const inspector = document.querySelector<HTMLElement>(
+      '[data-slide-strip="inspector"]')!;
+    const allocation = document.querySelector<HTMLElement>(
+      "[data-slide-strip-allocation]")!;
+    const moreInspectors = document.querySelector<HTMLElement>(
+      "[data-more-inspectors]")!;
+    inspector.dispatchEvent(new WheelEvent("wheel", {
+      deltaY: 100,
+      bubbles: true,
+      cancelable: true,
+    }));
+    moreInspectors.focus();
+    navigation.style.width = "150px";
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const result = {
+      pressure: navigation.dataset.pressure,
+      inspectorFallback: inspector.dataset.fallback,
+      focused: document.activeElement instanceof HTMLElement
+        ? document.activeElement.dataset.slideStripId
+        : undefined,
+      controlsHidden: allocation.hidden,
+    };
+    binding.disconnect();
+    return result;
+  });
+
+  expect(state.pressure).toBe("terminal");
+  expect(state.controlsHidden).toBe(true);
+  expect(state.focused).toBe("a");
+  expect(state.inspectorFallback).toBe("true");
 });
 
 test("edge indicators do not replace an item hit target", async ({ page }) => {

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -531,7 +531,7 @@ test("edge indicators do not replace an item hit target", async ({ page }) => {
     });
   expect(triangles.before).toBe("4px");
   expect(triangles.after).toBe("4px");
-  expect(triangles.height).toBe(18);
+  expect(triangles.height).toBe(28);
 });
 
 test("a mounted empty SlideStrip applies its empty state", async ({ page }) => {

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -381,29 +381,6 @@ test("temporary pressure does not discard the retained allocation", async ({
   await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
 });
 
-test("a narrower stable ladder commits its clamped allocation", async ({
-  page,
-}) => {
-  await page.setViewportSize({ width: 660, height: 900 });
-  await page.goto("/browser/workspace-titlebar.html?member=1");
-
-  const moreSubjects = page.locator("[data-more-subjects]");
-  for (let attempt = 0; attempt < 10; attempt++) {
-    if (await moreSubjects.getAttribute("aria-disabled") === "true") break;
-    await moreSubjects.click();
-  }
-  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
-
-  await page.setViewportSize({ width: 640, height: 900 });
-  await expect(page.locator(".lensbar")).toHaveAttribute(
-    "data-pressure",
-    "ladder");
-  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
-
-  await page.setViewportSize({ width: 660, height: 900 });
-  await expect(moreSubjects).toHaveAttribute("aria-disabled", "false");
-});
-
 test("manual windows survive resize and reset with inspector inventory", async ({
   page,
 }) => {

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -6,6 +6,16 @@ async function box(page: Page, selector: string) {
   return value!;
 }
 
+async function slideAfter(page: Page, selector: string) {
+  await page.locator(selector).evaluate(element => {
+    element.dispatchEvent(new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      deltaY: 100,
+    }));
+  });
+}
+
 test("the title bar contains the inspected target without tab-like workspace identity", async ({
   page,
 }) => {
@@ -106,6 +116,33 @@ test("keyboard tab activation preserves focus across shell replacement", async (
   await expect(packageSubject).toBeFocused();
 });
 
+test("removed focused tabs fall back to the persistent shell control", async ({
+  page,
+}) => {
+  await page.goto("/browser/workspace-titlebar.html");
+
+  const metadata = page.getByRole("tab", { name: "Metadata" });
+  await metadata.focus();
+  await page.evaluate(() => window.renderPackageScopeProbe());
+
+  await expect(page.locator(".brand")).toBeFocused();
+  await expect(page.locator(".slide-strip-inspector")).toHaveAttribute(
+    "data-initial-anchor",
+    "overview");
+});
+
+test("replaced allocation controls park focus on the persistent shell", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  await page.locator("[data-more-subjects]").focus();
+  await page.evaluate(() => window.rerenderScopeBarProbe());
+
+  await expect(page.locator(".brand")).toBeFocused();
+});
+
 test("packages without an embedded icon use NuGet's package fallback", async ({
   page,
 }) => {
@@ -132,7 +169,9 @@ test("right-side actions yield from labels to arrows to nothing", async ({
   for (const width of [800, 761]) {
     await page.setViewportSize({ width, height: 900 });
     await page.goto("/browser/workspace-titlebar.html?member=1");
-    await expect(page.locator(".lensbar .lens-label").first()).toBeVisible();
+    await expect(
+      page.locator(".slide-strip-inspector .lens-label").first(),
+    ).toBeVisible();
     expect(await page.evaluate(() =>
       document.documentElement.scrollWidth
       - document.documentElement.clientWidth)).toBeLessThanOrEqual(0);
@@ -152,18 +191,11 @@ test("right-side actions yield from labels to arrows to nothing", async ({
     .toHaveText("Search");
   await expect(page.locator(".title-search-label-compact")).toBeVisible();
   await expect(page.locator(".title-navigation .nav-history")).toBeVisible();
-  const compactInspectorLabels = page.locator(".lensbar .lens-label");
-  await expect(compactInspectorLabels).toHaveCount(5);
-  expect(await compactInspectorLabels.evaluateAll(labels =>
-    labels.every(label => getComputedStyle(label).display === "none")))
-    .toBe(true);
-  await expect(page.locator(".lensbar .lens kbd")).toHaveText([
-    "1",
-    "2",
-    "3",
-    "4",
-    "5",
-  ]);
+  const inspectorStrip = page.locator(".slide-strip-inspector");
+  await expect(inspectorStrip).toHaveAttribute("data-mode", "label");
+  await expect(
+    inspectorStrip.locator("[data-inspector-tab]:not([hidden])"),
+  ).toHaveCount(4);
   const callGraph = page.getByRole("tab", { name: "Call graph" });
   await expect(callGraph).toBeVisible();
   await expect(callGraph).toHaveAttribute("aria-selected", "false");
@@ -216,20 +248,33 @@ test("right-side actions yield from labels to arrows to nothing", async ({
   expect(await page.evaluate(() => window.focusWorkbenchSearchProbe()))
     .toBe(false);
   await expect(page.locator(".title-navigation .nav-history")).toBeVisible();
-  await expect(page.locator("#share")).toBeHidden();
+  await expect(page.locator("#share")).toBeVisible();
   await expect(page.locator("#open-settings")).toBeVisible();
   await expect(page.locator("#help")).toBeVisible();
 
   await page.setViewportSize({ width: 560, height: 900 });
   await expect(page.locator(".title-navigation .nav-history")).toBeHidden();
-  await expect(page.locator("#open-settings")).toBeHidden();
+  await expect(page.locator("#open-settings")).toBeVisible();
   await expect(page.locator("#help")).toBeVisible();
 
   await page.setViewportSize({ width: 480, height: 900 });
   await expect(page.locator("#help")).toBeVisible();
+  await expect(inspectorStrip).toHaveAttribute("data-mode", "label");
+  await expect(
+    inspectorStrip.locator(
+      '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveCount(2);
+  expect(await inspectorStrip.locator(
+    '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="short-label"]',
+  ).evaluateAll(labels =>
+    labels.every(label => getComputedStyle(label).display === "none")))
+    .toBe(true);
 
   await page.setViewportSize({ width: 400, height: 900 });
-  await expect(page.locator("#help")).toBeHidden();
+  await expect(page.locator("#share")).toBeHidden();
+  await expect(page.locator("#open-settings")).toBeVisible();
+  await expect(page.locator("#help")).toBeVisible();
   const horizontalOverflow = await page.evaluate(() =>
     document.documentElement.scrollWidth - document.documentElement.clientWidth);
   expect(horizontalOverflow).toBeLessThanOrEqual(0);
@@ -237,6 +282,303 @@ test("right-side actions yield from labels to arrows to nothing", async ({
   const narrowTypeList = await box(page, ".type-list");
   expect(narrowNamespacePicker.y + narrowNamespacePicker.height)
     .toBeLessThanOrEqual(narrowTypeList.y);
+});
+
+test("SlideStrip slides one uniform window without stealing external focus", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 560, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const inspector = page.locator(".slide-strip-inspector");
+  await expect(inspector).toHaveAttribute("data-mode", "label");
+  await expect(
+    inspector.locator(
+      '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Overview", "Call graph"]);
+  await expect(inspector.locator("[data-slide-strip-before]")).toBeHidden();
+  await expect(inspector.locator("[data-slide-strip-after]")).toBeVisible();
+
+  const help = page.locator("#help");
+  await help.focus();
+  await slideAfter(page, ".slide-strip-inspector");
+  await expect(help).toBeFocused();
+  await expect(
+    inspector.locator(
+      '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Call graph", "Facts"]);
+  await expect(inspector.locator("[data-slide-strip-before]")).toBeVisible();
+  await expect(inspector.locator("[data-slide-strip-after]")).toBeVisible();
+
+  const callGraph = page.getByRole("tab", { name: "Call graph" });
+  await callGraph.focus();
+  await page.keyboard.press("ArrowRight");
+  const facts = page.getByRole("tab", { name: "Facts" });
+  await expect(facts).toBeFocused();
+  await expect(facts).toHaveAttribute("aria-selected", "false");
+  await expect(page.locator('[data-member-section="overview"]'))
+    .toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("End");
+  const annotated = page.getByRole("tab", { name: "Annotated source" });
+  await expect(annotated).toBeFocused();
+  await expect(annotated).toBeVisible();
+  await expect(inspector).toHaveAttribute("data-fallback", "false");
+});
+
+test("allocation controls move between adjacent stable result pairs", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const subject = page.locator(".slide-strip-subject");
+  const inspector = page.locator(".slide-strip-inspector");
+  const moreSubjects = page.locator("[data-more-subjects]");
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "false");
+  await expect(
+    subject.locator(
+      '[data-subject-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Type", "Member"]);
+  await expect(
+    inspector.locator(
+      '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Overview", "Call graph", "Facts", "Source"]);
+
+  await moreSubjects.click();
+  await expect(moreSubjects).toBeFocused();
+  await expect(
+    subject.locator(
+      '[data-subject-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Package", "Type", "Member"]);
+  await expect(
+    inspector.locator(
+      '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["Overview", "Call graph", "Facts"]);
+});
+
+test("temporary pressure does not discard the retained allocation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const moreSubjects = page.locator("[data-more-subjects]");
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (await moreSubjects.getAttribute("aria-disabled") === "true") break;
+    await moreSubjects.click();
+  }
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.setViewportSize({ width: 760, height: 900 });
+
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
+});
+
+test("a narrower stable ladder commits its clamped allocation", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 660, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const moreSubjects = page.locator("[data-more-subjects]");
+  for (let attempt = 0; attempt < 10; attempt++) {
+    if (await moreSubjects.getAttribute("aria-disabled") === "true") break;
+    await moreSubjects.click();
+  }
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
+
+  await page.setViewportSize({ width: 640, height: 900 });
+  await expect(page.locator(".lensbar")).toHaveAttribute(
+    "data-pressure",
+    "ladder");
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
+
+  await page.setViewportSize({ width: 660, height: 900 });
+  await expect(moreSubjects).toHaveAttribute("aria-disabled", "false");
+});
+
+test("manual windows survive resize and reset with inspector inventory", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 560, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const inspector = page.locator(".slide-strip-inspector");
+  const visibleLabels = () => inspector.locator(
+    '[data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+  );
+  const help = page.locator("#help");
+  await help.focus();
+  await slideAfter(page, ".slide-strip-inspector");
+  await expect(visibleLabels()).toHaveText(["Call graph", "Facts"]);
+  await expect(help).toBeFocused();
+  await expect(page.locator('[data-member-section="call-graph"]'))
+    .toHaveAttribute("tabindex", "0");
+  await expect(page.locator('[data-member-section="overview"]'))
+    .toHaveAttribute("tabindex", "-1");
+
+  await page.setViewportSize({ width: 800, height: 900 });
+  await expect(visibleLabels()).toHaveCount(5);
+  await page.setViewportSize({ width: 560, height: 900 });
+  await expect(visibleLabels()).toHaveCount(2);
+  await expect(page.locator('[data-member-section="overview"]')).toBeHidden();
+  await expect(inspector.locator("[data-slide-strip-before]")).toBeVisible();
+
+  const memberSubject = page.locator('[data-scope="member"]');
+  await memberSubject.focus();
+  await page.keyboard.press("ArrowLeft");
+  const typeSubject = page.locator('[data-scope="type"]');
+  await expect(typeSubject).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(typeSubject).toHaveAttribute("aria-selected", "true");
+  await expect(page.locator(".slide-strip-inspector")).toHaveAttribute(
+    "data-mode",
+    "label");
+  await expect(
+    page.locator(
+      '.slide-strip-inspector [data-inspector-tab]:not([hidden]) [data-slide-strip-representation="label"]',
+    ),
+  ).toHaveText(["API", "Metadata", "Source"]);
+});
+
+test("removing a focused allocation control transfers focus before removal", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 760, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const moreSubjects = page.locator("[data-more-subjects]");
+  await moreSubjects.focus();
+  await expect(moreSubjects).toBeFocused();
+  await page.setViewportSize({ width: 400, height: 900 });
+
+  await expect(page.locator("[data-slide-strip-allocation]")).toBeHidden();
+  await expect(page.locator('[data-scope="member"]')).toBeFocused();
+  await expect(page.locator(".slide-strip-subject [tabindex='0']"))
+    .toHaveCount(1);
+
+  await page.setViewportSize({ width: 760, height: 900 });
+  await moreSubjects.focus();
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  await expect(page.locator("[data-slide-strip-allocation]")).toBeHidden();
+  await expect(page.locator('[data-scope="member"]')).toBeFocused();
+  await expect(page.locator(".slide-strip-subject [tabindex='0']"))
+    .toHaveCount(1);
+});
+
+test("edge indicators do not replace an item hit target", async ({ page }) => {
+  await page.setViewportSize({ width: 560, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const target = await page.locator(".slide-strip-inspector").evaluate(
+    element => {
+      const bounds = element.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        bounds.right - 2,
+        bounds.top + bounds.height / 2);
+      return hit?.closest("[data-inspector-tab]")
+        ?.getAttribute("data-member-section") ?? null;
+    });
+
+  expect(target).toBe("call-graph");
+});
+
+test("oversized end alignment exposes the item's ending edge", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 560, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  const edges = await page.locator(".slide-strip-inspector").evaluate(
+    element => {
+      element.style.width = "100px";
+      element.dataset.fallback = "true";
+      element.dataset.oversizedAlignment = "end";
+      const items = element.querySelector<HTMLElement>(".slide-strip-items");
+      if (!items) throw new Error("Inspector strip items are unavailable.");
+      items.style.width = "200px";
+      return {
+        strip: element.getBoundingClientRect().right,
+        items: items.getBoundingClientRect().right,
+      };
+    });
+
+  expect(edges.items).toBeCloseTo(edges.strip, 0);
+});
+
+test("terminal pressure preserves both strips without page overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+
+  await expect(page.locator(".lensbar")).toHaveAttribute(
+    "data-pressure",
+    "terminal");
+  await expect(page.locator("[data-slide-strip-allocation]")).toBeHidden();
+  await expect(
+    page.locator(".slide-strip-subject [data-subject-tab]:not([hidden])"),
+  ).toHaveCount(1);
+  await expect(
+    page.locator(".slide-strip-inspector [data-inspector-tab]:not([hidden])"),
+  ).not.toHaveCount(0);
+  expect(await page.evaluate(() =>
+    document.documentElement.scrollWidth - document.documentElement.clientWidth))
+    .toBeLessThanOrEqual(0);
+});
+
+test("subject-only layout reserves the empty-strip context label", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 800, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1&empty=1");
+
+  const bounds = await page.evaluate(() => {
+    const bar = document.querySelector<HTMLElement>(".lensbar");
+    const context = document.querySelector<HTMLElement>(".lens-context");
+    if (!bar || !context) throw new Error("Subject-only context is unavailable.");
+    return {
+      barRight: bar.getBoundingClientRect().right,
+      contextRight: context.getBoundingClientRect().right,
+    };
+  });
+  expect(bounds.contextRight).toBeLessThanOrEqual(bounds.barRight);
+  await expect(page.locator(".lens-context")).toHaveText(
+    "Filtered member list");
+});
+
+test("reduced motion preserves the same SlideStrip result", async ({ page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+  const snapshot = () => page.locator(".lensbar").evaluate(element => ({
+    pressure: element.dataset.pressure,
+    strips: [...element.querySelectorAll<HTMLElement>("[data-slide-strip]")]
+      .map(strip => ({
+        kind: strip.dataset.slideStrip,
+        mode: strip.dataset.mode,
+        visible: [...strip.querySelectorAll<HTMLElement>(
+          "[data-slide-strip-id]:not([hidden])",
+        )].map(item => item.dataset.slideStripId),
+      })),
+  }));
+  const ordinary = await snapshot();
+  expect(ordinary.strips.find(strip => strip.kind === "inspector")?.mode)
+    .toBe("short-label");
+
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.reload();
+  await expect(page.locator(".lensbar")).toHaveAttribute(
+    "data-pressure",
+    ordinary.pressure ?? "");
+  expect(await snapshot()).toEqual(ordinary);
 });
 
 test("Annotated Source keeps its sole Explore entry under shell pressure", async ({

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -534,6 +534,70 @@ test("edge indicators do not replace an item hit target", async ({ page }) => {
   expect(triangles.height).toBe(18);
 });
 
+test("a mounted empty SlideStrip applies its empty state", async ({ page }) => {
+  await page.goto("/browser/workspace-titlebar.html");
+
+  const state = await page.evaluate(async () => {
+    const { SlideStripDomController } = await import(
+      "../src/slide-strip-dom.ts");
+    const outside = document.createElement("button");
+    outside.textContent = "Outside";
+    document.body.append(outside);
+    outside.focus();
+
+    const element = document.createElement("div");
+    element.className = "slide-strip";
+    element.innerHTML = `
+      <div class="slide-strip-items"></div>
+      <span data-slide-strip-before></span>
+      <span data-slide-strip-after></span>`;
+    document.body.append(element);
+    const controller = new SlideStripDomController(
+      element,
+      [],
+      {
+        modes: [{ kind: "label", minimumVisible: 1, gap: 0 }],
+        initialAnchor: "empty",
+        preferredDirection: "after",
+        continuityKey: "empty",
+        fallbackVisibilityFloor: 28,
+        oversizedAlignment: "start",
+      },
+      { key: "empty" });
+    const resolved = controller.resolve(100);
+    controller.apply(resolved);
+    return {
+      result: resolved.result,
+      current: controller.current,
+      width: element.style.width,
+      mode: element.dataset.mode,
+      minimumWidth: controller.minimumOuterWidth,
+      preferredWidth: controller.preferredOuterWidth,
+      fallbackWidth: controller.fallbackOuterWidth,
+      beforeHidden: element.querySelector<HTMLElement>(
+        "[data-slide-strip-before]")?.hidden,
+      afterHidden: element.querySelector<HTMLElement>(
+        "[data-slide-strip-after]")?.hidden,
+      slide: controller.slide("after"),
+      outsideFocused: document.activeElement === outside,
+    };
+  });
+
+  expect(state).toEqual({
+    result: null,
+    current: null,
+    width: "100px",
+    mode: undefined,
+    minimumWidth: 0,
+    preferredWidth: 0,
+    fallbackWidth: 0,
+    beforeHidden: true,
+    afterHidden: true,
+    slide: false,
+    outsideFocused: true,
+  });
+});
+
 test("representation-specific gaps participate in measured capacity", async ({
   page,
 }) => {
@@ -560,6 +624,31 @@ test("representation-specific gaps participate in measured capacity", async ({
     });
   expect(layout.fallback).toBe("false");
   expect(layout.mode).not.toBe("short-label");
+  expect(layout.itemsWidth).toBeLessThanOrEqual(layout.stripWidth + 0.5);
+});
+
+test("item margins participate in measured capacity", async ({ page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+  await page.addStyleTag({
+    content: `
+      .slide-strip-inspector[data-mode="short-label"] .slide-strip-item {
+        margin-right: 12px;
+      }`,
+  });
+  await page.evaluate(() => window.rerenderScopeBarProbe());
+
+  const layout = await page.locator(".slide-strip-inspector").evaluate(
+    element => {
+      const items = element.querySelector<HTMLElement>(".slide-strip-items");
+      if (!items) throw new Error("Inspector items are unavailable.");
+      return {
+        fallback: element.dataset.fallback,
+        stripWidth: element.getBoundingClientRect().width,
+        itemsWidth: items.getBoundingClientRect().width,
+      };
+    });
+  expect(layout.fallback).toBe("false");
   expect(layout.itemsWidth).toBeLessThanOrEqual(layout.stripWidth + 0.5);
 });
 

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -362,6 +362,56 @@ test("allocation controls move between adjacent stable result pairs", async ({
   ).toHaveText(["Overview", "Call graph", "Facts"]);
 });
 
+test("every allocation level strictly trades subject for inspector richness", async ({
+  page,
+}) => {
+  const modeOrder = ["label", "short-label", "icon", "index"];
+  for (const width of [600, 760]) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/browser/workspace-titlebar.html?member=1");
+    await page.getByRole("tab", { name: "Overview" }).click();
+
+    const subject = page.locator(".slide-strip-subject");
+    const inspector = page.locator(".slide-strip-inspector");
+    const moreSubjects = page.locator("[data-more-subjects]");
+    const levels: {
+      subjectCount: number;
+      inspectorMode: number;
+      inspectorCount: number;
+    }[] = [];
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const mode = await inspector.getAttribute("data-mode");
+      levels.push({
+        subjectCount: await subject.locator(
+          "[data-subject-tab]:not([hidden])",
+        ).count(),
+        inspectorMode: modeOrder.indexOf(mode ?? ""),
+        inspectorCount: await inspector.locator(
+          "[data-inspector-tab]:not([hidden])",
+        ).count(),
+      });
+      if (await moreSubjects.getAttribute("aria-disabled") === "true") break;
+      await moreSubjects.click();
+    }
+
+    await expect(moreSubjects).toHaveAttribute("aria-disabled", "true");
+    expect(levels.length).toBeGreaterThan(1);
+    for (let index = 1; index < levels.length; index++) {
+      const previous = levels[index - 1];
+      const current = levels[index];
+      if (!previous || !current) {
+        throw new Error("Allocation ladder snapshot is incomplete.");
+      }
+      expect(current.subjectCount).toBeGreaterThan(previous.subjectCount);
+      expect(
+        current.inspectorMode > previous.inspectorMode
+        || (current.inspectorMode === previous.inspectorMode
+          && current.inspectorCount < previous.inspectorCount),
+      ).toBe(true);
+    }
+  }
+});
+
 test("temporary pressure does not discard the retained allocation", async ({
   page,
 }) => {
@@ -466,6 +516,51 @@ test("edge indicators do not replace an item hit target", async ({ page }) => {
     });
 
   expect(target).toBe("call-graph");
+  const triangles = await page.locator(".slide-strip-inspector").evaluate(
+    element => {
+      const before = getComputedStyle(
+        element.querySelector<HTMLElement>("[data-slide-strip-before]")!);
+      const after = getComputedStyle(
+        element.querySelector<HTMLElement>("[data-slide-strip-after]")!);
+      return {
+        before: before.borderRightWidth,
+        after: after.borderLeftWidth,
+        height: Number.parseFloat(after.borderTopWidth)
+          + Number.parseFloat(after.borderBottomWidth),
+      };
+    });
+  expect(triangles.before).toBe("4px");
+  expect(triangles.after).toBe("4px");
+  expect(triangles.height).toBe(18);
+});
+
+test("representation-specific gaps participate in measured capacity", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1");
+  await page.addStyleTag({
+    content: `
+      .slide-strip-inspector[data-mode="short-label"] .slide-strip-items {
+        gap: 60px;
+      }`,
+  });
+  await page.evaluate(() => window.rerenderScopeBarProbe());
+
+  const layout = await page.locator(".slide-strip-inspector").evaluate(
+    element => {
+      const items = element.querySelector<HTMLElement>(".slide-strip-items");
+      if (!items) throw new Error("Inspector items are unavailable.");
+      return {
+        fallback: element.dataset.fallback,
+        mode: element.dataset.mode,
+        stripWidth: element.getBoundingClientRect().width,
+        itemsWidth: items.getBoundingClientRect().width,
+      };
+    });
+  expect(layout.fallback).toBe("false");
+  expect(layout.mode).not.toBe("short-label");
+  expect(layout.itemsWidth).toBeLessThanOrEqual(layout.stripWidth + 0.5);
 });
 
 test("oversized end alignment exposes the item's ending edge", async ({
@@ -549,6 +644,9 @@ test("reduced motion preserves the same SlideStrip result", async ({ page }) => 
   const ordinary = await snapshot();
   expect(ordinary.strips.find(strip => strip.kind === "inspector")?.mode)
     .toBe("short-label");
+  await expect(page.locator(
+    '.slide-strip-inspector [data-inspector-tab]:not([hidden]) [data-slide-strip-representation="short-label"]',
+  )).toHaveText(["O", "CG", "F"]);
 
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.reload();

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -405,14 +405,36 @@ test("width-only changes retain the initially applied window", async ({
     const wider = snapshot();
     controller.apply(controller.resolve(170));
     const complete = snapshot();
+    controller.apply(controller.resolve(100));
+    const moved = controller.slide("after");
+    const slid = snapshot();
+    controller.apply(controller.resolve(170));
+    const expandedAfterSlide = snapshot();
+    controller.apply(controller.resolve(110));
+    const narrowedAfterSlide = snapshot();
 
-    return { initial, wider, complete };
+    return {
+      initial,
+      wider,
+      complete,
+      moved,
+      slid,
+      expandedAfterSlide,
+      narrowedAfterSlide,
+    };
   });
 
   expect(state).toEqual({
     initial: { visible: ["a", "b"], leading: "a" },
     wider: { visible: ["a", "b"], leading: "a" },
     complete: { visible: ["a", "b", "c"], leading: "a" },
+    moved: true,
+    slid: { visible: ["c"], leading: "c" },
+    expandedAfterSlide: {
+      visible: ["a", "b", "c"],
+      leading: "c",
+    },
+    narrowedAfterSlide: { visible: ["b", "c"], leading: "c" },
   });
 });
 
@@ -543,9 +565,11 @@ test("manual windows survive resize and reset with inspector inventory", async (
   await page.setViewportSize({ width: 800, height: 900 });
   await expect(visibleLabels()).toHaveCount(5);
   await page.setViewportSize({ width: 560, height: 900 });
-  await expect(visibleLabels()).toHaveCount(2);
-  await expect(page.locator('[data-member-section="overview"]')).toBeHidden();
-  await expect(inspector.locator("[data-slide-strip-before]")).toBeVisible();
+  const narrowedLabels = await visibleLabels().allTextContents();
+  expect(narrowedLabels).toContain("Call graph");
+  await expect(page.locator('[data-member-section="call-graph"]'))
+    .toHaveAttribute("tabindex", "0");
+  await expect(help).toBeFocused();
 
   const memberSubject = page.locator('[data-scope="member"]');
   await memberSubject.focus();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -231,6 +231,7 @@ import {
   createScopeBarState,
   renderScopeBar as renderScopeBarPure,
   restoreScopeBarFocus,
+  scopeBarShortLabel,
   type ScopeBarBinding,
 } from "./scope-bar.ts";
 import {
@@ -2607,7 +2608,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     ? document.activeElement
     : null;
   const scopeBarOwnsFocus = focusedElement
-    ?.closest("[data-scope-bar]") !== null;
+    ?.closest("[data-scope-bar]") != null;
   const scopeBarFocus = focusedElement
     ? captureScopeBarFocus(focusedElement)
     : null;
@@ -3035,51 +3036,48 @@ function hasEffectiveInspector(): boolean {
 
 function packageLensPresentation(
   id: PackageLens,
-): readonly [shortLabel: string, icon: string] {
+): string {
   switch (id) {
-    case "overview": return ["OV", "◫"];
-    case "dependencies": return ["DEP", "⇄"];
-    case "integrations": return ["INT", "⌁"];
-    case "opportunities": return ["OPP", "◇"];
-    case "analysis": return ["AN", "∿"];
-    case "metadata": return ["META", "≡"];
+    case "overview": return "◫";
+    case "dependencies": return "⇄";
+    case "integrations": return "⌁";
+    case "opportunities": return "◇";
+    case "analysis": return "∿";
+    case "metadata": return "≡";
     default: return assertNever(id, "package lens presentation");
   }
 }
 
 function typeLensPresentation(
   id: TypeLens,
-): readonly [shortLabel: string, icon: string] {
+): string {
   switch (id) {
-    case "api": return ["API", "⌘"];
-    case "metadata": return ["META", "≡"];
-    case "source": return ["SRC", "⌑"];
+    case "api": return "⌘";
+    case "metadata": return "≡";
+    case "source": return "⌑";
     default: return assertNever(id, "type lens presentation");
   }
 }
 
 function memberSectionPresentation(
   id: MemberSection,
-): readonly [shortLabel: string, icon: string] {
+): string {
   switch (id) {
-    case "overview": return ["OV", "◫"];
-    case "call-graph": return ["CG", "⑂"];
-    case "facts": return ["FX", "·"];
-    case "source": return ["SRC", "⌑"];
-    case "annotated": return ["ANN", "✎"];
+    case "overview": return "◫";
+    case "call-graph": return "⑂";
+    case "facts": return "·";
+    case "source": return "⌑";
+    case "annotated": return "✎";
     default: return assertNever(id, "member section presentation");
   }
 }
 
 function scopeBarInspectorDefinitions<TId extends string>(
   definitions: readonly (readonly [TId, string])[],
-  presentation: (
-    id: TId,
-  ) => readonly [shortLabel: string, icon: string],
+  presentation: (id: TId) => string,
 ): readonly (readonly [TId, string, string, string])[] {
   return definitions.map(([id, label]) => {
-    const [shortLabel, icon] = presentation(id);
-    return [id, label, shortLabel, icon];
+    return [id, label, scopeBarShortLabel(label), presentation(id)];
   });
 }
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -228,8 +228,10 @@ import {
 import {
   bindScopeBar,
   captureScopeBarFocus,
+  createScopeBarState,
   renderScopeBar as renderScopeBarPure,
   restoreScopeBarFocus,
+  type ScopeBarBinding,
 } from "./scope-bar.ts";
 import {
   bindWorkspaceSubject,
@@ -852,6 +854,8 @@ interface StateOverrides {
 type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides;
 
 const state: AppState = initialState;
+const scopeBarState = createScopeBarState();
+let scopeBarBinding: ScopeBarBinding | null = null;
 type FailedWorkspaceUrlState = WorkspaceUrlPreservation & (
   | { kind: "canonical" }
   | {
@@ -2599,9 +2603,15 @@ function typeDisplayName(
 function render(options: { synchronizeUrl?: boolean } = {}) {
   sourceInspection.cancelHiddenRequest();
   document.body.classList.remove("package-query-route");
-  const scopeBarFocus = document.activeElement instanceof HTMLElement
-    ? captureScopeBarFocus(document.activeElement)
+  const focusedElement = document.activeElement instanceof HTMLElement
+    ? document.activeElement
     : null;
+  const scopeBarOwnsFocus = focusedElement
+    ?.closest("[data-scope-bar]") !== null;
+  const scopeBarFocus = focusedElement
+    ? captureScopeBarFocus(focusedElement)
+    : null;
+  scopeBarBinding?.disconnect();
 
   // The Settings page is a modal-style full view layered over whatever the user came from
   // (home or a package). It owns no URL — it's a preferences panel, not shareable content —
@@ -2693,6 +2703,10 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     ? ' role="tabpanel" aria-labelledby="active-inspector-tab"'
     : "";
 
+  if (scopeBarOwnsFocus) {
+    app.tabIndex = -1;
+    app.focus({ preventScroll: true });
+  }
   app.innerHTML = `
     <div class="workbench"${state.memberAnnotatedModal ? " inert" : ""}>
       ${workbenchShellHtml({
@@ -2784,7 +2798,18 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     };
   }
   bindEvents();
-  if (scopeBarFocus) restoreScopeBarFocus(document, scopeBarFocus);
+  if (scopeBarOwnsFocus) {
+    let restored = false;
+    if (scopeBarFocus) {
+      scopeBarBinding?.revealFocusTarget(scopeBarFocus);
+      restored = restoreScopeBarFocus(document, scopeBarFocus);
+    }
+    if (!restored) {
+      document.querySelector<HTMLElement>(".brand")
+        ?.focus({ preventScroll: true });
+    }
+    app.removeAttribute("tabindex");
+  }
   restorePackageQueryReturnFocus();
   restorePackageQueryWorkspaceFocus();
   recordNav();
@@ -3008,6 +3033,56 @@ function hasEffectiveInspector(): boolean {
   return typeLensesFor(state.package).some(([id]) => id === state.lens);
 }
 
+function packageLensPresentation(
+  id: PackageLens,
+): readonly [shortLabel: string, icon: string] {
+  switch (id) {
+    case "overview": return ["OV", "◫"];
+    case "dependencies": return ["DEP", "⇄"];
+    case "integrations": return ["INT", "⌁"];
+    case "opportunities": return ["OPP", "◇"];
+    case "analysis": return ["AN", "∿"];
+    case "metadata": return ["META", "≡"];
+    default: return assertNever(id, "package lens presentation");
+  }
+}
+
+function typeLensPresentation(
+  id: TypeLens,
+): readonly [shortLabel: string, icon: string] {
+  switch (id) {
+    case "api": return ["API", "⌘"];
+    case "metadata": return ["META", "≡"];
+    case "source": return ["SRC", "⌑"];
+    default: return assertNever(id, "type lens presentation");
+  }
+}
+
+function memberSectionPresentation(
+  id: MemberSection,
+): readonly [shortLabel: string, icon: string] {
+  switch (id) {
+    case "overview": return ["OV", "◫"];
+    case "call-graph": return ["CG", "⑂"];
+    case "facts": return ["FX", "·"];
+    case "source": return ["SRC", "⌑"];
+    case "annotated": return ["ANN", "✎"];
+    default: return assertNever(id, "member section presentation");
+  }
+}
+
+function scopeBarInspectorDefinitions<TId extends string>(
+  definitions: readonly (readonly [TId, string])[],
+  presentation: (
+    id: TId,
+  ) => readonly [shortLabel: string, icon: string],
+): readonly (readonly [TId, string, string, string])[] {
+  return definitions.map(([id, label]) => {
+    const [shortLabel, icon] = presentation(id);
+    return [id, label, shortLabel, icon];
+  });
+}
+
 function renderScopeBar() {
   const sc = scope();
   const selected = selectedType();
@@ -3027,7 +3102,9 @@ function renderScopeBar() {
   if (sc === "package") {
     return renderScopeBarPure({
       scope: sc,
-      strip: packageLensesFor(state.package),
+      strip: scopeBarInspectorDefinitions(
+        packageLensesFor(state.package),
+        packageLensPresentation),
       activeStripId: state.packageLens,
       stripAttribute: "data-package-lens",
       panelId: "inspector-panel",
@@ -3039,7 +3116,9 @@ function renderScopeBar() {
     const member = selectedMember(selected);
     return renderScopeBarPure({
       scope: sc,
-      strip: member ? memberSectionsFor(member) : [],
+      strip: scopeBarInspectorDefinitions(
+        member ? memberSectionsFor(member) : [],
+        memberSectionPresentation),
       activeStripId: state.memberSection,
       stripAttribute: "data-member-section",
       panelId: "inspector-panel",
@@ -3053,7 +3132,9 @@ function renderScopeBar() {
       scope: sc,
       // `typeLensesFor` rather than the raw catalog: a runtime pack offers only the API
       // lens, and reading the catalog directly here would skip that restriction.
-      strip: typeLensesFor(state.package),
+      strip: scopeBarInspectorDefinitions(
+        typeLensesFor(state.package),
+        typeLensPresentation),
       activeStripId: state.lens,
       stripAttribute: "data-lens",
       panelId: "inspector-panel",
@@ -5079,7 +5160,7 @@ function bindTypePanelEvents() {
 }
 
 function bindScopeBarEvents() {
-  bindScopeBar(document, {
+  scopeBarBinding = bindScopeBar(document, {
     onMemberSectionSelect: section => {
       applyMemberSection(section);
     },
@@ -5124,7 +5205,7 @@ function bindScopeBarEvents() {
       state.memberBrowseTypeId = "";
       render();
     },
-  });
+  }, scopeBarState);
 }
 
 function bindSettingsPanelEvents() {

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -12,6 +12,7 @@ import {
   SlideStripDomController,
   type SlideStripAppliedResult,
   type SlideStripContinuityState,
+  type SlideStripResolveIntent,
 } from "./slide-strip-dom.ts";
 import type {
   SlideStripItem,
@@ -71,6 +72,15 @@ interface AllocationPair {
 interface AllocationFocusTransfer {
   strip: "subject" | "inspector";
   id: string;
+}
+
+function focusTransferIntent(
+  transfer: AllocationFocusTransfer | null,
+  strip: AllocationFocusTransfer["strip"],
+): SlideStripResolveIntent {
+  return transfer?.strip === strip
+    ? { pendingFocusId: transfer.id }
+    : {};
 }
 
 const EMPTY_BINDING: ScopeBarBinding = {
@@ -474,6 +484,14 @@ function inspectorAtLeastAsRich(
       && left.visibleCount >= right.visibleCount);
 }
 
+function inspectorStrictlyRicher(
+  left: SlideStripResult,
+  right: SlideStripResult,
+): boolean {
+  return inspectorAtLeastAsRich(left, right)
+    && !inspectorAtLeastAsRich(right, left);
+}
+
 function pairDominates(left: AllocationPair, right: AllocationPair): boolean {
   const subjectAtLeast = left.subject.result.visibleCount
     >= right.subject.result.visibleCount;
@@ -618,14 +636,36 @@ class ScopeBarController implements ScopeBarBinding {
       }, { passive: false }));
     this.moreSubjects?.addEventListener("click", () => {
       if (this.moreSubjects?.getAttribute("aria-disabled") === "true") return;
-      this.state.allocationOrdinal = this.renderedAllocationOrdinal + 1;
-      this.layout();
+      this.moveAllocation(1);
     });
     this.moreInspectors?.addEventListener("click", () => {
       if (this.moreInspectors?.getAttribute("aria-disabled") === "true") return;
-      this.state.allocationOrdinal = this.renderedAllocationOrdinal - 1;
-      this.layout();
+      this.moveAllocation(-1);
     });
+  }
+
+  private moveAllocation(delta: -1 | 1): void {
+    const candidate = this.allocationCandidate(delta);
+    if (!candidate) return;
+    this.state.allocationOrdinal = candidate.ordinal;
+    this.renderedAllocationOrdinal = candidate.ordinal;
+    this.applyPair(candidate.pair, "ladder", true);
+    this.updateAllocationButtons();
+  }
+
+  private allocationCandidate(
+    delta: -1 | 1,
+  ): { pair: AllocationPair; ordinal: number } | null {
+    const subject = this.subject.current?.result;
+    const inspector = this.inspector?.current?.result;
+    if (!subject || !inspector) return null;
+    const candidates = this.ladder.map((pair, ordinal) => ({ pair, ordinal }));
+    if (delta < 0) candidates.reverse();
+    return candidates.find(({ pair }) => delta > 0
+      ? pair.subject.result.visibleCount > subject.visibleCount
+        && inspectorStrictlyRicher(inspector, pair.inspector.result)
+      : pair.subject.result.visibleCount < subject.visibleCount
+        && inspectorStrictlyRicher(pair.inspector.result, inspector)) ?? null;
   }
 
   private controllerFor(
@@ -706,19 +746,8 @@ class ScopeBarController implements ScopeBarBinding {
   ): void {
     this.navigation.dataset.pressure = pressure;
     if (controls) this.setControlsVisible(true);
-    const transfer = this.allocationFocusTransfer(controls);
-    const subject = transfer?.strip === "subject"
-      ? this.subject.resolveRequired(
-          pair.subject.outerWidth,
-          { pendingFocusId: transfer.id })
-      : pair.subject;
-    const inspector = transfer?.strip === "inspector"
-      ? this.inspector?.resolveRequired(
-          pair.inspector.outerWidth,
-          { pendingFocusId: transfer.id }) ?? pair.inspector
-      : pair.inspector;
-    this.subject.apply(subject);
-    this.inspector?.apply(inspector);
+    this.subject.apply(pair.subject);
+    this.inspector?.apply(pair.inspector);
     this.setControlsVisible(controls);
   }
 
@@ -738,12 +767,18 @@ class ScopeBarController implements ScopeBarBinding {
     const subjectMinimum = this.subject.minimumOuterWidth;
     const inspectorMinimum = this.inspector.minimumOuterWidth;
     const noControlsWidth = Math.max(0, available - this.overhead(false));
+    const transfer = this.allocationFocusTransfer(false);
+    const subjectIntent = focusTransferIntent(transfer, "subject");
+    const inspectorIntent = focusTransferIntent(transfer, "inspector");
     if (noControlsWidth
       >= this.subject.preferredOuterWidth + this.inspector.preferredOuterWidth) {
       this.applyPair({
-        subject: this.subject.resolveRequired(this.subject.preferredOuterWidth),
+        subject: this.subject.resolveRequired(
+          this.subject.preferredOuterWidth,
+          subjectIntent),
         inspector: this.inspector.resolveRequired(
-          this.inspector.preferredOuterWidth),
+          this.inspector.preferredOuterWidth,
+          inspectorIntent),
       }, "all-preferred", false);
       return;
     }
@@ -769,25 +804,33 @@ class ScopeBarController implements ScopeBarBinding {
       }
     }
 
+    const noControlsSubjectMinimum = this.subject.minimumOuterWidthFor(
+      subjectIntent.pendingFocusId);
+    const noControlsInspectorMinimum = this.inspector.minimumOuterWidthFor(
+      inspectorIntent.pendingFocusId);
     if (noControlsWidth
-      >= subjectMinimum + inspectorMinimum) {
+      >= noControlsSubjectMinimum + noControlsInspectorMinimum) {
       const provisionalInspectorWidth = noControlsWidth
-        - subjectMinimum;
+        - noControlsSubjectMinimum;
       const inspector = this.inspector.resolveRequired(
-        provisionalInspectorWidth);
+        provisionalInspectorWidth,
+        inspectorIntent);
       const exactInspectorWidth = Math.min(
         provisionalInspectorWidth,
         inspector.result.requiredWidth + this.inspector.chromeWidth);
       this.applyPair({
         subject: this.subject.resolveRequired(
-          noControlsWidth - exactInspectorWidth),
-        inspector: this.inspector.resolveRequired(exactInspectorWidth),
+          noControlsWidth - exactInspectorWidth,
+          subjectIntent),
+        inspector: this.inspector.resolveRequired(
+          exactInspectorWidth,
+          inspectorIntent),
       }, "control-free", false);
       return;
     }
 
     this.applyPair(
-      this.terminalPair(noControlsWidth),
+      this.terminalPair(noControlsWidth, subjectIntent, inspectorIntent),
       "terminal",
       false);
   }
@@ -864,7 +907,11 @@ class ScopeBarController implements ScopeBarBinding {
     });
   }
 
-  private terminalPair(stripWidth: number): AllocationPair {
+  private terminalPair(
+    stripWidth: number,
+    subjectIntent: SlideStripResolveIntent = {},
+    inspectorIntent: SlideStripResolveIntent = {},
+  ): AllocationPair {
     if (!this.inspector) {
       throw new Error("Terminal allocation requires an inspector strip.");
     }
@@ -873,9 +920,11 @@ class ScopeBarController implements ScopeBarBinding {
     if (stripWidth < minimumInternalWidth) {
       return {
         subject: this.subject.resolveRequired(
-          this.subject.fallbackOuterWidth),
+          this.subject.fallbackOuterWidth,
+          subjectIntent),
         inspector: this.inspector.resolveRequired(
-          this.inspector.fallbackOuterWidth),
+          this.inspector.fallbackOuterWidth,
+          inspectorIntent),
       };
     }
     const targetSubject = Math.floor(stripWidth / 3);
@@ -897,8 +946,12 @@ class ScopeBarController implements ScopeBarBinding {
         || inspectorWidth < this.inspector!.fallbackOuterWidth) {
         return [];
       }
-      const subject = this.subject.resolveRequired(subjectWidth);
-      const inspector = this.inspector!.resolveRequired(inspectorWidth);
+      const subject = this.subject.resolveRequired(
+        subjectWidth,
+        subjectIntent);
+      const inspector = this.inspector!.resolveRequired(
+        inspectorWidth,
+        inspectorIntent);
       const subjectUnused = subject.result.fallback
         ? 0
         : Math.max(
@@ -933,14 +986,11 @@ class ScopeBarController implements ScopeBarBinding {
 
   private updateAllocationButtons(): void {
     if (!this.moreSubjects || !this.moreInspectors) return;
-    const atInspectorBound = this.renderedAllocationOrdinal <= 0;
-    const atSubjectBound =
-      this.renderedAllocationOrdinal >= this.ladder.length - 1;
     this.moreInspectors.setAttribute(
       "aria-disabled",
-      String(atInspectorBound));
+      String(this.allocationCandidate(-1) === null));
     this.moreSubjects.setAttribute(
       "aria-disabled",
-      String(atSubjectBound));
+      String(this.allocationCandidate(1) === null));
   }
 }

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -8,14 +8,24 @@ import {
   type TypeLens,
   type WorkspaceScope,
 } from "./data.ts";
+import {
+  SlideStripDomController,
+  type SlideStripAppliedResult,
+  type SlideStripContinuityState,
+} from "./slide-strip-dom.ts";
+import type {
+  SlideStripItem,
+  SlideStripPolicy,
+  SlideStripResult,
+} from "./slide-strip.ts";
 
-type LensDefinition<TId extends string = string> = readonly [id: TId, label: string];
+type LensDefinition<TId extends string = string> = readonly [
+  id: TId,
+  label: string,
+  shortLabel?: string,
+  icon?: string,
+];
 
-// `TId` is inferred from the strip catalog, so the active id has to be a member of the
-// strip being rendered. A `string` there let a caller pass an id no button carries, which
-// renders a strip with nothing active and no failure anywhere. `NoInfer` keeps the strip
-// as the sole inference site; without it TypeScript infers the union of both and a
-// mismatched pair type-checks.
 export interface RenderScopeBarOptions<TId extends string = string> {
   scope: WorkspaceScope;
   strip: readonly LensDefinition<TId>[];
@@ -40,6 +50,42 @@ export type ScopeBarFocusTarget =
   | { kind: "package-lens"; value: PackageLens }
   | { kind: "scope"; value: WorkspaceScope }
   | { kind: "type-lens"; value: TypeLens };
+
+export interface ScopeBarState {
+  subject: SlideStripContinuityState;
+  inspector: SlideStripContinuityState;
+  allocationKey: string;
+  allocationOrdinal: number;
+}
+
+export interface ScopeBarBinding {
+  disconnect(): void;
+  revealFocusTarget(target: ScopeBarFocusTarget): void;
+}
+
+interface AllocationPair {
+  subject: SlideStripAppliedResult;
+  inspector: SlideStripAppliedResult;
+}
+
+interface AllocationFocusTransfer {
+  strip: "subject" | "inspector";
+  id: string;
+}
+
+const EMPTY_BINDING: ScopeBarBinding = {
+  disconnect() {},
+  revealFocusTarget() {},
+};
+
+export function createScopeBarState(): ScopeBarState {
+  return {
+    subject: { key: "" },
+    inspector: { key: "" },
+    allocationKey: "",
+    allocationOrdinal: 0,
+  };
+}
 
 export function captureScopeBarFocus(
   element: HTMLElement,
@@ -79,7 +125,7 @@ export function restoreScopeBarFocus(
       ?? element.dataset.lens
       ?? element.dataset.memberSection
     ) === value);
-  if (!replacement) return false;
+  if (!replacement || replacement.hidden) return false;
   tabs.forEach(tab => {
     tab.tabIndex = tab === replacement ? 0 : -1;
   });
@@ -87,39 +133,18 @@ export function restoreScopeBarFocus(
   return true;
 }
 
-export function bindScopeBar(
-  root: ParentNode,
-  actions: ScopeBarBindingActions,
-) {
-  bindRovingTabs([
-    ...root.querySelectorAll<HTMLButtonElement>("[data-subject-tab]"),
-  ]);
-  bindRovingTabs([
-    ...root.querySelectorAll<HTMLButtonElement>("[data-inspector-tab]"),
-  ]);
-  root.querySelectorAll<HTMLElement>("[data-scope]").forEach(button =>
-    button.addEventListener("click", () => {
-      const scope = button.dataset.scope;
-      if (isWorkspaceScope(scope)) actions.onScopeSelect(scope);
-    }));
-  root.querySelectorAll<HTMLElement>("[data-package-lens]").forEach(button =>
-    button.addEventListener("click", () => {
-      const lens = button.dataset.packageLens;
-      if (isPackageLens(lens)) actions.onPackageLensSelect(lens);
-    }));
-  root.querySelectorAll<HTMLElement>("[data-lens]").forEach(button =>
-    button.addEventListener("click", () => {
-      const lens = button.dataset.lens;
-      if (isTypeLens(lens)) actions.onTypeLensSelect(lens);
-    }));
-  root.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button =>
-    button.addEventListener("click", () => {
-      const section = button.dataset.memberSection;
-      if (isMemberSection(section)) actions.onMemberSectionSelect(section);
-    }));
+function targetIdentity(target: ScopeBarFocusTarget): string {
+  return target.value;
 }
 
-function bindRovingTabs(tabs: readonly HTMLButtonElement[]): void {
+function targetStrip(target: ScopeBarFocusTarget): "subject" | "inspector" {
+  return target.kind === "scope" ? "subject" : "inspector";
+}
+
+function bindRovingTabs(
+  tabs: readonly HTMLButtonElement[],
+  reveal: (target: HTMLButtonElement) => void,
+): void {
   tabs.forEach((tab, index) =>
     tab.addEventListener("keydown", event => {
       if (event.key === "Enter" || event.key === " ") {
@@ -140,6 +165,7 @@ function bindRovingTabs(tabs: readonly HTMLButtonElement[]): void {
       const target = tabs[targetIndex];
       if (!target) return;
       event.preventDefault();
+      reveal(target);
       tabs.forEach(candidate => {
         candidate.tabIndex = -1;
       });
@@ -148,9 +174,81 @@ function bindRovingTabs(tabs: readonly HTMLButtonElement[]): void {
     }));
 }
 
-function lensButton(
+export function bindScopeBar(
+  root: ParentNode,
+  actions: ScopeBarBindingActions,
+  state?: ScopeBarState,
+): ScopeBarBinding {
+  const controller = state
+    ? ScopeBarController.create(root, state)
+    : null;
+  bindRovingTabs([
+    ...root.querySelectorAll<HTMLButtonElement>("[data-subject-tab]"),
+  ], target => controller?.reveal(target));
+  bindRovingTabs([
+    ...root.querySelectorAll<HTMLButtonElement>("[data-inspector-tab]"),
+  ], target => controller?.reveal(target));
+  root.querySelectorAll<HTMLElement>("[data-scope]").forEach(button =>
+    button.addEventListener("click", () => {
+      const scope = button.dataset.scope;
+      if (isWorkspaceScope(scope)) actions.onScopeSelect(scope);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-package-lens]").forEach(button =>
+    button.addEventListener("click", () => {
+      const lens = button.dataset.packageLens;
+      if (isPackageLens(lens)) actions.onPackageLensSelect(lens);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-lens]").forEach(button =>
+    button.addEventListener("click", () => {
+      const lens = button.dataset.lens;
+      if (isTypeLens(lens)) actions.onTypeLensSelect(lens);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-member-section]").forEach(button =>
+    button.addEventListener("click", () => {
+      const section = button.dataset.memberSection;
+      if (isMemberSection(section)) actions.onMemberSectionSelect(section);
+    }));
+  return controller ?? EMPTY_BINDING;
+}
+
+function presentationHtml(
+  label: string,
+  shortLabel: string | undefined,
+  icon: string | undefined,
+  index: number,
+  escapeHtml: (value: unknown) => string,
+): string {
+  return [
+    `<span class="slide-strip-label lens-label" data-slide-strip-representation="label">${escapeHtml(label)}</span>`,
+    shortLabel
+      ? `<span class="slide-strip-short-label" data-slide-strip-representation="short-label">${escapeHtml(shortLabel)}</span>`
+      : "",
+    icon
+      ? `<span class="slide-strip-icon" data-slide-strip-representation="icon" aria-hidden="true">${escapeHtml(icon)}</span>`
+      : "",
+    `<kbd data-slide-strip-representation="index" aria-hidden="true">${index + 1}</kbd>`,
+  ].join("");
+}
+
+function itemData(
   id: string,
   label: string,
+  shortLabel: string | undefined,
+  icon: string | undefined,
+  escapeHtml: (value: unknown) => string,
+): string {
+  return [
+    `data-slide-strip-id="${escapeHtml(id)}"`,
+    `data-slide-strip-label="${escapeHtml(label)}"`,
+    shortLabel
+      ? `data-slide-strip-short-label="${escapeHtml(shortLabel)}"`
+      : "",
+    icon ? `data-slide-strip-icon="${escapeHtml(icon)}"` : "",
+  ].filter(Boolean).join(" ");
+}
+
+function lensButton(
+  definition: LensDefinition,
   active: boolean,
   tabStop: boolean,
   attribute: string,
@@ -158,26 +256,45 @@ function lensButton(
   panelId: string | undefined,
   escapeHtml: (value: unknown) => string,
 ): string {
+  const [id, label, shortLabel, icon] = definition;
   const escapedLabel = escapeHtml(label);
   const activeAttributes = active
     ? ` id="active-inspector-tab"${panelId ? ` aria-controls="${escapeHtml(panelId)}"` : ""}`
     : "";
-  return `<button class="lens ${active ? "active" : ""}" ${attribute}="${id}" data-inspector-tab role="tab" aria-selected="${active}" tabindex="${tabStop ? "0" : "-1"}"${activeAttributes} aria-label="${escapedLabel}" title="${escapedLabel}"><span class="lens-label">${escapedLabel}</span><kbd aria-hidden="true">${index + 1}</kbd></button>`;
+  return `<button class="slide-strip-item lens ${active ? "active" : ""}" ${attribute}="${escapeHtml(id)}" ${itemData(id, label, shortLabel, icon, escapeHtml)} data-inspector-tab role="tab" aria-selected="${active}" tabindex="${tabStop ? "0" : "-1"}"${activeAttributes} aria-label="${escapedLabel}" title="${escapedLabel}">${presentationHtml(label, shortLabel, icon, index, escapeHtml)}</button>`;
 }
 
 function scopeSegment(
-  id: string,
+  id: WorkspaceScope,
   label: string,
   active: boolean,
   subjectPanelId: string,
+  index: number,
+  escapeHtml: (value: unknown) => string,
 ): string {
   const activeAttributes = active ? ' id="active-subject-tab"' : "";
-  return `<button class="scope-seg ${active ? "active" : ""}" data-scope="${id}" role="tab" aria-selected="${active}" tabindex="${active ? "0" : "-1"}"${activeAttributes} data-subject-tab aria-controls="${subjectPanelId}">${label}</button>`;
+  return `<button class="slide-strip-item scope-seg ${active ? "active" : ""}" data-scope="${id}" ${itemData(id, label, undefined, undefined, escapeHtml)} role="tab" aria-selected="${active}" tabindex="${active ? "0" : "-1"}"${activeAttributes} data-subject-tab aria-controls="${subjectPanelId}" aria-label="${escapeHtml(label)}" title="${escapeHtml(label)}">${presentationHtml(label, undefined, undefined, index, escapeHtml)}</button>`;
 }
 
-// The leading control is the subject ladder. Workspace manages retained coordinates;
-// Package, Type, and Member swap in their applicable inspectors. Library joins once its
-// product-issued descriptor and behavior are available.
+function edgeIndicators(): string {
+  return `
+    <span class="slide-strip-edge before" data-slide-strip-before hidden aria-hidden="true"></span>
+    <span class="slide-strip-edge after" data-slide-strip-after hidden aria-hidden="true"></span>`;
+}
+
+function subjectDefinitions(
+  showMemberScope: boolean,
+): readonly (readonly [WorkspaceScope, string])[] {
+  return [
+    ["workspace", "Workspace"],
+    ["package", "Package"],
+    ["type", "Type"],
+    ...(showMemberScope
+      ? [["member", "Member"] as const]
+      : []),
+  ];
+}
+
 export function renderScopeBar<TId extends string>(
   options: RenderScopeBarOptions<TId>,
 ): string {
@@ -202,31 +319,574 @@ export function renderScopeBar<TId extends string>(
       : scope === "type"
         ? "Type"
         : "Member";
+  const subjects = subjectDefinitions(showMemberScope);
+  const subjectIds = subjects.map(([id]) => id).join(",");
+  const inspectorIds = strip.map(([id]) => id).join(",");
+  const inspectorAnchor = activeIndex >= 0
+    ? activeStripId
+    : strip[0]?.[0] ?? "";
+  const subjectAnchor = subjects.some(([id]) => id === scope)
+    ? scope
+    : subjects.at(-1)?.[0] ?? "";
   const escapedSubjectPanelId = escapeHtml(subjectPanelId);
-  const stripHtml = strip.length > 0
-    ? `<div class="inspector-strip" role="tablist" aria-label="${subjectLabel} lenses">${strip
-        .map(([id, label], index) => lensButton(
-          id,
-          label,
-          index === activeIndex,
-          index === (activeIndex >= 0 ? activeIndex : 0),
-          stripAttribute,
-          index,
-          panelId,
-          escapeHtml))
-        .join("")}</div>`
+  const inspectorHtml = strip.length > 0
+    ? `
+      <div class="slide-strip slide-strip-inspector inspector-strip"
+           data-slide-strip="inspector"
+           data-continuity-key="${escapeHtml(`${scope}:${inspectorIds}:v1`)}"
+           data-initial-anchor="${escapeHtml(inspectorAnchor)}"
+           role="tablist"
+           aria-label="${subjectLabel} lenses">
+        <div class="slide-strip-items">
+          ${strip.map((definition, index) => lensButton(
+            definition,
+            index === activeIndex,
+            index === (activeIndex >= 0 ? activeIndex : 0),
+            stripAttribute,
+            index,
+            panelId,
+            escapeHtml)).join("")}
+        </div>
+        ${edgeIndicators()}
+      </div>`
     : (emptyStripLabel
         ? `<span class="lens-context">${escapeHtml(emptyStripLabel)}</span>`
         : "");
   return `
-    <nav class="lensbar" aria-label="Subjects and inspectors">
-      <div class="scope-switch" role="tablist" aria-label="Subject">
-        ${scopeSegment("workspace", "Workspace", scope === "workspace", escapedSubjectPanelId)}
-        ${scopeSegment("package", "Package", scope === "package", escapedSubjectPanelId)}
-        ${scopeSegment("type", "Type", scope === "type", escapedSubjectPanelId)}
-        ${showMemberScope ? scopeSegment("member", "Member", scope === "member", escapedSubjectPanelId) : ""}
+    <nav class="lensbar"
+         data-scope-bar
+         data-allocation-key="${escapeHtml(`${scope}:${inspectorIds}`)}"
+         aria-label="Subjects and inspectors">
+      <div class="slide-strip slide-strip-subject scope-switch"
+           data-slide-strip="subject"
+           data-continuity-key="${escapeHtml(`${subjectIds}:v1`)}"
+           data-initial-anchor="${subjectAnchor}"
+           role="tablist"
+           aria-label="Subject">
+        <div class="slide-strip-items">
+          ${subjects.map(([id, label], index) =>
+            scopeSegment(
+              id,
+              label,
+              scope === id,
+              escapedSubjectPanelId,
+              index,
+              escapeHtml)).join("")}
+        </div>
+        ${edgeIndicators()}
       </div>
-      <span class="lens-separator"></span>
-      ${stripHtml}
+      ${strip.length > 0
+        ? `<div class="slide-strip-allocation" data-slide-strip-allocation hidden>
+            <button type="button" data-more-subjects aria-label="Show more subjects">‹</button>
+            <button type="button" data-more-inspectors aria-label="Show more inspectors">›</button>
+          </div>
+          <span class="lens-separator" aria-hidden="true"></span>`
+        : ""}
+      ${inspectorHtml}
     </nav>`;
+}
+
+function readItems(element: HTMLElement): readonly SlideStripItem[] {
+  return [...element.querySelectorAll<HTMLElement>("[data-slide-strip-id]")]
+    .map(item => {
+      const id = item.dataset.slideStripId;
+      const label = item.dataset.slideStripLabel;
+      if (!id || !label) {
+        throw new Error("SlideStrip item markup requires identity and Label.");
+      }
+      return {
+        id,
+        label,
+        ...(item.dataset.slideStripShortLabel
+          ? { shortLabel: item.dataset.slideStripShortLabel }
+          : {}),
+        ...(item.dataset.slideStripIcon
+          ? { icon: item.dataset.slideStripIcon }
+          : {}),
+      };
+    });
+}
+
+function readPolicy(
+  element: HTMLElement,
+  items: readonly SlideStripItem[],
+  subject: boolean,
+): SlideStripPolicy {
+  const initialAnchor = element.dataset.initialAnchor;
+  const continuityKey = element.dataset.continuityKey;
+  if (!initialAnchor || !continuityKey) {
+    throw new Error("SlideStrip markup requires anchor and continuity key.");
+  }
+  return {
+    modes: subject
+      ? [{ kind: "label", minimumVisible: 1, gap: 0 }]
+      : [
+          { kind: "label", minimumVisible: 2, gap: 0 },
+          { kind: "short-label", minimumVisible: 2, gap: 0 },
+          { kind: "icon", minimumVisible: 2, gap: 0 },
+          { kind: "index", minimumVisible: 2, gap: 0 },
+        ],
+    initialAnchor,
+    preferredDirection: "after",
+    continuityKey,
+    fallbackVisibilityFloor: subject ? 48 : 28,
+    oversizedAlignment: "start",
+  };
+}
+
+function outerWidth(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  return element.getBoundingClientRect().width
+    + Number.parseFloat(style.marginLeft || "0")
+    + Number.parseFloat(style.marginRight || "0");
+}
+
+function resultKey(result: SlideStripResult): string {
+  return `${result.mode}:${result.visibleIds.join(",")}`;
+}
+
+function inspectorAtLeastAsRich(
+  left: SlideStripResult,
+  right: SlideStripResult,
+): boolean {
+  return left.modeIndex < right.modeIndex
+    || (left.modeIndex === right.modeIndex
+      && left.visibleCount >= right.visibleCount);
+}
+
+function pairDominates(left: AllocationPair, right: AllocationPair): boolean {
+  const subjectAtLeast = left.subject.result.visibleCount
+    >= right.subject.result.visibleCount;
+  const inspectorAtLeast = inspectorAtLeastAsRich(
+    left.inspector.result,
+    right.inspector.result);
+  const strict = left.subject.result.visibleCount
+      > right.subject.result.visibleCount
+    || !inspectorAtLeastAsRich(right.inspector.result, left.inspector.result);
+  return subjectAtLeast && inspectorAtLeast && strict;
+}
+
+function requestedMinimum(
+  controller: SlideStripDomController,
+  result: SlideStripResult,
+): number {
+  const mode = controller.policy.modes[result.modeIndex];
+  return Math.min(
+    mode?.minimumVisible ?? 1,
+    controller.items.length);
+}
+
+function satisfiesPolicyMinimum(
+  controller: SlideStripDomController,
+  applied: SlideStripAppliedResult,
+): boolean {
+  return !applied.result.fallback
+    && applied.result.visibleCount >= requestedMinimum(
+      controller,
+      applied.result);
+}
+
+class ScopeBarController implements ScopeBarBinding {
+  private readonly navigation: HTMLElement;
+  private readonly state: ScopeBarState;
+  private readonly subject: SlideStripDomController;
+  private readonly inspector: SlideStripDomController | null;
+  private readonly allocation: HTMLElement | null;
+  private readonly separator: HTMLElement | null;
+  private readonly context: HTMLElement | null;
+  private readonly moreSubjects: HTMLButtonElement | null;
+  private readonly moreInspectors: HTMLButtonElement | null;
+  private readonly observer: ResizeObserver | null;
+  private ladder: readonly AllocationPair[] = [];
+  private renderedAllocationOrdinal = 0;
+  private observedWidth = -1;
+
+  static create(root: ParentNode, state: ScopeBarState): ScopeBarController | null {
+    const navigation = root.querySelector<HTMLElement>("[data-scope-bar]");
+    return navigation ? new ScopeBarController(navigation, state) : null;
+  }
+
+  private constructor(navigation: HTMLElement, state: ScopeBarState) {
+    this.navigation = navigation;
+    this.state = state;
+    const subjectElement = navigation.querySelector<HTMLElement>(
+      '[data-slide-strip="subject"]');
+    if (!subjectElement) throw new Error("Scope bar requires a subject strip.");
+    const subjectItems = readItems(subjectElement);
+    this.subject = new SlideStripDomController(
+      subjectElement,
+      subjectItems,
+      readPolicy(subjectElement, subjectItems, true),
+      state.subject);
+    const inspectorElement = navigation.querySelector<HTMLElement>(
+      '[data-slide-strip="inspector"]');
+    if (inspectorElement) {
+      const inspectorItems = readItems(inspectorElement);
+      this.inspector = new SlideStripDomController(
+        inspectorElement,
+        inspectorItems,
+        readPolicy(inspectorElement, inspectorItems, false),
+        state.inspector);
+    } else {
+      this.inspector = null;
+    }
+    this.allocation = navigation.querySelector(
+      "[data-slide-strip-allocation]");
+    this.separator = navigation.querySelector(".lens-separator");
+    this.context = navigation.querySelector(".lens-context");
+    this.moreSubjects = navigation.querySelector("[data-more-subjects]");
+    this.moreInspectors = navigation.querySelector("[data-more-inspectors]");
+    const allocationKey = navigation.dataset.allocationKey ?? "";
+    if (state.allocationKey !== allocationKey) {
+      state.allocationKey = allocationKey;
+      state.allocationOrdinal = 0;
+    }
+    this.bind();
+    this.observedWidth = this.availableWidth();
+    this.layout(this.observedWidth);
+    this.observer = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(() => {
+          const available = this.availableWidth();
+          if (available === this.observedWidth) return;
+          this.observedWidth = available;
+          this.layout(available);
+        });
+    this.observer?.observe(navigation);
+  }
+
+  disconnect(): void {
+    this.observer?.disconnect();
+  }
+
+  revealFocusTarget(target: ScopeBarFocusTarget): void {
+    const controller = targetStrip(target) === "subject"
+      ? this.subject
+      : this.inspector;
+    controller?.revealForFocus(targetIdentity(target));
+  }
+
+  reveal(target: HTMLButtonElement): void {
+    const id = target.dataset.slideStripId;
+    if (!id) return;
+    const controller = target.closest('[data-slide-strip="subject"]')
+      ? this.subject
+      : this.inspector;
+    controller?.revealForFocus(id);
+  }
+
+  private bind(): void {
+    this.navigation.querySelectorAll<HTMLElement>("[data-slide-strip]")
+      .forEach(strip => strip.addEventListener("wheel", event => {
+        const delta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
+          ? event.deltaX
+          : event.deltaY;
+        if (delta === 0) return;
+        const moved = this.controllerFor(strip)?.slide(
+          delta < 0 ? "before" : "after") ?? false;
+        if (moved) event.preventDefault();
+      }, { passive: false }));
+    this.moreSubjects?.addEventListener("click", () => {
+      if (this.moreSubjects?.getAttribute("aria-disabled") === "true") return;
+      this.state.allocationOrdinal = this.renderedAllocationOrdinal + 1;
+      this.layout();
+    });
+    this.moreInspectors?.addEventListener("click", () => {
+      if (this.moreInspectors?.getAttribute("aria-disabled") === "true") return;
+      this.state.allocationOrdinal = this.renderedAllocationOrdinal - 1;
+      this.layout();
+    });
+  }
+
+  private controllerFor(
+    element: Element,
+  ): SlideStripDomController | null {
+    const strip = element.closest<HTMLElement>("[data-slide-strip]");
+    return strip?.dataset.slideStrip === "subject"
+      ? this.subject
+      : strip?.dataset.slideStrip === "inspector"
+        ? this.inspector
+        : null;
+  }
+
+  private availableWidth(): number {
+    const style = getComputedStyle(this.navigation);
+    return Math.max(
+      0,
+      this.navigation.clientWidth
+      - Number.parseFloat(style.paddingLeft || "0")
+      - Number.parseFloat(style.paddingRight || "0"));
+  }
+
+  private gap(): number {
+    const style = getComputedStyle(this.navigation);
+    return Number.parseFloat(style.columnGap || style.gap || "0");
+  }
+
+  private separatorWidth(): number {
+    return this.separator ? outerWidth(this.separator) : 0;
+  }
+
+  private allocationWidth(): number {
+    if (!this.allocation) return 0;
+    const hidden = this.allocation.hidden;
+    this.allocation.hidden = false;
+    const width = outerWidth(this.allocation);
+    this.allocation.hidden = hidden;
+    return width;
+  }
+
+  private overhead(withControls: boolean): number {
+    if (!this.inspector) return 0;
+    return this.separatorWidth()
+      + (withControls ? this.allocationWidth() : 0)
+      + this.gap() * (withControls ? 3 : 2);
+  }
+
+  private setControlsVisible(visible: boolean): void {
+    if (this.allocation) this.allocation.hidden = !visible;
+  }
+
+  private allocationFocusTransfer(
+    controls: boolean,
+  ): AllocationFocusTransfer | null {
+    if (controls || !this.allocation || this.allocation.hidden) return null;
+    const active = this.navigation.ownerDocument.activeElement;
+    if (!this.allocation.contains(active)) return null;
+    if (this.moreSubjects?.contains(active)) {
+      const selected = this.subject.element.querySelector<HTMLElement>(
+        '[aria-selected="true"]');
+      const id = selected?.dataset.slideStripId;
+      return id ? { strip: "subject", id } : null;
+    }
+    const selectedInspector = this.inspector?.element
+      .querySelector<HTMLElement>('[aria-selected="true"]');
+    const inspectorId = selectedInspector?.dataset.slideStripId;
+    if (inspectorId) return { strip: "inspector", id: inspectorId };
+    const selectedSubject = this.subject.element.querySelector<HTMLElement>(
+      '[aria-selected="true"]');
+    const subjectId = selectedSubject?.dataset.slideStripId;
+    return subjectId ? { strip: "subject", id: subjectId } : null;
+  }
+
+  private applyPair(
+    pair: AllocationPair,
+    pressure: string,
+    controls: boolean,
+  ): void {
+    this.navigation.dataset.pressure = pressure;
+    if (controls) this.setControlsVisible(true);
+    const transfer = this.allocationFocusTransfer(controls);
+    const subject = transfer?.strip === "subject"
+      ? this.subject.resolve(
+          pair.subject.outerWidth,
+          { pendingFocusId: transfer.id })
+      : pair.subject;
+    const inspector = transfer?.strip === "inspector"
+      ? this.inspector?.resolve(
+          pair.inspector.outerWidth,
+          { pendingFocusId: transfer.id }) ?? pair.inspector
+      : pair.inspector;
+    this.subject.apply(subject);
+    this.inspector?.apply(inspector);
+    this.setControlsVisible(controls);
+  }
+
+  private layout(available = this.availableWidth()): void {
+    if (!this.inspector) {
+      this.setControlsVisible(false);
+      this.navigation.dataset.pressure = "subject-only";
+      const contextWidth = this.context
+        ? outerWidth(this.context) + this.gap()
+        : 0;
+      this.subject.apply(this.subject.resolve(
+        Math.max(
+          available - contextWidth,
+          this.subject.fallbackOuterWidth)));
+      return;
+    }
+    const subjectMinimum = this.subject.minimumOuterWidth;
+    const inspectorMinimum = this.inspector.minimumOuterWidth;
+    const noControlsWidth = Math.max(0, available - this.overhead(false));
+    if (noControlsWidth
+      >= this.subject.preferredOuterWidth + this.inspector.preferredOuterWidth) {
+      this.applyPair({
+        subject: this.subject.resolve(this.subject.preferredOuterWidth),
+        inspector: this.inspector.resolve(this.inspector.preferredOuterWidth),
+      }, "all-preferred", false);
+      return;
+    }
+
+    const controlsWidth = Math.max(0, available - this.overhead(true));
+    if (controlsWidth
+      >= subjectMinimum + inspectorMinimum) {
+      this.ladder = this.buildLadder(
+        controlsWidth,
+        subjectMinimum,
+        inspectorMinimum);
+      if (this.ladder.length > 0) {
+        this.state.allocationOrdinal = Math.max(
+          0,
+          Math.min(this.state.allocationOrdinal, this.ladder.length - 1));
+        this.renderedAllocationOrdinal = this.state.allocationOrdinal;
+        const pair = this.ladder[this.renderedAllocationOrdinal];
+        if (pair) {
+          this.applyPair(pair, "ladder", true);
+          this.updateAllocationButtons();
+          return;
+        }
+      }
+    }
+
+    if (noControlsWidth
+      >= subjectMinimum + inspectorMinimum) {
+      const provisionalInspectorWidth = noControlsWidth
+        - subjectMinimum;
+      const inspector = this.inspector.resolve(provisionalInspectorWidth);
+      const exactInspectorWidth = Math.min(
+        provisionalInspectorWidth,
+        inspector.result.requiredWidth + this.inspector.chromeWidth);
+      this.applyPair({
+        subject: this.subject.resolve(
+          noControlsWidth - exactInspectorWidth),
+        inspector: this.inspector.resolve(exactInspectorWidth),
+      }, "control-free", false);
+      return;
+    }
+
+    this.applyPair(
+      this.terminalPair(noControlsWidth),
+      "terminal",
+      false);
+  }
+
+  private buildLadder(
+    stripWidth: number,
+    subjectMinimum: number,
+    inspectorMinimum: number,
+  ): readonly AllocationPair[] {
+    if (!this.inspector) return [];
+    const candidates = new Set<number>([
+      inspectorMinimum,
+      stripWidth - subjectMinimum,
+      ...this.inspector.candidateOuterWidths,
+      ...this.subject.candidateOuterWidths.map(width => stripWidth - width),
+    ]);
+    const pairs: AllocationPair[] = [];
+    for (const candidate of [...candidates].sort((left, right) => left - right)) {
+      if (candidate < inspectorMinimum
+        || candidate > stripWidth - subjectMinimum) {
+        continue;
+      }
+      const inspectorProbe = this.inspector.resolve(candidate);
+      if (!satisfiesPolicyMinimum(this.inspector, inspectorProbe)) continue;
+      const exactInspectorWidth = inspectorProbe.result.requiredWidth
+        + this.inspector.chromeWidth;
+      const subject = this.subject.resolve(stripWidth - exactInspectorWidth);
+      const inspector = this.inspector.resolve(exactInspectorWidth);
+      if (!satisfiesPolicyMinimum(this.subject, subject)
+        || !satisfiesPolicyMinimum(this.inspector, inspector)) {
+        continue;
+      }
+      pairs.push({ subject, inspector });
+    }
+    const distinct = [...new Map(pairs.map(pair => [
+      `${resultKey(pair.subject.result)}|${resultKey(pair.inspector.result)}`,
+      pair,
+    ])).values()];
+    const pareto = distinct.filter(pair =>
+      !distinct.some(candidate =>
+        candidate !== pair && pairDominates(candidate, pair)));
+    return pareto.sort((left, right) => {
+      if (left.inspector.result.modeIndex !== right.inspector.result.modeIndex) {
+        return left.inspector.result.modeIndex
+          - right.inspector.result.modeIndex;
+      }
+      if (left.inspector.result.visibleCount
+        !== right.inspector.result.visibleCount) {
+        return right.inspector.result.visibleCount
+          - left.inspector.result.visibleCount;
+      }
+      return left.subject.result.visibleCount
+        - right.subject.result.visibleCount;
+    });
+  }
+
+  private terminalPair(stripWidth: number): AllocationPair {
+    if (!this.inspector) {
+      throw new Error("Terminal allocation requires an inspector strip.");
+    }
+    const minimumInternalWidth = this.subject.fallbackOuterWidth
+      + this.inspector.fallbackOuterWidth;
+    if (stripWidth < minimumInternalWidth) {
+      return {
+        subject: this.subject.resolve(this.subject.fallbackOuterWidth),
+        inspector: this.inspector.resolve(this.inspector.fallbackOuterWidth),
+      };
+    }
+    const targetSubject = Math.floor(stripWidth / 3);
+    const clampedTargetSubject = Math.max(
+      this.subject.fallbackOuterWidth,
+      Math.min(
+        targetSubject,
+        stripWidth - this.inspector.fallbackOuterWidth));
+    const candidates = new Set<number>([
+      this.subject.fallbackOuterWidth,
+      stripWidth - this.inspector.fallbackOuterWidth,
+      clampedTargetSubject,
+      ...this.subject.candidateOuterWidths,
+      ...this.inspector.candidateOuterWidths.map(width => stripWidth - width),
+    ]);
+    const pairs = [...candidates].flatMap(subjectWidth => {
+      const inspectorWidth = stripWidth - subjectWidth;
+      if (subjectWidth < this.subject.fallbackOuterWidth
+        || inspectorWidth < this.inspector!.fallbackOuterWidth) {
+        return [];
+      }
+      const subject = this.subject.resolve(subjectWidth);
+      const inspector = this.inspector!.resolve(inspectorWidth);
+      const subjectUnused = subject.result.fallback
+        ? 0
+        : Math.max(
+            0,
+            subjectWidth
+            - subject.result.requiredWidth
+            - this.subject.chromeWidth);
+      const inspectorUnused = inspector.result.fallback
+        ? 0
+        : Math.max(
+            0,
+            inspectorWidth
+            - inspector.result.requiredWidth
+            - this.inspector!.chromeWidth);
+      return [{
+        pair: { subject, inspector },
+        unused: subjectUnused + inspectorUnused,
+        distance: Math.abs(subjectWidth - targetSubject),
+        inspectorWidth,
+      }];
+    });
+    pairs.sort((left, right) =>
+      left.unused - right.unused
+      || left.distance - right.distance
+      || right.inspectorWidth - left.inspectorWidth);
+    const selected = pairs[0];
+    if (!selected) {
+      throw new Error("Scope bar terminal allocation has no valid candidate.");
+    }
+    return selected.pair;
+  }
+
+  private updateAllocationButtons(): void {
+    if (!this.moreSubjects || !this.moreInspectors) return;
+    const atInspectorBound = this.renderedAllocationOrdinal <= 0;
+    const atSubjectBound =
+      this.renderedAllocationOrdinal >= this.ladder.length - 1;
+    this.moreInspectors.setAttribute(
+      "aria-disabled",
+      String(atInspectorBound));
+    this.moreSubjects.setAttribute(
+      "aria-disabled",
+      String(atSubjectBound));
+  }
 }

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -708,12 +708,12 @@ class ScopeBarController implements ScopeBarBinding {
     if (controls) this.setControlsVisible(true);
     const transfer = this.allocationFocusTransfer(controls);
     const subject = transfer?.strip === "subject"
-      ? this.subject.resolve(
+      ? this.subject.resolveRequired(
           pair.subject.outerWidth,
           { pendingFocusId: transfer.id })
       : pair.subject;
     const inspector = transfer?.strip === "inspector"
-      ? this.inspector?.resolve(
+      ? this.inspector?.resolveRequired(
           pair.inspector.outerWidth,
           { pendingFocusId: transfer.id }) ?? pair.inspector
       : pair.inspector;
@@ -729,7 +729,7 @@ class ScopeBarController implements ScopeBarBinding {
       const contextWidth = this.context
         ? outerWidth(this.context) + this.gap()
         : 0;
-      this.subject.apply(this.subject.resolve(
+      this.subject.apply(this.subject.resolveRequired(
         Math.max(
           available - contextWidth,
           this.subject.fallbackOuterWidth)));
@@ -741,8 +741,9 @@ class ScopeBarController implements ScopeBarBinding {
     if (noControlsWidth
       >= this.subject.preferredOuterWidth + this.inspector.preferredOuterWidth) {
       this.applyPair({
-        subject: this.subject.resolve(this.subject.preferredOuterWidth),
-        inspector: this.inspector.resolve(this.inspector.preferredOuterWidth),
+        subject: this.subject.resolveRequired(this.subject.preferredOuterWidth),
+        inspector: this.inspector.resolveRequired(
+          this.inspector.preferredOuterWidth),
       }, "all-preferred", false);
       return;
     }
@@ -772,14 +773,15 @@ class ScopeBarController implements ScopeBarBinding {
       >= subjectMinimum + inspectorMinimum) {
       const provisionalInspectorWidth = noControlsWidth
         - subjectMinimum;
-      const inspector = this.inspector.resolve(provisionalInspectorWidth);
+      const inspector = this.inspector.resolveRequired(
+        provisionalInspectorWidth);
       const exactInspectorWidth = Math.min(
         provisionalInspectorWidth,
         inspector.result.requiredWidth + this.inspector.chromeWidth);
       this.applyPair({
-        subject: this.subject.resolve(
+        subject: this.subject.resolveRequired(
           noControlsWidth - exactInspectorWidth),
-        inspector: this.inspector.resolve(exactInspectorWidth),
+        inspector: this.inspector.resolveRequired(exactInspectorWidth),
       }, "control-free", false);
       return;
     }
@@ -808,12 +810,13 @@ class ScopeBarController implements ScopeBarBinding {
         || candidate > stripWidth - subjectMinimum) {
         continue;
       }
-      const inspectorProbe = this.inspector.resolve(candidate);
+      const inspectorProbe = this.inspector.resolveRequired(candidate);
       if (!satisfiesPolicyMinimum(this.inspector, inspectorProbe)) continue;
       const exactInspectorWidth = inspectorProbe.result.requiredWidth
         + this.inspector.chromeWidth;
-      const subject = this.subject.resolve(stripWidth - exactInspectorWidth);
-      const inspector = this.inspector.resolve(exactInspectorWidth);
+      const subject = this.subject.resolveRequired(
+        stripWidth - exactInspectorWidth);
+      const inspector = this.inspector.resolveRequired(exactInspectorWidth);
       if (!satisfiesPolicyMinimum(this.subject, subject)
         || !satisfiesPolicyMinimum(this.inspector, inspector)) {
         continue;
@@ -869,8 +872,10 @@ class ScopeBarController implements ScopeBarBinding {
       + this.inspector.fallbackOuterWidth;
     if (stripWidth < minimumInternalWidth) {
       return {
-        subject: this.subject.resolve(this.subject.fallbackOuterWidth),
-        inspector: this.inspector.resolve(this.inspector.fallbackOuterWidth),
+        subject: this.subject.resolveRequired(
+          this.subject.fallbackOuterWidth),
+        inspector: this.inspector.resolveRequired(
+          this.inspector.fallbackOuterWidth),
       };
     }
     const targetSubject = Math.floor(stripWidth / 3);
@@ -892,8 +897,8 @@ class ScopeBarController implements ScopeBarBinding {
         || inspectorWidth < this.inspector!.fallbackOuterWidth) {
         return [];
       }
-      const subject = this.subject.resolve(subjectWidth);
-      const inspector = this.inspector!.resolve(inspectorWidth);
+      const subject = this.subject.resolveRequired(subjectWidth);
+      const inspector = this.inspector!.resolveRequired(inspectorWidth);
       const subjectUnused = subject.result.fallback
         ? 0
         : Math.max(

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -87,6 +87,13 @@ export function createScopeBarState(): ScopeBarState {
   };
 }
 
+export function clampAllocationOrdinal(
+  requested: number,
+  levelCount: number,
+): number {
+  return Math.max(0, Math.min(requested, levelCount - 1));
+}
+
 export function captureScopeBarFocus(
   element: HTMLElement,
 ): ScopeBarFocusTarget | null {
@@ -725,9 +732,9 @@ class ScopeBarController implements ScopeBarBinding {
         subjectMinimum,
         inspectorMinimum);
       if (this.ladder.length > 0) {
-        this.state.allocationOrdinal = Math.max(
-          0,
-          Math.min(this.state.allocationOrdinal, this.ladder.length - 1));
+        this.state.allocationOrdinal = clampAllocationOrdinal(
+          this.state.allocationOrdinal,
+          this.ladder.length);
         this.renderedAllocationOrdinal = this.state.allocationOrdinal;
         const pair = this.ladder[this.renderedAllocationOrdinal];
         if (pair) {

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -611,7 +611,8 @@ class ScopeBarController implements ScopeBarBinding {
     const controller = targetStrip(target) === "subject"
       ? this.subject
       : this.inspector;
-    controller?.revealForFocus(targetIdentity(target));
+    this.synchronizeAfterStripTransition(
+      controller?.revealForFocus(targetIdentity(target)) ?? false);
   }
 
   reveal(target: HTMLButtonElement): void {
@@ -620,7 +621,8 @@ class ScopeBarController implements ScopeBarBinding {
     const controller = target.closest('[data-slide-strip="subject"]')
       ? this.subject
       : this.inspector;
-    controller?.revealForFocus(id);
+    this.synchronizeAfterStripTransition(
+      controller?.revealForFocus(id) ?? false);
   }
 
   private bind(): void {
@@ -632,7 +634,9 @@ class ScopeBarController implements ScopeBarBinding {
         if (delta === 0) return;
         const moved = this.controllerFor(strip)?.slide(
           delta < 0 ? "before" : "after") ?? false;
-        if (moved) event.preventDefault();
+        if (!moved) return;
+        this.synchronizeAfterStripTransition(true);
+        event.preventDefault();
       }, { passive: false }));
     this.moreSubjects?.addEventListener("click", () => {
       if (this.moreSubjects?.getAttribute("aria-disabled") === "true") return;
@@ -677,6 +681,36 @@ class ScopeBarController implements ScopeBarBinding {
       : strip?.dataset.slideStrip === "inspector"
         ? this.inspector
         : null;
+  }
+
+  private synchronizeAfterStripTransition(changed: boolean): void {
+    if (!changed
+      || !this.inspector
+      || this.navigation.dataset.pressure !== "ladder") {
+      return;
+    }
+    const stripWidth = Math.max(
+      0,
+      this.observedWidth - this.overhead(true));
+    const subjectMinimum = this.subject.minimumOuterWidth;
+    const inspectorMinimum = this.inspector.minimumOuterWidth;
+    if (stripWidth < subjectMinimum + inspectorMinimum) {
+      this.layout(this.observedWidth);
+      return;
+    }
+    this.ladder = this.buildLadder(
+      stripWidth,
+      subjectMinimum,
+      inspectorMinimum);
+    if (this.ladder.length === 0) {
+      this.layout(this.observedWidth);
+      return;
+    }
+    this.state.allocationOrdinal = clampAllocationOrdinal(
+      this.state.allocationOrdinal,
+      this.ladder.length);
+    this.renderedAllocationOrdinal = this.state.allocationOrdinal;
+    this.updateAllocationButtons();
   }
 
   private availableWidth(): number {

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -94,6 +94,15 @@ export function clampAllocationOrdinal(
   return Math.max(0, Math.min(requested, levelCount - 1));
 }
 
+export function scopeBarShortLabel(label: string): string {
+  return label
+    .trim()
+    .split(/\s+/)
+    .map(word => word[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
 export function captureScopeBarFocus(
   element: HTMLElement,
 ): ScopeBarFocusTarget | null {
@@ -448,8 +457,12 @@ function outerWidth(element: HTMLElement): number {
     + Number.parseFloat(style.marginRight || "0");
 }
 
-function resultKey(result: SlideStripResult): string {
-  return `${result.mode}:${result.visibleIds.join(",")}`;
+function allocationRichnessKey(pair: AllocationPair): string {
+  return [
+    pair.subject.result.visibleCount,
+    pair.inspector.result.modeIndex,
+    pair.inspector.result.visibleCount,
+  ].join(":");
 }
 
 function inspectorAtLeastAsRich(
@@ -471,6 +484,16 @@ function pairDominates(left: AllocationPair, right: AllocationPair): boolean {
       > right.subject.result.visibleCount
     || !inspectorAtLeastAsRich(right.inspector.result, left.inspector.result);
   return subjectAtLeast && inspectorAtLeast && strict;
+}
+
+function resultWindowDistance(
+  result: SlideStripResult,
+  current: SlideStripResult | undefined,
+): number {
+  return current
+    ? Math.abs(result.startIndex - current.startIndex)
+      + Math.abs(result.endIndex - current.endIndex)
+    : 0;
 }
 
 function requestedMinimum(
@@ -797,10 +820,29 @@ class ScopeBarController implements ScopeBarBinding {
       }
       pairs.push({ subject, inspector });
     }
-    const distinct = [...new Map(pairs.map(pair => [
-      `${resultKey(pair.subject.result)}|${resultKey(pair.inspector.result)}`,
-      pair,
-    ])).values()];
+    const distinctByRichness = new Map<string, AllocationPair>();
+    const currentSubject = this.subject.current?.result;
+    const currentInspector = this.inspector.current?.result;
+    for (const pair of pairs) {
+      const key = allocationRichnessKey(pair);
+      const existing = distinctByRichness.get(key);
+      if (!existing) {
+        distinctByRichness.set(key, pair);
+        continue;
+      }
+      const existingDistance = resultWindowDistance(
+        existing.subject.result,
+        currentSubject)
+        + resultWindowDistance(existing.inspector.result, currentInspector);
+      const candidateDistance = resultWindowDistance(
+        pair.subject.result,
+        currentSubject)
+        + resultWindowDistance(pair.inspector.result, currentInspector);
+      if (candidateDistance < existingDistance) {
+        distinctByRichness.set(key, pair);
+      }
+    }
+    const distinct = [...distinctByRichness.values()];
     const pareto = distinct.filter(pair =>
       !distinct.some(candidate =>
         candidate !== pair && pairDominates(candidate, pair)));

--- a/prototypes/inspect-web/src/slide-strip-dom.ts
+++ b/prototypes/inspect-web/src/slide-strip-dom.ts
@@ -154,8 +154,16 @@ export class SlideStripDomController {
   }
 
   get minimumOuterWidth(): number {
+    return this.minimumOuterWidthFor();
+  }
+
+  minimumOuterWidthFor(pendingFocusId?: string): number {
     const focusedId = this.focusedId();
-    const key = `${focusedId ?? ""}:${this.state.leadingId ?? ""}`;
+    const key = [
+      focusedId ?? "",
+      this.state.leadingId ?? "",
+      pendingFocusId ?? "",
+    ].join(":");
     if (this.minimumWidthCache?.key === key) {
       return this.minimumWidthCache.width;
     }
@@ -168,6 +176,7 @@ export class SlideStripDomController {
         ...(this.state.leadingId === undefined
           ? {}
           : { retainedLeadingId: this.state.leadingId }),
+        ...(pendingFocusId === undefined ? {} : { pendingFocusId }),
       }) + this.chromeWidth;
     this.minimumWidthCache = { key, width };
     return width;
@@ -254,6 +263,8 @@ export class SlideStripDomController {
     if (this.edgeAfter) this.edgeAfter.hidden = !result.trailingHidden;
     this.relocateHiddenTabStop();
     this.applied = applied;
+    const leading = result.visibleIds[0];
+    if (leading !== undefined) this.state.leadingId = leading;
   }
 
   revealForFocus(id: string): boolean {
@@ -263,7 +274,6 @@ export class SlideStripDomController {
     this.apply(this.resolveRequired(
       current.outerWidth,
       { pendingFocusId: id }));
-    this.retainAppliedLeading();
     return true;
   }
 
@@ -276,7 +286,6 @@ export class SlideStripDomController {
       direction);
     if (!windowTarget) return false;
     this.apply(this.resolveRequired(current.outerWidth, { windowTarget }));
-    this.retainAppliedLeading();
     return true;
   }
 
@@ -329,11 +338,6 @@ export class SlideStripDomController {
   private button(id: string): HTMLButtonElement | null {
     return this.buttons.find(
       button => button.dataset.slideStripId === id) ?? null;
-  }
-
-  private retainAppliedLeading(): void {
-    const leading = this.applied?.result?.visibleIds[0];
-    if (leading !== undefined) this.state.leadingId = leading;
   }
 
   private relocateHiddenTabStop(): void {

--- a/prototypes/inspect-web/src/slide-strip-dom.ts
+++ b/prototypes/inspect-web/src/slide-strip-dom.ts
@@ -29,6 +29,15 @@ export interface SlideStripAppliedResult {
   outerWidth: number;
 }
 
+interface SlideStripEmptyAppliedResult {
+  result: null;
+  outerWidth: number;
+}
+
+export type SlideStripResolvedResult =
+  | SlideStripAppliedResult
+  | SlideStripEmptyAppliedResult;
+
 function numericStyle(value: string): number {
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -45,6 +54,13 @@ function elementChromeWidth(element: HTMLElement): number {
 function elementGap(element: HTMLElement): number {
   const style = getComputedStyle(element);
   return numericStyle(style.columnGap || style.gap);
+}
+
+function elementOuterWidth(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  return element.getBoundingClientRect().width
+    + numericStyle(style.marginLeft)
+    + numericStyle(style.marginRight);
 }
 
 function itemId(
@@ -84,7 +100,7 @@ export class SlideStripDomController {
   private readonly buttons: readonly HTMLButtonElement[];
   private readonly edgeBefore: HTMLElement | null;
   private readonly edgeAfter: HTMLElement | null;
-  private applied: SlideStripAppliedResult | null = null;
+  private applied: SlideStripResolvedResult | null = null;
   private minimumWidthCache:
     { key: string; width: number } | null = null;
 
@@ -128,11 +144,13 @@ export class SlideStripDomController {
   }
 
   get current(): SlideStripAppliedResult | null {
-    return this.applied;
+    return this.applied?.result ? this.applied : null;
   }
 
   get fallbackOuterWidth(): number {
-    return this.policy.fallbackVisibilityFloor + this.chromeWidth;
+    return (this.items.length === 0
+      ? 0
+      : this.policy.fallbackVisibilityFloor) + this.chromeWidth;
   }
 
   get minimumOuterWidth(): number {
@@ -167,7 +185,7 @@ export class SlideStripDomController {
   resolve(
     outerWidth: number,
     intent: SlideStripResolveIntent = {},
-  ): SlideStripAppliedResult {
+  ): SlideStripResolvedResult {
     const focusedId = this.focusedId();
     const options: ResolveSlideStripOptions = {
       items: this.items,
@@ -186,15 +204,33 @@ export class SlideStripDomController {
         : { windowTarget: intent.windowTarget }),
     };
     const result = resolveSlideStrip(options);
-    if (!result) {
-      throw new Error("A mounted SlideStrip cannot have an empty inventory.");
-    }
     return { result, outerWidth };
   }
 
-  apply(applied: SlideStripAppliedResult): void {
+  resolveRequired(
+    outerWidth: number,
+    intent: SlideStripResolveIntent = {},
+  ): SlideStripAppliedResult {
+    const applied = this.resolve(outerWidth, intent);
+    if (!applied.result) {
+      throw new Error("The composed SlideStrip requires a non-empty inventory.");
+    }
+    return applied;
+  }
+
+  apply(applied: SlideStripResolvedResult): void {
     const { result, outerWidth } = applied;
     this.element.style.width = `${Math.max(0, outerWidth)}px`;
+    if (!result) {
+      delete this.element.dataset.mode;
+      delete this.element.dataset.fallback;
+      delete this.element.dataset.oversizedAlignment;
+      this.buttons.forEach(button => button.hidden = true);
+      if (this.edgeBefore) this.edgeBefore.hidden = true;
+      if (this.edgeAfter) this.edgeAfter.hidden = true;
+      this.applied = applied;
+      return;
+    }
     this.element.dataset.mode = result.mode;
     this.element.dataset.fallback = String(result.fallback);
     this.element.dataset.oversizedAlignment = result.oversizedAlignment;
@@ -223,21 +259,23 @@ export class SlideStripDomController {
   revealForFocus(id: string): boolean {
     if (!this.items.some(item => item.id === id)) return false;
     const current = this.applied;
-    if (!current) return false;
-    this.apply(this.resolve(current.outerWidth, { pendingFocusId: id }));
+    if (!current?.result) return false;
+    this.apply(this.resolveRequired(
+      current.outerWidth,
+      { pendingFocusId: id }));
     this.retainAppliedLeading();
     return true;
   }
 
   slide(direction: SlideStripDirection): boolean {
     const current = this.applied;
-    if (!current) return false;
+    if (!current?.result) return false;
     const windowTarget = adjacentSlideTarget(
       this.items,
       current.result,
       direction);
     if (!windowTarget) return false;
-    this.apply(this.resolve(current.outerWidth, { windowTarget }));
+    this.apply(this.resolveRequired(current.outerWidth, { windowTarget }));
     this.retainAppliedLeading();
     return true;
   }
@@ -262,7 +300,7 @@ export class SlideStripDomController {
         const id = itemId(button);
         if (id === undefined) continue;
         const widths = measurements.get(id) ?? {};
-        widths[mode.kind] = button.getBoundingClientRect().width;
+        widths[mode.kind] = elementOuterWidth(button);
         measurements.set(id, widths);
       }
     }
@@ -294,7 +332,7 @@ export class SlideStripDomController {
   }
 
   private retainAppliedLeading(): void {
-    const leading = this.applied?.result.visibleIds[0];
+    const leading = this.applied?.result?.visibleIds[0];
     if (leading !== undefined) this.state.leadingId = leading;
   }
 

--- a/prototypes/inspect-web/src/slide-strip-dom.ts
+++ b/prototypes/inspect-web/src/slide-strip-dom.ts
@@ -1,0 +1,313 @@
+import {
+  adjacentSlideTarget,
+  resolveSlideStrip,
+  slideStripCandidateWidths,
+  slideStripMinimumWidth,
+  slideStripPreferredWidth,
+  type ResolveSlideStripOptions,
+  type SlideStripDirection,
+  type SlideStripItem,
+  type SlideStripItemMeasurement,
+  type SlideStripPolicy,
+  type SlideStripRepresentation,
+  type SlideStripResult,
+  type SlideStripWindowTarget,
+} from "./slide-strip.ts";
+
+export interface SlideStripContinuityState {
+  key: string;
+  leadingId?: string;
+}
+
+export interface SlideStripResolveIntent {
+  pendingFocusId?: string;
+  windowTarget?: SlideStripWindowTarget;
+}
+
+export interface SlideStripAppliedResult {
+  result: SlideStripResult;
+  outerWidth: number;
+}
+
+function numericStyle(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function elementChromeWidth(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  return numericStyle(style.paddingLeft)
+    + numericStyle(style.paddingRight)
+    + numericStyle(style.borderLeftWidth)
+    + numericStyle(style.borderRightWidth);
+}
+
+function elementGap(element: HTMLElement): number {
+  const style = getComputedStyle(element);
+  return numericStyle(style.columnGap || style.gap);
+}
+
+function itemId(
+  element: HTMLElement | null,
+): string | undefined {
+  const id = element?.dataset.slideStripId;
+  return id || undefined;
+}
+
+function measuredPolicy(
+  policy: SlideStripPolicy,
+  gap: number,
+): SlideStripPolicy {
+  return {
+    ...policy,
+    modes: policy.modes.map(mode => ({ ...mode, gap })),
+  };
+}
+
+export class SlideStripDomController {
+  readonly element: HTMLElement;
+  readonly items: readonly SlideStripItem[];
+  readonly state: SlideStripContinuityState;
+  readonly chromeWidth: number;
+  readonly measurements: readonly SlideStripItemMeasurement[];
+  readonly policy: SlideStripPolicy;
+  private readonly candidateWidths: readonly number[];
+  private readonly preferredWidth: number;
+  private readonly buttons: readonly HTMLButtonElement[];
+  private readonly edgeBefore: HTMLElement | null;
+  private readonly edgeAfter: HTMLElement | null;
+  private applied: SlideStripAppliedResult | null = null;
+  private minimumWidthCache:
+    { key: string; width: number } | null = null;
+
+  constructor(
+    element: HTMLElement,
+    items: readonly SlideStripItem[],
+    policy: SlideStripPolicy,
+    state: SlideStripContinuityState,
+  ) {
+    this.element = element;
+    this.items = items;
+    this.state = state;
+    this.buttons = [
+      ...element.querySelectorAll<HTMLButtonElement>("[data-slide-strip-id]"),
+    ];
+    this.edgeBefore = element.querySelector("[data-slide-strip-before]");
+    this.edgeAfter = element.querySelector("[data-slide-strip-after]");
+    this.chromeWidth = elementChromeWidth(element);
+    const itemContainer = element.querySelector<HTMLElement>(
+      ".slide-strip-items");
+    if (!itemContainer) {
+      throw new Error("SlideStrip requires a .slide-strip-items container.");
+    }
+    const gap = elementGap(itemContainer);
+    this.policy = measuredPolicy(policy, gap);
+    this.measurements = this.measure();
+    this.candidateWidths = slideStripCandidateWidths(
+      this.items,
+      this.measurements,
+      this.policy);
+    this.preferredWidth = slideStripPreferredWidth(
+      this.items,
+      this.measurements,
+      this.policy);
+    if (state.key !== policy.continuityKey
+      || (state.leadingId !== undefined
+        && !items.some(item => item.id === state.leadingId))) {
+      state.key = policy.continuityKey;
+      delete state.leadingId;
+    }
+  }
+
+  get current(): SlideStripAppliedResult | null {
+    return this.applied;
+  }
+
+  get fallbackOuterWidth(): number {
+    return this.policy.fallbackVisibilityFloor + this.chromeWidth;
+  }
+
+  get minimumOuterWidth(): number {
+    const focusedId = this.focusedId();
+    const key = `${focusedId ?? ""}:${this.state.leadingId ?? ""}`;
+    if (this.minimumWidthCache?.key === key) {
+      return this.minimumWidthCache.width;
+    }
+    const width = slideStripMinimumWidth(
+      this.items,
+      this.measurements,
+      this.policy,
+      {
+        ...(focusedId === undefined ? {} : { focusedId }),
+        ...(this.state.leadingId === undefined
+          ? {}
+          : { retainedLeadingId: this.state.leadingId }),
+      }) + this.chromeWidth;
+    this.minimumWidthCache = { key, width };
+    return width;
+  }
+
+  get preferredOuterWidth(): number {
+    return this.preferredWidth + this.chromeWidth;
+  }
+
+  get candidateOuterWidths(): readonly number[] {
+    return this.candidateWidths
+      .map(width => width + this.chromeWidth);
+  }
+
+  resolve(
+    outerWidth: number,
+    intent: SlideStripResolveIntent = {},
+  ): SlideStripAppliedResult {
+    const focusedId = this.focusedId();
+    const options: ResolveSlideStripOptions = {
+      items: this.items,
+      measurements: this.measurements,
+      policy: this.policy,
+      viewportWidth: Math.max(0, outerWidth - this.chromeWidth),
+      ...(this.state.leadingId === undefined
+        ? {}
+        : { retainedLeadingId: this.state.leadingId }),
+      ...(focusedId === undefined ? {} : { focusedId }),
+      ...(intent.pendingFocusId === undefined
+        ? {}
+        : { pendingFocusId: intent.pendingFocusId }),
+      ...(intent.windowTarget === undefined
+        ? {}
+        : { windowTarget: intent.windowTarget }),
+    };
+    const result = resolveSlideStrip(options);
+    if (!result) {
+      throw new Error("A mounted SlideStrip cannot have an empty inventory.");
+    }
+    return { result, outerWidth };
+  }
+
+  apply(applied: SlideStripAppliedResult): void {
+    const { result, outerWidth } = applied;
+    this.element.style.width = `${Math.max(0, outerWidth)}px`;
+    this.element.dataset.mode = result.mode;
+    this.element.dataset.fallback = String(result.fallback);
+    this.element.dataset.oversizedAlignment = result.oversizedAlignment;
+
+    const pending = result.pendingFocusId === undefined
+      ? null
+      : this.button(result.pendingFocusId);
+    if (pending) {
+      pending.hidden = false;
+      this.buttons.forEach(button => {
+        button.tabIndex = button === pending ? 0 : -1;
+      });
+      pending.focus({ preventScroll: true });
+    }
+
+    const visible = new Set<string>(result.visibleIds);
+    this.buttons.forEach(button => {
+      button.hidden = !visible.has(button.dataset.slideStripId ?? "");
+    });
+    if (this.edgeBefore) this.edgeBefore.hidden = !result.leadingHidden;
+    if (this.edgeAfter) this.edgeAfter.hidden = !result.trailingHidden;
+    this.relocateHiddenTabStop();
+    this.applied = applied;
+  }
+
+  revealForFocus(id: string): boolean {
+    if (!this.items.some(item => item.id === id)) return false;
+    const current = this.applied;
+    if (!current) return false;
+    this.apply(this.resolve(current.outerWidth, { pendingFocusId: id }));
+    this.retainAppliedLeading();
+    return true;
+  }
+
+  slide(direction: SlideStripDirection): boolean {
+    const current = this.applied;
+    if (!current) return false;
+    const windowTarget = adjacentSlideTarget(
+      this.items,
+      current.result,
+      direction);
+    if (!windowTarget) return false;
+    this.apply(this.resolve(current.outerWidth, { windowTarget }));
+    this.retainAppliedLeading();
+    return true;
+  }
+
+  private measure(): readonly SlideStripItemMeasurement[] {
+    const priorMode = this.element.dataset.mode;
+    const priorVisibility = this.element.style.visibility;
+    const hidden = this.buttons.map(button => button.hidden);
+    this.element.style.visibility = "hidden";
+    this.buttons.forEach(button => button.hidden = false);
+    const measurements = new Map<string, Partial<
+      Record<SlideStripRepresentation, number>
+    >>();
+    for (const mode of this.policy.modes) {
+      this.element.dataset.mode = mode.kind;
+      for (const button of this.buttons) {
+        const id = itemId(button);
+        if (id === undefined) continue;
+        const widths = measurements.get(id) ?? {};
+        widths[mode.kind] = button.getBoundingClientRect().width;
+        measurements.set(id, widths);
+      }
+    }
+    this.buttons.forEach((button, index) => {
+      button.hidden = hidden[index] ?? false;
+    });
+    if (priorMode === undefined) delete this.element.dataset.mode;
+    else this.element.dataset.mode = priorMode;
+    this.element.style.visibility = priorVisibility;
+    return this.items.map(item => ({
+      id: item.id,
+      widths: measurements.get(item.id) ?? {},
+    }));
+  }
+
+  private focusedId(): string | undefined {
+    const active = this.element.ownerDocument.activeElement;
+    return active instanceof HTMLElement && this.element.contains(active)
+      ? itemId(active)
+      : undefined;
+  }
+
+  private button(id: string): HTMLButtonElement | null {
+    return this.buttons.find(
+      button => button.dataset.slideStripId === id) ?? null;
+  }
+
+  private retainAppliedLeading(): void {
+    const leading = this.applied?.result.visibleIds[0];
+    if (leading !== undefined) this.state.leadingId = leading;
+  }
+
+  private relocateHiddenTabStop(): void {
+    const active = this.element.ownerDocument.activeElement;
+    if (active instanceof HTMLElement && this.element.contains(active)) return;
+    const holder = this.buttons.find(button => button.tabIndex === 0);
+    if (!holder?.hidden) return;
+    const visible = this.buttons.filter(button => !button.hidden);
+    if (visible.length === 0) return;
+    const selected = visible.find(
+      button => button.getAttribute("aria-selected") === "true");
+    const priorIndex = holder ? this.buttons.indexOf(holder) : -1;
+    const replacement = selected ?? visible.reduce((best, button) => {
+      if (priorIndex < 0) return best;
+      const bestDistance = Math.abs(this.buttons.indexOf(best) - priorIndex);
+      const distance = Math.abs(this.buttons.indexOf(button) - priorIndex);
+      if (distance < bestDistance) return button;
+      if (distance > bestDistance) return best;
+      return this.policy.preferredDirection === "after"
+        ? (this.buttons.indexOf(button) > this.buttons.indexOf(best)
+          ? button
+          : best)
+        : (this.buttons.indexOf(button) < this.buttons.indexOf(best)
+          ? button
+          : best);
+    }, visible[0]!);
+    this.buttons.forEach(button => {
+      button.tabIndex = button === replacement ? 0 : -1;
+    });
+  }
+}

--- a/prototypes/inspect-web/src/slide-strip-dom.ts
+++ b/prototypes/inspect-web/src/slide-strip-dom.ts
@@ -56,12 +56,20 @@ function itemId(
 
 function measuredPolicy(
   policy: SlideStripPolicy,
-  gap: number,
+  gaps: ReadonlyMap<SlideStripRepresentation, number>,
 ): SlideStripPolicy {
   return {
     ...policy,
-    modes: policy.modes.map(mode => ({ ...mode, gap })),
+    modes: policy.modes.map(mode => ({
+      ...mode,
+      gap: gaps.get(mode.kind) ?? mode.gap,
+    })),
   };
+}
+
+interface DomMeasurements {
+  itemMeasurements: readonly SlideStripItemMeasurement[];
+  gaps: ReadonlyMap<SlideStripRepresentation, number>;
 }
 
 export class SlideStripDomController {
@@ -100,9 +108,9 @@ export class SlideStripDomController {
     if (!itemContainer) {
       throw new Error("SlideStrip requires a .slide-strip-items container.");
     }
-    const gap = elementGap(itemContainer);
-    this.policy = measuredPolicy(policy, gap);
-    this.measurements = this.measure();
+    const measurements = this.measure(policy, itemContainer);
+    this.policy = measuredPolicy(policy, measurements.gaps);
+    this.measurements = measurements.itemMeasurements;
     this.candidateWidths = slideStripCandidateWidths(
       this.items,
       this.measurements,
@@ -234,7 +242,10 @@ export class SlideStripDomController {
     return true;
   }
 
-  private measure(): readonly SlideStripItemMeasurement[] {
+  private measure(
+    policy: SlideStripPolicy,
+    itemContainer: HTMLElement,
+  ): DomMeasurements {
     const priorMode = this.element.dataset.mode;
     const priorVisibility = this.element.style.visibility;
     const hidden = this.buttons.map(button => button.hidden);
@@ -243,8 +254,10 @@ export class SlideStripDomController {
     const measurements = new Map<string, Partial<
       Record<SlideStripRepresentation, number>
     >>();
-    for (const mode of this.policy.modes) {
+    const gaps = new Map<SlideStripRepresentation, number>();
+    for (const mode of policy.modes) {
       this.element.dataset.mode = mode.kind;
+      gaps.set(mode.kind, elementGap(itemContainer));
       for (const button of this.buttons) {
         const id = itemId(button);
         if (id === undefined) continue;
@@ -259,10 +272,13 @@ export class SlideStripDomController {
     if (priorMode === undefined) delete this.element.dataset.mode;
     else this.element.dataset.mode = priorMode;
     this.element.style.visibility = priorVisibility;
-    return this.items.map(item => ({
-      id: item.id,
-      widths: measurements.get(item.id) ?? {},
-    }));
+    return {
+      itemMeasurements: this.items.map(item => ({
+        id: item.id,
+        widths: measurements.get(item.id) ?? {},
+      })),
+      gaps,
+    };
   }
 
   private focusedId(): string | undefined {

--- a/prototypes/inspect-web/src/slide-strip-dom.ts
+++ b/prototypes/inspect-web/src/slide-strip-dom.ts
@@ -264,7 +264,9 @@ export class SlideStripDomController {
     this.relocateHiddenTabStop();
     this.applied = applied;
     const leading = result.visibleIds[0];
-    if (leading !== undefined) this.state.leadingId = leading;
+    if (this.state.leadingId === undefined && leading !== undefined) {
+      this.state.leadingId = leading;
+    }
   }
 
   revealForFocus(id: string): boolean {
@@ -274,6 +276,7 @@ export class SlideStripDomController {
     this.apply(this.resolveRequired(
       current.outerWidth,
       { pendingFocusId: id }));
+    this.retainAppliedLeading();
     return true;
   }
 
@@ -286,6 +289,7 @@ export class SlideStripDomController {
       direction);
     if (!windowTarget) return false;
     this.apply(this.resolveRequired(current.outerWidth, { windowTarget }));
+    this.retainAppliedLeading();
     return true;
   }
 
@@ -338,6 +342,11 @@ export class SlideStripDomController {
   private button(id: string): HTMLButtonElement | null {
     return this.buttons.find(
       button => button.dataset.slideStripId === id) ?? null;
+  }
+
+  private retainAppliedLeading(): void {
+    const leading = this.applied?.result?.visibleIds[0];
+    if (leading !== undefined) this.state.leadingId = leading;
   }
 
   private relocateHiddenTabStop(): void {

--- a/prototypes/inspect-web/src/slide-strip.ts
+++ b/prototypes/inspect-web/src/slide-strip.ts
@@ -1,0 +1,483 @@
+export type SlideStripRepresentation =
+  | "label"
+  | "short-label"
+  | "icon"
+  | "index";
+
+export type SlideStripDirection = "before" | "after";
+
+export interface SlideStripItem<TId extends string = string> {
+  id: TId;
+  label: string;
+  shortLabel?: string;
+  icon?: string;
+}
+
+export interface SlideStripMode {
+  kind: SlideStripRepresentation;
+  minimumVisible: number;
+  gap: number;
+}
+
+export interface SlideStripPolicy<TId extends string = string> {
+  modes: readonly SlideStripMode[];
+  initialAnchor: TId;
+  preferredDirection: SlideStripDirection;
+  continuityKey: string;
+  fallbackVisibilityFloor: number;
+  oversizedAlignment: "start" | "end";
+}
+
+export interface SlideStripItemMeasurement<TId extends string = string> {
+  id: TId;
+  widths: Readonly<Partial<Record<SlideStripRepresentation, number>>>;
+}
+
+export interface SlideStripWindowTarget<TId extends string = string> {
+  id: TId;
+  edge: SlideStripDirection;
+}
+
+export interface ResolveSlideStripOptions<TId extends string = string> {
+  items: readonly SlideStripItem<TId>[];
+  measurements: readonly SlideStripItemMeasurement<TId>[];
+  policy: SlideStripPolicy<TId>;
+  viewportWidth: number;
+  retainedLeadingId?: TId;
+  focusedId?: TId;
+  pendingFocusId?: TId;
+  windowTarget?: SlideStripWindowTarget<TId>;
+}
+
+export type SlideStripRequiredIdentity<TId extends string = string> = Pick<
+  ResolveSlideStripOptions<TId>,
+  "retainedLeadingId" | "focusedId" | "pendingFocusId"
+>;
+
+export interface SlideStripResult<TId extends string = string> {
+  mode: SlideStripRepresentation;
+  modeIndex: number;
+  visibleIds: readonly TId[];
+  startIndex: number;
+  endIndex: number;
+  requiredWidth: number;
+  visibleCount: number;
+  leadingHidden: boolean;
+  trailingHidden: boolean;
+  fallback: boolean;
+  oversizedAlignment: "start" | "end";
+  pendingFocusId?: TId;
+}
+
+interface CandidateWindow {
+  startIndex: number;
+  endIndex: number;
+  requiredWidth: number;
+  visibleCount: number;
+}
+
+interface ModeResolution {
+  mode: SlideStripMode;
+  modeIndex: number;
+  candidate: CandidateWindow | null;
+}
+
+function representationAvailable<TId extends string>(
+  item: SlideStripItem<TId>,
+  kind: SlideStripRepresentation,
+): boolean {
+  if (kind === "short-label") return Boolean(item.shortLabel);
+  if (kind === "icon") return Boolean(item.icon);
+  return true;
+}
+
+function viableModes<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  policy: SlideStripPolicy<TId>,
+): readonly { mode: SlideStripMode; modeIndex: number }[] {
+  return policy.modes.flatMap((mode, modeIndex) =>
+    items.every(item => representationAvailable(item, mode.kind))
+      ? [{ mode, modeIndex }]
+      : []);
+}
+
+function itemIndex<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  id: TId | undefined,
+): number {
+  return id === undefined ? -1 : items.findIndex(item => item.id === id);
+}
+
+function measurementWidths<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  measurements: readonly SlideStripItemMeasurement<TId>[],
+  kind: SlideStripRepresentation,
+): readonly number[] {
+  const byId = new Map(measurements.map(item => [item.id, item.widths]));
+  return items.map(item => {
+    const width = byId.get(item.id)?.[kind];
+    if (width === undefined || !Number.isFinite(width) || width <= 0) {
+      throw new Error(
+        `SlideStrip is missing a positive ${kind} width for ${JSON.stringify(item.id)}.`);
+    }
+    return width;
+  });
+}
+
+function windowWidth(
+  widths: readonly number[],
+  startIndex: number,
+  endIndex: number,
+  gap: number,
+): number {
+  let width = 0;
+  for (let index = startIndex; index <= endIndex; index++) {
+    width += widths[index] ?? 0;
+  }
+  return width + Math.max(0, endIndex - startIndex) * gap;
+}
+
+function includesIndex(
+  candidate: CandidateWindow,
+  index: number,
+): boolean {
+  return index < 0
+    || (candidate.startIndex <= index && index <= candidate.endIndex);
+}
+
+function compareCandidates(
+  left: CandidateWindow,
+  right: CandidateWindow,
+  retainedIndex: number,
+  anchorIndex: number,
+  direction: SlideStripDirection,
+): number {
+  if (left.visibleCount !== right.visibleCount) {
+    return right.visibleCount - left.visibleCount;
+  }
+  const origin = retainedIndex >= 0 ? retainedIndex : anchorIndex;
+  const leftMovement = Math.abs(left.startIndex - origin);
+  const rightMovement = Math.abs(right.startIndex - origin);
+  if (leftMovement !== rightMovement) return leftMovement - rightMovement;
+  return direction === "after"
+    ? right.startIndex - left.startIndex
+    : left.startIndex - right.startIndex;
+}
+
+function enumerateModeWindows<TId extends string>(
+  options: ResolveSlideStripOptions<TId>,
+  mode: SlideStripMode,
+  requireFocusedDuringSlide: boolean,
+): readonly CandidateWindow[] {
+  const widths = measurementWidths(
+    options.items,
+    options.measurements,
+    mode.kind);
+  const pendingIndex = itemIndex(options.items, options.pendingFocusId);
+  const focusedIndex = itemIndex(options.items, options.focusedId);
+  const constrainedFocusedIndex = pendingIndex >= 0 ? -1 : focusedIndex;
+  const targetIndex = itemIndex(options.items, options.windowTarget?.id);
+  const retainedIndex = itemIndex(options.items, options.retainedLeadingId);
+  const anchorIndex = itemIndex(options.items, options.policy.initialAnchor);
+  const requiresInitialAnchor = pendingIndex < 0
+    && focusedIndex < 0
+    && targetIndex < 0
+    && retainedIndex < 0;
+  const candidates: CandidateWindow[] = [];
+
+  for (let startIndex = 0; startIndex < options.items.length; startIndex++) {
+    for (
+      let endIndex = startIndex;
+      endIndex < options.items.length;
+      endIndex++
+    ) {
+      const requiredWidth = windowWidth(
+        widths,
+        startIndex,
+        endIndex,
+        mode.gap);
+      if (requiredWidth > options.viewportWidth) break;
+      const candidate = {
+        startIndex,
+        endIndex,
+        requiredWidth,
+        visibleCount: endIndex - startIndex + 1,
+      };
+      if (!includesIndex(candidate, pendingIndex)) continue;
+      if (requiresInitialAnchor && !includesIndex(candidate, anchorIndex)) {
+        continue;
+      }
+      if (targetIndex >= 0) {
+        if (options.windowTarget?.edge === "before"
+          && startIndex !== targetIndex) {
+          continue;
+        }
+        if (options.windowTarget?.edge === "after"
+          && endIndex !== targetIndex) {
+          continue;
+        }
+        if (requireFocusedDuringSlide
+          && !includesIndex(candidate, constrainedFocusedIndex)) {
+          continue;
+        }
+      } else if (constrainedFocusedIndex >= 0
+        && !includesIndex(candidate, constrainedFocusedIndex)) {
+        continue;
+      }
+      candidates.push(candidate);
+    }
+  }
+
+  return candidates;
+}
+
+function requestedCount<TId extends string>(
+  mode: SlideStripMode,
+  items: readonly SlideStripItem<TId>[],
+): number {
+  return Math.min(mode.minimumVisible, items.length);
+}
+
+function fallbackId<TId extends string>(
+  options: ResolveSlideStripOptions<TId>,
+  pendingFocusId: TId | undefined,
+): TId {
+  const candidates = [
+    pendingFocusId,
+    options.windowTarget?.id,
+    options.focusedId,
+    options.retainedLeadingId,
+    options.policy.initialAnchor,
+  ];
+  for (const id of candidates) {
+    if (id !== undefined && itemIndex(options.items, id) >= 0) return id;
+  }
+  const first = options.items[0];
+  if (!first) throw new Error("SlideStrip fallback requires an installed item.");
+  return first.id;
+}
+
+function validateSlideStrip<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  policy: SlideStripPolicy<TId>,
+): void {
+  if (!Number.isFinite(policy.fallbackVisibilityFloor)
+    || policy.fallbackVisibilityFloor <= 0) {
+    throw new Error("SlideStrip fallback visibility floor must be positive.");
+  }
+  if (policy.modes.length === 0
+    || policy.modes[0]?.kind !== "label"
+    || policy.modes.filter(mode => mode.kind === "label").length !== 1) {
+    throw new Error("SlideStrip policy must begin with exactly one Label mode.");
+  }
+  const kinds = new Set<SlideStripRepresentation>();
+  for (const mode of policy.modes) {
+    if (kinds.has(mode.kind)) {
+      throw new Error(`SlideStrip policy duplicates ${mode.kind} mode.`);
+    }
+    if (!Number.isInteger(mode.minimumVisible) || mode.minimumVisible <= 0) {
+      throw new Error("SlideStrip mode minimum visible count must be positive.");
+    }
+    if (!Number.isFinite(mode.gap) || mode.gap < 0) {
+      throw new Error("SlideStrip mode gap must be non-negative.");
+    }
+    kinds.add(mode.kind);
+  }
+  const ids = new Set<TId>();
+  for (const item of items) {
+    if (!item.label) {
+      throw new Error(
+        `SlideStrip item ${JSON.stringify(item.id)} requires a Label.`);
+    }
+    if (ids.has(item.id)) {
+      throw new Error(
+        `SlideStrip item identity ${JSON.stringify(item.id)} is duplicated.`);
+    }
+    ids.add(item.id);
+  }
+  if (items.length > 0 && !ids.has(policy.initialAnchor)) {
+    throw new Error("SlideStrip initial anchor must identify an installed item.");
+  }
+}
+
+export function resolveSlideStrip<TId extends string>(
+  options: ResolveSlideStripOptions<TId>,
+): SlideStripResult<TId> | null {
+  validateSlideStrip(options.items, options.policy);
+  if (!Number.isFinite(options.viewportWidth) || options.viewportWidth < 0) {
+    throw new Error("SlideStrip viewport width must be non-negative.");
+  }
+  if (options.items.length === 0) return null;
+
+  const modes = viableModes(options.items, options.policy);
+  const canRetainFocusedDuringSlide = options.windowTarget !== undefined
+    && options.focusedId !== undefined
+    && modes.some(({ mode }) =>
+      enumerateModeWindows(options, mode, true).length > 0);
+  const pendingFocusId = options.pendingFocusId
+    ?? (options.windowTarget !== undefined
+      && options.focusedId !== undefined
+      && !canRetainFocusedDuringSlide
+      ? options.windowTarget.id
+      : undefined);
+  const effectiveOptions = pendingFocusId === undefined
+    ? options
+    : { ...options, pendingFocusId };
+  const retainedIndex = itemIndex(
+    options.items,
+    options.retainedLeadingId);
+  const anchorIndex = itemIndex(options.items, options.policy.initialAnchor);
+  const resolutions: ModeResolution[] = modes.map(({ mode, modeIndex }) => {
+    const candidates = [...enumerateModeWindows(
+      effectiveOptions,
+      mode,
+      canRetainFocusedDuringSlide)];
+    candidates.sort((left, right) => compareCandidates(
+      left,
+      right,
+      retainedIndex,
+      anchorIndex,
+      options.policy.preferredDirection));
+    return { mode, modeIndex, candidate: candidates[0] ?? null };
+  });
+  const preferred = resolutions[0];
+  if (!preferred) {
+    throw new Error("SlideStrip requires its viable Label mode.");
+  }
+  const baseline = preferred.candidate?.visibleCount ?? 0;
+  let selected = baseline >= requestedCount(preferred.mode, options.items)
+    ? preferred
+    : resolutions.slice(1).find(resolution => {
+        const count = resolution.candidate?.visibleCount ?? 0;
+        return count >= requestedCount(resolution.mode, options.items)
+          && count > baseline;
+      });
+  selected ??= resolutions.reduce((best, resolution) => {
+    const bestCount = best.candidate?.visibleCount ?? 0;
+    const count = resolution.candidate?.visibleCount ?? 0;
+    return count > bestCount ? resolution : best;
+  }, preferred);
+
+  if (!selected.candidate) {
+    const id = fallbackId(options, pendingFocusId);
+    const index = itemIndex(options.items, id);
+    const widths = measurementWidths(
+      options.items,
+      options.measurements,
+      selected.mode.kind);
+    const result: SlideStripResult<TId> = {
+      mode: selected.mode.kind,
+      modeIndex: selected.modeIndex,
+      visibleIds: [id],
+      startIndex: index,
+      endIndex: index,
+      requiredWidth: widths[index] ?? options.policy.fallbackVisibilityFloor,
+      visibleCount: 1,
+      leadingHidden: index > 0,
+      trailingHidden: index < options.items.length - 1,
+      fallback: true,
+      oversizedAlignment: options.policy.oversizedAlignment,
+      ...(pendingFocusId === undefined ? {} : { pendingFocusId }),
+    };
+    return result;
+  }
+
+  const candidate = selected.candidate;
+  return {
+    mode: selected.mode.kind,
+    modeIndex: selected.modeIndex,
+    visibleIds: options.items
+      .slice(candidate.startIndex, candidate.endIndex + 1)
+      .map(item => item.id),
+    startIndex: candidate.startIndex,
+    endIndex: candidate.endIndex,
+    requiredWidth: candidate.requiredWidth,
+    visibleCount: candidate.visibleCount,
+    leadingHidden: candidate.startIndex > 0,
+    trailingHidden: candidate.endIndex < options.items.length - 1,
+    fallback: false,
+    oversizedAlignment: options.policy.oversizedAlignment,
+    ...(pendingFocusId === undefined ? {} : { pendingFocusId }),
+  };
+}
+
+export function slideStripCandidateWidths<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  measurements: readonly SlideStripItemMeasurement<TId>[],
+  policy: SlideStripPolicy<TId>,
+): readonly number[] {
+  validateSlideStrip(items, policy);
+  if (items.length === 0) return [0];
+  const widths = new Set<number>([policy.fallbackVisibilityFloor]);
+  for (const { mode } of viableModes(items, policy)) {
+    const itemWidths = measurementWidths(items, measurements, mode.kind);
+    for (let startIndex = 0; startIndex < items.length; startIndex++) {
+      for (
+        let endIndex = startIndex;
+        endIndex < items.length;
+        endIndex++
+      ) {
+        widths.add(windowWidth(itemWidths, startIndex, endIndex, mode.gap));
+      }
+    }
+  }
+  return [...widths].sort((left, right) => left - right);
+}
+
+export function slideStripMinimumWidth<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  measurements: readonly SlideStripItemMeasurement<TId>[],
+  policy: SlideStripPolicy<TId>,
+  requiredIdentity: SlideStripRequiredIdentity<TId> = {},
+): number {
+  if (items.length === 0) return 0;
+  const requiredId = requiredIdentity.pendingFocusId
+    ?? requiredIdentity.focusedId
+    ?? requiredIdentity.retainedLeadingId;
+  for (const viewportWidth of slideStripCandidateWidths(
+    items,
+    measurements,
+    policy)) {
+    const result = resolveSlideStrip({
+      items,
+      measurements,
+      policy,
+      viewportWidth,
+      ...(requiredId === undefined ? {} : { focusedId: requiredId }),
+    });
+    if (!result) continue;
+    const mode = policy.modes[result.modeIndex];
+    if (mode
+      && result.visibleCount >= requestedCount(mode, items)
+      && !result.fallback) {
+      return viewportWidth;
+    }
+  }
+  return policy.fallbackVisibilityFloor;
+}
+
+export function slideStripPreferredWidth<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  measurements: readonly SlideStripItemMeasurement<TId>[],
+  policy: SlideStripPolicy<TId>,
+): number {
+  if (items.length === 0) return 0;
+  validateSlideStrip(items, policy);
+  const labelMode = policy.modes[0];
+  if (!labelMode) throw new Error("SlideStrip requires a Label mode.");
+  const widths = measurementWidths(items, measurements, "label");
+  return windowWidth(widths, 0, items.length - 1, labelMode.gap);
+}
+
+export function adjacentSlideTarget<TId extends string>(
+  items: readonly SlideStripItem<TId>[],
+  current: SlideStripResult<TId> | null,
+  direction: SlideStripDirection,
+): SlideStripWindowTarget<TId> | null {
+  if (!current) return null;
+  const index = direction === "after"
+    ? current.endIndex + 1
+    : current.startIndex - 1;
+  const item = items[index];
+  return item ? { id: item.id, edge: direction } : null;
+}

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -251,8 +251,8 @@ body {
   top: 50%;
   width: 0;
   height: 0;
-  border-top: 9px solid transparent;
-  border-bottom: 9px solid transparent;
+  border-top: 14px solid transparent;
+  border-bottom: 14px solid transparent;
   transform: translateY(-50%);
   pointer-events: none;
 }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -197,7 +197,7 @@ body {
   align-items: center;
   min-width: 0;
   height: 100%;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   padding: 0 6px;
   overflow-x: auto;
   overflow-y: hidden;
@@ -207,7 +207,34 @@ body {
   gap: 2px;
 }
 .lensbar::-webkit-scrollbar { height: 0; }
-.lensbar button {
+.slide-strip {
+  position: relative;
+  flex: none;
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+.slide-strip-items {
+  display: flex;
+  align-items: center;
+  width: max-content;
+  height: 100%;
+  gap: 2px;
+}
+.slide-strip[data-fallback="true"][data-oversized-alignment="end"] .slide-strip-items {
+  position: absolute;
+  right: 0;
+}
+.slide-strip-item[hidden] { display: none; }
+.slide-strip [data-slide-strip-representation] { display: none; }
+.slide-strip[data-mode="label"] [data-slide-strip-representation="label"],
+.slide-strip[data-mode="short-label"] [data-slide-strip-representation="short-label"],
+.slide-strip[data-mode="icon"] [data-slide-strip-representation="icon"],
+.slide-strip[data-mode="index"] [data-slide-strip-representation="index"] {
+  display: inline;
+}
+.slide-strip button {
   height: 38px;
   padding: 0 12px;
   border: 0;
@@ -218,11 +245,53 @@ body {
 }
 .lensbar button:hover { color: var(--text); background: rgba(255,255,255,.015); }
 .lensbar button.active { color: var(--text); border-bottom-color: var(--accent); }
-.inspector-strip { display: flex; align-items: center; gap: 2px; }
+.slide-strip-edge {
+  position: absolute;
+  z-index: 2;
+  top: 6px;
+  bottom: 6px;
+  width: 8px;
+  pointer-events: none;
+}
+.slide-strip-edge.before {
+  left: 0;
+  border-left: 2px solid var(--accent);
+  background: linear-gradient(90deg, var(--panel), transparent);
+}
+.slide-strip-edge.after {
+  right: 0;
+  border-right: 2px solid var(--accent);
+  background: linear-gradient(270deg, var(--panel), transparent);
+}
+.slide-strip-allocation {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+}
+.slide-strip-allocation[hidden] { display: none; }
+.slide-strip-allocation button {
+  width: 22px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--dim);
+  font: 13px var(--mono);
+}
+.slide-strip-allocation button:hover:not([aria-disabled="true"]) {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+.slide-strip-allocation button[aria-disabled="true"] {
+  opacity: .35;
+  cursor: default;
+}
 .home-lens { color: var(--text) !important; font-weight: 600; cursor: pointer; }
 .home-lens.active { border-bottom-color: var(--accent); }
 .home-lens span { color: var(--accent); margin-right: 6px; }
-.scope-switch { display: flex; align-items: center; gap: 2px; padding: 3px; margin-right: 4px; background: rgba(127,127,127,.08); border: 1px solid var(--line); border-radius: 8px; }
+.scope-switch { padding: 3px; background: rgba(127,127,127,.08); border: 1px solid var(--line); border-radius: 8px; }
 .scope-switch button.scope-seg {
   height: 26px;
   padding: 0 12px;
@@ -236,7 +305,7 @@ body {
 }
 .scope-switch button.scope-seg:hover { color: var(--text); background: rgba(127,127,127,.12); }
 .scope-switch button.scope-seg.active { color: #fff; background: var(--accent); border-bottom-color: transparent; }
-.lens-separator { width: 1px; height: 17px; background: var(--line); margin: 0 5px; }
+.lens-separator { flex: none; width: 1px; height: 17px; background: var(--line); margin: 0 4px; }
 .workspace-coordinate-list { min-height: 0; overflow: auto; padding: 8px; }
 .workspace-coordinate {
   display: grid;
@@ -391,7 +460,7 @@ body {
   max-width: 320px;
   min-width: 72px;
 }
-.lens kbd { margin-left: 8px; color: var(--dim); font: 10px var(--mono); }
+.lens kbd { color: var(--dim); font: 10px var(--mono); }
 .lens-context { color: var(--dim); font: 10px var(--mono); }
 
 .workspace {
@@ -1282,9 +1351,6 @@ kbd {
   .brand span:last-child { display: none; }
   .inspected-target { gap: 6px; padding: 0 10px; }
   .subject-path-separator { margin: 0 6px; }
-  .lensbar button.lens { width: 28px; padding: 0; }
-  .lensbar .lens-label { display: none; }
-  .lensbar .lens kbd { margin-left: 0; }
   .workspace { grid-template-columns: 44% 56%; }
   .type-browser:not(.member-nav) .namespace-chips, .pane-footer { display: none; }
   .type-browser { grid-template-rows: 40px 38px auto auto minmax(0, 1fr); }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -248,20 +248,21 @@ body {
 .slide-strip-edge {
   position: absolute;
   z-index: 2;
-  top: 6px;
-  bottom: 6px;
-  width: 8px;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-top: 9px solid transparent;
+  border-bottom: 9px solid transparent;
+  transform: translateY(-50%);
   pointer-events: none;
 }
 .slide-strip-edge.before {
   left: 0;
-  border-left: 2px solid var(--accent);
-  background: linear-gradient(90deg, var(--panel), transparent);
+  border-right: 4px solid var(--accent);
 }
 .slide-strip-edge.after {
   right: 0;
-  border-right: 2px solid var(--accent);
-  background: linear-gradient(270deg, var(--panel), transparent);
+  border-left: 4px solid var(--accent);
 }
 .slide-strip-allocation {
   flex: none;

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -248,21 +248,20 @@ body {
 .slide-strip-edge {
   position: absolute;
   z-index: 2;
-  top: 50%;
-  width: 0;
-  height: 0;
-  border-top: 14px solid transparent;
-  border-bottom: 14px solid transparent;
-  transform: translateY(-50%);
+  top: 6px;
+  bottom: 6px;
+  width: 8px;
   pointer-events: none;
 }
 .slide-strip-edge.before {
   left: 0;
-  border-right: 4px solid var(--accent);
+  border-left: 2px solid var(--accent);
+  background: linear-gradient(90deg, var(--panel), transparent);
 }
 .slide-strip-edge.after {
   right: 0;
-  border-left: 4px solid var(--accent);
+  border-right: 2px solid var(--accent);
+  background: linear-gradient(270deg, var(--panel), transparent);
 }
 .slide-strip-allocation {
   flex: none;

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -6,6 +6,7 @@ import {
   clampAllocationOrdinal,
   renderScopeBar,
   restoreScopeBarFocus,
+  scopeBarShortLabel,
   type ScopeBarBindingActions,
 } from "../src/scope-bar.ts";
 import { fakeDom } from "./fake-dom.ts";
@@ -14,6 +15,13 @@ test("allocation ordinals clamp to the current stable ladder", () => {
   assert.equal(clampAllocationOrdinal(3, 2), 1);
   assert.equal(clampAllocationOrdinal(1, 4), 1);
   assert.equal(clampAllocationOrdinal(-1, 4), 0);
+});
+
+test("scope-bar short labels are word initialisms", () => {
+  assert.equal(scopeBarShortLabel("Overview"), "O");
+  assert.equal(scopeBarShortLabel("Call graph"), "CG");
+  assert.equal(scopeBarShortLabel("Annotated source"), "AS");
+  assert.equal(scopeBarShortLabel("API"), "A");
 });
 
 class FakeElement {

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -135,8 +135,8 @@ test("workspace scope leads the subject ladder without an inspector", () => {
 
   assert.match(
     html,
-    /data-scope="workspace" role="tab" aria-selected="true" tabindex="0" id="active-subject-tab" data-subject-tab aria-controls="subject-panel"[\s\S]*data-scope="package"[\s\S]*data-scope="type"/);
-  assert.doesNotMatch(html, /package-coordinate-controls|class="lens /);
+    /data-scope="workspace"[^>]*role="tab" aria-selected="true" tabindex="0" id="active-subject-tab" data-subject-tab aria-controls="subject-panel"[\s\S]*data-scope="package"[\s\S]*data-scope="type"/);
+  assert.doesNotMatch(html, /package-coordinate-controls|class="[^"]* lens(?: |")/);
 });
 
 test("type scope bindings dispatch only scope and type-lens controls", () => {
@@ -246,7 +246,7 @@ test("subject and inspector strips omit package coordinate selectors", () => {
     escapeHtml,
   });
 
-  assert.match(html, /class="scope-switch"[\s\S]*class="lens-separator"[\s\S]*data-lens="api"/);
+  assert.match(html, /class="[^"]*scope-switch[^"]*"[\s\S]*class="lens-separator"[\s\S]*data-lens="api"/);
   assert.doesNotMatch(
     html,
     /package-coordinate-controls|package-version|framework-select/);
@@ -261,11 +261,11 @@ test("package scope marks only the package segment and the active package lens",
     escapeHtml,
   });
 
-  assert.match(html, /data-scope="package" role="tab" aria-selected="true"/);
-  assert.match(html, /data-scope="type" role="tab" aria-selected="false"/);
+  assert.match(html, /data-scope="package"[^>]*role="tab" aria-selected="true"/);
+  assert.match(html, /data-scope="type"[^>]*role="tab" aria-selected="false"/);
   assert.doesNotMatch(html, /data-scope="member"/);
-  assert.match(html, /class="lens active" data-package-lens="dependencies"/);
-  assert.doesNotMatch(html, /class="lens active" data-package-lens="overview"/);
+  assert.match(html, /class="[^"]*\blens active" data-package-lens="dependencies"/);
+  assert.doesNotMatch(html, /class="[^"]*\blens active" data-package-lens="overview"/);
 });
 
 test("type scope marks the type segment and renders the fixed type lenses", () => {
@@ -278,15 +278,15 @@ test("type scope marks the type segment and renders the fixed type lenses", () =
     escapeHtml,
   });
 
-  assert.match(html, /data-scope="type" role="tab" aria-selected="true"/);
+  assert.match(html, /data-scope="type"[^>]*role="tab" aria-selected="true"/);
   assert.doesNotMatch(html, /data-scope="member"/);
-  assert.match(html, /class="lens active" data-lens="api"/);
+  assert.match(html, /class="[^"]*\blens active" data-lens="api"/);
   assert.match(
     html,
-    /role="tab" aria-selected="true" tabindex="0" id="active-inspector-tab" aria-controls="inspector-panel"[\s\S]*aria-label="API" title="API"><span class="lens-label">API<\/span><kbd aria-hidden="true">1<\/kbd>/);
+    /role="tab" aria-selected="true" tabindex="0" id="active-inspector-tab" aria-controls="inspector-panel"[\s\S]*aria-label="API" title="API">[\s\S]*data-slide-strip-representation="label">API<\/span>[\s\S]*data-slide-strip-representation="index" aria-hidden="true">1<\/kbd>/);
   assert.match(
     html,
-    /class="inspector-strip" role="tablist" aria-label="Type lenses"/);
+    /class="[^"]*inspector-strip"[\s\S]*role="tablist"[\s\S]*aria-label="Type lenses"/);
   assert.match(html, /data-lens="metadata"/);
   assert.match(html, /data-lens="source"/);
 });
@@ -300,8 +300,8 @@ test("member scope adds a member segment alongside package and type", () => {
     escapeHtml,
   });
 
-  assert.match(html, /data-scope="member" role="tab" aria-selected="true"/);
-  assert.match(html, /class="lens active" data-member-section="facts"/);
+  assert.match(html, /data-scope="member"[^>]*role="tab" aria-selected="true"/);
+  assert.match(html, /class="[^"]*\blens active" data-member-section="facts"/);
 });
 
 test("type scope can expose the first-class member segment", () => {
@@ -314,7 +314,7 @@ test("type scope can expose the first-class member segment", () => {
     escapeHtml,
   });
 
-  assert.match(html, /data-scope="member" role="tab" aria-selected="false"/);
+  assert.match(html, /data-scope="member"[^>]*role="tab" aria-selected="false"/);
 });
 
 test("member scope names an empty filtered strip", () => {
@@ -341,13 +341,13 @@ test("lens buttons separate accessible labels from compact order symbols", () =>
 
   assert.match(
     html,
-    /role="tab" aria-selected="true" tabindex="0" id="active-inspector-tab"[\s\S]*aria-label="API" title="API"><span class="lens-label">API<\/span><kbd aria-hidden="true">1<\/kbd>/);
+    /role="tab" aria-selected="true" tabindex="0" id="active-inspector-tab"[\s\S]*aria-label="API" title="API">[\s\S]*data-slide-strip-representation="label">API<\/span>[\s\S]*data-slide-strip-representation="index" aria-hidden="true">1<\/kbd>/);
   assert.match(
     html,
-    /role="tab" aria-selected="false" tabindex="-1"[\s\S]*aria-label="Metadata" title="Metadata"><span class="lens-label">Metadata<\/span><kbd aria-hidden="true">2<\/kbd>/);
+    /role="tab" aria-selected="false" tabindex="-1"[\s\S]*aria-label="Metadata" title="Metadata">[\s\S]*data-slide-strip-representation="label">Metadata<\/span>[\s\S]*data-slide-strip-representation="index" aria-hidden="true">2<\/kbd>/);
   assert.match(
     html,
-    /aria-label="Source" title="Source"><span class="lens-label">Source<\/span><kbd aria-hidden="true">3<\/kbd>/);
+    /aria-label="Source" title="Source">[\s\S]*data-slide-strip-representation="label">Source<\/span>[\s\S]*data-slide-strip-representation="index" aria-hidden="true">3<\/kbd>/);
 });
 
 test("lens button labels are escaped", () => {
@@ -364,19 +364,35 @@ test("lens button labels are escaped", () => {
 });
 
 test("no strip entry is marked active when nothing matches activeStripId", () => {
-  const html = renderScopeBar({
+  const html = renderScopeBar<string>({
     scope: "package",
     strip: [["overview", "Overview"]],
-    activeStripId: null,
+    activeStripId: "dependencies",
     stripAttribute: "data-package-lens",
     escapeHtml,
   });
 
-  assert.doesNotMatch(html, /class="lens active"/);
+  assert.match(html, /data-slide-strip="inspector"[\s\S]*data-initial-anchor="overview"/);
+  assert.doesNotMatch(html, /class="[^"]*\blens active"/);
   assert.match(
     html,
-    /data-package-lens="overview" data-inspector-tab role="tab" aria-selected="false" tabindex="0"/);
+    /data-package-lens="overview"[^>]*data-inspector-tab role="tab" aria-selected="false" tabindex="0"/);
   assert.doesNotMatch(
     html,
     /data-package-lens="overview"[^>]*aria-controls=/);
+});
+
+test("a missing active subject anchors to the nearest installed subject", () => {
+  const html = renderScopeBar({
+    scope: "member",
+    strip: [],
+    activeStripId: null,
+    stripAttribute: "data-member-section",
+    showMemberScope: false,
+    escapeHtml,
+  });
+
+  assert.match(
+    html,
+    /data-slide-strip="subject"[\s\S]*data-initial-anchor="type"/);
 });

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -3,11 +3,18 @@ import test from "node:test";
 import {
   bindScopeBar,
   captureScopeBarFocus,
+  clampAllocationOrdinal,
   renderScopeBar,
   restoreScopeBarFocus,
   type ScopeBarBindingActions,
 } from "../src/scope-bar.ts";
 import { fakeDom } from "./fake-dom.ts";
+
+test("allocation ordinals clamp to the current stable ladder", () => {
+  assert.equal(clampAllocationOrdinal(3, 2), 1);
+  assert.equal(clampAllocationOrdinal(1, 4), 1);
+  assert.equal(clampAllocationOrdinal(-1, 4), 0);
+});
 
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;

--- a/prototypes/inspect-web/test/slide-strip.test.ts
+++ b/prototypes/inspect-web/test/slide-strip.test.ts
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  adjacentSlideTarget,
+  resolveSlideStrip,
+  slideStripMinimumWidth,
+  type SlideStripItem,
+  type SlideStripItemMeasurement,
+  type SlideStripMode,
+  type SlideStripPolicy,
+} from "../src/slide-strip.ts";
+
+const items = [
+  { id: "overview", label: "Overview", shortLabel: "OV", icon: "◫" },
+  { id: "call-graph", label: "Call graph", shortLabel: "CG", icon: "⑂" },
+  { id: "facts", label: "Facts", shortLabel: "FX", icon: "·" },
+  { id: "source", label: "Source", shortLabel: "SRC", icon: "⌘" },
+] as const satisfies readonly SlideStripItem[];
+
+const modes = [
+  { kind: "label", minimumVisible: 2, gap: 2 },
+  { kind: "short-label", minimumVisible: 2, gap: 2 },
+  { kind: "icon", minimumVisible: 2, gap: 2 },
+  { kind: "index", minimumVisible: 2, gap: 2 },
+] as const satisfies readonly SlideStripMode[];
+
+const policy: SlideStripPolicy = {
+  modes,
+  initialAnchor: "overview",
+  preferredDirection: "after",
+  continuityKey: "inspectors-v1",
+  fallbackVisibilityFloor: 24,
+  oversizedAlignment: "start",
+};
+
+const labelPolicy: SlideStripPolicy = {
+  ...policy,
+  modes: [{ kind: "label", minimumVisible: 1, gap: 2 }],
+};
+
+function measured(
+  widths: readonly [
+    number,
+    number,
+    number,
+    number,
+  ],
+): readonly SlideStripItemMeasurement[] {
+  return items.map((item, index) => {
+    const label = widths[index];
+    if (label === undefined) {
+      throw new Error(`Missing test width at index ${index}.`);
+    }
+    return {
+      id: item.id,
+      widths: {
+        label,
+        "short-label": 30,
+        icon: 22,
+        index: 24,
+      },
+    };
+  });
+}
+
+test("empty inventory has one empty state", () => {
+  assert.equal(resolveSlideStrip({
+    items: [],
+    measurements: [],
+    policy: { ...policy, initialAnchor: "" },
+    viewportWidth: 100,
+  }), null);
+});
+
+test("a visible window uses one representation and remains contiguous", () => {
+  const result = resolveSlideStrip({
+    items,
+    measurements: measured([80, 90, 60, 70]),
+    policy,
+    viewportWidth: 174,
+  });
+
+  assert.equal(result?.mode, "label");
+  assert.deepEqual(result?.visibleIds, ["overview", "call-graph"]);
+  assert.equal(result?.leadingHidden, false);
+  assert.equal(result?.trailingHidden, true);
+});
+
+test("optional mode is skipped when one item omits its representation", () => {
+  const incomplete = items.map(item => item.id === "facts"
+    ? { id: item.id, label: item.label, icon: item.icon }
+    : item);
+  const result = resolveSlideStrip({
+    items: incomplete,
+    measurements: measured([90, 90, 90, 90]),
+    policy,
+    viewportWidth: 62,
+  });
+
+  assert.equal(result?.mode, "icon");
+  assert.deepEqual(result?.visibleIds, ["overview", "call-graph"]);
+});
+
+test("compact mode requires a density benefit over failed Label", () => {
+  const noBenefit = measured([50, 50, 50, 50]).map(item => ({
+    ...item,
+    widths: {
+      label: 50,
+      "short-label": 50,
+      icon: 50,
+      index: 50,
+    },
+  }));
+  const result = resolveSlideStrip({
+    items,
+    measurements: noBenefit,
+    policy,
+    viewportWidth: 50,
+  });
+
+  assert.equal(result?.mode, "label");
+  assert.equal(result?.visibleCount, 1);
+});
+
+test("non-monotonic requested counts select the first qualifying mode", () => {
+  const nonMonotonicPolicy: SlideStripPolicy = {
+    ...policy,
+    modes: [
+      { kind: "label", minimumVisible: 2, gap: 2 },
+      { kind: "short-label", minimumVisible: 4, gap: 2 },
+      { kind: "index", minimumVisible: 2, gap: 2 },
+    ],
+  };
+  const result = resolveSlideStrip({
+    items,
+    measurements: measured([80, 80, 80, 80]),
+    policy: nonMonotonicPolicy,
+    viewportWidth: 76,
+  });
+
+  assert.equal(result?.mode, "index");
+  assert.equal(result?.visibleCount, 3);
+});
+
+test("retained leading identity wins equal-count placement", () => {
+  const result = resolveSlideStrip({
+    items,
+    measurements: measured([50, 50, 50, 50]),
+    policy,
+    viewportWidth: 102,
+    retainedLeadingId: "call-graph",
+  });
+
+  assert.deepEqual(result?.visibleIds, ["call-graph", "facts"]);
+  assert.equal(result?.leadingHidden, true);
+  assert.equal(result?.trailingHidden, true);
+});
+
+test("directional slide pins the adjacent hidden item and retains focus", () => {
+  const measurements = measured([40, 40, 40, 40]);
+  const current = resolveSlideStrip({
+    items,
+    measurements,
+    policy: labelPolicy,
+    viewportWidth: 82,
+  });
+  assert.ok(current);
+  const retainedLeadingId = current.visibleIds[0];
+  assert.ok(retainedLeadingId);
+  const target = adjacentSlideTarget(items, current, "after");
+  assert.deepEqual(target, { id: "facts", edge: "after" });
+
+  const result = resolveSlideStrip({
+    items,
+    measurements,
+    policy: labelPolicy,
+    viewportWidth: 82,
+    retainedLeadingId,
+    focusedId: "call-graph",
+    ...(target ? { windowTarget: target } : {}),
+  });
+
+  assert.deepEqual(result?.visibleIds, ["call-graph", "facts"]);
+  assert.equal(result?.pendingFocusId, undefined);
+});
+
+test("directional slide transfers in-strip focus when it cannot coexist", () => {
+  const measurements = measured([40, 80, 40, 40]);
+  const current = resolveSlideStrip({
+    items,
+    measurements,
+    policy: labelPolicy,
+    viewportWidth: 82,
+  });
+  assert.ok(current);
+  const retainedLeadingId = current.visibleIds[0];
+  assert.ok(retainedLeadingId);
+  const target = adjacentSlideTarget(items, current, "after");
+  assert.ok(target);
+
+  const result = resolveSlideStrip({
+    items,
+    measurements,
+    policy: labelPolicy,
+    viewportWidth: 40,
+    retainedLeadingId,
+    focusedId: "overview",
+    windowTarget: target,
+  });
+
+  assert.deepEqual(result?.visibleIds, ["call-graph"]);
+  assert.equal(result?.pendingFocusId, "call-graph");
+});
+
+test("external-focus slide installs an oversized adjacent singleton", () => {
+  const twoItems = items.slice(0, 2);
+  const measurements = measured([40, 200, 40, 40]).slice(0, 2);
+  const current = resolveSlideStrip({
+    items: twoItems,
+    measurements,
+    policy: { ...labelPolicy, initialAnchor: "overview" },
+    viewportWidth: 100,
+  });
+  const target = adjacentSlideTarget(twoItems, current, "after");
+  assert.deepEqual(target, { id: "call-graph", edge: "after" });
+
+  const result = resolveSlideStrip({
+    items: twoItems,
+    measurements,
+    policy: { ...labelPolicy, initialAnchor: "overview" },
+    viewportWidth: 100,
+    retainedLeadingId: "overview",
+    ...(target ? { windowTarget: target } : {}),
+  });
+
+  assert.deepEqual(result?.visibleIds, ["call-graph"]);
+  assert.equal(result?.fallback, true);
+  assert.equal(result?.requiredWidth, 200);
+  assert.equal(result?.pendingFocusId, undefined);
+});
+
+test("focus navigation outranks retained placement", () => {
+  const result = resolveSlideStrip({
+    items,
+    measurements: measured([50, 50, 50, 50]),
+    policy,
+    viewportWidth: 102,
+    retainedLeadingId: "overview",
+    pendingFocusId: "source",
+  });
+
+  assert.deepEqual(result?.visibleIds, ["facts", "source"]);
+  assert.equal(result?.pendingFocusId, "source");
+});
+
+test("focus navigation may replace the previously focused window", () => {
+  const result = resolveSlideStrip({
+    items,
+    measurements: measured([50, 50, 50, 50]),
+    policy,
+    viewportWidth: 102,
+    retainedLeadingId: "overview",
+    focusedId: "overview",
+    pendingFocusId: "source",
+  });
+
+  assert.deepEqual(result?.visibleIds, ["facts", "source"]);
+  assert.equal(result?.fallback, false);
+  assert.equal(result?.pendingFocusId, "source");
+});
+
+test("minimum width chooses a viable policy minimum", () => {
+  assert.equal(
+    slideStripMinimumWidth(
+      items,
+      measured([80, 90, 60, 70]),
+      policy),
+    46);
+});
+
+test("minimum width is resolved around the effective required identity", () => {
+  assert.equal(
+    slideStripMinimumWidth(
+      items,
+      measured([20, 20, 100, 20]),
+      labelPolicy,
+      { focusedId: "facts" }),
+    100);
+  assert.equal(
+    slideStripMinimumWidth(
+      items,
+      measured([100, 20, 20, 20]),
+      {
+        ...labelPolicy,
+        modes: [{ kind: "label", minimumVisible: 2, gap: 2 }],
+      },
+      { retainedLeadingId: "overview" }),
+    122);
+});
+
+test("invalid policies and inventories fail visibly", () => {
+  assert.throws(() => resolveSlideStrip({
+    items,
+    measurements: measured([50, 50, 50, 50]),
+    policy: { ...policy, modes: modes.slice(1) },
+    viewportWidth: 100,
+  }), /begin with exactly one Label/);
+  assert.throws(() => resolveSlideStrip({
+    items,
+    measurements: measured([50, 50, 50, 50]),
+    policy: { ...policy, initialAnchor: "missing" },
+    viewportWidth: 100,
+  }), /initial anchor/);
+  assert.throws(() => resolveSlideStrip({
+    items: [{ id: "empty", label: "" }],
+    measurements: [{ id: "empty", widths: { label: 20 } }],
+    policy: { ...policy, initialAnchor: "empty" },
+    viewportWidth: 100,
+  }), /requires a Label/);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -1539,16 +1539,18 @@ test("typed scope bar owns its rendered control bindings", () => {
   const rootScopeCall = onlyCallExpressionNamed(appSyntax, "bindScopeBarEvents");
   assert.equal(rootScopeCall.arguments.length, 0);
   const innerScopeCall = onlyCallExpressionNamed(appSyntax, "bindScopeBar");
-  assert.equal(innerScopeCall.arguments.length, 2);
+  assert.equal(innerScopeCall.arguments.length, 3);
   assertIdentifierArgument(innerScopeCall, 0, "document", "bindScopeBar");
+  assertIdentifierArgument(innerScopeCall, 2, "scopeBarState", "bindScopeBar");
   assert.equal(
     callExpressionsNamed(scopeEventBinder, "bindScopeBar").length,
     1);
   assert.equal(
-    directCallExpression(
-      onlySyntaxNode(scopeEventBinder.body.body, "bindScopeBarEvents body"),
-      "bindScopeBar"),
-    innerScopeCall);
+    scopeEventBinder.body.body.filter(statement =>
+      statement.type === "ExpressionStatement"
+      && statement.expression.type === "AssignmentExpression"
+      && statement.expression.right === innerScopeCall).length,
+    1);
   assert.equal(
     callExpressionsNamed(rootEventBinder, "bindScopeBarEvents").length,
     1);
@@ -2963,7 +2965,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /function restorePackageQueryWorkspaceFocus\(\) \{\s*const navigationSeq = packageQueryWorkspaceFocusNavigationSeq;[\s\S]*navigationSequence\.isCurrent\(navigationSeq\)[\s\S]*afterCurrentNavigationFrame\(\(\) => \{\s*if \(!focusLevelOneHeading\(\)\) \{\s*document\.querySelector<HTMLElement>\("#type-list"\)\?\.focus\(\)/);
   assert.match(
     appSource,
-    /bindEvents\(\);\s*if \(scopeBarFocus\) restoreScopeBarFocus\(document, scopeBarFocus\);\s*restorePackageQueryReturnFocus\(\);\s*restorePackageQueryWorkspaceFocus\(\)/);
+    /bindEvents\(\);\s*if \(scopeBarOwnsFocus\) \{\s*let restored = false;\s*if \(scopeBarFocus\) \{\s*scopeBarBinding\?\.revealFocusTarget\(scopeBarFocus\);\s*restored = restoreScopeBarFocus\(document, scopeBarFocus\);\s*\}\s*if \(!restored\) \{\s*document\.querySelector<HTMLElement>\("\.brand"\)\s*\?\.focus\(\{ preventScroll: true \}\);\s*\}\s*app\.removeAttribute\("tabindex"\);\s*\}\s*restorePackageQueryReturnFocus\(\);\s*restorePackageQueryWorkspaceFocus\(\)/);
   assert.match(
     popstate,
     /leftPackageQueryForWorkspaceSuccessor =\s*!state\.packageQueryReturnFocusPending;[\s\S]*if \(leftPackageQueryForWorkspaceSuccessor\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq/);

--- a/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
+++ b/prototypes/inspect-web/test/vocabulary-exhaustiveness.test.ts
@@ -38,7 +38,11 @@ const widenings = [
     find: '  ["source", "Source"]\n] as const;\n\nexport type TypeLens',
     replace: '  ["source", "Source"],\n  ["probe-type-lens", "Probe"]\n] as const;\n\nexport type TypeLens',
     token: "probe-type-lens",
-    dispatches: ["renderLens", "loadSelectedTypeLensData"],
+    dispatches: [
+      "typeLensPresentation",
+      "renderLens",
+      "loadSelectedTypeLensData",
+    ],
   },
   {
     vocabulary: "PackageLens",
@@ -46,7 +50,7 @@ const widenings = [
     find: '  ["metadata", "Metadata"]\n] as const;',
     replace: '  ["metadata", "Metadata"],\n  ["probe-package-lens", "Probe"]\n] as const;',
     token: "probe-package-lens",
-    dispatches: ["packageLensBody"],
+    dispatches: ["packageLensBody", "packageLensPresentation"],
   },
   {
     vocabulary: "MemberSection",
@@ -54,7 +58,13 @@ const widenings = [
     find: '  ["annotated", "Annotated source"],\n] as const;',
     replace: '  ["annotated", "Annotated source"],\n  ["probe-member-section", "Probe"],\n] as const;',
     token: "probe-member-section",
-    dispatches: ["loadMemberSectionContent", "applyView", "renderMember", "loadSelectionData"],
+    dispatches: [
+      "memberSectionPresentation",
+      "loadMemberSectionContent",
+      "applyView",
+      "renderMember",
+      "loadSelectionData",
+    ],
   },
   {
     vocabulary: "WorkspaceScope",


### PR DESCRIPTION
## Demo

Inspect Web now keeps subjects and inspectors as contiguous, uniformly rendered
windows instead of collapsing individual labels independently. At wide widths
both strips show complete labels; under pressure the inspector strip selects
one whole-strip compact representation, edge highlights disclose hidden
inventory, and the allocation arrows trade space between the two strips
without changing selection.

What to notice:

- narrowing moves from complete labels through stable sliding windows and
  compact inspector labels;
- wheel or keyboard navigation reveals adjacent hidden inspectors without
  stealing external focus;
- the active subject remains prominent while the inspector strip receives the
  remaining capacity;
- terminal pressure preserves at least one subject and one inspector without
  page-level overflow.

### Responsive production views

**760 px — Label windows with allocation controls**

![Inspect Web SlideStrip at 760 pixels](https://github.com/user-attachments/assets/82641c4c-bd2a-463c-b329-45a0d57a42a4)

**480 px — one full subject label and uniform inspector short labels**

![Inspect Web SlideStrip at 480 pixels](https://github.com/user-attachments/assets/670801d5-ed0b-4864-8b1f-af8a907eaeaf)

## Summary

- add a reusable measurement-driven `SlideStrip` resolver and DOM controller
- compose subject and inspector strips through a stable Pareto allocation
  ladder
- preserve focus, roving tab stops, retained windows, and allocation state
  across resize and shell replacement
- supply complete, word-initial short, icon, and index presentations for the
  first Inspect Web adopter

## Compatibility

Application-action relocation remains out of scope for this slice (#5482 and
#5483). The implementation preserves existing subject and inspector
identities, selection, activation, panel relationships, and URL state.

## Validation

- `npm test`
- `npm run test:browser`
- `npm run analyze`
- `npm run build`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`
