### PR TITLE
Implement source-scoped NuGet authentication contexts

### DIFF
--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -496,6 +496,12 @@ A user-configured V3 endpoint is different even when its host belongs to
 NuGet.org: it follows the configurable-source rules above and does not acquire
 the built-in Gallery's credential-free identity merely from its hostname.
 
+Credential-provider contexts are desktop-only. Browser/Wasm callers cannot
+create a `PluginAuthenticationContextOwner`; creation fails visibly with
+`PlatformNotSupportedException`, and V3 factory composition independently
+rejects a context on that platform. Browser sources continue to use the
+explicit session PAT contract owned by the browser-package-source design.
+
 #### Concurrency and refresh
 
 Acquisition is single-flight per context. Concurrent authorized challenges for
@@ -799,13 +805,19 @@ the associated V3 source pipeline; an unassociated call site cannot acquire
 plugin authority. Neither shape fixes the `nuget.config` path, which still
 depends on the caller threading an explicit credential through.
 
-The current handler caches acquired credentials by request-target origin so the
-service index and discovered package endpoints share one challenge response.
-Azure Artifacts adds the first path segment, which is the organization. This
-separates Azure organizations, but neither shape separates distinct configured
-sources inside one cache scope. The
-[source-scoped context](#source-scoped-plugin-authentication-context) is the
-target replacement; its implementation gates remain unverified.
+The legacy shared handler caches acquired credentials by request-target origin
+so the service index and discovered package endpoints share one challenge
+response. Azure Artifacts adds the first path segment, which is the
+organization. This separates Azure organizations, but neither rule separates
+distinct configured sources inside one cache scope.
+
+The
+[source-scoped context](#source-scoped-plugin-authentication-context) is
+implemented for owner-composed V3 source pipelines through
+`PackageSourceClientFactory.CreateWithPluginAuthentication`. Package-source
+composition issue #5603 is the named consumer that will replace the legacy
+shared-handler path; until then, that path does not claim source-scoped
+isolation.
 
 When an automatic redirect ends in an authentication challenge, credential acquisition remains
 scoped to the caller-selected source URI and the retry starts again from that URI. A redirect
@@ -827,8 +839,13 @@ Two tiers, in `src/NuGetFetch.Tests`:
     `IsRetry` progression, request-target cache scoping for ordinary hosts,
     organization scoping and GUID-alias reuse for Azure Artifacts, redirect
     isolation from credential scope and returned content, 403 opt-in, and that
-    an existing credential is not overwritten. It does not yet establish the
-    source-scoped context gates above.
+    an existing credential is not overwritten. It establishes only the legacy
+    shared-handler behavior.
+  - `PluginAuthenticationContextTests` pins every required source-scoped
+    context gate above. Pipeline mapping, disposal, resource-first challenge,
+    and redirect composition run through owner-composed V3 clients; focused
+    state, scope, refresh, and retirement vectors use hermetic handler
+    transports.
   - `PluginProtocolTests` runs a **real plugin process** — a cross-platform managed fixture that
     genuinely speaks the line protocol — so framing, the symmetric handshake, process death,
     selected shutdown behavior, and caller-cancellation classification are exercised end to end

--- a/src/NuGetFetch.Tests/PluginAuthenticationContextTests.cs
+++ b/src/NuGetFetch.Tests/PluginAuthenticationContextTests.cs
@@ -1,0 +1,1429 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using NuGetFetch.Plugins;
+
+namespace NuGetFetch.Tests;
+
+public sealed class PluginAuthenticationContextTests
+{
+    private const string SourceIndex =
+        "https://feed.example/v3/index.json";
+    private const string Resource =
+        "https://feed.example/v3/flat/contoso/index.json";
+    private const string ServiceIndex = """
+        {
+          "version": "3.0.0",
+          "resources": [
+            {
+              "@id": "https://feed.example/v3/flat/",
+              "@type": "PackageBaseAddress/3.0.0"
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task AnonymousSourceSharingOriginNeverReceivesPrivateSourceCredential()
+    {
+        var provider = new RecordingCredentialSource(
+            static (_, _, _) =>
+                Task.FromResult<PackageSourceCredential?>(
+                    new("user", "private-token")));
+        PackageSourceAssociation privateAssociation =
+            PackageSourceAssociation.Create();
+        PackageSourceAssociation anonymousAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext privateContext =
+            Context(
+                privateAssociation,
+                "https://same.example/private/index.json",
+                provider);
+        using OwnedAuthenticationContext anonymousContext =
+            Context(
+                anonymousAssociation,
+                "https://same.example/anonymous/index.json",
+                provider);
+        var privateTransport = ChallengeUntilAuthenticated();
+        var anonymousTransport = new RecordingTransport(
+            static (_, _, _) =>
+                Task.FromResult(Response(HttpStatusCode.OK)));
+        using HttpClient privateClient =
+            Client(privateContext, privateTransport);
+        using HttpClient anonymousClient =
+            Client(anonymousContext, anonymousTransport);
+
+        using HttpResponseMessage privateResponse =
+            await privateClient.GetAsync(
+                "https://same.example/private/index.json",
+                TestContext.Current.CancellationToken);
+        using HttpResponseMessage anonymousResponse =
+            await anonymousClient.GetAsync(
+                "https://same.example/anonymous/index.json",
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, privateResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, anonymousResponse.StatusCode);
+        Assert.Equal(1, provider.Calls);
+        Assert.Single(anonymousTransport.Requests);
+        Assert.Null(anonymousTransport.Requests[0].Authorization);
+    }
+
+    [Fact]
+    public async Task AuthorizedResourceReusesItsSourceContextCredential()
+    {
+        var provider = FixedCredential("source-token");
+        using OwnedAuthenticationContext context =
+            Context(PackageSourceAssociation.Create(), SourceIndex, provider);
+        var transport = ChallengeUntilAuthenticated();
+        using HttpClient client = Client(context, transport);
+
+        using (HttpResponseMessage source = await client.GetAsync(
+            SourceIndex,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, source.StatusCode);
+        }
+
+        using HttpResponseMessage resource = await client.GetAsync(
+            Resource,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, resource.StatusCode);
+        Assert.Equal(1, provider.Calls);
+        Assert.Equal(
+            BasicParameter("source-token"),
+            transport.Requests[^1].Authorization);
+    }
+
+    [Fact]
+    public async Task ResourceFirstChallengeUsesConfiguredProviderQuery()
+    {
+        var provider = FixedCredential("resource-token");
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext context =
+            Context(association, SourceIndex, provider);
+        var transport = V3ResourceFirstTransport();
+        using IPackageSourceClient source = V3(
+            association,
+            context,
+            transport);
+
+        PackageSourceOperationResult<PackageVersionResult> result =
+            await source.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result.Value);
+        Assert.Equal(["1.0.0"], result.Value.Candidates.Select(
+            candidate => candidate.Coordinate.Version));
+        Assert.Equal([SourceIndex], provider.Uris.Select(
+            uri => uri.AbsoluteUri));
+        Assert.Equal(
+            [null, BasicParameter("resource-token")],
+            transport.Requests
+                .Where(request => request.Uri == Resource)
+                .Select(request => request.Authorization));
+    }
+
+    [Fact]
+    public async Task SharedAssociationPipelinesShareAuthenticationContext()
+    {
+        var release = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new RecordingCredentialSource(
+            async (_, _, cancellationToken) =>
+            {
+                await release.Task.WaitAsync(cancellationToken);
+                return new PackageSourceCredential(
+                    "user",
+                    "shared-token");
+            });
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext ownedContext =
+            Context(association, SourceIndex, provider);
+        Assert.Throws<InvalidOperationException>(
+            () => PluginAuthenticationContextOwner.Create(
+                association,
+                new Uri(SourceIndex),
+                provider));
+        {
+            using IPackageSourceClient first = V3(
+                association,
+                ownedContext,
+                ChallengeV3Transport());
+            using IPackageSourceClient second = V3(
+                association,
+                ownedContext,
+                ChallengeV3Transport());
+
+            Task<PackageSourceOperationResult<PackageVersionResult>>
+                firstRequest = first.GetVersionsAsync(
+                    "contoso",
+                    TestContext.Current.CancellationToken);
+            Task<PackageSourceOperationResult<PackageVersionResult>>
+                secondRequest = second.GetVersionsAsync(
+                    "contoso",
+                    TestContext.Current.CancellationToken);
+            await provider.FirstStarted;
+            release.SetResult();
+            PackageSourceOperationResult<PackageVersionResult>[] responses =
+                await Task.WhenAll(firstRequest, secondRequest);
+            foreach (PackageSourceOperationResult<PackageVersionResult>
+                response in responses)
+            {
+                Assert.NotNull(response.Value);
+            }
+        }
+
+        Assert.Equal(1, provider.Calls);
+    }
+
+    [Fact]
+    public void AuthenticationContextRequiresMatchingAssociationAndEndpoint()
+    {
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext context =
+            Context(
+                association,
+                SourceIndex,
+                FixedCredential("token"));
+        PackageSourceDescriptor descriptor =
+            PackageSourceDescriptor.NuGetV3(
+                "feed",
+                "Feed",
+                new Uri(SourceIndex));
+
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                descriptor,
+                PackageSourceAssociation.Create(),
+                context));
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                PackageSourceDescriptor.NuGetV3(
+                    "foreign",
+                    "Foreign",
+                    new Uri(
+                        "https://foreign.example/v3/index.json")),
+                association,
+                context));
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                new PackageSource(
+                    "feed",
+                    SourceIndex),
+                PackageSourceAssociation.Create(),
+                context));
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                new PackageSource(
+                    "foreign",
+                    "https://foreign.example/v3/index.json"),
+                association,
+                context));
+
+        using IPackageSourceClient valid =
+            PackageSourceClientFactory.CreateWithPluginAuthentication(
+                new PackageSource(
+                    "feed",
+                    SourceIndex),
+                association,
+                context);
+        Assert.Same(
+            association,
+            valid.Source.Association);
+
+        context.Dispose();
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                descriptor,
+                association,
+                context));
+    }
+
+    [Fact]
+    public void LegacyCreateNullOptionsRemainUnambiguous()
+    {
+        using IPackageSourceClient legacySource =
+            PackageSourceClientFactory.Create(
+                new PackageSource("feed", SourceIndex),
+                PackageSourceAssociation.Create(),
+                null);
+        using IPackageSourceClient descriptor =
+            PackageSourceClientFactory.Create(
+                PackageSourceDescriptor.NuGetV3(
+                    "feed",
+                    "Feed",
+                    new Uri(SourceIndex)),
+                PackageSourceAssociation.Create(),
+                options: default);
+    }
+
+    [Fact]
+    public async Task SharedContextSurvivesIndividualPipelineDisposal()
+    {
+        var provider = FixedCredential("shared-token");
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext context =
+            Context(association, SourceIndex, provider);
+        var firstTransport = ChallengeV3Transport();
+        var survivorTransport = ChallengeV3Transport();
+        IPackageSourceClient first =
+            V3(association, context, firstTransport);
+        using IPackageSourceClient survivor =
+            V3(association, context, survivorTransport);
+
+        Assert.NotNull((await first.GetVersionsAsync(
+            "contoso",
+            TestContext.Current.CancellationToken)).Value);
+
+        first.Dispose();
+        Assert.NotNull((await survivor.GetVersionsAsync(
+            "contoso",
+            TestContext.Current.CancellationToken)).Value);
+
+        Assert.Equal(1, provider.Calls);
+        Assert.Equal(
+            BasicParameter("shared-token"),
+            survivorTransport.Requests[0].Authorization);
+
+        var activeRelease = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var activeProvider = new RecordingCredentialSource(
+            async (_, _, cancellationToken) =>
+            {
+                await activeRelease.Task.WaitAsync(cancellationToken);
+                return new PackageSourceCredential(
+                    "user",
+                    "active-token");
+            });
+        PackageSourceAssociation activeAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext activeContext =
+            Context(activeAssociation, SourceIndex, activeProvider);
+        IPackageSourceClient disposable = V3(
+            activeAssociation,
+            activeContext,
+            ChallengeV3Transport());
+        using IPackageSourceClient activeSurvivor = V3(
+            activeAssociation,
+            activeContext,
+            ChallengeV3Transport());
+        Task<PackageSourceOperationResult<PackageVersionResult>>
+            disposableRequest = disposable.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken);
+        await activeProvider.FirstStarted;
+
+        disposable.Dispose();
+        Task<PackageSourceOperationResult<PackageVersionResult>>
+            survivorRequest = activeSurvivor.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken);
+        activeRelease.SetResult();
+        Assert.NotNull((await survivorRequest).Value);
+        Assert.Equal(1, activeProvider.Calls);
+        _ = await disposableRequest;
+    }
+
+    [Fact]
+    public async Task CrossContextResourceCannotReadAcquireOrReplayCredential()
+    {
+        var provider = new RecordingCredentialSource(
+            static (uri, _, _) =>
+                Task.FromResult<PackageSourceCredential?>(
+                    uri.AbsolutePath.Contains(
+                        "/first/",
+                        StringComparison.Ordinal)
+                        ? new("user", "first-token")
+                        : null));
+        PackageSourceAssociation firstAssociation =
+            PackageSourceAssociation.Create();
+        PackageSourceAssociation secondAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext firstContext =
+            Context(
+                firstAssociation,
+                "https://same.example/first/index.json",
+                provider);
+        using OwnedAuthenticationContext secondContext =
+            Context(
+                secondAssociation,
+                "https://same.example/second/index.json",
+                provider);
+        using HttpClient first =
+            Client(firstContext, ChallengeUntilAuthenticated());
+        var secondTransport = ChallengeUntilAuthenticated();
+        using HttpClient second =
+            Client(secondContext, secondTransport);
+
+        using (HttpResponseMessage populated = await first.GetAsync(
+            "https://same.example/resource",
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, populated.StatusCode);
+        }
+
+        using HttpResponseMessage isolated = await second.GetAsync(
+            "https://same.example/resource",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, isolated.StatusCode);
+        Assert.Equal(2, provider.Calls);
+        Assert.Equal(
+            [
+                "https://same.example/first/index.json",
+                "https://same.example/second/index.json",
+            ],
+            provider.Uris.Select(uri => uri.AbsoluteUri));
+        Assert.Single(secondTransport.Requests);
+        Assert.Null(secondTransport.Requests[0].Authorization);
+    }
+
+    [Fact]
+    public async Task OutOfScopeResourceCannotReadAcquireOrReplayCredential()
+    {
+        var provider = FixedCredential("private-token");
+        using OwnedAuthenticationContext context =
+            Context(PackageSourceAssociation.Create(), SourceIndex, provider);
+        var transport = ChallengeUntilAuthenticated();
+        using HttpClient client = Client(context, transport);
+
+        using (HttpResponseMessage populated = await client.GetAsync(
+            SourceIndex,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, populated.StatusCode);
+        }
+
+        using HttpResponseMessage foreign = await client.GetAsync(
+            "https://foreign.example/resource",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, foreign.StatusCode);
+        Assert.Equal(1, provider.Calls);
+        RequestRecord request = Assert.Single(
+            transport.Requests,
+            request => request.Uri
+                == "https://foreign.example/resource");
+        Assert.Null(request.Authorization);
+    }
+
+    [Fact]
+    public async Task OrdinaryResourceScopeUsesCanonicalOrigin()
+    {
+        const string UnicodeSource =
+            "https://bücher.example/v3/index.json";
+        var provider = FixedCredential("idn-token");
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                UnicodeSource,
+                provider);
+        var transport = ChallengeUntilAuthenticated();
+        using var invoker = new HttpMessageInvoker(
+            new NuGetCredentialRedirectHandler(
+                context.Reference.Bind(transport)));
+
+        using (HttpResponseMessage populated = await SendAsync(
+            invoker,
+            UnicodeSource))
+        {
+            Assert.Equal(HttpStatusCode.OK, populated.StatusCode);
+        }
+
+        string[] authorized =
+        [
+            "https://xn--bcher-kva.example/other/path?x=1#fragment",
+            "https://BÜCHER.example:443/another",
+            "https://user@xn--bcher-kva.example/resource",
+        ];
+        string[] rejected =
+        [
+            "http://xn--bcher-kva.example/resource",
+            "https://other.example/resource",
+            "https://xn--bcher-kva.example:444/resource",
+            "file:///tmp/package",
+        ];
+
+        foreach (string target in authorized)
+        {
+            using HttpResponseMessage response =
+                await SendAsync(invoker, target);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        foreach (string target in rejected)
+        {
+            using HttpResponseMessage response =
+                await SendAsync(invoker, target);
+            Assert.Equal(
+                HttpStatusCode.Unauthorized,
+                response.StatusCode);
+        }
+
+        foreach (string target in authorized)
+        {
+            Assert.NotNull(Assert.Single(
+                transport.Requests,
+                request => request.Uri == CanonicalUri(target))
+                .Authorization);
+        }
+
+        foreach (string target in rejected)
+        {
+            Assert.Null(Assert.Single(
+                transport.Requests,
+                request => request.Uri == CanonicalUri(target))
+                .Authorization);
+        }
+
+        Assert.Equal(1, provider.Calls);
+    }
+
+    [Fact]
+    public async Task AzureResourceScopeIncludesOrganizationButAllowsNameGuidAliases()
+    {
+        const string AzureSource =
+            "https://pkgs.dev.azure.com/org/project/_packaging/feed/nuget/v3/index.json";
+        var provider = FixedCredential("azure-token");
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                AzureSource,
+                provider);
+        var transport = ChallengeUntilAuthenticated();
+        using HttpClient client = Client(context, transport);
+
+        using (HttpResponseMessage populated = await client.GetAsync(
+            AzureSource,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, populated.StatusCode);
+        }
+
+        const string Alias =
+            "https://pkgs.dev.azure.com/org/11111111-1111-1111-1111-111111111111"
+            + "/_packaging/22222222-2222-2222-2222-222222222222/nuget/v3/flat2/a";
+        const string Foreign =
+            "https://pkgs.dev.azure.com/other/project/_packaging/feed/nuget/v3/flat2/a";
+        using (HttpResponseMessage alias = await client.GetAsync(
+            Alias,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, alias.StatusCode);
+        }
+
+        using HttpResponseMessage foreign = await client.GetAsync(
+            Foreign,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, foreign.StatusCode);
+        Assert.NotNull(Assert.Single(
+            transport.Requests,
+            request => request.Uri == Alias).Authorization);
+        Assert.Null(Assert.Single(
+            transport.Requests,
+            request => request.Uri == Foreign).Authorization);
+        Assert.Equal(1, provider.Calls);
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquisitionIsSingleFlightPerContextAndIndependentAcrossContexts()
+    {
+        var provider = new ConcurrentCredentialSource();
+        PackageSourceAssociation firstAssociation =
+            PackageSourceAssociation.Create();
+        PackageSourceAssociation secondAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext firstContext =
+            Context(
+                firstAssociation,
+                "https://same.example/first/index.json",
+                provider);
+        using OwnedAuthenticationContext secondContext =
+            Context(
+                secondAssociation,
+                "https://same.example/second/index.json",
+                provider);
+        using HttpClient firstA =
+            Client(firstContext, ChallengeUntilAuthenticated());
+        using HttpClient firstB =
+            Client(firstContext, ChallengeUntilAuthenticated());
+        using HttpClient secondA =
+            Client(secondContext, ChallengeUntilAuthenticated());
+        using HttpClient secondB =
+            Client(secondContext, ChallengeUntilAuthenticated());
+
+        Task<HttpResponseMessage>[] requests =
+        [
+            firstA.GetAsync(
+                "https://same.example/first/a",
+                TestContext.Current.CancellationToken),
+            firstB.GetAsync(
+                "https://same.example/first/b",
+                TestContext.Current.CancellationToken),
+            secondA.GetAsync(
+                "https://same.example/second/a",
+                TestContext.Current.CancellationToken),
+            secondB.GetAsync(
+                "https://same.example/second/b",
+                TestContext.Current.CancellationToken),
+        ];
+        await provider.TwoContextsStarted;
+        provider.Release();
+        HttpResponseMessage[] responses =
+            await Task.WhenAll(requests);
+        foreach (HttpResponseMessage response in responses)
+        {
+            using (response)
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        Assert.Equal(2, provider.Calls);
+        Assert.Equal(2, provider.MaximumConcurrency);
+    }
+
+    [Fact]
+    public async Task RetiredContextRejectsLateCredentialPublication()
+    {
+        var provider = new LateCredentialSource();
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                SourceIndex,
+                provider);
+        var transport = ChallengeUntilAuthenticated();
+        using HttpClient client = Client(context, transport);
+        Task<HttpResponseMessage> pending =
+            client.GetAsync(
+                SourceIndex,
+                TestContext.Current.CancellationToken);
+        await provider.Started;
+
+        context.Dispose();
+        using HttpResponseMessage retired = await pending;
+        Assert.Equal(HttpStatusCode.Unauthorized, retired.StatusCode);
+        provider.Release();
+        await provider.Completed;
+
+        using HttpResponseMessage later = await client.GetAsync(
+            Resource,
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, later.StatusCode);
+        Assert.Equal(1, provider.Calls);
+        Assert.Null(transport.Requests[^1].Authorization);
+    }
+
+    [Fact]
+    public async Task RetiredContextRejectsPendingChallengeJoinAndLaterRequest()
+    {
+        var provider = new LateCredentialSource();
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                SourceIndex,
+                provider);
+        var firstTransport = ChallengeUntilAuthenticated();
+        var secondTransport = new PendingChallengeTransport();
+        using HttpClient first = Client(context, firstTransport);
+        using HttpClient second = Client(context, secondTransport);
+        Task<HttpResponseMessage> active =
+            first.GetAsync(
+                SourceIndex,
+                TestContext.Current.CancellationToken);
+        await provider.Started;
+        Task<HttpResponseMessage> challenged =
+            second.GetAsync(
+                Resource,
+                TestContext.Current.CancellationToken);
+        await secondTransport.ChallengeObserved;
+
+        context.Dispose();
+        secondTransport.ReleaseChallenge();
+        using HttpResponseMessage challengedResponse =
+            await challenged;
+        using HttpResponseMessage activeResponse =
+            await active;
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            challengedResponse.StatusCode);
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            activeResponse.StatusCode);
+
+        using HttpResponseMessage later = await second.GetAsync(
+            "https://feed.example/later",
+            TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, later.StatusCode);
+        Assert.Equal(1, provider.Calls);
+        provider.Release();
+        await provider.Completed;
+    }
+
+    [Fact]
+    public async Task ConcurrentRejectedCredentialRefreshesPublishOneNewVersion()
+    {
+        var provider = new RefreshCredentialSource();
+        var transport = new RefreshTransport();
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                SourceIndex,
+                provider);
+        using HttpClient client = Client(context, transport);
+
+        using (HttpResponseMessage populated = await client.GetAsync(
+            SourceIndex,
+            TestContext.Current.CancellationToken))
+        {
+            Assert.Equal(HttpStatusCode.OK, populated.StatusCode);
+        }
+
+        transport.RejectOldCredential = true;
+        Task<HttpResponseMessage>[] requests =
+        [
+            client.GetAsync(
+                "https://feed.example/a",
+                TestContext.Current.CancellationToken),
+            client.GetAsync(
+                "https://feed.example/b",
+                TestContext.Current.CancellationToken),
+        ];
+        await provider.RefreshStarted;
+        provider.ReleaseRefresh();
+        HttpResponseMessage[] responses =
+            await Task.WhenAll(requests);
+        foreach (HttpResponseMessage response in responses)
+        {
+            using (response)
+            {
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        Assert.Equal(2, provider.Calls);
+        Assert.Equal([false, true], provider.RetryFlags);
+        Assert.Equal(2, transport.NewCredentialUses);
+    }
+
+    [Fact]
+    public async Task ExplicitAuthorizationBypassesPluginContext()
+    {
+        var provider = FixedCredential("plugin-token");
+        using OwnedAuthenticationContext context =
+            Context(
+                PackageSourceAssociation.Create(),
+                SourceIndex,
+                provider);
+        var transport = new RecordingTransport(
+            static (request, _, _) =>
+                Task.FromResult(Response(
+                    request.Headers.Authorization?.Parameter
+                        == BasicParameter("plugin-token")
+                            ? HttpStatusCode.OK
+                            : HttpStatusCode.Unauthorized)));
+        using HttpClient client = Client(context, transport);
+        using var explicitRequest = new HttpRequestMessage(
+            HttpMethod.Get,
+            SourceIndex);
+        explicitRequest.Headers.Authorization =
+            Basic("configured-token");
+
+        using HttpResponseMessage explicitResponse =
+            await client.SendAsync(
+                explicitRequest,
+                TestContext.Current.CancellationToken);
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            explicitResponse.StatusCode);
+        Assert.Equal(0, provider.Calls);
+        Assert.Single(transport.Requests);
+
+        using HttpResponseMessage pluginResponse =
+            await client.GetAsync(
+                Resource,
+                TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, pluginResponse.StatusCode);
+        Assert.Equal(1, provider.Calls);
+    }
+
+    [Fact]
+    public async Task ForbiddenChallengeRequiresContextOptIn()
+    {
+        var provider = FixedCredential("plugin-token");
+        PackageSourceAssociation defaultAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext defaultContext =
+            Context(defaultAssociation, SourceIndex, provider);
+        var defaultTransport = new RecordingTransport(
+            static (request, _, _) =>
+                Task.FromResult(Response(
+                    request.Headers.Authorization is null
+                        ? HttpStatusCode.Forbidden
+                        : HttpStatusCode.OK)));
+        using HttpClient defaultClient =
+            Client(defaultContext, defaultTransport);
+
+        using HttpResponseMessage defaultResponse =
+            await defaultClient.GetAsync(
+                SourceIndex,
+                TestContext.Current.CancellationToken);
+        Assert.Equal(
+            HttpStatusCode.Forbidden,
+            defaultResponse.StatusCode);
+        Assert.Equal(0, provider.Calls);
+
+        PackageSourceAssociation optedInAssociation =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext optedInContext =
+            Context(
+                optedInAssociation,
+                SourceIndex,
+                provider,
+                promptOn403: true);
+        using HttpClient optedInClient =
+            Client(
+                optedInContext,
+                new RecordingTransport(
+                    static (request, _, _) =>
+                        Task.FromResult(Response(
+                            request.Headers.Authorization is null
+                                ? HttpStatusCode.Forbidden
+                                : HttpStatusCode.OK))));
+
+        using HttpResponseMessage optedInResponse =
+            await optedInClient.GetAsync(
+                SourceIndex,
+                TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, optedInResponse.StatusCode);
+        Assert.Equal(1, provider.Calls);
+    }
+
+    [Fact]
+    public async Task RequestClonePropagationPreservesContextAndRejection()
+    {
+        const string AzureSource =
+            "https://pkgs.dev.azure.com/org/project/_packaging/feed/nuget/v3/index.json";
+        var provider = FixedCredential("azure-token");
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext context =
+            Context(
+                association,
+                AzureSource,
+                provider);
+        var transport = new RedirectReentryTransport();
+        using IPackageSourceClient client =
+            PackageSourceClientFactory.Create(
+                PackageSourceDescriptor.NuGetV3(
+                    "azure",
+                    "Azure",
+                    new Uri(AzureSource)),
+                association,
+                transport,
+                authenticationContext: context);
+
+        PackageSourceOperationResult<PackageVersionResult> response =
+            await client.GetVersionsAsync(
+                "contoso",
+                TestContext.Current.CancellationToken);
+
+        Assert.NotNull(response.Value);
+        Assert.Equal(1, provider.Calls);
+        Assert.NotNull(Assert.Single(
+            transport.Requests,
+            request => request.Uri.Contains(
+                "/org/start/",
+                StringComparison.Ordinal)).Authorization);
+        Assert.Null(Assert.Single(
+            transport.Requests,
+            request => request.Uri.Contains(
+                "/other/",
+                StringComparison.Ordinal)).Authorization);
+        Assert.Null(Assert.Single(
+            transport.Requests,
+            request => request.Uri.EndsWith(
+                "/org/return",
+                StringComparison.Ordinal)).Authorization);
+    }
+
+    [Fact]
+    public void AuthenticationContextReferenceIsOpaque()
+    {
+        Type type = typeof(PluginAuthenticationContext);
+
+        Assert.True(type.IsSealed);
+        Assert.Empty(type.GetFields(
+            BindingFlags.Instance | BindingFlags.Public));
+        Assert.Empty(type.GetProperties(
+            BindingFlags.Instance | BindingFlags.Public));
+        Assert.DoesNotContain(
+            type.GetConstructors(
+                BindingFlags.Instance | BindingFlags.Public),
+            constructor => constructor.IsPublic);
+        Assert.Null(type.GetMethod(
+            nameof(ToString),
+            BindingFlags.Instance
+                | BindingFlags.Public
+                | BindingFlags.DeclaredOnly));
+    }
+
+    [Fact]
+    public async Task NuGetGalleryTransportCannotReachPluginAuthentication()
+    {
+        Assert.All(
+            typeof(PackageSourceClientFactory)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(method => method.Name == nameof(
+                    PackageSourceClientFactory.CreateGallery)),
+            method => Assert.DoesNotContain(
+                method.GetParameters(),
+                parameter => parameter.ParameterType
+                    == typeof(PluginAuthenticationContext)));
+
+        var provider = FixedCredential("must-not-run");
+        PackageSourceAssociation association =
+            PackageSourceAssociation.Create();
+        using OwnedAuthenticationContext context =
+            Context(association, SourceIndex, provider);
+        Assert.Throws<InvalidOperationException>(
+            () => PackageSourceClientFactory.CreateWithPluginAuthentication(
+                PackageSourceDescriptor.NuGetGallery,
+                association,
+                context));
+
+        var transport = new RecordingTransport(
+            static (_, _, _) =>
+                Task.FromResult(Response(
+                    HttpStatusCode.OK,
+                    """{"data":[]}""")));
+        using IPackageSourceClient gallery =
+            PackageSourceClientFactory.CreateGallery(
+                PackageSourceAssociation.Create(),
+                transport);
+        PackageSourceOperationResult<PackageSearchResult> search =
+            await gallery.SearchAsync(
+                "contoso",
+                cancellationToken:
+                    TestContext.Current.CancellationToken);
+
+        Assert.NotNull(search.Value);
+        Assert.Equal(0, provider.Calls);
+    }
+
+    private static OwnedAuthenticationContext Context(
+        PackageSourceAssociation association,
+        string providerQueryUri,
+        ICredentialSource provider,
+        bool promptOn403 = false) =>
+        new(
+            PluginAuthenticationContextOwner.Create(
+                association,
+                new Uri(providerQueryUri),
+                provider,
+                promptOn403));
+
+    private static HttpClient Client(
+        PluginAuthenticationContext context,
+        HttpMessageHandler transport) =>
+        new(
+            new NuGetCredentialRedirectHandler(
+                context.Bind(transport)));
+
+    private static IPackageSourceClient V3(
+        PackageSourceAssociation association,
+        PluginAuthenticationContext context,
+        HttpMessageHandler transport) =>
+        PackageSourceClientFactory.Create(
+            PackageSourceDescriptor.NuGetV3(
+                "feed",
+                "Feed",
+                new Uri(SourceIndex)),
+            association,
+            transport,
+            authenticationContext: context);
+
+    private static RecordingCredentialSource FixedCredential(
+        string password) =>
+        new(
+            (_, _, _) =>
+                Task.FromResult<PackageSourceCredential?>(
+                    new("user", password)));
+
+    private static RecordingTransport ChallengeUntilAuthenticated() =>
+        new(
+            static (request, _, _) =>
+                Task.FromResult(Response(
+                    request.Headers.Authorization is null
+                        ? HttpStatusCode.Unauthorized
+                        : HttpStatusCode.OK)));
+
+    private static RecordingTransport V3ResourceFirstTransport() =>
+        new(
+            static (request, _, _) =>
+            {
+                if (request.RequestUri!.AbsoluteUri == SourceIndex)
+                {
+                    return Task.FromResult(Response(
+                        HttpStatusCode.OK,
+                        ServiceIndex));
+                }
+
+                return Task.FromResult(
+                    request.Headers.Authorization is null
+                        ? Response(HttpStatusCode.Unauthorized)
+                        : Response(
+                            HttpStatusCode.OK,
+                            """{"versions":["1.0.0"]}"""));
+            });
+
+    private static RecordingTransport ChallengeV3Transport() =>
+        new(
+            static (request, _, _) =>
+            {
+                if (request.Headers.Authorization is null)
+                {
+                    return Task.FromResult(
+                        Response(HttpStatusCode.Unauthorized));
+                }
+
+                return Task.FromResult(
+                    request.RequestUri!.AbsoluteUri == SourceIndex
+                        ? Response(
+                            HttpStatusCode.OK,
+                            ServiceIndex)
+                        : Response(
+                            HttpStatusCode.OK,
+                            """{"versions":["1.0.0"]}"""));
+            });
+
+    private static HttpResponseMessage Response(
+        HttpStatusCode status,
+        string? body = null)
+    {
+        var response = new HttpResponseMessage(status);
+        if (body is not null)
+        {
+            response.Content = new StringContent(body);
+        }
+
+        return response;
+    }
+
+    private static AuthenticationHeaderValue Basic(string password) =>
+        new("Basic", BasicParameter(password));
+
+    private static string BasicParameter(string password) =>
+        Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"user:{password}"));
+
+    private static string CanonicalUri(string uri) =>
+        new Uri(uri).AbsoluteUri;
+
+    private static async Task<HttpResponseMessage> SendAsync(
+        HttpMessageInvoker invoker,
+        string target)
+    {
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri(target, UriKind.RelativeOrAbsolute));
+        return await invoker.SendAsync(
+            request,
+            TestContext.Current.CancellationToken);
+    }
+
+    private sealed class RecordingCredentialSource(
+        Func<
+            Uri,
+            bool,
+            CancellationToken,
+            Task<PackageSourceCredential?>> acquire)
+        : ICredentialSource
+    {
+        private readonly TaskCompletionSource _firstStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+
+        public bool HasCredentialSources => true;
+
+        public int Calls => _calls;
+
+        public Task FirstStarted => _firstStarted.Task;
+
+        public List<Uri> Uris { get; } = [];
+
+        public List<bool> RetryFlags { get; } = [];
+
+        public async Task<PackageSourceCredential?> GetCredentialsAsync(
+            Uri uri,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _calls);
+            lock (Uris)
+            {
+                Uris.Add(uri);
+                RetryFlags.Add(isRetry);
+            }
+
+            _firstStarted.TrySetResult();
+            return await acquire(
+                uri,
+                isRetry,
+                cancellationToken);
+        }
+    }
+
+    private sealed class RecordingTransport(
+        Func<
+            HttpRequestMessage,
+            int,
+            CancellationToken,
+            Task<HttpResponseMessage>> respond)
+        : HttpMessageHandler
+    {
+        private int _attempts;
+
+        public List<RequestRecord> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            int attempt = Interlocked.Increment(ref _attempts);
+            lock (Requests)
+            {
+                Requests.Add(new RequestRecord(
+                    request.RequestUri?.AbsoluteUri
+                        ?? request.RequestUri?.OriginalString
+                        ?? "",
+                    request.Headers.Authorization?.Parameter));
+            }
+
+            HttpResponseMessage response = await respond(
+                request,
+                attempt,
+                cancellationToken);
+            response.RequestMessage ??= request;
+            return response;
+        }
+    }
+
+    private sealed record RequestRecord(
+        string Uri,
+        string? Authorization);
+
+    private sealed class OwnedAuthenticationContext(
+        PluginAuthenticationContextOwner owner)
+        : IDisposable
+    {
+        public static implicit operator PluginAuthenticationContext(
+            OwnedAuthenticationContext context) =>
+            context.Reference;
+
+        public PluginAuthenticationContext Reference =>
+            owner.Context;
+
+        public void Dispose() => owner.Dispose();
+    }
+
+    private sealed class ConcurrentCredentialSource
+        : ICredentialSource
+    {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _twoContextsStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _active;
+        private int _calls;
+        private int _maximumConcurrency;
+
+        public bool HasCredentialSources => true;
+
+        public int Calls => _calls;
+
+        public int MaximumConcurrency => _maximumConcurrency;
+
+        public Task TwoContextsStarted =>
+            _twoContextsStarted.Task;
+
+        public void Release() => _release.TrySetResult();
+
+        public async Task<PackageSourceCredential?> GetCredentialsAsync(
+            Uri uri,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _calls);
+            int active = Interlocked.Increment(ref _active);
+            InterlockedExtensions.Max(
+                ref _maximumConcurrency,
+                active);
+            if (active == 2)
+            {
+                _twoContextsStarted.TrySetResult();
+            }
+
+            try
+            {
+                await _release.Task.WaitAsync(cancellationToken);
+                return new PackageSourceCredential(
+                    "user",
+                    uri.AbsolutePath.Contains(
+                        "/first/",
+                        StringComparison.Ordinal)
+                        ? "first"
+                        : "second");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _active);
+            }
+        }
+    }
+
+    private sealed class LateCredentialSource
+        : ICredentialSource
+    {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _completed =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+
+        public bool HasCredentialSources => true;
+
+        public int Calls => _calls;
+
+        public Task Started => _started.Task;
+
+        public Task Completed => _completed.Task;
+
+        public void Release() => _release.TrySetResult();
+
+        public async Task<PackageSourceCredential?> GetCredentialsAsync(
+            Uri uri,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _calls);
+            _started.TrySetResult();
+            await _release.Task;
+            _completed.TrySetResult();
+            return new PackageSourceCredential(
+                "user",
+                "late-token");
+        }
+    }
+
+    private sealed class PendingChallengeTransport
+        : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource _challengeObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ChallengeObserved =>
+            _challengeObserved.Task;
+
+        public void ReleaseChallenge() =>
+            _release.TrySetResult();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            _challengeObserved.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return Response(HttpStatusCode.Unauthorized);
+        }
+    }
+
+    private sealed class RefreshCredentialSource
+        : ICredentialSource
+    {
+        private readonly TaskCompletionSource _refreshStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _calls;
+
+        public bool HasCredentialSources => true;
+
+        public int Calls => _calls;
+
+        public Task RefreshStarted =>
+            _refreshStarted.Task;
+
+        public List<bool> RetryFlags { get; } = [];
+
+        public void ReleaseRefresh() => _release.TrySetResult();
+
+        public async Task<PackageSourceCredential?> GetCredentialsAsync(
+            Uri uri,
+            bool isRetry,
+            CancellationToken cancellationToken)
+        {
+            int call = Interlocked.Increment(ref _calls);
+            lock (RetryFlags)
+            {
+                RetryFlags.Add(isRetry);
+            }
+
+            if (call == 1)
+            {
+                return new PackageSourceCredential(
+                    "user",
+                    "old");
+            }
+
+            _refreshStarted.TrySetResult();
+            await _release.Task.WaitAsync(cancellationToken);
+            return new PackageSourceCredential(
+                "user",
+                "new");
+        }
+    }
+
+    private sealed class RefreshTransport
+        : HttpMessageHandler
+    {
+        private int _newCredentialUses;
+
+        public bool RejectOldCredential { get; set; }
+
+        public int NewCredentialUses => _newCredentialUses;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string? authorization =
+                request.Headers.Authorization?.Parameter;
+            if (authorization == BasicParameter("new"))
+            {
+                Interlocked.Increment(
+                    ref _newCredentialUses);
+                return Task.FromResult(
+                    Response(HttpStatusCode.OK));
+            }
+
+            if (authorization == BasicParameter("old")
+                && !RejectOldCredential)
+            {
+                return Task.FromResult(
+                    Response(HttpStatusCode.OK));
+            }
+
+            return Task.FromResult(
+                Response(HttpStatusCode.Unauthorized));
+        }
+    }
+
+    private sealed class RedirectReentryTransport
+        : HttpMessageHandler
+    {
+        public List<RequestRecord> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string uri = request.RequestUri!.AbsoluteUri;
+            Requests.Add(
+                new RequestRecord(
+                    uri,
+                    request.Headers.Authorization?.Parameter));
+            if (uri.EndsWith(
+                    "/org/project/_packaging/feed/nuget/v3/index.json",
+                    StringComparison.Ordinal))
+            {
+                if (request.Headers.Authorization is null)
+                {
+                    return Task.FromResult(
+                        Response(HttpStatusCode.Unauthorized));
+                }
+
+                return Task.FromResult(
+                    Response(
+                        HttpStatusCode.OK,
+                        """
+                        {
+                          "version": "3.0.0",
+                          "resources": [
+                            {
+                              "@id": "https://pkgs.dev.azure.com/org/start/",
+                              "@type": "PackageBaseAddress/3.0.0"
+                            }
+                          ]
+                        }
+                        """));
+            }
+
+            if (uri.Contains(
+                    "/org/start/",
+                    StringComparison.Ordinal))
+            {
+                return Task.FromResult(
+                    Redirect(
+                        "https://pkgs.dev.azure.com/other/redirect"));
+            }
+
+            if (uri.Contains(
+                    "/other/",
+                    StringComparison.Ordinal))
+            {
+                return Task.FromResult(
+                    Redirect(
+                        "https://pkgs.dev.azure.com/org/return"));
+            }
+
+            return Task.FromResult(
+                Response(
+                    HttpStatusCode.OK,
+                    """{"versions":["1.0.0"]}"""));
+        }
+
+        private static HttpResponseMessage Redirect(string target)
+        {
+            var response = Response(
+                HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri(target);
+            return response;
+        }
+    }
+
+    private static class InterlockedExtensions
+    {
+        public static void Max(
+            ref int target,
+            int value)
+        {
+            int current;
+            do
+            {
+                current = Volatile.Read(ref target);
+                if (current >= value)
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(
+                ref target,
+                value,
+                current) != current);
+        }
+    }
+}

--- a/src/NuGetFetch/NuGetCredentialRedirectHandler.cs
+++ b/src/NuGetFetch/NuGetCredentialRedirectHandler.cs
@@ -33,7 +33,15 @@ internal sealed class NuGetCredentialRedirectHandler(
                 {
                     if (redirectedRequest is not null)
                     {
+                        HttpRequestMessage? responseRequest =
+                            response.RequestMessage;
                         response.RequestMessage = request;
+                        if (!ReferenceEquals(
+                                responseRequest,
+                                redirectedRequest))
+                        {
+                            responseRequest?.Dispose();
+                        }
                     }
 
                     return response;
@@ -54,17 +62,28 @@ internal sealed class NuGetCredentialRedirectHandler(
                 }
                 finally
                 {
+                    HttpRequestMessage? responseRequest =
+                        response.RequestMessage;
                     response.Dispose();
+                    if (!ReferenceEquals(
+                            responseRequest,
+                            current))
+                    {
+                        responseRequest?.Dispose();
+                    }
                 }
 
-                redirectedRequest?.Dispose();
-                redirectedRequest = CreateRedirectRequest(
-                    request,
+                HttpRequestMessage? previousRedirect =
+                    redirectedRequest;
+                HttpRequestMessage nextRedirect = CreateRedirectRequest(
+                    current,
                     target,
                     SameOrigin(credentialOrigin, target)
                         ? authorization
                         : null);
-                current = redirectedRequest;
+                redirectedRequest = nextRedirect;
+                current = nextRedirect;
+                previousRedirect?.Dispose();
             }
         }
         finally

--- a/src/NuGetFetch/PackageSourceClients.cs
+++ b/src/NuGetFetch/PackageSourceClients.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using DotnetInspector.Networking;
 using InertText;
+using NuGetFetch.Plugins;
 using NuGet.Versioning;
 
 namespace NuGetFetch;
@@ -387,6 +388,42 @@ public static partial class PackageSourceClientFactory
     }
 
     /// <summary>
+    /// Adapts the existing desktop source model to a typed runtime client with
+    /// source-scoped plugin authentication.
+    /// </summary>
+    public static IPackageSourceClient CreateWithPluginAuthentication(
+        PackageSource source,
+        PackageSourceAssociation association,
+        PluginAuthenticationContext authenticationContext,
+        NuGetFetchOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(association);
+        if (!Uri.TryCreate(source.Url, UriKind.Absolute, out Uri? endpoint)
+            || endpoint.IsFile)
+        {
+            throw new PackageSourceClientUnavailableException(
+                PackageSourceKind.LocalFolder);
+        }
+        RequireAuthenticationAssociation(
+            association,
+            authenticationContext,
+            endpoint);
+
+        return new NuGetV3PackageSourceClient(
+            CreateResultFactory(
+                endpoint,
+                association,
+                PackageSourceKind.NuGetV3),
+            endpoint,
+            CreateOwnedTransport(
+                endpoint,
+                authenticationContext: authenticationContext),
+            options ?? new NuGetFetchOptions(),
+            source.Credential);
+    }
+
+    /// <summary>
     /// Creates a runtime client from credential-free configuration and optional
     /// ephemeral credentials.
     /// </summary>
@@ -419,6 +456,46 @@ public static partial class PackageSourceClientFactory
                     CreateResultFactory(descriptor, association),
                     descriptor.Endpoint,
                     CreateOwnedTransport(descriptor.Endpoint),
+                    options,
+                    credential),
+            _ => throw new PackageSourceClientUnavailableException(
+                descriptor.Kind),
+        };
+    }
+
+    /// <summary>
+    /// Creates a V3 runtime client with source-scoped plugin authentication.
+    /// </summary>
+    public static IPackageSourceClient CreateWithPluginAuthentication(
+        PackageSourceDescriptor descriptor,
+        PackageSourceAssociation association,
+        PluginAuthenticationContext authenticationContext,
+        NuGetFetchOptions? options = null,
+        PackageSourceCredential? credential = null)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+        ArgumentNullException.ThrowIfNull(association);
+        RequireAuthenticationAssociation(
+            association,
+            authenticationContext,
+            descriptor.Endpoint);
+        options ??= new NuGetFetchOptions();
+        if (descriptor.Kind == PackageSourceKind.NuGetGallery)
+        {
+            throw new InvalidOperationException(
+                "The NuGet Gallery source cannot use plugin authentication.");
+        }
+
+        return descriptor.Kind switch
+        {
+            PackageSourceKind.NuGetV3 when descriptor.Endpoint is not null =>
+                new NuGetV3PackageSourceClient(
+                    CreateResultFactory(descriptor, association),
+                    descriptor.Endpoint,
+                    CreateOwnedTransport(
+                        descriptor.Endpoint,
+                        authenticationContext:
+                            authenticationContext),
                     options,
                     credential),
             _ => throw new PackageSourceClientUnavailableException(
@@ -503,7 +580,8 @@ public static partial class PackageSourceClientFactory
         PackageSource source,
         PackageSourceAssociation association,
         HttpMessageHandler transport,
-        NuGetFetchOptions? options = null)
+        NuGetFetchOptions? options = null,
+        PluginAuthenticationContext? authenticationContext = null)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(association);
@@ -515,13 +593,24 @@ public static partial class PackageSourceClientFactory
                 PackageSourceKind.LocalFolder);
         }
 
+        if (authenticationContext is not null)
+        {
+            RequireAuthenticationAssociation(
+                association,
+                authenticationContext,
+                endpoint);
+        }
+
         return new NuGetV3PackageSourceClient(
             CreateResultFactory(
                 endpoint,
                 association,
                 PackageSourceKind.NuGetV3),
             endpoint,
-            CreateOwnedTransport(endpoint, transport),
+            CreateOwnedTransport(
+                endpoint,
+                transport,
+                authenticationContext),
             options ?? new NuGetFetchOptions(),
             source.Credential);
     }
@@ -531,7 +620,8 @@ public static partial class PackageSourceClientFactory
         PackageSourceAssociation association,
         HttpMessageHandler transport,
         NuGetFetchOptions? options = null,
-        PackageSourceCredential? credential = null)
+        PackageSourceCredential? credential = null,
+        PluginAuthenticationContext? authenticationContext = null)
     {
         ArgumentNullException.ThrowIfNull(descriptor);
         ArgumentNullException.ThrowIfNull(association);
@@ -557,10 +647,21 @@ public static partial class PackageSourceClientFactory
                 descriptor.Kind);
         }
 
+        if (authenticationContext is not null)
+        {
+            RequireAuthenticationAssociation(
+                association,
+                authenticationContext,
+                descriptor.Endpoint);
+        }
+
         return new NuGetV3PackageSourceClient(
             CreateResultFactory(descriptor, association),
             descriptor.Endpoint,
-            CreateOwnedTransport(descriptor.Endpoint!, transport),
+            CreateOwnedTransport(
+                descriptor.Endpoint!,
+                transport,
+                authenticationContext),
             options,
             credential);
     }
@@ -615,11 +716,23 @@ public static partial class PackageSourceClientFactory
 
     private static HttpClient CreateOwnedTransport(
         Uri source,
-        HttpMessageHandler? transport = null)
+        HttpMessageHandler? transport = null,
+        PluginAuthenticationContext? authenticationContext = null)
     {
         bool isBrowser = OperatingSystem.IsBrowser();
+        if (isBrowser && authenticationContext is not null)
+        {
+            throw new PlatformNotSupportedException(
+                "NuGet credential-provider plugins are not supported in Browser/Wasm.");
+        }
+
         HttpMessageHandler handler = transport
             ?? CreateV3TransportHandler(source, isBrowser);
+        if (authenticationContext is not null)
+        {
+            handler = authenticationContext.Bind(handler);
+        }
+
         if (!isBrowser)
         {
             handler = new NuGetCredentialRedirectHandler(handler);
@@ -629,6 +742,32 @@ public static partial class PackageSourceClientFactory
         {
             Timeout = Timeout.InfiniteTimeSpan,
         };
+    }
+
+    private static void RequireAuthenticationAssociation(
+        PackageSourceAssociation association,
+        PluginAuthenticationContext authenticationContext,
+        Uri? endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(authenticationContext);
+        if (authenticationContext.IsRetired)
+        {
+            throw new InvalidOperationException(
+                "The plugin authentication context has retired.");
+        }
+
+        if (!authenticationContext.IsBoundTo(association))
+        {
+            throw new InvalidOperationException(
+                "The plugin authentication context belongs to another package source association.");
+        }
+
+        if (endpoint is not null
+            && !authenticationContext.IsResourceInScope(endpoint))
+        {
+            throw new InvalidOperationException(
+                "The V3 source endpoint is outside the plugin authentication context's resource scope.");
+        }
     }
 
     private static HttpClient CreateGalleryTransport()

--- a/src/NuGetFetch/Plugins/PluginAuthenticationContext.cs
+++ b/src/NuGetFetch/Plugins/PluginAuthenticationContext.cs
@@ -1,0 +1,621 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace NuGetFetch.Plugins;
+
+/// <summary>
+/// Owns the lifetime of one configured source's plugin authentication context.
+/// </summary>
+public sealed class PluginAuthenticationContextOwner : IDisposable
+{
+    private static readonly ConditionalWeakTable<
+        PackageSourceAssociation,
+        PluginAuthenticationContextOwner> LiveContexts = new();
+
+    private readonly PackageSourceAssociation _association;
+    private readonly PluginAuthenticationContext _context;
+    private int _disposed;
+
+    private PluginAuthenticationContextOwner(
+        PackageSourceAssociation association,
+        Uri providerQueryUri,
+        ICredentialSource provider,
+        bool promptOn403)
+    {
+        _association = association;
+        _context = new PluginAuthenticationContext(
+            association,
+            providerQueryUri,
+            provider,
+            promptOn403);
+    }
+
+    /// <summary>
+    /// Gets the non-owning opaque reference supplied to source pipelines.
+    /// </summary>
+    public PluginAuthenticationContext Context => _context;
+
+    /// <summary>
+    /// Creates the authentication context owned by one configured source authority.
+    /// </summary>
+    public static PluginAuthenticationContextOwner Create(
+        PackageSourceAssociation association,
+        Uri providerQueryUri,
+        ICredentialSource provider,
+        bool promptOn403 = false)
+    {
+        ArgumentNullException.ThrowIfNull(association);
+        ArgumentNullException.ThrowIfNull(providerQueryUri);
+        ArgumentNullException.ThrowIfNull(provider);
+        if (OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "NuGet credential-provider plugins are not supported in Browser/Wasm.");
+        }
+
+        var owner = new PluginAuthenticationContextOwner(
+            association,
+            providerQueryUri,
+            provider,
+            promptOn403);
+        try
+        {
+            LiveContexts.Add(association, owner);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException(
+                "The package source association already has a live plugin authentication context.",
+                exception);
+        }
+
+        return owner;
+    }
+
+    /// <summary>
+    /// Retires the configured source context and clears its credential state.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        _context.Retire();
+        LiveContexts.Remove(_association);
+    }
+}
+
+/// <summary>
+/// Opaque non-owning reference to one configured source's plugin credential state.
+/// </summary>
+public sealed class PluginAuthenticationContext
+{
+    private const string AzureArtifactsHost = "pkgs.dev.azure.com";
+
+    private readonly object _sync = new();
+    private readonly PackageSourceAssociation _association;
+    private readonly Uri _providerQueryUri;
+    private readonly ICredentialSource _provider;
+    private readonly ResourceScope _resourceScope;
+    private readonly bool _promptOn403;
+    private PackageSourceCredential? _credential;
+    private long _version;
+    private AcquisitionFlight? _flight;
+    private bool _retired;
+
+    internal PluginAuthenticationContext(
+        PackageSourceAssociation association,
+        Uri providerQueryUri,
+        ICredentialSource provider,
+        bool promptOn403)
+    {
+        if (!ResourceScope.TryCreate(
+                providerQueryUri,
+                out ResourceScope resourceScope))
+        {
+            throw new ArgumentException(
+                "The plugin provider-query URI must identify an absolute HTTP or HTTPS package source.",
+                nameof(providerQueryUri));
+        }
+
+        _association = association;
+        _providerQueryUri = providerQueryUri;
+        _provider = provider;
+        _resourceScope = resourceScope;
+        _promptOn403 = promptOn403;
+    }
+
+    internal bool HasCredentialSources => _provider.HasCredentialSources;
+
+    internal bool IsBoundTo(PackageSourceAssociation association) =>
+        ReferenceEquals(_association, association);
+
+    internal bool IsResourceInScope(Uri resource) =>
+        ResourceScope.TryCreate(resource, out ResourceScope resourceScope)
+        && _resourceScope.Equals(resourceScope);
+
+    internal bool IsRetired
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _retired;
+            }
+        }
+    }
+
+    internal bool IsCredentialChallenge(HttpStatusCode status) =>
+        status == HttpStatusCode.Unauthorized
+        || _promptOn403 && status == HttpStatusCode.Forbidden;
+
+    internal Participation Read(
+        Uri target,
+        out CredentialSnapshot snapshot)
+    {
+        if (!ResourceScope.TryCreate(target, out ResourceScope targetScope)
+            || !_resourceScope.Equals(targetScope))
+        {
+            snapshot = default;
+            return Participation.Rejected;
+        }
+
+        lock (_sync)
+        {
+            if (_retired)
+            {
+                snapshot = default;
+                return Participation.Retired;
+            }
+
+            snapshot = new CredentialSnapshot(_credential, _version);
+            return Participation.Allowed;
+        }
+    }
+
+    internal async Task<PackageSourceCredential?> AcquireAsync(
+        long observedVersion,
+        bool isRetry,
+        CancellationToken cancellationToken)
+    {
+        bool hasCredentialSources = HasCredentialSources;
+        AcquisitionFlight flight;
+        bool start;
+        lock (_sync)
+        {
+            if (_retired)
+            {
+                return null;
+            }
+
+            if (_version != observedVersion && _credential is not null)
+            {
+                return _credential;
+            }
+
+            if (!hasCredentialSources)
+            {
+                return null;
+            }
+
+            start = _flight is null;
+            flight = _flight ??= new AcquisitionFlight();
+        }
+
+        if (start)
+        {
+            flight.Start(
+                this,
+                _provider,
+                _providerQueryUri,
+                isRetry);
+        }
+
+        PackageSourceCredential? acquired =
+            await flight.Completion
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+        lock (_sync)
+        {
+            if (_retired)
+            {
+                return null;
+            }
+
+            return _version != observedVersion
+                && _credential is not null
+                    ? _credential
+                    : acquired;
+        }
+    }
+
+    internal HttpMessageHandler Bind(HttpMessageHandler innerHandler)
+    {
+        ArgumentNullException.ThrowIfNull(innerHandler);
+        return new SourcePluginAuthenticationHandler(this, innerHandler);
+    }
+
+    internal void Retire()
+    {
+        AcquisitionFlight? flight;
+        lock (_sync)
+        {
+            if (_retired)
+            {
+                return;
+            }
+
+            _retired = true;
+            _credential = null;
+            _version++;
+            flight = _flight;
+        }
+
+        flight?.Retire();
+    }
+
+    private void Complete(
+        AcquisitionFlight flight,
+        PackageSourceCredential? credential,
+        Exception? failure,
+        CancellationToken cancellationToken)
+    {
+        bool retired;
+        lock (_sync)
+        {
+            retired = _retired;
+            if (ReferenceEquals(_flight, flight))
+            {
+                _flight = null;
+                if (!retired && failure is null && credential is not null)
+                {
+                    _credential = credential;
+                    _version++;
+                }
+            }
+        }
+
+        if (retired)
+        {
+            flight.TrySetResult(null);
+        }
+        else if (failure is OperationCanceledException)
+        {
+            flight.TrySetCanceled(cancellationToken);
+        }
+        else if (failure is not null)
+        {
+            flight.TrySetException(failure);
+        }
+        else
+        {
+            flight.TrySetResult(credential);
+        }
+    }
+
+    internal enum Participation
+    {
+        Allowed,
+        Rejected,
+        Retired,
+    }
+
+    internal readonly record struct CredentialSnapshot(
+        PackageSourceCredential? Credential,
+        long Version);
+
+    private sealed class AcquisitionFlight
+    {
+        private readonly object _sync = new();
+        private readonly CancellationTokenSource _cancellation = new();
+        private readonly TaskCompletionSource<PackageSourceCredential?>
+            _completion = new(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _disposed;
+
+        public Task<PackageSourceCredential?> Completion => _completion.Task;
+
+        public void Start(
+            PluginAuthenticationContext context,
+            ICredentialSource provider,
+            Uri providerQueryUri,
+            bool isRetry)
+        {
+            _ = Task.Run(
+                () => RunAsync(
+                    context,
+                    provider,
+                    providerQueryUri,
+                    isRetry),
+                CancellationToken.None);
+        }
+
+        public void Retire()
+        {
+            CancelAndDispose(dispose: false);
+            TrySetResult(null);
+        }
+
+        public void TrySetResult(PackageSourceCredential? credential) =>
+            _completion.TrySetResult(credential);
+
+        public void TrySetCanceled(CancellationToken cancellationToken) =>
+            _completion.TrySetCanceled(cancellationToken);
+
+        public void TrySetException(Exception exception) =>
+            _completion.TrySetException(exception);
+
+        private async Task RunAsync(
+            PluginAuthenticationContext context,
+            ICredentialSource provider,
+            Uri providerQueryUri,
+            bool isRetry)
+        {
+            PackageSourceCredential? credential = null;
+            Exception? failure = null;
+            try
+            {
+                _cancellation.Token.ThrowIfCancellationRequested();
+                credential = await provider
+                    .GetCredentialsAsync(
+                        providerQueryUri,
+                        isRetry,
+                        _cancellation.Token)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+
+            context.Complete(
+                this,
+                credential,
+                failure,
+                _cancellation.Token);
+            CancelAndDispose(dispose: true);
+        }
+
+        private void CancelAndDispose(bool dispose)
+        {
+            lock (_sync)
+            {
+                if (dispose)
+                {
+                    if (!_disposed)
+                    {
+                        _cancellation.Dispose();
+                        _disposed = true;
+                    }
+
+                    return;
+                }
+
+                if (!_disposed)
+                {
+                    _cancellation.Cancel();
+                }
+            }
+        }
+    }
+
+    private readonly record struct ResourceScope(
+        string Scheme,
+        string Host,
+        int Port,
+        string? AzureOrganization)
+    {
+        public static bool TryCreate(
+            Uri uri,
+            out ResourceScope scope)
+        {
+            scope = default;
+            if (!uri.IsAbsoluteUri
+                || uri.Scheme is not ("http" or "https"))
+            {
+                return false;
+            }
+
+            string host;
+            try
+            {
+                host = uri.IdnHost.ToLowerInvariant();
+            }
+            catch (UriFormatException)
+            {
+                return false;
+            }
+
+            if (host.Length == 0)
+            {
+                return false;
+            }
+
+            string? organization = null;
+            if (host.Equals(
+                    AzureArtifactsHost,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                organization = uri.Segments
+                    .Select(segment => segment.Trim('/'))
+                    .FirstOrDefault(segment => segment.Length > 0);
+                if (organization is null)
+                {
+                    return false;
+                }
+            }
+
+            scope = new ResourceScope(
+                uri.Scheme.ToLowerInvariant(),
+                host,
+                uri.Port,
+                organization);
+            return true;
+        }
+    }
+}
+
+internal sealed class SourcePluginAuthenticationHandler(
+    PluginAuthenticationContext context,
+    HttpMessageHandler innerHandler)
+    : DelegatingHandler(innerHandler)
+{
+    private static readonly HttpRequestOptionsKey<
+        PluginAuthenticationContext> RejectedContext =
+        new("NuGetFetch.PluginAuthenticationContextRejected");
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.RequestUri is null
+            || request.Headers.Authorization is not null
+            || IsRejected(request))
+        {
+            return await base.SendAsync(
+                request,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        PluginAuthenticationContext.Participation participation =
+            context.Read(
+                request.RequestUri,
+                out PluginAuthenticationContext.CredentialSnapshot snapshot);
+        if (participation != PluginAuthenticationContext.Participation.Allowed)
+        {
+            if (participation == PluginAuthenticationContext.Participation.Rejected)
+            {
+                request.Options.Set(RejectedContext, context);
+            }
+
+            return await base.SendAsync(
+                request,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        int attempts = 0;
+        while (true)
+        {
+            HttpRequestMessage attempt = CloneRequest(request);
+            HttpResponseMessage? response = null;
+            bool transferResponse = false;
+            bool transferAttempt = false;
+            try
+            {
+                if (snapshot.Credential is not null)
+                {
+                    attempt.Headers.Authorization =
+                        CreateBasicHeader(snapshot.Credential);
+                }
+
+                response = await base.SendAsync(
+                    attempt,
+                    cancellationToken).ConfigureAwait(false);
+                if (!context.IsCredentialChallenge(response.StatusCode)
+                    || ++attempts >= PluginAuthenticationHandler.MaxAuthRetries)
+                {
+                    response.RequestMessage ??= attempt;
+                    transferAttempt =
+                        ReferenceEquals(response.RequestMessage, attempt);
+                    transferResponse = true;
+                    return response;
+                }
+
+                PackageSourceCredential? acquired =
+                    await context.AcquireAsync(
+                        snapshot.Version,
+                        isRetry: snapshot.Credential is not null,
+                        cancellationToken).ConfigureAwait(false);
+                if (acquired is null)
+                {
+                    response.RequestMessage ??= attempt;
+                    transferAttempt =
+                        ReferenceEquals(response.RequestMessage, attempt);
+                    transferResponse = true;
+                    return response;
+                }
+
+                participation = context.Read(
+                    request.RequestUri,
+                    out snapshot);
+                if (participation
+                    != PluginAuthenticationContext.Participation.Allowed)
+                {
+                    response.RequestMessage ??= attempt;
+                    transferAttempt =
+                        ReferenceEquals(response.RequestMessage, attempt);
+                    transferResponse = true;
+                    return response;
+                }
+            }
+            finally
+            {
+                if (!transferResponse && response is not null)
+                {
+                    HttpRequestMessage? responseRequest =
+                        response.RequestMessage;
+                    response.Dispose();
+                    if (!ReferenceEquals(responseRequest, attempt))
+                    {
+                        responseRequest?.Dispose();
+                    }
+                }
+
+                if (!transferAttempt)
+                {
+                    attempt.Dispose();
+                }
+            }
+        }
+    }
+
+    private bool IsRejected(HttpRequestMessage request) =>
+        request.Options.TryGetValue(
+            RejectedContext,
+            out PluginAuthenticationContext? rejected)
+        && ReferenceEquals(rejected, context);
+
+    private static AuthenticationHeaderValue CreateBasicHeader(
+        PackageSourceCredential credential)
+    {
+        string encoded = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(
+                $"{credential.Username}:{credential.Password}"));
+        return new AuthenticationHeaderValue("Basic", encoded);
+    }
+
+    private static HttpRequestMessage CloneRequest(
+        HttpRequestMessage request)
+    {
+        var clone = new HttpRequestMessage(
+            request.Method,
+            request.RequestUri)
+        {
+            Version = request.Version,
+            VersionPolicy = request.VersionPolicy,
+            Content = request.Content,
+        };
+
+        foreach (KeyValuePair<string, IEnumerable<string>> header
+            in request.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(
+                header.Key,
+                header.Value);
+        }
+
+        foreach (KeyValuePair<string, object?> option
+            in request.Options)
+        {
+            clone.Options.Set(
+                new HttpRequestOptionsKey<object?>(option.Key),
+                option.Value);
+        }
+
+        return clone;
+    }
+}


### PR DESCRIPTION
## Mission and claim

Build robust, capable features that provide foundational capabilities or
compelling user experiences and are conventionally sound, delightfully new or
unique, or both.

This PR implements the authentication-owned substrate from #5305: plugin
credential state now belongs to one configured NuGet V3 source authority
rather than every request target sharing a network scope.

- `PluginAuthenticationContextOwner` creates and retires one context for an
  exact caller-issued `PackageSourceAssociation`.
- Pipelines receive an opaque, non-owning context reference and compose it
  through the explicit
  `PackageSourceClientFactory.CreateWithPluginAuthentication` path.
- Provider lookup always uses the configured service-index URI, while each
  concrete request independently passes ordinary-origin or Azure-organization
  resource authorization.
- Credential acquisition and rejected-version refresh are single-flight per
  context; distinct contexts remain independent.
- Retirement denies new use immediately and prevents late publication.
- Redirect hops re-enter authentication, preserve rejection, and never copy a
  plugin-produced header.
- Explicit authorization retains precedence, Gallery remains credential-free,
  and Browser/Wasm rejects credential-provider contexts.

The sole normative owner is
[`docs/design/nuget-authentication.md#source-scoped-plugin-authentication-context`](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/nuget-authentication.md#source-scoped-plugin-authentication-context).
The implementation consumes `PackageSourceAssociation`, V3 factory and
transport composition, and configured-source authority decisions without
redefining their owners.

## Demo

A real local TCP server exposes two configured V3 authorities on one origin.
The private authority's advertised resource supplies the first challenge. The
provider is queried with the configured private service-index URI, while the
anonymous authority succeeds without receiving the private credential:

```text
Private versions: 1.0.0
Anonymous versions: 1.0.0
Provider query: http://127.0.0.1:<port>/private/index.json
Private resource authenticated: True
Anonymous source received credential: False
```

## Compatibility and boundary

The plugin-aware factory uses a distinct
`CreateWithPluginAuthentication` name so existing
`Create(source, association, null/default)` calls remain source-compatible.
Legacy `PackageSourceIdentity`, configured credentials, retry bounds, and
challenge reporting are unchanged.

This focused slice does **not** claim CLI-wide source isolation. The existing
process-global `SetAuthenticationDecorator` path remains until the package
source model adopts one owner per canonical configured authority. #5603 is the
named package-owner consumer that will perform that integration and remove the
legacy path. Gallery services, local-folder acquisition, configured-source
canonicalization, and browser PAT handling are outside this PR.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/NuGetFetch.Tests -c Release` — 948 total, 0 failed,
  11 skipped live/platform tests
- `dotnet publish prototypes/inspect-web/engine/InspectWeb.Engine.csproj -c Release`
- `npx markdownlint-cli docs/design/nuget-authentication.md`
- Public API TCP demo shown above

`PluginAuthenticationContextTests` contains every Release gate named by the
owner: same-origin anonymous isolation, resource-first configured-query lookup,
shared-association lifetime, cross-context and out-of-scope denial, ordinary
and Azure scope, per-context concurrency, retirement, version-aware refresh,
explicit-authorization precedence, redirect rejection propagation, opaque
context references, and Gallery exclusion.

Part of #5305.
