### PR TITLE
Issue portable Workspace context addresses

### DIFF
--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -359,6 +359,54 @@ validates the supplied selectors against its contract. Missing, ambiguous, or
 incompatible inputs are typed failures; a consumer never invents an undeclared
 selector or silently broadens the query.
 
+### Resolved context addresses and descriptors
+
+Workspace Definitions issues one `WorkspaceContextAddress` for every context
+in a resolved canonical definition composition. Its two components are the
+exact workspace record `id` and exact context `name`. Equality is ordinal over
+both preserved strings. The pair is sufficient because context names are
+unique within one workspace; framework, RID, members, scenario id, schema
+version, and display text do not participate in address equality.
+
+The address is relative to one activated canonical definition composition, not
+a global semantic identity. An equal pair from another registry, bundle,
+session, or activation does not itself establish correspondence. A later
+execution receipt that compares addresses across hosts must retain the exact
+activation scope in which each address is interpreted. This owner issues the
+relative address only; it does not define that receipt or infer a runtime
+binding-context relation.
+
+`ResolvedWorkspaceContext` retains a compact `WorkspaceContextDescriptor`
+containing the address and the context's declared framework and RID. Its
+acquisition member recipe remains separately available on the resolved context
+and is deliberately absent from the descriptor: equal membership is not
+context identity, and a host does not need to hash or format members to
+distinguish contexts. The context name remains the guaranteed visible
+discriminator; hosts may combine it with the target fields for presentation,
+but formatted labels are never address inputs.
+
+Packet transposition preserves the existing projection boundary. Decoding one
+canonical packet assigns the packet-local workspace id `share-workspace` and
+context names `g0`, `g1`, and so on in packet order. CLI and Browser therefore
+receive equal relative addresses after decoding the same packet. Projecting an
+authored definition set and decoding the packet replaces its authored
+addresses; the packet does not carry those bundle-local names. Two independent
+packet activations may each contain `(share-workspace, g0)`, so equality across
+those activations remains a receipt-level question rather than an address
+claim.
+
+These properties are gated by
+`WorkspaceContextAddress_UsesExactOrdinalValueEquality`,
+`ResolveScenario_IssuesContextAddressesAndDescriptors`, and
+`ToDefinitions_ResolvedContextsUsePacketLocalAddresses`.
+
+This focused contract supports the replay and receipt work in #4647 and its
+CLI and Browser Integration Census consumers #5529 and #5530. The separate
+Analysis Universe Realization adoption in #5554 owns preservation of the exact
+provider-local context correspondence. This section makes no Analysis
+Universe, Integration, host rendering, navigation, acquisition, or execution
+claim.
+
 ### Complete committed views
 
 Definition schema version 2 replaces the flat version-1 view with one
@@ -1856,7 +1904,9 @@ Definition records and product demos (this slice):
 - `InspectionDefinitionRegistry` stores peer records by `(kind, id)`, resolves
   scenarios by explicit id, and lowers package/platform/embedded coordinates to
   `WorkspaceMemberCoordinate` for `WorkspaceContextLoader` (group `subscribe`
-  expressions and filesystem coordinates are typed failures in this slice);
+  expressions and filesystem coordinates are typed failures in this slice).
+  Each resolved context retains its activation-relative
+  `WorkspaceContextAddress` and compact target descriptor;
 - `ProductInspectionDemos` is a static id→factory registry (smooth-markdown-table
   `RendererRegistry` style) of the product home scenarios (Methods tour plus
   multiple Call Graph shapes); listing is metadata-only and

--- a/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionDefinitionTests.cs
@@ -619,6 +619,71 @@ public class InspectionDefinitionTests
     }
 
     [Fact]
+    public void WorkspaceContextAddress_UsesExactOrdinalValueEquality()
+    {
+        var first = new WorkspaceContextAddress("workspace", "context");
+        var equal = new WorkspaceContextAddress("workspace", "context");
+
+        Assert.Equal(first, equal);
+        Assert.NotEqual(
+            first,
+            new WorkspaceContextAddress("Workspace", "context"));
+        Assert.NotEqual(
+            first,
+            new WorkspaceContextAddress("workspace", "Context"));
+        Assert.Throws<ArgumentException>(
+            () => new WorkspaceContextAddress("", "context"));
+        Assert.Throws<ArgumentException>(
+            () => new WorkspaceContextAddress("workspace", " "));
+    }
+
+    [Fact]
+    public void ResolveScenario_IssuesContextAddressesAndDescriptors()
+    {
+        var member = new DefinitionMemberCoordinate.PackageCoordinate(
+            "P",
+            "1.0.0",
+            "net10.0");
+        var registry = new InspectionDefinitionRegistry();
+        registry.Add(new WorkspaceDefinition(
+            1,
+            "workspace",
+            [
+                new WorkspaceContextDefinition(
+                    "first",
+                    framework: "net10.0",
+                    members: [member]),
+                new WorkspaceContextDefinition(
+                    "second",
+                    framework: "net10.0",
+                    runtimeIdentifier: "linux-x64",
+                    members: [member]),
+            ]));
+        registry.Add(new ScenarioDefinition(
+            1,
+            "scenario",
+            workspace: "workspace",
+            context: "second"));
+
+        ResolvedScenario resolved = registry.ResolveScenario("scenario");
+
+        Assert.Equal(
+            [
+                new WorkspaceContextAddress("workspace", "first"),
+                new WorkspaceContextAddress("workspace", "second"),
+            ],
+            resolved.Contexts.Select(context => context.Address));
+        Assert.Equal("first", resolved.Contexts[0].Descriptor.Name);
+        Assert.Equal("net10.0", resolved.Contexts[0].Descriptor.Framework);
+        Assert.Null(resolved.Contexts[0].Descriptor.RuntimeIdentifier);
+        Assert.Equal("linux-x64", resolved.Contexts[1].Descriptor.RuntimeIdentifier);
+        Assert.Same(resolved.Contexts[1], resolved.SelectedContext);
+        Assert.Same(
+            resolved.Contexts[1].Descriptor,
+            resolved.SelectedContext!.Descriptor);
+    }
+
+    [Fact]
     public void Registry_RecordsAndScenarios_AreEnumerationSnapshots()
     {
         var registry = new InspectionDefinitionRegistry();

--- a/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketTransposerTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceSharePacketTransposerTests.cs
@@ -94,6 +94,40 @@ public sealed class WorkspaceSharePacketTransposerTests
     }
 
     [Fact]
+    public void ToDefinitions_ResolvedContextsUsePacketLocalAddresses()
+    {
+        WorkspaceSharePacketDefinitionSet definitions = Transpose(
+            CreatePacket(
+                [
+                    Package("P", framework: "net10.0"),
+                    Package("Q", framework: "net10.0"),
+                ],
+                [
+                    new WorkspaceShareContext([0]),
+                    new WorkspaceShareContext([1]),
+                ],
+                selectedContextIndex: 1));
+        var registry = new InspectionDefinitionRegistry();
+        foreach (InspectionDefinitionRecord record in definitions.Records)
+            registry.Add(record);
+
+        ResolvedScenario resolved =
+            registry.ResolveScenario(WorkspaceSharePacketTransposer.ScenarioId);
+
+        Assert.Equal(
+            [
+                new WorkspaceContextAddress(
+                    WorkspaceSharePacketTransposer.WorkspaceId,
+                    "g0"),
+                new WorkspaceContextAddress(
+                    WorkspaceSharePacketTransposer.WorkspaceId,
+                    "g1"),
+            ],
+            resolved.Contexts.Select(context => context.Address));
+        Assert.Same(resolved.Contexts[1], resolved.SelectedContext);
+    }
+
+    [Fact]
     public void ToPacket_UsesOnlyContextWhenScenarioSelectionIsImplicit()
     {
         WorkspaceSharePacket packet = CreatePacket(

--- a/src/DotnetInspector.Queries/Definitions/InspectionDefinitionRegistry.cs
+++ b/src/DotnetInspector.Queries/Definitions/InspectionDefinitionRegistry.cs
@@ -182,9 +182,12 @@ public sealed class InspectionDefinitionRegistry
             .ToArray();
 
         return new ResolvedWorkspaceContext(
-            context.Name,
-            context.Framework,
-            context.RuntimeIdentifier,
+            new WorkspaceContextDescriptor(
+                new WorkspaceContextAddress(
+                    workspace.Id,
+                    context.Name),
+                context.Framework,
+                context.RuntimeIdentifier),
             new ReadOnlyCollection<WorkspaceMemberCoordinate>(members));
     }
 
@@ -284,22 +287,22 @@ public sealed class ResolvedScenario
 public sealed class ResolvedWorkspaceContext
 {
     internal ResolvedWorkspaceContext(
-        string name,
-        string? framework,
-        string? runtimeIdentifier,
+        WorkspaceContextDescriptor descriptor,
         IReadOnlyList<WorkspaceMemberCoordinate> members)
     {
-        Name = name;
-        Framework = framework;
-        RuntimeIdentifier = runtimeIdentifier;
+        Descriptor = descriptor;
         Members = members;
     }
 
-    public string Name { get; }
+    public WorkspaceContextDescriptor Descriptor { get; }
 
-    public string? Framework { get; }
+    public WorkspaceContextAddress Address => Descriptor.Address;
 
-    public string? RuntimeIdentifier { get; }
+    public string Name => Descriptor.Name;
+
+    public string? Framework => Descriptor.Framework;
+
+    public string? RuntimeIdentifier => Descriptor.RuntimeIdentifier;
 
     public IReadOnlyList<WorkspaceMemberCoordinate> Members { get; }
 }

--- a/src/DotnetInspector.Queries/Definitions/WorkspaceContextAddress.cs
+++ b/src/DotnetInspector.Queries/Definitions/WorkspaceContextAddress.cs
@@ -1,0 +1,52 @@
+namespace DotnetInspector.Queries.Definitions;
+
+/// <summary>
+/// Portable address of one context within an activated canonical workspace
+/// definition composition.
+/// </summary>
+/// <remarks>
+/// The address is relative to its activation. Equal addresses from different
+/// activations do not by themselves prove context correspondence.
+/// </remarks>
+public sealed record WorkspaceContextAddress
+{
+    public WorkspaceContextAddress(
+        string workspaceId,
+        string contextName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contextName);
+        WorkspaceId = workspaceId;
+        ContextName = contextName;
+    }
+
+    public string WorkspaceId { get; }
+
+    public string ContextName { get; }
+}
+
+/// <summary>
+/// Compact owner-issued facts for identifying and displaying one resolved
+/// workspace context.
+/// </summary>
+public sealed record WorkspaceContextDescriptor
+{
+    public WorkspaceContextDescriptor(
+        WorkspaceContextAddress address,
+        string? framework,
+        string? runtimeIdentifier)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        Address = address;
+        Framework = framework;
+        RuntimeIdentifier = runtimeIdentifier;
+    }
+
+    public WorkspaceContextAddress Address { get; }
+
+    public string Name => Address.ContextName;
+
+    public string? Framework { get; }
+
+    public string? RuntimeIdentifier { get; }
+}


### PR DESCRIPTION
Closes #5553.

Workspace Definitions now issues one typed, activation-relative address and
compact descriptor for every resolved context. The address preserves the exact
workspace record id and context name with ordinal value equality; it does not
pretend to be a global identity or a provider-local correspondence token.

## Demo

The host-neutral resolution API now produces stable relative coordinates:

```csharp
ResolvedScenario authored = registry.ResolveScenario("scenario");

authored.Contexts.Select(context => context.Address)
// workspace / first
// workspace / second
```

The same API after canonical share-packet transposition produces packet-local
coordinates:

```csharp
ResolvedScenario shared = registry.ResolveScenario("share-scenario");

shared.Contexts.Select(context => context.Address)
// share-workspace / g0
// share-workspace / g1
```

What to notice:

- equal-member contexts remain distinct because their owner-issued names
  differ;
- packet order becomes `g0`, `g1`, and so on without leaking array position
  into consumers; and
- the compact descriptor carries the address plus framework/RID, while the
  acquisition member recipe remains separate and cannot become identity by
  accident.

A neighboring single-context authored workspace uses the same resolution path
and receives `(workspace id, context name)` without a special case.

## Change

- Add `WorkspaceContextAddress` and `WorkspaceContextDescriptor`.
- Retain the descriptor on `ResolvedWorkspaceContext` while preserving its
  existing `Name`, `Framework`, and `RuntimeIdentifier` API.
- Define the packet and activation scope explicitly in
  `workspace-definitions.md`.
- Gate authored and packet-local addressing, selected-context correspondence,
  exact ordinal equality, and descriptor target facts.

## Boundary

This slice does not define global activation identity or bridge
`IIntegrationBindingContextIdentity`. #5554 owns the later Analysis Universe
correspondence, and #4647 owns the normalized cross-host execution receipt.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --no-build --project src/DotnetInspector.Queries.Tests -c Release`
- `npx markdownlint-cli docs/design/workspace-definitions.md`
