### PR TITLE
Add producer-issued Finding census identity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
 | [Finding Nomenclature](design/finding-nomenclature.md) | Canonical observation/change vocabulary, arity ladder, operation outcomes, and Research composition boundary. |
 | [Finding Producer Design](design/finding-producers.md) | Choosing producer ownership, payloads, identities, result shapes, matching modes, and higher-rung boundaries. |
+| [Finding Instance Census](design/finding-instance-census.md) | Producer-issued receipt and per-instance keys for one sealed Finding census, including exact-association validation. |
 | [Finding Value Semantics](design/finding-value-equality.md) | Equality and hashing for Finding-owned structural values, ordered collections, identity sets, union cases, and operation objects. |
 | [Performance Analysis Baselines](analysis-baselines.md) | Internal baselines of what each analysis type finds over a fixed corpus, with effectiveness ratings for the one-stop-shop Performance Analysis view. |
 | [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,7 @@ depends on typed models.
 
 | Region | Place in flow | Responsibility | Primary authority |
 | ------ | ------------- | -------------- | ----------------- |
-| `ILInspector.Findings` | Result contracts | Domain-free observation, census, matching, transition, comparison, and correlation contracts. | [Finding nomenclature](design/finding-nomenclature.md), [Finding producers](design/finding-producers.md) |
+| `ILInspector.Findings` | Result contracts | Domain-free observation, sealed-census identity, matching, transition, comparison, and correlation contracts. | [Finding nomenclature](design/finding-nomenclature.md), [Finding instance census](design/finding-instance-census.md), [Finding producers](design/finding-producers.md) |
 | `ILInspector.Instructions` | Decode substrate | Shared instruction decoding and exception-region-aware basic blocks. | [Instruction substrate](design/instruction-substrate.md) |
 | `ILInspector.ControlFlow` | Flow substrate | Shared control-flow, dominance, and dataflow kernels. | [Instruction substrate](design/instruction-substrate.md) |
 | `ILInspector.Text` | Text producer | Exact ordered line inspection and generic text comparison on the Finding spine. | [Finding producers](design/finding-producers.md) |

--- a/docs/design/finding-instance-census.md
+++ b/docs/design/finding-instance-census.md
@@ -1,0 +1,279 @@
+# Finding instance census
+
+This document owns producer-issued identity for one sealed Finding census. It
+defines the receipt, per-instance key, canonical entry association, sealing
+operation, and validation outcome supplied by `ILInspector.Findings`.
+
+[Finding nomenclature](finding-nomenclature.md) owns observation, census, and
+operation-outcome meanings. [Finding coordinates](finding-coordinates.md) owns
+subject, correspondence, producer order, and provenance. [Finding value
+semantics](finding-value-equality.md) owns .NET equality and hashing.
+
+The end-to-end adoption is tracked by
+[issue #5515](https://github.com/richlander/dotnet-inspect/issues/5515):
+
+- Research preserves the identity through Facts and Annotated Source under
+  [issue #4717](https://github.com/richlander/dotnet-inspect/issues/4717);
+- the CLI consumes it under
+  [issue #4718](https://github.com/richlander/dotnet-inspect/issues/4718); and
+- Inspect Web transports and uses it under
+  [issues #5516](https://github.com/richlander/dotnet-inspect/issues/5516) and
+  [#5517](https://github.com/richlander/dotnet-inspect/issues/5517).
+
+## Problem
+
+One successful producer execution may emit multiple Findings with equal
+subjects, descriptors, correspondence keys, payloads, details, and rendered
+coordinates. Those observations remain separate census instances. A consumer
+that derives an identifier from those fields collapses multiplicity and cannot
+prove that independently constructed projections describe the same execution.
+
+Existing Finding coordinates answer different questions:
+
+| Coordinate | Question |
+| --- | --- |
+| `FindingSubject.Key` | What subject was inspected? |
+| `FindingKey` | Which observations correspond across versions? |
+| `Finding<T>.Ordinal` | Where did an ordered producer observe this value? |
+| Producer payload | What typed provenance supports the observation? |
+| Census receipt and instance key | Which exact occurrence belongs to this sealed execution? |
+
+The new identity is a separate axis. It must not be reconstructed from another
+axis even when current values happen to agree.
+
+## Contract
+
+`ILInspector.Findings` supplies four host-neutral types:
+
+| Type | Contract |
+| --- | --- |
+| `FindingCensusReceipt` | Opaque, non-default identifier for one sealed census. |
+| `FindingInstanceKey` | Positive compact key, injective only within one receipt. |
+| `FindingCensusEntry<T>` | One key associated with the exact `Finding<T>` reference admitted at sealing. |
+| `FindingCensus<T>` | Immutable ordered Findings and keyed entries from one seal operation. |
+
+The durable instance identity is the pair:
+
+```text
+(FindingCensusReceipt, FindingInstanceKey)
+```
+
+A key alone is not an identity. Equal numeric keys in different censuses are
+expected and unrelated.
+
+### Sealing
+
+`FindingCensus<T>.Seal` performs one eager enumeration and immutable
+materialization. It rejects:
+
+- a null collection;
+- a default `ImmutableArray<Finding<T>>`; and
+- a null Finding at any position.
+
+Only after materialization succeeds does the operation issue a non-default
+receipt and assign keys in census order. Keys are positive and one-based:
+entry zero receives key one, entry one receives key two, and so on. This leaves
+the default integer representation invalid without adding a second validity
+bit.
+
+The census retains:
+
+- `Findings`, preserving the original order and multiplicity; and
+- `Entries`, preserving the same order and exact Finding references.
+
+For every valid index `i`:
+
+```text
+Entries[i].Key.Value == i + 1
+ReferenceEquals(Entries[i].Finding, Findings[i])
+```
+
+The key is instance identity, not producer order authority. A later projection
+may filter or reorder entries while preserving each owner-issued key. Consumers
+must not reconstruct a key from a filtered position, a producer ordinal, or
+Finding content. The canonical `Entries` collection is the assignment
+authority; its one-based construction is not a public key-minting algorithm.
+
+### Empty census
+
+A successful empty census receives a non-default receipt and empty initialized
+collections. It is distinct from:
+
+- a second empty census produced by another seal;
+- `FindingInspection<T>.Absent`; and
+- `FindingInspection<T>.Failed`.
+
+The receipt proves which successful execution produced the empty census even
+though there are no instance keys.
+
+## Identity and equality
+
+The identity and equality shapes are deliberate:
+
+- `FindingCensusReceipt` has value equality over its opaque `Guid` value.
+- `FindingInstanceKey` has value equality over its positive integer value.
+- A receipt/key pair supplies one execution-local instance identity.
+- `FindingCensus<T>` uses reference identity. Independently sealing equal
+  Finding collections creates different census operations and different
+  receipts.
+- `FindingCensusEntry<T>` is an association object, not a structural value.
+  Consumers compare its key under the containing receipt and retain its exact
+  Finding reference.
+- `Finding<T>` equality, hashing, correspondence, and payload behavior do not
+  change.
+
+The receipt uses `Guid.NewGuid()` rather than object identity or a process-wide
+counter. A typed `Guid` wrapper is compact, host-neutral, NativeAOT-compatible,
+and can cross the managed/browser result boundary later without making this
+design own a serialization format. The seal operation excludes `Guid.Empty`.
+
+Receipt and key constructors are internal. Consumers retain owner-issued typed
+values in process; they cannot mint or rehydrate typed identity from raw
+components. A host adapter may project the public raw values outward under its
+own wire contract, but this design does not make inbound parsing or
+reconstruction valid.
+
+Per-census keys use a counter rather than random values. One sealing operation
+coordinates the full collection, so sequential assignment provides absolute
+injectivity within the receipt without probabilistic collision handling.
+
+## Validation
+
+`FindingCensus<T>.Validate` admits a candidate receipt and a proposed complete
+bijection. `FindingCensus<T>.ValidateEntry` admits one retained entry so a
+filtered projection does not need to pretend it contains the whole census.
+Candidate entries are constructible so projections can return their retained
+key/Finding associations to the owner for validation. Constructibility does
+not mint a valid identity: only the census receipt, canonical key range, and
+exact association establish admission.
+
+Validation does not require candidate enumeration order to match census order.
+It verifies a bijection by key and returns either
+`FindingCensusValidation.Valid` or
+`FindingCensusValidation.Invalid(FindingCensusValidationFailure)`.
+
+Failures use this deterministic precedence:
+
+1. `DefaultReceipt`
+2. `WrongReceipt`
+3. `UninitializedEntries`
+4. `NullEntry`
+5. `DefaultKey`
+6. `DuplicateKey`
+7. `ExtraKey`
+8. `MissingKey`
+9. `SubstitutedFinding`
+
+Collection and key-shape checks complete before exact Finding association is
+evaluated. Duplicate, extra, missing, and substituted failures identify the
+relevant `FindingInstanceKey`. Null-entry and default-key failures identify the
+first offending index in candidate enumeration order; their key remains
+default. When more than one non-default key could report the same failure
+class, the smallest key is reported. Key-set and association outcomes are
+therefore independent of candidate enumeration order.
+
+Failure coordinates are closed by kind:
+
+| Failure | `Key` | `InputIndex` |
+| --- | --- | --- |
+| `DefaultReceipt`, `WrongReceipt`, `UninitializedEntries` | Default | Null |
+| `NullEntry` | Default | First offending index for `Validate`; null for `ValidateEntry` |
+| `DefaultKey` | Default | First offending index for `Validate`; null for `ValidateEntry` |
+| `DuplicateKey`, `ExtraKey`, `MissingKey`, `SubstitutedFinding` | Relevant non-default key | Null |
+
+Substitution uses `ReferenceEquals`, not Finding value equality. Two
+structurally equal Findings remain distinct instances, and placing one under
+the other's valid key is rejected.
+
+`ValidateEntry` uses the same receipt, default-key, key-range, and substitution
+rules. Duplicate and missing keys are whole-projection properties and therefore
+apply only to `Validate`.
+
+The validator throws only for a null `entries` argument. Invalid typed state,
+including a default immutable array or null entry, returns a typed failure
+rather than an exception or a success-shaped empty result.
+
+## Composition boundaries
+
+This contract is the Finding-owned substrate. Adoption remains with its
+consumers:
+
+- producers decide where a sealed census belongs in their operation result;
+- Research owns preserving receipt/key identity through its projection
+  lifecycle;
+- the CLI owns command and structured-output presentation;
+- Inspect Web owns managed result transport and cross-view interaction.
+
+`FindingInspection<T>.Complete` remains an ordered Finding value. It does not
+gain receipt identity in this slice: inspection topology and sealed-census
+instance identity are independent concerns. A producer or composer may retain
+both where both contracts are required.
+
+The public receipt and key values are sufficient for a host adapter to project
+them. This design does not define JSON names, text formatting as a durable
+protocol, parsing, deserialization, packet persistence, or cross-session
+rehydration.
+
+Receipt inequality is the staleness and replacement discriminator available to
+consumers. Research and host owners decide when a newer operation supersedes an
+older one and reject non-matching receipts at their respective admission
+boundaries.
+
+## Convention basis
+
+The design follows established conventions by role:
+
+- Roslyn workspace IDs use opaque producer-issued `Guid` wrappers.
+- Roslyn `DiagnosticBag` separates mutable collection from one immutable seal.
+- OpenTelemetry uses a two-level trace/item identity rather than deriving an
+  item identity from display data.
+- SARIF separates run and result GUIDs from content-derived fingerprints.
+
+Two conventions deliberately do not transfer:
+
+- SARIF fingerprints identify logical recurrence across runs and may collapse
+  display-equal results.
+- vstest derives test identity from content and source fields; that behavior is
+  the anti-pattern for preserving multiplicity within one execution.
+
+## Evidence
+
+The Release executable gates in
+`src/ILInspector.ILDiff.Tests/FindingCensusTests.cs` verify:
+
+- `Seal_PreservesOrderMultiplicityAndExactInstances` proves independent equal
+  seals, distinct receipts and keys, exact references, and reordered
+  validation;
+- `Seal_ReceiptsSuccessfulEmptyCensusesIndependently` proves initialized,
+  separately receipted empty censuses;
+- `Seal_RejectsInvalidCollections` proves construction-time collection
+  containment;
+- `Validate_DistinguishesReceiptAndCollectionFailures` proves receipt,
+  initialization, null-entry, and null-argument behavior;
+- `Validate_DistinguishesKeySetFailures` proves default, duplicate, extra, and
+  missing key outcomes;
+- `Validate_RejectsValueEqualFindingSubstitution` proves exact-reference
+  association rather than Finding value equality; and
+- `ValidateEntry_AdmitsSubsetsWithoutWeakeningAssociation` proves filtered
+  projections retain receipt and exact-association admission;
+- `Validate_UsesDeterministicFailurePrecedence` proves validation ordering is
+  stable when duplicate, extra, missing, and substituted defects coexist; and
+- `Validate_ReportsSmallestKeyIndependentOfCandidateOrder` proves smallest-key
+  diagnostics do not depend on projection order.
+
+The invariant is finite construction and validation over one immutable
+collection. It has no concurrent admission, replacement, or scheduling
+lifecycle, so executable exhaustive gates are the appropriate oracle; no TLA+
+model is required.
+
+## Non-claims
+
+This design does not:
+
+- define cross-version correspondence, matching, or fingerprints;
+- make instance identity durable across process executions or seal operations;
+- change Finding value equality or hashing;
+- make the instance key an ordinal, source coordinate, or provenance value;
+- require every Finding producer to adopt the census in this slice;
+- define Research, CLI, or browser presentation behavior; or
+- define serialization, parsing, packet persistence, or cross-session identity.

--- a/docs/design/finding-instance-census.md
+++ b/docs/design/finding-instance-census.md
@@ -246,6 +246,8 @@ The Release executable gates in
   validation;
 - `Seal_ReceiptsSuccessfulEmptyCensusesIndependently` proves initialized,
   separately receipted empty censuses;
+- `Seal_EnumeratesInputExactlyOnce` proves one eager enumeration retains the
+  original ordered Finding references;
 - `Seal_RejectsInvalidCollections` proves construction-time collection
   containment;
 - `Validate_DistinguishesReceiptAndCollectionFailures` proves receipt,
@@ -257,7 +259,9 @@ The Release executable gates in
 - `ValidateEntry_AdmitsSubsetsWithoutWeakeningAssociation` proves filtered
   projections retain receipt and exact-association admission;
 - `Validate_UsesDeterministicFailurePrecedence` proves validation ordering is
-  stable when duplicate, extra, missing, and substituted defects coexist; and
+  stable when duplicate, extra, missing, and substituted defects coexist;
+- `Validate_UsesFullFailurePrecedence` proves the complete receipt, collection,
+  key-shape, and association precedence plus first-input diagnostics; and
 - `Validate_ReportsSmallestKeyIndependentOfCandidateOrder` proves smallest-key
   diagnostics do not depend on projection order.
 

--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -14,7 +14,7 @@ how consumers use these values.
 
 ## Contract
 
-Finding-owned values compose four equality shapes:
+Finding-owned values compose six equality shapes:
 
 | Shape | Examples | Equality contract |
 | --- | --- | --- |

--- a/docs/design/finding-value-equality.md
+++ b/docs/design/finding-value-equality.md
@@ -18,10 +18,12 @@ Finding-owned values compose four equality shapes:
 
 | Shape | Examples | Equality contract |
 | --- | --- | --- |
-| Structural composition | `FindingSubject`, `Finding<T>`, and the cases of `PairFinding<T>` | Every equality-participating field composes its own contract. Generic payload fields use `EqualityComparer<T>.Default`. |
+| Structural composition | `FindingSubject`, `Finding<T>`, the cases of `PairFinding<T>`, and census validation values | Every equality-participating field composes its own contract. Generic payload fields use `EqualityComparer<T>.Default`. |
 | Ordered collection value | Complete censuses, match evidence, completed transition streams, and correlated occurrences | Sequence equality: order and multiplicity are significant. |
 | Identity-set value | `FindingEquivalence` allow lists | Set equality: enumeration order and duplicate input are insignificant. |
-| Operation object | `FindingCensusCorrelation<T>` and `FindingCorrelation<T>` | Reference identity. Their durable inputs and projected values retain their own contracts. |
+| Scoped identity value | `FindingCensusReceipt` and `FindingInstanceKey` | Value equality for each component; one instance identity is the receipt/key pair. |
+| Association object | `FindingCensusEntry<T>` | Reference identity. Its key and Finding retain their own contracts. |
+| Operation object | `FindingCensus<T>`, `FindingCensusCorrelation<T>`, and `FindingCorrelation<T>` | Reference identity. Their durable inputs and projected values retain their own contracts. |
 
 Closed union wrappers compose the equality of their active case. Two
 `FindingInspection<T>` values, for example, are equal only when they have the
@@ -93,6 +95,8 @@ payload values are unequal.
 Consumers must choose the contract they need:
 
 - use `FindingKey` and the matcher for cross-version correspondence;
+- use the receipt/key pair owned by [Finding instance
+  census](finding-instance-census.md) for one occurrence in one sealed census;
 - use Finding value equality for already-materialized content;
 - use a producer-owned comparer for a domain-specific payload equivalence; and
 - use object identity when retaining one correlation operation instance.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -288,6 +288,9 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Finding nomenclature](design/finding-nomenclature.md): observation/change semantics, operation outcomes, and Research composition boundaries.
 - [Finding producer design](design/finding-producers.md): how to choose owners, payloads, identities, result shapes, and matching modes.
 - [Finding coordinates](design/finding-coordinates.md): separation of subject identity, correspondence, optional producer order, and typed provenance.
+- [Finding instance census](design/finding-instance-census.md): producer-issued
+  receipt and per-instance keys for one sealed execution census, with
+  bijection and exact-association validation.
 - [Finding value semantics](design/finding-value-equality.md): .NET equality
   and hashing for Finding-owned structural values, ordered collections,
   identity sets, union cases, and reference-identity operation objects.

--- a/src/ILInspector.Findings/FindingCensus.cs
+++ b/src/ILInspector.Findings/FindingCensus.cs
@@ -1,0 +1,336 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace ILInspector.Findings;
+
+/// <summary>
+/// Opaque producer-issued identity for one sealed Finding census.
+/// </summary>
+public readonly record struct FindingCensusReceipt
+{
+    internal FindingCensusReceipt(Guid value)
+    {
+        if (value == Guid.Empty)
+            throw new ArgumentException("Receipt must not be empty.", nameof(value));
+        Value = value;
+    }
+
+    public Guid Value { get; }
+    public bool IsDefault => Value == Guid.Empty;
+
+    public override string ToString()
+        => Value.ToString("D", CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// A compact Finding instance key whose scope is one <see cref="FindingCensusReceipt"/>.
+/// </summary>
+public readonly record struct FindingInstanceKey
+{
+    internal FindingInstanceKey(int value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        Value = value;
+    }
+
+    public int Value { get; }
+    public bool IsDefault => Value == 0;
+
+    public override string ToString()
+        => Value.ToString(CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// One candidate or canonical key-to-Finding association within a census receipt.
+/// </summary>
+public sealed class FindingCensusEntry<T>
+    where T : notnull
+{
+    public FindingCensusEntry(FindingInstanceKey key, Finding<T> finding)
+    {
+        Key = key;
+        Finding = finding ?? throw new ArgumentNullException(nameof(finding));
+    }
+
+    public FindingInstanceKey Key { get; }
+    public Finding<T> Finding { get; }
+}
+
+/// <summary>
+/// Why candidate entries do not reproduce one sealed Finding census.
+/// </summary>
+public enum FindingCensusValidationFailureKind
+{
+    DefaultReceipt,
+    WrongReceipt,
+    UninitializedEntries,
+    NullEntry,
+    DefaultKey,
+    DuplicateKey,
+    ExtraKey,
+    MissingKey,
+    SubstitutedFinding,
+}
+
+/// <summary>
+/// Typed evidence that candidate entries do not reproduce one sealed Finding census.
+/// </summary>
+public sealed record FindingCensusValidationFailure
+{
+    internal FindingCensusValidationFailure(
+        FindingCensusValidationFailureKind kind,
+        FindingInstanceKey key = default,
+        int? inputIndex = null)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        if (inputIndex is < 0)
+            throw new ArgumentOutOfRangeException(nameof(inputIndex));
+
+        Kind = kind;
+        Key = key;
+        InputIndex = inputIndex;
+    }
+
+    public FindingCensusValidationFailureKind Kind { get; }
+    public FindingInstanceKey Key { get; }
+    public int? InputIndex { get; }
+}
+
+/// <summary>
+/// The typed outcome of validating a candidate census projection.
+/// </summary>
+[Union]
+public sealed record FindingCensusValidation
+{
+    public FindingCensusValidation(Valid value) => Value = Guard(value);
+    public FindingCensusValidation(Invalid value) => Value = Guard(value);
+
+    static object Guard(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return value;
+    }
+
+    public object? Value { get; }
+
+    public sealed record Valid
+    {
+        internal static Valid Instance { get; } = new();
+
+        private Valid()
+        {
+        }
+    }
+
+    public sealed record Invalid
+    {
+        internal Invalid(FindingCensusValidationFailure failure)
+            => Failure = failure ?? throw new ArgumentNullException(nameof(failure));
+
+        public FindingCensusValidationFailure Failure { get; }
+    }
+}
+
+/// <summary>
+/// One immutable ordered Finding census with producer-issued instance identity.
+/// </summary>
+public sealed class FindingCensus<T>
+    where T : notnull
+{
+    FindingCensus(
+        FindingCensusReceipt receipt,
+        ImmutableArray<Finding<T>> findings,
+        ImmutableArray<FindingCensusEntry<T>> entries)
+    {
+        Receipt = receipt;
+        Findings = findings;
+        Entries = entries;
+    }
+
+    public FindingCensusReceipt Receipt { get; }
+    public ImmutableArray<Finding<T>> Findings { get; }
+    public ImmutableArray<FindingCensusEntry<T>> Entries { get; }
+
+    public static FindingCensus<T> Seal(IEnumerable<Finding<T>> findings)
+    {
+        ArgumentNullException.ThrowIfNull(findings);
+        if (findings is ImmutableArray<Finding<T>> findingArray
+            && findingArray.IsDefault)
+        {
+            throw new ArgumentException(
+                "Findings must be initialized.",
+                nameof(findings));
+        }
+
+        var sealedFindings = findings.ToImmutableArray();
+        for (int i = 0; i < sealedFindings.Length; i++)
+        {
+            if (sealedFindings[i] is null)
+            {
+                throw new ArgumentException(
+                    $"Finding at index {i} must not be null.",
+                    nameof(findings));
+            }
+        }
+
+        Guid receiptValue;
+        do
+        {
+            receiptValue = Guid.NewGuid();
+        }
+        while (receiptValue == Guid.Empty);
+
+        var entries = ImmutableArray.CreateBuilder<FindingCensusEntry<T>>(
+            sealedFindings.Length);
+        for (int i = 0; i < sealedFindings.Length; i++)
+        {
+            entries.Add(new FindingCensusEntry<T>(
+                new FindingInstanceKey(i + 1),
+                sealedFindings[i]));
+        }
+
+        return new FindingCensus<T>(
+            new FindingCensusReceipt(receiptValue),
+            sealedFindings,
+            entries.MoveToImmutable());
+    }
+
+    public FindingCensusValidation Validate(
+        FindingCensusReceipt receipt,
+        IEnumerable<FindingCensusEntry<T>> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        if (receipt.IsDefault)
+            return Invalid(FindingCensusValidationFailureKind.DefaultReceipt);
+        if (receipt != Receipt)
+            return Invalid(FindingCensusValidationFailureKind.WrongReceipt);
+        if (entries is ImmutableArray<FindingCensusEntry<T>> entryArray
+            && entryArray.IsDefault)
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.UninitializedEntries);
+        }
+
+        var candidateEntries = entries.ToImmutableArray();
+        for (int i = 0; i < candidateEntries.Length; i++)
+        {
+            if (candidateEntries[i] is null)
+            {
+                return Invalid(
+                    FindingCensusValidationFailureKind.NullEntry,
+                    inputIndex: i);
+            }
+        }
+
+        int defaultKeyIndex = -1;
+        for (int i = 0; i < candidateEntries.Length; i++)
+        {
+            if (candidateEntries[i].Key.IsDefault)
+            {
+                defaultKeyIndex = i;
+                break;
+            }
+        }
+        if (defaultKeyIndex >= 0)
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.DefaultKey,
+                inputIndex: defaultKeyIndex);
+        }
+
+        FindingInstanceKey duplicateKey = candidateEntries
+            .GroupBy(entry => entry.Key)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .OrderBy(key => key.Value)
+            .FirstOrDefault();
+        if (!duplicateKey.IsDefault)
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.DuplicateKey,
+                duplicateKey);
+        }
+
+        FindingInstanceKey extraKey = candidateEntries
+            .Select(entry => entry.Key)
+            .Where(key => key.Value > Entries.Length)
+            .OrderBy(key => key.Value)
+            .FirstOrDefault();
+        if (!extraKey.IsDefault)
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.ExtraKey,
+                extraKey);
+        }
+
+        var byKey = candidateEntries.ToDictionary(entry => entry.Key);
+        for (int keyValue = 1; keyValue <= Entries.Length; keyValue++)
+        {
+            var key = new FindingInstanceKey(keyValue);
+            if (!byKey.ContainsKey(key))
+            {
+                return Invalid(
+                    FindingCensusValidationFailureKind.MissingKey,
+                    key);
+            }
+        }
+
+        for (int i = 0; i < Entries.Length; i++)
+        {
+            FindingCensusEntry<T> canonical = Entries[i];
+            if (!ReferenceEquals(
+                canonical.Finding,
+                byKey[canonical.Key].Finding))
+            {
+                return Invalid(
+                    FindingCensusValidationFailureKind.SubstitutedFinding,
+                    canonical.Key);
+            }
+        }
+
+        return FindingCensusValidation.Valid.Instance;
+    }
+
+    /// <summary>
+    /// Validates one retained entry without requiring a projection to contain the whole census.
+    /// </summary>
+    public FindingCensusValidation ValidateEntry(
+        FindingCensusReceipt receipt,
+        FindingCensusEntry<T>? entry)
+    {
+        if (receipt.IsDefault)
+            return Invalid(FindingCensusValidationFailureKind.DefaultReceipt);
+        if (receipt != Receipt)
+            return Invalid(FindingCensusValidationFailureKind.WrongReceipt);
+        if (entry is null)
+            return Invalid(FindingCensusValidationFailureKind.NullEntry);
+        if (entry.Key.IsDefault)
+            return Invalid(FindingCensusValidationFailureKind.DefaultKey);
+        if (entry.Key.Value > Entries.Length)
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.ExtraKey,
+                entry.Key);
+        }
+
+        FindingCensusEntry<T> canonical = Entries[entry.Key.Value - 1];
+        if (!ReferenceEquals(canonical.Finding, entry.Finding))
+        {
+            return Invalid(
+                FindingCensusValidationFailureKind.SubstitutedFinding,
+                entry.Key);
+        }
+
+        return FindingCensusValidation.Valid.Instance;
+    }
+
+    static FindingCensusValidation Invalid(
+        FindingCensusValidationFailureKind kind,
+        FindingInstanceKey key = default,
+        int? inputIndex = null)
+        => new(new FindingCensusValidation.Invalid(
+            new FindingCensusValidationFailure(kind, key, inputIndex)));
+}

--- a/src/ILInspector.ILDiff.Tests/FindingCensusTests.cs
+++ b/src/ILInspector.ILDiff.Tests/FindingCensusTests.cs
@@ -1,0 +1,384 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.ILDiff.Tests;
+
+public class FindingCensusTests
+{
+    static readonly FindingSubject Subject = new("test", "test");
+    static readonly FindingDescriptor Descriptor = new("test.item", "item");
+
+    static Finding<string> Finding(string payload = "same")
+        => new(
+            Subject,
+            Descriptor,
+            new FindingKey("same"),
+            payload,
+            Detail: "same");
+
+    static FindingCensusValidationFailure Failure(
+        FindingCensusValidation validation)
+        => validation switch
+        {
+            FindingCensusValidation.Invalid invalid => invalid.Failure,
+            FindingCensusValidation.Valid => throw new Xunit.Sdk.XunitException(
+                "Expected invalid census validation."),
+        };
+
+    [Fact]
+    public void Seal_PreservesOrderMultiplicityAndExactInstances()
+    {
+        var first = Finding();
+        var second = Finding();
+        Assert.Equal(first, second);
+        Assert.NotSame(first, second);
+
+        var census = FindingCensus<string>.Seal([first, second]);
+        var independentlySealed = FindingCensus<string>.Seal([first, second]);
+
+        Assert.False(census.Receipt.IsDefault);
+        Assert.NotEqual(census.Receipt, independentlySealed.Receipt);
+        Assert.Equal(
+            census.Entries[0].Key,
+            independentlySealed.Entries[0].Key);
+        Assert.Equal([first, second], census.Findings);
+        Assert.Equal([1, 2], census.Entries.Select(entry => entry.Key.Value));
+        Assert.Same(first, census.Entries[0].Finding);
+        Assert.Same(second, census.Entries[1].Finding);
+
+        FindingCensusValidation validation = census.Validate(
+            census.Receipt,
+            census.Entries.Reverse());
+        Assert.True(validation is FindingCensusValidation.Valid);
+    }
+
+    [Fact]
+    public void Seal_ReceiptsSuccessfulEmptyCensusesIndependently()
+    {
+        var first = FindingCensus<string>.Seal([]);
+        var second = FindingCensus<string>.Seal([]);
+
+        Assert.False(first.Receipt.IsDefault);
+        Assert.NotEqual(first.Receipt, second.Receipt);
+        Assert.Empty(first.Findings);
+        Assert.Empty(first.Entries);
+        Assert.True(
+            first.Validate(first.Receipt, [])
+                is FindingCensusValidation.Valid);
+    }
+
+    [Fact]
+    public void Seal_RejectsInvalidCollections()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => FindingCensus<string>.Seal(null!));
+        Assert.Throws<ArgumentException>(
+            () => FindingCensus<string>.Seal(
+                default(ImmutableArray<Finding<string>>)));
+        Assert.Throws<ArgumentException>(
+            () => FindingCensus<string>.Seal([null!]));
+        Assert.Throws<ArgumentNullException>(
+            () => new FindingCensusEntry<string>(default, null!));
+    }
+
+    [Fact]
+    public void Validate_DistinguishesReceiptAndCollectionFailures()
+    {
+        var finding = Finding();
+        var census = FindingCensus<string>.Seal([finding]);
+        var other = FindingCensus<string>.Seal([finding]);
+
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DefaultReceipt,
+            Failure(census.Validate(default, census.Entries)).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.WrongReceipt,
+            Failure(census.Validate(other.Receipt, census.Entries)).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.UninitializedEntries,
+            Failure(census.Validate(
+                census.Receipt,
+                default(ImmutableArray<FindingCensusEntry<string>>))).Kind);
+
+        ImmutableArray<FindingCensusEntry<string>> entriesWithNull = [null!];
+        FindingCensusValidationFailure nullEntry = Failure(census.Validate(
+            census.Receipt,
+            entriesWithNull));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.NullEntry,
+            nullEntry.Kind);
+        Assert.Equal(0, nullEntry.InputIndex);
+        Assert.Throws<ArgumentNullException>(
+            () => census.Validate(census.Receipt, null!));
+    }
+
+    [Fact]
+    public void Validate_DistinguishesKeySetFailures()
+    {
+        var first = Finding();
+        var second = Finding();
+        var census = FindingCensus<string>.Seal([first, second]);
+        var larger = FindingCensus<string>.Seal([first, second, Finding()]);
+
+        FindingCensusValidationFailure defaultKey = Failure(census.Validate(
+            census.Receipt,
+            [
+                new FindingCensusEntry<string>(default, first),
+                census.Entries[1],
+            ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DefaultKey,
+            defaultKey.Kind);
+        Assert.Equal(0, defaultKey.InputIndex);
+
+        FindingCensusValidationFailure duplicate = Failure(census.Validate(
+            census.Receipt,
+            [
+                census.Entries[0],
+                new FindingCensusEntry<string>(
+                    census.Entries[0].Key,
+                    second),
+            ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DuplicateKey,
+            duplicate.Kind);
+        Assert.Equal(1, duplicate.Key.Value);
+
+        FindingCensusValidationFailure extra = Failure(census.Validate(
+            census.Receipt,
+            [
+                census.Entries[0],
+                new FindingCensusEntry<string>(
+                    larger.Entries[2].Key,
+                    second),
+            ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.ExtraKey,
+            extra.Kind);
+        Assert.Equal(3, extra.Key.Value);
+
+        FindingCensusValidationFailure missing = Failure(census.Validate(
+            census.Receipt,
+            [census.Entries[1]]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.MissingKey,
+            missing.Kind);
+        Assert.Equal(1, missing.Key.Value);
+    }
+
+    [Fact]
+    public void Validate_RejectsValueEqualFindingSubstitution()
+    {
+        var first = Finding();
+        var second = Finding();
+        var substitute = Finding();
+        var census = FindingCensus<string>.Seal([first, second]);
+
+        Assert.Equal(first, substitute);
+        Assert.NotSame(first, substitute);
+
+        FindingCensusValidationFailure failure = Failure(census.Validate(
+            census.Receipt,
+            [
+                new FindingCensusEntry<string>(
+                    census.Entries[0].Key,
+                    substitute),
+                census.Entries[1],
+            ]));
+
+        Assert.Equal(
+            FindingCensusValidationFailureKind.SubstitutedFinding,
+            failure.Kind);
+        Assert.Equal(1, failure.Key.Value);
+    }
+
+    [Fact]
+    public void ValidateEntry_AdmitsSubsetsWithoutWeakeningAssociation()
+    {
+        var first = Finding();
+        var second = Finding();
+        var substitute = Finding();
+        var census = FindingCensus<string>.Seal([first, second]);
+        var other = FindingCensus<string>.Seal([first, second]);
+        var larger = FindingCensus<string>.Seal([first, second, Finding()]);
+
+        Assert.True(
+            census.ValidateEntry(census.Receipt, census.Entries[1])
+                is FindingCensusValidation.Valid);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DefaultReceipt,
+            Failure(census.ValidateEntry(
+                default,
+                census.Entries[1])).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.WrongReceipt,
+            Failure(census.ValidateEntry(
+                other.Receipt,
+                census.Entries[1])).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.NullEntry,
+            Failure(census.ValidateEntry(
+                census.Receipt,
+                null)).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DefaultKey,
+            Failure(census.ValidateEntry(
+                census.Receipt,
+                new FindingCensusEntry<string>(
+                    default,
+                    second))).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.ExtraKey,
+            Failure(census.ValidateEntry(
+                census.Receipt,
+                new FindingCensusEntry<string>(
+                    larger.Entries[2].Key,
+                    second))).Kind);
+        Assert.Equal(
+            FindingCensusValidationFailureKind.SubstitutedFinding,
+            Failure(census.ValidateEntry(
+                census.Receipt,
+                new FindingCensusEntry<string>(
+                    census.Entries[1].Key,
+                    substitute))).Kind);
+    }
+
+    [Fact]
+    public void Validate_UsesDeterministicFailurePrecedence()
+    {
+        var first = Finding();
+        var second = Finding();
+        var census = FindingCensus<string>.Seal([first, second]);
+        var larger = FindingCensus<string>.Seal([first, second, Finding()]);
+
+        FindingCensusValidationFailure duplicateBeforeExtra = Failure(
+            census.Validate(
+                census.Receipt,
+                [
+                    census.Entries[1],
+                    new FindingCensusEntry<string>(
+                        census.Entries[1].Key,
+                        first),
+                    new FindingCensusEntry<string>(
+                        larger.Entries[2].Key,
+                        second),
+                ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.DuplicateKey,
+            duplicateBeforeExtra.Kind);
+        Assert.Equal(2, duplicateBeforeExtra.Key.Value);
+
+        FindingCensusValidationFailure extraBeforeMissing = Failure(
+            census.Validate(
+                census.Receipt,
+                [
+                    census.Entries[1],
+                    new FindingCensusEntry<string>(
+                        larger.Entries[2].Key,
+                        first),
+                ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.ExtraKey,
+            extraBeforeMissing.Kind);
+        Assert.Equal(3, extraBeforeMissing.Key.Value);
+
+        FindingCensusValidationFailure missingBeforeSubstitution = Failure(
+            census.Validate(
+                census.Receipt,
+                [
+                    new FindingCensusEntry<string>(
+                        census.Entries[1].Key,
+                        first),
+                ]));
+        Assert.Equal(
+            FindingCensusValidationFailureKind.MissingKey,
+            missingBeforeSubstitution.Kind);
+        Assert.Equal(1, missingBeforeSubstitution.Key.Value);
+    }
+
+    [Fact]
+    public void Validate_ReportsSmallestKeyIndependentOfCandidateOrder()
+    {
+        Finding<string>[] findings =
+            [Finding("1"), Finding("2"), Finding("3"), Finding("4")];
+        var census = FindingCensus<string>.Seal(findings);
+        var larger = FindingCensus<string>.Seal(
+            [.. findings, Finding("5"), Finding("6")]);
+
+        FindingCensusEntry<string>[] duplicateEntries =
+        [
+            census.Entries[1],
+            census.Entries[0],
+            census.Entries[1],
+            census.Entries[0],
+            census.Entries[2],
+            census.Entries[3],
+        ];
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.DuplicateKey,
+            1,
+            duplicateEntries);
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.DuplicateKey,
+            1,
+            duplicateEntries.Reverse());
+
+        FindingCensusEntry<string>[] extraEntries =
+        [
+            .. census.Entries,
+            new FindingCensusEntry<string>(
+                larger.Entries[5].Key,
+                findings[0]),
+            new FindingCensusEntry<string>(
+                larger.Entries[4].Key,
+                findings[1]),
+        ];
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.ExtraKey,
+            5,
+            extraEntries);
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.ExtraKey,
+            5,
+            extraEntries.Reverse());
+
+        FindingCensusEntry<string>[] missingEntries =
+            [census.Entries[3], census.Entries[1]];
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.MissingKey,
+            1,
+            missingEntries);
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.MissingKey,
+            1,
+            missingEntries.Reverse());
+
+        FindingCensusEntry<string>[] substitutedEntries =
+        [
+            new(census.Entries[1].Key, Finding("2")),
+            new(census.Entries[0].Key, Finding("1")),
+            census.Entries[2],
+            census.Entries[3],
+        ];
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.SubstitutedFinding,
+            1,
+            substitutedEntries);
+        AssertFailureKey(
+            FindingCensusValidationFailureKind.SubstitutedFinding,
+            1,
+            substitutedEntries.Reverse());
+
+        void AssertFailureKey(
+            FindingCensusValidationFailureKind kind,
+            int key,
+            IEnumerable<FindingCensusEntry<string>> entries)
+        {
+            FindingCensusValidationFailure failure = Failure(
+                census.Validate(census.Receipt, entries));
+            Assert.Equal(kind, failure.Kind);
+            Assert.Equal(key, failure.Key.Value);
+        }
+    }
+}

--- a/src/ILInspector.ILDiff.Tests/FindingCensusTests.cs
+++ b/src/ILInspector.ILDiff.Tests/FindingCensusTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Immutable;
 
 using ILInspector.Findings;
@@ -26,6 +27,19 @@ public class FindingCensusTests
                 "Expected invalid census validation."),
         };
 
+    static FindingCensusValidationFailure AssertFailure(
+        FindingCensusValidation validation,
+        FindingCensusValidationFailureKind kind,
+        int key = 0,
+        int? inputIndex = null)
+    {
+        FindingCensusValidationFailure failure = Failure(validation);
+        Assert.Equal(kind, failure.Kind);
+        Assert.Equal(key, failure.Key.Value);
+        Assert.Equal(inputIndex, failure.InputIndex);
+        return failure;
+    }
+
     [Fact]
     public void Seal_PreservesOrderMultiplicityAndExactInstances()
     {
@@ -43,9 +57,13 @@ public class FindingCensusTests
             census.Entries[0].Key,
             independentlySealed.Entries[0].Key);
         Assert.Equal([first, second], census.Findings);
+        Assert.Same(first, census.Findings[0]);
+        Assert.Same(second, census.Findings[1]);
         Assert.Equal([1, 2], census.Entries.Select(entry => entry.Key.Value));
         Assert.Same(first, census.Entries[0].Finding);
         Assert.Same(second, census.Entries[1].Finding);
+        Assert.Same(census.Findings[0], census.Entries[0].Finding);
+        Assert.Same(census.Findings[1], census.Entries[1].Finding);
 
         FindingCensusValidation validation = census.Validate(
             census.Receipt,
@@ -69,6 +87,22 @@ public class FindingCensusTests
     }
 
     [Fact]
+    public void Seal_EnumeratesInputExactlyOnce()
+    {
+        var first = Finding();
+        var second = Finding();
+        var findings = new OneShotEnumerable<Finding<string>>([first, second]);
+
+        var census = FindingCensus<string>.Seal(findings);
+
+        Assert.Equal(1, findings.EnumerationCount);
+        Assert.Same(first, census.Findings[0]);
+        Assert.Same(second, census.Findings[1]);
+        Assert.Same(first, census.Entries[0].Finding);
+        Assert.Same(second, census.Entries[1].Finding);
+    }
+
+    [Fact]
     public void Seal_RejectsInvalidCollections()
     {
         Assert.Throws<ArgumentNullException>(
@@ -89,26 +123,27 @@ public class FindingCensusTests
         var census = FindingCensus<string>.Seal([finding]);
         var other = FindingCensus<string>.Seal([finding]);
 
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(default, census.Entries),
             FindingCensusValidationFailureKind.DefaultReceipt,
-            Failure(census.Validate(default, census.Entries)).Kind);
-        Assert.Equal(
+            key: 0);
+        AssertFailure(
+            census.Validate(other.Receipt, census.Entries),
             FindingCensusValidationFailureKind.WrongReceipt,
-            Failure(census.Validate(other.Receipt, census.Entries)).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.UninitializedEntries,
-            Failure(census.Validate(
+            key: 0);
+        AssertFailure(
+            census.Validate(
                 census.Receipt,
-                default(ImmutableArray<FindingCensusEntry<string>>))).Kind);
+                default(ImmutableArray<FindingCensusEntry<string>>)),
+            FindingCensusValidationFailureKind.UninitializedEntries,
+            key: 0);
 
         ImmutableArray<FindingCensusEntry<string>> entriesWithNull = [null!];
-        FindingCensusValidationFailure nullEntry = Failure(census.Validate(
-            census.Receipt,
-            entriesWithNull));
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(census.Receipt, entriesWithNull),
             FindingCensusValidationFailureKind.NullEntry,
-            nullEntry.Kind);
-        Assert.Equal(0, nullEntry.InputIndex);
+            key: 0,
+            inputIndex: 0);
         Assert.Throws<ArgumentNullException>(
             () => census.Validate(census.Receipt, null!));
     }
@@ -121,50 +156,47 @@ public class FindingCensusTests
         var census = FindingCensus<string>.Seal([first, second]);
         var larger = FindingCensus<string>.Seal([first, second, Finding()]);
 
-        FindingCensusValidationFailure defaultKey = Failure(census.Validate(
-            census.Receipt,
-            [
-                new FindingCensusEntry<string>(default, first),
-                census.Entries[1],
-            ]));
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(
+                census.Receipt,
+                [
+                    new FindingCensusEntry<string>(default, first),
+                    census.Entries[1],
+                ]),
             FindingCensusValidationFailureKind.DefaultKey,
-            defaultKey.Kind);
-        Assert.Equal(0, defaultKey.InputIndex);
+            key: 0,
+            inputIndex: 0);
 
-        FindingCensusValidationFailure duplicate = Failure(census.Validate(
-            census.Receipt,
-            [
-                census.Entries[0],
-                new FindingCensusEntry<string>(
-                    census.Entries[0].Key,
-                    second),
-            ]));
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(
+                census.Receipt,
+                [
+                    census.Entries[0],
+                    new FindingCensusEntry<string>(
+                        census.Entries[0].Key,
+                        second),
+                ]),
             FindingCensusValidationFailureKind.DuplicateKey,
-            duplicate.Kind);
-        Assert.Equal(1, duplicate.Key.Value);
+            key: 1);
 
-        FindingCensusValidationFailure extra = Failure(census.Validate(
-            census.Receipt,
-            [
-                census.Entries[0],
-                new FindingCensusEntry<string>(
-                    larger.Entries[2].Key,
-                    second),
-            ]));
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(
+                census.Receipt,
+                [
+                    census.Entries[0],
+                    new FindingCensusEntry<string>(
+                        larger.Entries[2].Key,
+                        second),
+                ]),
             FindingCensusValidationFailureKind.ExtraKey,
-            extra.Kind);
-        Assert.Equal(3, extra.Key.Value);
+            key: 3);
 
-        FindingCensusValidationFailure missing = Failure(census.Validate(
-            census.Receipt,
-            [census.Entries[1]]));
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(
+                census.Receipt,
+                [census.Entries[1]]),
             FindingCensusValidationFailureKind.MissingKey,
-            missing.Kind);
-        Assert.Equal(1, missing.Key.Value);
+            key: 1);
     }
 
     [Fact]
@@ -178,19 +210,17 @@ public class FindingCensusTests
         Assert.Equal(first, substitute);
         Assert.NotSame(first, substitute);
 
-        FindingCensusValidationFailure failure = Failure(census.Validate(
-            census.Receipt,
-            [
-                new FindingCensusEntry<string>(
-                    census.Entries[0].Key,
-                    substitute),
-                census.Entries[1],
-            ]));
-
-        Assert.Equal(
+        AssertFailure(
+            census.Validate(
+                census.Receipt,
+                [
+                    new FindingCensusEntry<string>(
+                        census.Entries[0].Key,
+                        substitute),
+                    census.Entries[1],
+                ]),
             FindingCensusValidationFailureKind.SubstitutedFinding,
-            failure.Kind);
-        Assert.Equal(1, failure.Key.Value);
+            key: 1);
     }
 
     [Fact]
@@ -206,42 +236,48 @@ public class FindingCensusTests
         Assert.True(
             census.ValidateEntry(census.Receipt, census.Entries[1])
                 is FindingCensusValidation.Valid);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.DefaultReceipt,
-            Failure(census.ValidateEntry(
+        AssertFailure(
+            census.ValidateEntry(
                 default,
-                census.Entries[1])).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.WrongReceipt,
-            Failure(census.ValidateEntry(
+                census.Entries[1]),
+            FindingCensusValidationFailureKind.DefaultReceipt,
+            key: 0);
+        AssertFailure(
+            census.ValidateEntry(
                 other.Receipt,
-                census.Entries[1])).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.NullEntry,
-            Failure(census.ValidateEntry(
+                census.Entries[1]),
+            FindingCensusValidationFailureKind.WrongReceipt,
+            key: 0);
+        AssertFailure(
+            census.ValidateEntry(
                 census.Receipt,
-                null)).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.DefaultKey,
-            Failure(census.ValidateEntry(
+                null),
+            FindingCensusValidationFailureKind.NullEntry,
+            key: 0);
+        AssertFailure(
+            census.ValidateEntry(
                 census.Receipt,
                 new FindingCensusEntry<string>(
                     default,
-                    second))).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.ExtraKey,
-            Failure(census.ValidateEntry(
+                    second)),
+            FindingCensusValidationFailureKind.DefaultKey,
+            key: 0);
+        AssertFailure(
+            census.ValidateEntry(
                 census.Receipt,
                 new FindingCensusEntry<string>(
                     larger.Entries[2].Key,
-                    second))).Kind);
-        Assert.Equal(
-            FindingCensusValidationFailureKind.SubstitutedFinding,
-            Failure(census.ValidateEntry(
+                    second)),
+            FindingCensusValidationFailureKind.ExtraKey,
+            key: 3);
+        AssertFailure(
+            census.ValidateEntry(
                 census.Receipt,
                 new FindingCensusEntry<string>(
                     census.Entries[1].Key,
-                    substitute))).Kind);
+                    substitute)),
+            FindingCensusValidationFailureKind.SubstitutedFinding,
+            key: 2);
     }
 
     [Fact]
@@ -252,7 +288,7 @@ public class FindingCensusTests
         var census = FindingCensus<string>.Seal([first, second]);
         var larger = FindingCensus<string>.Seal([first, second, Finding()]);
 
-        FindingCensusValidationFailure duplicateBeforeExtra = Failure(
+        AssertFailure(
             census.Validate(
                 census.Receipt,
                 [
@@ -263,13 +299,11 @@ public class FindingCensusTests
                     new FindingCensusEntry<string>(
                         larger.Entries[2].Key,
                         second),
-                ]));
-        Assert.Equal(
+                ]),
             FindingCensusValidationFailureKind.DuplicateKey,
-            duplicateBeforeExtra.Kind);
-        Assert.Equal(2, duplicateBeforeExtra.Key.Value);
+            key: 2);
 
-        FindingCensusValidationFailure extraBeforeMissing = Failure(
+        AssertFailure(
             census.Validate(
                 census.Receipt,
                 [
@@ -277,24 +311,64 @@ public class FindingCensusTests
                     new FindingCensusEntry<string>(
                         larger.Entries[2].Key,
                         first),
-                ]));
-        Assert.Equal(
+                ]),
             FindingCensusValidationFailureKind.ExtraKey,
-            extraBeforeMissing.Kind);
-        Assert.Equal(3, extraBeforeMissing.Key.Value);
+            key: 3);
 
-        FindingCensusValidationFailure missingBeforeSubstitution = Failure(
+        AssertFailure(
             census.Validate(
                 census.Receipt,
                 [
                     new FindingCensusEntry<string>(
                         census.Entries[1].Key,
                         first),
-                ]));
-        Assert.Equal(
+                ]),
             FindingCensusValidationFailureKind.MissingKey,
-            missingBeforeSubstitution.Kind);
-        Assert.Equal(1, missingBeforeSubstitution.Key.Value);
+            key: 1);
+    }
+
+    [Fact]
+    public void Validate_UsesFullFailurePrecedence()
+    {
+        var first = Finding();
+        var second = Finding();
+        var census = FindingCensus<string>.Seal([first, second]);
+        var other = FindingCensus<string>.Seal([first, second]);
+
+        ImmutableArray<FindingCensusEntry<string>> uninitialized = default;
+        AssertFailure(
+            census.Validate(default, uninitialized),
+            FindingCensusValidationFailureKind.DefaultReceipt);
+        AssertFailure(
+            census.Validate(other.Receipt, uninitialized),
+            FindingCensusValidationFailureKind.WrongReceipt);
+        AssertFailure(
+            census.Validate(census.Receipt, uninitialized),
+            FindingCensusValidationFailureKind.UninitializedEntries);
+
+        FindingCensusEntry<string>[] nullBeforeDefault =
+        [
+            census.Entries[0],
+            null!,
+            new(default, second),
+            null!,
+        ];
+        AssertFailure(
+            census.Validate(census.Receipt, nullBeforeDefault),
+            FindingCensusValidationFailureKind.NullEntry,
+            inputIndex: 1);
+
+        FindingCensusEntry<string>[] defaultBeforeDuplicate =
+        [
+            census.Entries[0],
+            census.Entries[0],
+            new(default, second),
+            new(default, second),
+        ];
+        AssertFailure(
+            census.Validate(census.Receipt, defaultBeforeDuplicate),
+            FindingCensusValidationFailureKind.DefaultKey,
+            inputIndex: 2);
     }
 
     [Fact]
@@ -374,11 +448,25 @@ public class FindingCensusTests
             FindingCensusValidationFailureKind kind,
             int key,
             IEnumerable<FindingCensusEntry<string>> entries)
+            => AssertFailure(
+                census.Validate(census.Receipt, entries),
+                kind,
+                key);
+    }
+
+    sealed class OneShotEnumerable<T>(IEnumerable<T> values) : IEnumerable<T>
+    {
+        int _enumerationCount;
+
+        public int EnumerationCount => _enumerationCount;
+
+        public IEnumerator<T> GetEnumerator()
         {
-            FindingCensusValidationFailure failure = Failure(
-                census.Validate(census.Receipt, entries));
-            Assert.Equal(kind, failure.Kind);
-            Assert.Equal(key, failure.Key.Value);
+            if (Interlocked.Increment(ref _enumerationCount) != 1)
+                throw new InvalidOperationException("The sequence was enumerated twice.");
+            return values.GetEnumerator();
         }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION
## Summary

- seal an immutable ordered Finding census with one opaque receipt and positive per-instance keys
- preserve display-identical multiplicity and exact `Finding<T>` reference associations
- validate both complete projection bijections and filtered single-entry projections with typed failures
- keep `Finding<T>`, `FindingInspection<T>`, correspondence, ordinals, serialization, Research, and host behavior unchanged

Closes #4986. Tracks end-to-end adoption in #5515; the first real Facts/Annotated Source projection gate remains Research-owned by #4717.

## Candidate frame

- **Change classification:** shared host-neutral Finding substrate.
- **Complexity basis:** two value-equal Findings in one successful execution remain distinct instances, while independently loaded projections must reject substitutions and wrong/stale census results. Content-derived identity cannot meet that reliability requirement because it collapses multiplicity. `docs/design/finding-instance-census.md#problem` and `#contract` own this basis.
- **Supported caller and input:** a trusted Finding producer or composer supplies one initialized Finding sequence to `FindingCensus<T>.Seal`; Research later retains owner-issued entries through supported projections.
- **Consumers and host plan:** #4717 preserves identity through Research Facts and Annotated Source; #4718 adopts it in the CLI; #5516 transports it in Inspect Web; #5517 uses it for browser cross-view selection. #5515 is the overall tracker. No single-host exception or approval is required.
- **Current slice:** receipt/key construction, immutable sealing, exact association, complete and subset validation, equality boundaries, and exhaustive Finding-owned gates.
- **Residual work:** Research, CLI, and browser adoption remain independently correct later slices; this head exposes no unfinished host behavior.
- **Security classification:** not applicable — ordinary correctness for trusted in-process producers, not an untrusted-input containment change. The actor and boundary are stated in `docs/design/finding-instance-census.md#composition-boundaries`.
- **Rendering strategy:** not applicable — the exact-head diff adds no renderer, rendering domain, output section, Markout bypass, or host path. `docs/design/finding-instance-census.md#composition-boundaries` assigns all presentation to later host owners.
- **Convention basis:** opaque Roslyn-style GUID wrappers, immutable sealing, and two-level run/item identity. Content-derived SARIF fingerprints and vstest IDs are deliberate non-models because they collapse this census multiplicity.
- **Pathological case and gate:** separately allocated but value-equal Findings must receive distinct keys; a value-equal substitute under a valid key must fail. `Seal_PreservesOrderMultiplicityAndExactInstances` and `Validate_RejectsValueEqualFindingSubstitution` enforce that boundary.

## Demo

A file-based app referenced `ILInspector.Findings`, sealed two separately allocated but value-equal Findings, and attempted to substitute a third value-equal instance under key 1:

```csharp
var first = Duplicate();
var second = Duplicate();
var census = FindingCensus<string>.Seal([first, second]);

foreach (FindingCensusEntry<string> entry in census.Entries)
    Console.WriteLine($"key {entry.Key}: same instance = {ReferenceEquals(entry.Finding, first)}");

var substitution = census.ValidateEntry(
    census.Receipt,
    new FindingCensusEntry<string>(census.Entries[0].Key, Duplicate()));
```

```text
value-equal: True
receipt: 88cbeb39-7161-4be7-8762-05916effc73c
key 1: same instance = True
key 2: same instance = False
value-equal substitution: SubstitutedFinding
```

The same gate validates a reversed complete projection and a legitimate one-entry subset. `Seal_EnumeratesInputExactlyOnce` is the neighboring one-shot producer scenario.

## Design

`docs/design/finding-instance-census.md` owns sealing, receipt/key construction, exact association, validation precedence, equality boundaries, and non-claims. No TLA+ model is used: this is a finite immutable construction and validation invariant with no replacement, concurrency, or scheduling lifecycle inside the owner.

## Validation

- `dotnet run --project src/ILInspector.ILDiff.Tests -c Release` — 253 passed
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/finding-instance-census.md docs/design/finding-value-equality.md docs/README.md docs/overview.md docs/architecture.md`
- `git diff --check origin/main...HEAD`