### PR TITLE
Add judgeable design checks to review prompt

### DIFF
--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -74,6 +74,31 @@ does not depend on that later work for correctness. Do report success-shaped
 unfinished behavior or a slice whose current correctness depends on a future
 change.
 
+When a candidate adds or expands a capability, substrate, host path, or broad
+rendering domain, review only design properties visible in the exact head and
+facts supplied in the candidate frame. The frame must state the complexity
+basis, consumer and end-to-end plan, and rendering strategy, or explain why
+each does not apply.
+
+Judge whether added complexity is required for robust reliability or
+correctness or enables a compelling user-observable experience. Verify that
+the visible design matches its named consumer and host plan, keeps reusable
+concepts host-neutral and hosts reasonably thin, and does not depend on
+unplanned later work for the current slice's correctness. Shared substrate
+must plan benefit and enablement through both the CLI and browser/Wasm hosts;
+for substrate intentionally limited to one consumer or host, the frame must
+supply the recorded approval and exact approved scope. Treat that record as a
+candidate-formation fact: verify that the design conforms to it, but do not
+infer, grant, or broaden approval.
+
+For rendering, verify that structured information survives to the rendering
+boundary. Markout is the default host-neutral, multi-format substrate. A
+host-specific path that bypasses it must identify the host, rationale, typed
+input model, and lowering boundary. A broad information domain must document
+where structured typing lives and who owns each format lowering, whether it
+uses Markout or another approach. Do not demand these obligations from a change
+to which the frame explains they do not apply.
+
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.
 A preserved non-CI fixture is design evidence, not the enforcing gate; the
@@ -97,8 +122,11 @@ owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
-claimed consequence. Return the framing defect instead of inventing a broader
-review property.
+claimed consequence. For an applicable capability, substrate, host, or
+rendering change, also stop when the required complexity basis, consumer and
+end-to-end plan, applicable approval record, or rendering strategy is absent.
+Return the framing defect instead of inventing the missing plan, approval, or
+broader review property.
 
 Treat the assigned review worktree as read-only. Do not run `git reset`,
 `git add`, or `git commit`; do not rebase or checkout another revision. Put

--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -77,19 +77,21 @@ change.
 When a candidate adds or expands a capability, substrate, host path, or broad
 rendering domain, review only design properties visible in the exact head and
 facts supplied in the candidate frame. The frame must state the complexity
-basis, consumer and end-to-end plan, and rendering strategy, or explain why
-each does not apply.
+basis; named consumer, focused issue, overall end-to-end tracker, host
+enablement plan, and any applicable approval record and exact scope; and
+rendering strategy, or explain why each does not apply.
 
-Judge whether added complexity is required for robust reliability or
-correctness or enables a compelling user-observable experience. Verify that
-the visible design matches its named consumer and host plan, keeps reusable
-concepts host-neutral and hosts reasonably thin, and does not depend on
-unplanned later work for the current slice's correctness. Shared substrate
-must plan benefit and enablement through both the CLI and browser/Wasm hosts;
-for substrate intentionally limited to one consumer or host, the frame must
-supply the recorded approval and exact approved scope. Treat that record as a
-candidate-formation fact: verify that the design conforms to it, but do not
-infer, grant, or broaden approval.
+Verify that the stated complexity basis identifies a specific reliability or
+correctness requirement or user-observable experience, and that the visible
+design's added complexity serves that basis. Do not independently judge whether
+an experience is compelling. Verify that the design matches its named consumer
+and host plan, keeps reusable concepts host-neutral and hosts reasonably thin,
+and does not depend on unplanned later work for the current slice's
+correctness. Shared substrate must plan benefit and enablement through both the
+CLI and browser/Wasm hosts; for substrate intentionally limited to one consumer
+or host, the frame must supply the recorded approval and exact approved scope.
+Treat that record as a candidate-formation fact: verify that the design
+conforms to it, but do not infer, grant, or broaden approval.
 
 For rendering, verify that structured information survives to the rendering
 boundary. Markout is the default host-neutral, multi-format substrate. A
@@ -123,8 +125,9 @@ owning claim defines a concrete observable requirement.
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
 claimed consequence. For an applicable capability, substrate, host, or
-rendering change, also stop when the required complexity basis, consumer and
-end-to-end plan, applicable approval record, or rendering strategy is absent.
+rendering change, also stop when the required complexity basis; named consumer,
+focused issue, overall end-to-end tracker, or host enablement plan; applicable
+approval record or exact scope; or rendering strategy is incomplete or absent.
 Return the framing defect instead of inventing the missing plan, approval, or
 broader review property.
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -311,9 +311,10 @@ required real-run evidence. The appended material may narrow the review but
 must not weaken or broaden the prompt's trust model and finding-admission rules.
 It also records the user purpose, convention or best-practice baseline,
 intentional divergence, analogous implementation evidence, pathological or
-boundary case and gate, current slice and residual work, and the demo with a
-neighboring case. Use `Not applicable — <reason>` for a field that genuinely
-does not apply.
+boundary case and gate, complexity basis, consumer and host plan, rendering
+strategy, current slice and residual work, and the demo with a neighboring
+case. Use `Not applicable — <reason>` for a field that genuinely does not
+apply.
 Agents that prefer a structured composition aid may instead fill the optional
 [`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md),
 which includes the same fixed prompt followed by candidate placeholders.
@@ -324,10 +325,17 @@ or variable input, the boundary through which it reaches the claim, trusted
 parties and excluded scenarios, the user purpose, baseline and any divergence,
 relevant analogous evidence, pathological case and gate, current slice,
 residual work, demo and neighboring case, the observable consequence, and the
-evidence that would falsify the claim. For a correctness review without an
-untrusted actor, name the ordinary supported caller and input instead. If those
-fields cannot be filled or explained as not applicable, return to design or
-scope clarification before spending a review round.
+evidence that would falsify the claim. For an applicable capability, substrate,
+host, or broad rendering change, candidate formation must also supply the
+complexity basis, named consumer, focused issue, overall end-to-end tracker,
+host-enablement plan, any recorded single-consumer or single-host approval and
+its exact scope, and the rendering strategy. Reviewers judge the visible
+design's consistency with those supplied facts; they do not grant approvals or
+invent roadmap decisions. State the facts directly in the self-contained
+prompt; links may support them but do not replace them. For a correctness
+review without an untrusted actor, name the ordinary supported caller and input
+instead. If required fields cannot be filled or explained as not applicable,
+return to design or scope clarification before spending a review round.
 
 Give every seat the same completed prompt except for its worktree path. State
 candidate facts rather than rewarding findings; the canonical prompt already

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -74,6 +74,31 @@ does not depend on that later work for correctness. Do report success-shaped
 unfinished behavior or a slice whose current correctness depends on a future
 change.
 
+When a candidate adds or expands a capability, substrate, host path, or broad
+rendering domain, review only design properties visible in the exact head and
+facts supplied in the candidate frame. The frame must state the complexity
+basis, consumer and end-to-end plan, and rendering strategy, or explain why
+each does not apply.
+
+Judge whether added complexity is required for robust reliability or
+correctness or enables a compelling user-observable experience. Verify that
+the visible design matches its named consumer and host plan, keeps reusable
+concepts host-neutral and hosts reasonably thin, and does not depend on
+unplanned later work for the current slice's correctness. Shared substrate
+must plan benefit and enablement through both the CLI and browser/Wasm hosts;
+for substrate intentionally limited to one consumer or host, the frame must
+supply the recorded approval and exact approved scope. Treat that record as a
+candidate-formation fact: verify that the design conforms to it, but do not
+infer, grant, or broaden approval.
+
+For rendering, verify that structured information survives to the rendering
+boundary. Markout is the default host-neutral, multi-format substrate. A
+host-specific path that bypasses it must identify the host, rationale, typed
+input model, and lowering boundary. A broad information domain must document
+where structured typing lives and who owns each format lowering, whether it
+uses Markout or another approach. Do not demand these obligations from a change
+to which the frame explains they do not apply.
+
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.
 A preserved non-CI fixture is design evidence, not the enforcing gate; the
@@ -97,8 +122,11 @@ owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
-claimed consequence. Return the framing defect instead of inventing a broader
-review property.
+claimed consequence. For an applicable capability, substrate, host, or
+rendering change, also stop when the required complexity basis, consumer and
+end-to-end plan, applicable approval record, or rendering strategy is absent.
+Return the framing defect instead of inventing the missing plan, approval, or
+broader review property.
 
 Treat the assigned review worktree as read-only. Do not run `git reset`,
 `git add`, or `git commit`; do not rebase or checkout another revision. Put
@@ -143,6 +171,17 @@ leaving a placeholder.
   choice; its scope, rationale, and evidence, or state none}
 - **Analogous implementation evidence:** {observed behaviors, omissions, and
   boundaries; identify what assumptions transfer, or why none applies}
+- **Complexity basis:** {why this is the simplest sufficient design and which
+  reliability, correctness, or user-observable experience requires any added
+  complexity; or why this field does not apply}
+- **Consumer and host plan:** {consumer named by the specification, focused
+  issue, overall end-to-end tracker, and planned host enablement; for
+  single-consumer or single-host substrate, include the supplied approval
+  record and exact scope; or why this field does not apply}
+- **Rendering strategy:** {typed information model and Markout lowerings, or
+  the host-specific alternative with host, rationale, and lowering ownership;
+  for a broad domain, include every planned format boundary; or why this field
+  does not apply}
 - **Change intent:** {what behavior or contract this candidate changes}
 - **Supported actor or caller:** {ordinary caller, producer, user, or external
   actor relevant to the claim}
@@ -185,10 +224,11 @@ the exact owned claim.}
 
 {List concrete properties derived from the review frame. Describe properties,
 not attacks, and do not broaden the actor, input, boundary, or exclusions.
-Include the baseline or divergence, pathological case and gate, analogous
-evidence transfer, current-slice coherence, and demonstrated neighboring case
-when applicable. Do not turn subjective product purpose or taste into a
-property.}
+Include the baseline or divergence, complexity basis, consumer and host plan,
+rendering strategy, pathological case and gate, analogous evidence transfer,
+current-slice coherence, and demonstrated neighboring case when applicable.
+Do not turn subjective product purpose or taste into a property or ask the
+reviewer to grant an approval supplied by candidate formation.}
 
 ### Prior findings and carried-forward obligations
 

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -77,19 +77,21 @@ change.
 When a candidate adds or expands a capability, substrate, host path, or broad
 rendering domain, review only design properties visible in the exact head and
 facts supplied in the candidate frame. The frame must state the complexity
-basis, consumer and end-to-end plan, and rendering strategy, or explain why
-each does not apply.
+basis; named consumer, focused issue, overall end-to-end tracker, host
+enablement plan, and any applicable approval record and exact scope; and
+rendering strategy, or explain why each does not apply.
 
-Judge whether added complexity is required for robust reliability or
-correctness or enables a compelling user-observable experience. Verify that
-the visible design matches its named consumer and host plan, keeps reusable
-concepts host-neutral and hosts reasonably thin, and does not depend on
-unplanned later work for the current slice's correctness. Shared substrate
-must plan benefit and enablement through both the CLI and browser/Wasm hosts;
-for substrate intentionally limited to one consumer or host, the frame must
-supply the recorded approval and exact approved scope. Treat that record as a
-candidate-formation fact: verify that the design conforms to it, but do not
-infer, grant, or broaden approval.
+Verify that the stated complexity basis identifies a specific reliability or
+correctness requirement or user-observable experience, and that the visible
+design's added complexity serves that basis. Do not independently judge whether
+an experience is compelling. Verify that the design matches its named consumer
+and host plan, keeps reusable concepts host-neutral and hosts reasonably thin,
+and does not depend on unplanned later work for the current slice's
+correctness. Shared substrate must plan benefit and enablement through both the
+CLI and browser/Wasm hosts; for substrate intentionally limited to one consumer
+or host, the frame must supply the recorded approval and exact approved scope.
+Treat that record as a candidate-formation fact: verify that the design
+conforms to it, but do not infer, grant, or broaden approval.
 
 For rendering, verify that structured information survives to the rendering
 boundary. Markout is the default host-neutral, multi-format substrate. A
@@ -123,8 +125,9 @@ owning claim defines a concrete observable requirement.
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
 claimed consequence. For an applicable capability, substrate, host, or
-rendering change, also stop when the required complexity basis, consumer and
-end-to-end plan, applicable approval record, or rendering strategy is absent.
+rendering change, also stop when the required complexity basis; named consumer,
+focused issue, overall end-to-end tracker, or host enablement plan; applicable
+approval record or exact scope; or rendering strategy is incomplete or absent.
 Return the framing defect instead of inventing the missing plan, approval, or
 broader review property.
 


### PR DESCRIPTION
## Summary

- extend the self-contained canonical review prompt with conditional checks for
  capability, substrate, host, and broad-rendering designs
- require candidate formation to supply complexity, consumer/E2E, host,
  approval, and rendering facts directly in the prompt
- limit reviewers to judging the exact-head design against those supplied
  facts; reviewers do not grant approvals or invent roadmap decisions
- add matching structured fields to the optional fill-in template and dispatch
  requirements

## Demo

Before this change, a reviewer could receive:

```text
Change intent: Add a shared rendering substrate.
```

The prompt did not require enough self-contained context to judge whether the
design had a consumer, justified its complexity, served both hosts, carried an
approved exception, or preserved structured rendering.

After this change, candidate formation supplies:

```text
Complexity basis: <judgeable correctness, reliability, or UX need>
Consumer and host plan: <consumer, focused issue, E2E tracker, host slices,
  and any exact approved exception>
Rendering strategy: <typed model and Markout lowerings, or the explicit
  host-specific alternative>
```

The reviewer judges whether the exact-head design matches those facts. Missing
applicable context is a framing defect; approval and roadmap creation remain
outside the reviewer's role. An ordinary focused bug fix can explain why each
field is not applicable.

## Validation

- `npx markdownlint-cli docs/adversarial-review-prompt.md docs/templates/adversarial-review-prompt.md docs/round-orchestration.md`
- verified that the template's fixed prefix is byte-identical to the canonical
  prompt

This changes contributor review guidance only; it does not change product
behavior.
