### PR TITLE
Clarify consumer-led shared substrate guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ development model and rationale. The binding summary:
 - **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
   code. Duplicated host logic triggers a review for a shared abstraction that
   would also benefit another future host.
+- **Choose rendering strategy deliberately.** Use Markout as the default
+  host-neutral substrate for centralized, multi-format rendering, and call out
+  host-specific rendering that bypasses it. Broad information domains such as
+  call graphs and diffs require a documented structured-typing and format-
+  lowering strategy, whether it uses Markout or another approach.
 - **Demonstrate the pathological case.** Build boundary and failure fixtures;
   run contract-defining cases in CI and preserve valuable non-CI probes as
   reproducible design evidence.
@@ -76,20 +81,10 @@ development model and rationale. The binding summary:
 ## Session resume
 
 The transcript survives a resumed session; repository and PR state may not.
-Before continuing:
-
-1. Confirm the worktree, branch, and head from git. Fetch the effective base and
-   re-check the PR per [Canonical round flow](#canonical-round-flow). Do not pull
-   or rebase a pushed branch to catch up.
-2. Rename the window and re-announce the PR as described below.
-3. State which case applies:
-
-- **Mid-stream:** continue, but handle conflicts, failed gates, or moved bases
-  first. Do not revisit decisions already settled in the transcript.
-- **Waiting on the user:** restate the full question and options, then wait.
-- **Task complete:** state what landed and what proves it, then propose the next
-  task without starting it.
-- **Unclear:** explain what the transcript claims and what git shows, then wait.
+Follow [Resume a session](docs/agent-session-state.md#resume-a-session) to
+confirm the worktree and PR, refresh the effective base, restore window
+identity, and classify the session. Handle conflicts, failed gates, or moved
+bases first, and do not revisit decisions already settled in the transcript.
 
 ## Making your work findable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ development model and rationale. The binding summary:
   substrate identifies its consumer in the specification and issue, links an
   overall end-to-end tracker, and may land its consumer in a later slice.
   Shared substrate must benefit and plan enablement through both the CLI and
-  browser/Wasm hosts.
+  browser/Wasm hosts; a single-consumer or single-host substrate requires
+  explicit user approval from the start.
 - **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
   code. Duplicated host logic triggers a review for a shared abstraction that
   would also benefit another future host.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,19 @@ development model and rationale. The binding summary:
 
 - **Start from convention and best practice.** Name and justify any deliberate
   divergence, whether stricter or looser, and document its scope.
+- **Prefer the simplest sufficient design.** Add complexity only when robust
+  reliability or correctness requires it, or when it enables a compelling
+  user-observable experience.
 - **Design first and state the basis.** Name one normative owner and exact
   claim, then supporting designs, models, constraints, and evidence by role.
+- **Start capabilities from named consumers.** Every new capability or
+  substrate identifies its consumer in the specification and issue, links an
+  overall end-to-end tracker, and plans enablement through both the CLI and
+  browser/Wasm hosts. The consumer may land later; shared substrate must
+  benefit both hosts.
+- **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
+  code. Duplicated host logic triggers a review for a shared abstraction that
+  would also benefit another future host.
 - **Demonstrate the pathological case.** Build boundary and failure fixtures;
   run contract-defining cases in CI and preserve valuable non-CI probes as
   reproducible design evidence.
@@ -133,39 +144,8 @@ The user may adjust a sequencing gate for a specific task or PR. Follow that
 direction, record its scope and evidentiary consequence, and preserve every
 other requirement. An adjustment does not make failed validation successful,
 make an unmergeable PR ready, or transfer fixed-head evidence to a new head.
-
-### Standing adjustments
-
-- **Review ordinary non-Markdown changes in parallel with CI:** requires user
-  approval; conflict recovery is the explicit exception. A CI failure requiring
-  an author change still supersedes the attempt, and all findings carry forward.
-- **Pre-authorize merge for the final head:** after clean reviews or a waiver,
-  the user may authorize its exact head and base ref. Keep auto-merge unarmed
-  while gates are pending; after green preflight, use the [exact-head
-  precondition](docs/github-api-operations.md#bind-merge-mutations-to-the-head).
-  Head/base-ref change or invalidated evidence expires authorization;
-  no-interaction tip movement within the same base ref preserves it.
-- **"CI is ready":** the user's statement that CI has no failures and the PR is
-  mergeable. Trust it without re-checking and move to the next task, such as
-  dispatching the next round's reviewers.
-- **Authorizing the next round before CI completes:** the agent does not need
-  to check CI status first; proceed with the authorized round.
-- **Skip re-review after a trivial base interaction:** requires the user's
-  approval for one exact integration head and its mechanically resolved
-  interaction at one exact analyzed base tip, offered only for a
-  `main`-targeting PR or bottom open stack slice whose waiver lineage starts at
-  one immutable review-clean head and recorded base (a renewal may only
-  integrate a further moved base from that same lineage).
-  Every overlap must resolve mechanically — analyzed base side verbatim, or
-  drop the PR's change to that file — and the cumulative diff against the
-  newest base must stay a subset of the original reviewed diff with no
-  surviving reviewed claim, contract, or behavior changed. `review-clean` stays
-  absent on the integration head. Later no-interaction base movement extends
-  the waiver and recorded merge authorization to the analyzed tip without
-  moving the head or asking again; head movement or any other interaction
-  expires both. Semantic conflict resolution or new authored change requires
-  ordinary re-review. Evidence to publish:
-  [Trivial-interaction re-review waiver](docs/round-orchestration.md#trivial-interaction-re-review-waiver).
+The standing adjustments and their exact evidence requirements live in
+[User-directed workflow adjustments](docs/round-orchestration.md#user-directed-workflow-adjustments).
 
 ## Before changing files
 
@@ -365,13 +345,6 @@ Test-tool activation (`ilasm`/`ildasm`/`mdv`), the IL round-trip commands, and
 the `IsPackable`/`VersionPrefix` release rules live in
 [`docs/dev-environment.md`](docs/dev-environment.md#test-tooling-activation).
 
-### Package acquisition and throwaway probes
-
-If nuget.org is disabled and restore reports `NU1603` for an uncached pin, or
-you need a throwaway probe, see
-[`docs/dev-environment.md`](docs/dev-environment.md) for the source-override
-and file-based-app commands.
-
 ## Evidence and validation
 
 Match evidence to the claim and use the smallest existing check that proves it.
@@ -422,8 +395,8 @@ section and [round orchestration](docs/round-orchestration.md) explain them.
    author change restarts the *same* round.
 7. **Six rounds, then stop** and ask for another block.
 8. **Never merge without explicit user authorization** for that specific PR.
-   A recorded exact-head merge authorization satisfies this rule; see
-   [Standing adjustments](#standing-adjustments).
+   A recorded exact-head merge authorization satisfies this rule; see the
+   [user-directed workflow adjustments](docs/round-orchestration.md#user-directed-workflow-adjustments).
 
 ### Canonical round flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ development model and rationale. The binding summary:
   claim, then supporting designs, models, constraints, and evidence by role.
 - **Start capabilities from named consumers.** Every new capability or
   substrate identifies its consumer in the specification and issue, links an
-  overall end-to-end tracker, and plans enablement through both the CLI and
-  browser/Wasm hosts. The consumer may land later; shared substrate must
-  benefit both hosts.
+  overall end-to-end tracker, and may land its consumer in a later slice.
+  Shared substrate must benefit and plan enablement through both the CLI and
+  browser/Wasm hosts.
 - **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
   code. Duplicated host logic triggers a review for a shared abstraction that
   would also benefit another future host.

--- a/docs/agent-session-state.md
+++ b/docs/agent-session-state.md
@@ -4,6 +4,25 @@
 binding rules: every window identifies its PR, current state, and any decision
 it needs. This document owns the tmux mechanics and the reasoning behind them.
 
+## Resume a session
+
+The transcript survives a resumed session; repository and PR state may not.
+Before continuing:
+
+1. Confirm the worktree, branch, and head from git. Fetch the effective base and
+   re-check the PR per
+   [Canonical round flow](../AGENTS.md#canonical-round-flow). Do not pull or
+   rebase a pushed branch to catch up.
+2. Rename the window and re-announce the PR as described below.
+3. State which case applies:
+
+- **Mid-stream:** continue, but handle conflicts, failed gates, or moved bases
+  first. Do not revisit decisions already settled in the transcript.
+- **Waiting on the user:** restate the full question and options, then wait.
+- **Task complete:** state what landed and what proves it, then propose the next
+  task without starting it.
+- **Unclear:** explain what the transcript claims and what git shows, then wait.
+
 ## Detecting tmux
 
 Everything below applies only inside a tmux pane. Test with `[ -n "$TMUX" ]`

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -76,11 +76,18 @@ start. The consumer may land in a later slice, but the focused specification
 and implementation issue must identify it, and a single overall end-to-end
 tracking issue must link the substrate and consumer work.
 
-Shared product substrate must have a planned benefit in both current product
+Shared product substrate defaults to planned benefit in both current product
 hosts: the CLI and browser/Wasm. The end-to-end tracker records the planned
-enablement slices for both hosts from the outset. This keeps substrate tied to
-observable value and tests whether the boundary belongs in shared code rather
-than one host.
+enablement slices for both hosts from the outset. A substrate intended for only
+one consumer or host requires explicit user approval before implementation;
+record the approved scope in its specification, implementation issue, and
+end-to-end tracker from the start.
+
+`InertString` illustrates the shared default: its containment contract must
+work for all consumers. `ts-jsexport` is an approved exception: its website-only
+consumer and single-host target were intentional from the beginning. The
+default and exception both keep substrate tied to observable value and make
+the shared-versus-host-specific boundary explicit before implementation.
 
 Keep each host as thin as reasonably possible. Hosts own gestures, policy,
 operation lifetime, composition, and presentation; reusable concepts and

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -20,6 +20,19 @@ a feature uniquely valuable; it does not excuse weak boundaries, evidence, or
 reliability. The strongest work combines dependable foundations with a
 capability or experience worth choosing.
 
+## Prefer the simplest sufficient design
+
+Bias toward the simplest design that satisfies the owning contract. Add
+states, layers, abstractions, protocols, or policy only when they are required
+for robust reliability or correctness, or when they enable a compelling
+user-observable experience. Name that requirement and the evidence that will
+show the added complexity earns its cost.
+
+Speculative generality, possible future reuse, and internal elegance alone do
+not justify complexity. Simplicity does not permit fragile behavior, hidden
+failure, or a diminished experience; it keeps the solution no more elaborate
+than the demonstrated need.
+
 ## Convention and best practice are the baseline
 
 Start from the applicable convention and best practice rather than inventing a
@@ -55,6 +68,26 @@ established oracle, a TLA+ model, a pathological fixture, or a specification
 developed closely with the user can reveal the actual boundary before code
 makes an accidental behavior expensive to undo. Much of the architecture is
 the act of bounding a contract and making its important properties invariant.
+
+## Start capabilities from consumers
+
+Every new capability or substrate must name a concrete consumer from the
+start. The consumer may land in a later slice, but the focused specification
+and implementation issue must identify it, and a single overall end-to-end
+tracking issue must link the substrate and consumer work.
+
+Shared product substrate must have a planned benefit in both current product
+hosts: the CLI and browser/Wasm. The end-to-end tracker records the planned
+enablement slices for both hosts from the outset. This keeps substrate tied to
+observable value and tests whether the boundary belongs in shared code rather
+than one host.
+
+Keep each host as thin as reasonably possible. Hosts own gestures, policy,
+operation lifetime, composition, and presentation; reusable concepts and
+algorithms belong in host-neutral code. When multiple hosts duplicate logic,
+look for a coherent shared concept that would also benefit a future host rather
+than preserving parallel implementations or extracting an abstraction solely
+to remove repeated lines.
 
 ## Demonstrate the pathological case
 

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -96,6 +96,30 @@ look for a coherent shared concept that would also benefit a future host rather
 than preserving parallel implementations or extracting an abstraction solely
 to remove repeated lines.
 
+## Choose rendering strategy deliberately
+
+`dotnet-inspect` uses Markout as its default host-neutral rendering substrate
+to centralize rendering and support multiple output formats. Preserve typed
+information until the rendering boundary so one domain model can lower into
+the structures each format can express.
+
+Call out every rendering path that bypasses Markout for a host-specific
+approach. Its owning specification must name the host, the reason the rendering
+is host-specific, the typed information model it consumes, and why a shared
+Markout lowering is not the chosen boundary.
+
+Broad information domains require a documented rendering-strategy decision
+before implementation. Call graphs and diffs are positive examples of
+expanding Markout around structured domain types and explicit lowering
+mechanics: the same information can become a Mermaid diagram, Markdown table,
+tabular stream, or another supported shape without making formatted text the
+domain model.
+
+Markout is the default, not an automatic answer. A broad domain may choose
+another approach when its design documents where structured typing lives, who
+owns each lowering, which paths are host-specific, and how additional hosts or
+formats consume the information without reconstructing its semantics.
+
 ## Demonstrate the pathological case
 
 Do not demonstrate only the expected or friendly case. Identify the case, or

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -3,13 +3,53 @@
 `AGENTS.md` owns the binding rules for adversarial review: what a candidate is,
 when a round may start, what makes a review review-clean, and when to stop. This
 document owns the operational side — how to find out where the round stands, how
-to dispatch and reconcile it, and what to do when the base moves under a clean
-result.
+to dispatch and reconcile it, how approved workflow adjustments apply, and what
+to do when the base moves under a clean result.
 
 Read [Adversarial review](../AGENTS.md#adversarial-review) first. This document
 owns operational transitions and reporting, not the rules that decide
 eligibility, recovery, completion, or carry-forward. Where it applies one of
 those rules, it cites the owner rather than restating it.
+
+## User-directed workflow adjustments
+
+[AGENTS.md](../AGENTS.md#user-directed-workflow-adjustments) states the binding
+boundary: a user adjustment changes only its named sequencing gate and cannot
+make failed evidence successful or transfer fixed-head evidence. The following
+standing adjustments define their exact scope and effect.
+
+### Standing adjustments
+
+- **Review ordinary non-Markdown changes in parallel with CI:** requires user
+  approval; conflict recovery is the explicit exception. A CI failure requiring
+  an author change still supersedes the attempt, and all findings carry forward.
+- **Pre-authorize merge for the final head:** after clean reviews or a waiver,
+  the user may authorize its exact head and base ref. Keep auto-merge unarmed
+  while gates are pending; after green preflight, use the [exact-head
+  precondition](github-api-operations.md#bind-merge-mutations-to-the-head).
+  Head/base-ref change or invalidated evidence expires authorization;
+  no-interaction tip movement within the same base ref preserves it.
+- **"CI is ready":** the user's statement that CI has no failures and the PR is
+  mergeable. Trust it without re-checking and move to the next task, such as
+  dispatching the next round's reviewers.
+- **Authorizing the next round before CI completes:** the agent does not need
+  to check CI status first; proceed with the authorized round.
+- **Skip re-review after a trivial base interaction:** requires the user's
+  approval for one exact integration head and its mechanically resolved
+  interaction at one exact analyzed base tip, offered only for a
+  `main`-targeting PR or bottom open stack slice whose waiver lineage starts at
+  one immutable review-clean head and recorded base (a renewal may only
+  integrate a further moved base from that same lineage).
+  Every overlap must resolve mechanically — analyzed base side verbatim, or
+  drop the PR's change to that file — and the cumulative diff against the
+  newest base must stay a subset of the original reviewed diff with no
+  surviving reviewed claim, contract, or behavior changed. `review-clean` stays
+  absent on the integration head. Later no-interaction base movement extends
+  the waiver and recorded merge authorization to the analyzed tip without
+  moving the head or asking again; head movement or any other interaction
+  expires both. Semantic conflict resolution or new authored change requires
+  ordinary re-review. Evidence to publish:
+  [Trivial-interaction re-review waiver](#trivial-interaction-re-review-waiver).
 
 ## Candidate lifecycle
 
@@ -518,7 +558,7 @@ not start or spend a replacement round.
 ### Trivial-interaction re-review waiver
 
 The binding criteria and evidentiary limits live in
-[Standing adjustments](../AGENTS.md#standing-adjustments). Approval covers one
+[Standing adjustments](#standing-adjustments). Approval covers one
 exact integration head and its mechanically resolved interaction at the named
 base tip; later no-interaction tips extend that lineage without changing the
 head. After the integration head is pushed, publish this evidence before

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -112,7 +112,7 @@ tell a restack from a rewrite.
 
 The only moved-stack-head exception is the bottom open slice after it targets
 `main`. If its base integration satisfies the
-[trivial-interaction waiver](../AGENTS.md#standing-adjustments) and the user
+[trivial-interaction waiver](round-orchestration.md#standing-adjustments) and the user
 approves that exact head, it may proceed without another review-clean round.
 That integration is not an upper-slice restack: it neither rewrites a child
 onto a newly landed parent nor changes a surviving reviewed claim. The waiver


### PR DESCRIPTION
## Summary

- bias designs toward the simplest solution sufficient for reliability,
  correctness, or a compelling user-observable experience
- require every new capability or substrate to name a consumer in its
  specification and issue, link an overall end-to-end tracker, and plan
  enablement through both the CLI and browser/Wasm hosts
- require explicit user approval from the start when substrate intentionally
  serves only one consumer or host
- keep hosts thin by placing reusable concepts and algorithms in host-neutral
  code and treating duplicated host logic as a prompt to examine a shared
  abstraction
- use Markout as the default host-neutral, multi-format rendering substrate;
  require host-specific renderers to be explicit and broad information domains
  to document their structured typing and format-lowering strategy
- restore `AGENTS.md` below its 600-line cap by moving detailed standing
  workflow adjustments and resume mechanics to their owning documents

## Demo

Before this guidance, a design could introduce shared substrate without
recording which product experience would consume it or how both hosts would
adopt it.

After this guidance, the design record starts with:

```text
Consumer: <concrete product capability>
Capability issue: #<focused issue>
End-to-end tracker: #<overall tracker>
CLI enablement: #<planned slice>
Browser/Wasm enablement: #<planned slice>
Complexity basis: <required correctness, reliability, or user experience>
Single-consumer approval: <not applicable, or approved scope and decision>
Rendering strategy: <Markout lowerings, or documented host-specific approach>
```

This makes the intended shared boundary and both host-specific enablement
slices reviewable before substrate implementation begins. `InertString`
illustrates the shared default because it must work for all consumers;
`ts-jsexport` illustrates an approved website-only exception whose single-host
scope was intentional from the start.

For broad rendering domains, the same record identifies where structured types
live and how they lower into supported formats. Call graphs and diffs illustrate
the intended pattern: preserve the information model, then choose a Mermaid,
table, stream, or other rendering at the boundary.

## Validation

- `npx markdownlint-cli AGENTS.md docs/agent-session-state.md docs/development-practices.md docs/round-orchestration.md docs/stacked-prs.md`
- `wc -l AGENTS.md` (`585`)

This changes contributor guidance only; it does not change product behavior.
