### PR TITLE
Implement AnalysisDiff<T>

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ depends on typed models.
 
 | Region | Place in flow | Responsibility | Primary authority |
 | ------ | ------------- | -------------- | ----------------- |
-| `ILInspector.Findings` | Result contracts | Domain-free observation, census, matching, transition, comparison, and correlation contracts. | [Finding nomenclature](design/finding-nomenclature.md), [Finding producers](design/finding-producers.md) |
+| `ILInspector.Findings` | Result contracts | Domain-free observation, census, matching, transition, complete analysis-diff, and correlation contracts. | [Finding nomenclature](design/finding-nomenclature.md), [Analysis diff](design/analysis-diff.md), [Finding producers](design/finding-producers.md) |
 | `ILInspector.Instructions` | Decode substrate | Shared instruction decoding and exception-region-aware basic blocks. | [Instruction substrate](design/instruction-substrate.md) |
 | `ILInspector.ControlFlow` | Flow substrate | Shared control-flow, dominance, and dataflow kernels. | [Instruction substrate](design/instruction-substrate.md) |
 | `ILInspector.Text` | Text producer | Exact ordered line inspection and generic text comparison on the Finding spine. | [Finding producers](design/finding-producers.md) |

--- a/docs/design/analysis-diff.md
+++ b/docs/design/analysis-diff.md
@@ -2,9 +2,11 @@
 
 ## Status and ownership
 
-This document proposes the `ILInspector.Findings`-owned `AnalysisDiff<T>`
-information format for
-[#5491](https://github.com/richlander/dotnet-inspect/issues/5491).
+This document defines the `ILInspector.Findings`-owned `AnalysisDiff<T>`
+information format designed in
+[#5491](https://github.com/richlander/dotnet-inspect/issues/5491) and
+implemented in
+[#5504](https://github.com/richlander/dotnet-inspect/issues/5504).
 
 The normative claim is:
 
@@ -29,8 +31,10 @@ Producers own:
 Consumers own statistics, equivalence policy, prioritization, querying,
 projection, and presentation.
 
-All behavior in this document is unverified until the implementation effort
-names and adds the Release gates under [Required gates](#required-gates).
+The format is implemented by `AnalysisDiff<T>`, `AnalysisDiffRelation`, and the
+correspondence classification enums. The Release gates under
+[Required gates](#required-gates) verify the Finding-owned construction and
+value contracts.
 
 The product already has a user-visible `Analysis Diff` section and CLR
 presentation types named `DiffSections.AnalysisDiff`, `AnalysisDiffView`, and
@@ -466,20 +470,31 @@ relation per item.
 
 ## Required gates
 
-The implementation effort must add Release gates proving at least:
+The Release test
+`src/ILInspector.Instructions.Tests/AnalysisDiffTests.cs` verifies:
 
-- empty, addition-only, removal-only, one-to-one, one-to-many, many-to-one, and
+- `AnalysisDiff_ConstructsEmptyDiff` and
+  `AnalysisDiff_ConstructsOneSidedAndAllCorrespondenceArities` cover empty,
+  addition-only, removal-only, one-to-one, one-to-many, many-to-one, and
   many-to-many construction;
-- a moved-and-changed correspondence;
-- explicit unclassified content and placement;
-- rejection of default arrays, null items, empty relations, unsorted or
-  duplicate coordinates, multi-item additions or removals, out-of-range
-  coordinates, overlap, and incomplete endpoint coverage;
-- canonical relation order and equality across permuted relation input;
-- sequence value equality and hashing over independently allocated equal
-  values;
-- unequal relation membership or classification producing unequal values; and
-- payload equality remaining independent of correspondence.
+- `AnalysisDiff_CarriesOrthogonalCorrespondenceFacets` covers moved-and-changed
+  correspondence plus explicit unclassified content and placement;
+- `AnalysisDiff_PreservesPathologicalMixedTopology` reproduces the mixed
+  one-to-many, moved-and-changed, unchanged, removal, and addition
+  demonstration;
+- `AnalysisDiff_RejectsDefaultArraysAndNullValues`,
+  `AnalysisDiffRelation_RejectsInvalidCoordinates`,
+  `AnalysisDiffRelation_RejectsUnknownClassifications`, and
+  `AnalysisDiff_RejectsOutOfRangeOverlapAndIncompleteCoverage` cover the
+  construction failures;
+- `AnalysisDiff_CanonicalizesRelationOrder` covers canonical storage, equality,
+  and hashing across permuted relation input;
+- `AnalysisDiff_UsesSequenceValueEquality` covers independently allocated equal
+  endpoint and relation values;
+- `AnalysisDiff_DistinguishesMembershipAndClassification` covers unequal
+  relation membership and classifications; and
+- `AnalysisDiff_PayloadEqualityDoesNotEstablishCorrespondence` covers the
+  boundary between materialized payload equality and correspondence.
 
 Producer adapters and consumer statistics name their own gates. These
 construction gates do not prove a producer's correspondence or classification

--- a/docs/design/finding-nomenclature.md
+++ b/docs/design/finding-nomenclature.md
@@ -19,6 +19,12 @@ A `Finding<T>` is one independently identifiable occurrence in one version. A
 observations. An unchanged pair is still a transition even though it carries no
 difference.
 
+`AnalysisDiff<T>` is the complete two-endpoint information document when
+relations may connect item populations rather than one old and one new
+observation. It composes singleton additions and removals with one-to-one,
+one-to-many, many-to-one, or many-to-many correspondences without turning that
+population relation into implied item pairs.
+
 The non-generic interfaces preserve heterogeneous collections without merging
 the concepts:
 
@@ -53,7 +59,7 @@ second semantic axis.
 | **Observation** | One independently identifiable occurrence about one subject at one version. | The semantic meaning of `Finding<T>`. |
 | **Change** / **transition** | The classified old/new relationship between observations. | The semantic meaning of `PairFinding<T>`. Prefer **transition** for topology and **change** in user-facing prose. |
 | **Difference** | A non-equivalence class or delta carried by a transition, such as moved or encoding-only. | Do not use it for every pair; an unchanged pair has no difference. |
-| **Diff** | A comparison operation, artifact, report, or presentation containing changes. | Appropriate for `ApiDiff`, `IlBodyDiff`, unified diff text, and CLI `diff`; not for one-version observations. |
+| **Diff** | A comparison operation, artifact, report, or presentation containing changes. | Appropriate for `AnalysisDiff<T>`, `ApiDiff`, `IlBodyDiff`, unified diff text, and CLI `diff`; not for one-version observations. |
 | **Evidence** | Information used to support a conclusion. | A Finding, transition, structural diff, failure, or provenance record may serve as evidence. Do not create a parallel `Evidence*` row hierarchy merely to rename the Finding model. |
 | **Detail** | Explanatory payload or rendered elaboration. | A field or presentation concept, not a model family. |
 | **Census** | The complete observation collection from a successful inspection. | Usually a semantic unit rather than a payload family. `FindingCensusCorrelation<T>` is the explicit N-address operation outcome when whole-census state, including `Complete([])`, must survive correlation. |
@@ -68,6 +74,7 @@ Information types are durable values:
 | --- | --- | --- |
 | `Finding<T>` | One | One observation with a typed payload. |
 | `PairFinding<T>` | Two | One classified transition composed from observations. |
+| `AnalysisDiff<T>` | Two | Complete ordered endpoint sequences partitioned into one-sided and corresponding relations. |
 | `CorrelatedFinding<T>` | More than two | Durable occurrences of one exact identity, labelled with their evaluated version addresses. |
 
 Operation outcomes describe one invocation:

--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -19,7 +19,7 @@ Finding-owned values compose four equality shapes:
 | Shape | Examples | Equality contract |
 | --- | --- | --- |
 | Structural composition | `FindingSubject`, `Finding<T>`, and the cases of `PairFinding<T>` | Every equality-participating field composes its own contract. Generic payload fields use `EqualityComparer<T>.Default`. |
-| Ordered collection value | Complete censuses, match evidence, completed transition streams, and correlated occurrences | Sequence equality: order and multiplicity are significant. |
+| Ordered collection value | Complete censuses, match evidence, completed transition streams, analysis-diff endpoints and canonical relations, and correlated occurrences | Sequence equality: order and multiplicity are significant. |
 | Identity-set value | `FindingEquivalence` allow lists | Set equality: enumeration order and duplicate input are insignificant. |
 | Operation object | `FindingCensusCorrelation<T>` and `FindingCorrelation<T>` | Reference identity. Their durable inputs and projected values retain their own contracts. |
 
@@ -35,6 +35,12 @@ prevented matching. `CorrelatedFinding<T>` is a durable value and composes its
 correlation key with its ordered occurrences; the operation object that
 produced it remains reference-identity state.
 
+`AnalysisDiff<T>` composes its ordered Before and After item sequences with its
+canonical relation population. Relation caller order is nonsemantic because
+construction canonicalizes it before equality. Relation coordinate order,
+membership, content classification, and placement classification remain
+value-significant.
+
 ## Ordered collections
 
 These public collections carry sequence semantics:
@@ -47,6 +53,8 @@ These public collections carry sequence semantics:
 | `FindingMatch.MoveCandidates` | Deferred move-candidate order |
 | `FindingMatch.SoftCandidates` | Deferred soft-correspondence order |
 | `FindingComparison<T>.Complete.Pairs` | Transition-stream order |
+| `AnalysisDiff<T>.Before` and `.After` | Producer-issued endpoint order |
+| `AnalysisDiff<T>.Relations` | Canonical Before-first, then Addition order |
 | `CorrelatedFinding<T>.Occurrences` | Version-position order |
 
 Independently allocated arrays with equal elements in equal positions are
@@ -79,7 +87,7 @@ produce equal hash codes.
 
 ## Payload boundary
 
-`Finding<T>` and `PairFinding<T>` compose the payload's
+`Finding<T>`, `PairFinding<T>`, and `AnalysisDiff<T>` compose the payload's
 `EqualityComparer<T>.Default` behavior; the Finding layer does not reinterpret
 opaque payloads. A collection-bearing producer payload that promises semantic
 value equality must define that equality itself or supply the producer
@@ -128,6 +136,12 @@ move candidates. Its non-empty value equality is covered by
 `FindingMatch_UsesOrderedSequenceEquality`; candidate construction and ordering
 are covered separately by
 `src/ILInspector.ILDiff.Tests/FindingPilotTests.cs`.
+
+The Release test
+`src/ILInspector.Instructions.Tests/AnalysisDiffTests.cs` verifies canonical
+relation equality and hashing, independently allocated equal endpoint and
+coordinate arrays, unequal membership and classifications, invalid collection
+state, and the boundary between payload equality and correspondence.
 
 ## Non-claims
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -66,7 +66,7 @@ substrates, and inspection producers that will extend that space.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation and unsafety occurrences, method signals, and whole-assembly leverage without decompiling to C#. `AnalysisFindings` exposes reusable typed censuses and comparisons for allocations, call sites, unsafe operations, and unsafe declaration/body evidence.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
-- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, comparison, whole-census correlation, and exact-identity correlation contracts shared by product producers. The `timeline` command composes Metadata and Analysis producers over those same correlation contracts.
+- `src/ILInspector.Findings/` contains the domain-free observation, inspection, matching, transition, comparison, complete analysis-diff, whole-census correlation, and exact-identity correlation contracts shared by product producers. The `timeline` command composes Metadata and Analysis producers over those same correlation contracts.
 - `src/ILInspector.ILDiff/` owns IL body and assembly comparison over decoded
   instruction streams: canonicalization, alignment, Finding projection, typed
   failures, and producer-owned diff presentation.

--- a/src/ILInspector.Findings/AnalysisDiff.cs
+++ b/src/ILInspector.Findings/AnalysisDiff.cs
@@ -1,0 +1,362 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Findings;
+
+/// <summary>The producer's content assertion for one correspondence.</summary>
+public enum AnalysisDiffContentKind
+{
+    Unclassified,
+    Unchanged,
+    Changed,
+}
+
+/// <summary>The producer's placement assertion for one correspondence.</summary>
+public enum AnalysisDiffPlacementKind
+{
+    Unclassified,
+    Stable,
+    Moved,
+}
+
+/// <summary>
+/// One closed relation in an <see cref="AnalysisDiff{T}"/>. One-sided relations expose only
+/// their occupied endpoint; content and placement classifications exist only on correspondence.
+/// </summary>
+public abstract record AnalysisDiffRelation
+{
+    private AnalysisDiffRelation()
+    {
+    }
+
+    // Records synthesize a protected copy constructor. This inaccessible abstract member prevents
+    // external records from using that constructor to extend the closed relation hierarchy.
+    private protected abstract void EnsureKnownRelation();
+
+    /// <summary>One item present only in the After sequence.</summary>
+    public sealed record Addition : AnalysisDiffRelation
+    {
+        public Addition(ImmutableArray<int> AfterCoordinates)
+        {
+            this.AfterCoordinates = ValidateCoordinates(
+                AfterCoordinates,
+                nameof(AfterCoordinates),
+                expectedCount: 1);
+        }
+
+        public ImmutableArray<int> AfterCoordinates { get; }
+
+        private protected override void EnsureKnownRelation()
+        {
+        }
+
+        public bool Equals(Addition? other)
+            => other is not null
+                && FindingValueEquality.SequenceEqual(
+                    AfterCoordinates,
+                    other.AfterCoordinates);
+
+        public override int GetHashCode()
+            => FindingValueEquality.SequenceHashCode(AfterCoordinates);
+    }
+
+    /// <summary>One item present only in the Before sequence.</summary>
+    public sealed record Removal : AnalysisDiffRelation
+    {
+        public Removal(ImmutableArray<int> BeforeCoordinates)
+        {
+            this.BeforeCoordinates = ValidateCoordinates(
+                BeforeCoordinates,
+                nameof(BeforeCoordinates),
+                expectedCount: 1);
+        }
+
+        public ImmutableArray<int> BeforeCoordinates { get; }
+
+        private protected override void EnsureKnownRelation()
+        {
+        }
+
+        public bool Equals(Removal? other)
+            => other is not null
+                && FindingValueEquality.SequenceEqual(
+                    BeforeCoordinates,
+                    other.BeforeCoordinates);
+
+        public override int GetHashCode()
+            => FindingValueEquality.SequenceHashCode(BeforeCoordinates);
+    }
+
+    /// <summary>
+    /// One producer-issued correspondence between non-empty Before and After populations.
+    /// Population correspondence does not imply pairwise correspondence between their items.
+    /// </summary>
+    public sealed record Correspondence : AnalysisDiffRelation
+    {
+        public Correspondence(
+            ImmutableArray<int> BeforeCoordinates,
+            ImmutableArray<int> AfterCoordinates,
+            AnalysisDiffContentKind Content,
+            AnalysisDiffPlacementKind Placement)
+        {
+            this.BeforeCoordinates = ValidateCoordinates(
+                BeforeCoordinates,
+                nameof(BeforeCoordinates));
+            this.AfterCoordinates = ValidateCoordinates(
+                AfterCoordinates,
+                nameof(AfterCoordinates));
+            this.Content = Validate(Content, nameof(Content));
+            this.Placement = Validate(Placement, nameof(Placement));
+        }
+
+        public ImmutableArray<int> BeforeCoordinates { get; }
+        public ImmutableArray<int> AfterCoordinates { get; }
+        public AnalysisDiffContentKind Content { get; }
+        public AnalysisDiffPlacementKind Placement { get; }
+
+        private protected override void EnsureKnownRelation()
+        {
+        }
+
+        public bool Equals(Correspondence? other)
+            => other is not null
+                && FindingValueEquality.SequenceEqual(
+                    BeforeCoordinates,
+                    other.BeforeCoordinates)
+                && FindingValueEquality.SequenceEqual(
+                    AfterCoordinates,
+                    other.AfterCoordinates)
+                && Content == other.Content
+                && Placement == other.Placement;
+
+        public override int GetHashCode()
+            => HashCode.Combine(
+                FindingValueEquality.SequenceHashCode(BeforeCoordinates),
+                FindingValueEquality.SequenceHashCode(AfterCoordinates),
+                Content,
+                Placement);
+    }
+
+    static ImmutableArray<int> ValidateCoordinates(
+        ImmutableArray<int> coordinates,
+        string parameterName,
+        int? expectedCount = null)
+    {
+        if (coordinates.IsDefault)
+            throw new ArgumentException("Coordinates must be initialized.", parameterName);
+        if (expectedCount is int count && coordinates.Length != count)
+        {
+            throw new ArgumentException(
+                $"The relation requires exactly {count} coordinate.",
+                parameterName);
+        }
+        if (coordinates.IsEmpty)
+            throw new ArgumentException("Coordinates must not be empty.", parameterName);
+
+        for (int i = 0; i < coordinates.Length; i++)
+        {
+            int coordinate = coordinates[i];
+            if (coordinate < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    parameterName,
+                    coordinate,
+                    "Coordinates must be non-negative.");
+            }
+            if (i > 0 && coordinate <= coordinates[i - 1])
+            {
+                throw new ArgumentException(
+                    "Coordinates must be strictly ascending and duplicate-free.",
+                    parameterName);
+            }
+        }
+
+        return coordinates;
+    }
+
+    static AnalysisDiffContentKind Validate(
+        AnalysisDiffContentKind content,
+        string parameterName)
+        => content switch
+        {
+            AnalysisDiffContentKind.Unclassified => content,
+            AnalysisDiffContentKind.Unchanged => content,
+            AnalysisDiffContentKind.Changed => content,
+            _ => throw new ArgumentOutOfRangeException(parameterName, content, "Unknown content kind."),
+        };
+
+    static AnalysisDiffPlacementKind Validate(
+        AnalysisDiffPlacementKind placement,
+        string parameterName)
+        => placement switch
+        {
+            AnalysisDiffPlacementKind.Unclassified => placement,
+            AnalysisDiffPlacementKind.Stable => placement,
+            AnalysisDiffPlacementKind.Moved => placement,
+            _ => throw new ArgumentOutOfRangeException(parameterName, placement, "Unknown placement kind."),
+        };
+}
+
+/// <summary>
+/// A complete immutable partition of two ordered item sequences into producer-issued one-sided
+/// and corresponding relations.
+/// </summary>
+public sealed record AnalysisDiff<T>
+    where T : notnull
+{
+    public AnalysisDiff(
+        ImmutableArray<T> Before,
+        ImmutableArray<T> After,
+        ImmutableArray<AnalysisDiffRelation> Relations)
+    {
+        this.Before = ValidateItems(Before, nameof(Before));
+        this.After = ValidateItems(After, nameof(After));
+        this.Relations = ValidateAndCanonicalize(
+            Relations,
+            Before.Length,
+            After.Length);
+    }
+
+    public ImmutableArray<T> Before { get; }
+    public ImmutableArray<T> After { get; }
+    public ImmutableArray<AnalysisDiffRelation> Relations { get; }
+
+    public bool Equals(AnalysisDiff<T>? other)
+        => other is not null
+            && FindingValueEquality.SequenceEqual(Before, other.Before)
+            && FindingValueEquality.SequenceEqual(After, other.After)
+            && FindingValueEquality.SequenceEqual(Relations, other.Relations);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            FindingValueEquality.SequenceHashCode(Before),
+            FindingValueEquality.SequenceHashCode(After),
+            FindingValueEquality.SequenceHashCode(Relations));
+
+    public void Deconstruct(
+        out ImmutableArray<T> Before,
+        out ImmutableArray<T> After,
+        out ImmutableArray<AnalysisDiffRelation> Relations)
+        => (Before, After, Relations) = (this.Before, this.After, this.Relations);
+
+    static ImmutableArray<T> ValidateItems(
+        ImmutableArray<T> items,
+        string parameterName)
+    {
+        if (items.IsDefault)
+            throw new ArgumentException("Endpoint items must be initialized.", parameterName);
+        if (items.Any(item => item is null))
+            throw new ArgumentException("Endpoint items must not contain null values.", parameterName);
+        return items;
+    }
+
+    static ImmutableArray<AnalysisDiffRelation> ValidateAndCanonicalize(
+        ImmutableArray<AnalysisDiffRelation> relations,
+        int beforeCount,
+        int afterCount)
+    {
+        if (relations.IsDefault)
+            throw new ArgumentException("Relations must be initialized.", nameof(Relations));
+        if (relations.Any(relation => relation is null))
+            throw new ArgumentException("Relations must not contain null values.", nameof(Relations));
+
+        var beforeCoverage = new bool[beforeCount];
+        var afterCoverage = new bool[afterCount];
+
+        for (int relationIndex = 0; relationIndex < relations.Length; relationIndex++)
+        {
+            switch (relations[relationIndex])
+            {
+                case AnalysisDiffRelation.Addition addition:
+                    MarkCoordinates(
+                        addition.AfterCoordinates,
+                        afterCoverage,
+                        "After",
+                        relationIndex);
+                    break;
+                case AnalysisDiffRelation.Removal removal:
+                    MarkCoordinates(
+                        removal.BeforeCoordinates,
+                        beforeCoverage,
+                        "Before",
+                        relationIndex);
+                    break;
+                case AnalysisDiffRelation.Correspondence correspondence:
+                    MarkCoordinates(
+                        correspondence.BeforeCoordinates,
+                        beforeCoverage,
+                        "Before",
+                        relationIndex);
+                    MarkCoordinates(
+                        correspondence.AfterCoordinates,
+                        afterCoverage,
+                        "After",
+                        relationIndex);
+                    break;
+                default:
+                    throw new ArgumentException(
+                        $"Relation {relationIndex} has an unknown relation type.",
+                        nameof(Relations));
+            }
+        }
+
+        RequireCompleteCoverage(beforeCoverage, "Before");
+        RequireCompleteCoverage(afterCoverage, "After");
+
+        return
+        [
+            .. relations
+                .OrderBy(CanonicalGroup)
+                .ThenBy(FirstCoordinate),
+        ];
+    }
+
+    static void MarkCoordinates(
+        ImmutableArray<int> coordinates,
+        bool[] coverage,
+        string endpoint,
+        int relationIndex)
+    {
+        foreach (int coordinate in coordinates)
+        {
+            if ((uint)coordinate >= (uint)coverage.Length)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(Relations),
+                    coordinate,
+                    $"{endpoint} coordinate {coordinate} in relation {relationIndex} is out of range.");
+            }
+            if (coverage[coordinate])
+            {
+                throw new ArgumentException(
+                    $"{endpoint} coordinate {coordinate} occurs in more than one relation.",
+                    nameof(Relations));
+            }
+
+            coverage[coordinate] = true;
+        }
+    }
+
+    static void RequireCompleteCoverage(bool[] coverage, string endpoint)
+    {
+        int missingCoordinate = Array.IndexOf(coverage, false);
+        if (missingCoordinate >= 0)
+        {
+            throw new ArgumentException(
+                $"{endpoint} coordinate {missingCoordinate} does not occur in any relation.",
+                nameof(Relations));
+        }
+    }
+
+    static int CanonicalGroup(AnalysisDiffRelation relation)
+        => relation is AnalysisDiffRelation.Addition ? 1 : 0;
+
+    static int FirstCoordinate(AnalysisDiffRelation relation)
+        => relation switch
+        {
+            AnalysisDiffRelation.Addition addition => addition.AfterCoordinates[0],
+            AnalysisDiffRelation.Removal removal => removal.BeforeCoordinates[0],
+            AnalysisDiffRelation.Correspondence correspondence
+                => correspondence.BeforeCoordinates[0],
+            _ => throw new InvalidOperationException("Unknown analysis diff relation type."),
+        };
+}

--- a/src/ILInspector.Instructions.Tests/AnalysisDiffTests.cs
+++ b/src/ILInspector.Instructions.Tests/AnalysisDiffTests.cs
@@ -1,0 +1,387 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Instructions.Tests;
+
+public class AnalysisDiffTests
+{
+    [Fact]
+    public void AnalysisDiff_ConstructsEmptyDiff()
+    {
+        var diff = new AnalysisDiff<string>([], [], []);
+
+        Assert.Empty(diff.Before);
+        Assert.Empty(diff.After);
+        Assert.Empty(diff.Relations);
+    }
+
+    [Fact]
+    public void AnalysisDiff_ConstructsOneSidedAndAllCorrespondenceArities()
+    {
+        var additionOnly = new AnalysisDiff<string>(
+            [],
+            ["a", "b"],
+            [Addition(1), Addition(0)]);
+        var removalOnly = new AnalysisDiff<string>(
+            ["a", "b"],
+            [],
+            [Removal(1), Removal(0)]);
+        var oneToOne = Corresponding(
+            ["a"],
+            ["b"],
+            Correspondence([0], [0]));
+        var oneToMany = Corresponding(
+            ["a"],
+            ["b", "c"],
+            Correspondence([0], [0, 1]));
+        var manyToOne = Corresponding(
+            ["a", "b"],
+            ["c"],
+            Correspondence([0, 1], [0]));
+        var manyToMany = Corresponding(
+            ["a", "b"],
+            ["c", "d", "e"],
+            Correspondence([0, 1], [0, 1, 2]));
+
+        Assert.Collection(
+            additionOnly.Relations,
+            relation => Assert.Equal([0], Assert.IsType<AnalysisDiffRelation.Addition>(relation).AfterCoordinates),
+            relation => Assert.Equal([1], Assert.IsType<AnalysisDiffRelation.Addition>(relation).AfterCoordinates));
+        Assert.Collection(
+            removalOnly.Relations,
+            relation => Assert.Equal([0], Assert.IsType<AnalysisDiffRelation.Removal>(relation).BeforeCoordinates),
+            relation => Assert.Equal([1], Assert.IsType<AnalysisDiffRelation.Removal>(relation).BeforeCoordinates));
+        Assert.Single(oneToOne.Relations);
+        Assert.Single(oneToMany.Relations);
+        Assert.Single(manyToOne.Relations);
+        Assert.Single(manyToMany.Relations);
+    }
+
+    [Fact]
+    public void AnalysisDiff_CarriesOrthogonalCorrespondenceFacets()
+    {
+        var movedAndChanged = Correspondence(
+            [0],
+            [0],
+            AnalysisDiffContentKind.Changed,
+            AnalysisDiffPlacementKind.Moved);
+        var unclassified = Correspondence(
+            [1],
+            [1],
+            AnalysisDiffContentKind.Unclassified,
+            AnalysisDiffPlacementKind.Unclassified);
+        var diff = new AnalysisDiff<string>(
+            ["a", "b"],
+            ["c", "d"],
+            [unclassified, movedAndChanged]);
+
+        var first = Assert.IsType<AnalysisDiffRelation.Correspondence>(diff.Relations[0]);
+        Assert.Equal(AnalysisDiffContentKind.Changed, first.Content);
+        Assert.Equal(AnalysisDiffPlacementKind.Moved, first.Placement);
+
+        var second = Assert.IsType<AnalysisDiffRelation.Correspondence>(diff.Relations[1]);
+        Assert.Equal(AnalysisDiffContentKind.Unclassified, second.Content);
+        Assert.Equal(AnalysisDiffPlacementKind.Unclassified, second.Placement);
+    }
+
+    [Fact]
+    public void AnalysisDiff_PreservesPathologicalMixedTopology()
+    {
+        var diff = new AnalysisDiff<string>(
+            ["beta", "alpha", "gamma", "obsolete"],
+            ["beta-a", "beta-b", "gamma", "alpha-2", "delta"],
+            [
+                Addition(4),
+                Removal(3),
+                Correspondence(
+                    [2],
+                    [2],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Stable),
+                Correspondence(
+                    [1],
+                    [3],
+                    AnalysisDiffContentKind.Changed,
+                    AnalysisDiffPlacementKind.Moved),
+                Correspondence(
+                    [0],
+                    [0, 1],
+                    AnalysisDiffContentKind.Changed,
+                    AnalysisDiffPlacementKind.Stable),
+            ]);
+
+        Assert.Collection(
+            diff.Relations,
+            relation =>
+            {
+                var correspondence =
+                    Assert.IsType<AnalysisDiffRelation.Correspondence>(relation);
+                Assert.Equal([0], correspondence.BeforeCoordinates);
+                Assert.Equal([0, 1], correspondence.AfterCoordinates);
+            },
+            relation =>
+            {
+                var correspondence =
+                    Assert.IsType<AnalysisDiffRelation.Correspondence>(relation);
+                Assert.Equal([1], correspondence.BeforeCoordinates);
+                Assert.Equal([3], correspondence.AfterCoordinates);
+                Assert.Equal(AnalysisDiffContentKind.Changed, correspondence.Content);
+                Assert.Equal(AnalysisDiffPlacementKind.Moved, correspondence.Placement);
+            },
+            relation => Assert.Equal(
+                [2],
+                Assert.IsType<AnalysisDiffRelation.Correspondence>(relation).BeforeCoordinates),
+            relation => Assert.Equal(
+                [3],
+                Assert.IsType<AnalysisDiffRelation.Removal>(relation).BeforeCoordinates),
+            relation => Assert.Equal(
+                [4],
+                Assert.IsType<AnalysisDiffRelation.Addition>(relation).AfterCoordinates));
+    }
+
+    [Fact]
+    public void AnalysisDiff_RejectsDefaultArraysAndNullValues()
+    {
+        ImmutableArray<string> defaultItems = default;
+        ImmutableArray<AnalysisDiffRelation> defaultRelations = default;
+
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>(defaultItems, [], []));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>([], defaultItems, []));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>([], [], defaultRelations));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>([null!], [], [Removal(0)]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>([], [null!], [Addition(0)]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>([], [], [null!]));
+    }
+
+    [Fact]
+    public void AnalysisDiffRelation_RejectsInvalidCoordinates()
+    {
+        ImmutableArray<int> defaultCoordinates = default;
+
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Addition(defaultCoordinates));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Removal(defaultCoordinates));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence(defaultCoordinates, [0]));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence([0], defaultCoordinates));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Addition([]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Removal([]));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence([], [0]));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence([0], []));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence([1, 0], [0]));
+        Assert.Throws<ArgumentException>(
+            () => Correspondence([0, 0], [0]));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Correspondence([-1], [0]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Addition([0, 1]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiffRelation.Removal([0, 1]));
+    }
+
+    [Fact]
+    public void AnalysisDiffRelation_RejectsUnknownClassifications()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Correspondence(
+                [0],
+                [0],
+                (AnalysisDiffContentKind)int.MaxValue,
+                AnalysisDiffPlacementKind.Stable));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Correspondence(
+                [0],
+                [0],
+                AnalysisDiffContentKind.Unchanged,
+                (AnalysisDiffPlacementKind)int.MaxValue));
+    }
+
+    [Fact]
+    public void AnalysisDiff_RejectsOutOfRangeOverlapAndIncompleteCoverage()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AnalysisDiff<string>([], ["a"], [Addition(1)]));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new AnalysisDiff<string>(["a"], [], [Removal(1)]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>(
+                ["a"],
+                ["b"],
+                [Correspondence([0], [0]), Removal(0)]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>(
+                ["a"],
+                ["b"],
+                [Correspondence([0], [0]), Addition(0)]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>(["a", "b"], ["c"], [Correspondence([0], [0])]));
+        Assert.Throws<ArgumentException>(
+            () => new AnalysisDiff<string>(["a"], ["b", "c"], [Correspondence([0], [0])]));
+    }
+
+    [Fact]
+    public void AnalysisDiff_CanonicalizesRelationOrder()
+    {
+        var first = new AnalysisDiff<string>(
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+            [
+                Addition(2),
+                Correspondence([1], [0]),
+                Removal(2),
+                Correspondence([0], [1]),
+            ]);
+        var equivalent = new AnalysisDiff<string>(
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+            [
+                Correspondence([0], [1]),
+                Removal(2),
+                Addition(2),
+                Correspondence([1], [0]),
+            ]);
+
+        Assert.Collection(
+            first.Relations,
+            relation => Assert.Equal([0], Assert.IsType<AnalysisDiffRelation.Correspondence>(relation).BeforeCoordinates),
+            relation => Assert.Equal([1], Assert.IsType<AnalysisDiffRelation.Correspondence>(relation).BeforeCoordinates),
+            relation => Assert.Equal([2], Assert.IsType<AnalysisDiffRelation.Removal>(relation).BeforeCoordinates),
+            relation => Assert.Equal([2], Assert.IsType<AnalysisDiffRelation.Addition>(relation).AfterCoordinates));
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+    }
+
+    [Fact]
+    public void AnalysisDiff_UsesSequenceValueEquality()
+    {
+        string firstA = new('a', 1);
+        string secondA = new('a', 1);
+        string firstB = new('b', 1);
+        string secondB = new('b', 1);
+        var relations = new AnalysisDiffRelation[]
+        {
+            Correspondence([0], [0]),
+            Correspondence([1], [1]),
+        };
+
+        var first = new AnalysisDiff<string>(
+            [firstA, firstB],
+            ["c", "d"],
+            [.. relations]);
+        var equivalent = new AnalysisDiff<string>(
+            [secondA, secondB],
+            [new('c', 1), new('d', 1)],
+            [
+                Correspondence([0], [0]),
+                Correspondence([1], [1]),
+            ]);
+        var reordered = new AnalysisDiff<string>(
+            [firstB, firstA],
+            ["c", "d"],
+            [.. relations]);
+        var differentMultiplicity = new AnalysisDiff<string>(
+            [firstA, firstA],
+            ["c", "d"],
+            [.. relations]);
+
+        Assert.NotSame(firstA, secondA);
+        Assert.NotSame(firstB, secondB);
+        Assert.Equal(first, equivalent);
+        Assert.Equal(first.GetHashCode(), equivalent.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, differentMultiplicity);
+    }
+
+    [Fact]
+    public void AnalysisDiff_DistinguishesMembershipAndClassification()
+    {
+        var original = Corresponding(
+            ["a", "b"],
+            ["c", "d"],
+            Correspondence(
+                [0, 1],
+                [0, 1],
+                AnalysisDiffContentKind.Changed,
+                AnalysisDiffPlacementKind.Stable));
+        var differentMembership = new AnalysisDiff<string>(
+            ["a", "b"],
+            ["c", "d"],
+            [
+                Correspondence([0], [0]),
+                Correspondence([1], [1]),
+            ]);
+        var differentContent = Corresponding(
+            ["a", "b"],
+            ["c", "d"],
+            Correspondence(
+                [0, 1],
+                [0, 1],
+                AnalysisDiffContentKind.Unchanged,
+                AnalysisDiffPlacementKind.Stable));
+        var differentPlacement = Corresponding(
+            ["a", "b"],
+            ["c", "d"],
+            Correspondence(
+                [0, 1],
+                [0, 1],
+                AnalysisDiffContentKind.Changed,
+                AnalysisDiffPlacementKind.Moved));
+
+        Assert.NotEqual(original, differentMembership);
+        Assert.NotEqual(original, differentContent);
+        Assert.NotEqual(original, differentPlacement);
+        Assert.NotEqual<AnalysisDiffRelation>(Addition(0), Removal(0));
+    }
+
+    [Fact]
+    public void AnalysisDiff_PayloadEqualityDoesNotEstablishCorrespondence()
+    {
+        var oneSided = new AnalysisDiff<string>(
+            ["same"],
+            ["same"],
+            [Addition(0), Removal(0)]);
+        var corresponding = Corresponding(
+            ["same"],
+            ["same"],
+            Correspondence(
+                [0],
+                [0],
+                AnalysisDiffContentKind.Unclassified,
+                AnalysisDiffPlacementKind.Unclassified));
+
+        Assert.NotEqual(oneSided, corresponding);
+    }
+
+    static AnalysisDiff<string> Corresponding(
+        ImmutableArray<string> before,
+        ImmutableArray<string> after,
+        AnalysisDiffRelation.Correspondence relation)
+        => new(before, after, [relation]);
+
+    static AnalysisDiffRelation.Addition Addition(params int[] coordinates)
+        => new([.. coordinates]);
+
+    static AnalysisDiffRelation.Removal Removal(params int[] coordinates)
+        => new([.. coordinates]);
+
+    static AnalysisDiffRelation.Correspondence Correspondence(
+        ImmutableArray<int> beforeCoordinates,
+        ImmutableArray<int> afterCoordinates,
+        AnalysisDiffContentKind content = AnalysisDiffContentKind.Unchanged,
+        AnalysisDiffPlacementKind placement = AnalysisDiffPlacementKind.Stable)
+        => new(beforeCoordinates, afterCoordinates, content, placement);
+}


### PR DESCRIPTION
`ILInspector.Findings` now provides the complete immutable `AnalysisDiff<T>` information format defined by #5493: ordered Before/After sequences, closed singleton Addition and Removal relations, N:M Correspondence relations with orthogonal content and placement facets, exhaustive partition validation, canonical relation ordering, and explicit value semantics.

## Demo

The design pathological case is now executable product construction rather than a prose-only shape. One diff retains all five facts together:

```text
Before beta          -> After beta-a, beta-b   Changed + Stable
Before alpha         -> After alpha-2          Changed + Moved
Before gamma         -> After gamma            Unchanged + Stable
Before obsolete      ->                        Removal
                         After delta             Addition
```

The constructor stores those relations canonically by Before coordinate, followed by the Addition, without inferring item pairs inside the one-to-many beta relation or degrading the moved alpha relation to remove-plus-add.

## Validation

- `dotnet run --project src/ILInspector.Instructions.Tests -c Release` — 58 passed
- `dotnet build dotnet-inspect.slnx -c Release --no-restore` — succeeded with 0 warnings
- `npx markdownlint-cli docs/architecture.md docs/overview.md docs/design/analysis-diff.md docs/design/finding-nomenclature.md docs/design/finding-value-equality.md` — passed

## Compatibility and boundaries

This is a new dependency-free Findings value contract. It does not add a universal `FindingComparison<T>` converter, matching or movement inference, serialization, consumer statistics, Markout lowering, or producer adoption.

Stack slice 2: targets the design branch from #5493. The next slice implements `ComparisonDocument<T>`; fixture and producer adoption remain separate.

Closes #5504.