### PR TITLE
Bind projected navigation members to declarations

### DIFF
--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -551,20 +551,23 @@ The generation-free classification follows this table:
 | --- | --- |
 | One or more returned Types with exact definition identity | `Available`; retain every exact Type and Member row in producer order plus all peer evidence |
 | Complete successful production with zero Types and no inspection failures | `Unavailable` |
-| No exact Type plus participant rejection, participant failure, inspection failure, missing exact Type or projected-Member declaring-Type identity, or projection omission | `Failed` with the original typed evidence |
+| No exact Type plus participant rejection, participant failure, inspection failure, missing exact Type or unresolved projected-Member declaration identity, or projection omission | `Failed` with the original typed evidence |
 | Exact Types plus any of those failures | `Available` and partial; retain the exact rows and original typed evidence |
 
 Projection truncation never proves that an omitted Library is empty. A returned
 Type without exact `MetadataTypeDefinitionName` is retained as identity-failure
 evidence and is not reconstructed from display text, metadata token, or list
-position. #5437 added the exact typed declaring-Type definition identity to a
-Member projected onto another Type. The current Navigation classifier has not
-yet adopted that field and still retains the complete producer row as typed
-identity-failure evidence rather than rewriting it as a declaration on the
-containing Type. The Workspace-rooted implementation consumes the typed
-identity and never reconstructs it from canonical declaring text. Returned
-exact rows remain trustworthy when another row or participant fails; failure
-does not erase positive evidence.
+position. A Member projected onto another Type resolves its
+`DeclaringTypeDefinitionName` against exact Type rows in the same Library. One
+unique match retains the producer row beneath its containing Type while its
+`MemberSubject` binds the declaration Type and the declaration-scoped
+`MemberAnchor`, exact-joining the declaration Member by its producer-issued
+metadata token. Missing identity, no returned exact declaration, or multiple
+matching Type or Member rows retains the complete producer row as typed failure
+evidence and emits no Member subject. Classification never parses display or
+canonical declaring text as lookup identity. Returned exact rows remain
+trustworthy when another row or participant fails; failure does not erase
+positive evidence.
 
 Every admitted Library remains an available Library candidate for initial
 subject recommendation. Only exact returned Type rows become Type candidates.
@@ -574,7 +577,14 @@ produce a navigation snapshot.
 
 This classification is gated by
 `NavigationSubjectInventoryTests.EveryBoundedInventoryRow_PreservesProducerOrderAndIdentity`,
+`ProjectedMemberFromRealProducer_BindsDeclarationTypeAndAnchor`,
 `ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed`,
+`ProjectedMemberWithUnreturnedDeclaringType_FailsClosed`,
+`ProjectedMemberWithAmbiguousDeclaringType_FailsClosed`,
+`ProjectedMemberWithoutDeclarationMemberIdentity_FailsClosed`,
+`ProjectedMemberWithUnreturnedDeclarationMember_FailsClosed`,
+`ProjectedMemberWithAmbiguousDeclarationMember_FailsClosed`,
+`ProjectedMemberLookup_DoesNotUseDeclaringText`,
 `SuccessfulProducerRows_AreTrustworthyDespitePeerFailure`,
 `CompleteSuccessfulEmptyInventory_IsUnavailable`,
 `NoCandidateWithIndeterminateProducer_IsFailed`,

--- a/src/DotnetInspector.Queries.Tests/NavigationSubjectInventoryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/NavigationSubjectInventoryTests.cs
@@ -62,7 +62,7 @@ public sealed class NavigationSubjectInventoryTests
     }
 
     [Fact]
-    public void ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed()
+    public void ProjectedMemberFromRealProducer_BindsDeclarationTypeAndAnchor()
     {
         var participant = new AssemblyContextParticipant(
             ResolvedAssemblyReference.CreateFromPath(
@@ -106,31 +106,292 @@ public sealed class NavigationSubjectInventoryTests
         NavigationTypeInventoryRow receiver = Assert.Single(
             types.Rows,
             row => row.ProducerRow.FullName == typeof(InventoryFixture).FullName);
-        Assert.DoesNotContain(
+        NavigationMemberInventoryRow projected = Assert.Single(
             receiver.Members,
             row => row.ProducerRow.Name == nameof(InventoryExtensions.Extend));
-        NavigationInventoryEvidence.MemberIdentityMissing extension =
-            Assert.Single(
-                types.Evidence
-                    .OfType<
-                        NavigationInventoryEvidence.MemberIdentityMissing>(),
-                evidence =>
-                    evidence.ProducerRow.Name
-                        == nameof(InventoryExtensions.Extend)
-                    && ReferenceEquals(
-                        evidence.ContainingType,
-                        receiver.ProducerRow));
-        Assert.NotNull(extension.ProducerRow.DeclaringTypeCanonicalName);
         NavigationTypeInventoryRow declaring = Assert.Single(
             types.Rows,
             row => row.ProducerRow.FullName
                 == typeof(InventoryExtensions).FullName);
-        Assert.Contains(
+        NavigationMemberInventoryRow declaration = Assert.Single(
             declaring.Members,
             row => row.ProducerRow.Name
                     == nameof(InventoryExtensions.Extend)
                 && row.ProducerRow.DeclaringTypeCanonicalName is null
                 && row.Subject.DeclaringType == declaring.Subject);
+        Assert.Equal(
+            declaring.ProducerRow.DefinitionName,
+            projected.ProducerRow.DeclaringTypeDefinitionName);
+        Assert.Same(declaring.Subject, projected.Subject.DeclaringType);
+        Assert.NotEqual(receiver.Subject, projected.Subject.DeclaringType);
+        Assert.Equal(
+            declaration.Subject.Identity.Member,
+            projected.Subject.Identity.Member);
+        Assert.DoesNotContain(
+            types.Evidence,
+            evidence => evidence
+                    is NavigationInventoryEvidence
+                        .ProjectedMemberIdentityFailure failure
+                && ReferenceEquals(
+                    failure.ProducerRow,
+                    projected.ProducerRow));
+    }
+
+    [Fact]
+    public void ProjectedMemberWithoutTypedDeclaringIdentity_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        ApiMember projected = ProjectedMember(
+            "Extend",
+            declaringType: null);
+        ApiType receiver = Type("Receiver", "public", projected);
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver))).Types);
+
+        Assert.Empty(Assert.Single(types.Rows).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclaringTypeIdentityMissing,
+            failure.Kind);
+        Assert.Same(receiver, failure.ContainingType);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberWithUnreturnedDeclaringType_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        ApiMember projected = ProjectedMember(
+            "Extend",
+            TypeName("Other", "Extensions"));
+        ApiType receiver = Type("Receiver", "public", projected);
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver))).Types);
+
+        Assert.Empty(Assert.Single(types.Rows).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclaringTypeNotReturned,
+            failure.Kind);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberWithAmbiguousDeclaringType_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        MetadataTypeDefinitionName declaringType =
+            TypeName("Sample", "Extensions");
+        ApiMember projected = ProjectedMember("Extend", declaringType);
+        ApiType receiver = Type("Receiver", "public", projected);
+        ApiType first = Type("FirstExtensions", "public");
+        ApiType second = Type("SecondExtensions", "public");
+        first.DefinitionName = declaringType;
+        second.DefinitionName = declaringType;
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver, first, second))).Types);
+
+        Assert.Empty(
+            Assert.Single(
+                types.Rows,
+                row => ReferenceEquals(
+                    row.ProducerRow,
+                    receiver)).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclaringTypeAmbiguous,
+            failure.Kind);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberWithoutDeclarationMemberIdentity_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        MetadataTypeDefinitionName declaringType =
+            TypeName("Sample", "Extensions");
+        ApiMember projected = ProjectedMember(
+            "Extend",
+            declaringType,
+            metadataToken: null);
+        ApiType receiver = Type("Receiver", "public", projected);
+        ApiType declaring = Type("Extensions", "public", Member("Extend"));
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver, declaring))).Types);
+
+        Assert.Empty(
+            Assert.Single(
+                types.Rows,
+                row => ReferenceEquals(
+                    row.ProducerRow,
+                    receiver)).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclarationMemberIdentityMissing,
+            failure.Kind);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberWithUnreturnedDeclarationMember_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        MetadataTypeDefinitionName declaringType =
+            TypeName("Sample", "Extensions");
+        ApiMember projected = ProjectedMember("Extend", declaringType);
+        ApiType receiver = Type("Receiver", "public", projected);
+        ApiType declaring = Type("Extensions", "public");
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver, declaring))).Types);
+
+        Assert.Empty(
+            Assert.Single(
+                types.Rows,
+                row => ReferenceEquals(
+                    row.ProducerRow,
+                    receiver)).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclarationMemberNotReturned,
+            failure.Kind);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberWithAmbiguousDeclarationMember_FailsClosed()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        MetadataTypeDefinitionName declaringType =
+            TypeName("Sample", "Extensions");
+        ApiMember projected = ProjectedMember("Extend", declaringType);
+        ApiType receiver = Type("Receiver", "public", projected);
+        ApiMember first = Member("Extend");
+        first.MetadataToken = projected.MetadataToken;
+        ApiMember second = Member("Extend");
+        second.MetadataToken = projected.MetadataToken;
+        ApiType declaring =
+            Type("Extensions", "public", first, second);
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver, declaring))).Types);
+
+        Assert.Empty(
+            Assert.Single(
+                types.Rows,
+                row => ReferenceEquals(
+                    row.ProducerRow,
+                    receiver)).Members);
+        NavigationInventoryEvidence.ProjectedMemberIdentityFailure failure =
+            Assert.IsType<
+                NavigationInventoryEvidence.ProjectedMemberIdentityFailure>(
+                    Assert.Single(types.Evidence));
+        Assert.Equal(
+            NavigationProjectedMemberIdentityFailureKind
+                .DeclarationMemberAmbiguous,
+            failure.Kind);
+        Assert.Same(projected, failure.ProducerRow);
+    }
+
+    [Fact]
+    public void ProjectedMemberLookup_DoesNotUseDeclaringText()
+    {
+        RealizedMemberCoordinate.Package coordinate = Coordinate();
+        WorkspaceContextMember library = Library(coordinate, "Library");
+        MetadataTypeDefinitionName declaringType =
+            TypeName("Sample", "Extensions");
+        ApiMember projected = ProjectedMember("Extend", declaringType);
+        projected.DeclaringType = "Misleading.Display";
+        projected.DeclaringTypeCanonicalName = "Misleading.Canonical";
+        ApiType receiver = Type("Receiver", "public", projected);
+        ApiMember declaration = Member("Extend");
+        declaration.MetadataToken = projected.MetadataToken;
+        ApiType declaring =
+            Type("Extensions", "public", declaration);
+
+        NavigationTypeInventoryOutcome.Available types =
+            Assert.IsType<NavigationTypeInventoryOutcome.Available>(
+                Classify(
+                    coordinate,
+                    [library],
+                    library,
+                    Surface(Available(library, receiver, declaring))).Types);
+
+        NavigationTypeInventoryRow declaringRow = Assert.Single(
+            types.Rows,
+            row => ReferenceEquals(row.ProducerRow, declaring));
+        NavigationMemberInventoryRow projectedRow = Assert.Single(
+            Assert.Single(
+                types.Rows,
+                row => ReferenceEquals(
+                    row.ProducerRow,
+                    receiver)).Members);
+        Assert.Same(
+            declaringRow.Subject,
+            projectedRow.Subject.DeclaringType);
+        Assert.Equal(
+            ApiMemberIdentity.GetMemberAnchor(declaring, declaration),
+            projectedRow.Subject.Identity.Member);
     }
 
     [Fact]
@@ -511,6 +772,20 @@ public sealed class NavigationSubjectInventoryTests
             Kind = "method",
             Signature = $"void {name}()",
         };
+
+    static ApiMember ProjectedMember(
+        string name,
+        MetadataTypeDefinitionName? declaringType,
+        int? metadataToken = 0x06000001)
+    {
+        ApiMember member = Member(name);
+        member.Kind = "extension-method";
+        member.MetadataToken = metadataToken;
+        member.DeclaringType = "Display text is not identity";
+        member.DeclaringTypeCanonicalName = "Sample.Extensions";
+        member.DeclaringTypeDefinitionName = declaringType;
+        return member;
+    }
 
     static ApiSurfaceInspectionFailure InspectionFailure(string operation) =>
         new(

--- a/src/DotnetInspector.Queries/NavigationSubjectInventory.cs
+++ b/src/DotnetInspector.Queries/NavigationSubjectInventory.cs
@@ -4,6 +4,17 @@ using ILInspector.Metadata;
 
 namespace DotnetInspector.Queries;
 
+/// <summary>Why a projected Member could not acquire exact declaration identity.</summary>
+public enum NavigationProjectedMemberIdentityFailureKind
+{
+    DeclaringTypeIdentityMissing,
+    DeclaringTypeNotReturned,
+    DeclaringTypeAmbiguous,
+    DeclarationMemberIdentityMissing,
+    DeclarationMemberNotReturned,
+    DeclarationMemberAmbiguous,
+}
+
 /// <summary>Typed evidence that prevented one complete Type inventory.</summary>
 public abstract record NavigationInventoryEvidence
 {
@@ -84,23 +95,27 @@ public abstract record NavigationInventoryEvidence
         public ApiType ProducerRow { get; }
     }
 
-    /// <summary>A projected Member lacked an exact local declaring Type.</summary>
-    public sealed record MemberIdentityMissing : NavigationInventoryEvidence
+    /// <summary>A projected Member could not bind one exact local declaration.</summary>
+    public sealed record ProjectedMemberIdentityFailure :
+        NavigationInventoryEvidence
     {
-        internal MemberIdentityMissing(
+        internal ProjectedMemberIdentityFailure(
             StructuralSubjectIdentity.LibrarySubject library,
             ApiType containingType,
-            ApiMember producerRow)
+            ApiMember producerRow,
+            NavigationProjectedMemberIdentityFailureKind kind)
             : base(library)
         {
             ArgumentNullException.ThrowIfNull(containingType);
             ArgumentNullException.ThrowIfNull(producerRow);
             ContainingType = containingType;
             ProducerRow = producerRow;
+            Kind = kind;
         }
 
         public ApiType ContainingType { get; }
         public ApiMember ProducerRow { get; }
+        public NavigationProjectedMemberIdentityFailureKind Kind { get; }
     }
 
     /// <summary>A projection bound omitted this Library and every later row.</summary>
@@ -157,10 +172,11 @@ public sealed record NavigationTypeInventoryRow
         foreach (NavigationMemberInventoryRow? member in members)
         {
             if (member is null
-                || member.Subject.DeclaringType != subject)
+                || member.Subject.DeclaringType.Library != subject.Library)
             {
                 throw new ArgumentException(
-                    "Every exact Member row must belong to its containing Type.",
+                    "Every exact Member row must belong to the containing "
+                        + "Type's Library.",
                     nameof(members));
             }
         }
@@ -647,6 +663,17 @@ public static class NavigationSubjectInventoryClassification
         var rows = ImmutableArray.CreateBuilder<NavigationTypeInventoryRow>();
         var evidence =
             ImmutableArray.CreateBuilder<NavigationInventoryEvidence>();
+        void AddProjectedMemberFailure(
+            ApiType containingType,
+            ApiMember member,
+            NavigationProjectedMemberIdentityFailureKind kind)
+            => evidence.Add(
+                new NavigationInventoryEvidence.ProjectedMemberIdentityFailure(
+                    library,
+                    containingType,
+                    member,
+                    kind));
+
         foreach (ApiSurfaceInspectionFailure? failure
             in available.InspectionFailures)
         {
@@ -667,6 +694,10 @@ public static class NavigationSubjectInventoryClassification
                 ApiType,
                 StructuralSubjectIdentity.TypeSubject>(
                     ReferenceEqualityComparer.Instance);
+        var typeByDefinition =
+            new Dictionary<MetadataTypeDefinitionName, ApiType>();
+        var ambiguousTypeDefinitions =
+            new HashSet<MetadataTypeDefinitionName>();
         foreach (ApiType? type in available.Surface.Types)
         {
             if (type is null)
@@ -686,6 +717,8 @@ public static class NavigationSubjectInventoryClassification
             StructuralSubjectIdentity.TypeSubject subject =
                 StructuralSubjectIdentity.ForType(library, definition);
             subjectByType.Add(type, subject);
+            if (!typeByDefinition.TryAdd(definition, type))
+                ambiguousTypeDefinitions.Add(definition);
         }
 
         foreach (ApiType? type in available.Surface.Types)
@@ -714,13 +747,101 @@ public static class NavigationSubjectInventoryClassification
                         "API Type rows cannot contain null Member rows.",
                         nameof(available));
                 }
-                if (member.DeclaringTypeCanonicalName is not null)
+                if (member.DeclaringTypeCanonicalName is not null
+                    || member.DeclaringTypeDefinitionName is not null)
                 {
-                    evidence.Add(
-                        new NavigationInventoryEvidence.MemberIdentityMissing(
-                            library,
+                    if (member.DeclaringTypeDefinitionName
+                        is not { } declaringTypeDefinition)
+                    {
+                        AddProjectedMemberFailure(
                             type,
-                            member));
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclaringTypeIdentityMissing);
+                        continue;
+                    }
+                    if (ambiguousTypeDefinitions.Contains(
+                        declaringTypeDefinition))
+                    {
+                        AddProjectedMemberFailure(
+                            type,
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclaringTypeAmbiguous);
+                        continue;
+                    }
+                    if (!typeByDefinition.TryGetValue(
+                        declaringTypeDefinition,
+                        out ApiType? declaringType)
+                        || declaringType is null)
+                    {
+                        AddProjectedMemberFailure(
+                            type,
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclaringTypeNotReturned);
+                        continue;
+                    }
+                    if (member.MetadataToken is not { } declarationToken)
+                    {
+                        AddProjectedMemberFailure(
+                            type,
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclarationMemberIdentityMissing);
+                        continue;
+                    }
+
+                    ApiMember? declaration = null;
+                    bool declarationIsAmbiguous = false;
+                    foreach (ApiMember? candidate in declaringType.Members)
+                    {
+                        if (candidate is null)
+                        {
+                            throw new ArgumentException(
+                                "API Type rows cannot contain null Member rows.",
+                                nameof(available));
+                        }
+                        if (candidate.DeclaringTypeCanonicalName is not null
+                            || candidate.DeclaringTypeDefinitionName is not null
+                            || candidate.MetadataToken != declarationToken)
+                        {
+                            continue;
+                        }
+                        if (declaration is not null)
+                        {
+                            declarationIsAmbiguous = true;
+                            break;
+                        }
+                        declaration = candidate;
+                    }
+                    if (declarationIsAmbiguous)
+                    {
+                        AddProjectedMemberFailure(
+                            type,
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclarationMemberAmbiguous);
+                        continue;
+                    }
+                    if (declaration is null)
+                    {
+                        AddProjectedMemberFailure(
+                            type,
+                            member,
+                            NavigationProjectedMemberIdentityFailureKind
+                                .DeclarationMemberNotReturned);
+                        continue;
+                    }
+
+                    members.Add(
+                        new NavigationMemberInventoryRow(
+                            member,
+                            StructuralSubjectIdentity.ForMember(
+                                subjectByType[declaringType],
+                                ApiMemberIdentity.GetMemberAnchor(
+                                    declaringType,
+                                    declaration))));
                     continue;
                 }
                 members.Add(


### PR DESCRIPTION
## Summary

Projected API members now remain in the receiver Type's inventory row while
their Navigation subject binds the exact declaration Type and the exact
declaration-side Member anchor.

- Resolve `DeclaringTypeDefinitionName` only against exact Type rows in the
  same Library.
- Resolve the declaration Member by its producer-issued metadata token and
  reuse its complete `MemberAnchor`.
- Retain typed failure evidence and emit no false Member subject when either
  join is missing, not returned, or ambiguous.
- Keep display and canonical declaring text out of lookup identity.

The capability is host-neutral. Its named consumers remain the CLI work in
#5513 and the Browser/Wasm work in #5510 and #5511; #5512 tracks the
end-to-end Navigation experience.

## Demo

The real API-surface producer projects
`InventoryExtensions.Extend` beneath `InventoryFixture`.

| | Inventory placement | Subject declaration | Member anchor |
| --- | --- | --- | --- |
| Before | Receiver Type | No subject emitted | Identity failure |
| After | Receiver Type | `InventoryExtensions` | Exact declaration-side anchor |

The focused executable gate demonstrates the producer-to-Navigation path:

```text
dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class 'DotnetInspector.Queries.Tests.NavigationSubjectInventoryTests'

Total: 17, Errors: 0, Failed: 0, Skipped: 0
```

Neighboring malformed bounded surfaces demonstrate visible typed failures for
missing, unreturned, and ambiguous Type or Member identity, including
misleading declaring text that cannot redirect the typed join.

## Compatibility and non-claims

- Preserves declaration-side Member behavior and producer order.
- Uses existing host-neutral Query and Metadata contracts; it does not add a
  host or rendering surface.
- Does not render Navigation, compose snapshots, or mint actions.
- Uses the current coordinate-rooted subject seam; #5518 must preserve this
  declaration binding when structural identity becomes Workspace-rooted.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  - 1,080 passed
- Replacement-head focused gate after parent integration
  - 17 passed
- `npx markdownlint-cli docs/design/inspection-subject-navigation.md`
- `git diff --check`

## Stack

- Upper slice targeting parent PR #5524
- Parent head used to form this candidate:
  `06ea69de02702e81507933a00d6317a6704f5e30`
- This slice contains only projected-Member Navigation identity adoption.

Closes #5539
