### PR TITLE
Adopt MTP for CLI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,16 +437,7 @@ jobs:
 
       - name: Run embedded skill tests
         shell: bash
-        run: |
-          set -euo pipefail
-          results="$RUNNER_TEMP/skill-tests.xml"
-          dotnet run --project src/dotnet-inspect.Tests -c Release -- \
-            -class "DotnetInspector.Tests.SkillCommandTests" \
-            -xml "$results"
-          if ! grep -Eq 'total="[1-9][0-9]*"' "$results"; then
-            echo "::error::Skill test filter selected no tests." >&2
-            exit 1
-          fi
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class "DotnetInspector.Tests.SkillCommandTests"
 
   # Build and run the PR test matrix on Ubuntu 24.04. Windows, macOS, and Ubuntu
   # 26.04 compatibility suites run daily in Deep Inspect, where
@@ -561,7 +552,7 @@ jobs:
         run: eng/restore-iltools.sh --rid ${{ matrix.rid }} --mdv >> "$GITHUB_PATH"
 
       - name: Run CLI tests (fast)
-        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-not-trait "Speed=Slow"
 
       - name: Run GitHub Packages fixture test
         id: package_fixture
@@ -572,14 +563,14 @@ jobs:
           DOTNET_INSPECT_PACKAGE_FIXTURE_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          results="$RUNNER_TEMP/package-fixture-tests.xml"
+          results_dir="$RUNNER_TEMP"
+          results_name="package-fixture-tests.xml"
+          results="$results_dir/$results_name"
           dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
-            -method '*Package_Manifest_RendersToolManifestRows*' \
-            -xml "$results"
-          if ! grep -Eq 'total="[1-9][0-9]*"' "$results"; then
-            echo "::error::Package fixture test filter selected no tests." >&2
-            exit 1
-          fi
+            --filter-method '*Package_Manifest_RendersToolManifestRows*' \
+            --report-xunit \
+            --report-xunit-filename "$results_name" \
+            --results-directory "$results_dir"
           if ! grep -Eq '<assembly[^>]+skipped="0"' "$results"; then
             echo "::error::Package fixture test skipped authenticated execution." >&2
             exit 1

--- a/.github/workflows/publish-package-fixtures.yml
+++ b/.github/workflows/publish-package-fixtures.yml
@@ -51,16 +51,7 @@ jobs:
 
       - name: Validate fixture catalog
         shell: bash
-        run: |
-          set -euo pipefail
-          results="$RUNNER_TEMP/package-fixture-tests.xml"
-          dotnet run --project src/dotnet-inspect.Tests -c Release -- \
-            -class "DotnetInspector.Tests.PackageFixtureTests" \
-            -xml "$results"
-          if ! grep -Eq 'total="[1-9][0-9]*"' "$results"; then
-            echo "::error::Package fixture test filter selected no tests." >&2
-            exit 1
-          fi
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class "DotnetInspector.Tests.PackageFixtureTests"
 
       - name: Pack fixture packages
         shell: bash

--- a/.github/workflows/windows-pr.yml
+++ b/.github/workflows/windows-pr.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run CLI tests
         if: inputs.suite == 'cli'
-        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-not-trait "Speed=Slow"
 
       - name: Run services tests
         if: inputs.suite == 'services'

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -194,7 +194,8 @@ Notes:
   of the entry gate for behavior changes, but iterate against a class filter and
   run the full suite before requesting review.
 - **PR CI runs only the fast unit subset.** The `test` job in `ci.yml` runs
-  `dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait-
+  `dotnet run --project src/dotnet-inspect.Tests -c Release --
+  --filter-not-trait
   "Speed=Slow"`, `dotnet run --project src/ILInspector.Decompiler.Tests -c
   Release -- -trait- "Speed=Slow"`, and the matching fast Analysis/IL
   round-trip filters. These gate command surface, pass logic, printer, importer

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -269,7 +269,7 @@ subsequent reads, and exactly 25 projected rows. Run it with:
 
 ```bash
 dotnet run --project src/dotnet-inspect.Tests -c Release -- \
-  -method '*PackageProfileDefaultScale*'
+  --filter-method '*PackageProfileDefaultScale*'
 ```
 
 L1 does not reference Markout.

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -148,6 +148,12 @@ turn zero execution into success. This pins why that opt-out is outside the
 repository evidence profile rather than motivating a second command-line
 parser.
 
+`MtpTestHostTests` is the outcome-level gate for the first adopter,
+`dotnet-inspect.Tests`. It starts the built test apphost and covers the
+unmatched, valid, and mixed valid/stale filter outcomes. The suite's workflow
+contract tests pin its MTP call sites and preserve the authenticated package
+fixture's stronger not-skipped receipt.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/eng/package-fixtures/README.md
+++ b/eng/package-fixtures/README.md
@@ -118,7 +118,7 @@ export DOTNET_INSPECT_PACKAGE_FIXTURE_USER="$(gh api user --jq .login)"
 read -rsp "GitHub Packages PAT: " DOTNET_INSPECT_PACKAGE_FIXTURE_TOKEN
 export DOTNET_INSPECT_PACKAGE_FIXTURE_TOKEN
 dotnet run --project src/dotnet-inspect.Tests -c Release -- \
-  -method '*Package_Manifest_RendersToolManifestRows*'
+  --filter-method '*Package_Manifest_RendersToolManifestRows*'
 unset DOTNET_INSPECT_PACKAGE_FIXTURE_TOKEN
 ```
 

--- a/src/dotnet-inspect.Tests/CiWorkflowTests.cs
+++ b/src/dotnet-inspect.Tests/CiWorkflowTests.cs
@@ -53,16 +53,20 @@ public class CiWorkflowTests
                 Workflow,
                 "DOTNET_INSPECT_PACKAGE_FIXTURE_TOKEN: ${{ github.token }}"));
         Assert.Contains(
-            "-method '*Package_Manifest_RendersToolManifestRows*'",
-            fixtureStep);
-        Assert.Contains(
-            "Package fixture test filter selected no tests.",
+            "--filter-method '*Package_Manifest_RendersToolManifestRows*'",
             fixtureStep);
         Assert.Contains(
             "Package fixture test skipped authenticated execution.",
             fixtureStep);
         Assert.Contains(
             "grep -Eq '<assembly[^>]+skipped=\"0\"'",
+            fixtureStep);
+        Assert.Contains("--report-xunit", fixtureStep);
+        Assert.Contains(
+            "--report-xunit-filename \"$results_name\"",
+            fixtureStep);
+        Assert.Contains(
+            "--results-directory \"$results_dir\"",
             fixtureStep);
         Assert.Contains("continue-on-error: true", fixtureStep);
         Assert.Contains("id: package_fixture", fixtureStep);

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -808,7 +808,7 @@ public class IlToolsActivationTests
             (
                 "cli",
                 "dotnet run --project src/dotnet-inspect.Tests -c Release -- " +
-                "-trait- \"Speed=Slow\""),
+                "--filter-not-trait \"Speed=Slow\""),
             (
                 "services",
                 "dotnet run --project " +

--- a/src/dotnet-inspect.Tests/MtpTestHostTests.cs
+++ b/src/dotnet-inspect.Tests/MtpTestHostTests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+
+namespace DotnetInspector.Tests;
+
+public class MtpTestHostTests
+{
+    private const string FixtureMethod =
+        "DotnetInspector.Tests.MtpTestHostTests.SelectionFixture_Passes";
+
+    [Fact]
+    public async Task UnmatchedFilter_ExitsWithZeroTestsCode()
+    {
+        ProcessResult result = await RunHostAsync(
+            "--filter-method",
+            "DotnetInspector.Tests.MtpTestHostTests.DefinitelyNoSuchTest5099");
+
+        AssertExitCode(8, result);
+    }
+
+    [Fact]
+    public async Task ValidFilter_RunsSelectedTest()
+    {
+        ProcessResult result = await RunHostAsync(
+            "--filter-method",
+            FixtureMethod);
+
+        AssertExitCode(0, result);
+    }
+
+    [Fact]
+    public async Task MixedValidAndStaleValues_UseAggregateMinimum()
+    {
+        ProcessResult result = await RunHostAsync(
+            "--filter-class",
+            typeof(MtpTestHostTests).FullName!,
+            "DotnetInspector.Tests.DefinitelyNoSuchClass5099",
+            "--filter-method",
+            FixtureMethod);
+
+        AssertExitCode(0, result);
+    }
+
+    [Fact]
+    public void SelectionFixture_Passes()
+    {
+    }
+
+    private static async Task<ProcessResult> RunHostAsync(params string[] arguments)
+    {
+        string executable = Path.Combine(
+            AppContext.BaseDirectory,
+            OperatingSystem.IsWindows()
+                ? "dotnet-inspect.Tests.exe"
+                : "dotnet-inspect.Tests");
+        Assert.True(
+            File.Exists(executable),
+            $"Expected the test apphost at '{executable}'.");
+
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (string argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using Process process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException(
+                $"Could not start test apphost '{executable}'.");
+        Task<string> stdout = process.StandardOutput.ReadToEndAsync(
+            TestContext.Current.CancellationToken);
+        Task<string> stderr = process.StandardError.ReadToEndAsync(
+            TestContext.Current.CancellationToken);
+        await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+        return new(
+            process.ExitCode,
+            await stdout,
+            await stderr);
+    }
+
+    private static void AssertExitCode(int expected, ProcessResult result)
+    {
+        Assert.True(
+            result.ExitCode == expected,
+            $"Expected exit code {expected}, got {result.ExitCode}."
+                + Environment.NewLine
+                + "Standard output:"
+                + Environment.NewLine
+                + result.StandardOutput
+                + Environment.NewLine
+                + "Standard error:"
+                + Environment.NewLine
+                + result.StandardError);
+    }
+
+    private sealed record ProcessResult(
+        int ExitCode,
+        string StandardOutput,
+        string StandardError);
+}

--- a/src/dotnet-inspect.Tests/PackageFixtureTests.cs
+++ b/src/dotnet-inspect.Tests/PackageFixtureTests.cs
@@ -292,10 +292,7 @@ public sealed class PackageFixtureTests
             "https://nuget.pkg.github.com/richlander/index.json",
             workflow);
         Assert.Contains(
-            "-class \"DotnetInspector.Tests.PackageFixtureTests\"",
-            workflow);
-        Assert.Contains(
-            "grep -Eq 'total=\"[1-9][0-9]*\"'",
+            "--filter-class \"DotnetInspector.Tests.PackageFixtureTests\"",
             workflow);
         Assert.Contains(
             "-p:FixtureFamily=\"$FIXTURE_FAMILY\"",

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -11,6 +11,7 @@
     <IsAotCompatible>false</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adopt Microsoft Testing Platform for `dotnet-inspect.Tests`, the first ordinary
xUnit executable affected by #5379.

- select the packaged MTP runner without adding a direct runner dependency;
- migrate the suite's workflow and documentation call sites to MTP filter and
  report syntax;
- remove redundant XML test-count wrappers now owned by MTP's zero-test exit;
- preserve the authenticated package fixture's stronger not-skipped receipt;
- add apphost-level outcome tests for unmatched, valid, and mixed valid/stale
  filters.

This slice does not migrate other test executables. In particular, the
decompiler remains on its transitional native host until MTP can preserve its
independent discovery/execution identities and exactly-once completeness
receipt.

## Demo

Before this change, the native xUnit runner accepted a stale focused selector
as successful evidence:

```console
$ dotnet run --project src/dotnet-inspect.Tests -c Release -- \
    -method '*DefinitelyNoSuchTest5099*'
...
Total: 0
$ echo $?
0
```

With this suite configured for MTP, the equivalent stale selector is a failed
test execution:

```console
$ dotnet run --project src/dotnet-inspect.Tests -c Release -- \
    --filter-method '*DefinitelyNoSuchTest5099*'
...
Test run summary: Zero tests ran
$ echo $?
8
```

A valid fully qualified method filter still exits `0`. A mixed valid/stale
selection also exits `0`, demonstrating the intended boundary: MTP guarantees
aggregate non-vacuity, not per-value contribution inside a multi-value filter.

## Validation

```console
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
  --filter-not-trait Speed=Slow
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
  --filter-class '*MtpTestHostTests*'
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
  --filter-method '*CiWorkflowTests*' \
  --filter-method '*IlToolsActivationTests*' \
  --filter-method '*PackageFixtureTests*'
npx markdownlint-cli docs/design/xunit-test-host.md \
  docs/design/inspection-layers.md \
  docs/decompiler-correctness-pipeline.md \
  eng/package-fixtures/README.md
git diff --check origin/main...HEAD
```

The focused MTP host tests pass 4/4, and the workflow contract selection passes
43/43.
