### PR TITLE
Clarify composition absence claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,11 +353,13 @@ are load-bearing everywhere:
   claim must name its enforcing gate or say `unverified`. A gate counts only
   when it runs in the suite's Release configuration; use runtime opt-ins, not
   `[Conditional("DEBUG")]`.
-- **Absence-claim coverage is a user choice.** Before proceeding, propose full,
-  partial, or no gate coverage and get the user's selection. An analyzer or
-  NativeAOT evidence for NativeAOT-prohibited behavior may be a gate; the
+- **Composition absence-claim coverage is a user choice.** Before asserting
+  that a product or repository boundary contains no dependency, runtime, API
+  family, prohibited construct, or unsupported platform capability, propose
+  full, partial, or no gate coverage. Negatively phrased algorithmic correctness
+  properties use ordinary contract gates. The
   [evidence guide](docs/evidence-and-validation.md#absence-claims-choose-their-coverage)
-  owns the detailed coverage and residual rules.
+  owns the detailed rules.
 - **Harnesses don't manufacture the evidence they check.** They own
   orchestration, fixtures, oracles, and reporting, but must exercise
   product-owned artifact construction — never construct, normalize, or repair

--- a/docs/evidence-and-validation.md
+++ b/docs/evidence-and-validation.md
@@ -59,6 +59,18 @@ it runs in the suite's Release configuration; use runtime opt-ins, not
 
 ### Absence claims choose their coverage
 
+An absence claim in this section is about product or repository composition:
+within a stated boundary, a dependency, runtime, API family, prohibited
+construct, or unsupported platform capability is not present or used. For
+example, "the product has no Python runtime or dependency" is an absence claim
+because the set of implementation dependencies and paths can change as the
+repository evolves.
+
+A product algorithm postcondition is not an absence claim merely because it is
+phrased negatively. "Classification does not emit a Member with the wrong
+declaring Type" is an ordinary correctness property over supported inputs and
+uses normal contract gates.
+
 An absence claim may have full, partial, or no gate coverage. Full coverage
 names a gate for the complete stated boundary. Partial coverage names what the
 gate establishes and marks the residual explicitly. No coverage marks the


### PR DESCRIPTION
## Summary

Clarifies that the evidence policy's required coverage choice applies to
product and repository **composition absence claims**, not every correctness
property phrased negatively.

- Keep the binding `AGENTS.md` rule concise and composition-specific.
- Define the detailed boundary in `docs/evidence-and-validation.md`.
- Preserve the existing full, partial, and no-coverage choices unchanged.

## Demo

Before this clarification, “absence claim” could be read as any statement using
“does not” or “never,” which incorrectly pulled ordinary algorithmic
postconditions into a user-selected evidence posture.

After:

| Claim | Evidence treatment |
| --- | --- |
| “The product has no Python runtime or dependency.” | Composition absence claim: choose full, partial, or no gate coverage. |
| “Classification does not emit a Member with the wrong declaring Type.” | Product correctness property: use ordinary contract gates. |

What to notice: the distinction follows what the claim is about—product
composition versus algorithm behavior—not whether its sentence is negative.

A neighboring composition claim such as “this supported boundary does not use
a prohibited API family” still follows the existing absence-coverage choice.

## Compatibility and boundaries

This is guidance-only. It does not change the available evidence postures,
prescribe one posture for every composition claim, or alter any product
algorithm contract.

## Validation

- `wc -l AGENTS.md` → 592 lines
- `npx markdownlint-cli AGENTS.md docs/evidence-and-validation.md`
- `git diff --check`

Closes #5537
