### PR TITLE
Make Workspace a packet viewer

### DIFF
--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -378,28 +378,50 @@ finally the arrows disappear.
 
 ### Workspace surface
 
-Workspace is the first subject and the only persistent entry point for retained
-coordinate management. Its working surface consumes product-issued descriptors
-for every open coordinate and shows:
+Workspace is the first subject and the persistent entry point for workspace
+packet inspection and retained-coordinate management. The primary inventory is
+the set of product-issued packets, not the deduplicated runtime workspaces that
+realize them. A packet composes its Workspace, navigation, and initial view as
+defined by [Workspace Definitions](workspace-definitions.md); two packets remain
+separately selectable when they reuse the same underlying Workspace. The first
+browser adoption retains resolved product demo scenarios for the current
+session.
+
+Selecting a packet is observational: it changes the packet detail shown in the
+content pane and starts no acquisition or inspection work. The detail shows its
+owner-issued title and summary, declared workspace members, initial navigation
+target, and initial view. A separate, explicit `Open workspace` action executes
+the selected packet. The selected packet's title replaces the generic
+`Workspace` content heading and inspected-target label.
+
+Selection and runtime state remain separate. The selected packet title orients
+the packet viewer; it does not claim that the packet uniquely owns the loaded
+Workspace or that its initial view is active. The loaded Workspace section
+reports runtime state without inferring packet identity from matching
+coordinates. Packet selection preserves focus on the selected inventory entry.
+
+The same content pane separately lists the runtime Workspace's loaded
+coordinates with:
 
 - coordinate identity and acquisition kind;
 - optional owner-issued current-subject context;
-- loading, ready, or failed state;
-- an activation action; and
+- loading, ready, or failed state; and
 - an explicit Close action.
 
-Activating or closing an entry submits its opaque identity and renders the
-returned workspace outcome. The UI does not choose a subject, lens, successor,
-or fallback for the product. Separate coordinates remain separate even when
-their display package IDs match.
+Opening a packet or closing a coordinate submits its opaque identity and
+renders the returned workspace outcome. The UI does not choose a subject, lens,
+successor, or fallback for the product. Separate packets remain separate even
+when their display package IDs and complete coordinate sets match.
 
 Closing an inactive coordinate preserves the active coordinate's inspection
 state and keeps Workspace selected. Closing the active coordinate selects the
-returned successor while remaining in Workspace. Share and refresh preserve
-the Workspace subject and its retained coordinates.
+returned successor while remaining in Workspace. Share and refresh preserve the Workspace subject and its retained coordinates.
+The home-demo packet inventory is session-scoped until scenario identity is
+part of the share format; after refresh, the generic current Workspace remains
+viewable without reconstructing a demo identity from matching coordinates.
 
-Workspace renders stable focus targets for its heading and every coordinate
-entry, including the returned active entry. Post-result focus and failure
+Workspace renders stable focus targets for its heading, every packet entry, and
+every coordinate action. Post-result focus and failure
 handling are owned by
 [Inspect Web Navigation Consumer](inspect-web-navigation-consumer.md#workspace-result-focus).
 

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -18,7 +18,14 @@ import {
   focusWorkbenchSearch,
   workbenchShellHtml,
 } from "../src/shell-controls.ts";
-import { renderWorkspaceSubject } from "../src/workspace-subject.ts";
+import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
+import {
+  bindWorkspaceSubject,
+  focusWorkspacePacket,
+  renderWorkspacePacketView,
+  renderWorkspaceSubject,
+  retainWorkspacePacket,
+} from "../src/workspace-subject.ts";
 
 declare global {
   interface Window {
@@ -56,7 +63,7 @@ const packageIcon = params.has("fallback")
   ? defaultPackageIcon
   : systemTextJsonIcon;
 const subjectPath = workspaceMode
-  ? [{ kind: "workspace", label: "Workspace", copyable: false }]
+  ? [{ kind: "workspace", label: "System.Text.Json", copyable: false }]
   : packageMode
     ? [{ kind: "package", label: "System.Text.Json", copyable: true }]
     : memberMode
@@ -114,6 +121,100 @@ const coordinates = [
     isRuntimePack: false,
   },
 ];
+const packetDefinitions: readonly BrowserHomeDemoResolved[] = [
+  {
+    id: "stj-serializer",
+    title: "System.Text.Json",
+    summary: "Browse a real package API",
+    workspaceMembers: [{
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    }],
+    tabs: [],
+    focusTabIndex: 0,
+    view: {
+      library: null,
+      type: "System.Text.Json.JsonSerializer",
+      memberAnchor: null,
+      memberKey: null,
+      section: "Methods",
+    },
+  },
+  {
+    id: "stj-serialize-callgraph",
+    title: "Serialize call graph",
+    summary: "Dense package-local STJ graph",
+    workspaceMembers: [{
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    }],
+    tabs: [],
+    focusTabIndex: 0,
+    view: {
+      library: null,
+      type: "System.Text.Json.JsonSerializer",
+      memberAnchor: "1dc14dd1fb",
+      memberKey: "method:Serialize",
+      section: "Call Graph",
+    },
+  },
+  {
+    id: "stj-getdecimal-callgraph",
+    title: "JsonElement.GetDecimal",
+    summary: "STJ number parse path",
+    workspaceMembers: [{
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    }],
+    tabs: [],
+    focusTabIndex: 0,
+    view: {
+      library: null,
+      type: "System.Text.Json.JsonElement",
+      memberAnchor: "cfd9980a6c",
+      memberKey: "method:GetDecimal",
+      section: "Call Graph",
+    },
+  },
+];
+let workspacePackets: BrowserHomeDemoResolved[] = [];
+for (const packet of packetDefinitions)
+  workspacePackets = retainWorkspacePacket(workspacePackets, packet);
+let selectedWorkspacePacketId = workspacePackets[0]?.id ?? "";
+
+function selectedWorkspacePacket(): BrowserHomeDemoResolved | null {
+  return workspacePackets.find(
+    packet => packet.id === selectedWorkspacePacketId) ?? null;
+}
+
+function workspaceNavigationHtml(): string {
+  return renderWorkspaceSubject({
+    packets: workspacePackets,
+    selectedPacketId: selectedWorkspacePacketId,
+    escapeHtml,
+  });
+}
+
+function workspaceDetailHtml(): string {
+  return renderWorkspacePacketView({
+    packet: selectedWorkspacePacket(),
+    packages: coordinates.slice(0, 1),
+    activePackage: coordinates[0] ?? null,
+    escapeHtml,
+    packageIdentityKey: item =>
+      `${item.id}@${item.version}::${item.activeFramework}`,
+  });
+}
+
 let activeScope: WorkspaceScope = workspaceMode
   ? "workspace"
   : packageMode
@@ -179,31 +280,7 @@ function scopeBarHtml() {
 }
 
 const navigationHtml = workspaceMode
-  ? renderWorkspaceSubject({
-      packets: coordinates.map((coordinate, index) => ({
-        id: `packet-${index}`,
-        title: `${coordinate.id} packet ${index + 1}`,
-        summary: "A retained workspace packet",
-        workspaceMembers: [{
-          kind: "package",
-          id: coordinate.id,
-          version: coordinate.version,
-          framework: coordinate.activeFramework,
-          assembly: null,
-        }],
-        tabs: [],
-        focusTabIndex: 0,
-        view: {
-          library: null,
-          type: null,
-          memberAnchor: null,
-          memberKey: null,
-          section: "Methods",
-        },
-      })),
-      selectedPacketId: "packet-0",
-      escapeHtml,
-    })
+  ? workspaceNavigationHtml()
   : `<section class="type-browser">
       <header class="browser-head">Target inventory</header>
       <label class="type-search">
@@ -270,7 +347,9 @@ app.innerHTML = `
       ${navigationHtml}
       <section class="detail-pane">
         <article id="inspector-panel" class="detail-scroll"${workspaceMode ? "" : ' role="tabpanel" aria-labelledby="active-inspector-tab"'}>
-          <h1>${subjectPath.at(-1)?.label}</h1>
+          ${workspaceMode
+            ? workspaceDetailHtml()
+            : `<h1>${subjectPath.at(-1)?.label}</h1>`}
           ${packageMode ? `
             <section class="document-section package-coordinate-editor">
               <div class="section-title"><h2>Package coordinate</h2><span>1 target framework</span></div>
@@ -343,7 +422,48 @@ function bindHarnessScopeBar() {
   }, scopeBarState);
 }
 
+function renderHarnessWorkspace(packetId: string) {
+  if (!workspacePackets.some(packet => packet.id === packetId)) return;
+  selectedWorkspacePacketId = packetId;
+  const navigation =
+    document.querySelector<HTMLElement>(".workspace-nav");
+  const detail =
+    document.querySelector<HTMLElement>("#inspector-panel");
+  const path =
+    document.querySelector<HTMLElement>(".subject-path");
+  const pathSegment =
+    path?.querySelector<HTMLElement>(".subject-path-segment");
+  if (!navigation || !detail || !path || !pathSegment)
+    throw new Error("The workspace packet harness is incomplete.");
+  navigation.outerHTML = workspaceNavigationHtml();
+  detail.innerHTML = workspaceDetailHtml();
+  const title = selectedWorkspacePacket()?.title ?? "Current workspace";
+  path.setAttribute("aria-label", title);
+  path.title = title;
+  pathSegment.textContent = title;
+  bindHarnessWorkspace();
+  requestAnimationFrame(() =>
+    focusWorkspacePacket(document, packetId));
+}
+
+function bindHarnessWorkspace() {
+  if (!workspaceMode) return;
+  bindWorkspaceSubject(document, {
+    onSelect: renderHarnessWorkspace,
+    onOpen: packetId => {
+      const count = Number(document.body.dataset.workspaceExecutionCount ?? "0");
+      document.body.dataset.workspaceExecutionCount = String(count + 1);
+      document.body.dataset.workspaceExecution = packetId;
+    },
+    onClose: packageKey => {
+      document.body.dataset.workspaceClose = packageKey;
+    },
+  });
+}
+
 bindHarnessScopeBar();
+bindHarnessWorkspace();
+if (workspaceMode) document.body.dataset.workspaceExecutionCount = "0";
 
 window.focusWorkbenchSearchProbe = () => focusWorkbenchSearch(document);
 window.renderPackageScopeProbe = () => {

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -114,7 +114,6 @@ const coordinates = [
     isRuntimePack: false,
   },
 ];
-const activeCoordinate = coordinates[0] ?? null;
 let activeScope: WorkspaceScope = workspaceMode
   ? "workspace"
   : packageMode
@@ -181,11 +180,29 @@ function scopeBarHtml() {
 
 const navigationHtml = workspaceMode
   ? renderWorkspaceSubject({
-      packages: coordinates,
-      activePackage: activeCoordinate,
+      packets: coordinates.map((coordinate, index) => ({
+        id: `packet-${index}`,
+        title: `${coordinate.id} packet ${index + 1}`,
+        summary: "A retained workspace packet",
+        workspaceMembers: [{
+          kind: "package",
+          id: coordinate.id,
+          version: coordinate.version,
+          framework: coordinate.activeFramework,
+          assembly: null,
+        }],
+        tabs: [],
+        focusTabIndex: 0,
+        view: {
+          library: null,
+          type: null,
+          memberAnchor: null,
+          memberKey: null,
+          section: "Methods",
+        },
+      })),
+      selectedPacketId: "packet-0",
       escapeHtml,
-      packageIdentityKey: item =>
-        `${item.id}@${item.version}::${item.activeFramework}`,
     })
   : `<section class="type-browser">
       <header class="browser-head">Target inventory</header>

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1066,18 +1066,18 @@ test("the title line advertises the typed Package, Type, and Member path", async
   expect(zone.y + zone.height).toBeLessThanOrEqual(workspace.y);
 });
 
-test("Workspace gives retained coordinates the pane and keeps Share readable", async ({
+test("Workspace gives retained packets the pane and keeps Share readable", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
 
-  const list = await box(page, ".workspace-coordinate-list");
-  const lastCoordinate = await box(page, ".workspace-coordinate:last-child");
+  const list = await box(page, ".workspace-packet-list");
+  const lastPacket = await box(page, ".workspace-packet:last-child");
   const share = await box(page, "#share");
 
   expect(list.height).toBeGreaterThan(200);
-  expect(lastCoordinate.y + lastCoordinate.height)
+  expect(lastPacket.y + lastPacket.height)
     .toBeLessThanOrEqual(list.y + list.height);
   expect(share.width).toBeGreaterThan(40);
   await expect(page.locator("#copy-name")).toHaveCount(0);

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1083,3 +1083,48 @@ test("Workspace gives retained packets the pane and keeps Share readable", async
   await expect(page.locator("#copy-name")).toHaveCount(0);
   await expect(page.locator("[data-subject-copy]")).toHaveCount(0);
 });
+
+test("Workspace packet selection is observational and Open executes", async ({
+  page,
+}) => {
+  await page.goto("/browser/workspace-titlebar.html?workspace=1");
+
+  const packets = page.locator("[data-workspace-packet]");
+  await expect(packets).toHaveCount(3);
+  expect(await packets.evaluateAll(elements =>
+    elements.map(element => element.getAttribute("data-workspace-packet"))))
+    .toEqual([
+    "stj-serializer",
+    "stj-serialize-callgraph",
+    "stj-getdecimal-callgraph",
+  ]);
+  const href = page.url();
+  const serialize = page.locator(
+    '[data-workspace-packet="stj-serialize-callgraph"]');
+  await serialize.click();
+
+  await expect(serialize).toBeFocused();
+  await expect(page.locator(".workspace-heading h1"))
+    .toHaveText("Serialize call graph");
+  await expect(page.locator(".subject-path-segment"))
+    .toHaveText("Serialize call graph");
+  await expect(page.locator("body"))
+    .toHaveAttribute("data-workspace-execution-count", "0");
+  expect(page.url()).toBe(href);
+
+  const getDecimal = page.locator(
+    '[data-workspace-packet="stj-getdecimal-callgraph"]');
+  await getDecimal.click();
+  await expect(getDecimal).toBeFocused();
+  await expect(page.locator(".workspace-heading h1"))
+    .toHaveText("JsonElement.GetDecimal");
+  expect(page.url()).toBe(href);
+
+  await page.getByRole("button", { name: "Open workspace" }).click();
+  await expect(page.locator("body"))
+    .toHaveAttribute("data-workspace-execution-count", "1");
+  await expect(page.locator("body"))
+    .toHaveAttribute(
+      "data-workspace-execution",
+      "stj-getdecimal-callgraph");
+});

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -158,6 +158,7 @@ import {
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
   type ProductHomeDemoId,
+  type ProductHomeDemoResolved,
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,
@@ -237,6 +238,8 @@ import {
 } from "./scope-bar.ts";
 import {
   bindWorkspaceSubject,
+  focusWorkspacePacket,
+  renderWorkspacePacketView,
   renderWorkspaceSubject,
 } from "./workspace-subject.ts";
 import {
@@ -735,6 +738,8 @@ const initialState = {
   memberDocumentationKey: "",
   lens: "api" as const,
   packageLens: "overview" as const,
+  workspacePackets: [],
+  selectedWorkspacePacketId: "",
   workspaceSubjectOpen: false,
   atPackageRoot: false,
   typeFilter: "",
@@ -798,6 +803,7 @@ const initialState = {
 interface StateOverrides {
   packages: AppPackage[];
   package: AppPackage | null;
+  workspacePackets: ProductHomeDemoResolved[];
   workspaceShareBasis: BrowserWorkspaceShareState | null;
   platformIndex: PlatformIndex | null;
   queryNoticeRetryAction: RetryAction;
@@ -2920,7 +2926,11 @@ function inspectedSubjectPath(
   current: AppTypeSurface | null | undefined,
 ): readonly SubjectPathSegment[] {
   if (scope() === "workspace") {
-    return [{ kind: "workspace", label: "Workspace", copyable: false }];
+    return [{
+      kind: "workspace",
+      label: selectedWorkspacePacket()?.title ?? "Current workspace",
+      copyable: false,
+    }];
   }
   const path: SubjectPathSegment[] = [{
     kind: "package",
@@ -2971,10 +2981,9 @@ function renderInspectedSubjectPath(
 
 function renderWorkspaceNavPane() {
   return renderWorkspaceSubject({
-    packages: state.packages,
-    activePackage: state.package,
+    packets: state.workspacePackets,
+    selectedPacketId: state.selectedWorkspacePacketId || null,
     escapeHtml,
-    packageIdentityKey,
   });
 }
 
@@ -3194,26 +3203,13 @@ function renderPackageView() {
 }
 
 function renderWorkspaceView() {
-  const packages = state.packages.filter(item => !item.isRuntimePack);
-  const current = state.package && !state.package.isRuntimePack
-    ? state.package
-    : packages[0] ?? null;
-  const platform = runtimePackPackage();
-  return `<header class="type-heading workspace-heading">
-    <div class="type-badge">W</div>
-    <div>
-      <div class="type-namespace">Inspection workspace</div>
-      <h1>Workspace</h1>
-      <code class="type-signature">${packages.length} coordinate${packages.length === 1 ? "" : "s"} · platform ${platform ? "available" : "not loaded"}</code>
-    </div>
-  </header>
-  <section class="workspace-overview">
-    <h2>Current coordinate</h2>
-    ${current
-      ? `<p><strong>${escapeHtml(current.id)}</strong> ${escapeHtml(current.version)} · ${escapeHtml(current.activeFramework)}</p>`
-      : "<p>No package coordinate is open.</p>"}
-    <p>Use Search to open another package. Platform libraries are included when the workspace requires them.</p>
-  </section>`;
+  return renderWorkspacePacketView({
+    packet: selectedWorkspacePacket(),
+    packages: state.packages,
+    activePackage: state.package,
+    escapeHtml,
+    packageIdentityKey,
+  });
 }
 
 function packageLensBody() {
@@ -5478,11 +5474,8 @@ const graphBackActions: GraphBackBindingActions = {
 
 function bindWorkspaceSubjectEvents() {
   bindWorkspaceSubject(document, {
-    onActivate: key => {
-      const packageModel = state.packages.find(
-        item => packageIdentityKey(item) === key);
-      if (packageModel) selectWorkspacePackage(packageModel);
-    },
+    onSelect: selectWorkspacePacket,
+    onOpen: runHomeDemo,
     onClose: closeWorkspacePackage,
   });
 }
@@ -7432,8 +7425,35 @@ function bindHomeEvents() {
 // deep links built from the resolved projection; member-bound Call Graph demos
 // execute through one generated engine operation over the product-resolved
 // workspace and view.
+function selectedWorkspacePacket(): ProductHomeDemoResolved | null {
+  return state.workspacePackets.find(
+    packet => packet.id === state.selectedWorkspacePacketId) ?? null;
+}
+
+function selectWorkspacePacket(packetId: string): void {
+  if (!state.workspacePackets.some(packet => packet.id === packetId)) return;
+  state.selectedWorkspacePacketId = packetId;
+  state.workspaceSubjectOpen = true;
+  state.atPackageRoot = true;
+  render();
+  afterCurrentNavigationFrame(() =>
+    focusWorkspacePacket(document, packetId));
+}
+
+function retainWorkspacePacket(packet: ProductHomeDemoResolved): void {
+  const index = state.workspacePackets.findIndex(
+    candidate => candidate.id === packet.id);
+  if (index < 0) {
+    state.workspacePackets = [...state.workspacePackets, packet];
+  } else {
+    const packets = state.workspacePackets.slice();
+    packets[index] = packet;
+    state.workspacePackets = packets;
+  }
+  state.selectedWorkspacePacketId = packet.id;
+}
+
 function runHomeDemo(kind: ProductHomeDemoId) {
-  state.home = false;
   const resolveResult = inspectResolveHomeDemo(kind);
   const resolved = resolveResult.found ? resolveResult.demo : null;
   if (!resolved) {
@@ -7443,6 +7463,8 @@ function runHomeDemo(kind: ProductHomeDemoId) {
     render();
     return;
   }
+  retainWorkspacePacket(resolved);
+  state.home = false;
   const link = productHomeDemoLocationHref(
     resolved,
     inspectEncodeWorkspaceShareState);

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -241,6 +241,7 @@ import {
   focusWorkspacePacket,
   renderWorkspacePacketView,
   renderWorkspaceSubject,
+  retainWorkspacePacket as retainWorkspacePacketInList,
 } from "./workspace-subject.ts";
 import {
   bindDocViewer,
@@ -7441,15 +7442,9 @@ function selectWorkspacePacket(packetId: string): void {
 }
 
 function retainWorkspacePacket(packet: ProductHomeDemoResolved): void {
-  const index = state.workspacePackets.findIndex(
-    candidate => candidate.id === packet.id);
-  if (index < 0) {
-    state.workspacePackets = [...state.workspacePackets, packet];
-  } else {
-    const packets = state.workspacePackets.slice();
-    packets[index] = packet;
-    state.workspacePackets = packets;
-  }
+  state.workspacePackets = retainWorkspacePacketInList(
+    state.workspacePackets,
+    packet);
   state.selectedWorkspacePacketId = packet.id;
 }
 

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -306,32 +306,64 @@ body {
 .scope-switch button.scope-seg:hover { color: var(--text); background: rgba(127,127,127,.12); }
 .scope-switch button.scope-seg.active { color: #fff; background: var(--accent); border-bottom-color: transparent; }
 .lens-separator { flex: none; width: 1px; height: 17px; background: var(--line); margin: 0 4px; }
-.workspace-coordinate-list { min-height: 0; overflow: auto; padding: 8px; }
-.workspace-coordinate {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 28px;
+.workspace-packet-list { min-height: 0; overflow: auto; padding: 8px; }
+.workspace-packet {
+  display: block;
+  width: 100%;
+  padding: 10px;
   border: 1px solid transparent;
-}
-.workspace-coordinate.active {
-  border-color: var(--line-strong);
-  background: var(--panel-active);
-}
-.workspace-coordinate button {
-  min-width: 0;
-  border: 0;
   background: transparent;
   color: var(--muted);
   text-align: left;
 }
-.workspace-coordinate > button:first-child { padding: 9px; }
-.workspace-coordinate strong,
-.workspace-coordinate span { display: block; overflow: hidden; text-overflow: ellipsis; }
-.workspace-coordinate strong { color: var(--text); font: 11px var(--mono); }
-.workspace-coordinate span { margin-top: 3px; color: var(--dim); font: 9px var(--mono); }
-.workspace-coordinate > button:last-child { text-align: center; }
-.workspace-overview { max-width: 760px; margin-top: 28px; }
-.workspace-overview h2 { margin-bottom: 12px; font-size: 14px; }
+.workspace-packet:hover { border-color: var(--line); background: rgba(127,127,127,.08); }
+.workspace-packet.active { border-color: var(--line-strong); background: var(--panel-active); }
+.workspace-packet strong,
+.workspace-packet span,
+.workspace-packet small { display: block; overflow: hidden; text-overflow: ellipsis; }
+.workspace-packet strong { color: var(--text); font: 11px var(--mono); }
+.workspace-packet span { margin-top: 4px; color: var(--muted); font-size: 11px; }
+.workspace-packet small { margin-top: 5px; color: var(--dim); font: 9px var(--mono); }
+.workspace-packet-empty { margin: 12px 8px; color: var(--dim); font-size: 11px; line-height: 1.5; }
+.workspace-overview { max-width: 900px; margin-top: 28px; }
 .workspace-overview p { color: var(--muted); line-height: 1.6; }
+.workspace-packet-introduction {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 20px;
+}
+.workspace-packet-introduction p { margin: 0; font-size: 14px; }
+.workspace-packet-introduction button { flex: none; padding: 8px 14px; }
+.workspace-packet-section { margin-top: 14px; }
+.workspace-detail-list { list-style: none; margin: 0; padding: 0; }
+.workspace-detail-list li {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 12px;
+  padding: 10px 0;
+  border-top: 1px solid var(--line);
+}
+.workspace-detail-list li:first-child { border-top: 0; }
+.workspace-detail-list li > span { color: var(--dim); font: 9px var(--mono); text-transform: uppercase; }
+.workspace-detail-list li > strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; font: 12px var(--mono); }
+.workspace-detail-list li > small { color: var(--muted); font: 10px var(--mono); }
+.workspace-detail-list.loaded li { grid-template-columns: 110px minmax(0, 1fr) auto auto; }
+.workspace-detail-list.loaded li.active > strong { color: var(--accent); }
+.workspace-detail-list.loaded button { padding: 3px 7px; }
+.workspace-view-details { margin: 0; }
+.workspace-view-details div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--line);
+}
+.workspace-view-details div:first-child { border-top: 0; }
+.workspace-view-details dt { color: var(--dim); font: 9px var(--mono); text-transform: uppercase; }
+.workspace-view-details dd { min-width: 0; margin: 0; overflow-wrap: anywhere; font: 11px var(--mono); }
 .subject-zone {
   min-width: 0;
   display: flex;
@@ -1359,6 +1391,15 @@ kbd {
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }
   .type-badge { width: 35px; height: 35px; }
   .type-heading p { grid-column: 1 / -1; }
+  .workspace-packet-introduction { align-items: flex-start; flex-direction: column; gap: 10px; }
+  .workspace-detail-list li,
+  .workspace-detail-list.loaded li {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 5px 10px;
+  }
+  .workspace-detail-list li > span { grid-column: 1 / -1; }
+  .workspace-detail-list li > small { grid-column: 1; }
+  .workspace-view-details div { grid-template-columns: 80px minmax(0, 1fr); }
 }
 
 @container title-navigation (max-width: 269px) {

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -1,6 +1,17 @@
 import type { PackageControlPackage } from "./package-controls.ts";
+import type {
+  BrowserHomeDemoMember,
+  BrowserHomeDemoResolved,
+} from "./inspect-web-engine.d.ts";
 
 export interface WorkspaceSubjectRenderOptions {
+  packets: readonly BrowserHomeDemoResolved[];
+  selectedPacketId: string | null;
+  escapeHtml: (value: unknown) => string;
+}
+
+export interface WorkspacePacketViewRenderOptions {
+  packet: BrowserHomeDemoResolved | null;
   packages: readonly PackageControlPackage[];
   activePackage: PackageControlPackage | null;
   escapeHtml: (value: unknown) => string;
@@ -8,7 +19,8 @@ export interface WorkspaceSubjectRenderOptions {
 }
 
 export interface WorkspaceSubjectBindingActions {
-  onActivate: (packageKey: string) => void;
+  onSelect: (packetId: string) => void;
+  onOpen: (packetId: string) => void;
   onClose: (packageKey: string) => void;
 }
 
@@ -16,43 +28,159 @@ export function renderWorkspaceSubject(
   options: WorkspaceSubjectRenderOptions,
 ): string {
   const {
+    packets,
+    selectedPacketId,
+    escapeHtml,
+  } = options;
+  const rows = packets.map(packet => {
+    const active = packet.id === selectedPacketId;
+    const target = [packet.view.section, packet.view.type]
+      .filter((value): value is string => Boolean(value))
+      .join(" · ") || "Workspace";
+    return `<button class="workspace-packet${active ? " active" : ""}" type="button" data-workspace-packet="${escapeHtml(packet.id)}" aria-current="${active ? "true" : "false"}">
+      <strong>${escapeHtml(packet.title)}</strong>
+      <span>${escapeHtml(packet.summary)}</span>
+      <small>${escapeHtml(target)}</small>
+    </button>`;
+  }).join("");
+  const content = rows
+    || `<p class="workspace-packet-empty">Open a demo to retain its workspace packet here.</p>`;
+  return `<aside class="type-browser workspace-nav">
+    <header class="browser-head"><span>WORKSPACE PACKETS</span><small>${packets.length}</small></header>
+    <div class="workspace-packet-list">${content}</div>
+  </aside>`;
+}
+
+function coordinateDetail(
+  member: BrowserHomeDemoMember,
+  escapeHtml: (value: unknown) => string,
+): string {
+  const details = [member.version, member.framework, member.assembly]
+    .filter((value): value is string => Boolean(value))
+    .map(escapeHtml)
+    .join(" · ");
+  const kind = member.kind === "package"
+    ? "NuGet package"
+    : member.kind === "platform"
+      ? "Platform"
+      : member.kind;
+  return `<li>
+    <span>${escapeHtml(kind)}</span>
+    <strong>${escapeHtml(member.id)}</strong>
+    ${details ? `<small>${details}</small>` : ""}
+  </li>`;
+}
+
+export function renderWorkspacePacketView(
+  options: WorkspacePacketViewRenderOptions,
+): string {
+  const {
+    packet,
     packages,
     activePackage,
     escapeHtml,
     packageIdentityKey,
   } = options;
-  const coordinates = packages.filter(item => !item.isRuntimePack);
-  const rows = coordinates.map(item => {
-    const key = escapeHtml(packageIdentityKey(item));
+  const title = packet?.title ?? "Current workspace";
+  const summary = packet?.summary
+    ?? "Live coordinates retained by this browser session.";
+  const declaredMembers = packet?.workspaceMembers.map(member =>
+    coordinateDetail(member, escapeHtml)).join("") ?? "";
+  const focusedTab = packet
+    ? packet.tabs[Math.min(
+        Math.max(packet.focusTabIndex, 0),
+        Math.max(packet.tabs.length - 1, 0))]
+    : null;
+  const viewRows = packet
+    ? [
+        ["Starts at", focusedTab?.member.id ?? null],
+        ["Section", packet.view.section],
+        ["Library", packet.view.library],
+        ["Type", packet.view.type],
+        ["Member", packet.view.memberKey ?? packet.view.memberAnchor],
+      ].filter((row): row is [string, string] => Boolean(row[1]))
+    : [];
+  const loadedCoordinates = packages.map(item => {
+    const key = packageIdentityKey(item);
     const active = Boolean(
       activePackage
-      && packageIdentityKey(item) === packageIdentityKey(activePackage));
-    return `<div class="workspace-coordinate${active ? " active" : ""}">
-      <button type="button" data-workspace-package="${key}">
-        <strong>${escapeHtml(item.id)}</strong>
-        <span>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</span>
-      </button>
-      <button type="button" data-workspace-close="${key}" aria-label="Close ${escapeHtml(item.id)} ${escapeHtml(item.version)} ${escapeHtml(item.activeFramework)}">×</button>
-    </div>`;
+      && packageIdentityKey(activePackage) === key);
+    const label = `${item.id} ${item.version} ${item.activeFramework}`;
+    return `<li class="${active ? "active" : ""}">
+      <span>${item.isRuntimePack ? "Platform" : "Loaded package"}</span>
+      <strong>${escapeHtml(item.id)}</strong>
+      <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
+      ${item.isRuntimePack
+        ? ""
+        : `<button type="button" data-workspace-close="${escapeHtml(key)}" aria-label="Close ${escapeHtml(label)}">Close</button>`}
+    </li>`;
   }).join("");
-  return `<aside class="type-browser workspace-nav">
-    <header class="browser-head"><span>WORKSPACE</span><small>${coordinates.length} open</small></header>
-    <div class="workspace-coordinate-list">${rows}</div>
-  </aside>`;
+  const packetDetails = packet
+    ? `<section class="document-section workspace-packet-section">
+        <div class="section-title"><h2>Packet workspace</h2><span>${packet.workspaceMembers.length} member${packet.workspaceMembers.length === 1 ? "" : "s"}</span></div>
+        <ul class="workspace-detail-list">${declaredMembers}</ul>
+      </section>
+      <section class="document-section workspace-packet-section">
+        <div class="section-title"><h2>Initial view</h2><span>selection only</span></div>
+        <dl class="workspace-view-details">${viewRows.map(([label, value]) =>
+          `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`).join("")}</dl>
+      </section>`
+    : "";
+  return `<header class="type-heading workspace-heading">
+    <div class="type-badge">W</div>
+    <div>
+      <div class="type-namespace">${packet ? "Workspace packet" : "Inspection workspace"}</div>
+      <h1>${escapeHtml(title)}</h1>
+      <code class="type-signature">${packet
+        ? `${packet.workspaceMembers.length} workspace member${packet.workspaceMembers.length === 1 ? "" : "s"} · ${packet.tabs.length} navigation target${packet.tabs.length === 1 ? "" : "s"}`
+        : `${packages.length} loaded coordinate${packages.length === 1 ? "" : "s"}`}</code>
+    </div>
+  </header>
+  <div class="workspace-overview">
+    <div class="workspace-packet-introduction">
+      <p>${escapeHtml(summary)}</p>
+      ${packet
+        ? `<button class="primary-action" type="button" data-workspace-open="${escapeHtml(packet.id)}">Open workspace</button>`
+        : ""}
+    </div>
+    ${packetDetails}
+    <section class="document-section workspace-packet-section">
+      <div class="section-title"><h2>Loaded workspace</h2><span>${packages.length} coordinate${packages.length === 1 ? "" : "s"}</span></div>
+      <p>Workspace packets may share these loaded coordinates without becoming the same packet.</p>
+      <ul class="workspace-detail-list loaded">${loadedCoordinates}</ul>
+    </section>
+  </div>`;
 }
 
 export function bindWorkspaceSubject(
   root: ParentNode,
   actions: WorkspaceSubjectBindingActions,
 ): void {
-  root.querySelectorAll<HTMLElement>("[data-workspace-package]").forEach(button =>
+  root.querySelectorAll<HTMLElement>("[data-workspace-packet]").forEach(button =>
     button.addEventListener("click", () => {
-      const key = button.dataset.workspacePackage;
-      if (key !== undefined) actions.onActivate(key);
+      const id = button.dataset.workspacePacket;
+      if (id !== undefined) actions.onSelect(id);
+    }));
+  root.querySelectorAll<HTMLElement>("[data-workspace-open]").forEach(button =>
+    button.addEventListener("click", () => {
+      const id = button.dataset.workspaceOpen;
+      if (id !== undefined) actions.onOpen(id);
     }));
   root.querySelectorAll<HTMLElement>("[data-workspace-close]").forEach(button =>
     button.addEventListener("click", () => {
       const key = button.dataset.workspaceClose;
       if (key !== undefined) actions.onClose(key);
     }));
+}
+
+export function focusWorkspacePacket(
+  root: ParentNode,
+  packetId: string,
+): boolean {
+  for (const button of root.querySelectorAll<HTMLElement>("[data-workspace-packet]")) {
+    if (button.dataset.workspacePacket !== packetId) continue;
+    button.focus();
+    return true;
+  }
+  return false;
 }

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -24,6 +24,17 @@ export interface WorkspaceSubjectBindingActions {
   onClose: (packageKey: string) => void;
 }
 
+export function retainWorkspacePacket(
+  packets: readonly BrowserHomeDemoResolved[],
+  packet: BrowserHomeDemoResolved,
+): BrowserHomeDemoResolved[] {
+  const index = packets.findIndex(candidate => candidate.id === packet.id);
+  if (index < 0) return [...packets, packet];
+  const retained = packets.slice();
+  retained[index] = packet;
+  return retained;
+}
+
 export function renderWorkspaceSubject(
   options: WorkspaceSubjectRenderOptions,
 ): string {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -5717,6 +5717,9 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /onClose: closeWorkspacePackage/);
   assert.match(
     appSource,
+    /onSelect: selectWorkspacePacket,\s+onOpen: runHomeDemo/);
+  assert.match(
+    appSource,
     /const key = assemblyId \|\| `legacy:\$\{asm\}`/);
   assert.match(
     appSource,

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -5,6 +5,7 @@ import {
   focusWorkspacePacket,
   renderWorkspacePacketView,
   renderWorkspaceSubject,
+  retainWorkspacePacket,
 } from "../src/workspace-subject.ts";
 import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import type { PackageControlPackage } from "../src/package-controls.ts";
@@ -77,6 +78,24 @@ test("Workspace lists independently selectable packets", () => {
   assert.match(html, /Serialize call graph[\s\S]*Dense package-local STJ graph/);
   assert.match(html, /JsonElement\.GetDecimal[\s\S]*STJ number parse path/);
   assert.doesNotMatch(html, /data-workspace-open/);
+});
+
+test("Workspace packet retention keys scenarios independently of coordinates", () => {
+  const sibling = {
+    ...packet,
+    id: "stj-getdecimal-callgraph",
+    title: "JsonElement.GetDecimal",
+  };
+  const retained = retainWorkspacePacket(
+    retainWorkspacePacket([], packet),
+    sibling);
+
+  assert.deepEqual(
+    retained.map(item => item.id),
+    ["stj-serialize-callgraph", "stj-getdecimal-callgraph"]);
+  assert.deepEqual(
+    retained.map(item => item.workspaceMembers),
+    [packet.workspaceMembers, packet.workspaceMembers]);
 });
 
 test("Workspace packet details distinguish packet data from loaded coordinates", () => {

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindWorkspaceSubject,
+  focusWorkspacePacket,
+  renderWorkspacePacketView,
   renderWorkspaceSubject,
 } from "../src/workspace-subject.ts";
+import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import type { PackageControlPackage } from "../src/package-controls.ts";
 import { fakeDom } from "./fake-dom.ts";
 
@@ -19,7 +22,64 @@ function packageIdentityKey(pkg: PackageControlPackage) {
   return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
 }
 
-test("Workspace lists package coordinates without presenting Platform as a workspace", () => {
+const packet: BrowserHomeDemoResolved = {
+  id: "stj-serialize-callgraph",
+  title: "Serialize call graph",
+  summary: "Dense package-local STJ graph",
+  workspaceMembers: [{
+    kind: "package",
+    id: "System.Text.Json",
+    version: "10.0.0",
+    framework: "net10.0",
+    assembly: null,
+  }],
+  tabs: [{
+    id: "stj",
+    member: {
+      kind: "package",
+      id: "System.Text.Json",
+      version: "10.0.0",
+      framework: "net10.0",
+      assembly: null,
+    },
+  }],
+  focusTabIndex: 0,
+  view: {
+    library: null,
+    type: "System.Text.Json.JsonSerializer",
+    memberAnchor: "1dc14dd1fb",
+    memberKey: "method:Serialize",
+    section: "Call Graph",
+  },
+};
+
+test("Workspace lists independently selectable packets", () => {
+  const sibling = {
+    ...packet,
+    id: "stj-getdecimal-callgraph",
+    title: "JsonElement.GetDecimal",
+    summary: "STJ number parse path",
+    view: {
+      ...packet.view,
+      type: "System.Text.Json.JsonElement",
+      memberKey: "method:GetDecimal",
+    },
+  };
+
+  const html = renderWorkspaceSubject({
+    packets: [packet, sibling],
+    selectedPacketId: packet.id,
+    escapeHtml,
+  });
+
+  assert.match(html, /WORKSPACE PACKETS[\s\S]*2/);
+  assert.match(html, /workspace-packet active/);
+  assert.match(html, /Serialize call graph[\s\S]*Dense package-local STJ graph/);
+  assert.match(html, /JsonElement\.GetDecimal[\s\S]*STJ number parse path/);
+  assert.doesNotMatch(html, /data-workspace-open/);
+});
+
+test("Workspace packet details distinguish packet data from loaded coordinates", () => {
   const active: PackageControlPackage = {
     id: "System.Text.Json",
     version: "10.0.0",
@@ -33,25 +93,33 @@ test("Workspace lists package coordinates without presenting Platform as a works
     isRuntimePack: true,
   };
 
-  const html = renderWorkspaceSubject({
+  const html = renderWorkspacePacketView({
+    packet,
     packages: [platform, active],
     activePackage: active,
     escapeHtml,
     packageIdentityKey,
   });
 
-  assert.match(html, /WORKSPACE[\s\S]*1 open/);
-  assert.match(html, /workspace-coordinate active/);
-  assert.match(html, /System\.Text\.Json[\s\S]*10\.0\.0 · net10\.0/);
-  assert.doesNotMatch(html, /Microsoft\.NETCore\.App|Platform/);
+  assert.match(html, /Workspace packet[\s\S]*Serialize call graph/);
+  assert.match(html, /Packet workspace[\s\S]*System\.Text\.Json/);
+  assert.match(html, /Initial view[\s\S]*Call Graph[\s\S]*method:Serialize/);
+  assert.match(html, /Loaded workspace[\s\S]*Microsoft\.NETCore\.App/);
+  assert.match(html, /data-workspace-open="stj-serialize-callgraph"/);
+  assert.match(html, />Open workspace</);
 });
 
-test("Workspace activation and Close dispatch package identity keys", () => {
+test("Workspace selection, explicit Open, and Close dispatch separate identities", () => {
   const listeners = new Map<string, EventListener>();
-  const activate = {
-    dataset: { workspacePackage: "activate-key" },
+  const select = {
+    dataset: { workspacePacket: "packet-key" },
     addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`activate:${name}`, listener),
+      listeners.set(`select:${name}`, listener),
+  };
+  const open = {
+    dataset: { workspaceOpen: "open-key" },
+    addEventListener: (name: string, listener: EventListener) =>
+      listeners.set(`open:${name}`, listener),
   };
   const close = {
     dataset: { workspaceClose: "close-key" },
@@ -60,20 +128,30 @@ test("Workspace activation and Close dispatch package identity keys", () => {
   };
   const root = {
     querySelectorAll: (selector: string) =>
-      selector === "[data-workspace-package]" ? [activate] : [close],
+      selector === "[data-workspace-packet]"
+        ? [select]
+        : selector === "[data-workspace-open]"
+          ? [open]
+          : [close],
   };
   const calls: string[] = [];
 
   bindWorkspaceSubject(
     fakeDom.parentNode(root),
     {
-      onActivate: key => calls.push(`activate:${key}`),
+      onSelect: key => calls.push(`select:${key}`),
+      onOpen: key => calls.push(`open:${key}`),
       onClose: key => calls.push(`close:${key}`),
     });
 
-  listeners.get("activate:click")?.(fakeDom.event());
+  listeners.get("select:click")?.(fakeDom.event());
+  listeners.get("open:click")?.(fakeDom.event());
   listeners.get("close:click")?.(fakeDom.event());
-  assert.deepEqual(calls, ["activate:activate-key", "close:close-key"]);
+  assert.deepEqual(calls, [
+    "select:packet-key",
+    "open:open-key",
+    "close:close-key",
+  ]);
 });
 
 test("Workspace Close names distinguish matching package ids", () => {
@@ -92,7 +170,8 @@ test("Workspace Close names distinguish matching package ids", () => {
     },
   ];
 
-  const html = renderWorkspaceSubject({
+  const html = renderWorkspacePacketView({
+    packet: null,
     packages,
     activePackage: packages[0] ?? null,
     escapeHtml,
@@ -101,4 +180,29 @@ test("Workspace Close names distinguish matching package ids", () => {
 
   assert.match(html, /aria-label="Close Example\.Package 1\.0\.0 net8\.0"/);
   assert.match(html, /aria-label="Close Example\.Package 2\.0\.0 net10\.0"/);
+});
+
+test("Workspace packet focus survives observational selection", () => {
+  let focused = "";
+  const root = {
+    querySelectorAll: () => [{
+      dataset: { workspacePacket: "first" },
+      focus: () => {
+        focused = "first";
+      },
+    }, {
+      dataset: { workspacePacket: "second" },
+      focus: () => {
+        focused = "second";
+      },
+    }],
+  };
+
+  assert.equal(
+    focusWorkspacePacket(fakeDom.parentNode(root), "second"),
+    true);
+  assert.equal(focused, "second");
+  assert.equal(
+    focusWorkspacePacket(fakeDom.parentNode(root), "missing"),
+    false);
 });


### PR DESCRIPTION
Build a clearer Inspect Web experience by preserving the distinction between a
portable workspace packet and the runtime Workspace that realizes it.

## Summary

- Retain each opened product demo scenario as an independently selectable
  workspace packet, even when several packets share the same package
  coordinates.
- Make packet-row selection observational and move execution to an explicit
  `Open workspace` action.
- Show packet title, summary, declared workspace members, initial navigation
  target, and initial view separately from the loaded runtime Workspace.
- Use the selected packet title in the content heading and inspected-target
  label, preserve packet-row focus across rendering, and retain coordinate
  Close actions in the loaded Workspace section.
- Keep the first adoption session-scoped; refresh continues to show the generic
  current Workspace because today's share format does not carry product demo
  scenario identity.

## Demo

1. From Home, open `System.Text.Json`, `Serialize call graph`, and
   `JsonElement.GetDecimal`.
2. Select the Workspace subject.
3. Select each retained packet in the left pane.

Notice that all three STJ packets remain independently viewable, selecting one
changes only its details, and the shared loaded `System.Text.Json` coordinate is
shown separately. `Open workspace` is the only action that executes the
selected packet.

![Workspace packet viewer showing three separately selectable System.Text.Json packets, the selected Serialize call graph packet details, and one shared loaded workspace coordinate](https://github.com/user-attachments/assets/01f44dcb-45c4-43b4-98a0-e415e5daae15)

## Validation

- `npm test` — 921 passed
- `npm run lint`
- `npm run build`
- `npx playwright test browser/workspace-titlebar.spec.ts --project=firefox` —
  29 passed
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 212
  passed
- `npx markdownlint-cli docs/design/inspect-web-navigation-presentation.md`

Refs #5510
