### PR TITLE
Implement inspect-web operation authority

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,7 @@ without referencing the CLI assembly.
 | Host | Place in flow | Role | Primary guide |
 | ---- | ------------- | ---- | ------------- |
 | `src/dotnet-inspect` | Product host | Complete command-line host, including source resolution, command orchestration, section selection, output models, and rendering. | [CLI host architecture](cli-architecture.md) |
-| `prototypes/inspect-web` | Product host | Browser/Wasm host and product UI over reusable engine and focused UI-control contracts. | [Inspect Web UI](design/inspect-web-ui.md) composition map, [SlideStrip](design/inspect-web-slide-strip.md) reusable control; target [operation authority](design/inspect-web-operation-authority.md) |
+| `prototypes/inspect-web` | Product host | Browser/Wasm host and product UI over reusable engine and focused UI-control contracts. | [Inspect Web UI](design/inspect-web-ui.md) composition map, [SlideStrip](design/inspect-web-slide-strip.md) reusable control, [operation authority](design/inspect-web-operation-authority.md) |
 | `tools/DecompilerHarness` | Correctness harness | Decompiler correctness, compile-back, corpus, and independent-oracle orchestration. | [Decompiler correctness pipeline](decompiler-correctness-pipeline.md) |
 | Focused apps and fixtures | Boundary canary | Narrow executable consumers that prove a reusable boundary without becoming product owners. | Their local README or owning design |
 

--- a/docs/design/inspect-web-async-composition.md
+++ b/docs/design/inspect-web-async-composition.md
@@ -21,9 +21,9 @@ The generated inspect-web facade and authenticated synchronous delegate support
 have landed through
 [#5003](https://github.com/richlander/dotnet-inspect/issues/5003) and
 [#5005](https://github.com/richlander/dotnet-inspect/issues/5005).
-The operation-authority, worker-runtime, and managed-operation-bridge product
-components have not landed. Their composed behavior therefore remains
-**unverified**.
+The operation-authority product component and its first Type Source adoption
+are implemented. The worker-runtime and managed-operation-bridge product
+components have not landed, so their composed behavior remains **unverified**.
 
 ## Composition responsibility
 
@@ -317,7 +317,7 @@ owner's evidence cannot stand in for another owner's behavior.
 
 | Claimed behavior | Owner and gate | Current status |
 | --- | --- | --- |
-| One logical outcome, current-view publication, cancellation, stale-event suppression, and quiescence | [Operation-authority model and `inspect-web-operation-authority` Release TypeScript gate](inspect-web-operation-authority.md#required-implementation-gate) | Abstract model checked; product component and gate **unverified** |
+| One logical outcome, current-view publication, cancellation, stale-event suppression, and quiescence | [Operation-authority model and `inspect-web-operation-authority` Release TypeScript gate](inspect-web-operation-authority.md#required-implementation-gate) | Abstract model checked; product component, gate, and first Type Source adoption implemented |
 | Worker message validity, epoch containment, readiness, liveness, draining, and realm release | [Worker-runtime models and `inspect-web-worker-protocol` plus `inspect-web-worker-lifecycle` Release gates](inspect-web-worker-runtime.md#required-implementation-gates) | Abstract models checked; product components and gates **unverified** |
 | DOM responsiveness while representative managed CPU work runs | Worker-runtime owner and [`inspect-web-worker-responsiveness` real-browser gate](inspect-web-worker-runtime.md#required-implementation-gates) | **Unverified** |
 | Keyed managed cancellation, exact reason, callback release, managed quiescence, shared-waiter detachment, and epoch-work handoff | [Managed-bridge model and `inspect-web-managed-operation-bridge` Release browser-host gate](inspect-web-managed-operation-bridge.md#required-implementation-gate) | Abstract model checked; product component and gate **unverified** |

--- a/docs/design/inspect-web-operation-authority.md
+++ b/docs/design/inspect-web-operation-authority.md
@@ -13,6 +13,18 @@ The checked
 establishes only the bounded abstract properties recorded with that model. It
 does not prove TypeScript, browser, producer, worker, or managed behavior.
 
+## Approved host scope
+
+This component is intentionally inspect-web browser-host policy. Replaceable
+DOM-view operation lifetime and current-view publication authority are its
+named host concerns; one existing source view is the first implementation
+consumer. The CLI has no corresponding named consumer, so this design does not
+create or claim a shared CLI/browser substrate.
+
+The user approved this single-host scope on 2026-09-02 before implementation.
+The same decision is recorded in implementation issue #5092 and end-to-end
+tracker #4937.
+
 ## Responsibility
 
 The inspect-web operation-authority component owns:
@@ -298,6 +310,12 @@ owner, including identities whose producer preparation is rejected. Neither ID
 nor sequence allocation resets or wraps during the page lifetime. Exhausting
 the safe-integer range rejects the start before producer preparation and leaves
 every existing session and cancellation count unchanged.
+
+An ID-source collision is visible through the same `identity-exhausted` result.
+The page owner consumes the attempted sequence, permanently exhausts that
+identity source, and does not prepare a producer or ask the source for another
+ID. This keeps the public result vocabulary closed while refusing to trust an
+allocator after it proposes a page-lifetime reuse.
 
 The sequence is allocation evidence for producer adapters that need bounded
 ordering or replay checks. It is not encoded into, parsed from, or compared
@@ -709,6 +727,7 @@ This owner does not claim:
   termination;
 - managed cancellation-token, progress-delegate, or result-envelope behavior;
 - generated-facade construction or bootstrap;
+- a CLI operation-authority abstraction;
 - feature rendering, retry, cache, shared-work, or queue semantics; or
 - browser responsiveness.
 

--- a/docs/design/inspect-web-operation-authority.md
+++ b/docs/design/inspect-web-operation-authority.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-This document defines the target main-thread operation-authority component for
+This document defines the main-thread operation-authority component for
 [issue #5092](https://github.com/richlander/dotnet-inspect/issues/5092).
-The component and its implementation gates have not landed, so operation-ID
-uniqueness, shared cancellation semantics, stale-publication safety, and
-quiescence remain **unverified** in the product.
+The component is implemented in
+`prototypes/inspect-web/src/operation-authority.ts` and first adopted by Type
+Source in `prototypes/inspect-web/src/source-inspection.ts`. Operation-ID
+uniqueness, operation cancellation, stale-publication safety, and quiescence
+are enforced by `prototypes/inspect-web/test/operation-authority.test.ts` and
+the Type Source adoption cases in
+`prototypes/inspect-web/test/source-inspection.test.ts`.
 
 The checked
 [operation-authority model](models/inspect-web-operation-authority/README.md)
@@ -630,8 +634,10 @@ owners.
 
 ## Required implementation gate
 
-`inspect-web-operation-authority` is a Release TypeScript gate. It does not yet
-exist and must include:
+`inspect-web-operation-authority` is the Release TypeScript gate implemented by
+`prototypes/inspect-web/test/operation-authority.test.ts`, with first-consumer
+coverage in `prototypes/inspect-web/test/source-inspection.test.ts`. Both run
+under the ordinary inspect-web `npm test` gate and include:
 
 - concurrent and sequential sessions receiving opaque IDs never previously
   allocated by the page owner, plus strictly increasing safe-integer sequences;

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -163,6 +163,7 @@ import {
   createSourceInspectionCoordinator,
   type GraphSourceRequest,
 } from "./source-inspection.ts";
+import { createOperationAuthorityPage } from "./operation-authority.ts";
 import {
   createMetadataInspectionCoordinator,
   type AppExplorerState,
@@ -929,8 +930,10 @@ function restoreCanonicalWorkspaceRestoreSnapshot(
 }
 
 const keybindings = createWorkbenchKeybindings();
+const operationAuthority = createOperationAuthorityPage();
 const sourceInspection = createSourceInspectionCoordinator({
   state,
+  operationAuthority,
   queryMemberSource: request => inspectMemberSource(
     request.packageId,
     request.version,
@@ -960,6 +963,10 @@ const sourceInspection = createSourceInspectionCoordinator({
     taste),
   memberSourceHasConcreteOverload,
   cancelEngineSourceRequest: () => cancelSourceInspection?.(),
+  reportOperationDiagnostic: diagnostic => {
+    console.error("Source operation authority failure.", diagnostic);
+    return undefined;
+  },
   describeError: errorMessage,
   render,
   renderPreservingMemberFocus,

--- a/prototypes/inspect-web/src/operation-authority.ts
+++ b/prototypes/inspect-web/src/operation-authority.ts
@@ -219,7 +219,7 @@ interface PageState {
   readonly lastResortConsole: OperationLastResortConsole;
   nextSequence: number;
   identityExhausted: boolean;
-  featureObserverActive: boolean;
+  featureObserverDepth: number;
 }
 
 interface OperationRecord<TValue, TError, TProgress> {
@@ -423,12 +423,11 @@ function publishFeature<TValue, TError, TProgress>(
   observer = session.featureObserver,
 ): boolean {
   if (observer === null) return false;
-  session.page.featureObserverActive = true;
+  session.page.featureObserverDepth++;
   try {
     observer.publish(event);
-    return true;
   } catch (error: unknown) {
-    session.page.featureObserverActive = false;
+    session.page.featureObserverDepth--;
     const failedOperationId = event.kind === "started" || event.kind === "replaced"
       ? event.operation.id
       : event.kind === "progress"
@@ -442,9 +441,9 @@ function publishFeature<TValue, TError, TProgress>(
         fault.cancellation.reason,
       );
     return false;
-  } finally {
-    session.page.featureObserverActive = false;
   }
+  session.page.featureObserverDepth--;
+  return true;
 }
 
 function createRecord<TValue, TError, TProgress>(
@@ -577,7 +576,7 @@ function cancelRecord<TValue, TError, TProgress>(
   record: OperationRecord<TValue, TError, TProgress>,
   reason: OperationCancelReason,
 ): OperationControlResult {
-  if (session.page.featureObserverActive)
+  if (session.page.featureObserverDepth > 0)
     return { kind: "rejected", reason: "feature-observer-active" };
   if (record.outcome !== null) return { kind: "no-op" };
 
@@ -628,7 +627,7 @@ function createPage(
     lastResortConsole: options.lastResortConsole ?? defaultLastResortConsole,
     nextSequence: 1,
     identityExhausted: false,
-    featureObserverActive: false,
+    featureObserverDepth: 0,
   };
 
   return {
@@ -646,7 +645,7 @@ function createPage(
 
       return {
         start: (input, adapter) => {
-          if (page.featureObserverActive) {
+          if (page.featureObserverDepth > 0) {
             return {
               kind: "rejected",
               reason: { kind: "feature-observer-active" },
@@ -750,14 +749,14 @@ function createPage(
           return { kind: "started", handle: candidate.handle };
         },
         cancelCurrent: reason => {
-          if (page.featureObserverActive)
+          if (page.featureObserverDepth > 0)
             return { kind: "rejected", reason: "feature-observer-active" };
           const current = session.current;
           if (current === null) return { kind: "no-op" };
           return cancelRecord(session, current, reason ?? "user");
         },
         dispose: () => {
-          if (page.featureObserverActive)
+          if (page.featureObserverDepth > 0)
             return { kind: "rejected", reason: "feature-observer-active" };
           if (session.disposed) return { kind: "no-op" };
 

--- a/prototypes/inspect-web/src/operation-authority.ts
+++ b/prototypes/inspect-web/src/operation-authority.ts
@@ -734,7 +734,7 @@ function createPage(
                   reason: "superseded",
                 };
           const published = publishFeature(session, event);
-          if (published) {
+          if (published && standardPublicationAuthority(session, candidate)) {
             candidate.activated = true;
             candidate.binding.activate();
           } else {

--- a/prototypes/inspect-web/src/operation-authority.ts
+++ b/prototypes/inspect-web/src/operation-authority.ts
@@ -1,0 +1,795 @@
+declare const operationIdBrand: unique symbol;
+
+export type OperationId = string & {
+  readonly [operationIdBrand]: "OperationId";
+};
+
+export interface OperationIdentity {
+  readonly id: OperationId;
+  readonly sequence: number;
+}
+
+export type OperationCancelReason =
+  | "user"
+  | "superseded"
+  | "disposed"
+  | "feature-observer-failed"
+  | "timeout"
+  | "worker-restarted";
+
+export type OperationTerminalOutcome<TValue, TError> =
+  | { readonly kind: "succeeded"; readonly value: TValue }
+  | { readonly kind: "failed"; readonly error: TError };
+
+export type OperationOutcome<TValue, TError> =
+  | OperationTerminalOutcome<TValue, TError>
+  | {
+      readonly kind: "canceled";
+      readonly reason: OperationCancelReason;
+    };
+
+export interface OperationProgress<TProgress> {
+  readonly operationId: OperationId;
+  readonly value: TProgress;
+}
+
+export type OperationControlResult =
+  | { readonly kind: "applied" }
+  | { readonly kind: "no-op" }
+  | {
+      readonly kind: "rejected";
+      readonly reason: "feature-observer-active";
+    };
+
+export interface OperationHandle<TValue, TError> {
+  readonly id: OperationId;
+  readonly outcome: Promise<OperationOutcome<TValue, TError>>;
+  readonly quiesced: Promise<void>;
+  cancel(reason?: OperationCancelReason): OperationControlResult;
+}
+
+export type OperationStartError<TPrepareError> =
+  | { readonly kind: "session-disposed" }
+  | { readonly kind: "session-changed" }
+  | { readonly kind: "identity-exhausted" }
+  | { readonly kind: "feature-observer-active" }
+  | {
+      readonly kind: "producer-rejected";
+      readonly error: TPrepareError;
+    };
+
+export type OperationStartResult<TValue, TError, TPrepareError> =
+  | {
+      readonly kind: "started";
+      readonly handle: OperationHandle<TValue, TError>;
+    }
+  | {
+      readonly kind: "rejected";
+      readonly reason: OperationStartError<TPrepareError>;
+    };
+
+export type OperationFeatureEvent<TValue, TError, TProgress> =
+  | {
+      readonly kind: "started";
+      readonly operation: OperationIdentity;
+    }
+  | {
+      readonly kind: "replaced";
+      readonly previousOperationId: OperationId;
+      readonly operation: OperationIdentity;
+      readonly reason: "superseded";
+    }
+  | {
+      readonly kind: "progress";
+      readonly progress: OperationProgress<TProgress>;
+    }
+  | {
+      readonly kind: "terminal";
+      readonly operationId: OperationId;
+      readonly outcome: OperationTerminalOutcome<TValue, TError>;
+    }
+  | {
+      readonly kind: "canceled";
+      readonly operationId: OperationId;
+      readonly reason: OperationCancelReason;
+    }
+  | {
+      readonly kind: "disposed";
+      readonly operationId: OperationId | null;
+    };
+
+export interface OperationFeatureObserver<TValue, TError, TProgress> {
+  readonly publish: (
+    event: OperationFeatureEvent<TValue, TError, TProgress>,
+  ) => undefined;
+}
+
+export interface OperationDiagnostic {
+  readonly kind:
+    | "producer-contract"
+    | "producer-callout"
+    | "feature-observer";
+  readonly operationId: OperationId | null;
+  readonly error: unknown;
+}
+
+export interface OperationDiagnosticObserver {
+  readonly report: (diagnostic: OperationDiagnostic) => undefined;
+}
+
+export interface OperationProducerSink<TValue, TError, TProgress> {
+  readonly reportProgress: (value: TProgress) => undefined;
+  readonly reportTerminal: (
+    outcome: OperationOutcome<TValue, TError>,
+  ) => undefined;
+  readonly reportQuiesced: () => undefined;
+  readonly reportUnexpectedFailure: (error: unknown) => undefined;
+}
+
+export interface PreparedOperationProducer {
+  readonly requestCancellation: (
+    reason: OperationCancelReason,
+  ) => undefined;
+  readonly activate: () => undefined;
+  readonly abandon: () => undefined;
+}
+
+export type OperationPreparation<TPrepareError> =
+  | {
+      readonly kind: "prepared";
+      readonly binding: PreparedOperationProducer;
+    }
+  | {
+      readonly kind: "rejected";
+      readonly error: TPrepareError;
+    };
+
+export interface OperationProducerAdapter<
+  TInput,
+  TValue,
+  TError,
+  TProgress,
+  TPrepareError,
+> {
+  readonly prepare: (
+    identity: OperationIdentity,
+    input: TInput,
+    sink: OperationProducerSink<TValue, TError, TProgress>,
+  ) => OperationPreparation<TPrepareError>;
+}
+
+export interface OperationSession<
+  TInput,
+  TValue,
+  TError,
+  TProgress,
+  TPrepareError,
+> {
+  start(
+    input: TInput,
+    adapter: OperationProducerAdapter<
+      TInput,
+      TValue,
+      TError,
+      TProgress,
+      TPrepareError
+    >,
+  ): OperationStartResult<TValue, TError, TPrepareError>;
+  cancelCurrent(reason?: OperationCancelReason): OperationControlResult;
+  dispose(): OperationControlResult;
+}
+
+export interface OperationSessionObservers<TValue, TError, TProgress> {
+  readonly feature: OperationFeatureObserver<TValue, TError, TProgress>;
+  readonly diagnostic: OperationDiagnosticObserver;
+}
+
+export interface OperationAuthorityPage {
+  createSession<TInput, TValue, TError, TProgress, TPrepareError>(
+    observers: OperationSessionObservers<TValue, TError, TProgress>,
+  ): OperationSession<TInput, TValue, TError, TProgress, TPrepareError>;
+}
+
+export interface OperationIdentityAllocationOptions {
+  readonly maximumSequence?: number;
+  readonly createId?: () => string;
+}
+
+export interface OperationLastResortConsole {
+  readonly report: (
+    diagnostic: OperationDiagnostic,
+    observerError: unknown,
+  ) => undefined;
+}
+
+export interface OperationAuthorityPageOptions {
+  readonly allocation?: OperationIdentityAllocationOptions;
+  readonly lastResortConsole?: OperationLastResortConsole;
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+interface PageState {
+  readonly maximumSequence: number;
+  readonly createId: () => string;
+  readonly allocatedIds: Set<string>;
+  readonly lastResortConsole: OperationLastResortConsole;
+  nextSequence: number;
+  identityExhausted: boolean;
+  featureObserverActive: boolean;
+}
+
+interface OperationRecord<TValue, TError, TProgress> {
+  readonly identity: OperationIdentity;
+  readonly outcomeDeferred: Deferred<OperationOutcome<TValue, TError>>;
+  readonly quiescedDeferred: Deferred<void>;
+  readonly handle: OperationHandle<TValue, TError>;
+  readonly sink: OperationProducerSink<TValue, TError, TProgress>;
+  binding: PreparedOperationProducer | null;
+  outcome: OperationOutcome<TValue, TError> | null;
+  activated: boolean;
+  cancellationReserved: boolean;
+  terminalReported: boolean;
+  released: boolean;
+}
+
+interface SessionState<TValue, TError, TProgress> {
+  readonly page: PageState;
+  readonly diagnosticObserver: OperationDiagnosticObserver;
+  featureObserver: OperationFeatureObserver<TValue, TError, TProgress> | null;
+  current: OperationRecord<TValue, TError, TProgress> | null;
+  revision: number;
+  disposed: boolean;
+}
+
+type PublicationAuthorityPredicate = <TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  record: OperationRecord<TValue, TError, TProgress>,
+) => boolean;
+
+const defaultLastResortConsole: OperationLastResortConsole = {
+  report: (diagnostic, observerError) => {
+    console.error(
+      "Operation authority diagnostic observer failed.",
+      diagnostic,
+      observerError,
+    );
+    return undefined;
+  },
+};
+
+const standardPublicationAuthority: PublicationAuthorityPredicate
+  = (session, record) =>
+    !session.disposed
+    && session.current === record
+    && record.outcome === null;
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: value => {
+      resolvePromise?.(value);
+    },
+  };
+}
+
+function brandOperationId(value: string): OperationId {
+  // The page allocator is the sole construction boundary for the opaque brand.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as OperationId;
+}
+
+function validateMaximumSequence(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0)
+    throw new RangeError("maximumSequence must be a non-negative safe integer.");
+  return value;
+}
+
+function reportDiagnostic<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  diagnostic: OperationDiagnostic,
+): void {
+  try {
+    session.diagnosticObserver.report(diagnostic);
+  } catch (observerError: unknown) {
+    try {
+      session.page.lastResortConsole.report(diagnostic, observerError);
+    } catch {
+      // The last-resort sink cannot safely report its own failure.
+    }
+  }
+}
+
+function producerContractError<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  record: OperationRecord<TValue, TError, TProgress>,
+  message: string,
+): void {
+  reportDiagnostic(session, {
+    kind: "producer-contract",
+    operationId: record.identity.id,
+    error: new Error(message),
+  });
+}
+
+function resolveOutcome<TValue, TError, TProgress>(
+  record: OperationRecord<TValue, TError, TProgress>,
+  outcome: OperationOutcome<TValue, TError>,
+): boolean {
+  if (record.outcome !== null) return false;
+  record.outcome = outcome;
+  record.outcomeDeferred.resolve(outcome);
+  return true;
+}
+
+function reserveCancellation<TValue, TError, TProgress>(
+  record: OperationRecord<TValue, TError, TProgress>,
+): boolean {
+  if (!record.activated || record.cancellationReserved || record.binding === null)
+    return false;
+  record.cancellationReserved = true;
+  return true;
+}
+
+function invokeCancellation<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  record: OperationRecord<TValue, TError, TProgress>,
+  reason: OperationCancelReason,
+): void {
+  const binding = record.binding;
+  if (binding === null) return;
+  try {
+    binding.requestCancellation(reason);
+  } catch (error: unknown) {
+    reportDiagnostic(session, {
+      kind: "producer-callout",
+      operationId: record.identity.id,
+      error,
+    });
+  }
+}
+
+function abandon<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  record: OperationRecord<TValue, TError, TProgress>,
+): void {
+  const binding = record.binding;
+  if (binding === null) return;
+  try {
+    binding.abandon();
+  } catch (error: unknown) {
+    reportDiagnostic(session, {
+      kind: "producer-callout",
+      operationId: record.identity.id,
+      error,
+    });
+    return;
+  }
+  if (!record.released) {
+    record.released = true;
+    record.quiescedDeferred.resolve(undefined);
+  }
+}
+
+function faultFeatureObserver<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  failedOperationId: OperationId | null,
+  error: unknown,
+): {
+  readonly cancellation:
+    | {
+        readonly record: OperationRecord<TValue, TError, TProgress>;
+        readonly reason: OperationCancelReason;
+      }
+    | null;
+} {
+  session.featureObserver = null;
+  let cancellation:
+    | {
+        readonly record: OperationRecord<TValue, TError, TProgress>;
+        readonly reason: OperationCancelReason;
+      }
+    | null = null;
+  const current = session.current;
+  if (!session.disposed) {
+    session.disposed = true;
+    session.current = null;
+    session.revision++;
+    if (current !== null && current.outcome === null) {
+      const reason = "feature-observer-failed";
+      resolveOutcome(current, { kind: "canceled", reason });
+      if (reserveCancellation(current))
+        cancellation = { record: current, reason };
+    }
+  }
+  reportDiagnostic(session, {
+    kind: "feature-observer",
+    operationId: failedOperationId,
+    error,
+  });
+  return { cancellation };
+}
+
+function publishFeature<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  event: OperationFeatureEvent<TValue, TError, TProgress>,
+  observer = session.featureObserver,
+): boolean {
+  if (observer === null) return false;
+  session.page.featureObserverActive = true;
+  try {
+    observer.publish(event);
+    return true;
+  } catch (error: unknown) {
+    session.page.featureObserverActive = false;
+    const failedOperationId = event.kind === "started" || event.kind === "replaced"
+      ? event.operation.id
+      : event.kind === "progress"
+        ? event.progress.operationId
+        : event.operationId;
+    const fault = faultFeatureObserver(session, failedOperationId, error);
+    if (fault.cancellation !== null)
+      invokeCancellation(
+        session,
+        fault.cancellation.record,
+        fault.cancellation.reason,
+      );
+    return false;
+  } finally {
+    session.page.featureObserverActive = false;
+  }
+}
+
+function createRecord<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  identity: OperationIdentity,
+  publicationAuthority: PublicationAuthorityPredicate,
+): OperationRecord<TValue, TError, TProgress> {
+  const outcomeDeferred = deferred<OperationOutcome<TValue, TError>>();
+  const quiescedDeferred = deferred<void>();
+  let record: OperationRecord<TValue, TError, TProgress>;
+
+  const sink: OperationProducerSink<TValue, TError, TProgress> = {
+    reportProgress: value => {
+      if (record.released) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported progress after resource release.",
+        );
+        return undefined;
+      }
+      if (publicationAuthority(session, record)) {
+        publishFeature(session, {
+          kind: "progress",
+          progress: { operationId: record.identity.id, value },
+        });
+      }
+      return undefined;
+    },
+    reportTerminal: outcome => {
+      if (record.released) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported a terminal outcome after resource release.",
+        );
+        return undefined;
+      }
+      if (record.terminalReported) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported more than one terminal outcome.",
+        );
+        return undefined;
+      }
+      record.terminalReported = true;
+      if (!publicationAuthority(session, record)) return undefined;
+      resolveOutcome(record, outcome);
+      session.revision++;
+      if (outcome.kind === "canceled") {
+        publishFeature(session, {
+          kind: "canceled",
+          operationId: record.identity.id,
+          reason: outcome.reason,
+        });
+      } else {
+        publishFeature(session, {
+          kind: "terminal",
+          operationId: record.identity.id,
+          outcome,
+        });
+      }
+      return undefined;
+    },
+    reportQuiesced: () => {
+      if (record.released) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported resource release more than once.",
+        );
+        return undefined;
+      }
+      if (!record.terminalReported) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported resource release before physical settlement.",
+        );
+        return undefined;
+      }
+      record.released = true;
+      record.quiescedDeferred.resolve(undefined);
+      return undefined;
+    },
+    reportUnexpectedFailure: error => {
+      if (record.released) {
+        producerContractError(
+          session,
+          record,
+          "Producer reported an unexpected failure after resource release.",
+        );
+        return undefined;
+      }
+      reportDiagnostic(session, {
+        kind: "producer-contract",
+        operationId: record.identity.id,
+        error,
+      });
+      return undefined;
+    },
+  };
+
+  const handle: OperationHandle<TValue, TError> = {
+    id: identity.id,
+    outcome: outcomeDeferred.promise,
+    quiesced: quiescedDeferred.promise,
+    cancel: reason => cancelRecord(session, record, reason ?? "user"),
+  };
+
+  record = {
+    identity,
+    outcomeDeferred,
+    quiescedDeferred,
+    handle,
+    sink,
+    binding: null,
+    outcome: null,
+    activated: false,
+    cancellationReserved: false,
+    terminalReported: false,
+    released: false,
+  };
+  return record;
+}
+
+function cancelRecord<TValue, TError, TProgress>(
+  session: SessionState<TValue, TError, TProgress>,
+  record: OperationRecord<TValue, TError, TProgress>,
+  reason: OperationCancelReason,
+): OperationControlResult {
+  if (session.page.featureObserverActive)
+    return { kind: "rejected", reason: "feature-observer-active" };
+  if (record.outcome !== null) return { kind: "no-op" };
+
+  resolveOutcome(record, { kind: "canceled", reason });
+  session.revision++;
+  const cancellationReserved = reserveCancellation(record);
+  publishFeature(session, {
+    kind: "canceled",
+    operationId: record.identity.id,
+    reason,
+  });
+  if (cancellationReserved) invokeCancellation(session, record, reason);
+  return { kind: "applied" };
+}
+
+function allocateIdentity(
+  page: PageState,
+):
+  | { readonly kind: "allocated"; readonly identity: OperationIdentity }
+  | {
+      readonly kind: "rejected";
+      readonly reason: { readonly kind: "identity-exhausted" };
+    } {
+  if (page.identityExhausted || page.nextSequence > page.maximumSequence)
+    return { kind: "rejected", reason: { kind: "identity-exhausted" } };
+  const sequence = page.nextSequence;
+  page.nextSequence++;
+  const id = brandOperationId(page.createId());
+  if (page.allocatedIds.has(id)) {
+    page.identityExhausted = true;
+    return { kind: "rejected", reason: { kind: "identity-exhausted" } };
+  }
+  page.allocatedIds.add(id);
+  return { kind: "allocated", identity: { id, sequence } };
+}
+
+function createPage(
+  options: OperationAuthorityPageOptions,
+  publicationAuthority: PublicationAuthorityPredicate,
+): OperationAuthorityPage {
+  const page: PageState = {
+    maximumSequence: validateMaximumSequence(
+      options.allocation?.maximumSequence ?? Number.MAX_SAFE_INTEGER,
+    ),
+    createId: options.allocation?.createId
+      ?? (() => globalThis.crypto.randomUUID()),
+    allocatedIds: new Set<string>(),
+    lastResortConsole: options.lastResortConsole ?? defaultLastResortConsole,
+    nextSequence: 1,
+    identityExhausted: false,
+    featureObserverActive: false,
+  };
+
+  return {
+    createSession: <TInput, TValue, TError, TProgress, TPrepareError>(
+      observers: OperationSessionObservers<TValue, TError, TProgress>,
+    ): OperationSession<TInput, TValue, TError, TProgress, TPrepareError> => {
+      const session: SessionState<TValue, TError, TProgress> = {
+        page,
+        featureObserver: observers.feature,
+        diagnosticObserver: observers.diagnostic,
+        current: null,
+        revision: 0,
+        disposed: false,
+      };
+
+      return {
+        start: (input, adapter) => {
+          if (page.featureObserverActive) {
+            return {
+              kind: "rejected",
+              reason: { kind: "feature-observer-active" },
+            };
+          }
+          if (session.disposed) {
+            return {
+              kind: "rejected",
+              reason: { kind: "session-disposed" },
+            };
+          }
+          const allocation = allocateIdentity(page);
+          if (allocation.kind === "rejected")
+            return { kind: "rejected", reason: allocation.reason };
+
+          const capturedRevision = session.revision;
+          const capturedCurrentId = session.current?.identity.id ?? null;
+          const candidate = createRecord<TValue, TError, TProgress>(
+            session,
+            allocation.identity,
+            publicationAuthority,
+          );
+          const preparation = adapter.prepare(
+            allocation.identity,
+            input,
+            candidate.sink,
+          );
+          const sessionChanged = session.revision !== capturedRevision
+            || (session.current?.identity.id ?? null) !== capturedCurrentId;
+
+          if (session.disposed) {
+            if (preparation.kind === "prepared") {
+              candidate.binding = preparation.binding;
+              abandon(session, candidate);
+            }
+            return {
+              kind: "rejected",
+              reason: { kind: "session-disposed" },
+            };
+          }
+          if (sessionChanged) {
+            if (preparation.kind === "prepared") {
+              candidate.binding = preparation.binding;
+              abandon(session, candidate);
+            }
+            return {
+              kind: "rejected",
+              reason: { kind: "session-changed" },
+            };
+          }
+          if (preparation.kind === "rejected") {
+            return {
+              kind: "rejected",
+              reason: {
+                kind: "producer-rejected",
+                error: preparation.error,
+              },
+            };
+          }
+
+          candidate.binding = preparation.binding;
+          const previous = session.current;
+          session.current = candidate;
+          session.revision++;
+
+          let priorCancellation:
+            | {
+                readonly record: OperationRecord<TValue, TError, TProgress>;
+                readonly reason: OperationCancelReason;
+              }
+            | null = null;
+          if (previous !== null && previous.outcome === null) {
+            const reason: OperationCancelReason = "superseded";
+            resolveOutcome(previous, { kind: "canceled", reason });
+            if (reserveCancellation(previous))
+              priorCancellation = { record: previous, reason };
+          }
+
+          const event: OperationFeatureEvent<TValue, TError, TProgress>
+            = previous === null
+              ? { kind: "started", operation: candidate.identity }
+              : {
+                  kind: "replaced",
+                  previousOperationId: previous.identity.id,
+                  operation: candidate.identity,
+                  reason: "superseded",
+                };
+          const published = publishFeature(session, event);
+          if (published) {
+            candidate.activated = true;
+            candidate.binding.activate();
+          } else {
+            abandon(session, candidate);
+          }
+          if (priorCancellation !== null)
+            invokeCancellation(
+              session,
+              priorCancellation.record,
+              priorCancellation.reason,
+            );
+          return { kind: "started", handle: candidate.handle };
+        },
+        cancelCurrent: reason => {
+          if (page.featureObserverActive)
+            return { kind: "rejected", reason: "feature-observer-active" };
+          const current = session.current;
+          if (current === null) return { kind: "no-op" };
+          return cancelRecord(session, current, reason ?? "user");
+        },
+        dispose: () => {
+          if (page.featureObserverActive)
+            return { kind: "rejected", reason: "feature-observer-active" };
+          if (session.disposed) return { kind: "no-op" };
+
+          const observer = session.featureObserver;
+          const current = session.current;
+          session.disposed = true;
+          session.current = null;
+          session.featureObserver = null;
+          session.revision++;
+          let cancellationReserved = false;
+          if (current !== null && current.outcome === null) {
+            resolveOutcome(current, {
+              kind: "canceled",
+              reason: "disposed",
+            });
+            cancellationReserved = reserveCancellation(current);
+          }
+          publishFeature(session, {
+            kind: "disposed",
+            operationId: current?.identity.id ?? null,
+          }, observer);
+          if (current !== null && cancellationReserved)
+            invokeCancellation(session, current, "disposed");
+          return { kind: "applied" };
+        },
+      };
+    },
+  };
+}
+
+export function createOperationAuthorityPage(
+  options: OperationAuthorityPageOptions = {},
+): OperationAuthorityPage {
+  return createPage(options, standardPublicationAuthority);
+}

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -203,6 +203,16 @@ export function createSourceInspectionCoordinator(
         request,
         preservedFocus: null,
       });
+      let engineCancellationRequested = false;
+      const cancelEngineIfOwned = (): undefined => {
+        if (engineCancellationRequested
+          || activeEngineTypeOperation !== identity.id) {
+          return undefined;
+        }
+        engineCancellationRequested = true;
+        dependencies.cancelEngineSourceRequest();
+        return undefined;
+      };
       const finish = (
         outcome:
           | { readonly kind: "succeeded"; readonly value: BrowserSource }
@@ -219,9 +229,7 @@ export function createSourceInspectionCoordinator(
         kind: "prepared",
         binding: {
           requestCancellation: () => {
-            if (activeEngineTypeOperation === identity.id)
-              dependencies.cancelEngineSourceRequest();
-            return undefined;
+            return cancelEngineIfOwned();
           },
           activate: () => {
             activeEngineTypeOperation = identity.id;
@@ -230,7 +238,7 @@ export function createSourceInspectionCoordinator(
               query = dependencies.queryTypeSource(request);
             } catch (error: unknown) {
               try {
-                dependencies.cancelEngineSourceRequest();
+                cancelEngineIfOwned();
               } catch (cancellationError: unknown) {
                 sink.reportUnexpectedFailure(cancellationError);
               }

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -8,6 +8,14 @@ import {
 } from "./data.ts";
 import type { BrowserSource } from "./inspect-web-engine.d.ts";
 import type { MemberFocusSnapshot } from "./member-focus.ts";
+import type {
+  OperationAuthorityPage,
+  OperationDiagnostic,
+  OperationFeatureEvent,
+  OperationId,
+  OperationProducerAdapter,
+  OperationSession,
+} from "./operation-authority.ts";
 
 interface SourceCoordinates {
   packageId: string;
@@ -70,6 +78,7 @@ export interface SourceInspectionState
 
 export interface SourceInspectionDependencies {
   state: SourceInspectionState;
+  operationAuthority: OperationAuthorityPage;
   queryMemberSource(request: MemberSourceQuery): Promise<BrowserSource>;
   queryTypeSource(request: TypeSourceQuery): Promise<BrowserSource>;
   queryGraphSource(
@@ -78,6 +87,9 @@ export interface SourceInspectionDependencies {
   ): Promise<BrowserSource>;
   memberSourceHasConcreteOverload(): boolean;
   cancelEngineSourceRequest(): void;
+  readonly reportOperationDiagnostic: (
+    diagnostic: OperationDiagnostic,
+  ) => undefined;
   describeError(error: unknown): string;
   render(): void;
   renderPreservingMemberFocus(
@@ -102,10 +114,175 @@ export function createSourceInspectionCoordinator(
   dependencies: SourceInspectionDependencies,
 ): SourceInspectionCoordinator {
   const { state } = dependencies;
+  interface TypeSourceOperationContext {
+    readonly request: TypeSourceLoadRequest;
+    preservedFocus: MemberFocusSnapshot | null;
+  }
+  type TypeSourceFeatureEvent =
+    OperationFeatureEvent<BrowserSource, unknown, never>;
+  type TypeSourceSession = OperationSession<
+    TypeSourceLoadRequest,
+    BrowserSource,
+    unknown,
+    never,
+    never
+  >;
+
+  const typeSourceOperations =
+    new Map<OperationId, TypeSourceOperationContext>();
+  let activeEngineTypeOperation: OperationId | null = null;
+  const typeSourceContext = (
+    operationId: OperationId,
+  ): TypeSourceOperationContext => {
+    const context = typeSourceOperations.get(operationId);
+    if (context === undefined)
+      throw new Error("Type source operation context is unavailable.");
+    return context;
+  };
+  const publishTypeSourceEvent = (event: TypeSourceFeatureEvent): undefined => {
+    switch (event.kind) {
+      case "started":
+      case "replaced": {
+        const context = typeSourceContext(event.operation.id);
+        beginSourceRequestState(state);
+        state.typeSourceKey = context.request.signature;
+        state.typeSource = null;
+        state.typeSourceError = "";
+        state.typeSourceLoading = true;
+        context.preservedFocus =
+          dependencies.renderPreservingMemberFocus();
+        break;
+      }
+      case "terminal": {
+        const context = typeSourceContext(event.operationId);
+        if (event.outcome.kind === "succeeded")
+          state.typeSource = event.outcome.value;
+        else
+          state.typeSourceError =
+            dependencies.describeError(event.outcome.error);
+        state.typeSourceLoading = false;
+        if (context.request.isVisible()) {
+          dependencies.renderPreservingMemberFocus(
+            context.preservedFocus,
+          );
+        }
+        break;
+      }
+      case "canceled":
+        state.typeSourceLoading = false;
+        state.typeSourceKey = "";
+        state.typeSourceError = "";
+        break;
+      case "disposed":
+        state.typeSourceLoading = false;
+        state.typeSourceKey = "";
+        state.typeSourceError = "";
+        break;
+      case "progress":
+        break;
+    }
+    return undefined;
+  };
+  const typeSourceSession: TypeSourceSession =
+    dependencies.operationAuthority.createSession({
+      feature: { publish: publishTypeSourceEvent },
+      diagnostic: {
+        report: diagnostic =>
+          dependencies.reportOperationDiagnostic(diagnostic),
+      },
+    });
+  const typeSourceAdapter: OperationProducerAdapter<
+    TypeSourceLoadRequest,
+    BrowserSource,
+    unknown,
+    never,
+    never
+  > = {
+    prepare: (identity, request, sink) => {
+      typeSourceOperations.set(identity.id, {
+        request,
+        preservedFocus: null,
+      });
+      const finish = (
+        outcome:
+          | { readonly kind: "succeeded"; readonly value: BrowserSource }
+          | { readonly kind: "failed"; readonly error: unknown },
+      ): undefined => {
+        sink.reportTerminal(outcome);
+        if (activeEngineTypeOperation === identity.id)
+          activeEngineTypeOperation = null;
+        typeSourceOperations.delete(identity.id);
+        sink.reportQuiesced();
+        return undefined;
+      };
+      return {
+        kind: "prepared",
+        binding: {
+          requestCancellation: () => {
+            if (activeEngineTypeOperation === identity.id)
+              dependencies.cancelEngineSourceRequest();
+            return undefined;
+          },
+          activate: () => {
+            activeEngineTypeOperation = identity.id;
+            let query: Promise<BrowserSource>;
+            try {
+              query = dependencies.queryTypeSource(request);
+            } catch (error: unknown) {
+              try {
+                dependencies.cancelEngineSourceRequest();
+              } catch (cancellationError: unknown) {
+                sink.reportUnexpectedFailure(cancellationError);
+              }
+              finish({ kind: "failed", error });
+              return undefined;
+            }
+            void query.then(
+              value => finish({ kind: "succeeded", value }),
+              (error: unknown) => finish({ kind: "failed", error }),
+            );
+            return undefined;
+          },
+          abandon: () => {
+            typeSourceOperations.delete(identity.id);
+            return undefined;
+          },
+        },
+      };
+    },
+  };
+
+  const rejectFeatureReentrancy = (operation: string): void => {
+    dependencies.reportOperationDiagnostic({
+      kind: "producer-contract",
+      operationId: null,
+      error: new Error(
+        `${operation} was attempted during source feature publication.`,
+      ),
+    });
+  };
+  const cancelTypeSource = (
+    reason: "user" | "superseded",
+  ): "applied" | "no-op" | "rejected" => {
+    const result = typeSourceSession.cancelCurrent(reason);
+    if (result.kind === "rejected") {
+      rejectFeatureReentrancy("Source cancellation");
+      return "rejected";
+    }
+    return result.kind;
+  };
+  const beginLegacySourceRequest = (): number => {
+    if (cancelTypeSource("superseded") === "rejected")
+      throw new Error("Cannot replace source work during feature publication.");
+    return beginSourceRequestState(state);
+  };
   const cancelCurrentRequest = () => {
-    const cancelled = cancelSourceRequestState(state);
-    if (cancelled) dependencies.cancelEngineSourceRequest();
-    return cancelled;
+    const typeCancellation = cancelTypeSource("user");
+    if (typeCancellation === "rejected") return false;
+    const legacyCancellation = cancelSourceRequestState(state);
+    if (legacyCancellation && typeCancellation !== "applied")
+      dependencies.cancelEngineSourceRequest();
+    return typeCancellation === "applied" || legacyCancellation;
   };
   const clearGraphSource = () => {
     cancelCurrentRequest();
@@ -138,7 +315,7 @@ export function createSourceInspectionCoordinator(
         return;
       }
 
-      const generation = beginSourceRequestState(state);
+      const generation = beginLegacySourceRequest();
       state.memberSourceKey = request.signature;
       state.memberSource = null;
       state.memberSourceLoading = true;
@@ -178,34 +355,23 @@ export function createSourceInspectionCoordinator(
         dependencies.renderPreservingMemberFocus();
         return;
       }
-      const generation = beginSourceRequestState(state);
-      state.typeSourceKey = request.signature;
-      state.typeSource = null;
-      state.typeSourceError = "";
-      state.typeSourceLoading = true;
-      const preservedFocus = dependencies.renderPreservingMemberFocus();
-      const ownsRequest = () =>
-        generation === state.sourceRequestGeneration
-        && state.typeSourceKey === request.signature;
-      try {
-        const result = await dependencies.queryTypeSource(request);
-        if (ownsRequest()) state.typeSource = result;
-      } catch (error) {
-        if (ownsRequest()) {
-          state.typeSourceError = dependencies.describeError(error);
-        }
-      } finally {
-        if (ownsRequest()) {
-          state.typeSourceLoading = false;
-          if (request.isVisible()) {
-            dependencies.renderPreservingMemberFocus(preservedFocus);
-          }
-        }
+      const result = typeSourceSession.start(request, typeSourceAdapter);
+      if (result.kind === "rejected") {
+        const reason = result.reason.kind;
+        dependencies.reportOperationDiagnostic({
+          kind: "producer-contract",
+          operationId: null,
+          error: new Error(
+            `Type source operation start was rejected: ${reason}.`,
+          ),
+        });
+        return;
       }
+      await result.handle.quiesced;
     },
 
     async openGraphSource(request, title) {
-      const generation = beginSourceRequestState(state);
+      const generation = beginLegacySourceRequest();
       const sequence = ++state.graphSourceSeq;
       state.graphSourceOpen = true;
       state.graphSourceTitle = title;

--- a/prototypes/inspect-web/test/operation-authority.test.ts
+++ b/prototypes/inspect-web/test/operation-authority.test.ts
@@ -1,0 +1,1652 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import {
+  createOperationAuthorityPage,
+  type OperationAuthorityPage,
+  type OperationAuthorityPageOptions,
+  type OperationCancelReason,
+  type OperationControlResult,
+  type OperationDiagnostic,
+  type OperationDiagnosticObserver,
+  type OperationFeatureEvent,
+  type OperationFeatureObserver,
+  type OperationHandle,
+  type OperationId,
+  type OperationIdentity,
+  type OperationPreparation,
+  type OperationProducerAdapter,
+  type OperationProducerSink,
+  type OperationSession,
+  type OperationStartResult,
+  type PreparedOperationProducer,
+} from "../src/operation-authority.ts";
+
+type TestEvent = OperationFeatureEvent<string, string, number>;
+type TestSink = OperationProducerSink<string, string, number>;
+type TestAdapter = OperationProducerAdapter<string, string, string, number, string>;
+type TestSession = OperationSession<string, string, string, number, string>;
+type TestStartResult = OperationStartResult<string, string, string>;
+type TestHandle = OperationHandle<string, string>;
+
+interface ProducerAttempt {
+  readonly identity: OperationIdentity;
+  readonly input: string;
+  readonly sink: TestSink;
+  readonly cancellations: OperationCancelReason[];
+  activated: boolean;
+  abandoned: boolean;
+}
+
+interface ProducerOptions {
+  readonly reject?: string;
+  readonly onPrepare?: (attempt: ProducerAttempt) => undefined;
+  readonly onActivate?: (attempt: ProducerAttempt) => undefined;
+  readonly onCancellation?: (
+    attempt: ProducerAttempt,
+    reason: OperationCancelReason,
+  ) => undefined;
+  readonly onAbandon?: (attempt: ProducerAttempt) => undefined;
+}
+
+interface ProducerHarness {
+  readonly adapter: TestAdapter;
+  readonly attempts: ProducerAttempt[];
+}
+
+interface SessionHarness {
+  readonly session: TestSession;
+  readonly events: TestEvent[];
+  readonly diagnostics: OperationDiagnostic[];
+}
+
+interface OperationAuthorityModule {
+  readonly createOperationAuthorityPage: typeof createOperationAuthorityPage;
+}
+
+function isOperationAuthorityModule(
+  value: unknown,
+): value is OperationAuthorityModule {
+  return typeof value === "object"
+    && value !== null
+    && "createOperationAuthorityPage" in value
+    && typeof value.createOperationAuthorityPage === "function";
+}
+
+function deterministicOptions(
+  maximumSequence = Number.MAX_SAFE_INTEGER,
+  createId?: () => string,
+): OperationAuthorityPageOptions {
+  let nextId = 1;
+  return {
+    allocation: {
+      maximumSequence,
+      createId: createId ?? (() => `operation-${nextId++}`),
+    },
+  };
+}
+
+function producer(options: ProducerOptions = {}): ProducerHarness {
+  const attempts: ProducerAttempt[] = [];
+  const adapter: TestAdapter = {
+    prepare: (identity, input, sink) => {
+      const attempt: ProducerAttempt = {
+        identity,
+        input,
+        sink,
+        cancellations: [],
+        activated: false,
+        abandoned: false,
+      };
+      attempts.push(attempt);
+      options.onPrepare?.(attempt);
+      if (options.reject !== undefined)
+        return { kind: "rejected", error: options.reject };
+      const binding: PreparedOperationProducer = {
+        requestCancellation: reason => {
+          attempt.cancellations.push(reason);
+          options.onCancellation?.(attempt, reason);
+          return undefined;
+        },
+        activate: () => {
+          attempt.activated = true;
+          options.onActivate?.(attempt);
+          return undefined;
+        },
+        abandon: () => {
+          attempt.abandoned = true;
+          options.onAbandon?.(attempt);
+          return undefined;
+        },
+      };
+      return { kind: "prepared", binding };
+    },
+  };
+  return { adapter, attempts };
+}
+
+function sessionHarness(
+  page: OperationAuthorityPage = createOperationAuthorityPage(
+    deterministicOptions(),
+  ),
+  publish?: (event: TestEvent) => undefined,
+  report?: (diagnostic: OperationDiagnostic) => undefined,
+): SessionHarness {
+  const events: TestEvent[] = [];
+  const diagnostics: OperationDiagnostic[] = [];
+  const session = page.createSession<string, string, string, number, string>({
+    feature: {
+      publish: event => {
+        events.push(event);
+        publish?.(event);
+        return undefined;
+      },
+    },
+    diagnostic: {
+      report: diagnostic => {
+        diagnostics.push(diagnostic);
+        report?.(diagnostic);
+        return undefined;
+      },
+    },
+  });
+  return { session, events, diagnostics };
+}
+
+function started(result: TestStartResult): TestHandle {
+  assert.equal(result.kind, "started");
+  if (result.kind !== "started")
+    throw new Error("Expected a started result.");
+  return result.handle;
+}
+
+function rejected(result: TestStartResult): Exclude<TestStartResult, {
+  readonly kind: "started";
+}>["reason"] {
+  assert.equal(result.kind, "rejected");
+  if (result.kind !== "rejected")
+    throw new Error("Expected a rejected result.");
+  return result.reason;
+}
+
+async function promiseSettled(promise: Promise<unknown>): Promise<boolean> {
+  let settled = false;
+  promise.then(
+    () => {
+      settled = true;
+      return undefined;
+    },
+    () => {
+      settled = true;
+      return undefined;
+    },
+  );
+  await Promise.resolve();
+  return settled;
+}
+
+test("page allocation is opaque, unique, and sequential across sessions", async () => {
+  const page = createOperationAuthorityPage(deterministicOptions());
+  const first = sessionHarness(page);
+  const second = sessionHarness(page);
+  const firstProducer = producer();
+  const secondProducer = producer();
+
+  const firstHandle = started(first.session.start("first", firstProducer.adapter));
+  const secondHandle = started(second.session.start("second", secondProducer.adapter));
+  const replacementHandle = started(first.session.start("replacement", firstProducer.adapter));
+
+  assert.deepEqual(
+    [
+      firstProducer.attempts[0]?.identity,
+      secondProducer.attempts[0]?.identity,
+      firstProducer.attempts[1]?.identity,
+    ],
+    [
+      { id: "operation-1", sequence: 1 },
+      { id: "operation-2", sequence: 2 },
+      { id: "operation-3", sequence: 3 },
+    ],
+  );
+  assert.equal(firstHandle.id, "operation-1");
+  assert.equal(secondHandle.id, "operation-2");
+  assert.equal(replacementHandle.id, "operation-3");
+  assert.deepEqual(await firstHandle.outcome, {
+    kind: "canceled",
+    reason: "superseded",
+  });
+});
+
+test("allocation limits must be non-negative safe integers", () => {
+  for (const maximumSequence of [
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ]) {
+    assert.throws(
+      () => createOperationAuthorityPage(deterministicOptions(maximumSequence)),
+      /maximumSequence must be a non-negative safe integer/u,
+    );
+  }
+});
+
+test("an identity seen by a rejecting producer is never reused", () => {
+  const page = createOperationAuthorityPage(
+    deterministicOptions(4, () => "reused"),
+  );
+  const first = sessionHarness(page);
+  const rejecting = producer({ reject: "not-ready" });
+
+  assert.deepEqual(rejected(first.session.start("first", rejecting.adapter)), {
+    kind: "producer-rejected",
+    error: "not-ready",
+  });
+  assert.equal(rejecting.attempts.length, 1);
+
+  const sameSessionProducer = producer();
+  assert.deepEqual(
+    rejected(first.session.start("same-session", sameSessionProducer.adapter)),
+    { kind: "identity-exhausted" },
+  );
+  const recreated = sessionHarness(page);
+  assert.deepEqual(
+    rejected(recreated.session.start("recreated", sameSessionProducer.adapter)),
+    { kind: "identity-exhausted" },
+  );
+  assert.equal(sameSessionProducer.attempts.length, 0);
+});
+
+for (const lifecycle of ["completion", "quiescence", "disposal"] as const) {
+  test(`identity reuse after ${lifecycle} is rejected before preparation`, () => {
+    const page = createOperationAuthorityPage(
+      deterministicOptions(3, () => "reused"),
+    );
+    const first = sessionHarness(page);
+    const firstProducer = producer();
+    started(first.session.start("first", firstProducer.adapter));
+    const attempt = firstProducer.attempts[0];
+    assert.ok(attempt);
+    if (lifecycle === "completion")
+      attempt.sink.reportTerminal({ kind: "succeeded", value: "done" });
+    if (lifecycle === "quiescence") {
+      attempt.sink.reportTerminal({ kind: "succeeded", value: "done" });
+      attempt.sink.reportQuiesced();
+    }
+    if (lifecycle === "disposal")
+      first.session.dispose();
+
+    const recreated = sessionHarness(page);
+    const nextProducer = producer();
+    assert.deepEqual(
+      rejected(recreated.session.start("next", nextProducer.adapter)),
+      { kind: "identity-exhausted" },
+    );
+    assert.equal(nextProducer.attempts.length, 0);
+  });
+}
+
+for (const transition of ["session-changed", "session-disposed"] as const) {
+  test(`an identity from an abandoned ${transition} preparation is never reused`, () => {
+    let idAttempt = 0;
+    const page = createOperationAuthorityPage(deterministicOptions(
+      transition === "session-changed" ? 3 : 2,
+      () => transition === "session-changed" && ++idAttempt === 2
+        ? "nested"
+        : "reused",
+    ));
+    const outer = sessionHarness(page);
+    const sameLifetimeSession = transition === "session-changed"
+      ? outer
+      : sessionHarness(page);
+    const nested = producer();
+    const outerProducer = producer({
+      onPrepare: () => {
+        if (transition === "session-changed")
+          started(outer.session.start("nested", nested.adapter));
+        else
+          assert.deepEqual(outer.session.dispose(), { kind: "applied" });
+        return undefined;
+      },
+    });
+
+    assert.deepEqual(
+      rejected(outer.session.start("outer", outerProducer.adapter)),
+      {
+        kind: transition === "session-changed"
+          ? "session-changed"
+          : "session-disposed",
+      },
+    );
+    assert.equal(outerProducer.attempts[0]?.abandoned, true);
+    assert.equal(outerProducer.attempts[0]?.activated, false);
+
+    const recreated = sessionHarness(page);
+    const reused = producer();
+    assert.deepEqual(
+      rejected(sameLifetimeSession.session.start("same-session-reuse", reused.adapter)),
+      { kind: "identity-exhausted" },
+    );
+    assert.deepEqual(
+      rejected(recreated.session.start("recreated-reuse", reused.adapter)),
+      { kind: "identity-exhausted" },
+    );
+    assert.equal(reused.attempts.length, 0);
+  });
+}
+
+test("the final sequence remains consumed after producer rejection", () => {
+  const page = createOperationAuthorityPage(deterministicOptions(2));
+  const harness = sessionHarness(page);
+  const currentProducer = producer();
+  const current = started(harness.session.start("current", currentProducer.adapter));
+  const rejecting = producer({ reject: "busy" });
+
+  assert.deepEqual(rejected(harness.session.start("rejected", rejecting.adapter)), {
+    kind: "producer-rejected",
+    error: "busy",
+  });
+  const neverPrepared = producer();
+  assert.deepEqual(
+    rejected(harness.session.start("exhausted", neverPrepared.adapter)),
+    { kind: "identity-exhausted" },
+  );
+  assert.equal(neverPrepared.attempts.length, 0);
+  assert.equal(currentProducer.attempts[0]?.cancellations.length, 0);
+  assert.equal(harness.events.length, 1);
+  assert.equal(current.id, "operation-1");
+});
+
+test("the final sequence remains consumed after abandoned preparation", () => {
+  const page = createOperationAuthorityPage(deterministicOptions(1));
+  const harness = sessionHarness(page);
+  const abandoning = producer({
+    onPrepare: () => {
+      harness.session.dispose();
+      return undefined;
+    },
+  });
+
+  assert.deepEqual(
+    rejected(harness.session.start("abandoned", abandoning.adapter)),
+    { kind: "session-disposed" },
+  );
+  assert.equal(abandoning.attempts[0]?.abandoned, true);
+  const recreated = sessionHarness(page);
+  const neverPrepared = producer();
+  assert.deepEqual(
+    rejected(recreated.session.start("exhausted", neverPrepared.adapter)),
+    { kind: "identity-exhausted" },
+  );
+  assert.equal(neverPrepared.attempts.length, 0);
+});
+
+test("preparation rejection leaves the current operation unchanged", async () => {
+  const harness = sessionHarness();
+  const currentProducer = producer();
+  const current = started(harness.session.start("current", currentProducer.adapter));
+  const rejecting = producer({ reject: "unsupported" });
+
+  assert.deepEqual(rejected(harness.session.start("candidate", rejecting.adapter)), {
+    kind: "producer-rejected",
+    error: "unsupported",
+  });
+  assert.equal(await promiseSettled(current.outcome), false);
+  assert.equal(currentProducer.attempts[0]?.cancellations.length, 0);
+  assert.deepEqual(harness.events.map(event => event.kind), ["started"]);
+});
+
+test("successful preparation reentrancy cannot overwrite a nested start", async () => {
+  const harness = sessionHarness();
+  const nested = producer();
+  let nestedHandle: TestHandle | undefined;
+  const outer = producer({
+    onPrepare: () => {
+      nestedHandle = started(harness.session.start("nested", nested.adapter));
+      return undefined;
+    },
+  });
+
+  assert.deepEqual(
+    rejected(harness.session.start("outer", outer.adapter)),
+    { kind: "session-changed" },
+  );
+  assert.equal(outer.attempts[0]?.abandoned, true);
+  assert.equal(outer.attempts[0]?.activated, false);
+  assert.equal(nested.attempts[0]?.activated, true);
+  assert.ok(nestedHandle);
+  assert.equal(await promiseSettled(nestedHandle.outcome), false);
+  assert.deepEqual(harness.events.map(event => event.kind), ["started"]);
+});
+
+test("successful preparation reentrancy cannot overwrite cancellation", async () => {
+  const harness = sessionHarness();
+  const currentProducer = producer();
+  const current = started(harness.session.start("current", currentProducer.adapter));
+  const outer = producer({
+    onPrepare: () => {
+      assert.deepEqual(harness.session.cancelCurrent(), { kind: "applied" });
+      return undefined;
+    },
+  });
+
+  assert.deepEqual(
+    rejected(harness.session.start("outer", outer.adapter)),
+    { kind: "session-changed" },
+  );
+  assert.equal(outer.attempts[0]?.abandoned, true);
+  assert.deepEqual(await current.outcome, {
+    kind: "canceled",
+    reason: "user",
+  });
+  assert.deepEqual(currentProducer.attempts[0]?.cancellations, ["user"]);
+});
+
+test("producer rejection after preparation reentrancy returns the session transition", () => {
+  const harness = sessionHarness();
+  const nested = producer();
+  const rejecting = producer({
+    reject: "stale-error",
+    onPrepare: () => {
+      started(harness.session.start("nested", nested.adapter));
+      return undefined;
+    },
+  });
+
+  assert.deepEqual(
+    rejected(harness.session.start("outer", rejecting.adapter)),
+    { kind: "session-changed" },
+  );
+  assert.deepEqual(harness.events.map(event => event.kind), ["started"]);
+  assert.deepEqual(harness.diagnostics, []);
+});
+
+test("producer rejection after preparation disposal returns disposal", () => {
+  const harness = sessionHarness();
+  const rejecting = producer({
+    reject: "stale-error",
+    onPrepare: () => {
+      harness.session.dispose();
+      return undefined;
+    },
+  });
+
+  assert.deepEqual(
+    rejected(harness.session.start("outer", rejecting.adapter)),
+    { kind: "session-disposed" },
+  );
+  assert.deepEqual(harness.events, [{
+    kind: "disposed",
+    operationId: null,
+  }]);
+  assert.deepEqual(harness.diagnostics, []);
+});
+
+test("activation sees an installed cancellable operation after start publication", async () => {
+  const order: string[] = [];
+  let harness: SessionHarness;
+  const activating = producer({
+    onActivate: () => {
+      order.push("activate");
+      assert.deepEqual(harness.session.cancelCurrent(), { kind: "applied" });
+      return undefined;
+    },
+    onCancellation: () => {
+      order.push("producer-cancel");
+      return undefined;
+    },
+  });
+  harness = sessionHarness(undefined, event => {
+    order.push(event.kind);
+    return undefined;
+  });
+
+  const handle = started(harness.session.start("work", activating.adapter));
+
+  assert.deepEqual(order, [
+    "started",
+    "activate",
+    "canceled",
+    "producer-cancel",
+  ]);
+  assert.deepEqual(await handle.outcome, {
+    kind: "canceled",
+    reason: "user",
+  });
+});
+
+test("synchronous activation failure reports terminal then quiescence", async () => {
+  const activating = producer({
+    onActivate: attempt => {
+      attempt.sink.reportTerminal({ kind: "failed", error: "activation-failed" });
+      attempt.sink.reportQuiesced();
+      return undefined;
+    },
+  });
+  const harness = sessionHarness();
+
+  const handle = started(harness.session.start("work", activating.adapter));
+
+  assert.deepEqual(await handle.outcome, {
+    kind: "failed",
+    error: "activation-failed",
+  });
+  await handle.quiesced;
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "terminal",
+  ]);
+});
+
+test("activation replacement leaves the nested operation authoritative", async () => {
+  const harness = sessionHarness();
+  const replacement = producer();
+  let replacementHandle: TestHandle | undefined;
+  const firstProducer = producer({
+    onActivate: () => {
+      replacementHandle = started(
+        harness.session.start("replacement", replacement.adapter),
+      );
+      return undefined;
+    },
+  });
+
+  const first = started(harness.session.start("first", firstProducer.adapter));
+
+  assert.ok(replacementHandle);
+  assert.deepEqual(await first.outcome, {
+    kind: "canceled",
+    reason: "superseded",
+  });
+  assert.equal(await promiseSettled(replacementHandle.outcome), false);
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+  ]);
+});
+
+test("activation disposal returns the captured canceled handle", async () => {
+  const harness = sessionHarness();
+  const activating = producer({
+    onActivate: () => {
+      assert.deepEqual(harness.session.dispose(), { kind: "applied" });
+      return undefined;
+    },
+  });
+
+  const handle = started(harness.session.start("work", activating.adapter));
+
+  assert.deepEqual(await handle.outcome, {
+    kind: "canceled",
+    reason: "disposed",
+  });
+  assert.deepEqual(rejected(harness.session.start("later", producer().adapter)), {
+    kind: "session-disposed",
+  });
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "disposed",
+  ]);
+});
+
+test("prior cancellation runs after replacement activation and stale reports are suppressed", () => {
+  const order: string[] = [];
+  const harness = sessionHarness(undefined, event => {
+    order.push(event.kind);
+    return undefined;
+  });
+  const firstProducer = producer({
+    onCancellation: attempt => {
+      order.push("prior-cancel");
+      attempt.sink.reportProgress(99);
+      attempt.sink.reportTerminal({ kind: "failed", error: "late" });
+      return undefined;
+    },
+  });
+  const secondProducer = producer({
+    onActivate: () => {
+      order.push("replacement-activate");
+      return undefined;
+    },
+  });
+  started(harness.session.start("first", firstProducer.adapter));
+
+  started(harness.session.start("second", secondProducer.adapter));
+
+  assert.deepEqual(order, [
+    "started",
+    "replaced",
+    "replacement-activate",
+    "prior-cancel",
+  ]);
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+  ]);
+});
+
+test("a prior cancellation endpoint may install another replacement", async () => {
+  const harness = sessionHarness();
+  const thirdProducer = producer();
+  let third: TestHandle | undefined;
+  const firstProducer = producer({
+    onCancellation: () => {
+      third = started(harness.session.start("third", thirdProducer.adapter));
+      return undefined;
+    },
+  });
+  const secondProducer = producer();
+  started(harness.session.start("first", firstProducer.adapter));
+
+  const second = started(harness.session.start("second", secondProducer.adapter));
+
+  assert.ok(third);
+  assert.deepEqual(await second.outcome, {
+    kind: "canceled",
+    reason: "superseded",
+  });
+  assert.equal(await promiseSettled(third.outcome), false);
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+    "replaced",
+  ]);
+});
+
+test("a prior cancellation endpoint may dispose the committed replacement", async () => {
+  const harness = sessionHarness();
+  const firstProducer = producer({
+    onCancellation: () => {
+      harness.session.dispose();
+      return undefined;
+    },
+  });
+  started(harness.session.start("first", firstProducer.adapter));
+
+  const second = started(harness.session.start("second", producer().adapter));
+
+  assert.deepEqual(await second.outcome, {
+    kind: "canceled",
+    reason: "disposed",
+  });
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+    "disposed",
+  ]);
+});
+
+for (const route of ["handle", "session", "dispose", "supersession"] as const) {
+  test(`throwing cancellation through ${route} keeps the committed outcome`, async () => {
+    const cancellationError = new Error(`${route}-cancellation`);
+    const harness = sessionHarness();
+    const throwing = producer({
+      onCancellation: () => {
+        throw cancellationError;
+      },
+    });
+    const handle = started(harness.session.start("first", throwing.adapter));
+
+    if (route === "handle")
+      assert.deepEqual(handle.cancel(), { kind: "applied" });
+    if (route === "session")
+      assert.deepEqual(harness.session.cancelCurrent(), { kind: "applied" });
+    if (route === "dispose")
+      assert.deepEqual(harness.session.dispose(), { kind: "applied" });
+    if (route === "supersession")
+      started(harness.session.start("second", producer().adapter));
+
+    const outcome = await handle.outcome;
+    if (route === "dispose") {
+      assert.deepEqual(outcome, { kind: "canceled", reason: "disposed" });
+    } else if (route === "supersession") {
+      assert.deepEqual(outcome, {
+        kind: "canceled",
+        reason: "superseded",
+      });
+    } else {
+      assert.deepEqual(outcome, { kind: "canceled", reason: "user" });
+    }
+    assert.equal(throwing.attempts[0]?.cancellations.length, 1);
+    assert.equal(harness.diagnostics.length, 1);
+    assert.deepEqual(harness.diagnostics[0], {
+      kind: "producer-callout",
+      operationId: handle.id,
+      error: cancellationError,
+    });
+    assert.deepEqual(handle.cancel("disposed"), { kind: "no-op" });
+    assert.equal(throwing.attempts[0]?.cancellations.length, 1);
+  });
+}
+
+test("deferred terminal outcome and quiescence are independent", async () => {
+  const harness = sessionHarness();
+  const deferredProducer = producer();
+  const handle = started(harness.session.start("work", deferredProducer.adapter));
+  const attempt = deferredProducer.attempts[0];
+  assert.ok(attempt);
+
+  assert.equal(await promiseSettled(handle.outcome), false);
+  assert.equal(await promiseSettled(handle.quiesced), false);
+  attempt.sink.reportTerminal({ kind: "succeeded", value: "done" });
+  assert.deepEqual(await handle.outcome, { kind: "succeeded", value: "done" });
+  assert.equal(await promiseSettled(handle.quiesced), false);
+  attempt.sink.reportQuiesced();
+  await handle.quiesced;
+});
+
+test("outcome and quiescence each resolve exactly once", async () => {
+  const harness = sessionHarness();
+  const activeProducer = producer();
+  const handle = started(harness.session.start("work", activeProducer.adapter));
+  let outcomeResolutions = 0;
+  let quiescenceResolutions = 0;
+  void handle.outcome.then(() => {
+    outcomeResolutions++;
+    return undefined;
+  });
+  void handle.quiesced.then(() => {
+    quiescenceResolutions++;
+    return undefined;
+  });
+  const sink = activeProducer.attempts[0]?.sink;
+  assert.ok(sink);
+
+  sink.reportTerminal({ kind: "succeeded", value: "first" });
+  sink.reportTerminal({ kind: "failed", error: "duplicate" });
+  sink.reportQuiesced();
+  sink.reportQuiesced();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(outcomeResolutions, 1);
+  assert.equal(quiescenceResolutions, 1);
+  assert.deepEqual(await handle.outcome, {
+    kind: "succeeded",
+    value: "first",
+  });
+});
+
+test("cancellation completes logically before producer release", async () => {
+  const harness = sessionHarness();
+  const activeProducer = producer();
+  const handle = started(harness.session.start("work", activeProducer.adapter));
+
+  assert.deepEqual(handle.cancel(), { kind: "applied" });
+  assert.deepEqual(await handle.outcome, { kind: "canceled", reason: "user" });
+  assert.equal(await promiseSettled(handle.quiesced), false);
+  activeProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "physical-cancel",
+  });
+  assert.equal(await promiseSettled(handle.quiesced), false);
+  activeProducer.attempts[0]?.sink.reportQuiesced();
+  await handle.quiesced;
+});
+
+test("cancellation normalizes the omitted reason and preserves the first reason", async () => {
+  const harness = sessionHarness();
+  const activeProducer = producer();
+  const handle = started(harness.session.start("work", activeProducer.adapter));
+
+  assert.deepEqual(handle.cancel(), { kind: "applied" });
+  assert.deepEqual(handle.cancel("disposed"), { kind: "no-op" });
+  assert.deepEqual(harness.session.cancelCurrent("feature-observer-failed"), {
+    kind: "no-op",
+  });
+  assert.deepEqual(await handle.outcome, { kind: "canceled", reason: "user" });
+  assert.deepEqual(activeProducer.attempts[0]?.cancellations, ["user"]);
+});
+
+test("exact feature events preserve transition ordering and variants", async () => {
+  const harness = sessionHarness();
+  const firstProducer = producer();
+  const first = started(harness.session.start("first", firstProducer.adapter));
+  firstProducer.attempts[0]?.sink.reportProgress(1);
+  const secondProducer = producer();
+  const second = started(harness.session.start("second", secondProducer.adapter));
+  secondProducer.attempts[0]?.sink.reportProgress(2);
+  secondProducer.attempts[0]?.sink.reportTerminal({
+    kind: "succeeded",
+    value: "result",
+  });
+  assert.deepEqual(harness.session.dispose(), { kind: "applied" });
+
+  assert.deepEqual(harness.events, [
+    {
+      kind: "started",
+      operation: { id: first.id, sequence: 1 },
+    },
+    {
+      kind: "progress",
+      progress: { operationId: first.id, value: 1 },
+    },
+    {
+      kind: "replaced",
+      previousOperationId: first.id,
+      operation: { id: second.id, sequence: 2 },
+      reason: "superseded",
+    },
+    {
+      kind: "progress",
+      progress: { operationId: second.id, value: 2 },
+    },
+    {
+      kind: "terminal",
+      operationId: second.id,
+      outcome: { kind: "succeeded", value: "result" },
+    },
+    {
+      kind: "disposed",
+      operationId: second.id,
+    },
+  ]);
+  assert.deepEqual(await first.outcome, {
+    kind: "canceled",
+    reason: "superseded",
+  });
+});
+
+for (const eventKind of [
+  "started",
+  "replaced",
+  "progress",
+  "terminal",
+  "canceled",
+  "disposed",
+] as const) {
+  test(`feature reentrancy is rejected first during ${eventKind}`, () => {
+    const page = createOperationAuthorityPage(deterministicOptions());
+    const quiet = sessionHarness(page);
+    const quietProducer = producer();
+    const quietHandle = started(quiet.session.start("quiet", quietProducer.adapter));
+    const reentrantProducer = producer();
+    const reentrantSession = sessionHarness(page).session;
+    const results: {
+      start?: TestStartResult;
+      handle?: OperationControlResult;
+      current?: OperationControlResult;
+      dispose?: OperationControlResult;
+    } = {};
+    let target: SessionHarness;
+    let armed = false;
+    target = sessionHarness(page, event => {
+      if (armed && event.kind === eventKind) {
+        results.start = reentrantSession.start("reentrant", reentrantProducer.adapter);
+        results.handle = quietHandle.cancel();
+        results.current = target.session.cancelCurrent();
+        results.dispose = target.session.dispose();
+      }
+      return undefined;
+    });
+    const targetProducer = producer();
+    let targetHandle: TestHandle;
+
+    if (eventKind === "started") {
+      armed = true;
+      targetHandle = started(target.session.start("first", targetProducer.adapter));
+    } else {
+      targetHandle = started(target.session.start("first", targetProducer.adapter));
+      armed = true;
+      if (eventKind === "replaced")
+        started(target.session.start("second", producer().adapter));
+      if (eventKind === "progress")
+        targetProducer.attempts[0]?.sink.reportProgress(1);
+      if (eventKind === "terminal")
+        targetProducer.attempts[0]?.sink.reportTerminal({
+          kind: "succeeded",
+          value: "done",
+        });
+      if (eventKind === "canceled")
+        targetHandle.cancel();
+      if (eventKind === "disposed")
+        target.session.dispose();
+    }
+
+    assert.deepEqual(rejected(results.start ?? {
+      kind: "started",
+      handle: targetHandle,
+    }), { kind: "feature-observer-active" });
+    const expected = {
+      kind: "rejected",
+      reason: "feature-observer-active",
+    };
+    assert.deepEqual(results.handle, expected);
+    assert.deepEqual(results.current, expected);
+    assert.deepEqual(results.dispose, expected);
+    assert.equal(reentrantProducer.attempts.length, 0);
+    assert.equal(quietProducer.attempts[0]?.cancellations.length, 0);
+  });
+}
+
+interface ThrowingFeatureResult {
+  readonly handle: TestHandle | null;
+  readonly priorHandle: TestHandle | null;
+  readonly producer: ProducerHarness;
+  readonly priorProducer: ProducerHarness | null;
+  readonly harness: SessionHarness;
+  readonly thrown: Error;
+}
+
+function throwDuringFeatureEvent(
+  eventKind: TestEvent["kind"],
+): ThrowingFeatureResult {
+  const thrown = new Error(`throw-${eventKind}`);
+  let armed = false;
+  const harness = sessionHarness(undefined, event => {
+    if (armed && event.kind === eventKind) throw thrown;
+    return undefined;
+  });
+  const activeProducer = producer();
+  let handle: TestHandle | null = null;
+  let priorHandle: TestHandle | null = null;
+  let priorProducer: ProducerHarness | null = null;
+
+  if (eventKind === "started") {
+    armed = true;
+    handle = started(harness.session.start("first", activeProducer.adapter));
+  } else {
+    priorHandle = started(harness.session.start("first", activeProducer.adapter));
+    armed = true;
+    if (eventKind === "replaced") {
+      priorProducer = activeProducer;
+      const replacement = producer();
+      handle = started(harness.session.start("second", replacement.adapter));
+      return {
+        handle,
+        priorHandle,
+        producer: replacement,
+        priorProducer,
+        harness,
+        thrown,
+      };
+    }
+    handle = priorHandle;
+    if (eventKind === "progress")
+      activeProducer.attempts[0]?.sink.reportProgress(1);
+    if (eventKind === "terminal")
+      activeProducer.attempts[0]?.sink.reportTerminal({
+        kind: "succeeded",
+        value: "done",
+      });
+    if (eventKind === "canceled")
+      handle.cancel();
+    if (eventKind === "disposed")
+      harness.session.dispose();
+  }
+  return {
+    handle,
+    priorHandle,
+    producer: activeProducer,
+    priorProducer,
+    harness,
+    thrown,
+  };
+}
+
+for (const eventKind of [
+  "started",
+  "replaced",
+  "progress",
+  "terminal",
+  "canceled",
+  "disposed",
+] as const) {
+  test(`a throwing ${eventKind} observer faults without leaking`, async () => {
+    const result = throwDuringFeatureEvent(eventKind);
+    const { handle, harness, producer: activeProducer } = result;
+    assert.ok(handle);
+    assert.equal(harness.diagnostics.length, 1);
+    assert.deepEqual(harness.diagnostics[0], {
+      kind: "feature-observer",
+      operationId: eventKind === "replaced"
+        ? handle.id
+        : eventKind === "started"
+          ? handle.id
+          : result.priorHandle?.id ?? null,
+      error: result.thrown,
+    });
+    assert.deepEqual(rejected(harness.session.start("later", producer().adapter)), {
+      kind: "session-disposed",
+    });
+
+    if (eventKind === "started" || eventKind === "replaced") {
+      assert.equal(activeProducer.attempts[0]?.activated, false);
+      assert.equal(activeProducer.attempts[0]?.abandoned, true);
+      await handle.quiesced;
+      assert.deepEqual(await handle.outcome, {
+        kind: "canceled",
+        reason: "feature-observer-failed",
+      });
+    }
+    if (eventKind === "progress") {
+      assert.deepEqual(await handle.outcome, {
+        kind: "canceled",
+        reason: "feature-observer-failed",
+      });
+      assert.deepEqual(activeProducer.attempts[0]?.cancellations, [
+        "feature-observer-failed",
+      ]);
+    }
+    if (eventKind === "terminal") {
+      assert.deepEqual(await handle.outcome, {
+        kind: "succeeded",
+        value: "done",
+      });
+      assert.deepEqual(activeProducer.attempts[0]?.cancellations, []);
+    }
+    if (eventKind === "canceled") {
+      assert.deepEqual(await handle.outcome, {
+        kind: "canceled",
+        reason: "user",
+      });
+      assert.deepEqual(activeProducer.attempts[0]?.cancellations, ["user"]);
+    }
+    if (eventKind === "disposed") {
+      assert.deepEqual(await handle.outcome, {
+        kind: "canceled",
+        reason: "disposed",
+      });
+      assert.deepEqual(activeProducer.attempts[0]?.cancellations, ["disposed"]);
+    }
+    if (eventKind === "replaced") {
+      assert.deepEqual(
+        result.priorProducer?.attempts[0]?.cancellations,
+        ["superseded"],
+      );
+    }
+    const eventsBefore = harness.events.length;
+    activeProducer.attempts[0]?.sink.reportProgress(99);
+    assert.equal(harness.events.length, eventsBefore);
+  });
+}
+
+test("diagnostic observers may reenter after state is final", async () => {
+  let harness: SessionHarness;
+  let nested: TestHandle | undefined;
+  const nestedProducer = producer();
+  const cancellationError = new Error("cancel");
+  harness = sessionHarness(undefined, undefined, diagnostic => {
+    assert.equal(diagnostic.kind, "producer-callout");
+    nested = started(harness.session.start("nested", nestedProducer.adapter));
+    return undefined;
+  });
+  const throwing = producer({
+    onCancellation: () => {
+      throw cancellationError;
+    },
+  });
+  const first = started(harness.session.start("first", throwing.adapter));
+
+  assert.deepEqual(first.cancel(), { kind: "applied" });
+
+  assert.ok(nested);
+  assert.deepEqual(await first.outcome, {
+    kind: "canceled",
+    reason: "user",
+  });
+  assert.equal(await promiseSettled(nested.outcome), false);
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "canceled",
+    "replaced",
+  ]);
+});
+
+test("throwing diagnostic observers use one non-recursive console fallback", () => {
+  const original = new Error("producer");
+  const observerFailure = new Error("observer");
+  const fallbacks: {
+    readonly diagnostic: OperationDiagnostic;
+    readonly observerError: unknown;
+  }[] = [];
+  const page = createOperationAuthorityPage({
+    ...deterministicOptions(),
+    lastResortConsole: {
+      report: (diagnostic, observerError) => {
+        fallbacks.push({ diagnostic, observerError });
+        return undefined;
+      },
+    },
+  });
+  const harness = sessionHarness(page, undefined, () => {
+    throw observerFailure;
+  });
+  const activeProducer = producer();
+  started(harness.session.start("work", activeProducer.adapter));
+
+  activeProducer.attempts[0]?.sink.reportUnexpectedFailure(original);
+
+  assert.equal(harness.diagnostics.length, 1);
+  assert.deepEqual(fallbacks, [{
+    diagnostic: {
+      kind: "producer-contract",
+      operationId: activeProducer.attempts[0]?.identity.id ?? null,
+      error: original,
+    },
+    observerError: observerFailure,
+  }]);
+});
+
+test("unexpected stale failure remains diagnostic without feature publication", () => {
+  const harness = sessionHarness();
+  const firstProducer = producer();
+  started(harness.session.start("first", firstProducer.adapter));
+  started(harness.session.start("second", producer().adapter));
+  const eventsBefore = harness.events.length;
+  const lateFailure = new Error("late-failure");
+
+  firstProducer.attempts[0]?.sink.reportUnexpectedFailure(lateFailure);
+
+  assert.equal(harness.events.length, eventsBefore);
+  assert.deepEqual(harness.diagnostics, [{
+    kind: "producer-contract",
+    operationId: firstProducer.attempts[0]?.identity.id ?? null,
+    error: lateFailure,
+  }]);
+});
+
+test("stale progress, success, failure, and release cannot change the current view", async () => {
+  const harness = sessionHarness();
+  const progressProducer = producer();
+  const progressHandle = started(
+    harness.session.start("progress", progressProducer.adapter),
+  );
+  const successProducer = producer();
+  const successHandle = started(
+    harness.session.start("success", successProducer.adapter),
+  );
+  const failureProducer = producer();
+  const failureHandle = started(
+    harness.session.start("failure", failureProducer.adapter),
+  );
+  const currentProducer = producer();
+  const current = started(harness.session.start("current", currentProducer.adapter));
+  const eventCount = harness.events.length;
+
+  progressProducer.attempts[0]?.sink.reportProgress(1);
+  progressProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "stale-progress-terminal",
+  });
+  successProducer.attempts[0]?.sink.reportTerminal({
+    kind: "succeeded",
+    value: "stale-success",
+  });
+  failureProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "stale-failure",
+  });
+  progressProducer.attempts[0]?.sink.reportQuiesced();
+  successProducer.attempts[0]?.sink.reportQuiesced();
+  failureProducer.attempts[0]?.sink.reportQuiesced();
+
+  assert.equal(harness.events.length, eventCount);
+  assert.equal(await promiseSettled(current.outcome), false);
+  assert.equal(currentProducer.attempts[0]?.cancellations.length, 0);
+  await progressHandle.quiesced;
+  await successHandle.quiesced;
+  await failureHandle.quiesced;
+});
+
+test("terminal, cancellation, and release races preserve their first authorities", async () => {
+  const terminalFirst = sessionHarness();
+  const terminalProducer = producer();
+  const terminalHandle = started(
+    terminalFirst.session.start("terminal-first", terminalProducer.adapter),
+  );
+  terminalProducer.attempts[0]?.sink.reportTerminal({
+    kind: "succeeded",
+    value: "done",
+  });
+  assert.deepEqual(terminalHandle.cancel(), { kind: "no-op" });
+  terminalProducer.attempts[0]?.sink.reportQuiesced();
+  assert.deepEqual(await terminalHandle.outcome, {
+    kind: "succeeded",
+    value: "done",
+  });
+  await terminalHandle.quiesced;
+
+  const cancelFirst = sessionHarness();
+  const cancelProducer = producer();
+  const cancelHandle = started(
+    cancelFirst.session.start("cancel-first", cancelProducer.adapter),
+  );
+  cancelHandle.cancel("disposed");
+  cancelProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "late",
+  });
+  cancelProducer.attempts[0]?.sink.reportQuiesced();
+  assert.deepEqual(await cancelHandle.outcome, {
+    kind: "canceled",
+    reason: "disposed",
+  });
+  await cancelHandle.quiesced;
+
+  const releaseFirst = sessionHarness();
+  const releaseProducer = producer();
+  const releaseHandle = started(
+    releaseFirst.session.start("release-first", releaseProducer.adapter),
+  );
+  releaseProducer.attempts[0]?.sink.reportQuiesced();
+  assert.equal(await promiseSettled(releaseHandle.quiesced), false);
+  assert.deepEqual(releaseHandle.cancel(), { kind: "applied" });
+  releaseProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "after-release",
+  });
+  releaseProducer.attempts[0]?.sink.reportQuiesced();
+  assert.deepEqual(await releaseHandle.outcome, {
+    kind: "canceled",
+    reason: "user",
+  });
+  await releaseHandle.quiesced;
+  assert.equal(releaseFirst.diagnostics.length, 1);
+  assert.equal(releaseFirst.diagnostics[0]?.kind, "producer-contract");
+});
+
+test("stale handles cannot affect replacements or settled operations", async () => {
+  const harness = sessionHarness();
+  const firstProducer = producer();
+  const first = started(harness.session.start("first", firstProducer.adapter));
+  const secondProducer = producer();
+  const second = started(harness.session.start("second", secondProducer.adapter));
+
+  assert.deepEqual(first.cancel("disposed"), { kind: "no-op" });
+  assert.equal(firstProducer.attempts[0]?.cancellations.length, 1);
+  assert.equal(secondProducer.attempts[0]?.cancellations.length, 0);
+  assert.equal(await promiseSettled(second.outcome), false);
+
+  secondProducer.attempts[0]?.sink.reportTerminal({
+    kind: "succeeded",
+    value: "done",
+  });
+  secondProducer.attempts[0]?.sink.reportQuiesced();
+  assert.deepEqual(second.cancel(), { kind: "no-op" });
+  assert.equal(secondProducer.attempts[0]?.cancellations.length, 0);
+  assert.deepEqual(await second.outcome, {
+    kind: "succeeded",
+    value: "done",
+  });
+});
+
+test("duplicate producer reports and callbacks after release are diagnostic", () => {
+  const harness = sessionHarness();
+  const activeProducer = producer();
+  started(harness.session.start("work", activeProducer.adapter));
+  const attempt = activeProducer.attempts[0];
+  assert.ok(attempt);
+
+  attempt.sink.reportTerminal({ kind: "succeeded", value: "done" });
+  attempt.sink.reportTerminal({ kind: "failed", error: "duplicate" });
+  attempt.sink.reportQuiesced();
+  attempt.sink.reportQuiesced();
+  attempt.sink.reportProgress(1);
+  attempt.sink.reportTerminal({ kind: "failed", error: "after-release" });
+  attempt.sink.reportUnexpectedFailure(new Error("after-release"));
+
+  assert.equal(harness.diagnostics.length, 5);
+  assert.ok(harness.diagnostics.every(
+    diagnostic => diagnostic.kind === "producer-contract",
+  ));
+});
+
+test("disposal before start publishes once and prevents producer activity", () => {
+  const harness = sessionHarness();
+  const neverPrepared = producer();
+
+  assert.deepEqual(harness.session.dispose(), { kind: "applied" });
+  assert.deepEqual(harness.session.dispose(), { kind: "no-op" });
+  assert.deepEqual(
+    rejected(harness.session.start("later", neverPrepared.adapter)),
+    { kind: "session-disposed" },
+  );
+  assert.deepEqual(harness.events, [{
+    kind: "disposed",
+    operationId: null,
+  }]);
+  assert.equal(neverPrepared.attempts.length, 0);
+});
+
+test("disposal commits before endpoint callbacks and consumes reports through release", async () => {
+  const harness = sessionHarness();
+  const reentrant = producer();
+  let reentrantResult: TestStartResult | undefined;
+  const activeProducer = producer({
+    onCancellation: attempt => {
+      reentrantResult = harness.session.start("reentrant", reentrant.adapter);
+      attempt.sink.reportProgress(1);
+      attempt.sink.reportTerminal({ kind: "failed", error: "disposed-late" });
+      attempt.sink.reportQuiesced();
+      return undefined;
+    },
+  });
+  const handle = started(harness.session.start("work", activeProducer.adapter));
+
+  assert.deepEqual(harness.session.dispose(), { kind: "applied" });
+
+  assert.deepEqual(rejected(reentrantResult ?? {
+    kind: "started",
+    handle,
+  }), { kind: "session-disposed" });
+  assert.equal(reentrant.attempts.length, 0);
+  assert.deepEqual(await handle.outcome, {
+    kind: "canceled",
+    reason: "disposed",
+  });
+  await handle.quiesced;
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "disposed",
+  ]);
+});
+
+test("removing the common publication-authority predicate admits stale progress", async (t) => {
+  function staleProgressKinds(page: OperationAuthorityPage): TestEvent["kind"][] {
+    const harness = sessionHarness(page);
+    const firstProducer = producer();
+    started(harness.session.start("first", firstProducer.adapter));
+    started(harness.session.start("second", producer().adapter));
+    firstProducer.attempts[0]?.sink.reportProgress(99);
+    return harness.events.map(event => event.kind);
+  }
+
+  assert.deepEqual(
+    staleProgressKinds(createOperationAuthorityPage(deterministicOptions())),
+    ["started", "replaced"],
+  );
+
+  const sourceUrl = new URL("../src/operation-authority.ts", import.meta.url);
+  const sourceText = await readFile(sourceUrl, "utf8");
+  const authorityAnchor =
+    "return createPage(options, standardPublicationAuthority);";
+  assert.equal(sourceText.split(authorityAnchor).length - 1, 1);
+  const mutatedText = sourceText.replace(
+    authorityAnchor,
+    "return createPage(options, session => !session.disposed);",
+  );
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "inspect-web-operation-authority-"),
+  );
+  t.after(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+  const mutatedPath = join(temporaryDirectory, "operation-authority.ts");
+  await writeFile(mutatedPath, mutatedText, "utf8");
+  const imported: unknown = await import(
+    `${pathToFileURL(mutatedPath).href}?mutation=publication-authority`
+  );
+  assert.ok(isOperationAuthorityModule(imported));
+  assert.deepEqual(
+    staleProgressKinds(imported.createOperationAuthorityPage(
+      deterministicOptions(),
+    )),
+    ["started", "replaced", "progress"],
+  );
+});
+
+test("observer-failure abandonment resolves quiescence once", async () => {
+  const observerError = new Error("observer");
+  let abandonments = 0;
+  const harness = sessionHarness(undefined, event => {
+    if (event.kind === "started") throw observerError;
+    return undefined;
+  });
+  const prepared = producer({
+    onAbandon: () => {
+      abandonments++;
+      return undefined;
+    },
+  });
+
+  const handle = started(harness.session.start("work", prepared.adapter));
+  let resolutions = 0;
+  void handle.quiesced.then(() => {
+    resolutions++;
+    return undefined;
+  });
+  await handle.quiesced;
+  prepared.attempts[0]?.sink.reportQuiesced();
+  await Promise.resolve();
+
+  assert.equal(abandonments, 1);
+  assert.equal(resolutions, 1);
+  assert.equal(harness.diagnostics.length, 2);
+  assert.equal(harness.diagnostics[0]?.kind, "feature-observer");
+  assert.equal(harness.diagnostics[1]?.kind, "producer-contract");
+});
+
+interface FetchRequest {
+  readonly signal: AbortSignal;
+  readonly promise: Promise<string>;
+  readonly resolve: (value: string) => void;
+}
+
+function fakeFetchRequests(): {
+  readonly fetch: (input: string, signal: AbortSignal) => Promise<string>;
+  readonly requests: FetchRequest[];
+} {
+  const requests: FetchRequest[] = [];
+  return {
+    requests,
+    fetch: (_input, signal) => {
+      let resolveRequest: ((value: string) => void) | undefined;
+      const promise = new Promise<string>((resolve) => {
+        resolveRequest = resolve;
+      });
+      requests.push({
+        signal,
+        promise,
+        resolve: value => resolveRequest?.(value),
+      });
+      return promise;
+    },
+  };
+}
+
+function browserFetchAdapter(
+  fetchText: (input: string, signal: AbortSignal) => Promise<string>,
+): TestAdapter {
+  return {
+    prepare: (_identity, input, sink) => {
+      const controller = new AbortController();
+      let activated = false;
+      const binding: PreparedOperationProducer = {
+        requestCancellation: () => {
+          controller.abort();
+          return undefined;
+        },
+        activate: () => {
+          activated = true;
+          void fetchText(input, controller.signal).then(
+            value => {
+              sink.reportTerminal({ kind: "succeeded", value });
+              sink.reportQuiesced();
+              return undefined;
+            },
+            (error: unknown) => {
+              sink.reportTerminal({
+                kind: "failed",
+                error: error instanceof Error ? error.message : String(error),
+              });
+              sink.reportQuiesced();
+              return undefined;
+            },
+          );
+          return undefined;
+        },
+        abandon: () => {
+          assert.equal(activated, false);
+          controller.abort();
+          return undefined;
+        },
+      };
+      return { kind: "prepared", binding };
+    },
+  };
+}
+
+test("a browser fetch adapter uses the same placement-independent authority", async () => {
+  const fake = fakeFetchRequests();
+  const adapter = browserFetchAdapter(fake.fetch);
+  const harness = sessionHarness();
+  const first = started(harness.session.start("/first", adapter));
+  const firstRequest = fake.requests[0];
+  assert.ok(firstRequest);
+  const second = started(harness.session.start("/second", adapter));
+  const secondRequest = fake.requests[1];
+  assert.ok(secondRequest);
+
+  assert.equal(firstRequest.signal.aborted, true);
+  firstRequest.resolve("stale");
+  await firstRequest.promise;
+  await first.quiesced;
+  assert.deepEqual(await first.outcome, {
+    kind: "canceled",
+    reason: "superseded",
+  });
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+  ]);
+
+  secondRequest.resolve("current");
+  await secondRequest.promise;
+  assert.deepEqual(await second.outcome, {
+    kind: "succeeded",
+    value: "current",
+  });
+  await second.quiesced;
+  assert.deepEqual(harness.events.map(event => event.kind), [
+    "started",
+    "replaced",
+    "terminal",
+  ]);
+});
+
+function compileTimeCallbackContracts(): void {
+  // @ts-expect-error Operation IDs can only be constructed by the page allocator.
+  const forgedOperationId: OperationId = "forged";
+  const validFeature: OperationFeatureObserver<string, string, number> = {
+    publish: _event => undefined,
+  };
+  const validDiagnostic: OperationDiagnosticObserver = {
+    report: _diagnostic => undefined,
+  };
+  const validSink: TestSink = {
+    reportProgress: _value => undefined,
+    reportTerminal: _outcome => undefined,
+    reportQuiesced: () => undefined,
+    reportUnexpectedFailure: _error => undefined,
+  };
+  const validBinding: PreparedOperationProducer = {
+    requestCancellation: _reason => undefined,
+    activate: () => undefined,
+    abandon: () => undefined,
+  };
+  const validAdapter: TestAdapter = {
+    prepare: () => ({ kind: "prepared", binding: validBinding }),
+  };
+  void validFeature;
+  void validDiagnostic;
+  void validSink;
+  void validAdapter;
+
+  const promiseFeature: OperationFeatureObserver<string, string, number> = {
+    // @ts-expect-error Feature publication is synchronous and returns exactly undefined.
+    publish: async _event => {},
+  };
+  const narrowedFeature: OperationFeatureObserver<string, string, number> = {
+    // @ts-expect-error The feature callback must accept every owner-issued event.
+    publish: (_event: Extract<TestEvent, { readonly kind: "started" }>) => undefined,
+  };
+  const promiseDiagnostic: OperationDiagnosticObserver = {
+    // @ts-expect-error Diagnostic delivery is synchronous and returns exactly undefined.
+    report: async _diagnostic => {},
+  };
+  const narrowedDiagnostic: OperationDiagnosticObserver = {
+    // @ts-expect-error The diagnostic callback must accept every diagnostic category.
+    report: (_diagnostic: OperationDiagnostic & {
+      readonly kind: "producer-contract";
+    }) => undefined,
+  };
+  const promiseSink: TestSink = {
+    // @ts-expect-error Producer sink callbacks never return Promises.
+    reportProgress: async _value => {},
+    reportTerminal: _outcome => undefined,
+    reportQuiesced: () => undefined,
+    reportUnexpectedFailure: _error => undefined,
+  };
+  const narrowedSink: TestSink = {
+    reportProgress: _value => undefined,
+    // @ts-expect-error A terminal callback cannot narrow the owner-issued outcome.
+    reportTerminal: (
+      _outcome: { readonly kind: "succeeded"; readonly value: string },
+    ) => undefined,
+    reportQuiesced: () => undefined,
+    reportUnexpectedFailure: _error => undefined,
+  };
+  const promiseBinding: PreparedOperationProducer = {
+    requestCancellation: _reason => undefined,
+    // @ts-expect-error Activation is synchronous and returns exactly undefined.
+    activate: async () => {},
+    // @ts-expect-error Abandonment is synchronous and returns exactly undefined.
+    abandon: async () => {},
+  };
+  const narrowedBinding: PreparedOperationProducer = {
+    // @ts-expect-error Cancellation must accept every owner-issued reason.
+    requestCancellation: (_reason: "user") => undefined,
+    activate: () => undefined,
+    abandon: () => undefined,
+  };
+  const promiseAdapter: TestAdapter = {
+    // @ts-expect-error Preparation is synchronous and returns a typed preparation result.
+    prepare: async () => ({ kind: "prepared", binding: validBinding }),
+  };
+  const narrowedAdapter: TestAdapter = {
+    // @ts-expect-error Preparation cannot narrow the feature-owned input.
+    prepare: (
+      _identity: OperationIdentity,
+      _input: "only-this-input",
+      _sink: TestSink,
+    ): OperationPreparation<string> => ({
+      kind: "prepared",
+      binding: validBinding,
+    }),
+  };
+  const narrowedSinkAdapter: TestAdapter = {
+    // @ts-expect-error Preparation cannot require a narrower sink shape.
+    prepare: (
+      _identity: OperationIdentity,
+      _input: string,
+      _sink: TestSink & { readonly producerOnly: true },
+    ): OperationPreparation<string> => ({
+      kind: "prepared",
+      binding: validBinding,
+    }),
+  };
+  const sequenceCoupledIdentitySource: OperationAuthorityPageOptions = {
+    allocation: {
+      // @ts-expect-error Opaque ID construction cannot depend on the sequence.
+      createId: (_sequence: number) => "sequence-coupled",
+    },
+  };
+  void forgedOperationId;
+  void promiseFeature;
+  void narrowedFeature;
+  void promiseDiagnostic;
+  void narrowedDiagnostic;
+  void promiseSink;
+  void narrowedSink;
+  void promiseBinding;
+  void narrowedBinding;
+  void promiseAdapter;
+  void narrowedAdapter;
+  void narrowedSinkAdapter;
+  void sequenceCoupledIdentitySource;
+}
+void compileTimeCallbackContracts;

--- a/prototypes/inspect-web/test/operation-authority.test.ts
+++ b/prototypes/inspect-web/test/operation-authority.test.ts
@@ -965,6 +965,36 @@ test("nested producer publication preserves the outer feature guard", async () =
   assert.equal(await promiseSettled(handle.outcome), false);
 });
 
+test("nested observer failure abandons the prepared binding before activation", async () => {
+  const activeProducer = producer();
+  let harness: SessionHarness;
+  harness = sessionHarness(undefined, event => {
+    if (event.kind === "started")
+      activeProducer.attempts[0]?.sink.reportProgress(1);
+    if (event.kind === "progress")
+      throw new Error("nested observer failed");
+    return undefined;
+  });
+
+  const handle = started(
+    harness.session.start("first", activeProducer.adapter),
+  );
+
+  assert.equal(activeProducer.attempts[0]?.activated, false);
+  assert.equal(activeProducer.attempts[0]?.abandoned, true);
+  assert.deepEqual(await handle.outcome, {
+    kind: "canceled",
+    reason: "feature-observer-failed",
+  });
+  await handle.quiesced;
+  assert.deepEqual(
+    harness.events.map(event => event.kind),
+    ["started", "progress"],
+  );
+  assert.equal(harness.diagnostics.length, 1);
+  assert.equal(harness.diagnostics[0]?.kind, "feature-observer");
+});
+
 interface ThrowingFeatureResult {
   readonly handle: TestHandle | null;
   readonly priorHandle: TestHandle | null;
@@ -1245,12 +1275,20 @@ test("terminal, cancellation, and release races preserve their first authorities
     kind: "succeeded",
     value: "done",
   });
+  terminalProducer.attempts[0]?.sink.reportTerminal({
+    kind: "failed",
+    error: "late",
+  });
   assert.deepEqual(terminalHandle.cancel(), { kind: "no-op" });
   terminalProducer.attempts[0]?.sink.reportQuiesced();
   assert.deepEqual(await terminalHandle.outcome, {
     kind: "succeeded",
     value: "done",
   });
+  assert.deepEqual(
+    terminalFirst.events.map(event => event.kind),
+    ["started", "terminal"],
+  );
   await terminalHandle.quiesced;
 
   const cancelFirst = sessionHarness();

--- a/prototypes/inspect-web/test/operation-authority.test.ts
+++ b/prototypes/inspect-web/test/operation-authority.test.ts
@@ -922,6 +922,49 @@ for (const eventKind of [
   });
 }
 
+test("nested producer publication preserves the outer feature guard", async () => {
+  const page = createOperationAuthorityPage(deterministicOptions());
+  const replacement = producer();
+  const activeProducer = producer();
+  let harness: SessionHarness;
+  let handle: TestHandle;
+  let startResult: TestStartResult | undefined;
+  let handleResult: OperationControlResult | undefined;
+  let currentResult: OperationControlResult | undefined;
+  let disposeResult: OperationControlResult | undefined;
+  harness = sessionHarness(page, event => {
+    if (event.kind === "progress" && event.progress.value === 1) {
+      activeProducer.attempts[0]?.sink.reportProgress(2);
+      startResult = harness.session.start("replacement", replacement.adapter);
+      handleResult = handle.cancel();
+      currentResult = harness.session.cancelCurrent();
+      disposeResult = harness.session.dispose();
+    }
+    return undefined;
+  });
+  handle = started(harness.session.start("first", activeProducer.adapter));
+
+  activeProducer.attempts[0]?.sink.reportProgress(1);
+
+  assert.deepEqual(rejected(startResult ?? {
+    kind: "started",
+    handle,
+  }), { kind: "feature-observer-active" });
+  const expectedControlResult = {
+    kind: "rejected",
+    reason: "feature-observer-active",
+  };
+  assert.deepEqual(handleResult, expectedControlResult);
+  assert.deepEqual(currentResult, expectedControlResult);
+  assert.deepEqual(disposeResult, expectedControlResult);
+  assert.deepEqual(
+    harness.events.map(event => event.kind),
+    ["started", "progress", "progress"],
+  );
+  assert.equal(replacement.attempts.length, 0);
+  assert.equal(await promiseSettled(handle.outcome), false);
+});
+
 interface ThrowingFeatureResult {
   readonly handle: TestHandle | null;
   readonly priorHandle: TestHandle | null;

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -386,6 +386,92 @@ test("type source replacement suppresses stale publication without cancelling th
   assert.equal(state.typeSourceLoading, false);
 });
 
+test("synchronous type source failure cannot cancel a reentrant replacement", async () => {
+  const replacementQuery = deferred<BrowserSource>();
+  let cancellations = 0;
+  let replacementLoad: Promise<void> | undefined;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  let coordinator!: ReturnType<typeof createSourceInspectionCoordinator>;
+  coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: request => {
+        if (request.type === "Example.First") {
+          replacementLoad = coordinator.loadTypeSource({
+            signature: "second",
+            packageId: "Example.Package",
+            version: "1.2.3",
+            framework: "net10.0",
+            assembly: "Example.Package",
+            type: "Example.Second",
+            taste: "[]",
+            isVisible: () => true,
+          });
+          throw new Error("first activation failed");
+        }
+        return replacementQuery.promise;
+      },
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+
+  await coordinator.loadTypeSource({
+    signature: "first",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.First",
+    taste: "[]",
+    isVisible: () => true,
+  });
+
+  assert.equal(cancellations, 0);
+  assert.equal(state.typeSourceKey, "second");
+  assert.equal(state.typeSourceLoading, true);
+  replacementQuery.resolve(source("replacement"));
+  assert.ok(replacementLoad);
+  await replacementLoad;
+  assert.equal(sourceText(state.typeSource), "replacement");
+  assert.equal(state.typeSourceLoading, false);
+});
+
+test("synchronous type source failure does not repeat reentrant cancellation", async () => {
+  let cancellations = 0;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  let coordinator!: ReturnType<typeof createSourceInspectionCoordinator>;
+  coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: () => {
+        assert.equal(coordinator.cancelCurrentRequest(), true);
+        throw new Error("activation failed after cancellation");
+      },
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+
+  await coordinator.loadTypeSource({
+    signature: "first",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.First",
+    taste: "[]",
+    isVisible: () => true,
+  });
+
+  assert.equal(cancellations, 1);
+  assert.equal(state.typeSourceKey, "");
+  assert.equal(state.typeSourceLoading, false);
+  assert.equal(state.typeSourceError, "");
+});
+
 test("legacy member source takeover cancels the authoritative type operation first", async () => {
   const typeQuery = deferred<BrowserSource>();
   let cancellations = 0;

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/source-inspection.ts";
 import type { BrowserSource } from "../src/inspect-web-engine.d.ts";
 import type { MemberFocusSnapshot } from "../src/member-focus.ts";
+import { createOperationAuthorityPage } from "../src/operation-authority.ts";
 
 function source(text: string): BrowserSource {
   return {
@@ -29,6 +30,10 @@ function focusSnapshot(selector = "#member-filter"): MemberFocusSnapshot {
     navigationScrollTop: null,
     focusLost: false,
   };
+}
+
+function sourceText(value: BrowserSource | null): string | undefined {
+  return value?.text;
 }
 
 function inspectionState(
@@ -70,13 +75,20 @@ function inspectionDependencies(
   state: SourceInspectionState,
   overrides: Partial<Omit<SourceInspectionDependencies, "state">> = {},
 ): SourceInspectionDependencies {
+  let nextOperationId = 1;
   return {
     state,
+    operationAuthority: createOperationAuthorityPage({
+      allocation: {
+        createId: () => `source-operation-${nextOperationId++}`,
+      },
+    }),
     queryMemberSource: async () => source("member"),
     queryTypeSource: async () => source("type"),
     queryGraphSource: async () => source("graph"),
     memberSourceHasConcreteOverload: () => true,
     cancelEngineSourceRequest: () => {},
+    reportOperationDiagnostic: () => undefined,
     describeError: error =>
       error instanceof Error ? error.message : String(error),
     render: () => {},
@@ -92,6 +104,16 @@ function deferred<T>() {
     resolve = accept;
   });
   return { promise, resolve };
+}
+
+async function promiseSettled(promise: Promise<unknown>): Promise<boolean> {
+  let settled = false;
+  void promise.then(() => {
+    settled = true;
+    return undefined;
+  });
+  await Promise.resolve();
+  return settled;
 }
 
 test("hidden source work is cancelled through the shared engine boundary", () => {
@@ -312,6 +334,173 @@ test("type source caches an owned result without repainting a hidden surface", a
   await coordinator.loadTypeSource(request);
   assert.equal(queries, 1);
   assert.equal(renders, 2);
+});
+
+test("type source replacement suppresses stale publication without cancelling the replacement", async () => {
+  const firstQuery = deferred<BrowserSource>();
+  const secondQuery = deferred<BrowserSource>();
+  let cancellations = 0;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: request =>
+        request.type === "Example.First"
+          ? firstQuery.promise
+          : secondQuery.promise,
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+  const request = {
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    taste: "[]",
+    isVisible: () => true,
+  };
+
+  const firstLoad = coordinator.loadTypeSource({
+    ...request,
+    signature: "first",
+    type: "Example.First",
+  });
+  const secondLoad = coordinator.loadTypeSource({
+    ...request,
+    signature: "second",
+    type: "Example.Second",
+  });
+
+  assert.equal(cancellations, 0);
+  assert.equal(state.typeSourceKey, "second");
+  firstQuery.resolve(source("stale"));
+  await firstLoad;
+  assert.equal(state.typeSource, null);
+  assert.equal(state.typeSourceLoading, true);
+
+  secondQuery.resolve(source("current"));
+  await secondLoad;
+  assert.equal(sourceText(state.typeSource), "current");
+  assert.equal(state.typeSourceLoading, false);
+});
+
+test("legacy member source takeover cancels the authoritative type operation first", async () => {
+  const typeQuery = deferred<BrowserSource>();
+  let cancellations = 0;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: async () => typeQuery.promise,
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+  const typeLoad = coordinator.loadTypeSource({
+    signature: "type",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    taste: "[]",
+    isVisible: () => false,
+  });
+
+  await coordinator.loadMemberSource({
+    signature: "member",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    member: "Build",
+    selectorKey: "method",
+    metadataToken: 42,
+    taste: "[]",
+    isCurrent: () => true,
+  });
+
+  assert.equal(cancellations, 1);
+  assert.equal(state.memberSource?.text, "member");
+  assert.equal(state.typeSource, null);
+  typeQuery.resolve(source("stale type"));
+  await typeLoad;
+  assert.equal(state.typeSource, null);
+});
+
+test("current type source failures remain visible and restore focus", async () => {
+  const renders: Array<string | null> = [];
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: async () => {
+        throw new Error("type source unavailable");
+      },
+      renderPreservingMemberFocus: fallback => {
+        renders.push(fallback?.selector ?? null);
+        return fallback ?? focusSnapshot("#type-list");
+      },
+    }));
+
+  await coordinator.loadTypeSource({
+    signature: "type",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    taste: "[]",
+    isVisible: () => true,
+  });
+
+  assert.equal(state.typeSourceError, "type source unavailable");
+  assert.equal(state.typeSourceLoading, false);
+  assert.deepEqual(renders, [null, "#type-list"]);
+});
+
+test("type cancellation completes logically before the query quiesces", async () => {
+  const query = deferred<BrowserSource>();
+  let cancellations = 0;
+  const state = inspectionState({
+    lens: "source",
+    selectedMemberKey: "",
+    memberSection: "overview",
+  });
+  const coordinator = createSourceInspectionCoordinator(
+    inspectionDependencies(state, {
+      queryTypeSource: async () => query.promise,
+      cancelEngineSourceRequest: () => cancellations++,
+    }));
+  const load = coordinator.loadTypeSource({
+    signature: "type",
+    packageId: "Example.Package",
+    version: "1.2.3",
+    framework: "net10.0",
+    assembly: "Example.Package",
+    type: "Example.Widget",
+    taste: "[]",
+    isVisible: () => true,
+  });
+
+  assert.equal(coordinator.cancelCurrentRequest(), true);
+  assert.equal(cancellations, 1);
+  assert.equal(state.typeSourceLoading, false);
+  assert.equal(state.typeSourceKey, "");
+  assert.equal(await promiseSettled(load), false);
+
+  query.resolve(source("late"));
+  await load;
+  assert.equal(state.typeSource, null);
+  assert.equal(coordinator.cancelCurrentRequest(), false);
+  assert.equal(cancellations, 1);
 });
 
 test("closing graph source invalidates its result and cancels the engine", async () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2999,9 +2999,18 @@ test("type projection completions render only while current and preserve navigat
   const typeSource =
     sourceInspectionSource.match(/async loadTypeSource\(request\)[\s\S]*?\n    },/)?.[0]
     ?? "";
+  const typeSourceAuthority =
+    sourceInspectionSource.match(
+      /const publishTypeSourceEvent = \(event: TypeSourceFeatureEvent\)[\s\S]*?const typeSourceSession:/,
+    )?.[0]
+    ?? "";
+  assert.match(
+    typeSourceAuthority,
+    /case "started":[\s\S]*case "replaced":[\s\S]*context\.preservedFocus =\s*dependencies\.renderPreservingMemberFocus\(\);[\s\S]*case "terminal":[\s\S]*state\.typeSourceLoading = false;[\s\S]*if \(context\.request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(\s*context\.preservedFocus,/);
   assert.match(
     typeSource,
-    /const preservedFocus = dependencies\.renderPreservingMemberFocus\(\);[\s\S]*const ownsRequest = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\);/);
+    /typeSourceSession\.start\(request, typeSourceAdapter\)[\s\S]*await result\.handle\.quiesced/);
+  assert.doesNotMatch(typeSource, /sourceRequestGeneration|ownsRequest/);
   assert.doesNotMatch(typeSource, /finally \{[\s\S]*dependencies\.render\(\)/);
   const typeMetadata =
     appSource.match(/async function loadSelectedTypeMetadata\([\s\S]*?\n}\n\n\/\/ Projects/)?.[0]
@@ -3138,6 +3147,11 @@ test("Type Source completion settles behind workbench overlays", () => {
   const typeSource =
     sourceInspectionSource.match(/async loadTypeSource\(request\)[\s\S]*?\n    },/)?.[0]
     ?? "";
+  const typeSourceAuthority =
+    sourceInspectionSource.match(
+      /const publishTypeSourceEvent = \(event: TypeSourceFeatureEvent\)[\s\S]*?const typeSourceSession:/,
+    )?.[0]
+    ?? "";
   assert.match(
     appSource,
     /function workbenchOverlayOwnsFocus\(\) \{\s*return workbenchModalOwnsFocus\(\);[\s\S]*function workbenchModalOwnsFocus\(\) \{\s*return state\.spotlightOpen\s*\|\| state\.graphSourceOpen\s*\|\| state\.docViewerOpen\s*\|\| state\.memberAnnotatedModal !== null;/);
@@ -3145,8 +3159,11 @@ test("Type Source completion settles behind workbench overlays", () => {
     appSource,
     /sourceInspection\.loadTypeSource\(\{[\s\S]*isVisible: \(\) =>\s*currentSourceOperationKind\(\) === "type"\s*&& !workbenchModalOwnsFocus\(\)/);
   assert.match(
+    typeSourceAuthority,
+    /case "terminal":[\s\S]*state\.typeSourceLoading = false;[\s\S]*if \(context\.request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(\s*context\.preservedFocus,/);
+  assert.match(
     typeSource,
-    /const ownsRequest = \(\) =>[\s\S]*if \(ownsRequest\(\)\) \{\s*state\.typeSourceLoading = false;\s*if \(request\.isVisible\(\)\) \{\s*dependencies\.renderPreservingMemberFocus\(preservedFocus\)/);
+    /typeSourceSession\.start\(request, typeSourceAdapter\)[\s\S]*await result\.handle\.quiesced/);
   assert.match(
     appSource,
     /function isInteractiveElement\(element: Element \| null\)[\s\S]*"button, a\[href\], input, select, textarea, summary, "[\s\S]*\[role=button\][\s\S]*id: "workspace\.drill-in"[\s\S]*key: "Enter"[\s\S]*!isInteractiveElement\([\s\S]*event\.target instanceof Element \? event\.target : null\)/);
@@ -3511,6 +3528,9 @@ test("source operations cancel when superseded or hidden", () => {
   assert.match(
     appSource,
     /cancelSourceQuery: cancelSourceInspection/);
+  assert.match(
+    appSource,
+    /const operationAuthority = createOperationAuthorityPage\(\);[\s\S]*createSourceInspectionCoordinator\(\{[\s\S]*operationAuthority,/);
 
   const renderBody =
     appSource.match(
@@ -3524,6 +3544,9 @@ test("source operations cancel when superseded or hidden", () => {
   assert.match(
     sourceInspectionSource,
     /const cancelCurrentRequest = \(\) => \{[\s\S]*cancelSourceRequestState\(state\)[\s\S]*cancelHiddenRequest\(\)[\s\S]*sourceSurfaceIsVisible\(\s*state,\s*dependencies\.memberSourceHasConcreteOverload\(\)\)[\s\S]*cancelCurrentRequest\(\)/);
+  assert.match(
+    sourceInspectionSource,
+    /dependencies\.operationAuthority\.createSession\([\s\S]*typeSourceSession\.start\(request, typeSourceAdapter\)[\s\S]*await result\.handle\.quiesced/);
   assert.match(appSource, /sourceInspection\.loadMemberSource\(\{/);
   assert.match(appSource, /sourceInspection\.loadTypeSource\(\{/);
   assert.match(appSource, /sourceInspection\.openGraphSource\(request, title\)/);


### PR DESCRIPTION
Implements the inspect-web main-thread operation authority and adopts it for
Type Source without changing query placement, source rendering, failure
wording, focus restoration, caching, or the managed source-operation
coordinator.

## Demo

The focused scenario starts two Type Source requests, resolves the superseded
request first, and then resolves the current request:

```console
$ node --test --test-name-pattern="type source replacement" \
    test/source-inspection.test.ts
✔ type source replacement suppresses stale publication without cancelling the replacement
```

What to notice:

- the first result cannot publish after the second operation becomes current;
- the stale cancellation endpoint cannot call the managed singleton
  `CancelCurrent` after the replacement owns it; and
- the second result still publishes and clears loading normally.

The neighboring
`legacy member source takeover cancels the authoritative type operation first`
case proves the untouched Member Source path can still replace Type Source
through the existing managed execution boundary.

## Design basis

- **Normative owner:** `docs/design/inspect-web-operation-authority.md`.
- **Exact claim:** one page owner allocates opaque non-reused operation
  identities, while each feature session admits publication only from its
  current pending operation and resolves logical outcome separately from
  physical quiescence.
- **Supporting evidence:** the checked model under
  `docs/design/models/inspect-web-operation-authority/` bounds the abstract
  lifecycle; `docs/design/inspect-web-async-composition.md` owns only adjacent
  sequencing and typed handoffs.
- **Complexity basis:** reentrancy, replacement, callback failure, and delayed
  physical settlement require an explicit two-phase producer binding and
  separate outcome/quiescence state. The common authority predicate and
  mutation gate make stale-publication safety non-vacuous.
- **Consumer and host plan:** Type Source is the named first consumer. #5092 is
  the focused implementation issue and #4937 is the end-to-end tracker. The
  user-approved scope, recorded in the design and both issues, is intentionally
  inspect-web browser-host policy; CLI enablement is outside this slice.
- **Rendering strategy:** not a rendering-domain change. The typed
  `BrowserSource` state and existing `renderPreservingMemberFocus` lowering
  remain feature-owned; this PR adds no Markout or format-lowering boundary.
- **Pathological case:** managed source cancellation is one global singleton.
  Replacement B activates first, so A's later cancellation endpoint must
  recognize that B owns the browser-side token and avoid canceling B.

## Changes

- Add a generic page-wide operation authority with:
  - opaque IDs independent from monotonic safe-integer sequences;
  - typed start rejection, cancellation, supersession, and disposal;
  - synchronous preparation, activation, abandonment, and observer contracts;
  - stale progress/terminal suppression;
  - feature and diagnostic exception containment; and
  - independent logical outcome and physical quiescence.
- Add mutation-backed and compile-time gates for identity, authority,
  reentrancy, callback shape, races, disposal, and adapter placement.
- Migrate only Type Source to the new authority while Member Source, graph
  source, generated facades, managed execution, and the shared cancellation
  coordinator remain in place.
- Route synchronous Type Source activation-failure cleanup through the same
  identity-checked, at-most-once cancellation endpoint as ordinary authority
  cancellation.
- Re-check current pending authority after feature publication so nested
  observer failure abandons rather than activates a faulted prepared binding.

## Compatibility boundary

This slice does not move .NET work to a worker, change generated facades,
change managed cancellation semantics, migrate Member or graph source, or add
new user-visible source behavior. Those adjacent steps remain owned by #5418,
#5419, and #5420.

## Validation

- `npm test` — 901 passed
- `npm run analyze`
- `npm run build`
- focused operation-authority, source-coordinator, and spotlight gates — 237
  passed after integrating `main`
- `markdownlint docs/design/inspect-web-operation-authority.md`

Closes #5092
