### PR TITLE
Implement ComparisonDocument<T> composition format

### DIFF
--- a/docs/design/comparison-document.md
+++ b/docs/design/comparison-document.md
@@ -2,9 +2,10 @@
 
 ## Status and ownership
 
-This document proposes the `ILInspector.Findings`-owned
+This document defines the `ILInspector.Findings`-owned
 `ComparisonDocument<T>` composition format for
-[#5499](https://github.com/richlander/dotnet-inspect/issues/5499).
+[#5499](https://github.com/richlander/dotnet-inspect/issues/5499), implemented
+in [#5550](https://github.com/richlander/dotnet-inspect/issues/5550).
 
 It is the second design slice in the structured-comparison delivery sequence:
 
@@ -50,8 +51,12 @@ The producer owns:
 Consumers own filtering, aggregation, analysis of `T`, navigation, and
 presentation.
 
-All behavior is unverified until the implementation effort adds the Release
-gates under [Required gates](#required-gates).
+The format is implemented by `ComparisonDocument<T>`,
+`ComparisonSubject<T>`, the closed subject-change and root-comparison cases,
+the exceptional-description value types, and the AOT-safe
+`ComparisonDocumentJson` codec. The Release gates under
+[Required gates](#required-gates) verify the Findings-owned construction,
+structured-form, and value contracts.
 
 ### Consumers and delivery
 

--- a/src/ILInspector.Findings/ComparisonDocument.cs
+++ b/src/ILInspector.Findings/ComparisonDocument.cs
@@ -1,0 +1,628 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Findings;
+
+/// <summary>How subject identifiers are interpreted within one comparison document.</summary>
+public enum SubjectCoordinateBasis
+{
+    /// <summary>Every subject identifier is complete in the producer's outer comparison context.</summary>
+    OuterContext,
+
+    /// <summary>Every subject identifier is complete relative to its corresponding root endpoint.</summary>
+    RootRelative,
+}
+
+/// <summary>The exceptional coordinate change described by a change description.</summary>
+public enum ComparisonExceptionalChangeKind
+{
+    Rename,
+    Move,
+    RenameAndMove,
+}
+
+/// <summary>
+/// One closed composition-level change for a comparison root or subject.
+/// Payload-internal changes remain owned by the payload.
+/// </summary>
+public abstract record ComparisonSubjectChange
+{
+    private ComparisonSubjectChange()
+    {
+    }
+
+    // Records synthesize a protected copy constructor. This inaccessible abstract member prevents
+    // external records from using that constructor to extend the closed change hierarchy.
+    private protected abstract void EnsureKnownChange();
+
+    /// <summary>No composition-level existence or coordinate change.</summary>
+    public sealed record Diff : ComparisonSubjectChange
+    {
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+
+    /// <summary>The subject exists only on the After endpoint.</summary>
+    public sealed record Addition : ComparisonSubjectChange
+    {
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+
+    /// <summary>The subject exists only on the Before endpoint.</summary>
+    public sealed record Deletion : ComparisonSubjectChange
+    {
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+
+    /// <summary>The local subject identity changed within one containing coordinate.</summary>
+    public sealed record Rename : ComparisonSubjectChange
+    {
+        public Rename(string ChangeId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ChangeId);
+            this.ChangeId = ChangeId;
+        }
+
+        public string ChangeId { get; }
+
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+
+    /// <summary>The containing coordinate changed while local subject identity was retained.</summary>
+    public sealed record Move : ComparisonSubjectChange
+    {
+        public Move(string ChangeId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ChangeId);
+            this.ChangeId = ChangeId;
+        }
+
+        public string ChangeId { get; }
+
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+
+    /// <summary>Both local subject identity and containing coordinate changed.</summary>
+    public sealed record RenameAndMove : ComparisonSubjectChange
+    {
+        public RenameAndMove(string ChangeId)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(ChangeId);
+            this.ChangeId = ChangeId;
+        }
+
+        public string ChangeId { get; }
+
+        private protected override void EnsureKnownChange()
+        {
+        }
+    }
+}
+
+/// <summary>A root comparison that is explicitly present or structurally not applicable.</summary>
+public abstract record ComparisonRootComparison<T>
+    where T : notnull
+{
+    private ComparisonRootComparison()
+    {
+    }
+
+    // Records synthesize a protected copy constructor. This inaccessible abstract member prevents
+    // external records from using that constructor to extend the closed presence hierarchy.
+    private protected abstract void EnsureKnownComparison();
+
+    /// <summary>The root has one comparison payload.</summary>
+    public sealed record Present : ComparisonRootComparison<T>
+    {
+        public Present(T Comparison)
+        {
+            if (Comparison is null)
+                throw new ArgumentNullException(nameof(Comparison));
+            this.Comparison = Comparison;
+        }
+
+        public T Comparison { get; }
+
+        private protected override void EnsureKnownComparison()
+        {
+        }
+
+        public bool Equals(Present? other)
+            => other is not null
+                && EqualityComparer<T>.Default.Equals(Comparison, other.Comparison);
+
+        public override int GetHashCode()
+            => EqualityComparer<T>.Default.GetHashCode(Comparison);
+    }
+
+    /// <summary>The payload type has no meaningful root-wide item space.</summary>
+    public sealed record NotApplicable : ComparisonRootComparison<T>
+    {
+        private protected override void EnsureKnownComparison()
+        {
+        }
+    }
+}
+
+/// <summary>One complete portable endpoint for an exceptional subject change.</summary>
+public sealed record ComparisonSubjectEndpoint
+{
+    public ComparisonSubjectEndpoint(string Identifier, string Display)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Identifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Display);
+        this.Identifier = Identifier;
+        this.Display = Display;
+    }
+
+    public string Identifier { get; }
+    public string Display { get; }
+}
+
+/// <summary>One producer-issued refinement of an exceptional coordinate change.</summary>
+public sealed record ComparisonTransformationDescriptor
+{
+    public ComparisonTransformationDescriptor(string Identifier, string Display)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Identifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Display);
+        this.Identifier = Identifier;
+        this.Display = Display;
+    }
+
+    public string Identifier { get; }
+    public string Display { get; }
+}
+
+/// <summary>The complete endpoint detail referenced by one exceptional root or subject.</summary>
+public sealed record ComparisonChangeDescription
+{
+    public ComparisonChangeDescription(
+        string Id,
+        ComparisonExceptionalChangeKind Kind,
+        ComparisonSubjectEndpoint Before,
+        ComparisonSubjectEndpoint After,
+        ImmutableArray<ComparisonTransformationDescriptor> Transformations)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Id);
+        this.Kind = Validate(Kind);
+        this.Before = Before ?? throw new ArgumentNullException(nameof(Before));
+        this.After = After ?? throw new ArgumentNullException(nameof(After));
+        if (StringComparer.Ordinal.Equals(Before.Identifier, After.Identifier))
+        {
+            throw new ArgumentException(
+                "Exceptional Before and After identifiers must differ.",
+                nameof(After));
+        }
+        if (Transformations.IsDefault)
+        {
+            throw new ArgumentException(
+                "Transformations must be initialized.",
+                nameof(Transformations));
+        }
+
+        var transformationIds = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < Transformations.Length; i++)
+        {
+            ComparisonTransformationDescriptor transformation =
+                Transformations[i]
+                ?? throw new ArgumentException(
+                    $"Transformation at index {i} must not be null.",
+                    nameof(Transformations));
+            if (!transformationIds.Add(transformation.Identifier))
+            {
+                throw new ArgumentException(
+                    $"Transformation identifier '{transformation.Identifier}' occurs more than once.",
+                    nameof(Transformations));
+            }
+        }
+
+        this.Id = Id;
+        this.Transformations = Transformations;
+    }
+
+    public string Id { get; }
+    public ComparisonExceptionalChangeKind Kind { get; }
+    public ComparisonSubjectEndpoint Before { get; }
+    public ComparisonSubjectEndpoint After { get; }
+    public ImmutableArray<ComparisonTransformationDescriptor> Transformations { get; }
+
+    public bool Equals(ComparisonChangeDescription? other)
+        => other is not null
+            && StringComparer.Ordinal.Equals(Id, other.Id)
+            && Kind == other.Kind
+            && Before == other.Before
+            && After == other.After
+            && FindingValueEquality.SequenceEqual(Transformations, other.Transformations);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            StringComparer.Ordinal.GetHashCode(Id),
+            Kind,
+            Before,
+            After,
+            FindingValueEquality.SequenceHashCode(Transformations));
+
+    static ComparisonExceptionalChangeKind Validate(
+        ComparisonExceptionalChangeKind kind)
+        => kind switch
+        {
+            ComparisonExceptionalChangeKind.Rename => kind,
+            ComparisonExceptionalChangeKind.Move => kind,
+            ComparisonExceptionalChangeKind.RenameAndMove => kind,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+}
+
+/// <summary>One ordered portable subject and its opaque comparison payload.</summary>
+public sealed record ComparisonSubject<T>
+    where T : notnull
+{
+    public ComparisonSubject(
+        string Identifier,
+        string Display,
+        ComparisonSubjectChange Change,
+        T Comparison)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(Identifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Display);
+        this.Change = Change ?? throw new ArgumentNullException(nameof(Change));
+        if (Comparison is null)
+            throw new ArgumentNullException(nameof(Comparison));
+
+        this.Identifier = Identifier;
+        this.Display = Display;
+        this.Comparison = Comparison;
+    }
+
+    public string Identifier { get; }
+    public string Display { get; }
+    public ComparisonSubjectChange Change { get; }
+    public T Comparison { get; }
+
+    public bool Equals(ComparisonSubject<T>? other)
+        => other is not null
+            && StringComparer.Ordinal.Equals(Identifier, other.Identifier)
+            && StringComparer.Ordinal.Equals(Display, other.Display)
+            && Change == other.Change
+            && EqualityComparer<T>.Default.Equals(Comparison, other.Comparison);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            StringComparer.Ordinal.GetHashCode(Identifier),
+            StringComparer.Ordinal.GetHashCode(Display),
+            Change,
+            EqualityComparer<T>.Default.GetHashCode(Comparison));
+}
+
+/// <summary>
+/// A complete immutable composition of one portable root, ordered portable subjects,
+/// opaque comparison payloads, and referenced exceptional coordinate changes.
+/// </summary>
+public sealed record ComparisonDocument<T>
+    where T : notnull
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public ComparisonDocument(
+        int SchemaVersion,
+        SubjectCoordinateBasis SubjectCoordinateBasis,
+        string Identifier,
+        string Display,
+        ComparisonSubjectChange Change,
+        ComparisonRootComparison<T> Comparison,
+        ImmutableArray<ComparisonSubject<T>> Subjects,
+        ImmutableArray<ComparisonChangeDescription> ChangeDescriptions)
+    {
+        if (SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SchemaVersion),
+                "Comparison document schema version is unsupported.");
+        }
+        this.SubjectCoordinateBasis = Validate(SubjectCoordinateBasis);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Identifier);
+        ArgumentException.ThrowIfNullOrWhiteSpace(Display);
+        this.Change = Change ?? throw new ArgumentNullException(nameof(Change));
+        this.Comparison = Comparison ?? throw new ArgumentNullException(nameof(Comparison));
+        this.Subjects = ValidateSubjects(Subjects);
+        this.ChangeDescriptions = ValidateAndCanonicalizeDescriptions(ChangeDescriptions);
+
+        ValidateTopology(
+            SubjectCoordinateBasis,
+            Identifier,
+            Display,
+            Change,
+            this.Subjects,
+            this.ChangeDescriptions);
+
+        this.SchemaVersion = SchemaVersion;
+        this.Identifier = Identifier;
+        this.Display = Display;
+    }
+
+    public int SchemaVersion { get; }
+    public SubjectCoordinateBasis SubjectCoordinateBasis { get; }
+    public string Identifier { get; }
+    public string Display { get; }
+    public ComparisonSubjectChange Change { get; }
+    public ComparisonRootComparison<T> Comparison { get; }
+    public ImmutableArray<ComparisonSubject<T>> Subjects { get; }
+    public ImmutableArray<ComparisonChangeDescription> ChangeDescriptions { get; }
+
+    public bool Equals(ComparisonDocument<T>? other)
+        => other is not null
+            && SchemaVersion == other.SchemaVersion
+            && SubjectCoordinateBasis == other.SubjectCoordinateBasis
+            && StringComparer.Ordinal.Equals(Identifier, other.Identifier)
+            && StringComparer.Ordinal.Equals(Display, other.Display)
+            && Change == other.Change
+            && Comparison == other.Comparison
+            && FindingValueEquality.SequenceEqual(Subjects, other.Subjects)
+            && FindingValueEquality.SequenceEqual(
+                ChangeDescriptions,
+                other.ChangeDescriptions);
+
+    public override int GetHashCode()
+        => HashCode.Combine(
+            SchemaVersion,
+            SubjectCoordinateBasis,
+            StringComparer.Ordinal.GetHashCode(Identifier),
+            StringComparer.Ordinal.GetHashCode(Display),
+            Change,
+            Comparison,
+            FindingValueEquality.SequenceHashCode(Subjects),
+            FindingValueEquality.SequenceHashCode(ChangeDescriptions));
+
+    static SubjectCoordinateBasis Validate(SubjectCoordinateBasis basis)
+        => basis switch
+        {
+            SubjectCoordinateBasis.OuterContext => basis,
+            SubjectCoordinateBasis.RootRelative => basis,
+            _ => throw new ArgumentOutOfRangeException(nameof(basis)),
+        };
+
+    static ImmutableArray<ComparisonSubject<T>> ValidateSubjects(
+        ImmutableArray<ComparisonSubject<T>> subjects)
+    {
+        if (subjects.IsDefault)
+            throw new ArgumentException("Subjects must be initialized.", nameof(Subjects));
+        for (int i = 0; i < subjects.Length; i++)
+        {
+            if (subjects[i] is null)
+            {
+                throw new ArgumentException(
+                    $"Subject at index {i} must not be null.",
+                    nameof(Subjects));
+            }
+        }
+        return subjects;
+    }
+
+    static ImmutableArray<ComparisonChangeDescription> ValidateAndCanonicalizeDescriptions(
+        ImmutableArray<ComparisonChangeDescription> descriptions)
+    {
+        if (descriptions.IsDefault)
+        {
+            throw new ArgumentException(
+                "Change descriptions must be initialized.",
+                nameof(ChangeDescriptions));
+        }
+
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        for (int i = 0; i < descriptions.Length; i++)
+        {
+            ComparisonChangeDescription description =
+                descriptions[i]
+                ?? throw new ArgumentException(
+                    $"Change description at index {i} must not be null.",
+                    nameof(ChangeDescriptions));
+            if (!ids.Add(description.Id))
+            {
+                throw new ArgumentException(
+                    $"Change description id '{description.Id}' occurs more than once.",
+                    nameof(ChangeDescriptions));
+            }
+        }
+
+        return [.. descriptions.OrderBy(description => description.Id, StringComparer.Ordinal)];
+    }
+
+    static void ValidateTopology(
+        SubjectCoordinateBasis basis,
+        string rootIdentifier,
+        string rootDisplay,
+        ComparisonSubjectChange rootChange,
+        ImmutableArray<ComparisonSubject<T>> subjects,
+        ImmutableArray<ComparisonChangeDescription> descriptions)
+    {
+        var descriptionsById =
+            descriptions.ToDictionary(description => description.Id, StringComparer.Ordinal);
+        var referenceCounts = descriptions.ToDictionary(
+            description => description.Id,
+            _ => 0,
+            StringComparer.Ordinal);
+
+        ValidateReference(
+            rootIdentifier,
+            rootDisplay,
+            rootChange,
+            descriptionsById,
+            referenceCounts,
+            owner: "Root");
+
+        if (basis == SubjectCoordinateBasis.RootRelative)
+            ValidateRootRelativeEndpointAvailability(rootChange, subjects);
+
+        bool hasEndpointTopology =
+            rootChange is not ComparisonSubjectChange.Diff
+            || subjects.Any(subject => subject.Change is not ComparisonSubjectChange.Diff);
+        var beforeIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+        var afterIdentifiers = new HashSet<string>(StringComparer.Ordinal);
+
+        for (int i = 0; i < subjects.Length; i++)
+        {
+            ComparisonSubject<T> subject = subjects[i];
+            ValidateReference(
+                subject.Identifier,
+                subject.Display,
+                subject.Change,
+                descriptionsById,
+                referenceCounts,
+                owner: $"Subject {i}");
+
+            switch (subject.Change)
+            {
+                case ComparisonSubjectChange.Diff:
+                    AddUnique(afterIdentifiers, subject.Identifier, "After");
+                    if (hasEndpointTopology)
+                        AddUnique(beforeIdentifiers, subject.Identifier, "Before");
+                    break;
+                case ComparisonSubjectChange.Addition:
+                    AddUnique(afterIdentifiers, subject.Identifier, "After");
+                    break;
+                case ComparisonSubjectChange.Deletion:
+                    AddUnique(beforeIdentifiers, subject.Identifier, "Before");
+                    break;
+                case ComparisonSubjectChange.Rename rename:
+                    AddExceptionalSubject(rename.ChangeId);
+                    break;
+                case ComparisonSubjectChange.Move move:
+                    AddExceptionalSubject(move.ChangeId);
+                    break;
+                case ComparisonSubjectChange.RenameAndMove renameAndMove:
+                    AddExceptionalSubject(renameAndMove.ChangeId);
+                    break;
+                default:
+                    throw new ArgumentException(
+                        $"Subject {i} has an unknown change type.",
+                        nameof(Subjects));
+            }
+
+            void AddExceptionalSubject(string changeId)
+            {
+                AddUnique(afterIdentifiers, subject.Identifier, "After");
+                AddUnique(
+                    beforeIdentifiers,
+                    descriptionsById[changeId].Before.Identifier,
+                    "Before");
+            }
+        }
+
+        foreach ((string id, int count) in referenceCounts)
+        {
+            if (count != 1)
+            {
+                throw new ArgumentException(
+                    $"Change description '{id}' must be referenced exactly once; found {count} references.",
+                    nameof(ChangeDescriptions));
+            }
+        }
+    }
+
+    static void ValidateReference(
+        string identifier,
+        string display,
+        ComparisonSubjectChange change,
+        Dictionary<string, ComparisonChangeDescription> descriptions,
+        Dictionary<string, int> referenceCounts,
+        string owner)
+    {
+        (string ChangeId, ComparisonExceptionalChangeKind Kind)? exceptional =
+            Exceptional(change);
+        if (exceptional is not { } value)
+            return;
+
+        if (!descriptions.TryGetValue(value.ChangeId, out var description))
+        {
+            throw new ArgumentException(
+                $"{owner} references unknown change description '{value.ChangeId}'.",
+                nameof(ChangeDescriptions));
+        }
+        if (description.Kind != value.Kind)
+        {
+            throw new ArgumentException(
+                $"{owner} change kind does not match description '{value.ChangeId}'.",
+                nameof(ChangeDescriptions));
+        }
+        if (!StringComparer.Ordinal.Equals(identifier, description.After.Identifier)
+            || !StringComparer.Ordinal.Equals(display, description.After.Display))
+        {
+            throw new ArgumentException(
+                $"{owner} primary identifier and display must equal description '{value.ChangeId}' After endpoint.",
+                nameof(ChangeDescriptions));
+        }
+
+        referenceCounts[value.ChangeId]++;
+    }
+
+    static void ValidateRootRelativeEndpointAvailability(
+        ComparisonSubjectChange rootChange,
+        ImmutableArray<ComparisonSubject<T>> subjects)
+    {
+        (bool RootBefore, bool RootAfter) = RequiredSides(rootChange);
+        for (int i = 0; i < subjects.Length; i++)
+        {
+            (bool SubjectBefore, bool SubjectAfter) = RequiredSides(subjects[i].Change);
+            if ((SubjectBefore && !RootBefore) || (SubjectAfter && !RootAfter))
+            {
+                throw new ArgumentException(
+                    $"Root-relative subject {i} requires an endpoint side absent from the root.",
+                    nameof(Subjects));
+            }
+        }
+    }
+
+    static (bool Before, bool After) RequiredSides(ComparisonSubjectChange change)
+        => change switch
+        {
+            ComparisonSubjectChange.Diff => (true, true),
+            ComparisonSubjectChange.Addition => (false, true),
+            ComparisonSubjectChange.Deletion => (true, false),
+            ComparisonSubjectChange.Rename => (true, true),
+            ComparisonSubjectChange.Move => (true, true),
+            ComparisonSubjectChange.RenameAndMove => (true, true),
+            _ => throw new ArgumentException(
+                "Unknown comparison subject change type.",
+                nameof(change)),
+        };
+
+    static (string ChangeId, ComparisonExceptionalChangeKind Kind)? Exceptional(
+        ComparisonSubjectChange change)
+        => change switch
+        {
+            ComparisonSubjectChange.Diff => null,
+            ComparisonSubjectChange.Addition => null,
+            ComparisonSubjectChange.Deletion => null,
+            ComparisonSubjectChange.Rename rename
+                => (rename.ChangeId, ComparisonExceptionalChangeKind.Rename),
+            ComparisonSubjectChange.Move move
+                => (move.ChangeId, ComparisonExceptionalChangeKind.Move),
+            ComparisonSubjectChange.RenameAndMove renameAndMove
+                => (renameAndMove.ChangeId, ComparisonExceptionalChangeKind.RenameAndMove),
+            _ => throw new ArgumentException(
+                "Unknown comparison subject change type.",
+                nameof(change)),
+        };
+
+    static void AddUnique(
+        HashSet<string> identifiers,
+        string identifier,
+        string endpoint)
+    {
+        if (!identifiers.Add(identifier))
+        {
+            throw new ArgumentException(
+                $"{endpoint} subject identifier '{identifier}' occurs more than once.",
+                nameof(Subjects));
+        }
+    }
+}

--- a/src/ILInspector.Findings/ComparisonDocumentJson.cs
+++ b/src/ILInspector.Findings/ComparisonDocumentJson.cs
@@ -11,6 +11,9 @@ namespace ILInspector.Findings;
 /// </summary>
 public static class ComparisonDocumentJson
 {
+    const int DefaultPayloadMaxDepth = 64;
+    const int EnvelopeDepthAllowance = 4;
+
     static readonly HashSet<string> DocumentPropertyNames =
     [
         "schema_version",
@@ -67,7 +70,11 @@ public static class ComparisonDocumentJson
         var buffer = new ArrayBufferWriter<byte>();
         using (var writer = new Utf8JsonWriter(
             buffer,
-            new JsonWriterOptions { Indented = indented }))
+            new JsonWriterOptions
+            {
+                Indented = indented,
+                MaxDepth = GetEnvelopeMaxDepth(payloadTypeInfo),
+            }))
         {
             WriteDocument(writer, document, payloadTypeInfo);
         }
@@ -92,6 +99,7 @@ public static class ComparisonDocumentJson
             {
                 AllowTrailingCommas = false,
                 CommentHandling = JsonCommentHandling.Disallow,
+                MaxDepth = GetEnvelopeMaxDepth(payloadTypeInfo),
             });
 
         try
@@ -550,5 +558,15 @@ public static class ComparisonDocumentJson
             throw new JsonException(
                 $"{path} must be {expected.ToString().ToLowerInvariant()}.");
         }
+    }
+
+    static int GetEnvelopeMaxDepth<T>(JsonTypeInfo<T> payloadTypeInfo)
+    {
+        int payloadMaxDepth = payloadTypeInfo.Options.MaxDepth is 0
+            ? DefaultPayloadMaxDepth
+            : payloadTypeInfo.Options.MaxDepth;
+        return payloadMaxDepth > int.MaxValue - EnvelopeDepthAllowance
+            ? int.MaxValue
+            : payloadMaxDepth + EnvelopeDepthAllowance;
     }
 }

--- a/src/ILInspector.Findings/ComparisonDocumentJson.cs
+++ b/src/ILInspector.Findings/ComparisonDocumentJson.cs
@@ -1,0 +1,554 @@
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ILInspector.Findings;
+
+/// <summary>
+/// AOT-safe structured JSON for comparison documents with caller-generated payload metadata.
+/// </summary>
+public static class ComparisonDocumentJson
+{
+    static readonly HashSet<string> DocumentPropertyNames =
+    [
+        "schema_version",
+        "subject_coordinate_basis",
+        "identifier",
+        "display",
+        "change_kinds",
+        "change_id",
+        "comparison",
+        "subjects",
+        "change_descriptions",
+    ];
+
+    static readonly HashSet<string> SubjectPropertyNames =
+    [
+        "identifier",
+        "display",
+        "change_kinds",
+        "change_id",
+        "comparison",
+    ];
+
+    static readonly HashSet<string> DescriptionPropertyNames =
+    [
+        "id",
+        "change_kinds",
+        "before",
+        "after",
+        "transformations",
+    ];
+
+    static readonly HashSet<string> EndpointPropertyNames =
+    [
+        "identifier",
+        "display",
+    ];
+
+    static readonly HashSet<string> TransformationPropertyNames =
+    [
+        "identifier",
+        "display",
+    ];
+
+    /// <summary>Serializes one document in its canonical structured form.</summary>
+    public static string Serialize<T>(
+        ComparisonDocument<T> document,
+        JsonTypeInfo<T> payloadTypeInfo,
+        bool indented = false)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(payloadTypeInfo);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(
+            buffer,
+            new JsonWriterOptions { Indented = indented }))
+        {
+            WriteDocument(writer, document, payloadTypeInfo);
+        }
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    /// <summary>
+    /// Deserializes one strict structured form and constructs the public model through
+    /// its normal validation path.
+    /// </summary>
+    public static ComparisonDocument<T> Deserialize<T>(
+        string json,
+        JsonTypeInfo<T> payloadTypeInfo)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(json);
+        ArgumentNullException.ThrowIfNull(payloadTypeInfo);
+
+        using JsonDocument parsed = JsonDocument.Parse(
+            json,
+            new JsonDocumentOptions
+            {
+                AllowTrailingCommas = false,
+                CommentHandling = JsonCommentHandling.Disallow,
+            });
+
+        try
+        {
+            return ReadDocument(parsed.RootElement, payloadTypeInfo);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new JsonException(
+                "Comparison-document JSON violates the comparison document contract.",
+                ex);
+        }
+    }
+
+    static void WriteDocument<T>(
+        Utf8JsonWriter writer,
+        ComparisonDocument<T> document,
+        JsonTypeInfo<T> payloadTypeInfo)
+        where T : notnull
+    {
+        writer.WriteStartObject();
+        writer.WriteNumber("schema_version", document.SchemaVersion);
+        writer.WriteString(
+            "subject_coordinate_basis",
+            document.SubjectCoordinateBasis switch
+            {
+                SubjectCoordinateBasis.OuterContext => "outer-context",
+                SubjectCoordinateBasis.RootRelative => "root-relative",
+                _ => throw new InvalidOperationException(
+                    "Comparison document has an unknown coordinate basis."),
+            });
+        writer.WriteString("identifier", document.Identifier);
+        writer.WriteString("display", document.Display);
+        WriteChange(writer, document.Change);
+
+        if (document.Comparison is ComparisonRootComparison<T>.Present present)
+        {
+            writer.WritePropertyName("comparison");
+            JsonSerializer.Serialize(writer, present.Comparison, payloadTypeInfo);
+        }
+        else if (document.Comparison is not ComparisonRootComparison<T>.NotApplicable)
+        {
+            throw new InvalidOperationException(
+                "Comparison document has an unknown root comparison case.");
+        }
+
+        writer.WritePropertyName("subjects");
+        writer.WriteStartArray();
+        foreach (ComparisonSubject<T> subject in document.Subjects)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("identifier", subject.Identifier);
+            writer.WriteString("display", subject.Display);
+            WriteChange(writer, subject.Change);
+            writer.WritePropertyName("comparison");
+            JsonSerializer.Serialize(writer, subject.Comparison, payloadTypeInfo);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+
+        writer.WritePropertyName("change_descriptions");
+        writer.WriteStartArray();
+        foreach (ComparisonChangeDescription description in document.ChangeDescriptions)
+            WriteDescription(writer, description);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    static void WriteChange(Utf8JsonWriter writer, ComparisonSubjectChange change)
+    {
+        switch (change)
+        {
+            case ComparisonSubjectChange.Diff:
+                return;
+            case ComparisonSubjectChange.Addition:
+                WriteKinds(writer, "addition");
+                return;
+            case ComparisonSubjectChange.Deletion:
+                WriteKinds(writer, "deletion");
+                return;
+            case ComparisonSubjectChange.Rename rename:
+                WriteKinds(writer, "rename");
+                writer.WriteString("change_id", rename.ChangeId);
+                return;
+            case ComparisonSubjectChange.Move move:
+                WriteKinds(writer, "move");
+                writer.WriteString("change_id", move.ChangeId);
+                return;
+            case ComparisonSubjectChange.RenameAndMove renameAndMove:
+                WriteKinds(writer, "rename", "move");
+                writer.WriteString("change_id", renameAndMove.ChangeId);
+                return;
+            default:
+                throw new InvalidOperationException(
+                    "Comparison document has an unknown subject change case.");
+        }
+    }
+
+    static void WriteKinds(Utf8JsonWriter writer, params string[] kinds)
+    {
+        writer.WritePropertyName("change_kinds");
+        writer.WriteStartArray();
+        foreach (string kind in kinds)
+            writer.WriteStringValue(kind);
+        writer.WriteEndArray();
+    }
+
+    static void WriteDescription(
+        Utf8JsonWriter writer,
+        ComparisonChangeDescription description)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("id", description.Id);
+        switch (description.Kind)
+        {
+            case ComparisonExceptionalChangeKind.Rename:
+                WriteKinds(writer, "rename");
+                break;
+            case ComparisonExceptionalChangeKind.Move:
+                WriteKinds(writer, "move");
+                break;
+            case ComparisonExceptionalChangeKind.RenameAndMove:
+                WriteKinds(writer, "rename", "move");
+                break;
+            default:
+                throw new InvalidOperationException(
+                    "Comparison document has an unknown description kind.");
+        }
+        WriteEndpoint(writer, "before", description.Before);
+        WriteEndpoint(writer, "after", description.After);
+
+        writer.WritePropertyName("transformations");
+        writer.WriteStartArray();
+        foreach (ComparisonTransformationDescriptor transformation in description.Transformations)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("identifier", transformation.Identifier);
+            writer.WriteString("display", transformation.Display);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+    }
+
+    static void WriteEndpoint(
+        Utf8JsonWriter writer,
+        string propertyName,
+        ComparisonSubjectEndpoint endpoint)
+    {
+        writer.WritePropertyName(propertyName);
+        writer.WriteStartObject();
+        writer.WriteString("identifier", endpoint.Identifier);
+        writer.WriteString("display", endpoint.Display);
+        writer.WriteEndObject();
+    }
+
+    static ComparisonDocument<T> ReadDocument<T>(
+        JsonElement element,
+        JsonTypeInfo<T> payloadTypeInfo)
+        where T : notnull
+    {
+        Dictionary<string, JsonElement> properties =
+            ReadObject(element, DocumentPropertyNames, "$");
+        int schemaVersion = ReadInt32(
+            Required(properties, "schema_version", "$"),
+            "$.schema_version");
+        SubjectCoordinateBasis basis = ReadCoordinateBasis(
+            Required(properties, "subject_coordinate_basis", "$"));
+        string identifier = ReadString(
+            Required(properties, "identifier", "$"),
+            "$.identifier");
+        string display = ReadString(
+            Required(properties, "display", "$"),
+            "$.display");
+        ComparisonSubjectChange change = ReadChange(properties, "$");
+        ComparisonRootComparison<T> comparison =
+            properties.TryGetValue("comparison", out JsonElement comparisonElement)
+                ? new ComparisonRootComparison<T>.Present(
+                    ReadPayload(comparisonElement, payloadTypeInfo, "$.comparison"))
+                : new ComparisonRootComparison<T>.NotApplicable();
+        ImmutableArray<ComparisonSubject<T>> subjects = ReadSubjects(
+            Required(properties, "subjects", "$"),
+            payloadTypeInfo);
+        ImmutableArray<ComparisonChangeDescription> descriptions = ReadDescriptions(
+            Required(properties, "change_descriptions", "$"));
+
+        return new ComparisonDocument<T>(
+            schemaVersion,
+            basis,
+            identifier,
+            display,
+            change,
+            comparison,
+            subjects,
+            descriptions);
+    }
+
+    static ImmutableArray<ComparisonSubject<T>> ReadSubjects<T>(
+        JsonElement element,
+        JsonTypeInfo<T> payloadTypeInfo)
+        where T : notnull
+    {
+        EnsureKind(element, JsonValueKind.Array, "$.subjects");
+        var subjects = ImmutableArray.CreateBuilder<ComparisonSubject<T>>();
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string path = $"$.subjects[{index}]";
+            Dictionary<string, JsonElement> properties =
+                ReadObject(item, SubjectPropertyNames, path);
+            subjects.Add(
+                new ComparisonSubject<T>(
+                    ReadString(
+                        Required(properties, "identifier", path),
+                        $"{path}.identifier"),
+                    ReadString(
+                        Required(properties, "display", path),
+                        $"{path}.display"),
+                    ReadChange(properties, path),
+                    ReadPayload(
+                        Required(properties, "comparison", path),
+                        payloadTypeInfo,
+                        $"{path}.comparison")));
+            index++;
+        }
+        return subjects.ToImmutable();
+    }
+
+    static ImmutableArray<ComparisonChangeDescription> ReadDescriptions(
+        JsonElement element)
+    {
+        EnsureKind(element, JsonValueKind.Array, "$.change_descriptions");
+        var descriptions = ImmutableArray.CreateBuilder<ComparisonChangeDescription>();
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string path = $"$.change_descriptions[{index}]";
+            Dictionary<string, JsonElement> properties =
+                ReadObject(item, DescriptionPropertyNames, path);
+            descriptions.Add(
+                new ComparisonChangeDescription(
+                    ReadString(
+                        Required(properties, "id", path),
+                        $"{path}.id"),
+                    ReadExceptionalKind(
+                        Required(properties, "change_kinds", path),
+                        $"{path}.change_kinds"),
+                    ReadEndpoint(
+                        Required(properties, "before", path),
+                        $"{path}.before"),
+                    ReadEndpoint(
+                        Required(properties, "after", path),
+                        $"{path}.after"),
+                    ReadTransformations(
+                        Required(properties, "transformations", path),
+                        $"{path}.transformations")));
+            index++;
+        }
+        return descriptions.ToImmutable();
+    }
+
+    static ComparisonSubjectEndpoint ReadEndpoint(
+        JsonElement element,
+        string path)
+    {
+        Dictionary<string, JsonElement> properties =
+            ReadObject(element, EndpointPropertyNames, path);
+        return new ComparisonSubjectEndpoint(
+            ReadString(
+                Required(properties, "identifier", path),
+                $"{path}.identifier"),
+            ReadString(
+                Required(properties, "display", path),
+                $"{path}.display"));
+    }
+
+    static ImmutableArray<ComparisonTransformationDescriptor> ReadTransformations(
+        JsonElement element,
+        string path)
+    {
+        EnsureKind(element, JsonValueKind.Array, path);
+        var transformations =
+            ImmutableArray.CreateBuilder<ComparisonTransformationDescriptor>();
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            string itemPath = $"{path}[{index}]";
+            Dictionary<string, JsonElement> properties =
+                ReadObject(item, TransformationPropertyNames, itemPath);
+            transformations.Add(
+                new ComparisonTransformationDescriptor(
+                    ReadString(
+                        Required(properties, "identifier", itemPath),
+                        $"{itemPath}.identifier"),
+                    ReadString(
+                        Required(properties, "display", itemPath),
+                        $"{itemPath}.display")));
+            index++;
+        }
+        return transformations.ToImmutable();
+    }
+
+    static ComparisonSubjectChange ReadChange(
+        Dictionary<string, JsonElement> properties,
+        string path)
+    {
+        bool hasKinds = properties.TryGetValue("change_kinds", out JsonElement kinds);
+        bool hasChangeId = properties.TryGetValue("change_id", out JsonElement changeId);
+        if (!hasKinds)
+        {
+            if (hasChangeId)
+            {
+                throw new JsonException(
+                    $"{path}.change_id is not valid when change_kinds is omitted.");
+            }
+            return new ComparisonSubjectChange.Diff();
+        }
+
+        string[] values = ReadKindStrings(kinds, $"{path}.change_kinds");
+        if (values is ["addition"])
+        {
+            RejectChangeId(hasChangeId, path);
+            return new ComparisonSubjectChange.Addition();
+        }
+        if (values is ["deletion"])
+        {
+            RejectChangeId(hasChangeId, path);
+            return new ComparisonSubjectChange.Deletion();
+        }
+        if (values is not (["rename"] or ["move"] or ["rename", "move"]))
+        {
+            throw new JsonException(
+                $"{path}.change_kinds is not a canonical comparison change.");
+        }
+
+        string id = ReadString(
+            hasChangeId
+                ? changeId
+                : throw new JsonException(
+                    $"{path}.change_id is required for rename and move changes."),
+            $"{path}.change_id");
+        if (values is ["rename"])
+            return new ComparisonSubjectChange.Rename(id);
+        if (values is ["move"])
+            return new ComparisonSubjectChange.Move(id);
+        return new ComparisonSubjectChange.RenameAndMove(id);
+    }
+
+    static void RejectChangeId(bool hasChangeId, string path)
+    {
+        if (hasChangeId)
+        {
+            throw new JsonException(
+                $"{path}.change_id is valid only for rename and move changes.");
+        }
+    }
+
+    static ComparisonExceptionalChangeKind ReadExceptionalKind(
+        JsonElement element,
+        string path)
+        => ReadKindStrings(element, path) switch
+        {
+            ["rename"] => ComparisonExceptionalChangeKind.Rename,
+            ["move"] => ComparisonExceptionalChangeKind.Move,
+            ["rename", "move"] => ComparisonExceptionalChangeKind.RenameAndMove,
+            _ => throw new JsonException(
+                $"{path} must contain rename, move, or rename followed by move."),
+        };
+
+    static string[] ReadKindStrings(JsonElement element, string path)
+    {
+        EnsureKind(element, JsonValueKind.Array, path);
+        var values = new List<string>();
+        int index = 0;
+        foreach (JsonElement item in element.EnumerateArray())
+        {
+            values.Add(ReadString(item, $"{path}[{index}]"));
+            index++;
+        }
+        return [.. values];
+    }
+
+    static SubjectCoordinateBasis ReadCoordinateBasis(JsonElement element)
+        => ReadString(element, "$.subject_coordinate_basis") switch
+        {
+            "outer-context" => SubjectCoordinateBasis.OuterContext,
+            "root-relative" => SubjectCoordinateBasis.RootRelative,
+            _ => throw new JsonException(
+                "$.subject_coordinate_basis has an unknown value."),
+        };
+
+    static T ReadPayload<T>(
+        JsonElement element,
+        JsonTypeInfo<T> payloadTypeInfo,
+        string path)
+        where T : notnull
+    {
+        if (element.ValueKind == JsonValueKind.Null)
+            throw new JsonException($"{path} must not be null.");
+
+        T? payload = element.Deserialize(payloadTypeInfo);
+        return payload is not null
+            ? payload
+            : throw new JsonException($"{path} deserialized to null.");
+    }
+
+    static Dictionary<string, JsonElement> ReadObject(
+        JsonElement element,
+        HashSet<string> allowedNames,
+        string path)
+    {
+        EnsureKind(element, JsonValueKind.Object, path);
+        var properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (!allowedNames.Contains(property.Name))
+                throw new JsonException($"{path} contains unknown property '{property.Name}'.");
+            if (!properties.TryAdd(property.Name, property.Value))
+                throw new JsonException($"{path} repeats property '{property.Name}'.");
+        }
+        return properties;
+    }
+
+    static JsonElement Required(
+        Dictionary<string, JsonElement> properties,
+        string name,
+        string path)
+        => properties.TryGetValue(name, out JsonElement value)
+            ? value
+            : throw new JsonException($"{path} is missing required property '{name}'.");
+
+    static string ReadString(JsonElement element, string path)
+    {
+        EnsureKind(element, JsonValueKind.String, path);
+        return element.GetString()
+            ?? throw new JsonException($"{path} must not be null.");
+    }
+
+    static int ReadInt32(JsonElement element, string path)
+    {
+        if (element.ValueKind != JsonValueKind.Number
+            || !element.TryGetInt32(out int value))
+        {
+            throw new JsonException($"{path} must be a 32-bit integer.");
+        }
+        return value;
+    }
+
+    static void EnsureKind(
+        JsonElement element,
+        JsonValueKind expected,
+        string path)
+    {
+        if (element.ValueKind != expected)
+        {
+            throw new JsonException(
+                $"{path} must be {expected.ToString().ToLowerInvariant()}.");
+        }
+    }
+}

--- a/src/ILInspector.Instructions.Tests/ComparisonDocumentJsonTests.cs
+++ b/src/ILInspector.Instructions.Tests/ComparisonDocumentJsonTests.cs
@@ -1,0 +1,468 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Instructions.Tests;
+
+public class ComparisonDocumentJsonTests
+{
+    [Fact]
+    public void Json_RoundTripsClosedPayloadAndAllCompositionCases()
+    {
+        ComparisonChangeDescription rootDescription = Description(
+            "root",
+            ComparisonExceptionalChangeKind.RenameAndMove,
+            "Old.Root",
+            "Old.Root<T>",
+            "New.Root",
+            "New.Root<T>");
+        ComparisonChangeDescription renameDescription = Description(
+            "rename",
+            ComparisonExceptionalChangeKind.Rename,
+            "Old",
+            "Old()",
+            "New",
+            "New()");
+        ComparisonChangeDescription moveDescription = new(
+            "move",
+            ComparisonExceptionalChangeKind.Move,
+            new ComparisonSubjectEndpoint("Old.Type.M", "Old.Type.M()"),
+            new ComparisonSubjectEndpoint("New.Type.M", "New.Type.M()"),
+            [
+                new ComparisonTransformationDescriptor(
+                    "dotnet.member.to-extension",
+                    "Moved to an extension member."),
+            ]);
+        var document = new ComparisonDocument<ComparisonDocumentTestPayload>(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            "New.Root",
+            "New.Root<T>",
+            new ComparisonSubjectChange.RenameAndMove("root"),
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.Present(
+                new("<root>&", "root")),
+            [
+                Subject("Diff", "Diff()", new ComparisonSubjectChange.Diff(), "left"),
+                Subject(
+                    "Added",
+                    "Added()",
+                    new ComparisonSubjectChange.Addition(),
+                    "after"),
+                Subject(
+                    "Deleted",
+                    "Deleted()",
+                    new ComparisonSubjectChange.Deletion(),
+                    "before"),
+                Subject(
+                    "New",
+                    "New()",
+                    new ComparisonSubjectChange.Rename("rename"),
+                    "renamed"),
+                Subject(
+                    "New.Type.M",
+                    "New.Type.M()",
+                    new ComparisonSubjectChange.Move("move"),
+                    "moved"),
+            ],
+            [moveDescription, rootDescription, renameDescription]);
+
+        string json = ComparisonDocumentJson.Serialize(
+            document,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload,
+            indented: true);
+        ComparisonDocument<ComparisonDocumentTestPayload> roundTrip =
+            ComparisonDocumentJson.Deserialize(
+                json,
+                ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+
+        Assert.Equal(document, roundTrip);
+        Assert.Contains("\\u003Croot\\u003E\\u0026", json);
+        Assert.True(
+            json.IndexOf("\"id\": \"move\"", StringComparison.Ordinal)
+            < json.IndexOf("\"id\": \"rename\"", StringComparison.Ordinal));
+        Assert.True(
+            json.IndexOf("\"id\": \"rename\"", StringComparison.Ordinal)
+            < json.IndexOf("\"id\": \"root\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Json_UsesCanonicalDiffAndNotApplicableOmissions()
+    {
+        var document = new ComparisonDocument<ComparisonDocumentTestPayload>(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.RootRelative,
+            "Root",
+            "Root",
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.NotApplicable(),
+            [
+                Subject(
+                    "Member",
+                    "Member()",
+                    new ComparisonSubjectChange.Diff(),
+                    "member"),
+            ],
+            []);
+
+        string json = ComparisonDocumentJson.Serialize(
+            document,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+
+        Assert.DoesNotContain("\"change_kinds\"", json);
+        Assert.DoesNotContain("\"change_id\"", json);
+        Assert.Equal(1, Count(json, "\"comparison\""));
+        Assert.Contains("\"subject_coordinate_basis\":\"root-relative\"", json);
+    }
+
+    [Fact]
+    public void Json_CanonicalizesDescriptionOrderAfterDeserialization()
+    {
+        const string json =
+            """
+            {
+              "schema_version": 1,
+              "subject_coordinate_basis": "outer-context",
+              "identifier": "AfterRoot",
+              "display": "AfterRoot",
+              "change_kinds": ["rename"],
+              "change_id": "z",
+              "subjects": [
+                {
+                  "identifier": "AfterMember",
+                  "display": "AfterMember",
+                  "change_kinds": ["move"],
+                  "change_id": "a",
+                  "comparison": { "text": "payload", "orientation": "after" }
+                }
+              ],
+              "change_descriptions": [
+                {
+                  "id": "z",
+                  "change_kinds": ["rename"],
+                  "before": { "identifier": "BeforeRoot", "display": "BeforeRoot" },
+                  "after": { "identifier": "AfterRoot", "display": "AfterRoot" },
+                  "transformations": []
+                },
+                {
+                  "id": "a",
+                  "change_kinds": ["move"],
+                  "before": { "identifier": "BeforeMember", "display": "BeforeMember" },
+                  "after": { "identifier": "AfterMember", "display": "AfterMember" },
+                  "transformations": []
+                }
+              ]
+            }
+            """;
+
+        ComparisonDocument<ComparisonDocumentTestPayload> document =
+            ComparisonDocumentJson.Deserialize(
+                json,
+                ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+        string canonical = ComparisonDocumentJson.Serialize(
+            document,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+
+        Assert.Equal(
+            ["a", "z"],
+            document.ChangeDescriptions.Select(description => description.Id));
+        Assert.True(
+            canonical.IndexOf("\"id\":\"a\"", StringComparison.Ordinal)
+            < canonical.IndexOf("\"id\":\"z\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Json_RoundTripsBothBasesIncludingEmptySubjects()
+    {
+        foreach (SubjectCoordinateBasis basis in Enum.GetValues<SubjectCoordinateBasis>())
+        {
+            var document = new ComparisonDocument<ComparisonDocumentTestPayload>(
+                ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+                basis,
+                "Root",
+                "Root",
+                new ComparisonSubjectChange.Addition(),
+                new ComparisonRootComparison<ComparisonDocumentTestPayload>.NotApplicable(),
+                [],
+                []);
+            string json = ComparisonDocumentJson.Serialize(
+                document,
+                ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+
+            ComparisonDocument<ComparisonDocumentTestPayload> roundTrip =
+                Deserialize(json);
+
+            Assert.Equal(basis, roundTrip.SubjectCoordinateBasis);
+            Assert.Empty(roundTrip.Subjects);
+        }
+    }
+
+    [Fact]
+    public void Json_EncodesEnvelopeOwnedUntrustedStringsAsData()
+    {
+        const string identifier = "Root\"\\\n";
+        const string display = "<root>&\t";
+        var document = new ComparisonDocument<ComparisonDocumentTestPayload>(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            identifier,
+            display,
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.NotApplicable(),
+            [],
+            []);
+
+        string json = ComparisonDocumentJson.Serialize(
+            document,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+        ComparisonDocument<ComparisonDocumentTestPayload> roundTrip =
+            Deserialize(json);
+
+        Assert.Contains("\\u0022", json);
+        Assert.Contains("\\\\", json);
+        Assert.Contains("\\n", json);
+        Assert.Contains("\\u003Croot\\u003E\\u0026\\t", json);
+        Assert.Equal(identifier, roundTrip.Identifier);
+        Assert.Equal(display, roundTrip.Display);
+    }
+
+    [Fact]
+    public void Json_RejectsEveryRootRelativeChildRequiringAnAbsentRootSide()
+    {
+        ComparisonSubjectChange[] additionRootInvalidChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Deletion(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+        ComparisonSubjectChange[] deletionRootInvalidChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Addition(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+
+        foreach (ComparisonSubjectChange childChange in additionRootInvalidChildren)
+            AssertMatrixRejection(new ComparisonSubjectChange.Addition(), childChange);
+        foreach (ComparisonSubjectChange childChange in deletionRootInvalidChildren)
+            AssertMatrixRejection(new ComparisonSubjectChange.Deletion(), childChange);
+    }
+
+    public static TheoryData<string> MalformedDocuments =>
+        new()
+        {
+            """
+            {"schema_version":1,"identifier":"R","display":"R","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"unknown","identifier":"R","display":"R","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","unknown":true,"subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","display":"Again","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["diff"],"subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["addition"],"change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","comparison":null,"subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","subjects":[{"identifier":"S","display":"S","comparison":null}],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":2,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["rename"],"change_id":"missing","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["move","rename"],"change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":[],"subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["rename","rename"],"change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["move","move"],"change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["addition","deletion"],"subjects":[],"change_descriptions":[]}
+            """,
+            """
+            {"schema_version":1,"subject_coordinate_basis":"outer-context","identifier":"R","display":"R","change_kinds":["addition","rename"],"change_id":"x","subjects":[],"change_descriptions":[]}
+            """,
+        };
+
+    [Theory]
+    [MemberData(nameof(MalformedDocuments))]
+    public void Json_RejectsMalformedAndNoncanonicalDocuments(string json)
+    {
+        Assert.Throws<JsonException>(
+            () => ComparisonDocumentJson.Deserialize(
+                json,
+                ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload));
+    }
+
+    [Fact]
+    public void Json_RejectsUnknownNestedAndMissingRequiredProperties()
+    {
+        const string unknownNested =
+            """
+            {
+              "schema_version": 1,
+              "subject_coordinate_basis": "outer-context",
+              "identifier": "R",
+              "display": "R",
+              "subjects": [
+                {
+                  "identifier": "S",
+                  "display": "S",
+                  "extra": 1,
+                  "comparison": { "text": "p", "orientation": "left" }
+                }
+              ],
+              "change_descriptions": []
+            }
+            """;
+        const string missingPayload =
+            """
+            {
+              "schema_version": 1,
+              "subject_coordinate_basis": "outer-context",
+              "identifier": "R",
+              "display": "R",
+              "subjects": [{ "identifier": "S", "display": "S" }],
+              "change_descriptions": []
+            }
+            """;
+
+        Assert.Throws<JsonException>(() => Deserialize(unknownNested));
+        Assert.Throws<JsonException>(() => Deserialize(missingPayload));
+    }
+
+    static ComparisonDocument<ComparisonDocumentTestPayload> Deserialize(string json)
+        => ComparisonDocumentJson.Deserialize(
+            json,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload);
+
+    static void AssertMatrixRejection(
+        ComparisonSubjectChange rootChange,
+        ComparisonSubjectChange childChange)
+    {
+        ImmutableArray<ComparisonChangeDescription> descriptions =
+            ExceptionalDescription(childChange);
+        var outerContext = new ComparisonDocument<ComparisonDocumentTestPayload>(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            "Root",
+            "Root",
+            rootChange,
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.NotApplicable(),
+            [
+                new(
+                    "Child",
+                    "Child",
+                    childChange,
+                    new("payload", "subject")),
+            ],
+            descriptions);
+        string json = ComparisonDocumentJson.Serialize(
+            outerContext,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentTestPayload)
+            .Replace(
+                "\"subject_coordinate_basis\":\"outer-context\"",
+                "\"subject_coordinate_basis\":\"root-relative\"",
+                StringComparison.Ordinal);
+
+        Assert.Throws<JsonException>(() => Deserialize(json));
+    }
+
+    static ComparisonSubject<ComparisonDocumentTestPayload> Subject(
+        string identifier,
+        string display,
+        ComparisonSubjectChange change,
+        string orientation)
+        => new(
+            identifier,
+            display,
+            change,
+            new ComparisonDocumentTestPayload("payload", orientation));
+
+    static ComparisonChangeDescription Description(
+        string id,
+        ComparisonExceptionalChangeKind kind,
+        string beforeIdentifier,
+        string beforeDisplay,
+        string afterIdentifier,
+        string afterDisplay)
+        => new(
+            id,
+            kind,
+            new ComparisonSubjectEndpoint(beforeIdentifier, beforeDisplay),
+            new ComparisonSubjectEndpoint(afterIdentifier, afterDisplay),
+            []);
+
+    static ImmutableArray<ComparisonChangeDescription> ExceptionalDescription(
+        ComparisonSubjectChange change)
+        => change switch
+        {
+            ComparisonSubjectChange.Rename rename =>
+            [
+                Description(
+                    rename.ChangeId,
+                    ComparisonExceptionalChangeKind.Rename,
+                    "BeforeChild",
+                    "BeforeChild",
+                    "Child",
+                    "Child"),
+            ],
+            ComparisonSubjectChange.Move move =>
+            [
+                Description(
+                    move.ChangeId,
+                    ComparisonExceptionalChangeKind.Move,
+                    "BeforeChild",
+                    "BeforeChild",
+                    "Child",
+                    "Child"),
+            ],
+            ComparisonSubjectChange.RenameAndMove renameAndMove =>
+            [
+                Description(
+                    renameAndMove.ChangeId,
+                    ComparisonExceptionalChangeKind.RenameAndMove,
+                    "BeforeChild",
+                    "BeforeChild",
+                    "Child",
+                    "Child"),
+            ],
+            _ => [],
+        };
+
+    static int Count(string value, string search)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = value.IndexOf(search, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += search.Length;
+        }
+        return count;
+    }
+}

--- a/src/ILInspector.Instructions.Tests/ComparisonDocumentJsonTests.cs
+++ b/src/ILInspector.Instructions.Tests/ComparisonDocumentJsonTests.cs
@@ -198,6 +198,39 @@ public class ComparisonDocumentJsonTests
     }
 
     [Fact]
+    public void Json_RoundTripsPayloadBeyondDefaultEnvelopeDepth()
+    {
+        ComparisonDocumentNestedPayload payload = new(70, null);
+        for (int depth = 69; depth >= 0; depth--)
+            payload = new(depth, payload);
+        var document = new ComparisonDocument<ComparisonDocumentNestedPayload>(
+            ComparisonDocument<ComparisonDocumentNestedPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            "Root",
+            "Root",
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<ComparisonDocumentNestedPayload>.NotApplicable(),
+            [
+                new(
+                    "Subject",
+                    "Subject",
+                    new ComparisonSubjectChange.Diff(),
+                    payload),
+            ],
+            []);
+
+        string json = ComparisonDocumentJson.Serialize(
+            document,
+            ComparisonDocumentTestJsonContext.Default.ComparisonDocumentNestedPayload);
+        ComparisonDocument<ComparisonDocumentNestedPayload> roundTrip =
+            ComparisonDocumentJson.Deserialize(
+                json,
+                ComparisonDocumentTestJsonContext.Default.ComparisonDocumentNestedPayload);
+
+        Assert.Equal(document, roundTrip);
+    }
+
+    [Fact]
     public void Json_EncodesEnvelopeOwnedUntrustedStringsAsData()
     {
         const string identifier = "Root\"\\\n";

--- a/src/ILInspector.Instructions.Tests/ComparisonDocumentTestJsonContext.cs
+++ b/src/ILInspector.Instructions.Tests/ComparisonDocumentTestJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace ILInspector.Instructions.Tests;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ComparisonDocumentTestPayload))]
+internal partial class ComparisonDocumentTestJsonContext : JsonSerializerContext;
+
+internal sealed record ComparisonDocumentTestPayload(string Text, string Orientation);

--- a/src/ILInspector.Instructions.Tests/ComparisonDocumentTestJsonContext.cs
+++ b/src/ILInspector.Instructions.Tests/ComparisonDocumentTestJsonContext.cs
@@ -2,8 +2,15 @@ using System.Text.Json.Serialization;
 
 namespace ILInspector.Instructions.Tests;
 
-[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSourceGenerationOptions(
+    MaxDepth = 128,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(ComparisonDocumentTestPayload))]
+[JsonSerializable(typeof(ComparisonDocumentNestedPayload))]
 internal partial class ComparisonDocumentTestJsonContext : JsonSerializerContext;
 
 internal sealed record ComparisonDocumentTestPayload(string Text, string Orientation);
+
+internal sealed record ComparisonDocumentNestedPayload(
+    int Depth,
+    ComparisonDocumentNestedPayload? Child);

--- a/src/ILInspector.Instructions.Tests/ComparisonDocumentTests.cs
+++ b/src/ILInspector.Instructions.Tests/ComparisonDocumentTests.cs
@@ -1,0 +1,1057 @@
+using System.Collections.Immutable;
+
+using ILInspector.Findings;
+
+namespace ILInspector.Instructions.Tests;
+
+public class ComparisonDocumentTests
+{
+    [Fact]
+    public void Constructor_PreservesSubjectOrderAndCanonicalizesDescriptions()
+    {
+        ComparisonChangeDescription rootDescription = Description(
+            "root-z",
+            ComparisonExceptionalChangeKind.Rename,
+            "OldRoot",
+            "OldRoot",
+            "NewRoot",
+            "NewRoot");
+        ComparisonChangeDescription subjectDescription = Description(
+            "subject-a",
+            ComparisonExceptionalChangeKind.Move,
+            "A.Type.M",
+            "A.Type.M()",
+            "B.Type.M",
+            "B.Type.M()");
+        var first = Subject(
+            "B.Type.M",
+            "B.Type.M()",
+            new ComparisonSubjectChange.Move("subject-a"),
+            "first");
+        var second = Subject(
+            "Stable",
+            "Stable",
+            new ComparisonSubjectChange.Diff(),
+            "second");
+
+        ComparisonDocument<string> document = Document(
+            identifier: "NewRoot",
+            display: "NewRoot",
+            change: new ComparisonSubjectChange.Rename("root-z"),
+            subjects: [first, second],
+            descriptions: [rootDescription, subjectDescription]);
+
+        Assert.Equal([first, second], document.Subjects);
+        Assert.Equal(
+            ["root-z", "subject-a"],
+            document.ChangeDescriptions.Select(description => description.Id));
+    }
+
+    [Fact]
+    public void Constructor_AcceptsEveryChangeCase()
+    {
+        ComparisonDocument<string> document = Document(
+            subjects:
+            [
+                Subject("Diff", "Diff", new ComparisonSubjectChange.Diff(), "diff"),
+                Subject("Added", "Added", new ComparisonSubjectChange.Addition(), "addition"),
+                Subject("Deleted", "Deleted", new ComparisonSubjectChange.Deletion(), "deletion"),
+                Subject(
+                    "Renamed",
+                    "Renamed",
+                    new ComparisonSubjectChange.Rename("rename"),
+                    "rename"),
+                Subject(
+                    "Moved",
+                    "Moved",
+                    new ComparisonSubjectChange.Move("move"),
+                    "move"),
+                Subject(
+                    "RenamedMoved",
+                    "RenamedMoved",
+                    new ComparisonSubjectChange.RenameAndMove("rename-move"),
+                    "rename-move"),
+            ],
+            descriptions:
+            [
+                Description(
+                    "rename",
+                    ComparisonExceptionalChangeKind.Rename,
+                    "OldName",
+                    "OldName",
+                    "Renamed",
+                    "Renamed"),
+                Description(
+                    "move",
+                    ComparisonExceptionalChangeKind.Move,
+                    "OldContainer.Moved",
+                    "OldContainer.Moved",
+                    "Moved",
+                    "Moved"),
+                Description(
+                    "rename-move",
+                    ComparisonExceptionalChangeKind.RenameAndMove,
+                    "OldContainer.OldName",
+                    "OldContainer.OldName",
+                    "RenamedMoved",
+                    "RenamedMoved"),
+            ]);
+
+        Assert.Collection(
+            document.Subjects,
+            subject => Assert.IsType<ComparisonSubjectChange.Diff>(subject.Change),
+            subject => Assert.IsType<ComparisonSubjectChange.Addition>(subject.Change),
+            subject => Assert.IsType<ComparisonSubjectChange.Deletion>(subject.Change),
+            subject => Assert.IsType<ComparisonSubjectChange.Rename>(subject.Change),
+            subject => Assert.IsType<ComparisonSubjectChange.Move>(subject.Change),
+            subject => Assert.IsType<ComparisonSubjectChange.RenameAndMove>(subject.Change));
+    }
+
+    [Fact]
+    public void Constructor_PreservesExplicitRootComparisonPresence()
+    {
+        var present = Document(
+            comparison: new ComparisonRootComparison<string>.Present("root"));
+        var absent = Document(
+            comparison: new ComparisonRootComparison<string>.NotApplicable());
+
+        Assert.Equal(
+            "root",
+            Assert.IsType<ComparisonRootComparison<string>.Present>(
+                present.Comparison).Comparison);
+        Assert.IsType<ComparisonRootComparison<string>.NotApplicable>(
+            absent.Comparison);
+    }
+
+    [Fact]
+    public void RootRelative_TwoSidedRootAcceptsEverySubjectKind()
+    {
+        ComparisonDocument<string> document = Document(
+            basis: SubjectCoordinateBasis.RootRelative,
+            subjects:
+            [
+                Subject("Diff", "Diff", new ComparisonSubjectChange.Diff()),
+                Subject("Added", "Added", new ComparisonSubjectChange.Addition()),
+                Subject("Deleted", "Deleted", new ComparisonSubjectChange.Deletion()),
+                Subject(
+                    "Renamed",
+                    "Renamed",
+                    new ComparisonSubjectChange.Rename("rename")),
+                Subject(
+                    "Moved",
+                    "Moved",
+                    new ComparisonSubjectChange.Move("move")),
+                Subject(
+                    "RenamedMoved",
+                    "RenamedMoved",
+                    new ComparisonSubjectChange.RenameAndMove("rename-move")),
+            ],
+            descriptions:
+            [
+                Description(
+                    "rename",
+                    ComparisonExceptionalChangeKind.Rename,
+                    "OldName",
+                    "OldName",
+                    "Renamed",
+                    "Renamed"),
+                Description(
+                    "move",
+                    ComparisonExceptionalChangeKind.Move,
+                    "OldContainer.Moved",
+                    "OldContainer.Moved",
+                    "Moved",
+                    "Moved"),
+                Description(
+                    "rename-move",
+                    ComparisonExceptionalChangeKind.RenameAndMove,
+                    "OldContainer.OldName",
+                    "OldContainer.OldName",
+                    "RenamedMoved",
+                    "RenamedMoved"),
+            ]);
+
+        Assert.Equal(6, document.Subjects.Length);
+    }
+
+    [Fact]
+    public void RootRelative_OneSidedRootsAcceptOnlySameSideSubjects()
+    {
+        ComparisonDocument<string> addition = Document(
+            basis: SubjectCoordinateBasis.RootRelative,
+            change: new ComparisonSubjectChange.Addition(),
+            subjects:
+            [
+                Subject(
+                    "Added",
+                    "Added",
+                    new ComparisonSubjectChange.Addition()),
+            ]);
+        ComparisonDocument<string> deletion = Document(
+            basis: SubjectCoordinateBasis.RootRelative,
+            change: new ComparisonSubjectChange.Deletion(),
+            subjects:
+            [
+                Subject(
+                    "Deleted",
+                    "Deleted",
+                    new ComparisonSubjectChange.Deletion()),
+            ]);
+
+        Assert.Single(addition.Subjects);
+        Assert.Single(deletion.Subjects);
+        Assert.Empty(
+            Document(
+                basis: SubjectCoordinateBasis.RootRelative,
+                change: new ComparisonSubjectChange.Addition()).Subjects);
+        Assert.Empty(
+            Document(
+                basis: SubjectCoordinateBasis.RootRelative,
+                change: new ComparisonSubjectChange.Deletion()).Subjects);
+    }
+
+    [Fact]
+    public void RootRelative_EveryRootKindAcceptsEmptySubjectPopulation()
+    {
+        ComparisonSubjectChange[] changes =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Addition(),
+            new ComparisonSubjectChange.Deletion(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+
+        foreach (ComparisonSubjectChange change in changes)
+        {
+            ImmutableArray<ComparisonChangeDescription> descriptions =
+                ExceptionalDescription(change, "Root", "Root");
+            ComparisonDocument<string> document = Document(
+                basis: SubjectCoordinateBasis.RootRelative,
+                change: change,
+                descriptions: descriptions);
+
+            Assert.Empty(document.Subjects);
+        }
+    }
+
+    [Fact]
+    public void RootRelative_RejectsEverySubjectRequiringAbsentRootSide()
+    {
+        ComparisonSubjectChange[] additionRootInvalidChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Deletion(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+        ComparisonSubjectChange[] deletionRootInvalidChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Addition(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+
+        foreach (ComparisonSubjectChange childChange in additionRootInvalidChildren)
+        {
+            Assert.Throws<ArgumentException>(
+                () => Document(
+                    basis: SubjectCoordinateBasis.RootRelative,
+                    change: new ComparisonSubjectChange.Addition(),
+                    subjects:
+                    [
+                        Subject("Child", "Child", childChange),
+                    ]));
+        }
+        foreach (ComparisonSubjectChange childChange in deletionRootInvalidChildren)
+        {
+            Assert.Throws<ArgumentException>(
+                () => Document(
+                    basis: SubjectCoordinateBasis.RootRelative,
+                    change: new ComparisonSubjectChange.Deletion(),
+                    subjects:
+                    [
+                        Subject("Child", "Child", childChange),
+                    ]));
+        }
+    }
+
+    [Fact]
+    public void RootRelative_ExceptionalRootKeepsStableChildDiff()
+    {
+        foreach (ComparisonSubjectChange rootChange in new ComparisonSubjectChange[]
+        {
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+        })
+        {
+            ComparisonDocument<string> document = Document(
+                basis: SubjectCoordinateBasis.RootRelative,
+                change: rootChange,
+                subjects:
+                [
+                    Subject(
+                        "MemberAnchor",
+                        "Member()",
+                        new ComparisonSubjectChange.Diff()),
+                ],
+                descriptions: ExceptionalDescription(rootChange, "Root", "Root"));
+
+            Assert.IsType<ComparisonSubjectChange.Diff>(
+                Assert.Single(document.Subjects).Change);
+        }
+    }
+
+    [Fact]
+    public void OuterContext_AllowsIndependentRootAndSubjectLifecycles()
+    {
+        ComparisonDocument<string> document = Document(
+            basis: SubjectCoordinateBasis.OuterContext,
+            change: new ComparisonSubjectChange.Addition(),
+            subjects:
+            [
+                Subject(
+                    "Deleted",
+                    "Deleted",
+                    new ComparisonSubjectChange.Deletion()),
+            ]);
+
+        Assert.Single(document.Subjects);
+    }
+
+    [Fact]
+    public void OuterContext_AcceptsEveryIndependentOneSidedRootCombination()
+    {
+        ComparisonSubjectChange[] additionRootChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Deletion(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+        ComparisonSubjectChange[] deletionRootChildren =
+        [
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonSubjectChange.Addition(),
+            new ComparisonSubjectChange.Rename("rename"),
+            new ComparisonSubjectChange.Move("move"),
+            new ComparisonSubjectChange.RenameAndMove("rename-move"),
+        ];
+
+        foreach (ComparisonSubjectChange childChange in additionRootChildren)
+        {
+            Assert.Single(
+                Document(
+                    change: new ComparisonSubjectChange.Addition(),
+                    subjects: [Subject("Child", "Child", childChange)],
+                    descriptions: ExceptionalDescription(
+                        childChange,
+                        "Child",
+                        "Child")).Subjects);
+        }
+        foreach (ComparisonSubjectChange childChange in deletionRootChildren)
+        {
+            Assert.Single(
+                Document(
+                    change: new ComparisonSubjectChange.Deletion(),
+                    subjects: [Subject("Child", "Child", childChange)],
+                    descriptions: ExceptionalDescription(
+                        childChange,
+                        "Child",
+                        "Child")).Subjects);
+        }
+    }
+
+    [Fact]
+    public void OuterContext_RequiresASeparateExceptionalChildWhenItsCoordinateChanges()
+    {
+        ComparisonChangeDescription rootDescription = Description(
+            "root",
+            ComparisonExceptionalChangeKind.Move,
+            "AssemblyA.Type",
+            "AssemblyA.Type",
+            "AssemblyB.Type",
+            "AssemblyB.Type");
+        ComparisonChangeDescription childDescription = Description(
+            "child",
+            ComparisonExceptionalChangeKind.Move,
+            "AssemblyA.Type.Member",
+            "AssemblyA.Type.Member()",
+            "AssemblyB.Type.Member",
+            "AssemblyB.Type.Member()");
+        ComparisonDocument<string> document = Document(
+            basis: SubjectCoordinateBasis.OuterContext,
+            identifier: "AssemblyB.Type",
+            display: "AssemblyB.Type",
+            change: new ComparisonSubjectChange.Move("root"),
+            subjects:
+            [
+                Subject(
+                    "AssemblyB.Type.Member",
+                    "AssemblyB.Type.Member()",
+                    new ComparisonSubjectChange.Move("child")),
+            ],
+            descriptions: [rootDescription, childDescription]);
+
+        Assert.Equal("root", Assert.IsType<ComparisonSubjectChange.Move>(
+            document.Change).ChangeId);
+        Assert.Equal("child", Assert.IsType<ComparisonSubjectChange.Move>(
+            Assert.Single(document.Subjects).Change).ChangeId);
+    }
+
+    [Fact]
+    public void Constructor_ComposesPortableCoordinatesAcrossRequiredScopes()
+    {
+        ComparisonDocument<ComparisonDocumentTestPayload>[] documents =
+        [
+            CoordinateDocument(
+                "Assembly.Type",
+                ["Assembly.Type.Member"],
+                "within-type"),
+            CoordinateDocument(
+                "Assembly",
+                ["TypeB.Member"],
+                "within-assembly"),
+            CoordinateDocument(
+                "PackageComparison",
+                ["AssemblyA.Type.Member", "AssemblyB.Type.Member"],
+                "cross-assembly"),
+        ];
+
+        Assert.Equal(
+            ["within-type", "within-assembly", "cross-assembly"],
+            documents.Select(
+                document => document.Subjects[0].Comparison.Orientation));
+        Assert.Equal(2, documents[2].Subjects.Length);
+    }
+
+    [Fact]
+    public void Constructor_RejectsUninitializedNullAndUnknownValues()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ComparisonDocument<string>(
+                2,
+                SubjectCoordinateBasis.OuterContext,
+                "Root",
+                "Root",
+                new ComparisonSubjectChange.Diff(),
+                new ComparisonRootComparison<string>.NotApplicable(),
+                [],
+                []));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Document(basis: (SubjectCoordinateBasis)int.MaxValue));
+        Assert.Throws<ArgumentException>(
+            () => Document(identifier: ""));
+        Assert.Throws<ArgumentException>(
+            () => Document(display: " "));
+        Assert.Throws<ArgumentNullException>(
+            () => new ComparisonDocument<string>(
+                ComparisonDocument<string>.CurrentSchemaVersion,
+                SubjectCoordinateBasis.OuterContext,
+                "Root",
+                "Root",
+                null!,
+                new ComparisonRootComparison<string>.NotApplicable(),
+                [],
+                []));
+        Assert.Throws<ArgumentNullException>(
+            () => new ComparisonDocument<string>(
+                ComparisonDocument<string>.CurrentSchemaVersion,
+                SubjectCoordinateBasis.OuterContext,
+                "Root",
+                "Root",
+                new ComparisonSubjectChange.Diff(),
+                null!,
+                [],
+                []));
+        Assert.Throws<ArgumentException>(
+            () => new ComparisonDocument<string>(
+                ComparisonDocument<string>.CurrentSchemaVersion,
+                SubjectCoordinateBasis.OuterContext,
+                "Root",
+                "Root",
+                new ComparisonSubjectChange.Diff(),
+                new ComparisonRootComparison<string>.NotApplicable(),
+                default,
+                []));
+        Assert.Throws<ArgumentException>(
+            () => new ComparisonDocument<string>(
+                ComparisonDocument<string>.CurrentSchemaVersion,
+                SubjectCoordinateBasis.OuterContext,
+                "Root",
+                "Root",
+                new ComparisonSubjectChange.Diff(),
+                new ComparisonRootComparison<string>.NotApplicable(),
+                [],
+                default));
+        Assert.Throws<ArgumentException>(
+            () => Document(subjects: [null!]));
+        Assert.Throws<ArgumentException>(
+            () => Document(descriptions: [null!]));
+        Assert.Throws<ArgumentNullException>(
+            () => new ComparisonSubject<string>(
+                "S",
+                "S",
+                new ComparisonSubjectChange.Diff(),
+                null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new ComparisonRootComparison<string>.Present(null!));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ComparisonChangeDescription(
+                "id",
+                (ComparisonExceptionalChangeKind)int.MaxValue,
+                new ComparisonSubjectEndpoint("before", "before"),
+                new ComparisonSubjectEndpoint("after", "after"),
+                []));
+    }
+
+    [Fact]
+    public void ChangeDescription_RejectsInvalidEndpointsAndTransformations()
+    {
+        Assert.Throws<ArgumentException>(
+            () => Description(
+                "id",
+                ComparisonExceptionalChangeKind.Rename,
+                "same",
+                "before",
+                "same",
+                "after"));
+        Assert.Throws<ArgumentException>(
+            () => new ComparisonChangeDescription(
+                "id",
+                ComparisonExceptionalChangeKind.Move,
+                new ComparisonSubjectEndpoint("before", "before"),
+                new ComparisonSubjectEndpoint("after", "after"),
+                default));
+        Assert.Throws<ArgumentException>(
+            () => new ComparisonChangeDescription(
+                "id",
+                ComparisonExceptionalChangeKind.Move,
+                new ComparisonSubjectEndpoint("before", "before"),
+                new ComparisonSubjectEndpoint("after", "after"),
+                [null!]));
+        Assert.Throws<ArgumentException>(
+            () => new ComparisonChangeDescription(
+                "id",
+                ComparisonExceptionalChangeKind.Move,
+                new ComparisonSubjectEndpoint("before", "before"),
+                new ComparisonSubjectEndpoint("after", "after"),
+                [
+                    new ComparisonTransformationDescriptor("kind", "first"),
+                    new ComparisonTransformationDescriptor("kind", "second"),
+                ]));
+    }
+
+    [Fact]
+    public void Constructor_RequiresDescriptionsToMatchExactlyOneReferrer()
+    {
+        ComparisonChangeDescription description = Description(
+            "change",
+            ComparisonExceptionalChangeKind.Rename,
+            "Before",
+            "Before",
+            "After",
+            "After");
+
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                identifier: "After",
+                display: "After",
+                change: new ComparisonSubjectChange.Rename("missing")));
+        Assert.Throws<ArgumentException>(
+            () => Document(descriptions: [description]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                identifier: "After",
+                display: "After",
+                change: new ComparisonSubjectChange.Rename("change"),
+                subjects:
+                [
+                    Subject(
+                        "After",
+                        "After",
+                        new ComparisonSubjectChange.Rename("change")),
+                ],
+                descriptions: [description]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                identifier: "After",
+                display: "After",
+                change: new ComparisonSubjectChange.Move("change"),
+                descriptions: [description]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                identifier: "Wrong",
+                display: "After",
+                change: new ComparisonSubjectChange.Rename("change"),
+                descriptions: [description]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                identifier: "After",
+                display: "Wrong",
+                change: new ComparisonSubjectChange.Rename("change"),
+                descriptions: [description]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                descriptions: [description, description]));
+    }
+
+    [Fact]
+    public void Constructor_RejectsDuplicateEndpointCoordinates()
+    {
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                subjects:
+                [
+                    Subject("Same", "First", new ComparisonSubjectChange.Diff()),
+                    Subject("Same", "Second", new ComparisonSubjectChange.Diff()),
+                ]));
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                subjects:
+                [
+                    Subject("Same", "Diff", new ComparisonSubjectChange.Diff()),
+                    Subject(
+                        "Same",
+                        "Deleted",
+                        new ComparisonSubjectChange.Deletion()),
+                ]));
+
+        ComparisonChangeDescription move = Description(
+            "move",
+            ComparisonExceptionalChangeKind.Move,
+            "Before",
+            "Before",
+            "After",
+            "After");
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                subjects:
+                [
+                    Subject(
+                        "Before",
+                        "Deleted",
+                        new ComparisonSubjectChange.Deletion()),
+                    Subject(
+                        "After",
+                        "After",
+                        new ComparisonSubjectChange.Move("move")),
+                ],
+                descriptions: [move]));
+
+        ComparisonChangeDescription firstMove = Description(
+            "first",
+            ComparisonExceptionalChangeKind.Move,
+            "SharedBefore",
+            "SharedBefore",
+            "FirstAfter",
+            "FirstAfter");
+        ComparisonChangeDescription secondMove = Description(
+            "second",
+            ComparisonExceptionalChangeKind.Move,
+            "SharedBefore",
+            "SharedBefore",
+            "SecondAfter",
+            "SecondAfter");
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                subjects:
+                [
+                    Subject(
+                        "FirstAfter",
+                        "FirstAfter",
+                        new ComparisonSubjectChange.Move("first")),
+                    Subject(
+                        "SecondAfter",
+                        "SecondAfter",
+                        new ComparisonSubjectChange.Move("second")),
+                ],
+                descriptions: [firstMove, secondMove]));
+
+        ComparisonChangeDescription diffCollision = Description(
+            "diff-collision",
+            ComparisonExceptionalChangeKind.Rename,
+            "Stable",
+            "Stable",
+            "Changed",
+            "Changed");
+        Assert.Throws<ArgumentException>(
+            () => Document(
+                subjects:
+                [
+                    Subject(
+                        "Stable",
+                        "Stable",
+                        new ComparisonSubjectChange.Diff()),
+                    Subject(
+                        "Changed",
+                        "Changed",
+                        new ComparisonSubjectChange.Rename("diff-collision")),
+                ],
+                descriptions: [diffCollision]));
+    }
+
+    [Fact]
+    public void Constructor_AllowsSameSpellingInSeparateEndpointSpaces()
+    {
+        ComparisonDocument<string> document = Document(
+            subjects:
+            [
+                Subject(
+                    "Same",
+                    "Deleted",
+                    new ComparisonSubjectChange.Deletion()),
+                Subject(
+                    "Same",
+                    "Added",
+                    new ComparisonSubjectChange.Addition()),
+            ]);
+
+        Assert.Equal(2, document.Subjects.Length);
+    }
+
+    [Fact]
+    public void ValueEquality_IncludesBasisOrderPayloadAndDescriptions()
+    {
+        ComparisonDocument<string> first = Document(
+            subjects:
+            [
+                Subject("A", "A", new ComparisonSubjectChange.Diff(), "one"),
+                Subject("B", "B", new ComparisonSubjectChange.Diff(), "two"),
+            ]);
+        ComparisonDocument<string> equal = Document(
+            subjects:
+            [
+                Subject("A", "A", new ComparisonSubjectChange.Diff(), "one"),
+                Subject("B", "B", new ComparisonSubjectChange.Diff(), "two"),
+            ]);
+        ComparisonDocument<string> reordered = Document(
+            subjects:
+            [
+                Subject("B", "B", new ComparisonSubjectChange.Diff(), "two"),
+                Subject("A", "A", new ComparisonSubjectChange.Diff(), "one"),
+            ]);
+        ComparisonDocument<string> differentBasis = Document(
+            basis: SubjectCoordinateBasis.RootRelative,
+            subjects:
+            [
+                Subject("A", "A", new ComparisonSubjectChange.Diff(), "one"),
+                Subject("B", "B", new ComparisonSubjectChange.Diff(), "two"),
+            ]);
+
+        Assert.Equal(first, equal);
+        Assert.Equal(first.GetHashCode(), equal.GetHashCode());
+        Assert.NotEqual(first, reordered);
+        Assert.NotEqual(first, differentBasis);
+    }
+
+    [Fact]
+    public void ValueEquality_DistinguishesContractDefiningTopologyAndPresence()
+    {
+        ComparisonDocument<string> emptyDiff = Document();
+        ComparisonDocument<string> emptyAddition = Document(
+            change: new ComparisonSubjectChange.Addition());
+        ComparisonDocument<string> rootPresent = Document(
+            comparison: new ComparisonRootComparison<string>.Present("root"));
+        ComparisonDocument<string> subjectDiff = Document(
+            subjects:
+            [
+                Subject("Subject", "Subject", new ComparisonSubjectChange.Diff()),
+            ]);
+        ComparisonDocument<string> subjectAddition = Document(
+            subjects:
+            [
+                Subject("Subject", "Subject", new ComparisonSubjectChange.Addition()),
+            ]);
+
+        Assert.NotEqual(emptyDiff, emptyAddition);
+        Assert.NotEqual(emptyDiff, rootPresent);
+        Assert.NotEqual(subjectDiff, subjectAddition);
+    }
+
+    [Fact]
+    public void PayloadEquality_IsIndependentOfSubjectIdentity()
+    {
+        var payload = new ComparisonDocumentTestPayload("same", "same");
+        var first = new ComparisonSubject<ComparisonDocumentTestPayload>(
+            "First",
+            "First",
+            new ComparisonSubjectChange.Diff(),
+            payload);
+        var second = new ComparisonSubject<ComparisonDocumentTestPayload>(
+            "Second",
+            "Second",
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonDocumentTestPayload("same", "same"));
+
+        Assert.NotEqual(first, second);
+        Assert.Equal(first.Comparison, second.Comparison);
+    }
+
+    [Fact]
+    public void SubjectTopology_RemainsIndependentOfOpaquePayloadDisposition()
+    {
+        var movedPayload = new ComparisonDocumentTestPayload(
+            "contains moved item relations",
+            "moved");
+        var unchangedPayload = new ComparisonDocumentTestPayload(
+            "contains unchanged item relations",
+            "unchanged");
+        ComparisonChangeDescription moveDescription = Description(
+            "move",
+            ComparisonExceptionalChangeKind.Move,
+            "Before",
+            "Before",
+            "After",
+            "After");
+        var document = new ComparisonDocument<ComparisonDocumentTestPayload>(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            "Root",
+            "Root",
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.NotApplicable(),
+            [
+                new(
+                    "Stable",
+                    "Stable",
+                    new ComparisonSubjectChange.Diff(),
+                    movedPayload),
+                new(
+                    "After",
+                    "After",
+                    new ComparisonSubjectChange.Move("move"),
+                    unchangedPayload),
+            ],
+            [moveDescription]);
+
+        Assert.IsType<ComparisonSubjectChange.Diff>(document.Subjects[0].Change);
+        Assert.IsType<ComparisonSubjectChange.Move>(document.Subjects[1].Change);
+    }
+
+    [Fact]
+    public void GenericPayload_PreservesPathologicalThreeRegionComposition()
+    {
+        AnalysisDiff<string> rootDiff = new(
+            ["Process:A", "Process:B", "Process:C"],
+            ["NewPartA:A", "NewPartB:B", "NewPartC:C"],
+            [
+                new AnalysisDiffRelation.Correspondence(
+                    [0],
+                    [0],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Moved),
+                new AnalysisDiffRelation.Correspondence(
+                    [1],
+                    [1],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Moved),
+                new AnalysisDiffRelation.Correspondence(
+                    [2],
+                    [2],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Moved),
+            ]);
+        AnalysisDiff<string> processDiff = new(
+            ["alpha", "beta", "gamma"],
+            ["alpha", "beta-prime", "gamma"],
+            [
+                new AnalysisDiffRelation.Correspondence(
+                    [0],
+                    [0],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Stable),
+                new AnalysisDiffRelation.Correspondence(
+                    [1],
+                    [1],
+                    AnalysisDiffContentKind.Changed,
+                    AnalysisDiffPlacementKind.Stable),
+                new AnalysisDiffRelation.Correspondence(
+                    [2],
+                    [2],
+                    AnalysisDiffContentKind.Unchanged,
+                    AnalysisDiffPlacementKind.Stable),
+            ]);
+        AnalysisDiff<string> newPart = new(
+            [],
+            ["body"],
+            [new AnalysisDiffRelation.Addition([0])]);
+
+        var document = new ComparisonDocument<AnalysisDiff<string>>(
+            ComparisonDocument<AnalysisDiff<string>>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.RootRelative,
+            "Assembly.Type",
+            "Assembly.Type",
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<AnalysisDiff<string>>.Present(rootDiff),
+            [
+                new(
+                    "Process",
+                    "Process()",
+                    new ComparisonSubjectChange.Diff(),
+                    processDiff),
+                new(
+                    "NewPartA",
+                    "NewPartA()",
+                    new ComparisonSubjectChange.Addition(),
+                    newPart),
+                new(
+                    "NewPartB",
+                    "NewPartB()",
+                    new ComparisonSubjectChange.Addition(),
+                    newPart),
+                new(
+                    "NewPartC",
+                    "NewPartC()",
+                    new ComparisonSubjectChange.Addition(),
+                    newPart),
+            ],
+            []);
+
+        Assert.Equal(rootDiff, Assert.IsType<
+            ComparisonRootComparison<AnalysisDiff<string>>.Present>(
+                document.Comparison).Comparison);
+        Assert.Equal(processDiff, document.Subjects[0].Comparison);
+        Assert.All(
+            rootDiff.Relations,
+            relation => Assert.Equal(
+                AnalysisDiffPlacementKind.Moved,
+                Assert.IsType<AnalysisDiffRelation.Correspondence>(
+                    relation).Placement));
+        Assert.All(
+            document.Subjects[1..],
+            subject => Assert.IsType<ComparisonSubjectChange.Addition>(subject.Change));
+    }
+
+    [Fact]
+    public void ChangeDescription_PreservesExtensionTransformations()
+    {
+        var toExtension = new ComparisonTransformationDescriptor(
+            "dotnet.member.to-extension",
+            "Converted to extension method");
+        var fromExtension = new ComparisonTransformationDescriptor(
+            "dotnet.member.from-extension",
+            "Converted from extension method");
+        ComparisonChangeDescription description = new(
+            "move",
+            ComparisonExceptionalChangeKind.Move,
+            new ComparisonSubjectEndpoint("Type.Member", "Type.Member()"),
+            new ComparisonSubjectEndpoint(
+                "Extensions.Member",
+                "Extensions.Member(Type)"),
+            [toExtension, fromExtension]);
+        ComparisonDocument<string> document = Document(
+            identifier: "Extensions.Member",
+            display: "Extensions.Member(Type)",
+            change: new ComparisonSubjectChange.Move("move"),
+            descriptions: [description]);
+
+        Assert.Equal(
+            [toExtension, fromExtension],
+            Assert.Single(document.ChangeDescriptions).Transformations);
+    }
+
+    static ComparisonDocument<ComparisonDocumentTestPayload> CoordinateDocument(
+        string rootIdentifier,
+        ImmutableArray<string> subjectIdentifiers,
+        string orientation)
+        => new(
+            ComparisonDocument<ComparisonDocumentTestPayload>.CurrentSchemaVersion,
+            SubjectCoordinateBasis.OuterContext,
+            rootIdentifier,
+            rootIdentifier,
+            new ComparisonSubjectChange.Diff(),
+            new ComparisonRootComparison<ComparisonDocumentTestPayload>.Present(
+                new("root item space", orientation)),
+            [..
+                subjectIdentifiers.Select(subjectIdentifier => new ComparisonSubject<
+                    ComparisonDocumentTestPayload>(
+                    subjectIdentifier,
+                    subjectIdentifier,
+                    new ComparisonSubjectChange.Diff(),
+                    new("subject item space", orientation)))],
+            []);
+
+    static ComparisonDocument<string> Document(
+        SubjectCoordinateBasis basis = SubjectCoordinateBasis.OuterContext,
+        string identifier = "Root",
+        string display = "Root",
+        ComparisonSubjectChange? change = null,
+        ComparisonRootComparison<string>? comparison = null,
+        ImmutableArray<ComparisonSubject<string>> subjects = default,
+        ImmutableArray<ComparisonChangeDescription> descriptions = default)
+        => new(
+            ComparisonDocument<string>.CurrentSchemaVersion,
+            basis,
+            identifier,
+            display,
+            change ?? new ComparisonSubjectChange.Diff(),
+            comparison ?? new ComparisonRootComparison<string>.NotApplicable(),
+            subjects.IsDefault ? [] : subjects,
+            descriptions.IsDefault ? [] : descriptions);
+
+    static ComparisonSubject<string> Subject(
+        string identifier,
+        string display,
+        ComparisonSubjectChange change,
+        string comparison = "payload")
+        => new(identifier, display, change, comparison);
+
+    static ComparisonChangeDescription Description(
+        string id,
+        ComparisonExceptionalChangeKind kind,
+        string beforeIdentifier,
+        string beforeDisplay,
+        string afterIdentifier,
+        string afterDisplay)
+        => new(
+            id,
+            kind,
+            new ComparisonSubjectEndpoint(beforeIdentifier, beforeDisplay),
+            new ComparisonSubjectEndpoint(afterIdentifier, afterDisplay),
+            []);
+
+    static ImmutableArray<ComparisonChangeDescription> ExceptionalDescription(
+        ComparisonSubjectChange change,
+        string afterIdentifier,
+        string afterDisplay)
+        => change switch
+        {
+            ComparisonSubjectChange.Rename rename =>
+            [
+                Description(
+                    rename.ChangeId,
+                    ComparisonExceptionalChangeKind.Rename,
+                    $"Before.{afterIdentifier}",
+                    $"Before {afterDisplay}",
+                    afterIdentifier,
+                    afterDisplay),
+            ],
+            ComparisonSubjectChange.Move move =>
+            [
+                Description(
+                    move.ChangeId,
+                    ComparisonExceptionalChangeKind.Move,
+                    $"Before.{afterIdentifier}",
+                    $"Before {afterDisplay}",
+                    afterIdentifier,
+                    afterDisplay),
+            ],
+            ComparisonSubjectChange.RenameAndMove renameAndMove =>
+            [
+                Description(
+                    renameAndMove.ChangeId,
+                    ComparisonExceptionalChangeKind.RenameAndMove,
+                    $"Before.{afterIdentifier}",
+                    $"Before {afterDisplay}",
+                    afterIdentifier,
+                    afterDisplay),
+            ],
+            _ => [],
+        };
+}


### PR DESCRIPTION
Part of #5526. Closes #5550.

## Claim

Implement the `ILInspector.Findings`-owned `ComparisonDocument<T>` envelope and its canonical AOT-safe structured form. The value model keeps portable root/subject identity, composition topology, and exceptional rename/move endpoints typed while leaving every comparison payload opaque.

## Demo

A producer can compose an ordinary subject and an exceptional move without putting Before/After baggage on every entry:

```csharp
var document = new ComparisonDocument<ComparisonPayload>(
    ComparisonDocument<ComparisonPayload>.CurrentSchemaVersion,
    SubjectCoordinateBasis.RootRelative,
    "AssemblyB.Type",
    "AssemblyB.Type",
    new ComparisonSubjectChange.Move("type-move"),
    new ComparisonRootComparison<ComparisonPayload>.NotApplicable(),
    [new("MemberAnchor", "Member()", new ComparisonSubjectChange.Diff(), payload)],
    [new(
        "type-move",
        ComparisonExceptionalChangeKind.Move,
        new("AssemblyA.Type", "AssemblyA.Type"),
        new("AssemblyB.Type", "AssemblyB.Type"),
        [])]);

string json = ComparisonDocumentJson.Serialize(
    document,
    ComparisonJsonContext.Default.ComparisonPayload);
```

The structured output keeps the common child compact and joins the exceptional root to a separate complete description:

```json
{
  "schema_version": 1,
  "subject_coordinate_basis": "root-relative",
  "identifier": "AssemblyB.Type",
  "display": "AssemblyB.Type",
  "change_kinds": ["move"],
  "change_id": "type-move",
  "subjects": [
    {
      "identifier": "MemberAnchor",
      "display": "Member()",
      "comparison": {}
    }
  ],
  "change_descriptions": [
    {
      "id": "type-move",
      "change_kinds": ["move"],
      "before": {
        "identifier": "AssemblyA.Type",
        "display": "AssemblyA.Type"
      },
      "after": {
        "identifier": "AssemblyB.Type",
        "display": "AssemblyB.Type"
      },
      "transformations": []
    }
  ]
}
```

Notice that Diff is represented only by omission, the root-relative member coordinate remains stable across the type move, and presentation never has to parse display text. The same generic envelope is also exercised with a type-wide `AnalysisDiff<string>` root payload plus member-level child payloads for the three-region extraction case.

## Implementation

- Add closed Diff, Addition, Deletion, Rename, Move, and Rename+Move cases plus explicit Present/NotApplicable root comparison presence.
- Enforce the root-relative endpoint matrix, primary endpoint-space uniqueness, exactly-once descriptions, After-primary agreement, distinct exceptional endpoints, and transformation identity uniqueness.
- Preserve semantic subject order, canonicalize descriptions by ordinal change ID, and compose payload equality through `EqualityComparer<T>.Default`.
- Add `ComparisonDocumentJson`, which accepts caller-generated `JsonTypeInfo<T>`, emits the canonical snake-case form, rejects unknown/duplicate/noncanonical properties, and reconstructs through the public validating constructors.
- Update the owning design to identify the implemented types and gates.

## Compatibility and boundaries

This is a new dependency-free Findings value contract. It does not add matching, rename/move detection, .NET coordinate grammar, Markout rendering, CLI/web behavior, or universal serialization for arbitrary runtime payload types. CLI Source Diff #5527 and Inspect Web #5528 remain the initial focused adopters; structural clones remain a second payload family.

## Validation

- `dotnet run --project src/ILInspector.Instructions.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/comparison-document.md`