### PR TITLE
Wire artifact sessions to exact group completion

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -300,10 +300,18 @@ reaching a lock.
 
 Disposal then disposes published groups. A group may already have an active
 callback that has not performed its first lazy content open. Artifact leases
-therefore outlive `Dispose()` and are released only after every dependent group
-reports quiescence. Synchronous disposal may initiate this deferred release; it
-must not invalidate content under an active callback. Cleanup failures compose
-with, and never replace, the active operation failure.
+therefore outlive `Dispose()` and are released only after every exact dependent
+group reports quiescence. The asynchronous `InspectionWorkspace` records this
+association from the published `ArtifactSetSession` and its query lease to the
+workspace-owned group objects whose participants carry registrations minted by
+that session. Ownership transfer requires the complete set of current dependent
+groups; later admission remains available for unrelated work but rejects a new
+group projected from that transferred session. It observes only those groups'
+owner-issued release receipts; an unrelated, foreign, or incomplete group set
+cannot authorize release. Cleanup failures compose with, and never replace,
+group cleanup results in the workspace close report. If coordinated group close
+faults, artifact cleanup still runs and its failures remain available from the
+terminal `CloseReport` before the original close failure is rethrown.
 
 ### Interaction model
 
@@ -329,14 +337,13 @@ demand's requested generation is also fixed once it arrives; the model does not
 represent a caller re-deriving a different generation when it replans after an
 incompatible admission terminates.
 
-The model checks the design intent stated in the prose above, not the current
-`ArtifactSetSession` implementation. `ArtifactSetSession`'s own doc comment
-states it "does not yet implement workspace-wide reservation, single-flight
-admission, or dependent-group quiescence": today it serves one caller per
-generation with no multi-demand join or incompatible-generation wait, and
-`Dispose()` releases every acquisition lease immediately rather than
-deferring release until dependent groups quiesce. Closing that gap is
-tracked as future implementation work, not a defect this model found.
+The model checks the design intent stated in the prose above. The asynchronous
+`InspectionWorkspace` now owns the exact published-session-to-dependent-group
+association and disposes the session only after all recorded group release
+receipts complete. `ArtifactSetSession` still serves one caller per generation
+with no workspace-wide reservation, multi-demand join, or
+incompatible-generation wait. Closing those admission gaps remains future
+implementation work, not a defect this model found.
 
 TLC 2026.08.21.155922 (rev `9787e65`, from the pinned `tla2tools.jar` v1.8.0 —
 see [`docs/runbooks/tla-plus-setup.md`](../runbooks/tla-plus-setup.md))
@@ -2362,8 +2369,10 @@ The migration is intentionally incremental:
    source-access authorization below core assembly Queries; keep NuGet symbol
    source policy in an optional companion.
 5. **Separate workspace realization.** Move package/platform realization out of
-   core assembly Queries into optional adapters or companion projects, and make
-   retained workspaces own multiple sealed artifact sessions.
+   core assembly Queries into optional adapters or companion projects. The
+   asynchronous workspace now owns exact sealed artifact sessions through their
+   dependent-group release receipts; package/platform realization migration and
+   multi-session host adoption remain outstanding.
 6. **Adapt package acquisition.** Reuse current package stores, source policy,
    package admission, and TFM selection behind a package artifact adapter.
 7. **Move package correspondence.** Have the package adapter mint typed
@@ -2444,7 +2453,11 @@ The target is complete only when tests equivalent to these exist:
 - `ArtifactAccess_RetainedOpenerCancellationEndsAtCallbackReturn`
 - `ArtifactAccess_StreamDisposalFailureStillReportsQuiescence`
 - `ArtifactAccess_MaterializationReadPreservesCallerCancellation`
-- `ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce`
+- `ArtifactSetSession_ReleasesLeasesOnlyAfterOpenArtifactStreamsQuiesce`
+- `WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces`
+- `RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet`
+- `WorkspaceClose_ReportsArtifactSessionCleanupFailure`
+- `WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedCloseFaults`
 - `ArtifactSetSession_DisposalCancelsInFlightMaterialization`
 - `ArtifactSetSession_CancellationCallbackFailureDoesNotSkipLeaseCleanup`
 - `ArtifactSetSession_PreservesPrimaryFailureWhenCleanupFails`

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -310,8 +310,9 @@ group projected from that transferred session. It observes only those groups'
 owner-issued release receipts; an unrelated, foreign, or incomplete group set
 cannot authorize release. Cleanup failures compose with, and never replace,
 group cleanup results in the workspace close report. If coordinated group close
-faults, artifact cleanup still runs and its failures remain available from the
-terminal `CloseReport` before the original close failure is rethrown.
+or its synchronous release request faults, artifact cleanup still runs and its
+failures remain available from the terminal `CloseReport` before the original
+close failure is rethrown.
 
 ### Interaction model
 
@@ -2458,6 +2459,7 @@ The target is complete only when tests equivalent to these exist:
 - `RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet`
 - `WorkspaceClose_ReportsArtifactSessionCleanupFailure`
 - `WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedCloseFaults`
+- `WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedReleaseRequestThrows`
 - `ArtifactSetSession_DisposalCancelsInFlightMaterialization`
 - `ArtifactSetSession_CancellationCallbackFailureDoesNotSkipLeaseCleanup`
 - `ArtifactSetSession_PreservesPrimaryFailureWhenCleanupFails`

--- a/eng/inspect-web-gate-projects.txt
+++ b/eng/inspect-web-gate-projects.txt
@@ -1,6 +1,7 @@
 src/CSharpText
 src/DotnetInspector.Artifacts
 src/DotnetInspector.Artifacts.Local
+src/DotnetInspector.Artifacts.Workspaces
 src/DotnetInspector.Core
 src/DotnetInspector.CSharpBodySlicer
 src/DotnetInspector.PackageQueries

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactSetSessionTests.cs
@@ -106,7 +106,7 @@ public sealed class ArtifactSetSessionTests
     }
 
     [Fact]
-    public async Task ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce()
+    public async Task ArtifactSetSession_ReleasesLeasesOnlyAfterOpenArtifactStreamsQuiesce()
     {
         CancellationToken cancellationToken =
             TestContext.Current.CancellationToken;

--- a/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -115,7 +115,7 @@ public abstract class ArtifactSetPublicationOutcome
 /// <c>ArtifactSetSession_ConcurrentTerminationWaitsForCleanup</c> and
 /// <c>ArtifactSetSession_ConcurrentAbortAndDisposalShareCleanup</c>.
 /// Content-access quiescence is gated by
-/// <c>ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce</c>
+/// <c>ArtifactSetSession_ReleasesLeasesOnlyAfterOpenArtifactStreamsQuiesce</c>
 /// and <c>ArtifactSetSession_DisposalCancelsInFlightMaterialization</c>.
 /// </remarks>
 public sealed class ArtifactSetSession : IAsyncDisposable

--- a/src/DotnetInspector.Artifacts/ArtifactAcquisition.cs
+++ b/src/DotnetInspector.Artifacts/ArtifactAcquisition.cs
@@ -11,9 +11,9 @@ public interface IArtifactAcquisitionDiagnostic
 /// Source-owned resource lifetime returned by one successful acquisition.
 /// </summary>
 /// <remarks>
-/// The future artifact-set owner must retain this lease until dependent groups
-/// quiesce. That lifetime is unverified until
-/// <c>ArtifactSetSession_ReleasesLeasesOnlyAfterDependentGroupsQuiesce</c>.
+/// The artifact workspace owner must retain this lease until dependent groups
+/// quiesce. That lifetime is gated by
+/// <c>WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces</c>.
 /// </remarks>
 public interface IArtifactAcquisitionLease : IAsyncDisposable
 {

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -899,8 +899,10 @@ public sealed class InspectionWorkspaceTests
             second.Session,
             second.QueryLease,
             [secondGroup]);
-        await firstWorkspace.CloseAsync();
+        InspectionWorkspaceCloseReport firstReport =
+            await firstWorkspace.CloseAsync();
         await secondWorkspace.CloseAsync();
+        Assert.Equal(3, firstReport.Groups.Length);
     }
 
     [Fact]
@@ -970,6 +972,57 @@ public sealed class InspectionWorkspaceTests
         Assert.Equal(
             "Synthetic coordinated close failure.",
             failure.Message);
+        Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
+        Assert.NotNull(workspace.CloseReport);
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedReleaseRequestThrows()
+    {
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        var participation =
+            new FaultingWorkspaceParticipation(
+                throwOnReleaseRequest: true);
+        ImmutableArray<
+            InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
+            admissions =
+                workspace.BeginCoordinatedGroupAdmissions(
+                    [participation]);
+        AssemblyContextGroup group =
+            admissions[0].CreateGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ],
+                options: null);
+        participation.Group = group;
+        Assert.True(
+            workspace.CompleteCoordinatedGroupAdmissions(
+                admissions,
+                [group]));
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [group]);
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => close);
+        Task<InspectionWorkspaceCloseReport> second =
+            workspace.CloseAsync();
+
+        Assert.Equal(
+            "Synthetic synchronous coordinated release failure.",
+            failure.Message);
+        Assert.Same(close, second);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => second);
         Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
         Assert.NotNull(workspace.CloseReport);
     }
@@ -1664,7 +1717,8 @@ public sealed class InspectionWorkspaceTests
         ResolvedAssemblyReference Assembly,
         TrackingArtifactAcquisitionLease AcquisitionLease);
 
-    sealed class FaultingWorkspaceParticipation
+    sealed class FaultingWorkspaceParticipation(
+        bool throwOnReleaseRequest = false)
         : IWorkspaceCoordinatedGroupParticipation
     {
         internal AssemblyContextGroup? Group { get; set; }
@@ -1676,6 +1730,12 @@ public sealed class InspectionWorkspaceTests
 
         public void RequestRelease()
         {
+            if (throwOnReleaseRequest)
+            {
+                throw new InvalidOperationException(
+                    "Synthetic synchronous coordinated release failure.");
+            }
+
             _ = (Group
                     ?? throw new InvalidOperationException(
                         "The coordinated group was not attached."))

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -1,4 +1,7 @@
+using DotnetInspector.Artifacts;
+using DotnetInspector.Artifacts.Workspaces;
 using ILInspector.Metadata;
+using System.Collections.Immutable;
 using System.Reflection;
 
 namespace DotnetInspector.Queries.Tests;
@@ -783,6 +786,195 @@ public sealed class InspectionWorkspaceTests
     }
 
     [Fact]
+    public async Task WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [group]);
+        var callbackEntered =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var callbackResume =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<AssemblyImageAccessResult<int>> operation =
+            group.UseAndReleaseAssemblySessionAsync(
+                artifact.Assembly,
+                async (_, _) =>
+                {
+                    callbackEntered.SetResult();
+                    await callbackResume.Task.WaitAsync(
+                        cancellationToken);
+                    return 1;
+                });
+        await callbackEntered.Task.WaitAsync(cancellationToken);
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+
+        Assert.False(close.IsCompleted);
+        Assert.Equal(0, artifact.AcquisitionLease.DisposeCount);
+        callbackResume.SetResult();
+        Assert.IsType<AssemblyImageAccessResult<int>.Available>(
+            await operation);
+        InspectionWorkspaceCloseReport report = await close;
+        Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
+        Assert.Empty(report.ArtifactSessionCleanupFailures);
+    }
+
+    [Fact]
+    public async Task RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet()
+    {
+        ArtifactAssembly first =
+            await CreateArtifactAssemblyAsync();
+        ArtifactAssembly second =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace firstWorkspace =
+            InspectionWorkspace.CreateAsynchronous();
+        InspectionWorkspace secondWorkspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup firstGroup =
+            firstWorkspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        first.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        AssemblyContextGroup otherFirstGroup =
+            firstWorkspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        first.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        AssemblyContextGroup secondGroup =
+            secondWorkspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        second.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        otherFirstGroup.Dispose();
+
+        Assert.Throws<ArgumentException>(
+            () => firstWorkspace.RegisterArtifactSession(
+                first.Session,
+                first.QueryLease,
+                [secondGroup]));
+        Assert.Throws<ArgumentException>(
+            () => firstWorkspace.RegisterArtifactSession(
+                first.Session,
+                first.QueryLease,
+                [firstGroup]));
+
+        firstWorkspace.RegisterArtifactSession(
+            first.Session,
+            first.QueryLease,
+            [firstGroup, otherFirstGroup]);
+        Assert.Throws<InvalidOperationException>(
+            () => firstWorkspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        first.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]));
+        TestAssembly unrelated = TestAssembly.Create();
+        firstWorkspace.CreateAssemblyContextGroup(
+            [unrelated.Participant]);
+        secondWorkspace.RegisterArtifactSession(
+            second.Session,
+            second.QueryLease,
+            [secondGroup]);
+        await firstWorkspace.CloseAsync();
+        await secondWorkspace.CloseAsync();
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_ReportsArtifactSessionCleanupFailure()
+    {
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync(
+                throwOnLeaseDisposal: true);
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup group =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [group]);
+
+        InspectionWorkspaceCloseReport report =
+            await workspace.CloseAsync();
+
+        Assert.IsType<IOException>(
+            Assert.Single(
+                report.ArtifactSessionCleanupFailures));
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedCloseFaults()
+    {
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        var participation =
+            new FaultingWorkspaceParticipation();
+        ImmutableArray<
+            InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
+            admissions =
+                workspace.BeginCoordinatedGroupAdmissions(
+                    [participation]);
+        AssemblyContextGroup group =
+            admissions[0].CreateGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ],
+                options: null);
+        participation.Group = group;
+        Assert.True(
+            workspace.CompleteCoordinatedGroupAdmissions(
+                admissions,
+                [group]));
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [group]);
+
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                workspace.CloseAsync);
+
+        Assert.Equal(
+            "Synthetic coordinated close failure.",
+            failure.Message);
+        Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
+        Assert.NotNull(workspace.CloseReport);
+    }
+
+    [Fact]
     public async Task WorkspaceClose_ConcurrentCallersShareCompletionAndReportInstance()
     {
         TestAssembly firstSource = TestAssembly.Create();
@@ -1387,6 +1579,119 @@ public sealed class InspectionWorkspaceTests
             AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
                     AssemblyBindingFailureKind.CandidateUnavailable));
+    }
+
+    static async Task<ArtifactAssembly>
+        CreateArtifactAssemblyAsync(
+            bool throwOnLeaseDisposal = false)
+    {
+        byte[] bytes =
+            await File.ReadAllBytesAsync(
+                typeof(InspectionWorkspaceTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+        var acquisitionLease =
+            new TrackingArtifactAcquisitionLease(
+                throwOnLeaseDisposal);
+        var session = new ArtifactSetSession();
+        await session.AddRequiredAcquisitionAsync(
+            (scope, _) =>
+            {
+                ArtifactContribution contribution =
+                    scope.Register(
+                        new TestArtifactProvenance(),
+                        _ => new MemoryStream(
+                            bytes,
+                            writable: false),
+                        kind: "managed-assembly");
+                return ValueTask.FromResult<
+                    ArtifactAcquisitionOutcome>(
+                        new ArtifactAcquisitionOutcome.Acquired(
+                            [contribution],
+                            acquisitionLease));
+            },
+            cancellationToken:
+                TestContext.Current.CancellationToken);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(
+                TestContext.Current.CancellationToken));
+        ArtifactQueryAuthorization authorization =
+            session.CreateQueryAuthorization();
+        ArtifactQueryLease queryLease =
+            session.IssueLease(authorization);
+        ArtifactDescriptor descriptor =
+            Assert.Single(session.GetCatalog(queryLease));
+        ArtifactContentReference content =
+            session.GetContentReference(
+                descriptor.Identity,
+                queryLease);
+        ResolvedAssemblyReference assembly =
+            ResolvedAssemblyReference.CreateFromArtifactIfManaged(
+                content.Registration,
+                content.OpenRead,
+                AssemblyResolutionProvenance.Local(
+                    "artifact workspace test"))
+            ?? throw new InvalidOperationException(
+                "The test artifact did not project as a managed assembly.");
+        return new ArtifactAssembly(
+            session,
+            queryLease,
+            assembly,
+            acquisitionLease);
+    }
+
+    sealed record TestArtifactProvenance : IArtifactProvenance;
+
+    sealed class TrackingArtifactAcquisitionLease(
+        bool throwOnDisposal)
+        : IArtifactAcquisitionLease
+    {
+        internal int DisposeCount { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return throwOnDisposal
+                ? ValueTask.FromException(
+                    new IOException(
+                        "Synthetic artifact acquisition lease cleanup failure."))
+                : ValueTask.CompletedTask;
+        }
+    }
+
+    sealed record ArtifactAssembly(
+        ArtifactSetSession Session,
+        ArtifactQueryLease QueryLease,
+        ResolvedAssemblyReference Assembly,
+        TrackingArtifactAcquisitionLease AcquisitionLease);
+
+    sealed class FaultingWorkspaceParticipation
+        : IWorkspaceCoordinatedGroupParticipation
+    {
+        internal AssemblyContextGroup? Group { get; set; }
+
+        public WorkspaceCoordinatedAdmissionGate WorkspaceAdmission
+        {
+            get;
+        } = new();
+
+        public void RequestRelease()
+        {
+            _ = (Group
+                    ?? throw new InvalidOperationException(
+                        "The coordinated group was not attached."))
+                .RequestReleaseAsync();
+        }
+
+        public async Task<InspectionWorkspaceGroupCloseResult>
+            GetCloseResultAsync(int registrationIndex)
+        {
+            await (Group
+                    ?? throw new InvalidOperationException(
+                        "The coordinated group was not attached."))
+                .ReleaseCompletion;
+            throw new InvalidOperationException(
+                "Synthetic coordinated close failure.");
+        }
     }
 
     sealed class ThrowingDisposeMemoryStream(byte[] bytes)

--- a/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
+++ b/src/DotnetInspector.Queries/DotnetInspector.Queries.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Artifacts.Workspaces\DotnetInspector.Artifacts.Workspaces.csproj" />
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\NuGetFetch\NuGetFetch.csproj" />

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -1096,7 +1096,10 @@ public sealed partial class InspectionWorkspace :
         if (published)
             return group;
 
-        admission?.Complete(registration);
+        admission?.Complete(
+            artifactOwnershipConflict
+                ? null
+                : registration);
         if (artifactOwnershipConflict)
         {
             group.Dispose();
@@ -1121,7 +1124,9 @@ public sealed partial class InspectionWorkspace :
     /// least one participant projected from this session, and no other group.
     /// A later group projected from a transferred session is rejected. The
     /// workspace disposes the query lease and session only after all stored
-    /// groups complete release.
+    /// groups complete release. These properties are gated by
+    /// <c>RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet</c> and
+    /// <c>WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces</c>.
     /// </remarks>
     internal void RegisterArtifactSession(
         ArtifactSetSession session,
@@ -1299,15 +1304,7 @@ public sealed partial class InspectionWorkspace :
         }
 
         if (startClose)
-        {
-            foreach (WorkspaceGroupAdmission admission
-                in plan.GroupAdmissions)
-            {
-                admission.TryRequestRelease();
-            }
-
             _closeStart!.SetResult(plan);
-        }
 
         return _closeTask!;
     }

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using DotnetInspector.Artifacts;
+using DotnetInspector.Artifacts.Workspaces;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.Queries;
@@ -953,12 +955,24 @@ internal sealed class WorkspaceCoordinatedAdmissionGate
 public sealed class InspectionWorkspaceCloseReport
 {
     internal InspectionWorkspaceCloseReport(
-        ImmutableArray<InspectionWorkspaceGroupCloseResult> groups)
+        ImmutableArray<InspectionWorkspaceGroupCloseResult> groups,
+        ImmutableArray<Exception> artifactSessionCleanupFailures)
     {
         Groups = groups;
+        ArtifactSessionCleanupFailures =
+            artifactSessionCleanupFailures;
     }
 
     public ImmutableArray<InspectionWorkspaceGroupCloseResult> Groups
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Cleanup failures retained from artifact sessions after their exact
+    /// dependent groups reached terminal release.
+    /// </summary>
+    public ImmutableArray<Exception> ArtifactSessionCleanupFailures
     {
         get;
     }
@@ -974,9 +988,11 @@ public sealed partial class InspectionWorkspace :
     readonly object _gate = new();
     readonly List<AssemblyContextGroup> _groups = [];
     readonly List<WorkspaceGroupAdmission> _admissions = [];
+    readonly List<WorkspaceArtifactSessionRegistration>
+        _artifactSessions = [];
     readonly InspectionWorkspaceLifetimeMode _lifetimeMode;
     readonly TaskCompletionSource<
-        ImmutableArray<WorkspaceGroupAdmission>>? _closeStart;
+        WorkspaceClosePlan>? _closeStart;
     readonly Task<InspectionWorkspaceCloseReport>? _closeTask;
     InspectionWorkspaceCloseReport? _closeReport;
     InspectionWorkspaceState _state;
@@ -1059,9 +1075,17 @@ public sealed partial class InspectionWorkspace :
                     admission.RegistrationIndex,
                     group);
         bool published;
+        bool artifactOwnershipConflict;
         lock (_gate)
         {
-            published = _state == InspectionWorkspaceState.Open;
+            artifactOwnershipConflict =
+                _state == InspectionWorkspaceState.Open
+                && _artifactSessions.Any(
+                    registration =>
+                        registration.DependsOn(group));
+            published =
+                _state == InspectionWorkspaceState.Open
+                && !artifactOwnershipConflict;
             if (published)
             {
                 _groups.Add(group);
@@ -1073,6 +1097,12 @@ public sealed partial class InspectionWorkspace :
             return group;
 
         admission?.Complete(registration);
+        if (artifactOwnershipConflict)
+        {
+            group.Dispose();
+            throw new InvalidOperationException(
+                "A group projected from a transferred artifact session cannot be admitted later.");
+        }
         if (_lifetimeMode
             == InspectionWorkspaceLifetimeMode.Synchronous)
         {
@@ -1080,6 +1110,110 @@ public sealed partial class InspectionWorkspace :
         }
 
         throw new ObjectDisposedException(nameof(InspectionWorkspace));
+    }
+
+    /// <summary>
+    /// Transfers one published artifact session and query lease to this
+    /// workspace and binds their release to exact dependent groups.
+    /// </summary>
+    /// <remarks>
+    /// The supplied set must contain every current workspace group with at
+    /// least one participant projected from this session, and no other group.
+    /// A later group projected from a transferred session is rejected. The
+    /// workspace disposes the query lease and session only after all stored
+    /// groups complete release.
+    /// </remarks>
+    internal void RegisterArtifactSession(
+        ArtifactSetSession session,
+        ArtifactQueryLease queryLease,
+        IEnumerable<AssemblyContextGroup> dependentGroups)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(queryLease);
+        ArgumentNullException.ThrowIfNull(dependentGroups);
+        if (_lifetimeMode
+            != InspectionWorkspaceLifetimeMode.Asynchronous)
+        {
+            throw new InvalidOperationException(
+                "Artifact sessions require a workspace created by CreateAsynchronous.");
+        }
+
+        ImmutableArray<AssemblyContextGroup> groups =
+            [.. dependentGroups];
+        if (groups.IsDefaultOrEmpty
+            || groups.Any(static group => group is null))
+        {
+            throw new ArgumentException(
+                "An artifact session requires at least one dependent group.",
+                nameof(dependentGroups));
+        }
+        if (groups.Distinct(ReferenceEqualityComparer.Instance).Count()
+            != groups.Length)
+        {
+            throw new ArgumentException(
+                "An artifact session cannot depend on the same group more than once.",
+                nameof(dependentGroups));
+        }
+
+        IReadOnlyList<ArtifactDescriptor> catalog =
+            session.GetCatalog(queryLease);
+        var registrations =
+            new HashSet<ArtifactAcquisitionRegistration>(
+                ReferenceEqualityComparer.Instance);
+        foreach (ArtifactDescriptor descriptor in catalog)
+        {
+            registrations.Add(
+                session.GetContentReference(
+                    descriptor.Identity,
+                    queryLease).Registration);
+        }
+
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(
+                _state != InspectionWorkspaceState.Open,
+                this);
+            var expectedGroups =
+                new HashSet<AssemblyContextGroup>(
+                    ReferenceEqualityComparer.Instance);
+            foreach (WorkspaceGroupAdmission admission in _admissions)
+            {
+                if (!admission.TryGetCompletedGroup(out AssemblyContextGroup? group))
+                {
+                    throw new InvalidOperationException(
+                        "Artifact session ownership cannot transfer while a workspace group admission is incomplete.");
+                }
+                if (group is not null
+                    && group.Participants.Any(participant =>
+                        participant.Assembly.Registration
+                            .ArtifactRegistration is
+                                ArtifactAcquisitionRegistration registration
+                        && registrations.Contains(registration)))
+                {
+                    expectedGroups.Add(group);
+                }
+            }
+            if (expectedGroups.Count == 0
+                || !expectedGroups.SetEquals(groups))
+            {
+                throw new ArgumentException(
+                    "The dependent groups must be the complete exact set of current workspace groups projected from this artifact session.",
+                    nameof(dependentGroups));
+            }
+            if (_artifactSessions.Any(registration =>
+                    ReferenceEquals(registration.Session, session)))
+            {
+                throw new InvalidOperationException(
+                    "The artifact session is already registered with this workspace.");
+            }
+
+            _artifactSessions.Add(
+                new WorkspaceArtifactSessionRegistration(
+                    session,
+                    queryLease,
+                    [.. registrations],
+                    groups));
+        }
     }
 
     public void Dispose()
@@ -1139,15 +1273,19 @@ public sealed partial class InspectionWorkspace :
                 "CloseAsync requires a workspace created by CreateAsynchronous.");
         }
 
-        ImmutableArray<WorkspaceGroupAdmission> admissions = default;
+        WorkspaceClosePlan plan = default;
         bool startClose = false;
         lock (_gate)
         {
             if (_state == InspectionWorkspaceState.Open)
             {
-                admissions = [.. _admissions];
+                ImmutableArray<WorkspaceGroupAdmission> admissions =
+                    [.. _admissions];
                 foreach (WorkspaceGroupAdmission admission in admissions)
                     admission.CloseWorkspaceAdmission();
+                plan = new WorkspaceClosePlan(
+                    admissions,
+                    [.. _artifactSessions]);
                 _state = InspectionWorkspaceState.Closing;
                 foreach (AssemblyContextGroup group in _groups)
                 {
@@ -1162,12 +1300,13 @@ public sealed partial class InspectionWorkspace :
 
         if (startClose)
         {
-            foreach (WorkspaceGroupAdmission admission in admissions)
+            foreach (WorkspaceGroupAdmission admission
+                in plan.GroupAdmissions)
             {
                 admission.TryRequestRelease();
             }
 
-            _closeStart!.SetResult(admissions);
+            _closeStart!.SetResult(plan);
         }
 
         return _closeTask!;
@@ -1262,7 +1401,12 @@ public sealed partial class InspectionWorkspace :
         bool published;
         lock (_gate)
         {
-            published = _state == InspectionWorkspaceState.Open;
+            published =
+                _state == InspectionWorkspaceState.Open
+                && !groups.Any(group =>
+                    _artifactSessions.Any(
+                        registration =>
+                            registration.DependsOn(group)));
             for (int index = 0; index < admissions.Length; index++)
             {
                 WorkspaceCoordinatedGroupAdmission admission =
@@ -1296,21 +1440,50 @@ public sealed partial class InspectionWorkspace :
     }
 
     async Task<InspectionWorkspaceCloseReport> CloseCoreAsync(
-        Task<ImmutableArray<WorkspaceGroupAdmission>> start)
+        Task<WorkspaceClosePlan> start)
     {
-        ImmutableArray<WorkspaceGroupAdmission> admissions =
+        WorkspaceClosePlan plan =
             await start.ConfigureAwait(false);
         var completionTasks =
             new Task<InspectionWorkspaceGroupCloseResult?>[
-                admissions.Length];
-        for (int index = 0; index < admissions.Length; index++)
+                plan.GroupAdmissions.Length];
+        for (int index = 0;
+            index < plan.GroupAdmissions.Length;
+            index++)
         {
             completionTasks[index] =
-                admissions[index].RequestReleaseAndGetResultAsync();
+                plan.GroupAdmissions[index]
+                    .RequestReleaseAndGetResultAsync();
         }
 
-        InspectionWorkspaceGroupCloseResult?[] completed =
-            await Task.WhenAll(completionTasks).ConfigureAwait(false);
+        var completed =
+            new InspectionWorkspaceGroupCloseResult?[
+                completionTasks.Length];
+        Exception? groupCloseFailure = null;
+        try
+        {
+            completed =
+                await Task.WhenAll(completionTasks).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            groupCloseFailure = exception;
+            for (int index = 0;
+                index < completionTasks.Length;
+                index++)
+            {
+                if (completionTasks[index].IsCompletedSuccessfully)
+                    completed[index] = completionTasks[index].Result;
+            }
+        }
+        ImmutableArray<Exception>.Builder artifactCleanupFailures =
+            ImmutableArray.CreateBuilder<Exception>();
+        foreach (WorkspaceArtifactSessionRegistration registration
+            in plan.ArtifactSessions)
+        {
+            artifactCleanupFailures.AddRange(
+                await registration.ReleaseAsync().ConfigureAwait(false));
+        }
         var reportGroups =
             ImmutableArray.CreateBuilder<
                 InspectionWorkspaceGroupCloseResult>();
@@ -1321,14 +1494,89 @@ public sealed partial class InspectionWorkspace :
         }
 
         var report = new InspectionWorkspaceCloseReport(
-            reportGroups.ToImmutable());
+            reportGroups.ToImmutable(),
+            artifactCleanupFailures.ToImmutable());
         lock (_gate)
         {
             _closeReport = report;
             _state = InspectionWorkspaceState.Closed;
         }
+        if (groupCloseFailure is not null)
+        {
+            return await Task.FromException<
+                    InspectionWorkspaceCloseReport>(
+                    groupCloseFailure)
+                .ConfigureAwait(false);
+        }
         return report;
     }
+
+    internal sealed class WorkspaceArtifactSessionRegistration
+    {
+        internal WorkspaceArtifactSessionRegistration(
+            ArtifactSetSession session,
+            ArtifactQueryLease queryLease,
+            ImmutableArray<ArtifactAcquisitionRegistration>
+                artifactRegistrations,
+            ImmutableArray<AssemblyContextGroup> dependentGroups)
+        {
+            Session = session;
+            QueryLease = queryLease;
+            ArtifactRegistrations = artifactRegistrations;
+            DependentGroups = dependentGroups;
+        }
+
+        internal ArtifactSetSession Session { get; }
+
+        ArtifactQueryLease QueryLease { get; }
+
+        ImmutableArray<ArtifactAcquisitionRegistration>
+            ArtifactRegistrations { get; }
+
+        ImmutableArray<AssemblyContextGroup> DependentGroups { get; }
+
+        internal bool DependsOn(AssemblyContextGroup group) =>
+            group.Participants.Any(participant =>
+                participant.Assembly.Registration.ArtifactRegistration
+                    is ArtifactAcquisitionRegistration registration
+                && ArtifactRegistrations.Contains(
+                    registration,
+                    ReferenceEqualityComparer.Instance));
+
+        internal async Task<IReadOnlyList<Exception>> ReleaseAsync()
+        {
+            await Task.WhenAll(
+                    DependentGroups.Select(
+                        static group => group.RequestReleaseAsync()))
+                .ConfigureAwait(false);
+            var failures = new List<Exception>();
+            try
+            {
+                QueryLease.Dispose();
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+            }
+
+            try
+            {
+                await Session.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+            }
+
+            failures.AddRange(Session.CleanupFailures);
+            return failures;
+        }
+    }
+
+    readonly record struct WorkspaceClosePlan(
+        ImmutableArray<WorkspaceGroupAdmission> GroupAdmissions,
+        ImmutableArray<WorkspaceArtifactSessionRegistration>
+            ArtifactSessions);
 
     internal sealed class WorkspaceCoordinatedGroupAdmission
     {
@@ -1364,6 +1612,7 @@ public sealed partial class InspectionWorkspace :
             InspectionWorkspaceGroupCloseResult?> _terminalCompletion =
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
         WorkspaceGroupRegistration? _registration;
+        AssemblyContextGroup? _completedGroup;
 
         internal int RegistrationIndex { get; } = registrationIndex;
 
@@ -1409,11 +1658,30 @@ public sealed partial class InspectionWorkspace :
             }
 
             lock (_gate)
+            {
                 _registration = registration;
+                _completedGroup = registration.Group;
+            }
 
             ObserveRelease(registration);
 
             _constructionCompletion.SetResult();
+        }
+
+        internal bool TryGetCompletedGroup(
+            out AssemblyContextGroup? group)
+        {
+            if (!_constructionCompletion.Task.IsCompleted)
+            {
+                group = null;
+                return false;
+            }
+
+            lock (_gate)
+            {
+                group = _completedGroup;
+                return true;
+            }
         }
 
         internal void SetRegistration(
@@ -1428,6 +1696,7 @@ public sealed partial class InspectionWorkspace :
                         "A workspace group admission completed more than once.");
                 }
                 _registration = registration;
+                _completedGroup = registration.Group;
             }
         }
 


### PR DESCRIPTION
This advances dotnet-inspect's mission to build robust, capable foundations for
compelling inspection experiences by making artifact lifetime ownership exact
and observable.

`InspectionWorkspace` now owns the association from a published
`ArtifactSetSession` to every exact dependent `AssemblyContextGroup`. It retains
the session and its query lease until all owner-issued group release receipts
complete, rejects foreign or incomplete group sets, prevents later groups from
using a transferred session, and reports artifact cleanup failures in the
terminal workspace close report.

## Demo

The focused scenario holds a group callback open while workspace close begins:

```text
workspace.CloseAsync()                    pending
artifact acquisition lease DisposeCount  0
release held group callback
workspace.CloseAsync()                    complete
artifact acquisition lease DisposeCount  1
```

Neighboring gates prove that a foreign or incomplete group set is rejected,
already-quiescent exact groups remain part of the association, coordinated close
faults do not skip artifact cleanup, and cleanup failures remain visible.

## Compatibility

The association is available only on asynchronous workspaces and currently has
no host caller. This is the prerequisite lifetime slice for the package
artifact pilot; package realization, CLI and inspect-web cutovers, PDB parity,
and browser budget/single-flight work remain separate follow-up slices.

The existing artifact-session stream-quiescence gate was renamed because it did
not prove assembly-group quiescence.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
  (1,066 passed)
- `dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release
  --no-build` (60 passed, 6 platform skips)
- `dotnet run eng/test-ci-change-detection.cs`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`
  (212 passed)
- `npm run build` in `prototypes/inspect-web`
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md`

Closes #5459
