### PR TITLE
Clarify absence-claim gate choices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,11 @@ are load-bearing everywhere:
   claim must name its enforcing gate or say `unverified`. A gate counts only
   when it runs in the suite's Release configuration; use runtime opt-ins, not
   `[Conditional("DEBUG")]`.
+- **Absence-claim coverage is a user choice.** Before proceeding, propose full,
+  partial, or no gate coverage and get the user's selection. An analyzer or
+  NativeAOT evidence for NativeAOT-prohibited behavior may be a gate; the
+  [evidence guide](docs/evidence-and-validation.md#absence-claims-choose-their-coverage)
+  owns the detailed coverage and residual rules.
 - **Harnesses don't manufacture the evidence they check.** They own
   orchestration, fixtures, oracles, and reporting, but must exercise
   product-owned artifact construction — never construct, normalize, or repair

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,7 @@ the `IsPackable`/`VersionPrefix` release rules live in
 Match evidence to the claim and use the smallest existing check that proves it.
 Detailed practices — matching evidence to claim types, the style-oracle
 consultation procedure, and the harness/product boundary — live in
-[`docs/evidence-and-validation.md`](docs/evidence-and-validation.md). Two rules
+[`docs/evidence-and-validation.md`](docs/evidence-and-validation.md). Three rules
 are load-bearing everywhere:
 
 - **Asserted properties name their gate.** A safety, soundness, or faithfulness

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -292,10 +292,22 @@ code is an attacker.
 ### Assemblies are parsed, never loaded
 
 Assembly, metadata, and method-body paths use
-`System.Reflection.PortableExecutable` and `System.Reflection.Metadata`. Product
-inspection must not introduce `Assembly.Load`, `AssemblyLoadContext`, reflection
-over inspected binaries, module initializers, or dependency resolution that
-executes target code.
+`System.Reflection.PortableExecutable` and `System.Reflection.Metadata`.
+Product inspection contains no `Assembly.Load` call and never loads inspected
+assemblies into the process.
+
+This is a user-approved partial-gate absence claim. Product projects set
+`IsAotCompatible`, so Release builds run NativeAOT compatibility analysis. The
+CI [`pack` job](../../.github/workflows/ci.yml) builds and installs the
+RID-specific NativeAOT tool, then executes canonical package, type, member, and
+platform-library inspections. NativeAOT prohibits dynamic assembly loading, so
+an `Assembly.Load` reached by those scenarios fails the smoke. The analysis is
+not a syntactic absence scan, and the smoke does not execute every inspection
+path; unexercised paths are the declared residual.
+
+`AssemblyLoadContext`, reflection over inspected binaries, module initializers,
+and dependency resolution that executes target code remain prohibited design
+directions. Their absence is not asserted as verified here.
 
 Reader-backed values remain inside their owning session. Values that cross a
 session boundary are copied or reduced to immutable tokens and shapes. This

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -293,17 +293,20 @@ code is an attacker.
 
 Assembly, metadata, and method-body paths use
 `System.Reflection.PortableExecutable` and `System.Reflection.Metadata`.
-Product inspection contains no `Assembly.Load` call and never loads inspected
-assemblies into the process.
+Product inspection contains no `Assembly.Load` call for inspected assemblies.
 
 This is a user-approved partial-gate absence claim. Product projects set
-`IsAotCompatible`, so Release builds run NativeAOT compatibility analysis. The
-CI [`pack` job](../../.github/workflows/ci.yml) builds and installs the
+`IsAotCompatible`, so Release builds run NativeAOT compatibility analysis and
+fail on the dynamic-loading uses that its diagnostics cover. That is a partial
+gate, not a syntactic scan of every `Assembly.Load` overload.
+
+When packaging-affecting changes select it, the CI
+[`pack` job](../../.github/workflows/ci.yml) builds and installs the
 RID-specific NativeAOT tool, then executes canonical package, type, member, and
-platform-library inspections. NativeAOT prohibits dynamic assembly loading, so
-an `Assembly.Load` reached by those scenarios fails the smoke. The analysis is
-not a syntactic absence scan, and the smoke does not execute every inspection
-path; unexercised paths are the declared residual.
+platform-library inspections. Those runs are supporting execution evidence,
+not an ordinary product-source-change gate. Unannotated overloads, changes for
+which the smoke is skipped, and inspection paths the smoke does not execute are
+the declared residual.
 
 `AssemblyLoadContext`, reflection over inspected binaries, module initializers,
 and dependency resolution that executes target code remain prohibited design

--- a/docs/design/untrusted-data-threat-model.md
+++ b/docs/design/untrusted-data-threat-model.md
@@ -308,9 +308,10 @@ not an ordinary product-source-change gate. Unannotated overloads, changes for
 which the smoke is skipped, and inspection paths the smoke does not execute are
 the declared residual.
 
-`AssemblyLoadContext`, reflection over inspected binaries, module initializers,
-and dependency resolution that executes target code remain prohibited design
-directions. Their absence is not asserted as verified here.
+`Assembly.Load`, `AssemblyLoadContext`, reflection over inspected binaries,
+module initializers, and dependency resolution that executes target code remain
+prohibited design directions. Their absence beyond the partial claim above is
+not asserted as verified here.
 
 Reader-backed values remain inside their owning session. Values that cross a
 session boundary are copied or reduced to immutable tokens and shapes. This

--- a/docs/evidence-and-validation.md
+++ b/docs/evidence-and-validation.md
@@ -66,10 +66,11 @@ claim `unverified`. All three are legitimate when the user accepts that
 evidence posture.
 
 A compiler or semantic analyzer that rejects the prohibited use is an
-acceptable gate. Release NativeAOT analysis, publication, or NativeAOT-executed
-tests are also acceptable gates for behavior that NativeAOT prohibits. State
-what each one establishes: NativeAOT compatibility analysis is not a syntactic
-absence scan, and executed tests cover the paths they exercise.
+acceptable gate. NativeAOT analyzer diagnostics are gates for the exact uses
+they reject, and NativeAOT-executed tests are gates for prohibited behavior on
+the paths they exercise. A successful NativeAOT publication alone establishes
+publishability, not API absence. State the exact diagnostic or executed
+scenario rather than generalizing either into a syntactic absence scan.
 
 Before implementing or strengthening an absence claim, propose full, partial,
 and no-gate options to the user. Name the recommended option, its evidence, and

--- a/docs/evidence-and-validation.md
+++ b/docs/evidence-and-validation.md
@@ -57,6 +57,24 @@ non-vacuity test that fails when the wiring is removed. A gate counts only when
 it runs in the suite's Release configuration; use runtime opt-ins, not
 `[Conditional("DEBUG")]`.
 
+### Absence claims choose their coverage
+
+An absence claim may have full, partial, or no gate coverage. Full coverage
+names a gate for the complete stated boundary. Partial coverage names what the
+gate establishes and marks the residual explicitly. No coverage marks the
+claim `unverified`. All three are legitimate when the user accepts that
+evidence posture.
+
+A compiler or semantic analyzer that rejects the prohibited use is an
+acceptable gate. Release NativeAOT analysis, publication, or NativeAOT-executed
+tests are also acceptable gates for behavior that NativeAOT prohibits. State
+what each one establishes: NativeAOT compatibility analysis is not a syntactic
+absence scan, and executed tests cover the paths they exercise.
+
+Before implementing or strengthening an absence claim, propose full, partial,
+and no-gate options to the user. Name the recommended option, its evidence, and
+any residual; proceed only after the user chooses the acceptable coverage.
+
 ## Harness boundary
 
 Harnesses own orchestration, fixtures, independent oracles, comparison, and


### PR DESCRIPTION
## Summary

Records the no-`Assembly.Load` product invariant as a user-approved
partial-gate absence claim. Existing Release NativeAOT compatibility analysis
is the gate for the dynamic-loading uses its diagnostics cover. The
packaging-selected NativeAOT package smoke is supporting execution evidence;
unannotated overloads, skipped smoke runs, and unexercised inspection paths are
the explicit residual.

Also clarifies the repository-wide decision rule for future absence claims:
an analyzer or relevant NativeAOT evidence can be a gate, full/partial/no gate
coverage are all legitimate, and the user selects the coverage after the agent
proposes the evidence and residual.

Closes #5488. Supersedes the source-analyzer approach in #5498.

## Demo

Before, an agent could read "name an enforcing gate or say `unverified`" as a
requirement to add a complete source-level prohibition:

```text
Claim: Product inspection contains no Assembly.Load call.
Agent action: Add a new banned-API analyzer without presenting evidence choices.
```

After, the required exchange and resulting claim are explicit:

```text
Agent proposal:
  Recommended: partial gate
  Gate:     Release NativeAOT diagnostics for the uses they reject
  Evidence: packaging-selected NativeAOT package/type/member/library smoke
  Residual: unannotated overloads, skipped smoke runs, and unexercised paths

User decision: accept partial gate

Threat-model claim:
  Product inspection contains no Assembly.Load call for inspected assemblies.
  NativeAOT diagnostics partially gate the claim; conditional smoke evidence
  and the residual are named without asserting syntactic proof.
```

What to notice: evidence is not inflated into a syntax proof, and the user
chooses the acceptable coverage before implementation. Neighboring claims can
instead select a rejecting analyzer for full coverage or explicitly remain
`unverified` with no gate.

## Compatibility and boundaries

This is documentation-only. It adds no analyzer, test project, build marker, or
anti-tamper policy, and it does not treat trusted repository code as an
attacker.

## Validation

- `npx --yes markdownlint-cli AGENTS.md docs/evidence-and-validation.md docs/design/untrusted-data-threat-model.md`
- `wc -l AGENTS.md` -> 590
- `git diff --check origin/main...HEAD`
