### PR TITLE
Require evidence for review non-applicability

### DIFF
--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -98,8 +98,14 @@ boundary. Markout is the default host-neutral, multi-format substrate. A
 host-specific path that bypasses it must identify the host, rationale, typed
 input model, and lowering boundary. A broad information domain must document
 where structured typing lives and who owns each format lowering, whether it
-uses Markout or another approach. Do not demand these obligations from a change
-to which the frame explains they do not apply.
+uses Markout or another approach.
+
+Do not accept claimed non-applicability at face value. Verify from the
+normative owner, change intent, changed surfaces, and exact-head diff that the
+candidate does not add or expand a capability, substrate, host path, or broad
+rendering domain. When a design establishes that boundary, the explanation
+must name its exact section. If the supplied facts and exact-head evidence do
+not establish non-applicability, return a framing defect.
 
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -313,8 +313,9 @@ It also records the user purpose, convention or best-practice baseline,
 intentional divergence, analogous implementation evidence, pathological or
 boundary case and gate, complexity basis, consumer and host plan, rendering
 strategy, current slice and residual work, and the demo with a neighboring
-case. Use `Not applicable — <reason>` for a field that genuinely does not
-apply.
+case. Use `Not applicable — <reason>` only when the reason names the relevant
+change classification and exact-head evidence; cite the owning design's exact
+section when it defines the boundary.
 Agents that prefer a structured composition aid may instead fill the optional
 [`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md),
 which includes the same fixed prompt followed by candidate placeholders.
@@ -334,7 +335,9 @@ design's consistency with those supplied facts; they do not grant approvals or
 invent roadmap decisions. State the facts directly in the self-contained
 prompt; links may support them but do not replace them. For a correctness
 review without an untrusted actor, name the ordinary supported caller and input
-instead. If required fields cannot be filled or explained as not applicable,
+instead. Candidate formation must make every non-applicability explanation
+judgeable from the normative owner, changed surfaces, and exact-head diff. If
+required fields cannot be filled or non-applicability cannot be established,
 return to design or scope clarification before spending a review round.
 
 Give every seat the same completed prompt except for its worktree path. State

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -98,8 +98,14 @@ boundary. Markout is the default host-neutral, multi-format substrate. A
 host-specific path that bypasses it must identify the host, rationale, typed
 input model, and lowering boundary. A broad information domain must document
 where structured typing lives and who owns each format lowering, whether it
-uses Markout or another approach. Do not demand these obligations from a change
-to which the frame explains they do not apply.
+uses Markout or another approach.
+
+Do not accept claimed non-applicability at face value. Verify from the
+normative owner, change intent, changed surfaces, and exact-head diff that the
+candidate does not add or expand a capability, substrate, host path, or broad
+rendering domain. When a design establishes that boundary, the explanation
+must name its exact section. If the supplied facts and exact-head evidence do
+not establish non-applicability, return a framing defect.
 
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.
@@ -156,9 +162,10 @@ are no qualifying findings, write **CLEAN** and name the exact reviewed head.
 
 Replace every `{...}` placeholder below, then append domain-specific
 instructions where indicated. Do not remove, weaken, paraphrase, reorder, or
-put other instructions before the fixed prompt above. Fill every field; when a
-field genuinely does not apply, write `Not applicable — <reason>` rather than
-leaving a placeholder.
+put other instructions before the fixed prompt above. Fill every field. Use
+`Not applicable — <reason>` only when the reason identifies the relevant
+change classification and exact-head evidence; cite the owning design's exact
+section when it defines the boundary.
 
 ## Required review frame
 


### PR DESCRIPTION
## Summary

- require reviewers to verify every claimed `Not applicable` classification
  from the normative owner, changed surfaces, and exact-head diff
- require an exact design section when a design establishes the applicability
  boundary, without forcing ordinary focused fixes to invent design documents
- make unsupported non-applicability a framing defect
- align the optional template and dispatch mechanics with the canonical prompt

## Stack

- Slice: 2 of 2
- Parent: #5523
- Base branch: `guidance/reviewer-design-checks`
- Remaining work: none

## Demo

Before this change, a candidate could state:

```text
Consumer and host plan: Not applicable.
Rendering strategy: Not applicable.
```

The reviewer was told not to demand those obligations when the frame explained
they did not apply, which could be read as accepting the classification.

After this change, the explanation must identify the change classification and
exact-head evidence. The reviewer independently checks the normative owner,
change intent, changed surfaces, and diff. If a design defines the boundary,
the frame names its exact section. A false or unsupported `Not applicable`
stops review as a framing defect.

A focused bug fix can still use:

```text
Consumer and host plan: Not applicable — this changes only the null check in
the existing operation owned by <owner>; the diff adds no capability,
substrate, host path, or rendering domain.
```

## Validation

- `npx markdownlint-cli docs/adversarial-review-prompt.md docs/templates/adversarial-review-prompt.md docs/round-orchestration.md`
- verified that the template's fixed prefix is byte-identical to the canonical
  prompt

This changes contributor review guidance only; it does not change product
behavior.
