### PR TITLE
Describe NativeAOT as partial no-load evidence

### DIFF
--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -411,18 +411,12 @@ worked example that document points at.
   `StringPreview_NeverExceedsCharBudgetEvenWhenEscaped`, because
   `StringBudget_…` asserts only that the full length is reported and the
   preview is non-empty.
-- **Parse, never load — the tool is execution incapable.** Reading is SRM-only,
-  and the shipped tool is Native AOT: there is no JIT, so `Assembly.Load` and
-  friends cannot bring new IL to life. Nothing the tool downloads can be
-  executed, whatever the metadata says. That is a structural property, not a
-  convention. The gate is the AOT build itself — `PublishAot` is `true` by
-  default for `src/dotnet-inspect`, and `release.yml` builds every shipped
-  RID-specific package that way, so a change that needed runtime code
-  generation would fail to build rather than fail a test. The one caveat worth
-  naming: the RID-neutral `any` fallback package is deliberately non-AOT
-  (`-p:PublishAot=false`), so on that package the property rests on the code
-  being SRM-only rather than on the runtime being unable to comply. A malformed
-  coded index resolves to a visible failure marker, not a fabricated target.
+- **Parse, never load.** Metadata-table projection uses SRM readers and must not
+  load or execute inspected assemblies. The composition absence claim that
+  this path contains no runtime-loading or execution mechanism has
+  user-selected no gate coverage and is `unverified`. NativeAOT publication is
+  not claimed as an absence gate. A malformed coded index resolves to a visible
+  failure marker, not a fabricated target.
 - **Heaps are explicit-only.** The string/blob/user-string/guid heaps are the largest
   amplification surface, so nothing that merely asks for *more output* may turn
   one on — only naming a heap section does. Verbosity is the axis that would

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -871,11 +871,12 @@ channel the check just closed.
 
 ### Status
 
-The bounded-traversal budgets, execution-incapable parsing, and opt-in heaps are
-implemented, with their gates named above. So are the visual-encoding spelling
-(#3636, extended to Unicode general categories in #3628), the failure-message
-rule, and both the trust and rendering axes, which `mdi` exposes as
-`--show-untrusted-text` and `--dangerously-print-raw`.
+The bounded-traversal budgets and opt-in heaps are implemented, with their gates
+named above. Parse-never-load is implemented with the partial NativeAOT evidence
+posture described above. So are the visual-encoding spelling (#3636, extended
+to Unicode general categories in #3628), the failure-message rule, and both the
+trust and rendering axes, which `mdi` exposes as `--show-untrusted-text` and
+`--dangerously-print-raw`.
 
 The identifier allow lists and `--survey` remain the **target model**: nothing
 validates an identifier's grammar, and refusal stops at the first violation

--- a/docs/design/metadata-table-projection.md
+++ b/docs/design/metadata-table-projection.md
@@ -412,11 +412,12 @@ worked example that document points at.
   `StringBudget_…` asserts only that the full length is reported and the
   preview is non-empty.
 - **Parse, never load.** Metadata-table projection uses SRM readers and must not
-  load or execute inspected assemblies. The composition absence claim that
-  this path contains no runtime-loading or execution mechanism has
-  user-selected no gate coverage and is `unverified`. NativeAOT publication is
-  not claimed as an absence gate. A malformed coded index resolves to a visible
-  failure marker, not a fabricated target.
+  load or execute inspected assemblies. Loading new IL assemblies at runtime is
+  unsupported by NativeAOT, and the shipped dotnet-inspect product graph is
+  maintained as NativeAOT-compatible. NativeAOT therefore provides
+  user-selected partial evidence for this composition absence claim, not a
+  syntactic or path-complete proof. A malformed coded index resolves to a
+  visible failure marker, not a fabricated target.
 - **Heaps are explicit-only.** The string/blob/user-string/guid heaps are the largest
   amplification surface, so nothing that merely asks for *more output* may turn
   one on — only naming a heap section does. Verbosity is the axis that would


### PR DESCRIPTION
## Summary

Scopes the metadata-table projection's parse-never-load control to its owning
path, preserves the prohibition on loading or executing inspected assemblies,
and records the user-selected partial NativeAOT evidence.

Loading new IL assemblies at runtime is unsupported by NativeAOT, and the
shipped dotnet-inspect product graph is maintained as NativeAOT-compatible.
Those facts support the absence claim without being presented as a syntactic or
path-complete proof. The change adds no analyzer or product behavior.

Follow-up to the consistency observation from #5521.

## Demo

Before:

```text
Nothing the tool downloads can be executed.
The gate is the AOT build itself.
```

After:

```text
Metadata-table projection must not load or execute inspected assemblies.
Evidence: runtime loading of new IL is unsupported by NativeAOT, and the
          product graph is maintained as NativeAOT-compatible
Coverage: partial; not a syntactic or path-complete proof
```

What to notice: the normative prohibition remains, and NativeAOT contributes
real but bounded evidence instead of being inflated into a complete absence
gate.

## Compatibility and boundaries

Documentation-only. The claim is limited to metadata-table projection rather
than redefining the complete tool or adding a new source-level gate.

## Validation

- `npx --yes markdownlint-cli docs/design/metadata-table-projection.md`
- `git diff --check origin/main...HEAD`
