### PR TITLE
Drop the dead ILInspector.Instructions internals grant

### DIFF
--- a/src/ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj
+++ b/src/ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ILInspector.ILDiff" />
-    <InternalsVisibleTo Include="ILInspector.Instructions" />
     <InternalsVisibleTo Include="ILInspector.Metadata" />
     <InternalsVisibleTo Include="ILInspector.Metadata.Tests" />
   </ItemGroup>


### PR DESCRIPTION
`ILInspector.MetadataPrimitives` grants `InternalsVisibleTo` to
`ILInspector.Instructions`, and that grant is dead. The assembly references none
of the eight internal types in `MetadataPrimitives` and no internal member of a
public one.

`InternalsVisibleTo` is a coarse, silent grant. It is all-or-nothing — the
grantee sees *every* internal in the assembly — and nothing fails when one stops
being necessary, so a stale entry keeps that surface exposed indefinitely. This
one was presumably earned once and outlived its use.

## Demo

The grant's own removal is the demonstration: delete the line, build everything.

```console
$ sed -i '/InternalsVisibleTo Include="ILInspector.Instructions"/d' \
    src/ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj
$ dotnet build dotnet-inspect.slnx -c Release
Build succeeded.
```

What to notice: **zero** errors and zero new warnings, across the whole solution
rather than just the grantee. Had `ILInspector.Instructions` touched a single
internal, this is a compile error, not a subtle regression — which is what makes
a one-line build the complete proof.

The neighboring case behaves as it should: removing any of the three surviving
grants does *not* build. `ILInspector.ILDiff` uses `StructuralEncodedSignature`,
`StructuralMethodKey`, `StructuralMethodLocalKey`, and `StructuralTypeKey`;
`ILInspector.Metadata` uses `MetadataTypeNameParts`, `MetadataTypeNameBudget`,
and `SystemTypeArgumentName`; the test assembly reaches the structural keys and
the budget. Only this entry is removable.

## Validation

`dotnet build dotnet-inspect.slnx -c Release` — succeeded, 0 errors, 0 warnings.

Removing a compile-time visibility grant cannot change runtime behavior once
compilation succeeds, so the build *is* the evidence; no suite can distinguish
the before and after.

## Boundary

No product code changes — one line of build configuration. No public API change,
no behavior change, no test change.

## Review

Trivial under `AGENTS.md`: a one-line deletion whose correctness the compiler
decides completely and mechanically.

Found while auditing the same `InternalsVisibleTo` list in #5450, and
deliberately kept out of that PR so its consolidation claim stays reviewable on
its own.
