### PR TITLE
Track generic type-argument angle brackets when splitting call arguments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1127,6 +1127,12 @@ public class CSharpStructuralComparisonTests
     // character set, breaking recognition the same way an unescaped
     // identifier would if it were rejected.
     [InlineData("Bar<@event,B>()", new[] { "Bar<@event,B>()" })]
+    // Round-2 review (GPT-5.6 Sol, seat A): a supplementary-plane Unicode
+    // identifier character (encoded as a UTF-16 surrogate pair) is valid
+    // generic type-argument syntax, but the round-1 fix still classified
+    // each `char` independently via `char.IsLetterOrDigit`, which rejects
+    // both halves of the surrogate pair.
+    [InlineData("Bar<\U0001D4CD,B>()", new[] { "Bar<\U0001D4CD,B>()" })]
     public void SplitTopLevelArguments_DoesNotSplitInsideGenericTypeArgumentList(
         string argsText,
         string[] expectedArguments)

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1121,6 +1121,12 @@ public class CSharpStructuralComparisonTests
     [InlineData("Bar<A,B>()", new[] { "Bar<A,B>()" })]
     [InlineData("Bar<A,receiver,B>()", new[] { "Bar<A,receiver,B>()" })]
     [InlineData("Dictionary<string, List<int>>.Empty", new[] { "Dictionary<string, List<int>>.Empty" })]
+    // Round-1 review (GPT-5.6 Sol): a C#-escaped (verbatim) identifier such
+    // as `@event` is valid generic type-argument syntax and is produced by
+    // this printer, but was outside TryFindGenericArgumentListEnd's accepted
+    // character set, breaking recognition the same way an unescaped
+    // identifier would if it were rejected.
+    [InlineData("Bar<@event,B>()", new[] { "Bar<@event,B>()" })]
     public void SplitTopLevelArguments_DoesNotSplitInsideGenericTypeArgumentList(
         string argsText,
         string[] expectedArguments)
@@ -1139,6 +1145,22 @@ public class CSharpStructuralComparisonTests
         // separator, exactly as before this fix.
         var arguments = CSharpStructuralDiffPrinter.SplitTopLevelArguments("a < b, c");
         Assert.Equal(["a < b", "c"], arguments);
+    }
+
+    [Fact]
+    public void SplitTopLevelArguments_StillSplitsAroundShiftOperatorArguments()
+    {
+        // Round-1 review (GPT-5.6 Sol): `<<`/`>>` are ordinary shift
+        // operators, not two adjacent generic-argument-list opens/closes --
+        // a real nested generic open always has an identifier between
+        // successive `<` characters (e.g. `Foo<Bar<Baz>>`), so two `<`
+        // characters can never legitimately be adjacent. Without this guard,
+        // the second `<` of `<<` was independently misrecognized as its own
+        // generic-list open, and the first `>` of the trailing `>>`
+        // incorrectly closed it, swallowing the genuine top-level commas
+        // between `a << b`, `receiver`, and `c >> d`.
+        var arguments = CSharpStructuralDiffPrinter.SplitTopLevelArguments("a << b, receiver, c >> d");
+        Assert.Equal(["a << b", "receiver", "c >> d"], arguments);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpStructuralComparisonTests.cs
@@ -1112,6 +1112,91 @@ public class CSharpStructuralComparisonTests
         Assert.Equal("", overlongDisplay.Detail);
     }
 
+    [Theory]
+    // Issue #5494: `SplitTopLevelArguments` must not mistake a comma nested
+    // inside a generic type-argument list for a top-level argument
+    // separator. The outer call always has exactly one top-level argument
+    // in these repros; a naive scan (no `<`/`>` tracking) would wrongly
+    // split it into two or three.
+    [InlineData("Bar<A,B>()", new[] { "Bar<A,B>()" })]
+    [InlineData("Bar<A,receiver,B>()", new[] { "Bar<A,receiver,B>()" })]
+    [InlineData("Dictionary<string, List<int>>.Empty", new[] { "Dictionary<string, List<int>>.Empty" })]
+    public void SplitTopLevelArguments_DoesNotSplitInsideGenericTypeArgumentList(
+        string argsText,
+        string[] expectedArguments)
+    {
+        var arguments = CSharpStructuralDiffPrinter.SplitTopLevelArguments(argsText);
+        Assert.Equal(expectedArguments, arguments);
+    }
+
+    [Fact]
+    public void SplitTopLevelArguments_StillSplitsPlainLessThanComparisonArguments()
+    {
+        // Guard against over-correcting #5494: a lone `<` with no matching
+        // `>` before the argument list ends is not a generic type-argument
+        // list -- it is an ordinary less-than comparison -- so the comma
+        // that follows it must still split as a top-level argument
+        // separator, exactly as before this fix.
+        var arguments = CSharpStructuralDiffPrinter.SplitTopLevelArguments("a < b, c");
+        Assert.Equal(["a < b", "c"], arguments);
+    }
+
+    [Fact]
+    public void TryFindArgumentSpan_LocatesArgumentPastNestedGenericTypeArgumentList()
+    {
+        // Companion to SplitTopLevelArguments_DoesNotSplitInsideGenericTypeArgumentList,
+        // exercised through the narrowing helper (#5486) directly: the sole
+        // top-level argument `Bar<A,B>()` must be found as argument 0, not
+        // split at the comma nested inside `<A,B>`.
+        const string text = "Foo(Bar<A,B>())";
+        Assert.True(CSharpStructuralDiffPrinter.TryFindArgumentSpan(text, 0, out int start, out int length));
+        Assert.Equal("Bar<A,B>()", text.Substring(start, length));
+
+        // And a genuinely inserted second top-level argument after the
+        // generic call must still be found correctly.
+        const string textWithSecondArgument = "Foo(Bar<A,B>(), receiver)";
+        Assert.True(CSharpStructuralDiffPrinter.TryFindArgumentSpan(textWithSecondArgument, 1, out int start2, out int length2));
+        Assert.Equal("receiver", textWithSecondArgument.Substring(start2, length2));
+    }
+
+    [Fact]
+    public void CompareStructure_DoesNotMistakeGenericTypeArgumentForQualifierMovedIntoArgument()
+    {
+        // Issue #5494 end-to-end: `receiver` never appears as a top-level
+        // call argument in either version -- it only ever appears nested
+        // inside a generic type-argument list (`Bar<A,receiver,B>`). The
+        // qualifier/argument shape must not be recognized here at all (the
+        // outer call's argument count is unchanged, 1 -> 1), so this must
+        // fall back to the honest text dump rather than claiming `receiver`
+        // "moved to argument N".
+        const string beforeText = "receiver.Foo(Bar<A,B>())";
+        const string afterText = "Foo(Bar<A,receiver,B>())";
+
+        var comparison = CSharpBodyDiff.CompareStructure(new(
+            "M",
+            Document(beforeText, "InvocationExpression", beforeText),
+            Document(afterText, "InvocationExpression", afterText),
+            [0],
+            [0],
+            [new CSharpNodeCorrespondence(0, 0)]));
+
+        var row = Assert.Single(comparison.Rows);
+        var beforeSpan = Assert.Single(row.BeforeSpans);
+        var afterSpan = Assert.Single(row.AfterSpans);
+
+        // No false narrowing to a generic-argument `receiver` token: the row
+        // must keep its full, un-narrowed call span on both sides.
+        Assert.Equal(0, beforeSpan.Start);
+        Assert.Equal(beforeText.Length, beforeSpan.Length);
+        Assert.Equal(0, afterSpan.Start);
+        Assert.Equal(afterText.Length, afterSpan.Length);
+
+        string beforeBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(comparison, CSharpStructuralSide.Before);
+        string afterBody = CSharpStructuralDiffPrinter.RenderAnnotatedBody(comparison, CSharpStructuralSide.After);
+        Assert.DoesNotContain("qualifier", beforeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("moved to argument", afterBody, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void RenderAnnotatedBody_FallsBackToTextDumpWhenQualifierRoleShapeIsNotRecognized()
     {

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -1306,7 +1306,8 @@ public static class CSharpStructuralDiffPrinter
     ///
     /// This is a best-effort textual heuristic, not a parser: it accepts
     /// only characters that can appear in a type-argument list (identifier
-    /// characters, <c>.</c>, <c>,</c>, whitespace, nested <c>&lt;&gt;</c>,
+    /// characters, the <c>@</c> verbatim-identifier escape prefix (e.g.
+    /// <c>@event</c>), <c>.</c>, <c>,</c>, whitespace, nested <c>&lt;&gt;</c>,
     /// and array-suffix <c>[]</c>) and bails (returns <c>false</c>) the
     /// moment it sees anything else -- a parenthesis, brace, quote,
     /// semicolon, or an arithmetic/comparison/logical operator -- treating
@@ -1337,7 +1338,7 @@ public static class CSharpStructuralDiffPrinter
                 continue;
             }
             if (char.IsLetterOrDigit(character)
-                || character is '_' or '.' or ',' or '[' or ']'
+                || character is '_' or '.' or ',' or '[' or ']' or '@'
                 || char.IsWhiteSpace(character))
             {
                 continue;
@@ -1374,10 +1375,23 @@ public static class CSharpStructuralDiffPrinter
             }
             if (character == '"') { inString = true; continue; }
             if (character == '\'') { inChar = true; continue; }
-            if (character == '<' && TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+            if (character == '<')
             {
-                index = genericClose;
-                continue;
+                // `<<` is always the shift-left operator, never two adjacent
+                // generic-argument-list opens (a real nested open always has
+                // an identifier between successive `<` characters, e.g.
+                // `Foo<Bar<Baz>>`). Skip both characters so the second `<`
+                // is never independently reconsidered as its own opener.
+                if (index + 1 < argsText.Length && argsText[index + 1] == '<')
+                {
+                    index++;
+                    continue;
+                }
+                if (TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+                {
+                    index = genericClose;
+                    continue;
+                }
             }
             if (character is '(' or '[' or '{') depth++;
             else if (character is ')' or ']' or '}') depth--;
@@ -1441,10 +1455,21 @@ public static class CSharpStructuralDiffPrinter
             }
             if (character == '"') { inString = true; continue; }
             if (character == '\'') { inChar = true; continue; }
-            if (character == '<' && TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+            if (character == '<')
             {
-                index = genericClose;
-                continue;
+                // See the matching comment in SplitTopLevelArguments: `<<`
+                // is always the shift-left operator, never two adjacent
+                // generic-argument-list opens.
+                if (index + 1 < argsText.Length && argsText[index + 1] == '<')
+                {
+                    index++;
+                    continue;
+                }
+                if (TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+                {
+                    index = genericClose;
+                    continue;
+                }
             }
             if (character is '(' or '[' or '{') { depth++; continue; }
             if (character is ')' or ']' or '}') { depth--; continue; }

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -1293,7 +1293,61 @@ public static class CSharpStructuralDiffPrinter
         return -1;
     }
 
-    static ImmutableArray<string> SplitTopLevelArguments(string argsText)
+    /// <summary>
+    /// If <paramref name="text"/>[<paramref name="lessThanIndex"/>] opens
+    /// what looks like a generic type-argument list (e.g. <c>Bar&lt;A, B&gt;</c>
+    /// or <c>Dictionary&lt;string, List&lt;int&gt;&gt;</c>), returns the index
+    /// of its matching closing <c>&gt;</c>. Used by
+    /// <see cref="SplitTopLevelArguments"/> and
+    /// <see cref="TryFindArgumentSpan"/> so a comma nested inside a generic
+    /// type-argument list (itself nested inside a call argument, e.g.
+    /// <c>Foo(Bar&lt;A,B&gt;())</c>) is never mistaken for a top-level
+    /// argument separator (issue #5494).
+    ///
+    /// This is a best-effort textual heuristic, not a parser: it accepts
+    /// only characters that can appear in a type-argument list (identifier
+    /// characters, <c>.</c>, <c>,</c>, whitespace, nested <c>&lt;&gt;</c>,
+    /// and array-suffix <c>[]</c>) and bails (returns <c>false</c>) the
+    /// moment it sees anything else -- a parenthesis, brace, quote,
+    /// semicolon, or an arithmetic/comparison/logical operator -- treating
+    /// the opening <c>&lt;</c> as an ordinary character (e.g. a
+    /// less-than/greater-than comparison such as <c>a &lt; b</c>), exactly
+    /// as before this method existed. A comparison chain that happens to
+    /// contain a second, unrelated <c>&gt;</c> before any disqualifying
+    /// character (e.g. <c>a &lt; b, c &gt; d</c>) can still be misread as a
+    /// generic argument list; full disambiguation requires a real C# parser
+    /// and is out of scope here (see #5494).
+    /// </summary>
+    static bool TryFindGenericArgumentListEnd(string text, int lessThanIndex, out int closeIndex)
+    {
+        closeIndex = -1;
+        int depth = 1;
+        for (int index = lessThanIndex + 1; index < text.Length; index++)
+        {
+            char character = text[index];
+            if (character == '<') { depth++; continue; }
+            if (character == '>')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    closeIndex = index;
+                    return true;
+                }
+                continue;
+            }
+            if (char.IsLetterOrDigit(character)
+                || character is '_' or '.' or ',' or '[' or ']'
+                || char.IsWhiteSpace(character))
+            {
+                continue;
+            }
+            return false;
+        }
+        return false;
+    }
+
+    internal static ImmutableArray<string> SplitTopLevelArguments(string argsText)
     {
         if (argsText.Trim().Length == 0)
             return [];
@@ -1320,6 +1374,11 @@ public static class CSharpStructuralDiffPrinter
             }
             if (character == '"') { inString = true; continue; }
             if (character == '\'') { inChar = true; continue; }
+            if (character == '<' && TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+            {
+                index = genericClose;
+                continue;
+            }
             if (character is '(' or '[' or '{') depth++;
             else if (character is ')' or ']' or '}') depth--;
             else if (character == ',' && depth == 0)
@@ -1382,6 +1441,11 @@ public static class CSharpStructuralDiffPrinter
             }
             if (character == '"') { inString = true; continue; }
             if (character == '\'') { inChar = true; continue; }
+            if (character == '<' && TryFindGenericArgumentListEnd(argsText, index, out int genericClose))
+            {
+                index = genericClose;
+                continue;
+            }
             if (character is '(' or '[' or '{') { depth++; continue; }
             if (character is ')' or ']' or '}') { depth--; continue; }
             if (character != ',' || depth != 0)

--- a/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpStructuralDiffPrinter.cs
@@ -1306,9 +1306,11 @@ public static class CSharpStructuralDiffPrinter
     ///
     /// This is a best-effort textual heuristic, not a parser: it accepts
     /// only characters that can appear in a type-argument list (identifier
-    /// characters, the <c>@</c> verbatim-identifier escape prefix (e.g.
-    /// <c>@event</c>), <c>.</c>, <c>,</c>, whitespace, nested <c>&lt;&gt;</c>,
-    /// and array-suffix <c>[]</c>) and bails (returns <c>false</c>) the
+    /// characters -- including supplementary-plane Unicode identifier
+    /// characters encoded as UTF-16 surrogate pairs -- the <c>@</c>
+    /// verbatim-identifier escape prefix (e.g. <c>@event</c>), <c>.</c>,
+    /// <c>,</c>, whitespace, nested <c>&lt;&gt;</c>, and array-suffix
+    /// <c>[]</c>) and bails (returns <c>false</c>) the
     /// moment it sees anything else -- a parenthesis, brace, quote,
     /// semicolon, or an arithmetic/comparison/logical operator -- treating
     /// the opening <c>&lt;</c> as an ordinary character (e.g. a
@@ -1337,12 +1339,30 @@ public static class CSharpStructuralDiffPrinter
                 }
                 continue;
             }
-            if (char.IsLetterOrDigit(character)
-                || character is '_' or '.' or ',' or '[' or ']' or '@'
+            if (character is '_' or '.' or ',' or '[' or ']' or '@'
                 || char.IsWhiteSpace(character))
             {
                 continue;
             }
+            if (char.IsHighSurrogate(character)
+                && index + 1 < text.Length
+                && char.IsLowSurrogate(text[index + 1]))
+            {
+                // A supplementary-plane identifier character (e.g. a
+                // mathematical alphanumeric symbol) is a single Unicode
+                // scalar value encoded as a UTF-16 surrogate pair; scan it
+                // as one Rune rather than rejecting on the lone high
+                // surrogate `char`.
+                var rune = new System.Text.Rune(character, text[index + 1]);
+                if (IsIdentifierPartRune(rune))
+                {
+                    index++;
+                    continue;
+                }
+                return false;
+            }
+            if (!char.IsSurrogate(character) && IsIdentifierPartRune(new System.Text.Rune(character)))
+                continue;
             return false;
         }
         return false;


### PR DESCRIPTION
Fixes #5494.

## Context

Round 2 review of PR #5490 (issue #5486) found that `SplitTopLevelArguments`
and `TryFindArgumentSpan` mishandle commas nested inside a generic
type-argument list (`<...>`). They already track nested `()`, `[]`, and `{}`
depth when splitting an invocation's top-level arguments, but not `<...>`
nesting, so a qualifier identifier appearing nested inside a generic
type-argument list could be mistaken for an inserted top-level call
argument.

## Fix

Add a shared `TryFindGenericArgumentListEnd` heuristic used by both
`SplitTopLevelArguments` and `TryFindArgumentSpan`: when an opening `<` is
followed only by identifier characters, `.`, `,`, whitespace, `[`, `]`, and
nested `<...>` before a matching `>`, the whole span is treated as a single
token and skipped. Otherwise (an operator, paren, brace, quote, or unmatched
`<`) the character is left alone, preserving existing behavior for ordinary
less-than/greater-than comparisons such as `Foo(a < b, c)`.

This is a best-effort textual heuristic, not a parser, and does not attempt
to resolve the general ambiguity between a generic argument list and a
double comparison chain (e.g. `a < b, c > d`) -- documented as a known,
out-of-scope limitation in the new helper's doc comment, matching the
original issue's framing.

## Demo

Repro from #5494. **This is not a natural code edit** -- issue #5494's own
history says so directly: it was constructed by a reviewer of PR #5490 as an
adversarial textual probe against the shared shape-recognition logic, not
observed from a real diff. Nobody would refactor
`receiver.Foo(Bar<A,B>())` into `Foo(Bar<A,receiver,B>())` by editing one
method body; the point of the shape is that `receiver` never appears as a
top-level call argument in either version -- it only ever appears nested
inside a generic type-argument list -- which is exactly what defeats a
comma-splitter that doesn't track `<...>` nesting.

**Original source.** To confirm the probe is genuine, legal C# and not an
invented string, both call expressions below are drawn verbatim from real,
independently compilable programs (verified with `dotnet run`, zero errors,
clean exit). They are two *unrelated* programs, not one program before and
after an edit: `receiver` is deliberately both a type name and a
parameter/qualifier name, which is legal C# (context disambiguates a simple
name as a type or a value), and that's what lets the identifier `receiver`
appear as a call qualifier in one program and as a generic type argument in
the other:

```csharp
// Program 1: Run is static; receiver is a Widget parameter, used as the
// extension-style qualifier for Foo. Produces: receiver.Foo(Bar<A,B>())
class A { }
class B { }
class receiver { }

class Widget
{
    static object Bar<T1, T2>() => null;
    object Foo(object x) => x;
    static object Run(Widget receiver) => receiver.Foo(Bar<A,B>());
}
```

```csharp
// Program 2: Run is an instance method (Foo is called unqualified, on the
// implicit `this`), and the type `receiver` now appears only nested inside
// Bar's 3-argument generic type-argument list. Produces: Foo(Bar<A,receiver,B>())
class A { }
class B { }
class receiver { }

class Widget
{
    static object Bar<T1, T2, T3>() => null;
    object Foo(object x) => x;
    object Run() => Foo(Bar<A,receiver,B>());
}
```

The printer operates on the call-expression text only (not full source
files). The regression test uses the two call expressions these programs
produce, presented here as the shape's before/after per #5494:

```csharp
// Before:
receiver.Foo(Bar<A,B>())
// After:
Foo(Bar<A,receiver,B>())
```

**Before this fix**, the printer falsely claimed `receiver` moved from
qualifier to a top-level call argument:

```text
BEFORE:
receiver.Foo(Bar<A,B>())
^^^^^^^^
raise: InvocationExpression; receiver: used as extension-call qualifier

AFTER:
Foo(Bar<A,receiver,B>())
//        ^^^^^^^^
//        raise: InvocationExpression; receiver: moved to argument 2 (static call)
```

**After this fix**, the shape is correctly not recognized (the outer call's
argument count is unchanged, 1 -> 1 in both versions), so the printer falls
back to the honest, generic text-changed description instead of a false
qualifier<->argument claim:

```text
BEFORE:
receiver.Foo(Bar<A,B>())
^^^^^^^^^^^^^^^^^^^^^^^^
raise: InvocationExpression; changed to Foo(Bar<A,receiver,B>())

AFTER:
Foo(Bar<A,receiver,B>())
^^^^^^^^^^^^^^^^^^^^^^^^
raise: InvocationExpression; changed from receiver.Foo(Bar<A,B>())
```

Both captures are real xUnit failure-message output from a temporary
`DEMO_CAPTURE`-gated throw added to the new regression test, run against the
pre-fix and post-fix printer respectively, then fully reverted before this
commit (`git diff` against the pushed commit is empty).

A neighboring, non-ambiguous generic-heavy shape (`Dictionary<string,
List<int>>.Empty`, nested generics with no comparison-operator risk) still
splits correctly, and a genuinely inserted second top-level argument
following a generic call (`Foo(Bar<A,B>(), receiver)`) is still found and
narrowed correctly -- see the new
`SplitTopLevelArguments_DoesNotSplitInsideGenericTypeArgumentList` and
`TryFindArgumentSpan_LocatesArgumentPastNestedGenericTypeArgumentList` tests.
A guard test
(`SplitTopLevelArguments_StillSplitsPlainLessThanComparisonArguments`)
confirms the pre-existing behavior for an ordinary less-than comparison
argument (`Foo(a < b, c)`) is unchanged.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`: builds clean.
- `dotnet exec artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class ILInspector.Decompiler.Tests.CSharpStructuralComparisonTests`:
  100/100 passing (94 pre-existing + 6 new).
- Full `ILInspector.Decompiler.Tests` suite (6228 test cases, run before this
  PR's change against the merge-base): 0 errors, 1 pre-existing failure
  traced to a fixture not built by the narrower project-only build command
  (resolved by building the full solution graph), 8 environment-gated skips
  (`ilasm`/`mdv` unavailable). Unrelated to this change.

## Scope

This affects only the shared low-level argument-splitting helpers, per
issue #5494's stated scope; it does not change the higher-level
narrowing/caption architecture.


