### PR TITLE
Model Inspect Web around multiple live workspaces

### DIFF
--- a/docs/design/inspect-web-navigation-consumer.md
+++ b/docs/design/inspect-web-navigation-consumer.md
@@ -465,10 +465,14 @@ Workspace from history metadata. The URL continues to carry the product-owned
 portable view state. For a known live Workspace, its current membership is
 authoritative: an older history entry may restore a view only while its
 required coordinate remains present, and an exact multi-coordinate entry may
-restore only while its ordered membership still matches. Otherwise the Browser
-replaces that stale entry with the current live projection instead of undoing a
-later add, replacement, or explicit Close. An absent or unknown Workspace ID
-has no live membership authority, so its URL may restore into Default.
+restore only while its ordered membership still matches. Floating packet
+coordinates match the resolved live coordinate they retained rather than
+becoming literal `latest` or empty pins. A compatible entry activates the
+retained package model and applies its view without reacquisition. Otherwise
+the Browser replaces that stale entry with the current live projection instead
+of undoing a later add, replacement, or explicit Close. An absent or unknown
+Workspace ID has no live membership authority, so its URL may restore into
+Default.
 Session-only canonical return locations used by routed surfaces such as Package
 query are retained per browser-session Workspace ID; selecting one Workspace
 cannot expose another Workspace's canonical snapshot through a return link.
@@ -516,11 +520,12 @@ this same test file are recorded in
   the composition-root assertions in `spotlight-identity.test.ts` jointly cover
   two Workspaces with overlapping coordinates, a delayed acquisition across an
   A-to-B-to-A switch, cancellation of an empty or partially acquired
-  restoration, Back and Forward between their history entries, rejection of a
-  closed coordinate from an older associated entry, absent and unknown history
-  Workspace IDs, per-Workspace canonical return locations, Query and Credits
-  history-adoption ordering, generation-gated runtime acquisition, and
-  `/#workspace` refresh. The Browser harness runs the
+  restoration, Back and Forward between their history entries, retained-model
+  activation without reacquisition, resolution-aware floating packet
+  membership, rejection of a closed coordinate from an older associated entry,
+  absent and unknown history Workspace IDs, per-Workspace canonical return
+  locations, Query and Credits history-adoption ordering, generation-gated
+  runtime acquisition, and `/#workspace` refresh. The Browser harness runs the
   production Workspace collection and renderer/binder helpers rather than the
   full Wasm application; the composition-root assertions pin their production
   wiring. Together they prove that late work changes neither the selected nor

--- a/docs/design/inspect-web-navigation-consumer.md
+++ b/docs/design/inspect-web-navigation-consumer.md
@@ -463,6 +463,9 @@ selects a known associated Workspace and only then applies the entry's URL
 restoration. An absent or unknown ID selects Default; traversal never creates a
 Workspace from history metadata. The URL continues to carry the product-owned
 portable state and remains authoritative for the selected projection.
+Session-only canonical return locations used by routed surfaces such as Package
+query are retained per browser-session Workspace ID; selecting one Workspace
+cannot expose another Workspace's canonical snapshot through a return link.
 
 `/#workspace` is the Workspace-subject route when no portable package snapshot
 belongs to that history entry. During the same browser session, restoring that
@@ -497,15 +500,20 @@ these named Inspect Web tests. Descriptor-rendering and widget-focus gates for
 this same test file are recorded in
 [Inspect Web Navigation Presentation](inspect-web-navigation-presentation.md#implementation-gates):
 
-- `workspace-session.test.ts` and an outcome-level Browser gate:
-  `live Workspace history and asynchronous results retain their owner` covers
-  two Workspaces with overlapping coordinates, a delayed acquisition that
-  completes after switching, Back and Forward between their history entries,
-  an absent and unknown history Workspace ID, and `/#workspace` refresh. It
-  proves that late work changes neither the selected nor foreign projection,
-  traversal selects only a known Workspace or Default before restoration,
-  equal coordinates do not alias caches, and an empty route cannot resurrect a
-  closed package.
+- `workspace-session.test.ts`, the production-component Browser gate
+  `live Workspace history and asynchronous results retain their owner`, and
+  the composition-root assertions in `spotlight-identity.test.ts` jointly cover
+  two Workspaces with overlapping coordinates, a delayed acquisition across an
+  A-to-B-to-A switch, Back and Forward between their history entries, absent
+  and unknown history Workspace IDs, per-Workspace canonical return locations,
+  Query and Credits history-adoption ordering, generation-gated runtime
+  acquisition, and `/#workspace` refresh. The Browser harness runs the
+  production Workspace collection and renderer/binder helpers rather than the
+  full Wasm application; the composition-root assertions pin their production
+  wiring. Together they prove that late work changes neither the selected nor
+  foreign projection, traversal selects only a known Workspace or Default
+  before restoration, equal coordinates do not alias session identity, and an
+  empty route cannot resurrect a closed package.
 - `navigation-consumer.test.ts`:
   `typed outcomes commit only returned state and release authority` covers
   applied, unavailable with and without a replacement snapshot, rejected,

--- a/docs/design/inspect-web-navigation-consumer.md
+++ b/docs/design/inspect-web-navigation-consumer.md
@@ -462,7 +462,13 @@ browser-session Workspace ID as private history metadata. Back or Forward first
 selects a known associated Workspace and only then applies the entry's URL
 restoration. An absent or unknown ID selects Default; traversal never creates a
 Workspace from history metadata. The URL continues to carry the product-owned
-portable state and remains authoritative for the selected projection.
+portable view state. For a known live Workspace, its current membership is
+authoritative: an older history entry may restore a view only while its
+required coordinate remains present, and an exact multi-coordinate entry may
+restore only while its ordered membership still matches. Otherwise the Browser
+replaces that stale entry with the current live projection instead of undoing a
+later add, replacement, or explicit Close. An absent or unknown Workspace ID
+has no live membership authority, so its URL may restore into Default.
 Session-only canonical return locations used by routed surfaces such as Package
 query are retained per browser-session Workspace ID; selecting one Workspace
 cannot expose another Workspace's canonical snapshot through a return link.
@@ -478,11 +484,16 @@ persistence is not yet claimed.
 
 Every asynchronous Browser acquisition or restoration captures both the
 originating browser-session Workspace ID and the existing navigation
-generation. It may mutate state only while both still match. Workspace
-selection starts a new navigation generation, cancels or invalidates
+generation. It may mutate state only while both still match. A restoration
+keeps its empty or partially acquired projection transactional: ordinary
+rendering and a superseding navigation cannot synchronize it into the live
+Workspace record. Success commits the complete projection and releases
+replaced package state no longer retained by a live Workspace; abandonment
+restores the prior live projection and releases transient package state.
+Workspace selection starts a new navigation generation, cancels or invalidates
 destination work, and resets Workspace-local object-reference caches before
 the selected projection is exposed. A late completion from Workspace A cannot
-populate Workspace B even when their coordinate sets are equal.
+populate Workspace B or erase A even when their coordinate sets are equal.
 
 ## Non-claims
 
@@ -504,16 +515,19 @@ this same test file are recorded in
   `live Workspace history and asynchronous results retain their owner`, and
   the composition-root assertions in `spotlight-identity.test.ts` jointly cover
   two Workspaces with overlapping coordinates, a delayed acquisition across an
-  A-to-B-to-A switch, Back and Forward between their history entries, absent
-  and unknown history Workspace IDs, per-Workspace canonical return locations,
-  Query and Credits history-adoption ordering, generation-gated runtime
-  acquisition, and `/#workspace` refresh. The Browser harness runs the
+  A-to-B-to-A switch, cancellation of an empty or partially acquired
+  restoration, Back and Forward between their history entries, rejection of a
+  closed coordinate from an older associated entry, absent and unknown history
+  Workspace IDs, per-Workspace canonical return locations, Query and Credits
+  history-adoption ordering, generation-gated runtime acquisition, and
+  `/#workspace` refresh. The Browser harness runs the
   production Workspace collection and renderer/binder helpers rather than the
   full Wasm application; the composition-root assertions pin their production
   wiring. Together they prove that late work changes neither the selected nor
-  foreign projection, traversal selects only a known Workspace or Default
-  before restoration, equal coordinates do not alias session identity, and an
-  empty route cannot resurrect a closed package.
+  foreign projection or erase the originating stable projection, traversal
+  selects only a known Workspace or Default before restoration, equal
+  coordinates do not alias session identity, and stale history cannot
+  resurrect a closed package.
 - `navigation-consumer.test.ts`:
   `typed outcomes commit only returned state and release authority` covers
   applied, unavailable with and without a replacement snapshot, rejected,

--- a/docs/design/inspect-web-navigation-consumer.md
+++ b/docs/design/inspect-web-navigation-consumer.md
@@ -447,6 +447,40 @@ the invoking row action. The request's package-ID/version submission and
 failure semantics are owned by
 [Package Query Experience](package-query-experience.md#layout).
 
+### Browser-session Workspace association
+
+The Browser host may retain several live Workspace projections before product
+Workspace identity and membership operations are available. Each projection
+has an opaque browser-session ID and retains only its packages, active
+coordinate, portable share basis, and in-app navigation stack.
+Theme, recent packages, engine status, package-query state, and the Workspace
+collection itself remain session-global. The browser-session ID is neither a
+product identity nor portable state.
+
+Every browser-history entry produced from a live Workspace carries its
+browser-session Workspace ID as private history metadata. Back or Forward first
+selects a known associated Workspace and only then applies the entry's URL
+restoration. An absent or unknown ID selects Default; traversal never creates a
+Workspace from history metadata. The URL continues to carry the product-owned
+portable state and remains authoritative for the selected projection.
+
+`/#workspace` is the Workspace-subject route when no portable package snapshot
+belongs to that history entry. During the same browser session, restoring that
+entry selects its associated live Workspace and leaves its current membership
+intact; browser view navigation is not package-membership undo. A Workspace
+whose final package was explicitly closed therefore remains empty and cannot
+resurrect that package through Back. Refresh starts a new session with an empty
+Default Workspace because the route carries no portable package snapshot and
+persistence is not yet claimed.
+
+Every asynchronous Browser acquisition or restoration captures both the
+originating browser-session Workspace ID and the existing navigation
+generation. It may mutate state only while both still match. Workspace
+selection starts a new navigation generation, cancels or invalidates
+destination work, and resets Workspace-local object-reference caches before
+the selected projection is exposed. A late completion from Workspace A cannot
+populate Workspace B even when their coordinate sets are equal.
+
 ## Non-claims
 
 This document does not render navigation descriptors, decide which subject or
@@ -463,6 +497,15 @@ these named Inspect Web tests. Descriptor-rendering and widget-focus gates for
 this same test file are recorded in
 [Inspect Web Navigation Presentation](inspect-web-navigation-presentation.md#implementation-gates):
 
+- `workspace-session.test.ts` and an outcome-level Browser gate:
+  `live Workspace history and asynchronous results retain their owner` covers
+  two Workspaces with overlapping coordinates, a delayed acquisition that
+  completes after switching, Back and Forward between their history entries,
+  an absent and unknown history Workspace ID, and `/#workspace` refresh. It
+  proves that late work changes neither the selected nor foreign projection,
+  traversal selects only a known Workspace or Default before restoration,
+  equal coordinates do not alias caches, and an empty route cannot resurrect a
+  closed package.
 - `navigation-consumer.test.ts`:
   `typed outcomes commit only returned state and release authority` covers
   applied, unavailable with and without a replacement snapshot, rejected,

--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -422,7 +422,9 @@ unknown session ID targets Default and never creates a phantom Workspace.
 History restores a view within the live Workspace's current membership; it
 does not restore an older membership set. When an associated entry requires a
 closed or replaced coordinate, the Browser reconciles that entry to the
-current Workspace surface instead of reacquiring the stale coordinate.
+current Workspace surface instead of reacquiring the stale coordinate. A
+compatible entry activates its retained package model without reacquisition;
+floating packet pins match the concrete live coordinates they resolved to.
 
 An empty Workspace has the canonical session route `/#workspace`. It renders
 the ordinary Workspace shell, inventory, Search action, and empty package

--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -324,9 +324,10 @@ System.Text.Json > System.Text.Json.JsonSerializer > DeserializeSync
 ```
 
 The path contains the applicable Package, Library, Type, and Member display
-identities supplied by their owners. Workspace renders `Workspace`. The
-presentation does not parse one display string to derive another, and the
-segments are orientation rather than inert navigation breadcrumbs.
+identities supplied by their owners. Workspace renders the selected live
+Workspace's session name. The presentation does not parse one display string
+to derive another, and the segments are orientation rather than inert
+navigation breadcrumbs.
 
 The Package segment receives the strongest visual emphasis, following
 npmx.dev's useful emphasis and direct-copy treatment for current package
@@ -338,7 +339,8 @@ Each product-issued Package, Library, Type, or Member segment is an individually
 copyable control. Activating one copies that segment's owner-issued canonical
 name, not the combined rendered path or text parsed from another segment.
 Workspace is presentation-owned retained-coordinate management and remains
-plain orientation text rather than inventing a canonical name.
+plain orientation text. Its session name is not a canonical or portable
+identity.
 
 The inspected target begins with a fixed-width root-icon slot. A package uses the
 embedded JPEG or PNG named by its validated nuspec `<icon>` declaration. The
@@ -380,56 +382,71 @@ finally the arrows disappear.
 
 ### Workspace surface
 
-Workspace is the first subject and the persistent entry point for workspace
-packet inspection and retained-coordinate management. The primary inventory is
-the set of product-issued packets, not the deduplicated runtime workspaces that
-realize them. A packet composes its Workspace, navigation, and initial view as
-defined by [Workspace Definitions](workspace-definitions.md); two packets remain
-separately selectable when they reuse the same underlying Workspace. The first
-browser adoption retains resolved product demo scenarios for the current
-session.
+Workspace is the first subject and the persistent entry point for the
+browser session's live Workspaces and their retained-coordinate management.
+Every live Workspace remains visible in one inventory even when several have
+equal coordinate sets. The selected Workspace supplies the active package,
+portable share basis, and in-app navigation-history projection. Those
+projections are session state, not product Workspace identities.
 
-Selecting a packet is observational: it changes the packet detail shown in the
-content pane and starts no acquisition or inspection work. The detail shows its
-owner-issued title and summary, declared workspace members, initial navigation
-target, and initial view. A separate, explicit `Open workspace` action executes
-the selected packet. The selected packet's title replaces the generic
-`Workspace` content heading and inspected-target label.
+The session begins with one `Default` Workspace. `New workspace` creates and
+selects an empty live Workspace with the next session name. The Browser surface
+bounds the live collection at four Workspaces. A non-default Workspace exposes
+an explicit `Remove workspace` action; Default cannot be removed. Closing the
+final coordinate leaves an empty Workspace visible and selected rather than
+routing Home or removing it.
 
-Selection and runtime state remain separate. The selected packet title orients
-the packet viewer; it does not claim that the packet uniquely owns the loaded
-Workspace or that its initial view is active. The loaded Workspace section
-reports runtime state without inferring packet identity from matching
-coordinates. Packet selection preserves focus on the selected inventory entry.
+Each inventory row and the selected Workspace detail infer presentation only
+from that Workspace's actual loaded package models:
 
-The same content pane separately lists the runtime Workspace's loaded
-coordinates with:
+- the session name and loaded-coordinate count;
+- package or Platform identity, version, and target framework;
+- the active coordinate; and
+- an explicit Close action for each removable package coordinate.
 
-- coordinate identity and acquisition kind;
-- optional owner-issued current-subject context;
-- loading, ready, or failed state; and
-- an explicit Close action.
+The inference does not mint identity, reconstruct a demo scenario, or treat a
+portable workspace packet as the user-facing Workspace. Browser-session
+Workspace IDs and names do not enter Share packets and are not a substitute for
+the product-issued identities and membership results tracked by
+[#5508](https://github.com/richlander/dotnet-inspect/issues/5508) and
+[#5583](https://github.com/richlander/dotnet-inspect/issues/5583).
 
-Opening a packet or closing a coordinate submits its opaque identity and
-renders the returned workspace outcome. The UI does not choose a subject, lens,
-successor, or fallback for the product. Separate packets remain separate even
-when their display package IDs and complete coordinate sets match.
+Selecting a Workspace is a real session transition. It preserves the outgoing
+Workspace projection, activates the selected projection, invalidates work
+owned by the outgoing navigation generation, renders the selected Workspace
+name in the content heading and inspected-target path, and preserves focus on
+the selected inventory entry. The Navigation Consumer associates browser
+history entries with the owning browser-session Workspace ID. Back or Forward
+selects a known associated Workspace before applying the entry; an absent or
+unknown session ID targets Default and never creates a phantom Workspace.
+
+An empty Workspace has the canonical session route `/#workspace`. It renders
+the ordinary Workspace shell, inventory, Search action, and empty package
+detail. Share is unavailable until the Workspace has a projectable package
+state. An older `/#workspace` history entry selects its associated live
+Workspace without undoing packages loaded since that entry was created.
+Refreshing that non-portable route returns to Default's empty Workspace shell;
+session-created Workspaces are not yet persisted.
+
+Product demos always replace the Default Workspace with the demo's exact
+resolved coordinates and view. They neither create Workspace rows nor merge
+their coordinates into a selected user-created Workspace. Ordinary package
+opening targets the selected Workspace.
 
 Closing an inactive coordinate preserves the active coordinate's inspection
 state and keeps Workspace selected. Closing the active coordinate selects the
-returned successor while remaining in Workspace. Share and refresh preserve the Workspace subject and its retained coordinates.
-The home-demo packet inventory is session-scoped until scenario identity is
-part of the share format; after refresh, the generic current Workspace remains
-viewable without reconstructing a demo identity from matching coordinates.
+returned successor while remaining in Workspace. Share and refresh preserve
+the Workspace subject and its retained coordinates, but this slice makes no
+persistence claim for the collection itself.
 
-Workspace renders stable focus targets for its heading, every packet entry, and
-every coordinate action. Post-result focus and failure
-handling are owned by
-[Inspect Web Navigation Consumer](inspect-web-navigation-consumer.md#workspace-result-focus).
+Workspace renders stable focus targets for its heading, every Workspace entry,
+and every coordinate action. Post-result focus, browser-history association,
+and deferred-effect authority are owned by
+[Inspect Web Navigation Consumer](inspect-web-navigation-consumer.md).
 
-Workspace also exposes the same Search and Open actions as the shell. It does
-not infer source identity, package equivalence, local-file correspondence, or
-a composite workspace name from display labels.
+Workspace also exposes the same Search and package-open actions as the shell.
+It does not infer source identity, package equivalence, local-file
+correspondence, or canonical Workspace identity from display labels.
 
 ### Lens navigation semantics
 
@@ -911,12 +928,25 @@ are proved by the gates in
 
 ### Workspace composition
 
-1. Supply two open-coordinate descriptors with different optional subject
-   context and status.
-2. Confirm that Workspace renders those descriptors without deriving identity
-   from their labels.
-3. Activate and close entries and confirm that each action submits the opaque
-   coordinate identity once and renders the returned workspace outcome.
+1. Start a browser session and confirm that one removable-coordinate inventory
+   named `Default` is visible.
+2. Load System.Text.Json into Default, create a second Workspace, and load
+   Microsoft.Extensions packages into it. Confirm that both Workspaces remain
+   visible and each detail is inferred only from its own package models.
+3. Switch repeatedly between the overlapping and disjoint coordinate sets.
+   Confirm that the selected Workspace name appears in the inspected-target path
+   and content heading, its package projection is active, and focus follows the
+   selected inventory entry.
+4. Create an empty Workspace, close the final coordinate in another non-default
+   Workspace, and confirm that both remain visible as empty Workspace
+   destinations. Refresh `/#workspace` and confirm that, after engine readiness,
+   the empty Default Workspace shell renders rather than Home.
+5. Remove a non-default Workspace and confirm that Default becomes selected.
+   Confirm that Default has no removal action and that creation is disabled at
+   four live Workspaces.
+6. Run three demos with equal System.Text.Json coordinates and different views.
+   Confirm that they replace Default's content without creating three rows or
+   mutating the selected user-created Workspace.
 
 Post-result focus and failure acceptance are specified by
 [Workspace focus acceptance](inspect-web-navigation-consumer.md#workspace-focus-acceptance).

--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -430,8 +430,9 @@ session-created Workspaces are not yet persisted.
 
 Product demos always replace the Default Workspace with the demo's exact
 resolved coordinates and view. They neither create Workspace rows nor merge
-their coordinates into a selected user-created Workspace. Ordinary package
-opening targets the selected Workspace.
+their coordinates into a selected user-created Workspace. A successful demo
+pushes its resolved destination so Browser Back returns to the initiating Home
+entry. Ordinary package opening targets the selected Workspace.
 
 Closing an inactive coordinate preserves the active coordinate's inspection
 state and keeps Workspace selected. Closing the active coordinate selects the

--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -419,6 +419,10 @@ the selected inventory entry. The Navigation Consumer associates browser
 history entries with the owning browser-session Workspace ID. Back or Forward
 selects a known associated Workspace before applying the entry; an absent or
 unknown session ID targets Default and never creates a phantom Workspace.
+History restores a view within the live Workspace's current membership; it
+does not restore an older membership set. When an associated entry requires a
+closed or replaced coordinate, the Browser reconciles that entry to the
+current Workspace surface instead of reacquiring the stale coordinate.
 
 An empty Workspace has the canonical session route `/#workspace`. It renders
 the ordinary Workspace shell, inventory, Search action, and empty package
@@ -436,9 +440,11 @@ entry. Ordinary package opening targets the selected Workspace.
 
 Closing an inactive coordinate preserves the active coordinate's inspection
 state and keeps Workspace selected. Closing the active coordinate selects the
-returned successor while remaining in Workspace. Share and refresh preserve
-the Workspace subject and its retained coordinates, but this slice makes no
-persistence claim for the collection itself.
+returned successor while remaining in Workspace. Closing a coordinate updates
+the live membership authority, so older browser-history entries cannot
+reacquire it as membership undo. Share and refresh preserve the Workspace
+subject and its retained coordinates, but this slice makes no persistence
+claim for the collection itself.
 
 Workspace renders stable focus targets for its heading, every Workspace entry,
 and every coordinate action. Post-result focus, browser-history association,

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1207,9 +1207,19 @@ The `eng/CiChangeDetection` gate, invoked through
 
 ## Interaction model
 
-Package tabs and the framework selector are workspace identity, not display
-state: changing either resolves a different workspace. Lenses this engine does
-not answer report the engine's failure rather than fixture results.
+The Browser session starts with one live Workspace named `Default` and can
+retain up to four live Workspaces. Each Workspace keeps its own loaded package
+projection, active coordinate, share basis, and in-app navigation stack.
+`New workspace` creates an empty selected Workspace; non-default Workspaces can
+be removed, while closing their final package leaves the empty Workspace
+visible. Package opening targets the selected Workspace. Product demos replace
+Default with their exact resolved coordinates and view, so demos neither create
+scenario rows nor pollute a user-created analysis Workspace. The collection is
+session-local; persistence is future work.
+
+Package coordinates and the framework selector are Workspace membership, not
+display state. Lenses this engine does not answer report the engine's failure
+rather than fixture results.
 
 `src/workspace-navigation.ts` owns the in-memory view history, monotonic
 navigation generation, URL routing and building, typed adaptation to the
@@ -1220,6 +1230,13 @@ that intercepts same-origin in-app anchor clicks
 browser behavior. Initial routing records the opaque `w=` value without decoding
 it, which preserves the bare-home paint before WebAssembly while allowing shared
 workspace resolution to run only after the engine is ready.
+`src/workspace-session.ts` owns the Browser-local live-Workspace collection,
+the selected projection, and private browser-history association. Async package
+work must retain both its originating Workspace ID and navigation generation;
+changing either rejects the completion. Empty Workspace state uses
+`/#workspace` so closing the last coordinate cannot leave a stale package URL.
+Within one session, returning to an older `/#workspace` history entry selects
+its live Workspace without treating Back as package-membership undo.
 `BrowserWorkspaceShareOperations` then routes decode through
 `WorkspaceSharePacketCodec` and `WorkspaceSharePacketTransposer`; encoding
 reverses the same path. TypeScript neither understands compact packet fields nor

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -18,20 +18,33 @@ import {
   focusWorkbenchSearch,
   workbenchShellHtml,
 } from "../src/shell-controls.ts";
-import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace,
   renderWorkspaceSubject,
-  retainWorkspacePacket,
+  renderWorkspaceView,
 } from "../src/workspace-subject.ts";
+import {
+  MAX_LIVE_WORKSPACES,
+  createLiveWorkspace,
+  createLiveWorkspaceSession,
+  removeLiveWorkspace,
+  selectLiveWorkspace,
+  selectedLiveWorkspace,
+  updateSelectedLiveWorkspace,
+  withWorkspaceHistoryId,
+  workspaceForHistory,
+  workspaceOperationIsCurrent,
+} from "../src/workspace-session.ts";
 
 declare global {
   interface Window {
     focusWorkbenchSearchProbe: () => boolean;
     renderPackageScopeProbe: () => void;
     rerenderScopeBarProbe: () => void;
+    beginDelayedWorkspaceLoadProbe: () => void;
+    completeDelayedWorkspaceLoadProbe: () => void;
+    restoreUnknownWorkspaceProbe: () => void;
   }
 }
 
@@ -63,7 +76,7 @@ const packageIcon = params.has("fallback")
   ? defaultPackageIcon
   : systemTextJsonIcon;
 const subjectPath = workspaceMode
-  ? [{ kind: "workspace", label: "System.Text.Json", copyable: false }]
+  ? [{ kind: "workspace", label: "Default", copyable: false }]
   : packageMode
     ? [{ kind: "package", label: "System.Text.Json", copyable: true }]
     : memberMode
@@ -121,94 +134,53 @@ const coordinates = [
     isRuntimePack: false,
   },
 ];
-const packetDefinitions: readonly BrowserHomeDemoResolved[] = [
-  {
-    id: "stj-serializer",
-    title: "System.Text.Json",
-    summary: "Browse a real package API",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonSerializer",
-      memberAnchor: null,
-      memberKey: null,
-      section: "Methods",
-    },
-  },
-  {
-    id: "stj-serialize-callgraph",
-    title: "Serialize call graph",
-    summary: "Dense package-local STJ graph",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonSerializer",
-      memberAnchor: "1dc14dd1fb",
-      memberKey: "method:Serialize",
-      section: "Call Graph",
-    },
-  },
-  {
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-    summary: "STJ number parse path",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonElement",
-      memberAnchor: "cfd9980a6c",
-      memberKey: "method:GetDecimal",
-      section: "Call Graph",
-    },
-  },
-];
-let workspacePackets: BrowserHomeDemoResolved[] = [];
-for (const packet of packetDefinitions)
-  workspacePackets = retainWorkspacePacket(workspacePackets, packet);
-let selectedWorkspacePacketId = workspacePackets[0]?.id ?? "";
+const workspaceSession =
+  createLiveWorkspaceSession<(typeof coordinates)[number]>("default");
+updateSelectedLiveWorkspace(workspaceSession, {
+  packages: params.has("empty-workspace") ? [] : coordinates.slice(0, 1),
+  activePackageKey: params.has("empty-workspace")
+    ? null
+    : "System.Text.Json@10.0.0::net10.0",
+  shareBasis: null,
+  navigation: { stack: [], index: -1 },
+});
+createLiveWorkspace(workspaceSession, "extensions");
+updateSelectedLiveWorkspace(workspaceSession, {
+  packages: coordinates.slice(1),
+  activePackageKey:
+    "Microsoft.Extensions.DependencyInjection@10.0.0::net10.0",
+  shareBasis: null,
+  navigation: { stack: [], index: -1 },
+});
+selectLiveWorkspace(workspaceSession, "default");
+let workspaceNavigationSequence = 0;
+let delayedWorkspaceOwner: {
+  workspaceId: string;
+  navigationSequence: number;
+} | null = null;
+if (workspaceMode) {
+  history.replaceState(
+    withWorkspaceHistoryId(history.state, "default"),
+    "",
+    location.href);
+}
 
-function selectedWorkspacePacket(): BrowserHomeDemoResolved | null {
-  return workspacePackets.find(
-    packet => packet.id === selectedWorkspacePacketId) ?? null;
+function selectedWorkspace() {
+  return selectedLiveWorkspace(workspaceSession);
 }
 
 function workspaceNavigationHtml(): string {
   return renderWorkspaceSubject({
-    packets: workspacePackets,
-    selectedPacketId: selectedWorkspacePacketId,
+    workspaces: workspaceSession.workspaces,
+    selectedWorkspaceId: workspaceSession.selectedWorkspaceId,
+    maximumWorkspaces: MAX_LIVE_WORKSPACES,
     escapeHtml,
   });
 }
 
 function workspaceDetailHtml(): string {
-  return renderWorkspacePacketView({
-    packet: selectedWorkspacePacket(),
-    packages: coordinates.slice(0, 1),
-    activePackage: coordinates[0] ?? null,
+  return renderWorkspaceView({
+    workspace: selectedWorkspace(),
     escapeHtml,
     packageIdentityKey: item =>
       `${item.id}@${item.version}::${item.activeFramework}`,
@@ -274,6 +246,9 @@ function scopeBarHtml() {
         : "data-lens",
     panelId: "inspector-panel",
     showMemberScope: memberMode,
+    ...(workspaceMode && params.has("empty-workspace")
+      ? { subjectScopes: ["workspace"] as const }
+      : {}),
     emptyStripLabel: emptyMode ? "Filtered member list" : "",
     escapeHtml,
   });
@@ -422,9 +397,12 @@ function bindHarnessScopeBar() {
   }, scopeBarState);
 }
 
-function renderHarnessWorkspace(packetId: string) {
-  if (!workspacePackets.some(packet => packet.id === packetId)) return;
-  selectedWorkspacePacketId = packetId;
+function renderHarnessWorkspace(
+  workspaceId: string,
+  pushHistory = true,
+) {
+  if (!selectLiveWorkspace(workspaceSession, workspaceId)) return;
+  workspaceNavigationSequence++;
   const navigation =
     document.querySelector<HTMLElement>(".workspace-nav");
   const detail =
@@ -434,28 +412,38 @@ function renderHarnessWorkspace(packetId: string) {
   const pathSegment =
     path?.querySelector<HTMLElement>(".subject-path-segment");
   if (!navigation || !detail || !path || !pathSegment)
-    throw new Error("The workspace packet harness is incomplete.");
+    throw new Error("The workspace harness is incomplete.");
   navigation.outerHTML = workspaceNavigationHtml();
   detail.innerHTML = workspaceDetailHtml();
-  const title = selectedWorkspacePacket()?.title ?? "Current workspace";
+  const title = selectedWorkspace().name;
   path.setAttribute("aria-label", title);
   path.title = title;
   pathSegment.textContent = title;
   bindHarnessWorkspace();
+  if (pushHistory) {
+    history.pushState(
+      withWorkspaceHistoryId(null, workspaceId),
+      "",
+      location.href);
+  }
   requestAnimationFrame(() =>
-    focusWorkspacePacket(document, packetId));
+    focusWorkspace(document, workspaceId));
 }
 
 function bindHarnessWorkspace() {
   if (!workspaceMode) return;
   bindWorkspaceSubject(document, {
     onSelect: renderHarnessWorkspace,
-    onOpen: packetId => {
-      const count = Number(document.body.dataset.workspaceExecutionCount ?? "0");
-      document.body.dataset.workspaceExecutionCount = String(count + 1);
-      document.body.dataset.workspaceExecution = packetId;
+    onCreate: () => {
+      const id = `workspace-${workspaceSession.workspaces.length + 1}`;
+      if (!createLiveWorkspace(workspaceSession, id)) return;
+      renderHarnessWorkspace(id);
     },
-    onClose: packageKey => {
+    onRemove: workspaceId => {
+      removeLiveWorkspace(workspaceSession, workspaceId);
+      renderHarnessWorkspace("default");
+    },
+    onClosePackage: packageKey => {
       document.body.dataset.workspaceClose = packageKey;
     },
   });
@@ -463,7 +451,12 @@ function bindHarnessWorkspace() {
 
 bindHarnessScopeBar();
 bindHarnessWorkspace();
-if (workspaceMode) document.body.dataset.workspaceExecutionCount = "0";
+if (workspaceMode) {
+  window.addEventListener("popstate", event => {
+    const workspace = workspaceForHistory(workspaceSession, event.state);
+    renderHarnessWorkspace(workspace.id, false);
+  });
+}
 
 window.focusWorkbenchSearchProbe = () => focusWorkbenchSearch(document);
 window.renderPackageScopeProbe = () => {
@@ -472,3 +465,34 @@ window.renderPackageScopeProbe = () => {
   renderHarnessScopeBar();
 };
 window.rerenderScopeBarProbe = renderHarnessScopeBar;
+window.beginDelayedWorkspaceLoadProbe = () => {
+  delayedWorkspaceOwner = {
+    workspaceId: workspaceSession.selectedWorkspaceId,
+    navigationSequence: workspaceNavigationSequence,
+  };
+};
+window.completeDelayedWorkspaceLoadProbe = () => {
+  const owner = delayedWorkspaceOwner;
+  delayedWorkspaceOwner = null;
+  if (!owner || !workspaceOperationIsCurrent(
+    workspaceSession,
+    owner,
+    workspaceNavigationSequence)) {
+    document.body.dataset.workspaceLateLoad = "rejected";
+    return;
+  }
+  const latePackage = coordinates[0];
+  if (!latePackage) throw new Error("The delayed package fixture is missing.");
+  selectedLiveWorkspace(workspaceSession).packages = [
+    ...selectedLiveWorkspace(workspaceSession).packages,
+    latePackage,
+  ];
+  document.body.dataset.workspaceLateLoad = "applied";
+  renderHarnessWorkspace(workspaceSession.selectedWorkspaceId, false);
+};
+window.restoreUnknownWorkspaceProbe = () => {
+  const workspace = workspaceForHistory(
+    workspaceSession,
+    withWorkspaceHistoryId(null, "unknown"));
+  renderHarnessWorkspace(workspace.id, false);
+};

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -28,14 +28,17 @@ import {
   MAX_LIVE_WORKSPACES,
   createLiveWorkspace,
   createLiveWorkspaceSession,
+  createWorkspaceProjectionTransactionController,
   removeLiveWorkspace,
   selectLiveWorkspace,
   selectedLiveWorkspace,
   updateSelectedLiveWorkspace,
   withWorkspaceHistoryId,
   workspaceForHistory,
+  workspaceHistoryMembershipStatus,
   workspaceOperationIsCurrent,
 } from "../src/workspace-session.ts";
+import { createNavigationSequence } from "../src/workspace-navigation.ts";
 
 declare global {
   interface Window {
@@ -44,6 +47,8 @@ declare global {
     rerenderScopeBarProbe: () => void;
     beginDelayedWorkspaceLoadProbe: () => void;
     completeDelayedWorkspaceLoadProbe: () => void;
+    supersedeWorkspaceRestorationProbe: () => void;
+    restoreClosedWorkspaceHistoryProbe: () => void;
     restoreMissingWorkspaceProbe: () => void;
     restoreUnknownWorkspaceProbe: () => void;
   }
@@ -490,6 +495,58 @@ window.completeDelayedWorkspaceLoadProbe = () => {
   ];
   document.body.dataset.workspaceLateLoad = "applied";
   renderHarnessWorkspace(workspaceSession.selectedWorkspaceId, false);
+};
+window.supersedeWorkspaceRestorationProbe = () => {
+  const session =
+    createLiveWorkspaceSession<(typeof coordinates)[number]>("transaction");
+  updateSelectedLiveWorkspace(session, {
+    packages: coordinates.slice(0, 1),
+    activePackageKey: "System.Text.Json@10.0.0::net10.0",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  let projection = coordinates.slice(0, 1);
+  const released: string[] = [];
+  const transactions = createWorkspaceProjectionTransactionController(
+    () => session,
+    {
+      currentPackages: () => projection,
+      synchronize: () => {
+        updateSelectedLiveWorkspace(session, {
+          packages: projection,
+          activePackageKey: null,
+          shareBasis: null,
+          navigation: { stack: [], index: -1 },
+        });
+      },
+      restore: workspace => {
+        projection = [...workspace.packages];
+      },
+      release: packageModel => released.push(packageModel.id),
+    });
+  const sequence = createNavigationSequence(() => transactions.abandon());
+  const navigationSequence = sequence.begin();
+  transactions.begin({
+    workspaceId: session.selectedWorkspaceId,
+    navigationSequence,
+  });
+  projection = coordinates.slice(0, 2);
+  sequence.begin();
+  document.body.dataset.workspaceRestorationProjection =
+    projection.map(packageModel => packageModel.id).join(",");
+  document.body.dataset.workspaceRestorationReleased = released.join(",");
+};
+window.restoreClosedWorkspaceHistoryProbe = () => {
+  const requested = coordinates[0];
+  if (!requested) throw new Error("The closed-package fixture is missing.");
+  document.body.dataset.workspaceHistoryMembership =
+    workspaceHistoryMembershipStatus(
+      workspaceSession,
+      withWorkspaceHistoryId(null, "default"),
+      [`${requested.id}@${requested.version}::${requested.activeFramework}`],
+      packageModel =>
+        `${packageModel.id}@${packageModel.version}::${packageModel.activeFramework}`,
+      false);
 };
 window.restoreUnknownWorkspaceProbe = () => {
   const workspace = workspaceForHistory(

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -44,6 +44,7 @@ declare global {
     rerenderScopeBarProbe: () => void;
     beginDelayedWorkspaceLoadProbe: () => void;
     completeDelayedWorkspaceLoadProbe: () => void;
+    restoreMissingWorkspaceProbe: () => void;
     restoreUnknownWorkspaceProbe: () => void;
   }
 }
@@ -146,7 +147,7 @@ updateSelectedLiveWorkspace(workspaceSession, {
 });
 createLiveWorkspace(workspaceSession, "extensions");
 updateSelectedLiveWorkspace(workspaceSession, {
-  packages: coordinates.slice(1),
+  packages: coordinates.slice(0, 2),
   activePackageKey:
     "Microsoft.Extensions.DependencyInjection@10.0.0::net10.0",
   shareBasis: null,
@@ -481,7 +482,7 @@ window.completeDelayedWorkspaceLoadProbe = () => {
     document.body.dataset.workspaceLateLoad = "rejected";
     return;
   }
-  const latePackage = coordinates[0];
+  const latePackage = coordinates[2];
   if (!latePackage) throw new Error("The delayed package fixture is missing.");
   selectedLiveWorkspace(workspaceSession).packages = [
     ...selectedLiveWorkspace(workspaceSession).packages,
@@ -494,5 +495,9 @@ window.restoreUnknownWorkspaceProbe = () => {
   const workspace = workspaceForHistory(
     workspaceSession,
     withWorkspaceHistoryId(null, "unknown"));
+  renderHarnessWorkspace(workspace.id, false);
+};
+window.restoreMissingWorkspaceProbe = () => {
+  const workspace = workspaceForHistory(workspaceSession, null);
   renderHarnessWorkspace(workspace.id, false);
 };

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -38,7 +38,10 @@ import {
   workspaceHistoryMembershipStatus,
   workspaceOperationIsCurrent,
 } from "../src/workspace-session.ts";
-import { createNavigationSequence } from "../src/workspace-navigation.ts";
+import {
+  createNavigationSequence,
+  workspaceShareTabsMatchResolved,
+} from "../src/workspace-navigation.ts";
 
 declare global {
   interface Window {
@@ -49,6 +52,7 @@ declare global {
     completeDelayedWorkspaceLoadProbe: () => void;
     supersedeWorkspaceRestorationProbe: () => void;
     restoreClosedWorkspaceHistoryProbe: () => void;
+    restoreFloatingWorkspaceHistoryProbe: () => void;
     restoreMissingWorkspaceProbe: () => void;
     restoreUnknownWorkspaceProbe: () => void;
   }
@@ -543,10 +547,45 @@ window.restoreClosedWorkspaceHistoryProbe = () => {
     workspaceHistoryMembershipStatus(
       workspaceSession,
       withWorkspaceHistoryId(null, "default"),
-      [`${requested.id}@${requested.version}::${requested.activeFramework}`],
-      packageModel =>
-        `${packageModel.id}@${packageModel.version}::${packageModel.activeFramework}`,
-      false);
+      packages => packages.some(
+        packageModel =>
+          packageModel.id === requested.id
+          && packageModel.version === requested.version
+          && packageModel.activeFramework === requested.activeFramework));
+};
+window.restoreFloatingWorkspaceHistoryProbe = () => {
+  const requested = coordinates[0];
+  if (!requested) throw new Error("The floating-package fixture is missing.");
+  const session =
+    createLiveWorkspaceSession<(typeof coordinates)[number]>("floating");
+  updateSelectedLiveWorkspace(session, {
+    packages: [requested],
+    activePackageKey:
+      `${requested.id}@${requested.version}::${requested.activeFramework}`,
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  document.body.dataset.workspaceFloatingHistoryMembership =
+    workspaceHistoryMembershipStatus(
+      session,
+      withWorkspaceHistoryId(null, "floating"),
+      packages => workspaceShareTabsMatchResolved(
+        [{
+          id: "t0",
+          kind: "package",
+          source: requested.id,
+          version: null,
+          framework: null,
+          runtimeIdentifier: null,
+        }],
+        packages.map((packageModel, index) => ({
+          id: `t${index}`,
+          kind: "package",
+          source: packageModel.id,
+          version: packageModel.version,
+          framework: packageModel.activeFramework,
+          runtimeIdentifier: null,
+        }))));
 };
 window.restoreUnknownWorkspaceProbe = () => {
   const workspace = workspaceForHistory(

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1145,6 +1145,15 @@ test("live Workspace history and asynchronous results retain their owner", async
     .toHaveAttribute("data-workspace-late-load", "rejected");
   await expect(page.locator(".workspace-detail-list"))
     .not.toContainText("Microsoft.Extensions.Http");
+  await page.evaluate(() => window.supersedeWorkspaceRestorationProbe());
+  await expect(page.locator("body"))
+    .toHaveAttribute(
+      "data-workspace-restoration-projection",
+      "System.Text.Json");
+  await expect(page.locator("body"))
+    .toHaveAttribute(
+      "data-workspace-restoration-released",
+      "Microsoft.Extensions.DependencyInjection");
 
   await page.goBack();
   await expect(page.locator(".workspace-heading h1")).toHaveText("Workspace 2");
@@ -1167,6 +1176,9 @@ test("live Workspace history and asynchronous results retain their owner", async
   await expect(page.locator('[data-scope="type"]')).toHaveCount(0);
   await expect(page.locator(".workspace-empty"))
     .toHaveText("No packages are loaded in this workspace.");
+  await page.evaluate(() => window.restoreClosedWorkspaceHistoryProbe());
+  await expect(page.locator("body"))
+    .toHaveAttribute("data-workspace-history-membership", "stale");
   await page.reload();
   await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
   await expect(page.locator(".workspace-empty"))

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1109,7 +1109,7 @@ test("live Workspace selection, creation, and removal preserve package isolation
   await expect(page.locator(".workspace-detail-list"))
     .toContainText("Microsoft.Extensions.DependencyInjection");
   await expect(page.locator(".workspace-detail-list"))
-    .not.toContainText("System.Text.Json");
+    .toContainText("System.Text.Json");
   expect(page.url()).toBe(href);
 
   await page.getByRole("button", { name: "New workspace" }).click();
@@ -1128,6 +1128,8 @@ test("live Workspace selection, creation, and removal preserve package isolation
   await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
   await expect(page.locator(".workspace-detail-list"))
     .toContainText("System.Text.Json");
+  await expect(page.locator(".workspace-detail-list"))
+    .not.toContainText("Microsoft.Extensions.DependencyInjection");
 });
 
 test("live Workspace history and asynchronous results retain their owner", async ({
@@ -1137,15 +1139,26 @@ test("live Workspace history and asynchronous results retain their owner", async
 
   await page.evaluate(() => window.beginDelayedWorkspaceLoadProbe());
   await page.locator('[data-workspace="extensions"]').click();
+  await page.locator('[data-workspace="default"]').click();
   await page.evaluate(() => window.completeDelayedWorkspaceLoadProbe());
   await expect(page.locator("body"))
     .toHaveAttribute("data-workspace-late-load", "rejected");
   await expect(page.locator(".workspace-detail-list"))
-    .not.toContainText("System.Text.Json");
+    .not.toContainText("Microsoft.Extensions.Http");
 
   await page.goBack();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Workspace 2");
+  await expect(page.locator(".workspace-detail-list"))
+    .not.toContainText("Microsoft.Extensions.Http");
+  await page.goBack();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+  await page.goForward();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Workspace 2");
+  await page.goForward();
   await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
   await page.evaluate(() => window.restoreUnknownWorkspaceProbe());
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+  await page.evaluate(() => window.restoreMissingWorkspaceProbe());
   await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
 
   await page.goto(

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1066,65 +1066,96 @@ test("the title line advertises the typed Package, Type, and Member path", async
   expect(zone.y + zone.height).toBeLessThanOrEqual(workspace.y);
 });
 
-test("Workspace gives retained packets the pane and keeps Share readable", async ({
+test("Workspace gives live workspaces the pane and keeps Share readable", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
 
-  const list = await box(page, ".workspace-packet-list");
-  const lastPacket = await box(page, ".workspace-packet:last-child");
+  const list = await box(page, ".workspace-list");
+  const lastWorkspace = await box(page, ".workspace-card:last-child");
   const share = await box(page, "#share");
 
   expect(list.height).toBeGreaterThan(200);
-  expect(lastPacket.y + lastPacket.height)
+  expect(lastWorkspace.y + lastWorkspace.height)
     .toBeLessThanOrEqual(list.y + list.height);
   expect(share.width).toBeGreaterThan(40);
   await expect(page.locator("#copy-name")).toHaveCount(0);
   await expect(page.locator("[data-subject-copy]")).toHaveCount(0);
 });
 
-test("Workspace packet selection is observational and Open executes", async ({
+test("live Workspace selection, creation, and removal preserve package isolation", async ({
   page,
 }) => {
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
 
-  const packets = page.locator("[data-workspace-packet]");
-  await expect(packets).toHaveCount(3);
-  expect(await packets.evaluateAll(elements =>
-    elements.map(element => element.getAttribute("data-workspace-packet"))))
+  const workspaces = page.locator("[data-workspace]");
+  await expect(workspaces).toHaveCount(2);
+  expect(await workspaces.evaluateAll(elements =>
+    elements.map(element => element.getAttribute("data-workspace"))))
     .toEqual([
-    "stj-serializer",
-    "stj-serialize-callgraph",
-    "stj-getdecimal-callgraph",
+    "default",
+    "extensions",
   ]);
   const href = page.url();
-  const serialize = page.locator(
-    '[data-workspace-packet="stj-serialize-callgraph"]');
-  await serialize.click();
+  const extensions = page.locator('[data-workspace="extensions"]');
+  await extensions.click();
 
-  await expect(serialize).toBeFocused();
+  await expect(extensions).toBeFocused();
   await expect(page.locator(".workspace-heading h1"))
-    .toHaveText("Serialize call graph");
+    .toHaveText("Workspace 2");
   await expect(page.locator(".subject-path-segment"))
-    .toHaveText("Serialize call graph");
-  await expect(page.locator("body"))
-    .toHaveAttribute("data-workspace-execution-count", "0");
+    .toHaveText("Workspace 2");
+  await expect(page.locator(".workspace-detail-list"))
+    .toContainText("Microsoft.Extensions.DependencyInjection");
+  await expect(page.locator(".workspace-detail-list"))
+    .not.toContainText("System.Text.Json");
   expect(page.url()).toBe(href);
 
-  const getDecimal = page.locator(
-    '[data-workspace-packet="stj-getdecimal-callgraph"]');
-  await getDecimal.click();
-  await expect(getDecimal).toBeFocused();
+  await page.getByRole("button", { name: "New workspace" }).click();
+  const created = page.locator('[data-workspace="workspace-3"]');
+  await expect(workspaces).toHaveCount(3);
+  await expect(created).toBeFocused();
   await expect(page.locator(".workspace-heading h1"))
-    .toHaveText("JsonElement.GetDecimal");
+    .toHaveText("Workspace 3");
+  await expect(page.locator(".workspace-empty"))
+    .toHaveText("No packages are loaded in this workspace.");
   expect(page.url()).toBe(href);
 
-  await page.getByRole("button", { name: "Open workspace" }).click();
+  await page.getByRole("button", { name: "Remove workspace" }).click();
+  await expect(workspaces).toHaveCount(2);
+  await expect(page.locator('[data-workspace="default"]')).toBeFocused();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+  await expect(page.locator(".workspace-detail-list"))
+    .toContainText("System.Text.Json");
+});
+
+test("live Workspace history and asynchronous results retain their owner", async ({
+  page,
+}) => {
+  await page.goto("/browser/workspace-titlebar.html?workspace=1");
+
+  await page.evaluate(() => window.beginDelayedWorkspaceLoadProbe());
+  await page.locator('[data-workspace="extensions"]').click();
+  await page.evaluate(() => window.completeDelayedWorkspaceLoadProbe());
   await expect(page.locator("body"))
-    .toHaveAttribute("data-workspace-execution-count", "1");
-  await expect(page.locator("body"))
-    .toHaveAttribute(
-      "data-workspace-execution",
-      "stj-getdecimal-callgraph");
+    .toHaveAttribute("data-workspace-late-load", "rejected");
+  await expect(page.locator(".workspace-detail-list"))
+    .not.toContainText("System.Text.Json");
+
+  await page.goBack();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+  await page.evaluate(() => window.restoreUnknownWorkspaceProbe());
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+
+  await page.goto(
+    "/browser/workspace-titlebar.html?workspace=1&empty-workspace=1#workspace");
+  await expect(page.locator('[data-scope="package"]')).toHaveCount(0);
+  await expect(page.locator('[data-scope="type"]')).toHaveCount(0);
+  await expect(page.locator(".workspace-empty"))
+    .toHaveText("No packages are loaded in this workspace.");
+  await page.reload();
+  await expect(page.locator(".workspace-heading h1")).toHaveText("Default");
+  await expect(page.locator(".workspace-empty"))
+    .toHaveText("No packages are loaded in this workspace.");
 });

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1136,6 +1136,9 @@ test("live Workspace history and asynchronous results retain their owner", async
   page,
 }) => {
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
+  await page.evaluate(() => window.restoreFloatingWorkspaceHistoryProbe());
+  await expect(page.locator("body"))
+    .toHaveAttribute("data-workspace-floating-history-membership", "current");
 
   await page.evaluate(() => window.beginDelayedWorkspaceLoadProbe());
   await page.locator('[data-workspace="extensions"]').click();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -246,6 +246,7 @@ import {
   createLiveWorkspace,
   createLiveWorkspaceSession,
   defaultLiveWorkspace,
+  rememberedLiveWorkspaceHref,
   removeLiveWorkspace,
   selectLiveWorkspace,
   selectedLiveWorkspace,
@@ -890,7 +891,7 @@ type FailedWorkspaceUrlState = WorkspaceUrlPreservation & (
   }
 );
 let failedWorkspaceUrlState: FailedWorkspaceUrlState | null = null;
-let lastCanonicalWorkspaceHref: string | null = null;
+const canonicalWorkspaceHrefs = new Map<string, string>();
 let packageQueryWorkspaceFocusNavigationSeq: number | null = null;
 let packageQueryHandoffNavigationSeq: number | null = null;
 
@@ -1392,6 +1393,17 @@ function workspaceHistoryState(value: unknown = history.state) {
   return withWorkspaceHistoryId(
     value,
     state.workspaceSession.selectedWorkspaceId);
+}
+
+function rememberCanonicalWorkspaceHref(href: string) {
+  canonicalWorkspaceHrefs.set(
+    state.workspaceSession.selectedWorkspaceId,
+    href);
+}
+
+function pushCurrentWorkspaceLocation(href: string) {
+  workspaceLocation.push(href, workspaceHistoryState(null));
+  rememberCanonicalWorkspaceHref(href);
 }
 
 function emptyWorkspaceUrl(): string {
@@ -3002,10 +3014,9 @@ function renderEmptyLiveWorkspace(
   restorePackageQueryReturnFocus();
   restorePackageQueryWorkspaceFocus();
   if (options.synchronizeUrl !== false) {
-    workspaceLocation.replace(
-      emptyWorkspaceUrl(),
-      workspaceHistoryState());
-    lastCanonicalWorkspaceHref = location.href;
+    const href = emptyWorkspaceUrl();
+    workspaceLocation.replace(href, workspaceHistoryState());
+    rememberCanonicalWorkspaceHref(href);
   }
 }
 
@@ -5085,7 +5096,7 @@ async function openPlatformLensLibrary(
       platformScopeTfm(),
       `${key}.dll`,
       pack ?? "",
-      () => state.packages.includes(originPackage),
+      isCurrent,
       originPackage.version);
     const loaded = runtimeResult.packageModel;
     if (!loaded) {
@@ -7007,17 +7018,17 @@ function syncUrl() {
     syncCurrentLiveWorkspace();
     if (state.atPackageRoot && state.package && !state.loading) {
       document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
-      workspaceLocation.replace(
-        buildStateUrl().toString(),
-        workspaceHistoryState());
-      lastCanonicalWorkspaceHref = location.href;
+      const href = buildStateUrl().toString();
+      workspaceLocation.replace(href, workspaceHistoryState());
+      rememberCanonicalWorkspaceHref(href);
       return;
     }
     const snapshot = captureWorkspaceUrlState();
     if (!snapshot || state.loading) return;
     document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
-    workspaceLocation.sync(snapshot, workspaceHistoryState());
-    lastCanonicalWorkspaceHref = location.href;
+    const href = workspaceLocation.build(snapshot).toString();
+    workspaceLocation.replace(href, workspaceHistoryState());
+    rememberCanonicalWorkspaceHref(href);
   } catch {
     // Keep the last canonical URL while the active Browser state is not projectable.
   }
@@ -7646,9 +7657,7 @@ function selectWorkspace(workspaceId: string): void {
   navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
-  workspaceLocation.push(
-    currentWorkspaceLocation(),
-    workspaceHistoryState(null));
+  pushCurrentWorkspaceLocation(currentWorkspaceLocation());
   afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
 }
 
@@ -7662,7 +7671,7 @@ function createWorkspace(): void {
   navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
-  workspaceLocation.push(emptyWorkspaceUrl(), workspaceHistoryState(null));
+  pushCurrentWorkspaceLocation(emptyWorkspaceUrl());
   afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
 }
 
@@ -7675,12 +7684,11 @@ function removeWorkspace(workspaceId: string): void {
   adoptLiveWorkspaceProjection(workspace);
   for (const packageModel of removed.packages)
     releasePackageModelCaches(packageModel);
+  canonicalWorkspaceHrefs.delete(removed.id);
   navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
-  workspaceLocation.push(
-    currentWorkspaceLocation(),
-    workspaceHistoryState(null));
+  pushCurrentWorkspaceLocation(currentWorkspaceLocation());
   afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
 }
 
@@ -7711,7 +7719,7 @@ function runHomeDemo(kind: ProductHomeDemoId) {
     observeAsync(runCallGraphDemo(kind), "Loading the call graph demo");
     return;
   }
-  workspaceLocation.push(link, workspaceHistoryState(null));
+  pushCurrentWorkspaceLocation(link);
   const loc = parseLocation();
   observeAsync(restoreWorkspaceFromLocation(loc, loc), "Loading the demo workspace");
 }
@@ -8024,15 +8032,18 @@ const packageQueryActions: PackageQueryBindingActions = {
 };
 
 function packageQueryWorkspaceHref(): string {
+  const rememberedHref = rememberedLiveWorkspaceHref(
+    state.workspaceSession,
+    canonicalWorkspaceHrefs);
+  if (rememberedHref) return rememberedHref;
   const residentPackage = state.package;
   if (!residentPackage) return "/";
-  return lastCanonicalWorkspaceHref
-    ?? buildPackageRootStateUrl(location.href, {
-      package: residentPackage.id,
-      version: residentPackage.version,
-      framework: residentPackage.activeFramework,
-      lens: state.packageLens,
-    }).toString();
+  return buildPackageRootStateUrl(location.href, {
+    package: residentPackage.id,
+    version: residentPackage.version,
+    framework: residentPackage.activeFramework,
+    lens: state.packageLens,
+  }).toString();
 }
 
 function renderPackageQueryPage() {
@@ -10340,8 +10351,10 @@ async function loadRuntimePack(
   platformVersion = "",
 ): Promise<RuntimeLoadResult> {
   const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationNavigationSequence = navigationSequence.current();
   const operationIsCurrent = () =>
     state.workspaceSession.selectedWorkspaceId === operationWorkspaceId
+    && navigationSequence.isCurrent(operationNavigationSequence)
     && isCurrent();
   const result = await packageAcquisition.loadRuntimePack(
     framework,
@@ -10361,8 +10374,10 @@ async function loadRuntimePackAssembly(
   platformVersion = "",
 ): Promise<RuntimeLoadResult> {
   const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationNavigationSequence = navigationSequence.current();
   const operationIsCurrent = () =>
     state.workspaceSession.selectedWorkspaceId === operationWorkspaceId
+    && navigationSequence.isCurrent(operationNavigationSequence)
     && isCurrent();
   const result = await packageAcquisition.loadRuntimePackAssembly(
     framework,
@@ -10523,7 +10538,9 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
       overload,
       true);
     state.loading = false;
-    render();
+    syncCurrentLiveWorkspace();
+    pushCurrentWorkspaceLocation(buildStateUrl().toString());
+    render({ synchronizeUrl: false });
     await renderMermaidCallGraph();
   } catch (error) {
     if (!operationIsCurrent()) return;
@@ -11605,6 +11622,7 @@ window.addEventListener("popstate", () => {
     clearNavigationError();
     prepareLiveWorkspaceSurface();
     syncCurrentLiveWorkspace();
+    rememberCanonicalWorkspaceHref(location.href);
     render({ synchronizeUrl: false });
     return;
   }

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -6860,9 +6860,11 @@ function workbenchModalOwnsFocus() {
     || state.memberAnnotatedModal !== null;
 }
 
-function resolvedWorkspaceShareTabs():
+function resolvedWorkspaceShareTabs(
+  packages: readonly AppPackage[] = state.packages,
+):
 BrowserWorkspaceShareState["tabs"] {
-  return state.packages.map((pkg, index) => ({
+  return packages.map((pkg, index) => ({
     id: `t${index}`,
     kind: pkg.isRuntimePack ? "group" : "package",
     source: pkg.isRuntimePack ? ":Platform" : pkg.id,
@@ -11593,41 +11595,45 @@ function dismissModalsForRoutedNavigation() {
   return dismissedAnnotatedSourceModal;
 }
 
-function requestedHistoryPackageKeys(
+function workspaceLocationMatchesPackageMembership(
   loc: ParsedLocation,
-): { keys: string[]; exact: boolean } | null {
-  if (loc.tabs?.length) {
-    return {
-      keys: loc.tabs.map(tab => packageIdentityKey({
-        id: tab.id,
-        version: tab.version,
-        activeFramework: tab.framework,
-      })),
-      exact: true,
-    };
+  packages: readonly AppPackage[],
+): boolean {
+  if (loc.tabs?.length && loc.shareState) {
+    return workspaceShareTabsMatchResolved(
+      loc.shareState.tabs,
+      resolvedWorkspaceShareTabs(packages));
   }
-  if (!loc.package || !loc.version || !loc.framework) return null;
-  return {
-    keys: [packageIdentityKey({
-      id: loc.package,
-      version: loc.version,
-      activeFramework: loc.framework,
-    })],
-    exact: false,
-  };
+  if (loc.tabs?.length) return workspaceCoordinatesMatch(packages, loc.tabs);
+  return packages.some(
+    packageModel => packageCoordinateMatchesLocation(packageModel, loc));
+}
+
+function workspaceLocationTargetPackage(
+  loc: ParsedLocation,
+  packages: readonly AppPackage[],
+): AppPackage | null {
+  const shareState = loc.shareState;
+  if (loc.tabs?.length && shareState) {
+    const activeIndex = shareState.tabs.findIndex(
+      tab => tab.id === shareState.activeTabId);
+    return activeIndex >= 0 ? packages[activeIndex] ?? null : null;
+  }
+  return packages.find(
+    packageModel => packageCoordinateMatchesLocation(packageModel, loc))
+    ?? null;
 }
 
 function historyRequestsStaleWorkspaceMembership(
   loc: ParsedLocation,
 ): boolean {
-  const request = requestedHistoryPackageKeys(loc);
-  if (!request) return false;
+  if (!(loc.tabs?.length)
+    && (!loc.package || !loc.version || !loc.framework)) return false;
   return workspaceHistoryMembershipStatus(
     state.workspaceSession,
     history.state,
-    request.keys,
-    packageIdentityKey,
-    request.exact) === "stale";
+    packages => workspaceLocationMatchesPackageMembership(loc, packages))
+      === "stale";
 }
 
 function reconcileLiveWorkspaceHistoryMembership() {
@@ -11773,7 +11779,8 @@ window.addEventListener("popstate", () => {
       "Restoring workspace history");
     return;
   }
-  if (loc.tabs?.length && !workspaceCoordinatesMatch(state.packages, loc.tabs)) {
+  if (loc.tabs?.length
+    && !workspaceLocationMatchesPackageMembership(loc, state.packages)) {
     observeAsync(
       restoreWorkspaceFromLocation(
         loc,
@@ -11783,9 +11790,9 @@ window.addEventListener("popstate", () => {
       "Restoring workspace history");
     return;
   }
+  const retainedTarget = workspaceLocationTargetPackage(loc, state.packages);
   if (loc.tabs?.length) {
-    const target = state.packages.find(candidate =>
-      packageCoordinateMatchesLocation(candidate, loc));
+    const target = retainedTarget;
     if (!target) {
       observeAsync(
         restoreWorkspaceFromLocation(
@@ -11797,10 +11804,14 @@ window.addEventListener("popstate", () => {
       return;
     }
     activatePackage(target, { resetAccessibility: true });
+  } else if (loc.package && retainedTarget) {
+    activatePackage(retainedTarget, { resetAccessibility: true });
   }
   state.home = false;
   applyLocationView(loc);
-  const samePackage = packageCoordinateMatchesLocation(state.package, loc);
+  const samePackage = retainedTarget
+    ? state.package === retainedTarget
+    : packageCoordinateMatchesLocation(state.package, loc);
   if (samePackage || !loc.package) {
     if (isRuntimePackId(state.package.id)) {
       // Back/forward within the platform: re-scope to the target library (or the

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -245,6 +245,7 @@ import {
   MAX_LIVE_WORKSPACES,
   createLiveWorkspace,
   createLiveWorkspaceSession,
+  createWorkspaceProjectionTransactionController,
   defaultLiveWorkspace,
   rememberedLiveWorkspaceHref,
   removeLiveWorkspace,
@@ -253,9 +254,11 @@ import {
   updateSelectedLiveWorkspace,
   withWorkspaceHistoryId,
   workspaceForHistory,
+  workspaceHistoryMembershipStatus,
   workspaceOperationIsCurrent,
   type LiveWorkspace,
   type LiveWorkspaceSession,
+  type WorkspaceOperationOwner,
 } from "./workspace-session.ts";
 import {
   bindDocViewer,
@@ -1361,13 +1364,45 @@ const navigationHistory = createNavigationHistory({
   apply: applyView,
   onExhausted: render,
 });
-const navigationSequence = createNavigationSequence();
+
+function workspaceProjectionTransactionMatches(
+  owner: WorkspaceOperationOwner,
+): boolean {
+  return workspaceProjectionTransactions.matches(owner);
+}
+
+function beginWorkspaceProjectionTransaction(owner: WorkspaceOperationOwner) {
+  syncCurrentLiveWorkspace();
+  workspaceProjectionTransactions.begin(owner);
+}
+
+function commitWorkspaceProjectionTransaction(
+  owner: WorkspaceOperationOwner,
+): boolean {
+  return workspaceProjectionTransactions.commit(owner);
+}
+
+const workspaceProjectionTransactions =
+  createWorkspaceProjectionTransactionController(
+    () => state.workspaceSession,
+    {
+      currentPackages: () => state.packages,
+      synchronize: syncCurrentLiveWorkspace,
+      restore: adoptLiveWorkspaceProjection,
+      release: releasePackageModelCaches,
+    });
+const navigationSequence = createNavigationSequence(
+  () => workspaceProjectionTransactions.abandon());
 
 function currentLiveWorkspace(): LiveWorkspace<AppPackage> {
   return selectedLiveWorkspace(state.workspaceSession);
 }
 
 function syncCurrentLiveWorkspace() {
+  if (workspaceProjectionTransactions
+    .blocksSelectedWorkspaceSynchronization()) {
+    return;
+  }
   updateSelectedLiveWorkspace(state.workspaceSession, {
     packages: state.packages,
     activePackageKey: state.package
@@ -1956,7 +1991,9 @@ function releasePackageModelCaches(packageModel: AppPackage) {
     ...state.packages,
     ...state.workspaceSession.workspaces
       .filter(workspace =>
-        workspace.id !== state.workspaceSession.selectedWorkspaceId)
+        workspace.id !== state.workspaceSession.selectedWorkspaceId
+        || workspaceProjectionTransactions
+          .blocksSelectedWorkspaceSynchronization())
       .flatMap(workspace => workspace.packages),
   ];
   if (!retainedPackages.some(
@@ -7652,9 +7689,11 @@ function selectWorkspace(workspaceId: string): void {
     afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspaceId));
     return;
   }
+  if (!state.workspaceSession.workspaces.some(
+    workspace => workspace.id === workspaceId)) return;
+  navigationSequence.begin();
   const workspace = adoptWorkspace(workspaceId);
   if (!workspace) return;
-  navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
   pushCurrentWorkspaceLocation(currentWorkspaceLocation());
@@ -7662,13 +7701,14 @@ function selectWorkspace(workspaceId: string): void {
 }
 
 function createWorkspace(): void {
+  if (state.workspaceSession.workspaces.length >= MAX_LIVE_WORKSPACES) return;
+  navigationSequence.begin();
   syncCurrentLiveWorkspace();
   const workspace = createLiveWorkspace(
     state.workspaceSession,
     crypto.randomUUID());
   if (!workspace) return;
   adoptLiveWorkspaceProjection(workspace);
-  navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
   pushCurrentWorkspaceLocation(emptyWorkspaceUrl());
@@ -7677,6 +7717,8 @@ function createWorkspace(): void {
 
 function removeWorkspace(workspaceId: string): void {
   if (workspaceId !== state.workspaceSession.selectedWorkspaceId) return;
+  if (currentLiveWorkspace().isDefault) return;
+  navigationSequence.begin();
   syncCurrentLiveWorkspace();
   const removed = removeLiveWorkspace(state.workspaceSession, workspaceId);
   if (!removed) return;
@@ -7685,7 +7727,6 @@ function removeWorkspace(workspaceId: string): void {
   for (const packageModel of removed.packages)
     releasePackageModelCaches(packageModel);
   canonicalWorkspaceHrefs.delete(removed.id);
-  navigationSequence.begin();
   prepareLiveWorkspaceSurface();
   render({ synchronizeUrl: false });
   pushCurrentWorkspaceLocation(currentWorkspaceLocation());
@@ -10560,12 +10601,13 @@ async function restoreWorkspaceFromLocation(
     : null,
 ) {
   const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationOwner: WorkspaceOperationOwner = {
+    workspaceId: operationWorkspaceId,
+    navigationSequence: navigationSeq,
+  };
   const operationIsCurrent = () => workspaceOperationIsCurrent(
     state.workspaceSession,
-    {
-      workspaceId: operationWorkspaceId,
-      navigationSequence: navigationSeq,
-    },
+    operationOwner,
     navigationSequence.current());
   if (!operationIsCurrent()) return;
   if (loc.routeFailure) {
@@ -10587,6 +10629,32 @@ async function restoreWorkspaceFromLocation(
     return;
   }
   if (!loc.package) return;
+  const packageLocation = { ...loc, package: loc.package };
+  beginWorkspaceProjectionTransaction(operationOwner);
+  try {
+    await restoreWorkspaceProjection(
+      packageLocation,
+      deep,
+      navigationSeq,
+      canonicalSnapshot,
+      operationOwner,
+      operationIsCurrent);
+  } finally {
+    if (workspaceProjectionTransactionMatches(operationOwner)) {
+      workspaceProjectionTransactions.abandon();
+      if (operationIsCurrent()) render();
+    }
+  }
+}
+
+async function restoreWorkspaceProjection(
+  loc: ParsedLocation & { package: string },
+  deep: DeepLink,
+  navigationSeq: number,
+  canonicalSnapshot: CanonicalWorkspaceRestoreSnapshot | null,
+  operationOwner: WorkspaceOperationOwner,
+  operationIsCurrent: () => boolean,
+) {
   state.queryNotice = loc.workspaceNotice || "";
   state.queryNoticeRetryAction = null;
   state.home = false;
@@ -10743,16 +10811,19 @@ async function restoreWorkspaceFromLocation(
     applyDeepLink(deep);
     commitWorkspaceShareBasis(loc.shareState);
     state.loading = false;
+    if (!commitWorkspaceProjectionTransaction(operationOwner)) return;
     render();
     await loadSelectionData();
   } else if (!isRuntimePackId(target.id)) {
     // The focused NuGet target failed to load during the silent background pass; re-run it in
     // the foreground so its error (e.g. a 404) surfaces properly instead of a blank workbench.
-    await loadPackage(target.id, target.version, target.framework, {
+    const loaded = await loadPackage(target.id, target.version, target.framework, {
       deepLink: deep,
       navigationSeq,
       queryNotice: state.queryNotice
     });
+    if (loaded && operationIsCurrent())
+      commitWorkspaceProjectionTransaction(operationOwner);
   } else {
     state.loading = false;
     const failure =
@@ -11522,6 +11593,53 @@ function dismissModalsForRoutedNavigation() {
   return dismissedAnnotatedSourceModal;
 }
 
+function requestedHistoryPackageKeys(
+  loc: ParsedLocation,
+): { keys: string[]; exact: boolean } | null {
+  if (loc.tabs?.length) {
+    return {
+      keys: loc.tabs.map(tab => packageIdentityKey({
+        id: tab.id,
+        version: tab.version,
+        activeFramework: tab.framework,
+      })),
+      exact: true,
+    };
+  }
+  if (!loc.package || !loc.version || !loc.framework) return null;
+  return {
+    keys: [packageIdentityKey({
+      id: loc.package,
+      version: loc.version,
+      activeFramework: loc.framework,
+    })],
+    exact: false,
+  };
+}
+
+function historyRequestsStaleWorkspaceMembership(
+  loc: ParsedLocation,
+): boolean {
+  const request = requestedHistoryPackageKeys(loc);
+  if (!request) return false;
+  return workspaceHistoryMembershipStatus(
+    state.workspaceSession,
+    history.state,
+    request.keys,
+    packageIdentityKey,
+    request.exact) === "stale";
+}
+
+function reconcileLiveWorkspaceHistoryMembership() {
+  clearNavigationError();
+  prepareLiveWorkspaceSurface();
+  const href = currentWorkspaceLocation();
+  workspaceLocation.replace(href, workspaceHistoryState(history.state));
+  rememberCanonicalWorkspaceHref(href);
+  syncCurrentLiveWorkspace();
+  render({ synchronizeUrl: false });
+}
+
 window.addEventListener("popstate", () => {
   const leftPackageQueryHandoff = currentPackageQueryHandoff();
   const navigationSeq = navigationSequence.begin();
@@ -11594,6 +11712,10 @@ window.addEventListener("popstate", () => {
   const loc = parseLocation();
   if (loc.routeFailure) {
     failWorkspaceRoute(loc.routeFailure.message);
+    return;
+  }
+  if (historyRequestsStaleWorkspaceMembership(loc)) {
+    reconcileLiveWorkspaceHistoryMembership();
     return;
   }
   if (!clearWorkspaceRouteFailure()) {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -8114,19 +8114,19 @@ const packageQueryActions: PackageQueryBindingActions = {
   onRun: runPackageQuery,
 };
 
-function packageQueryWorkspaceHref(): string {
+function packageQueryWorkspaceUrl(): URL {
   const rememberedHref = rememberedLiveWorkspaceHref(
     state.workspaceSession,
     canonicalWorkspaceHrefs);
-  if (rememberedHref) return rememberedHref;
+  if (rememberedHref) return new URL(rememberedHref, location.href);
   const residentPackage = state.package;
-  if (!residentPackage) return "/";
+  if (!residentPackage) return new URL("/", location.href);
   return buildPackageRootStateUrl(location.href, {
     package: residentPackage.id,
     version: residentPackage.version,
     framework: residentPackage.activeFramework,
     lens: state.packageLens,
-  }).toString();
+  });
 }
 
 function renderPackageQueryPage() {
@@ -8142,9 +8142,21 @@ function renderPackageQueryPage() {
       state.packageQueryCatalogError,
       state.packageQueryNavigationError,
     ].filter(Boolean).join(" "),
-    workspaceHref: packageQueryWorkspaceHref(),
     escapeHtml,
   });
+  const workspaceUrl = packageQueryWorkspaceUrl();
+  const workspaceLink =
+    document.querySelector<HTMLAnchorElement>("#package-query-workspace");
+  if (workspaceLink) {
+    workspaceLink.pathname = workspaceUrl.pathname;
+    workspaceLink.search = workspaceUrl.search;
+    workspaceLink.hash = workspaceUrl.hash;
+    workspaceLink.ariaLabel = workspaceUrl.pathname === "/"
+      && !workspaceUrl.search
+      && !workspaceUrl.hash
+      ? "dotnet inspect home"
+      : "dotnet inspect workspace";
+  }
   bindPackageQueryView(document, packageQueryActions);
   const focusRestoration = restorePackageQueryFocus(document, focus);
   if (focusRestoration !== "fallback") {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -158,7 +158,6 @@ import {
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
   type ProductHomeDemoId,
-  type ProductHomeDemoResolved,
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,
@@ -238,11 +237,25 @@ import {
 } from "./scope-bar.ts";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace as focusLiveWorkspace,
+  renderWorkspaceView as renderLiveWorkspaceView,
   renderWorkspaceSubject,
-  retainWorkspacePacket as retainWorkspacePacketInList,
 } from "./workspace-subject.ts";
+import {
+  MAX_LIVE_WORKSPACES,
+  createLiveWorkspace,
+  createLiveWorkspaceSession,
+  defaultLiveWorkspace,
+  removeLiveWorkspace,
+  selectLiveWorkspace,
+  selectedLiveWorkspace,
+  updateSelectedLiveWorkspace,
+  withWorkspaceHistoryId,
+  workspaceForHistory,
+  workspaceOperationIsCurrent,
+  type LiveWorkspace,
+  type LiveWorkspaceSession,
+} from "./workspace-session.ts";
 import {
   bindDocViewer,
   renderDocViewer as renderDocViewerPure,
@@ -636,6 +649,8 @@ const HOME_BOT_ANIMATION_DURATION_MS = 5500;
 const DEFAULT_REQUESTED_FRAMEWORK = "net10.0";
 let homeBotAnimationStartedAt: number | null = null;
 let homeReadyGlintPending = true;
+const initialWorkspaceSession =
+  createLiveWorkspaceSession<AppPackage>(crypto.randomUUID());
 const initialState = {
   theme: localStorage.getItem("inspect-theme") === "light" ? "light" : "dark",
   statusBarExpanded: false,
@@ -739,8 +754,7 @@ const initialState = {
   memberDocumentationKey: "",
   lens: "api" as const,
   packageLens: "overview" as const,
-  workspacePackets: [],
-  selectedWorkspacePacketId: "",
+  workspaceSession: initialWorkspaceSession,
   workspaceSubjectOpen: false,
   atPackageRoot: false,
   typeFilter: "",
@@ -804,7 +818,7 @@ const initialState = {
 interface StateOverrides {
   packages: AppPackage[];
   package: AppPackage | null;
-  workspacePackets: ProductHomeDemoResolved[];
+  workspaceSession: LiveWorkspaceSession<AppPackage>;
   workspaceShareBasis: BrowserWorkspaceShareState | null;
   platformIndex: PlatformIndex | null;
   queryNoticeRetryAction: RetryAction;
@@ -890,10 +904,28 @@ function captureCanonicalWorkspaceRestoreSnapshot():
 CanonicalWorkspaceRestoreSnapshot {
   sourceInspection.cancelCurrentRequest();
   cancelAnnotatedSourceRequest(state);
+  syncCurrentLiveWorkspace();
   const packages = structuredClone(state.packages);
   const activeKey = state.package
     ? packageIdentityKey(state.package)
     : null;
+  const workspaceSession: LiveWorkspaceSession<AppPackage> = {
+    selectedWorkspaceId: state.workspaceSession.selectedWorkspaceId,
+    nextWorkspaceNumber: state.workspaceSession.nextWorkspaceNumber,
+    workspaces: state.workspaceSession.workspaces.map(workspace => ({
+      ...workspace,
+      packages: workspace.id === state.workspaceSession.selectedWorkspaceId
+        ? packages
+        : [...workspace.packages],
+      shareBasis: workspace.shareBasis
+        ? structuredClone(workspace.shareBasis)
+        : null,
+      navigation: {
+        stack: workspace.navigation.stack.map(entry => ({ ...entry })),
+        index: workspace.navigation.index,
+      },
+    })),
+  };
   return {
     state: {
       ...state,
@@ -923,6 +955,7 @@ CanonicalWorkspaceRestoreSnapshot {
       recentPackages: structuredClone(state.recentPackages),
       spotlightPkgHits: structuredClone(state.spotlightPkgHits),
       history: [...state.history],
+      workspaceSession,
     },
     hasWorkspace: state.package !== null,
     navigation: navigationHistory.snapshot(),
@@ -1329,6 +1362,44 @@ const navigationHistory = createNavigationHistory({
 });
 const navigationSequence = createNavigationSequence();
 
+function currentLiveWorkspace(): LiveWorkspace<AppPackage> {
+  return selectedLiveWorkspace(state.workspaceSession);
+}
+
+function syncCurrentLiveWorkspace() {
+  updateSelectedLiveWorkspace(state.workspaceSession, {
+    packages: state.packages,
+    activePackageKey: state.package
+      ? packageIdentityKey(state.package)
+      : null,
+    shareBasis: state.workspaceShareBasis,
+    navigation: navigationHistory.snapshot(),
+  });
+}
+
+function adoptLiveWorkspaceProjection(workspace: LiveWorkspace<AppPackage>) {
+  state.packages = [...workspace.packages];
+  state.package = workspace.activePackageKey
+    ? state.packages.find(
+        pkg => packageIdentityKey(pkg) === workspace.activePackageKey) ?? null
+    : null;
+  state.workspaceShareBasis = workspace.shareBasis;
+  navigationHistory.restore(workspace.navigation);
+  spotlightCache = null;
+}
+
+function workspaceHistoryState(value: unknown = history.state) {
+  return withWorkspaceHistoryId(
+    value,
+    state.workspaceSession.selectedWorkspaceId);
+}
+
+function emptyWorkspaceUrl(): string {
+  const url = new URL("/", location.href);
+  url.hash = "workspace";
+  return url.toString();
+}
+
 function currentPackageQueryHandoff() {
   return packageQueryHandoffNavigationSeq !== null
     && navigationSequence.isCurrent(packageQueryHandoffNavigationSeq);
@@ -1405,6 +1476,7 @@ state.home = state.credits
   || (!state.packageQueryOpen
     && !initialLocation.package
     && !initialWorkspace.hasWorkspaceState
+    && !initialLocation.workspaceSubjectOpen
     && !initialLocation.routeFailure);
 state.queryNotice = "";
 if (initialLocation.package) {
@@ -1416,6 +1488,10 @@ if (initialLocation.lens) state.lens = initialLocation.lens;
 if (initialLocation.atPackageRoot) {
   state.atPackageRoot = true;
   state.packageLens = initialLocation.packageLens || "overview";
+}
+if (initialLocation.workspaceSubjectOpen) {
+  state.workspaceSubjectOpen = true;
+  state.atPackageRoot = true;
 }
 
 function deepLinkFromLocation(loc: ParsedLocation): DeepLink {
@@ -1864,12 +1940,22 @@ function retainPackageModel(
 
 function releasePackageModelCaches(packageModel: AppPackage) {
   const dependencyKey = workspaceDependencyKey(packageModel);
-  delete state.workspaceDependencies[dependencyKey];
-  delete state.workspaceDependencyErrors[dependencyKey];
-  state.workspaceDependencyLoads.delete(dependencyKey);
+  const retainedPackages = [
+    ...state.packages,
+    ...state.workspaceSession.workspaces
+      .filter(workspace =>
+        workspace.id !== state.workspaceSession.selectedWorkspaceId)
+      .flatMap(workspace => workspace.packages),
+  ];
+  if (!retainedPackages.some(
+    item => workspaceDependencyKey(item) === dependencyKey)) {
+    delete state.workspaceDependencies[dependencyKey];
+    delete state.workspaceDependencyErrors[dependencyKey];
+    state.workspaceDependencyLoads.delete(dependencyKey);
+  }
 
   const id = packageModel.id.toLowerCase();
-  if (!state.packages.some(item => item.id.toLowerCase() === id)) {
+  if (!retainedPackages.some(item => item.id.toLowerCase() === id)) {
     delete state.packageVersions[id];
     delete state.packageVersionsLoading[id];
   }
@@ -1941,7 +2027,12 @@ function closeWorkspacePackage(packageKey: string) {
   }
 
   state.package = null;
-  goHome();
+  state.workspaceShareBasis = null;
+  state.workspaceSubjectOpen = true;
+  state.atPackageRoot = true;
+  navigationHistory.restore({ stack: [], index: -1 });
+  syncCurrentLiveWorkspace();
+  render();
 }
 
 function activatePackage(
@@ -2661,7 +2752,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   packageQueryLiveAnnouncer.reset();
   // A loading/interstitial view holds one random bot for its whole appearance; any non-loading
   // view resets it so the next interstitial picks a fresh random bot (see interstitialBotSrc).
-  const showingInterstitial = state.loading || state.error || (!state.home && !state.package);
+  const showingInterstitial = state.loading || state.error;
   if (!showingInterstitial) loadingBotSrc = null;
   if (state.loading || state.error) {
     renderLoading();
@@ -2673,7 +2764,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     return;
   }
   if (!state.package) {
-    renderLoading();
+    renderEmptyLiveWorkspace(options);
     return;
   }
   const pkg = state.package;
@@ -2843,6 +2934,81 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
 }
 
+function renderEmptyLiveWorkspace(
+  options: { synchronizeUrl?: boolean } = {},
+) {
+  const workspace = currentLiveWorkspace();
+  const path: readonly SubjectPathSegment[] = [{
+    kind: "workspace",
+    label: workspace.name,
+    copyable: false,
+  }];
+  document.title = `dotnet-inspect -- ${workspace.name}`;
+  app.innerHTML = `
+    <div class="workbench">
+      ${workbenchShellHtml({
+        inspectedTargetHtml: `
+          <div class="inspected-target" aria-label="Inspected target">
+            <span class="subject-icon" aria-hidden="true">W</span>
+            <div class="subject-path" aria-label="${escapeHtml(workspace.name)}" title="${escapeHtml(workspace.name)}">
+              ${renderInspectedSubjectPath(path)}
+            </div>
+          </div>`,
+        titleNavigationHtml: `
+          <nav class="title-navigation" aria-label="Search and history">
+            <div class="nav-history">
+              <button id="nav-back" ${navigationHistory.canBack() ? "" : "disabled"} title="Back (Alt+← or Shift+←)" aria-label="Back">←</button>
+              <button id="nav-forward" ${navigationHistory.canForward() ? "" : "disabled"} title="Forward (Alt+→ or Shift+→)" aria-label="Forward">→</button>
+            </div>
+            <button id="open-search" class="title-search" type="button" aria-haspopup="dialog" title="Search (Ctrl/Command+P)">
+              <span class="title-search-glyph" aria-hidden="true">⌕</span>
+              <span class="title-search-label title-search-label-full">Search types, members, packages</span>
+              <span class="title-search-label title-search-label-compact">Search</span>
+              <kbd>Ctrl P</kbd>
+            </button>
+          </nav>`,
+      })}
+      <header class="subject-zone" aria-label="Subjects and inspectors">
+        ${renderScopeBar()}
+        <nav class="shell-actions" aria-label="Application">
+          <button id="share" type="button" disabled>Share</button>
+          <button id="open-settings" type="button">Settings</button>
+          <button id="help" type="button" aria-label="Keyboard help">?</button>
+        </nav>
+      </header>
+      <div class="notice-stack">
+        ${visibleQueryNotice()
+          ? `<div class="query-notice" role="alert">
+              <span class="query-notice-glyph">⚠</span>
+              <span class="query-notice-text">${escapeHtml(visibleQueryNotice())}</span>
+              ${state.queryNotice && state.queryNoticeRetryAction
+                ? '<button id="retry-notice" type="button">retry</button>'
+                : ""}
+              <button id="dismiss-notice" type="button" aria-label="Dismiss">×</button>
+            </div>`
+          : ""}
+      </div>
+      <main id="subject-panel" class="workspace" role="tabpanel" aria-labelledby="active-subject-tab">
+        ${renderWorkspaceNavPane()}
+        <section class="detail-pane">
+          <article id="inspector-panel" class="detail-scroll">
+            ${renderWorkspaceView()}
+          </article>
+        </section>
+      </main>
+      ${state.spotlightOpen ? spotlight.modalHtml() : ""}
+    </div>`;
+  bindEvents();
+  restorePackageQueryReturnFocus();
+  restorePackageQueryWorkspaceFocus();
+  if (options.synchronizeUrl !== false) {
+    workspaceLocation.replace(
+      emptyWorkspaceUrl(),
+      workspaceHistoryState());
+    lastCanonicalWorkspaceHref = location.href;
+  }
+}
+
 function maybeAutoLoadVisibleSource() {
   const kind = currentSourceOperationKind();
   if (kind === "graph") {
@@ -2929,7 +3095,7 @@ function inspectedSubjectPath(
   if (scope() === "workspace") {
     return [{
       kind: "workspace",
-      label: selectedWorkspacePacket()?.title ?? "Current workspace",
+      label: currentLiveWorkspace().name,
       copyable: false,
     }];
   }
@@ -2981,9 +3147,11 @@ function renderInspectedSubjectPath(
 }
 
 function renderWorkspaceNavPane() {
+  syncCurrentLiveWorkspace();
   return renderWorkspaceSubject({
-    packets: state.workspacePackets,
-    selectedPacketId: state.selectedWorkspacePacketId || null,
+    workspaces: state.workspaceSession.workspaces,
+    selectedWorkspaceId: state.workspaceSession.selectedWorkspaceId,
+    maximumWorkspaces: MAX_LIVE_WORKSPACES,
     escapeHtml,
   });
 }
@@ -3111,6 +3279,9 @@ function renderScopeBar() {
       stripAttribute: "data-workspace-lens",
       panelId: "inspector-panel",
       showMemberScope,
+      ...(state.package
+        ? {}
+        : { subjectScopes: ["workspace"] as const }),
       escapeHtml,
     });
   }
@@ -3204,10 +3375,9 @@ function renderPackageView() {
 }
 
 function renderWorkspaceView() {
-  return renderWorkspacePacketView({
-    packet: selectedWorkspacePacket(),
-    packages: state.packages,
-    activePackage: state.package,
+  syncCurrentLiveWorkspace();
+  return renderLiveWorkspaceView({
+    workspace: currentLiveWorkspace(),
     escapeHtml,
     packageIdentityKey,
   });
@@ -5475,9 +5645,10 @@ const graphBackActions: GraphBackBindingActions = {
 
 function bindWorkspaceSubjectEvents() {
   bindWorkspaceSubject(document, {
-    onSelect: selectWorkspacePacket,
-    onOpen: runHomeDemo,
-    onClose: closeWorkspacePackage,
+    onSelect: selectWorkspace,
+    onCreate: createWorkspace,
+    onRemove: removeWorkspace,
+    onClosePackage: closeWorkspacePackage,
   });
 }
 
@@ -6802,7 +6973,7 @@ function buildStateUrl(base = location.href) {
     const snapshot = captureWorkspaceUrlState();
     return snapshot
       ? workspaceLocation.build(snapshot, base)
-      : new URL(base);
+      : new URL(emptyWorkspaceUrl());
   }
   if (state.atPackageRoot && state.package) {
     return buildPackageRootStateUrl(base, {
@@ -6833,18 +7004,19 @@ function syncUrl() {
   if (currentPackageQueryHandoff()) return;
   if (retainFailedWorkspaceUrl()) return;
   try {
+    syncCurrentLiveWorkspace();
     if (state.atPackageRoot && state.package && !state.loading) {
       document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
       workspaceLocation.replace(
         buildStateUrl().toString(),
-        history.state);
+        workspaceHistoryState());
       lastCanonicalWorkspaceHref = location.href;
       return;
     }
     const snapshot = captureWorkspaceUrlState();
     if (!snapshot || state.loading) return;
     document.title = `dotnet-inspect -- ${packageDisplayName(state.package)}`;
-    workspaceLocation.sync(snapshot, history.state);
+    workspaceLocation.sync(snapshot, workspaceHistoryState());
     lastCanonicalWorkspaceHref = location.href;
   } catch {
     // Keep the last canonical URL while the active Browser state is not projectable.
@@ -7421,33 +7593,105 @@ function bindHomeEvents() {
   });
 }
 
-// Home buttons use product demo ids from engine `listHomeDemos` / `resolveHomeDemo`
-// (`ProductInspectionDemos` / CLI `demo <id>`). STJ + platform restore via share
-// deep links built from the resolved projection; member-bound Call Graph demos
-// execute through one generated engine operation over the product-resolved
-// workspace and view.
-function selectedWorkspacePacket(): ProductHomeDemoResolved | null {
-  return state.workspacePackets.find(
-    packet => packet.id === state.selectedWorkspacePacketId) ?? null;
-}
-
-function selectWorkspacePacket(packetId: string): void {
-  if (!state.workspacePackets.some(packet => packet.id === packetId)) return;
-  state.selectedWorkspacePacketId = packetId;
+function prepareLiveWorkspaceSurface() {
+  dismissModalsForRoutedNavigation();
+  invalidateMemberDestinationWork(state);
+  state.packageQueryOpen = false;
+  packageQueryController.cancel();
+  state.credits = false;
+  state.home = false;
+  state.loading = false;
+  state.error = "";
+  state.errorTitle = "";
+  state.errorDetail = "";
+  state.retryAction = null;
+  state.queryNotice = "";
+  state.queryNoticeRetryAction = null;
+  failedWorkspaceUrlState = null;
+  state.platformStack = [];
+  resetLocationFilters();
+  resetMemberSectionState();
   state.workspaceSubjectOpen = true;
   state.atPackageRoot = true;
-  render();
-  afterCurrentNavigationFrame(() =>
-    focusWorkspacePacket(document, packetId));
 }
 
-function retainWorkspacePacket(packet: ProductHomeDemoResolved): void {
-  state.workspacePackets = retainWorkspacePacketInList(
-    state.workspacePackets,
-    packet);
-  state.selectedWorkspacePacketId = packet.id;
+function adoptWorkspace(workspaceId: string): LiveWorkspace<AppPackage> | null {
+  if (workspaceId === state.workspaceSession.selectedWorkspaceId)
+    return currentLiveWorkspace();
+  syncCurrentLiveWorkspace();
+  const workspace = selectLiveWorkspace(state.workspaceSession, workspaceId);
+  if (!workspace) return null;
+  adoptLiveWorkspaceProjection(workspace);
+  return workspace;
 }
 
+function currentWorkspaceLocation(): string {
+  try {
+    return state.package
+      ? buildStateUrl().toString()
+      : emptyWorkspaceUrl();
+  } catch {
+    return emptyWorkspaceUrl();
+  }
+}
+
+function selectWorkspace(workspaceId: string): void {
+  if (workspaceId === state.workspaceSession.selectedWorkspaceId
+    && scope() === "workspace") {
+    afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspaceId));
+    return;
+  }
+  const workspace = adoptWorkspace(workspaceId);
+  if (!workspace) return;
+  navigationSequence.begin();
+  prepareLiveWorkspaceSurface();
+  render({ synchronizeUrl: false });
+  workspaceLocation.push(
+    currentWorkspaceLocation(),
+    workspaceHistoryState(null));
+  afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
+}
+
+function createWorkspace(): void {
+  syncCurrentLiveWorkspace();
+  const workspace = createLiveWorkspace(
+    state.workspaceSession,
+    crypto.randomUUID());
+  if (!workspace) return;
+  adoptLiveWorkspaceProjection(workspace);
+  navigationSequence.begin();
+  prepareLiveWorkspaceSurface();
+  render({ synchronizeUrl: false });
+  workspaceLocation.push(emptyWorkspaceUrl(), workspaceHistoryState(null));
+  afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
+}
+
+function removeWorkspace(workspaceId: string): void {
+  if (workspaceId !== state.workspaceSession.selectedWorkspaceId) return;
+  syncCurrentLiveWorkspace();
+  const removed = removeLiveWorkspace(state.workspaceSession, workspaceId);
+  if (!removed) return;
+  const workspace = currentLiveWorkspace();
+  adoptLiveWorkspaceProjection(workspace);
+  for (const packageModel of removed.packages)
+    releasePackageModelCaches(packageModel);
+  navigationSequence.begin();
+  prepareLiveWorkspaceSurface();
+  render({ synchronizeUrl: false });
+  workspaceLocation.push(
+    currentWorkspaceLocation(),
+    workspaceHistoryState(null));
+  afterCurrentNavigationFrame(() => focusLiveWorkspace(document, workspace.id));
+}
+
+function activateDefaultWorkspaceForDemo() {
+  const workspace = defaultLiveWorkspace(state.workspaceSession);
+  if (workspace.id !== state.workspaceSession.selectedWorkspaceId)
+    adoptWorkspace(workspace.id);
+}
+
+// Home buttons use product demo ids from engine `listHomeDemos` / `resolveHomeDemo`.
+// Every demo targets the Default live Workspace; demos do not create scenario rows.
 function runHomeDemo(kind: ProductHomeDemoId) {
   const resolveResult = inspectResolveHomeDemo(kind);
   const resolved = resolveResult.found ? resolveResult.demo : null;
@@ -7458,7 +7702,7 @@ function runHomeDemo(kind: ProductHomeDemoId) {
     render();
     return;
   }
-  retainWorkspacePacket(resolved);
+  activateDefaultWorkspaceForDemo();
   state.home = false;
   const link = productHomeDemoLocationHref(
     resolved,
@@ -7467,7 +7711,7 @@ function runHomeDemo(kind: ProductHomeDemoId) {
     observeAsync(runCallGraphDemo(kind), "Loading the call graph demo");
     return;
   }
-  workspaceLocation.push(link);
+  workspaceLocation.push(link, workspaceHistoryState(null));
   const loc = parseLocation();
   observeAsync(restoreWorkspaceFromLocation(loc, loc), "Loading the demo workspace");
 }
@@ -7491,7 +7735,7 @@ function goHome() {
   state.credits = false;
   state.home = true;
   spotlight.reset();
-  workspaceLocation.push("/");
+  workspaceLocation.push("/", workspaceHistoryState(null));
   render();
 }
 
@@ -7507,7 +7751,7 @@ function openCredits() {
   state.credits = true;
   state.home = true;
   spotlight.reset();
-  workspaceLocation.push("/credits");
+  workspaceLocation.push("/credits", workspaceHistoryState(null));
   render();
 }
 
@@ -7638,10 +7882,10 @@ function openPackageQueryRoute(seed = "") {
     "/query",
     predecessorEntryId
       ? packageQueryHistoryState(
-          null,
+          workspaceHistoryState(null),
           crypto.randomUUID(),
           { predecessorEntryId, returnFocus })
-      : null);
+      : workspaceHistoryState(null));
   render();
   focusPackageQueryInput();
 }
@@ -7663,7 +7907,7 @@ function closePackageQueryRoute() {
   state.credits = false;
   state.home = true;
   spotlight.reset();
-  workspaceLocation.replace("/");
+  workspaceLocation.replace("/", workspaceHistoryState(null));
   render();
 }
 
@@ -7752,7 +7996,9 @@ async function openPackageQueryRow(
   }
 
   packageQueryHandoffNavigationSeq = null;
-  workspaceLocation.push(buildStateUrl().toString());
+  workspaceLocation.push(
+    buildStateUrl().toString(),
+    workspaceHistoryState(null));
   render();
   focusTypeList();
 }
@@ -9841,6 +10087,16 @@ async function loadPackage(
   const background = options.background === true;
   const navigationSeq = options.navigationSeq
     ?? (background ? null : navigationSequence.begin());
+  const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationIsCurrent = () => navigationSeq === null
+    ? state.workspaceSession.selectedWorkspaceId === operationWorkspaceId
+    : workspaceOperationIsCurrent(
+        state.workspaceSession,
+        {
+          workspaceId: operationWorkspaceId,
+          navigationSequence: navigationSeq,
+        },
+        navigationSequence.current());
   const prevPackage = state.package;
   const prevRequested = {
     package: state.requestedPackage,
@@ -9870,9 +10126,7 @@ async function loadPackage(
       ...(options.replacePackage !== undefined
         ? { replacePackage: options.replacePackage }
         : {}),
-      ...(navigationSeq == null
-        ? {}
-        : { isCurrent: () => navigationSequence.isCurrent(navigationSeq) }),
+      isCurrent: operationIsCurrent,
     });
     if (!packageModel) return null;
     if (background) return packageModel;
@@ -9902,7 +10156,7 @@ async function loadPackage(
     await selectionData;
     return packageModel;
   } catch (error) {
-    if (navigationSeq != null && !navigationSequence.isCurrent(navigationSeq))
+    if (!operationIsCurrent())
       return null;
     const friendly = friendlyLoadError(error, packageId, version);
     if (background) {
@@ -10085,9 +10339,13 @@ async function loadRuntimePack(
   isCurrent: () => boolean = () => true,
   platformVersion = "",
 ): Promise<RuntimeLoadResult> {
+  const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationIsCurrent = () =>
+    state.workspaceSession.selectedWorkspaceId === operationWorkspaceId
+    && isCurrent();
   const result = await packageAcquisition.loadRuntimePack(
     framework,
-    isCurrent,
+    operationIsCurrent,
     platformVersion);
   return {
     packageModel: result.packageModel,
@@ -10102,11 +10360,15 @@ async function loadRuntimePackAssembly(
   isCurrent: () => boolean = () => true,
   platformVersion = "",
 ): Promise<RuntimeLoadResult> {
+  const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationIsCurrent = () =>
+    state.workspaceSession.selectedWorkspaceId === operationWorkspaceId
+    && isCurrent();
   const result = await packageAcquisition.loadRuntimePackAssembly(
     framework,
     assemblyFileName,
     pack,
-    isCurrent,
+    operationIsCurrent,
     platformVersion);
   return {
     packageModel: result.packageModel,
@@ -10118,6 +10380,14 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
   const retry = () =>
     observeAsync(runCallGraphDemo(demoId), "Loading the call graph demo");
   const navigationSeq = navigationSequence.begin();
+  const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationIsCurrent = () => workspaceOperationIsCurrent(
+    state.workspaceSession,
+    {
+      workspaceId: operationWorkspaceId,
+      navigationSequence: navigationSeq,
+    },
+    navigationSequence.current());
   state.loading = true;
   state.error = "";
   state.errorDetail = "";
@@ -10141,11 +10411,11 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
   try {
     result = await inspectRunHomeDemo(demoId);
   } catch (error) {
-    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    if (!operationIsCurrent()) return;
     fail(error);
     return;
   }
-  if (!navigationSequence.isCurrent(navigationSeq)) return;
+  if (!operationIsCurrent()) return;
   if (!result.found) {
     state.loading = false;
     state.error = `Unknown product home demo '${demoId}'.`;
@@ -10185,6 +10455,7 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
         "The engine-run demo selection was not present in its returned package surfaces.");
     }
 
+    clearWorkspacePackages();
     for (const packageModel of packages) {
       retainPackageModel(packageModel);
       recordRecentPackage(
@@ -10255,7 +10526,7 @@ async function runCallGraphDemo(demoId: ProductHomeDemoId) {
     render();
     await renderMermaidCallGraph();
   } catch (error) {
-    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    if (!operationIsCurrent()) return;
     fail(error);
   }
 }
@@ -10271,7 +10542,15 @@ async function restoreWorkspaceFromLocation(
     ? captureCanonicalWorkspaceRestoreSnapshot()
     : null,
 ) {
-  if (!navigationSequence.isCurrent(navigationSeq)) return;
+  const operationWorkspaceId = state.workspaceSession.selectedWorkspaceId;
+  const operationIsCurrent = () => workspaceOperationIsCurrent(
+    state.workspaceSession,
+    {
+      workspaceId: operationWorkspaceId,
+      navigationSequence: navigationSeq,
+    },
+    navigationSequence.current());
+  if (!operationIsCurrent()) return;
   if (loc.routeFailure) {
     failWorkspaceRoute(loc.routeFailure.message);
     return;
@@ -10351,11 +10630,11 @@ async function restoreWorkspaceFromLocation(
     if (isRuntimePackId(tab.id)) {
       const runtimeResult = await loadRuntimePack(
         tab.framework,
-        () => navigationSequence.isCurrent(navigationSeq),
+        operationIsCurrent,
         tab.version);
       loaded = runtimeResult.packageModel;
       runtimeFailureMessage = runtimeResult.failureMessage;
-      if (!loaded && navigationSequence.isCurrent(navigationSeq)) {
+      if (!loaded && operationIsCurrent()) {
         const failure =
           `Workspace restore was incomplete: ${tab.id}: ${runtimeFailureMessage
             || state.runtimePackError
@@ -10370,7 +10649,7 @@ async function restoreWorkspaceFromLocation(
         navigationSeq
       });
     }
-    if (!navigationSequence.isCurrent(navigationSeq)) return;
+    if (!operationIsCurrent()) return;
     if (!loaded) failedTabCount++;
     if (loaded && matchesTarget(tab)) loadedTargetModel = loaded;
   }
@@ -10408,7 +10687,7 @@ async function restoreWorkspaceFromLocation(
         loc.libraryPack,
         navigationSeq,
         () => restoreWorkspaceFromLocation(loc, deep));
-      if (!navigationSequence.isCurrent(navigationSeq)) return;
+      if (!operationIsCurrent()) return;
       if (!scoped) {
         if (loc.shareState) {
           failCanonicalWorkspaceRestore(
@@ -10584,7 +10863,9 @@ async function restoreInitialWorkspace() {
   const packageId = loc.package;
   if (!packageId) {
     state.loading = false;
-    state.home = true;
+    state.home = !loc.workspaceSubjectOpen;
+    state.workspaceSubjectOpen = loc.workspaceSubjectOpen;
+    state.atPackageRoot = loc.workspaceSubjectOpen;
     state.queryNotice = loc.workspaceNotice || "";
     render();
     return;
@@ -10773,8 +11054,15 @@ function navigateInAppUrl(url: URL) {
   if (focusWorkspace) {
     packageQueryWorkspaceFocusNavigationSeq = navigationSeq;
   }
-  workspaceLocation.push(url.toString());
+  workspaceLocation.push(url.toString(), workspaceHistoryState(null));
   const loc = parseLocation();
+  if (loc.workspaceSubjectOpen
+    && !loc.package
+    && !(loc.tabs && loc.tabs.length)) {
+    prepareLiveWorkspaceSurface();
+    render({ synchronizeUrl: false });
+    return;
+  }
   observeAsync(
     restoreWorkspaceFromLocation(loc, loc, navigationSeq),
     "Navigating");
@@ -11224,6 +11512,10 @@ window.addEventListener("popstate", () => {
   const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation();
   invalidateMemberDestinationWork(state);
   if (dismissedAnnotatedSourceModal) render({ synchronizeUrl: false });
+  const historyWorkspace = workspaceForHistory(
+    state.workspaceSession,
+    history.state);
+  adoptWorkspace(historyWorkspace.id);
   if (isPackageQueryPath(location.pathname)) {
     clearNavigationError();
     applyPackageQueryHistory(history.state);
@@ -11275,6 +11567,7 @@ window.addEventListener("popstate", () => {
     state.home =
       !pendingLocation.package
       && !pendingWorkspace.hasWorkspaceState
+      && !pendingLocation.workspaceSubjectOpen
       && !pendingLocation.routeFailure;
     state.loading = !state.home;
     if (state.home) clearNavigationError();
@@ -11305,7 +11598,19 @@ window.addEventListener("popstate", () => {
       null);
     return;
   }
-  const bareHome = !loc.package && !(loc.tabs && loc.tabs.length);
+  const emptyWorkspace = loc.workspaceSubjectOpen
+    && !loc.package
+    && !(loc.tabs && loc.tabs.length);
+  if (emptyWorkspace) {
+    clearNavigationError();
+    prepareLiveWorkspaceSurface();
+    syncCurrentLiveWorkspace();
+    render({ synchronizeUrl: false });
+    return;
+  }
+  const bareHome = !loc.workspaceSubjectOpen
+    && !loc.package
+    && !(loc.tabs && loc.tabs.length);
   if (bareHome) {
     // Navigated back to the bare root — show the intro/home page (engine stays warm).
     clearNavigationError();

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -352,7 +352,6 @@ export interface RenderPackageQueryOptions {
   prefix?: string;
   availableFacets: readonly QueryFacetTerm[];
   navigationError?: string;
-  workspaceHref?: string;
   escapeHtml: (value: unknown) => string;
 }
 
@@ -364,7 +363,6 @@ export function renderPackageQueryView(
     prefix = state.request?.scopeQuery ?? "",
     availableFacets,
     navigationError = "",
-    workspaceHref = "/",
     escapeHtml,
   } = options;
   const activeKeys = new Set(state.request?.facets.map(facet => facet.key) ?? []);
@@ -392,8 +390,6 @@ export function renderPackageQueryView(
       <header class="query-page-bar">
         ${renderBrand({
           id: "package-query-workspace",
-          href: workspaceHref,
-          ariaLabel: `dotnet inspect ${workspaceHref === "/" ? "home" : "workspace"}`,
         })}
         <button id="package-query-back" type="button">Back</button>
       </header>

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -35,6 +35,7 @@ export interface RenderScopeBarOptions<TId extends string = string> {
   panelId?: string;
   subjectPanelId?: string;
   showMemberScope?: boolean;
+  subjectScopes?: readonly WorkspaceScope[];
   emptyStripLabel?: string;
   escapeHtml: (value: unknown) => string;
 }
@@ -310,8 +311,9 @@ function edgeIndicators(): string {
 
 function subjectDefinitions(
   showMemberScope: boolean,
+  subjectScopes: readonly WorkspaceScope[] | undefined,
 ): readonly (readonly [WorkspaceScope, string])[] {
-  return [
+  const definitions: readonly (readonly [WorkspaceScope, string])[] = [
     ["workspace", "Workspace"],
     ["package", "Package"],
     ["type", "Type"],
@@ -319,6 +321,9 @@ function subjectDefinitions(
       ? [["member", "Member"] as const]
       : []),
   ];
+  return subjectScopes
+    ? definitions.filter(([id]) => subjectScopes.includes(id))
+    : definitions;
 }
 
 export function renderScopeBar<TId extends string>(
@@ -332,6 +337,7 @@ export function renderScopeBar<TId extends string>(
     panelId,
     subjectPanelId = "subject-panel",
     showMemberScope = scope === "member",
+    subjectScopes,
     emptyStripLabel = "",
     escapeHtml,
   } = options;
@@ -345,7 +351,7 @@ export function renderScopeBar<TId extends string>(
       : scope === "type"
         ? "Type"
         : "Member";
-  const subjects = subjectDefinitions(showMemberScope);
+  const subjects = subjectDefinitions(showMemberScope, subjectScopes);
   const subjectIds = subjects.map(([id]) => id).join(",");
   const inspectorIds = strip.map(([id]) => id).join(",");
   const inspectorAnchor = activeIndex >= 0

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -306,8 +306,8 @@ body {
 .scope-switch button.scope-seg:hover { color: var(--text); background: rgba(127,127,127,.12); }
 .scope-switch button.scope-seg.active { color: #fff; background: var(--accent); border-bottom-color: transparent; }
 .lens-separator { flex: none; width: 1px; height: 17px; background: var(--line); margin: 0 4px; }
-.workspace-packet-list { min-height: 0; overflow: auto; padding: 8px; }
-.workspace-packet {
+.workspace-list { min-height: 0; overflow: auto; padding: 8px; }
+.workspace-card {
   display: block;
   width: 100%;
   padding: 10px;
@@ -316,27 +316,29 @@ body {
   color: var(--muted);
   text-align: left;
 }
-.workspace-packet:hover { border-color: var(--line); background: rgba(127,127,127,.08); }
-.workspace-packet.active { border-color: var(--line-strong); background: var(--panel-active); }
-.workspace-packet strong,
-.workspace-packet span,
-.workspace-packet small { display: block; overflow: hidden; text-overflow: ellipsis; }
-.workspace-packet strong { color: var(--text); font: 11px var(--mono); }
-.workspace-packet span { margin-top: 4px; color: var(--muted); font-size: 11px; }
-.workspace-packet small { margin-top: 5px; color: var(--dim); font: 9px var(--mono); }
-.workspace-packet-empty { margin: 12px 8px; color: var(--dim); font-size: 11px; line-height: 1.5; }
+.workspace-card:hover { border-color: var(--line); background: rgba(127,127,127,.08); }
+.workspace-card.active { border-color: var(--line-strong); background: var(--panel-active); }
+.workspace-card strong,
+.workspace-card span,
+.workspace-card small { display: block; overflow: hidden; text-overflow: ellipsis; }
+.workspace-card strong { color: var(--text); font: 11px var(--mono); }
+.workspace-card span { margin-top: 4px; color: var(--muted); font-size: 11px; }
+.workspace-card small { margin-top: 5px; color: var(--dim); font: 9px var(--mono); }
+.workspace-nav-actions { padding: 8px; border-top: 1px solid var(--line); }
+.workspace-nav-actions button { width: 100%; padding: 7px 10px; }
 .workspace-overview { max-width: 900px; margin-top: 28px; }
 .workspace-overview p { color: var(--muted); line-height: 1.6; }
-.workspace-packet-introduction {
+.workspace-introduction {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
   margin-bottom: 20px;
 }
-.workspace-packet-introduction p { margin: 0; font-size: 14px; }
-.workspace-packet-introduction button { flex: none; padding: 8px 14px; }
-.workspace-packet-section { margin-top: 14px; }
+.workspace-introduction p { margin: 0; font-size: 14px; }
+.workspace-introduction button { flex: none; padding: 8px 14px; }
+.workspace-section { margin-top: 14px; }
+.workspace-empty { margin: 0; }
 .workspace-detail-list { list-style: none; margin: 0; padding: 0; }
 .workspace-detail-list li {
   display: grid;
@@ -509,7 +511,7 @@ body {
   background: var(--panel);
 }
 .type-browser.workspace-nav {
-  grid-template-rows: 40px minmax(0, 1fr);
+  grid-template-rows: 40px minmax(0, 1fr) auto;
 }
 .browser-head { display: flex; align-items: center; justify-content: space-between; padding: 0 10px 0 14px; border-bottom: 1px solid var(--line); background: var(--chrome); }
 .pane-label { color: var(--muted); font: 10px var(--mono); letter-spacing: .12em; }
@@ -1391,7 +1393,7 @@ kbd {
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }
   .type-badge { width: 35px; height: 35px; }
   .type-heading p { grid-column: 1 / -1; }
-  .workspace-packet-introduction { align-items: flex-start; flex-direction: column; gap: 10px; }
+  .workspace-introduction { align-items: flex-start; flex-direction: column; gap: 10px; }
   .workspace-detail-list li,
   .workspace-detail-list.loaded li {
     grid-template-columns: minmax(0, 1fr) auto;

--- a/prototypes/inspect-web/src/workspace-navigation.ts
+++ b/prototypes/inspect-web/src/workspace-navigation.ts
@@ -151,13 +151,17 @@ export interface NavigationSequence {
   isCurrent(candidate: number): boolean;
 }
 
-export function createNavigationSequence(): NavigationSequence {
+export function createNavigationSequence(
+  onSupersede: () => void = () => {},
+): NavigationSequence {
   let current = 0;
   return {
     begin() {
+      onSupersede();
       return ++current;
     },
     invalidate() {
+      onSupersede();
       current++;
     },
     current() {

--- a/prototypes/inspect-web/src/workspace-session.ts
+++ b/prototypes/inspect-web/src/workspace-session.ts
@@ -1,0 +1,175 @@
+import type {
+  NavigationHistorySnapshot,
+  WorkspaceView,
+} from "./workspace-navigation.ts";
+import type { BrowserWorkspaceShareState } from "./inspect-web-engine.d.ts";
+
+export const MAX_LIVE_WORKSPACES = 4;
+const DEFAULT_WORKSPACE_NAME = "Default";
+
+const WORKSPACE_HISTORY_KEY = "dotnetInspectWorkspaceId";
+
+export interface LiveWorkspace<TPackage> {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  packages: TPackage[];
+  activePackageKey: string | null;
+  shareBasis: BrowserWorkspaceShareState | null;
+  navigation: NavigationHistorySnapshot<WorkspaceView>;
+}
+
+export interface LiveWorkspaceSession<TPackage> {
+  workspaces: LiveWorkspace<TPackage>[];
+  selectedWorkspaceId: string;
+  nextWorkspaceNumber: number;
+}
+
+export interface WorkspaceProjection<TPackage> {
+  packages: readonly TPackage[];
+  activePackageKey: string | null;
+  shareBasis: BrowserWorkspaceShareState | null;
+  navigation: NavigationHistorySnapshot<WorkspaceView>;
+}
+
+function emptyNavigation(): NavigationHistorySnapshot<WorkspaceView> {
+  return { stack: [], index: -1 };
+}
+
+export function createLiveWorkspaceSession<TPackage>(
+  defaultWorkspaceId: string,
+): LiveWorkspaceSession<TPackage> {
+  return {
+    workspaces: [{
+      id: defaultWorkspaceId,
+      name: DEFAULT_WORKSPACE_NAME,
+      isDefault: true,
+      packages: [],
+      activePackageKey: null,
+      shareBasis: null,
+      navigation: emptyNavigation(),
+    }],
+    selectedWorkspaceId: defaultWorkspaceId,
+    nextWorkspaceNumber: 2,
+  };
+}
+
+export function selectedLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+): LiveWorkspace<TPackage> {
+  return session.workspaces.find(
+    workspace => workspace.id === session.selectedWorkspaceId)
+    ?? session.workspaces[0]!;
+}
+
+export function defaultLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+): LiveWorkspace<TPackage> {
+  return session.workspaces.find(workspace => workspace.isDefault)
+    ?? session.workspaces[0]!;
+}
+
+export function updateSelectedLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  projection: WorkspaceProjection<TPackage>,
+): void {
+  const workspace = selectedLiveWorkspace(session);
+  workspace.packages = [...projection.packages];
+  workspace.activePackageKey = projection.activePackageKey;
+  workspace.shareBasis = projection.shareBasis;
+  workspace.navigation = {
+    stack: projection.navigation.stack.map(entry => ({ ...entry })),
+    index: projection.navigation.index,
+  };
+}
+
+export function createLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  workspaceId: string,
+): LiveWorkspace<TPackage> | null {
+  if (session.workspaces.length >= MAX_LIVE_WORKSPACES) return null;
+  const workspace: LiveWorkspace<TPackage> = {
+    id: workspaceId,
+    name: `Workspace ${session.nextWorkspaceNumber++}`,
+    isDefault: false,
+    packages: [],
+    activePackageKey: null,
+    shareBasis: null,
+    navigation: emptyNavigation(),
+  };
+  session.workspaces.push(workspace);
+  session.selectedWorkspaceId = workspace.id;
+  return workspace;
+}
+
+export function selectLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  workspaceId: string,
+): LiveWorkspace<TPackage> | null {
+  const workspace = session.workspaces.find(
+    candidate => candidate.id === workspaceId);
+  if (!workspace) return null;
+  session.selectedWorkspaceId = workspace.id;
+  return workspace;
+}
+
+export function removeLiveWorkspace<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  workspaceId: string,
+): LiveWorkspace<TPackage> | null {
+  const index = session.workspaces.findIndex(
+    workspace => workspace.id === workspaceId);
+  const workspace = session.workspaces[index];
+  if (!workspace || workspace.isDefault) return null;
+  session.workspaces.splice(index, 1);
+  if (session.selectedWorkspaceId === workspaceId) {
+    session.selectedWorkspaceId = defaultLiveWorkspace(session).id;
+  }
+  return workspace;
+}
+
+function historyRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? { ...value }
+    : {};
+}
+
+export function workspaceHistoryId(value: unknown): string | null {
+  const workspaceId = historyRecord(value)[WORKSPACE_HISTORY_KEY];
+  return typeof workspaceId === "string" && workspaceId.length > 0
+    ? workspaceId
+    : null;
+}
+
+export function withWorkspaceHistoryId(
+  value: unknown,
+  workspaceId: string,
+): Record<string, unknown> {
+  return {
+    ...historyRecord(value),
+    [WORKSPACE_HISTORY_KEY]: workspaceId,
+  };
+}
+
+export function workspaceForHistory<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  historyState: unknown,
+): LiveWorkspace<TPackage> {
+  const workspaceId = workspaceHistoryId(historyState);
+  return session.workspaces.find(workspace => workspace.id === workspaceId)
+    ?? defaultLiveWorkspace(session);
+}
+
+export interface WorkspaceOperationOwner {
+  workspaceId: string;
+  navigationSequence: number;
+}
+
+export function workspaceOperationIsCurrent<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  owner: WorkspaceOperationOwner,
+  currentNavigationSequence: number,
+): boolean {
+  return session.selectedWorkspaceId === owner.workspaceId
+    && owner.navigationSequence === currentNavigationSequence;
+}

--- a/prototypes/inspect-web/src/workspace-session.ts
+++ b/prototypes/inspect-web/src/workspace-session.ts
@@ -168,22 +168,13 @@ export type WorkspaceHistoryMembershipStatus =
 export function workspaceHistoryMembershipStatus<TPackage>(
   session: LiveWorkspaceSession<TPackage>,
   historyState: unknown,
-  requestedPackageKeys: readonly string[],
-  packageKey: (value: TPackage) => string,
-  exact: boolean,
+  matchesCurrentMembership: (packages: readonly TPackage[]) => boolean,
 ): WorkspaceHistoryMembershipStatus {
   const workspaceId = workspaceHistoryId(historyState);
   const workspace = session.workspaces.find(
     candidate => candidate.id === workspaceId);
   if (!workspace) return "unassociated";
-  const currentPackageKeys = workspace.packages.map(packageKey);
-  const matches = exact
-    ? currentPackageKeys.length === requestedPackageKeys.length
-      && currentPackageKeys.every(
-        (key, index) => key === requestedPackageKeys[index])
-    : requestedPackageKeys.every(
-        requested => currentPackageKeys.includes(requested));
-  return matches ? "current" : "stale";
+  return matchesCurrentMembership(workspace.packages) ? "current" : "stale";
 }
 
 export function rememberedLiveWorkspaceHref<TPackage>(

--- a/prototypes/inspect-web/src/workspace-session.ts
+++ b/prototypes/inspect-web/src/workspace-session.ts
@@ -160,6 +160,13 @@ export function workspaceForHistory<TPackage>(
     ?? defaultLiveWorkspace(session);
 }
 
+export function rememberedLiveWorkspaceHref<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  canonicalHrefs: ReadonlyMap<string, string>,
+): string | null {
+  return canonicalHrefs.get(session.selectedWorkspaceId) ?? null;
+}
+
 export interface WorkspaceOperationOwner {
   workspaceId: string;
   navigationSequence: number;

--- a/prototypes/inspect-web/src/workspace-session.ts
+++ b/prototypes/inspect-web/src/workspace-session.ts
@@ -160,6 +160,32 @@ export function workspaceForHistory<TPackage>(
     ?? defaultLiveWorkspace(session);
 }
 
+export type WorkspaceHistoryMembershipStatus =
+  | "unassociated"
+  | "current"
+  | "stale";
+
+export function workspaceHistoryMembershipStatus<TPackage>(
+  session: LiveWorkspaceSession<TPackage>,
+  historyState: unknown,
+  requestedPackageKeys: readonly string[],
+  packageKey: (value: TPackage) => string,
+  exact: boolean,
+): WorkspaceHistoryMembershipStatus {
+  const workspaceId = workspaceHistoryId(historyState);
+  const workspace = session.workspaces.find(
+    candidate => candidate.id === workspaceId);
+  if (!workspace) return "unassociated";
+  const currentPackageKeys = workspace.packages.map(packageKey);
+  const matches = exact
+    ? currentPackageKeys.length === requestedPackageKeys.length
+      && currentPackageKeys.every(
+        (key, index) => key === requestedPackageKeys[index])
+    : requestedPackageKeys.every(
+        requested => currentPackageKeys.includes(requested));
+  return matches ? "current" : "stale";
+}
+
 export function rememberedLiveWorkspaceHref<TPackage>(
   session: LiveWorkspaceSession<TPackage>,
   canonicalHrefs: ReadonlyMap<string, string>,
@@ -170,6 +196,71 @@ export function rememberedLiveWorkspaceHref<TPackage>(
 export interface WorkspaceOperationOwner {
   workspaceId: string;
   navigationSequence: number;
+}
+
+export interface WorkspaceProjectionTransactionController {
+  begin(owner: WorkspaceOperationOwner): void;
+  commit(owner: WorkspaceOperationOwner): boolean;
+  abandon(): void;
+  blocksSelectedWorkspaceSynchronization(): boolean;
+  matches(owner: WorkspaceOperationOwner): boolean;
+}
+
+export interface WorkspaceProjectionTransactionDependencies<TPackage> {
+  currentPackages(): readonly TPackage[];
+  synchronize(): void;
+  restore(workspace: LiveWorkspace<TPackage>): void;
+  release(packageModel: TPackage): void;
+}
+
+export function createWorkspaceProjectionTransactionController<TPackage>(
+  currentSession: () => LiveWorkspaceSession<TPackage>,
+  dependencies: WorkspaceProjectionTransactionDependencies<TPackage>,
+): WorkspaceProjectionTransactionController {
+  let transaction: WorkspaceOperationOwner | null = null;
+  const matches = (owner: WorkspaceOperationOwner) =>
+    transaction?.workspaceId === owner.workspaceId
+    && transaction.navigationSequence === owner.navigationSequence;
+
+  return {
+    begin(owner) {
+      transaction = owner;
+    },
+    commit(owner) {
+      if (!matches(owner)) return false;
+      const session = currentSession();
+      const replacedPackages = session.workspaces.find(
+        workspace => workspace.id === owner.workspaceId)?.packages ?? [];
+      transaction = null;
+      dependencies.synchronize();
+      for (const packageModel of replacedPackages) {
+        if (!session.workspaces.some(
+          workspace => workspace.packages.includes(packageModel))) {
+          dependencies.release(packageModel);
+        }
+      }
+      return true;
+    },
+    abandon() {
+      const abandoned = transaction;
+      if (!abandoned) return;
+      transaction = null;
+      const session = currentSession();
+      if (session.selectedWorkspaceId !== abandoned.workspaceId) return;
+      const transientPackages = [...dependencies.currentPackages()];
+      const workspace = selectedLiveWorkspace(session);
+      dependencies.restore(workspace);
+      for (const packageModel of transientPackages) {
+        if (!workspace.packages.includes(packageModel))
+          dependencies.release(packageModel);
+      }
+    },
+    blocksSelectedWorkspaceSynchronization() {
+      const session = currentSession();
+      return transaction?.workspaceId === session.selectedWorkspaceId;
+    },
+    matches,
+  };
 }
 
 export function workspaceOperationIsCurrent<TPackage>(

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -1,164 +1,125 @@
 import type { PackageControlPackage } from "./package-controls.ts";
-import type {
-  BrowserHomeDemoMember,
-  BrowserHomeDemoResolved,
-} from "./inspect-web-engine.d.ts";
 
-export interface WorkspaceSubjectRenderOptions {
-  packets: readonly BrowserHomeDemoResolved[];
-  selectedPacketId: string | null;
+export interface WorkspaceSummary<TPackage extends PackageControlPackage> {
+  id: string;
+  name: string;
+  isDefault: boolean;
+  packages: readonly TPackage[];
+  activePackageKey: string | null;
+}
+
+export interface WorkspaceSubjectRenderOptions<
+  TPackage extends PackageControlPackage,
+> {
+  workspaces: readonly WorkspaceSummary<TPackage>[];
+  selectedWorkspaceId: string;
+  maximumWorkspaces: number;
   escapeHtml: (value: unknown) => string;
 }
 
-export interface WorkspacePacketViewRenderOptions {
-  packet: BrowserHomeDemoResolved | null;
-  packages: readonly PackageControlPackage[];
-  activePackage: PackageControlPackage | null;
+export interface WorkspaceViewRenderOptions<
+  TPackage extends PackageControlPackage,
+> {
+  workspace: WorkspaceSummary<TPackage>;
   escapeHtml: (value: unknown) => string;
-  packageIdentityKey: (pkg: PackageControlPackage) => string;
+  packageIdentityKey: (pkg: TPackage) => string;
 }
 
 export interface WorkspaceSubjectBindingActions {
-  onSelect: (packetId: string) => void;
-  onOpen: (packetId: string) => void;
-  onClose: (packageKey: string) => void;
+  onSelect: (workspaceId: string) => void;
+  onCreate: () => void;
+  onRemove: (workspaceId: string) => void;
+  onClosePackage: (packageKey: string) => void;
 }
 
-export function retainWorkspacePacket(
-  packets: readonly BrowserHomeDemoResolved[],
-  packet: BrowserHomeDemoResolved,
-): BrowserHomeDemoResolved[] {
-  const index = packets.findIndex(candidate => candidate.id === packet.id);
-  if (index < 0) return [...packets, packet];
-  const retained = packets.slice();
-  retained[index] = packet;
-  return retained;
+function packageSummary(
+  packages: readonly PackageControlPackage[],
+): string {
+  if (packages.length === 0) return "No packages loaded";
+  const first = packages[0]!;
+  if (packages.length === 1) return first.id;
+  return `${first.id} + ${packages.length - 1}`;
 }
 
-export function renderWorkspaceSubject(
-  options: WorkspaceSubjectRenderOptions,
+export function renderWorkspaceSubject<
+  TPackage extends PackageControlPackage,
+>(
+  options: WorkspaceSubjectRenderOptions<TPackage>,
 ): string {
   const {
-    packets,
-    selectedPacketId,
+    workspaces,
+    selectedWorkspaceId,
+    maximumWorkspaces,
     escapeHtml,
   } = options;
-  const rows = packets.map(packet => {
-    const active = packet.id === selectedPacketId;
-    const target = [packet.view.section, packet.view.type]
-      .filter((value): value is string => Boolean(value))
-      .join(" · ") || "Workspace";
-    return `<button class="workspace-packet${active ? " active" : ""}" type="button" data-workspace-packet="${escapeHtml(packet.id)}" aria-current="${active ? "true" : "false"}">
-      <strong>${escapeHtml(packet.title)}</strong>
-      <span>${escapeHtml(packet.summary)}</span>
-      <small>${escapeHtml(target)}</small>
+  const rows = workspaces.map(workspace => {
+    const active = workspace.id === selectedWorkspaceId;
+    return `<button class="workspace-card${active ? " active" : ""}" type="button" data-workspace="${escapeHtml(workspace.id)}" aria-current="${active ? "true" : "false"}">
+      <strong>${escapeHtml(workspace.name)}</strong>
+      <span>${escapeHtml(packageSummary(workspace.packages))}</span>
+      <small>${workspace.packages.length} coordinate${workspace.packages.length === 1 ? "" : "s"}</small>
     </button>`;
   }).join("");
-  const content = rows
-    || `<p class="workspace-packet-empty">Open a demo to retain its workspace packet here.</p>`;
+  const createDisabled = workspaces.length >= maximumWorkspaces;
   return `<aside class="type-browser workspace-nav">
-    <header class="browser-head"><span>WORKSPACE PACKETS</span><small>${packets.length}</small></header>
-    <div class="workspace-packet-list">${content}</div>
+    <header class="browser-head">
+      <span>WORKSPACES</span>
+      <small>${workspaces.length}</small>
+    </header>
+    <div class="workspace-list">${rows}</div>
+    <footer class="workspace-nav-actions">
+      <button type="button" data-workspace-create${createDisabled ? " disabled" : ""}>New workspace</button>
+    </footer>
   </aside>`;
 }
 
-function coordinateDetail(
-  member: BrowserHomeDemoMember,
-  escapeHtml: (value: unknown) => string,
-): string {
-  const details = [member.version, member.framework, member.assembly]
-    .filter((value): value is string => Boolean(value))
-    .map(escapeHtml)
-    .join(" · ");
-  const kind = member.kind === "package"
-    ? "NuGet package"
-    : member.kind === "platform"
-      ? "Platform"
-      : member.kind;
-  return `<li>
-    <span>${escapeHtml(kind)}</span>
-    <strong>${escapeHtml(member.id)}</strong>
-    ${details ? `<small>${details}</small>` : ""}
-  </li>`;
-}
-
-export function renderWorkspacePacketView(
-  options: WorkspacePacketViewRenderOptions,
+export function renderWorkspaceView<
+  TPackage extends PackageControlPackage,
+>(
+  options: WorkspaceViewRenderOptions<TPackage>,
 ): string {
   const {
-    packet,
-    packages,
-    activePackage,
+    workspace,
     escapeHtml,
     packageIdentityKey,
   } = options;
-  const title = packet?.title ?? "Current workspace";
-  const summary = packet?.summary
-    ?? "Live coordinates retained by this browser session.";
-  const declaredMembers = packet?.workspaceMembers.map(member =>
-    coordinateDetail(member, escapeHtml)).join("") ?? "";
-  const focusedTab = packet
-    ? packet.tabs[Math.min(
-        Math.max(packet.focusTabIndex, 0),
-        Math.max(packet.tabs.length - 1, 0))]
-    : null;
-  const viewRows = packet
-    ? [
-        ["Starts at", focusedTab?.member.id ?? null],
-        ["Section", packet.view.section],
-        ["Library", packet.view.library],
-        ["Type", packet.view.type],
-        ["Member", packet.view.memberKey ?? packet.view.memberAnchor],
-      ].filter((row): row is [string, string] => Boolean(row[1]))
-    : [];
-  const loadedCoordinates = packages.map(item => {
+  const loadedCoordinates = workspace.packages.map(item => {
     const key = packageIdentityKey(item);
-    const active = Boolean(
-      activePackage
-      && packageIdentityKey(activePackage) === key);
+    const active = workspace.activePackageKey === key;
     const label = `${item.id} ${item.version} ${item.activeFramework}`;
     return `<li class="${active ? "active" : ""}">
-      <span>${item.isRuntimePack ? "Platform" : "Loaded package"}</span>
+      <span>${item.isRuntimePack ? "Platform" : "NuGet package"}</span>
       <strong>${escapeHtml(item.id)}</strong>
       <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
       ${item.isRuntimePack
         ? ""
-        : `<button type="button" data-workspace-close="${escapeHtml(key)}" aria-label="Close ${escapeHtml(label)}">Close</button>`}
+        : `<button type="button" data-workspace-package-close="${escapeHtml(key)}" aria-label="Close ${escapeHtml(label)}">Close</button>`}
     </li>`;
   }).join("");
-  const packetDetails = packet
-    ? `<section class="document-section workspace-packet-section">
-        <div class="section-title"><h2>Packet workspace</h2><span>${packet.workspaceMembers.length} member${packet.workspaceMembers.length === 1 ? "" : "s"}</span></div>
-        <ul class="workspace-detail-list">${declaredMembers}</ul>
-      </section>
-      <section class="document-section workspace-packet-section">
-        <div class="section-title"><h2>Initial view</h2><span>selection only</span></div>
-        <dl class="workspace-view-details">${viewRows.map(([label, value]) =>
-          `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`).join("")}</dl>
-      </section>`
-    : "";
+  const packageCount = workspace.packages.length;
+  const summary = packageCount === 0
+    ? "This workspace is ready for packages. Search for a package to begin."
+    : `${packageCount} loaded coordinate${packageCount === 1 ? "" : "s"} available for analysis.`;
   return `<header class="type-heading workspace-heading">
     <div class="type-badge">W</div>
     <div>
-      <div class="type-namespace">${packet ? "Workspace packet" : "Inspection workspace"}</div>
-      <h1>${escapeHtml(title)}</h1>
-      <code class="type-signature">${packet
-        ? `${packet.workspaceMembers.length} workspace member${packet.workspaceMembers.length === 1 ? "" : "s"} · ${packet.tabs.length} navigation target${packet.tabs.length === 1 ? "" : "s"}`
-        : `${packages.length} loaded coordinate${packages.length === 1 ? "" : "s"}`}</code>
+      <div class="type-namespace">Inspection workspace</div>
+      <h1>${escapeHtml(workspace.name)}</h1>
+      <code class="type-signature">${escapeHtml(packageSummary(workspace.packages))}</code>
     </div>
   </header>
   <div class="workspace-overview">
-    <div class="workspace-packet-introduction">
+    <div class="workspace-introduction">
       <p>${escapeHtml(summary)}</p>
-      ${packet
-        ? `<button class="primary-action" type="button" data-workspace-open="${escapeHtml(packet.id)}">Open workspace</button>`
-        : ""}
+      ${workspace.isDefault
+        ? ""
+        : `<button type="button" data-workspace-remove="${escapeHtml(workspace.id)}">Remove workspace</button>`}
     </div>
-    ${packetDetails}
-    <section class="document-section workspace-packet-section">
-      <div class="section-title"><h2>Loaded workspace</h2><span>${packages.length} coordinate${packages.length === 1 ? "" : "s"}</span></div>
-      <p>Workspace packets may share these loaded coordinates without becoming the same packet.</p>
-      <ul class="workspace-detail-list loaded">${loadedCoordinates}</ul>
+    <section class="document-section workspace-section">
+      <div class="section-title"><h2>Packages</h2><span>${packageCount} coordinate${packageCount === 1 ? "" : "s"}</span></div>
+      ${packageCount === 0
+        ? '<p class="workspace-empty">No packages are loaded in this workspace.</p>'
+        : `<ul class="workspace-detail-list loaded">${loadedCoordinates}</ul>`}
     </section>
   </div>`;
 }
@@ -167,29 +128,31 @@ export function bindWorkspaceSubject(
   root: ParentNode,
   actions: WorkspaceSubjectBindingActions,
 ): void {
-  root.querySelectorAll<HTMLElement>("[data-workspace-packet]").forEach(button =>
+  root.querySelectorAll<HTMLElement>("[data-workspace]").forEach(button =>
     button.addEventListener("click", () => {
-      const id = button.dataset.workspacePacket;
+      const id = button.dataset.workspace;
       if (id !== undefined) actions.onSelect(id);
     }));
-  root.querySelectorAll<HTMLElement>("[data-workspace-open]").forEach(button =>
+  root.querySelectorAll<HTMLElement>("[data-workspace-create]").forEach(button =>
+    button.addEventListener("click", actions.onCreate));
+  root.querySelectorAll<HTMLElement>("[data-workspace-remove]").forEach(button =>
     button.addEventListener("click", () => {
-      const id = button.dataset.workspaceOpen;
-      if (id !== undefined) actions.onOpen(id);
+      const id = button.dataset.workspaceRemove;
+      if (id !== undefined) actions.onRemove(id);
     }));
-  root.querySelectorAll<HTMLElement>("[data-workspace-close]").forEach(button =>
-    button.addEventListener("click", () => {
-      const key = button.dataset.workspaceClose;
-      if (key !== undefined) actions.onClose(key);
+  root.querySelectorAll<HTMLElement>("[data-workspace-package-close]").forEach(
+    button => button.addEventListener("click", () => {
+      const key = button.dataset.workspacePackageClose;
+      if (key !== undefined) actions.onClosePackage(key);
     }));
 }
 
-export function focusWorkspacePacket(
+export function focusWorkspace(
   root: ParentNode,
-  packetId: string,
+  workspaceId: string,
 ): boolean {
-  for (const button of root.querySelectorAll<HTMLElement>("[data-workspace-packet]")) {
-    if (button.dataset.workspacePacket !== packetId) continue;
+  for (const button of root.querySelectorAll<HTMLElement>("[data-workspace]")) {
+    if (button.dataset.workspace !== workspaceId) continue;
     button.focus();
     return true;
   }

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -90,17 +90,16 @@ test("an unstarted query renders the composing empty state", () => {
   assert.match(html, /Query nuget\.org/);
 });
 
-test("the persistent brand opens the resident workspace", () => {
+test("the persistent brand starts from the same-origin root", () => {
   const html = renderPackageQueryView({
     state: initialQueryState(),
     availableFacets: FACETS,
-    workspaceHref: "/?package=Example&version=1.0.0",
     escapeHtml,
   });
 
   assert.match(
     html,
-    /id="package-query-workspace" class="brand" href="\/\?package=Example&amp;version=1\.0\.0" aria-label="dotnet inspect workspace"/);
+    /id="package-query-workspace" class="brand" href="\/" aria-label="dotnet inspect home"/);
 });
 
 test("a packageId cannot break out of the row's HTML attribute context via a quote", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2106,7 +2106,7 @@ test("annotated source Escape and history ownership track the mounted surface", 
     ?? "";
   assert.match(
     popstate,
-    /const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation\(\);\s*invalidateMemberDestinationWork\(state\);\s*if \(dismissedAnnotatedSourceModal\) render\(\{ synchronizeUrl: false \}\);\s*if \(isPackageQueryPath/);
+    /const dismissedAnnotatedSourceModal = dismissModalsForRoutedNavigation\(\);\s*invalidateMemberDestinationWork\(state\);\s*if \(dismissedAnnotatedSourceModal\) render\(\{ synchronizeUrl: false \}\);[\s\S]*adoptWorkspace\(historyWorkspace\.id\);\s*if \(isPackageQueryPath/);
   assert.match(
     appSource,
     /function render\(options: \{ synchronizeUrl\?: boolean \} = \{\}\)[\s\S]*if \(options\.synchronizeUrl !== false\) syncUrl\(\)/);
@@ -2593,7 +2593,7 @@ test("canonical restoration is atomic and history adopts the active packet basis
   assert.match(sync, /state\.atPackageRoot/);
   assert.match(
     sync,
-    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*history\.state\)/);
+    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*workspaceHistoryState\(\)\)/);
   assert.match(
     stateUrl,
     /state\.atPackageRoot && state\.package[\s\S]*buildPackageRootStateUrl/);
@@ -2611,7 +2611,7 @@ test("initial workspace packet resolution waits for the engine phase", () => {
     /const initialWorkspace = workspaceLocation\.preflightCurrent\(\);\s*const initialLocation = initialWorkspace\.visible/);
   assert.match(
     appSource,
-    /state\.packageQueryOpen = isPackageQueryPath\(location\.pathname\);[\s\S]*state\.home = state\.credits\s*\|\| \(!state\.packageQueryOpen\s*&& !initialLocation\.package\s*&& !initialWorkspace\.hasWorkspaceState\s*&& !initialLocation\.routeFailure\)/);
+    /state\.packageQueryOpen = isPackageQueryPath\(location\.pathname\);[\s\S]*state\.home = state\.credits\s*\|\| \(!state\.packageQueryOpen\s*&& !initialLocation\.package\s*&& !initialWorkspace\.hasWorkspaceState\s*&& !initialLocation\.workspaceSubjectOpen\s*&& !initialLocation\.routeFailure\)/);
   const restore = appSource.match(
     /async function restoreInitialWorkspace\(\)[\s\S]*?\n}\n\nfunction isStyleTier/)?.[0]
     ?? "";
@@ -2648,7 +2648,7 @@ test("malformed package routes use the contained restore failure path", () => {
     ?? "";
   assert.match(
     popstate,
-    /if \(loc\.routeFailure\) \{\s*failWorkspaceRoute\(loc\.routeFailure\.message\);\s*return;\s*\}\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}\s*const canonicalSnapshot = loc\.hasWorkspaceState[\s\S]*state\.queryNotice = loc\.workspaceNotice \|\| "";[\s\S]*const bareHome/);
+    /if \(loc\.routeFailure\) \{\s*failWorkspaceRoute\(loc\.routeFailure\.message\);\s*return;\s*\}\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}\s*const canonicalSnapshot = loc\.hasWorkspaceState[\s\S]*state\.queryNotice = loc\.workspaceNotice \|\| "";[\s\S]*const emptyWorkspace[\s\S]*const bareHome/);
 
   const failure = appSource.match(
     /function failWorkspaceRoute\([\s\S]*?\n}\n\nfunction failCanonicalWorkspaceRestore/)?.[0]
@@ -2658,7 +2658,7 @@ test("malformed package routes use the contained restore failure path", () => {
     /function failWorkspaceRoute\(message: string\) \{\s*if \(state\.package\)[\s\S]*failedWorkspaceUrlState = \{\s*kind: "route",\s*notice: `Package route failed: \$\{message\}`,[\s\S]*pathname: location\.pathname,\s*search: location\.search,\s*recoveryUrl: buildPackageRootStateUrl\(location\.href,[\s\S]*state\.errorTitle = "Package route failed";[\s\S]*state\.error = message;[\s\S]*state\.retryAction = retryUnavailable/);
   assert.match(
     appSource,
-    /function goHome\(\) \{\s*navigationSequence\.begin\(\);\s*state\.loading = false;[\s\S]*invalidateGraphMemberNavigation\(\);\s*clearNavigationError\(\);\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}[\s\S]*workspaceLocation\.push\("\/"\);[\s\S]*render\(\)/);
+    /function goHome\(\) \{\s*navigationSequence\.begin\(\);\s*state\.loading = false;[\s\S]*invalidateGraphMemberNavigation\(\);\s*clearNavigationError\(\);\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}[\s\S]*workspaceLocation\.push\("\/", workspaceHistoryState\(null\)\);[\s\S]*render\(\)/);
   assert.match(
     appSource,
     /function visibleQueryNotice\(\) \{\s*const routeNotice = failedWorkspaceUrlState\?\.kind === "route"\s*\? failedWorkspaceUrlState\.notice\s*: null;\s*return \[state\.queryNotice, routeNotice\]\s*\.filter\(Boolean\)\s*\.join\(" "\);\s*\}/);
@@ -2675,7 +2675,7 @@ test("malformed package routes use the contained restore failure path", () => {
     appSource.match(
       /<span class="query-notice-text">\${escapeHtml\(visibleQueryNotice\(\)\)}<\/span>/g,
     )?.length,
-    2);
+    3);
   assert.match(
     appSource,
     /state\.queryNotice && state\.queryNoticeRetryAction\s*\? '<button id="retry-notice"/);
@@ -2715,7 +2715,7 @@ test("last package close recovers a route before releasing the workspace", () =>
 
   assert.match(
     close,
-    /const removal = removeWorkspacePackage\([\s\S]*if \(!removal\.closed\) return;[\s\S]*if \(!removal\.active && !clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}[\s\S]*state\.packages = removal\.packages;\s*releasePackageModelCaches\(removal\.closed\);[\s\S]*state\.package = null;\s*goHome\(\);/);
+    /const removal = removeWorkspacePackage\([\s\S]*if \(!removal\.closed\) return;[\s\S]*if \(!removal\.active && !clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}[\s\S]*state\.packages = removal\.packages;\s*releasePackageModelCaches\(removal\.closed\);[\s\S]*state\.package = null;[\s\S]*state\.workspaceSubjectOpen = true;[\s\S]*syncCurrentLiveWorkspace\(\);\s*render\(\);/);
 });
 
 test("Workspace close preserves the subject unless the active coordinate changes", () => {
@@ -2857,7 +2857,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /@media \(max-width: 860px\) \{\s*body\.package-query-route \{ min-width: 0; \}/);
   assert.match(
     handoff,
-    /packageQueryController\.cancel\(\);\s*state\.packageQueryOpen = false;\s*const navigationSeq = navigationSequence\.begin\(\);\s*packageQueryHandoffNavigationSeq = navigationSeq;[\s\S]*await loadPackage\([\s\S]*\{ navigationSeq }\);[\s\S]*if \(!navigationSequence\.isCurrent\(navigationSeq\)\) \{\s*if \(packageQueryHandoffNavigationSeq === navigationSeq\)\s*packageQueryHandoffNavigationSeq = null;\s*return;\s*\}[\s\S]*packageQueryHandoffNavigationSeq = null;\s*workspaceLocation\.push\(buildStateUrl\(\)\.toString\(\)\)/);
+    /packageQueryController\.cancel\(\);\s*state\.packageQueryOpen = false;\s*const navigationSeq = navigationSequence\.begin\(\);\s*packageQueryHandoffNavigationSeq = navigationSeq;[\s\S]*await loadPackage\([\s\S]*\{ navigationSeq }\);[\s\S]*if \(!navigationSequence\.isCurrent\(navigationSeq\)\) \{\s*if \(packageQueryHandoffNavigationSeq === navigationSeq\)\s*packageQueryHandoffNavigationSeq = null;\s*return;\s*\}[\s\S]*packageQueryHandoffNavigationSeq = null;\s*workspaceLocation\.push\(\s*buildStateUrl\(\)\.toString\(\),\s*workspaceHistoryState\(null\)\)/);
   assert.match(
     syncUrl,
     /function syncUrl\(\) \{\s*if \(currentPackageQueryHandoff\(\)\) return;\s*if \(retainFailedWorkspaceUrl\(\)\) return;/);
@@ -2898,7 +2898,10 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /if \(state\.packageQueryOpen \|\| leftPackageQueryHandoff\) \{[\s\S]*packageQueryHandoffNavigationSeq = null;[\s\S]*state\.packageQueryReturnFocusPending =\s*state\.packageQueryReturnFocus !== null[\s\S]*isPackageQueryPredecessor\(\s*history\.state,\s*state\.packageQueryPredecessorEntryId\)/);
   assert.match(
     popstate,
-    /if \(!state\.engineReady\) \{\s*const pendingWorkspace = workspaceLocation\.preflightCurrent\(\);\s*const pendingLocation = pendingWorkspace\.visible;[\s\S]*state\.loading = !state\.home;[\s\S]*render\(\);\s*return;\s*\}\s*const loc = parseLocation\(\)/);
+    /const historyWorkspace = workspaceForHistory\([\s\S]*history\.state\);\s*adoptWorkspace\(historyWorkspace\.id\);\s*if \(isPackageQueryPath\(location\.pathname\)\)/);
+  assert.match(
+    popstate,
+    /if \(!state\.engineReady\) \{[\s\S]*render\(\);\s*return;\s*\}\s*const loc = parseLocation\(\)/);
   assert.match(
     popstate,
     /if \(leftPackageQueryForWorkspaceSuccessor\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*if \(!state\.engineReady\)/);
@@ -2922,10 +2925,10 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /function focusTypeList\([\s\S]*afterCurrentNavigationFrame\(\(\) => \{[\s\S]*"#type-list"/);
   assert.match(
     appSource,
-    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*history\.state\)/);
+    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*workspaceHistoryState\(\)\)/);
   assert.match(
     appSource,
-    /workspaceLocation\.sync\(snapshot, history\.state\)/);
+    /workspaceLocation\.sync\(snapshot, workspaceHistoryState\(\)\)/);
   assert.equal(
     appSource.match(
       /\? withScopeQuery\(state\.packageQueryState\.request, validPrefix\)/g)
@@ -5711,13 +5714,34 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /appendQueryNotice\(\s+friendly\.message,\s+options\.retryAction/);
   assert.match(
     workspaceSubjectSource,
-    /data-workspace-close=/);
+    /data-workspace-package-close=/);
   assert.match(
     appSource,
-    /onClose: closeWorkspacePackage/);
+    /onClosePackage: closeWorkspacePackage/);
   assert.match(
     appSource,
-    /onSelect: selectWorkspacePacket,\s+onOpen: runHomeDemo/);
+    /onSelect: selectWorkspace,\s+onCreate: createWorkspace,\s+onRemove: removeWorkspace/);
+  assert.match(
+    appSource,
+    /activateDefaultWorkspaceForDemo\(\)/);
+  assert.match(
+    appSource,
+    /workspaceOperationIsCurrent\(/);
+  assert.match(
+    appSource,
+    /workspaceForHistory\(\s*state\.workspaceSession,\s*history\.state\)/);
+  assert.match(
+    appSource,
+    /function renderEmptyLiveWorkspace\([\s\S]*state\.spotlightOpen \? spotlight\.modalHtml\(\)[\s\S]*restorePackageQueryReturnFocus\(\);[\s\S]*restorePackageQueryWorkspaceFocus\(\)/);
+  assert.match(
+    appSource,
+    /function releasePackageModelCaches\([\s\S]*workspace\.id !== state\.workspaceSession\.selectedWorkspaceId[\s\S]*flatMap\(workspace => workspace\.packages\)[\s\S]*workspaceDependencyKey\(item\) === dependencyKey/);
+  assert.match(
+    appSource,
+    /function prepareLiveWorkspaceSurface\(\)[\s\S]*state\.queryNotice = "";[\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*failedWorkspaceUrlState = null/);
+  assert.match(
+    appSource,
+    /state\.package = null;[\s\S]*state\.workspaceSubjectOpen = true;[\s\S]*navigationHistory\.restore\(\{ stack: \[\], index: -1 \}\);[\s\S]*syncCurrentLiveWorkspace\(\)/);
   assert.match(
     appSource,
     /const key = assemblyId \|\| `legacy:\$\{asm\}`/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2957,12 +2957,15 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
   assert.match(
     indexSource,
     /id="package-query-announcement"[\s\S]*class="query-announcement"[\s\S]*role="alert"[\s\S]*aria-live="assertive"[\s\S]*aria-atomic="true"/);
+  assert.doesNotMatch(
+    appSource,
+    /workspaceHref: packageQueryWorkspace(?:Href|Url)\(\)/);
   assert.match(
     appSource,
-    /workspaceHref: packageQueryWorkspaceHref\(\)/);
+    /const canonicalWorkspaceHrefs = new Map<string, string>\(\);[\s\S]*function packageQueryWorkspaceUrl\(\): URL \{\s*const rememberedHref = rememberedLiveWorkspaceHref\(\s*state\.workspaceSession,\s*canonicalWorkspaceHrefs\);\s*if \(rememberedHref\) return new URL\(rememberedHref, location\.href\);[\s\S]*buildPackageRootStateUrl/);
   assert.match(
     appSource,
-    /const canonicalWorkspaceHrefs = new Map<string, string>\(\);[\s\S]*function packageQueryWorkspaceHref\(\): string \{\s*const rememberedHref = rememberedLiveWorkspaceHref\(\s*state\.workspaceSession,\s*canonicalWorkspaceHrefs\);\s*if \(rememberedHref\) return rememberedHref;[\s\S]*buildPackageRootStateUrl/);
+    /app\.innerHTML = renderPackageQueryView\([\s\S]*const workspaceUrl = packageQueryWorkspaceUrl\(\);\s*const workspaceLink =\s*document\.querySelector<HTMLAnchorElement>\("#package-query-workspace"\);\s*if \(workspaceLink\) \{\s*workspaceLink\.pathname = workspaceUrl\.pathname;\s*workspaceLink\.search = workspaceUrl\.search;\s*workspaceLink\.hash = workspaceUrl\.hash;/);
   assert.match(
     appSource,
     /const focusWorkspace = state\.packageQueryOpen;\s*if \(focusWorkspace\) \{\s*state\.packageQueryOpen = false;\s*packageQueryController\.cancel\(\);\s*state\.packageQueryNavigationError = "";\s*\}\s*const navigationSeq = navigationSequence\.begin\(\);\s*if \(focusWorkspace\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*workspaceLocation\.push/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2593,7 +2593,7 @@ test("canonical restoration is atomic and history adopts the active packet basis
   assert.match(sync, /state\.atPackageRoot/);
   assert.match(
     sync,
-    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*workspaceHistoryState\(\)\)/);
+    /const href = buildStateUrl\(\)\.toString\(\);\s*workspaceLocation\.replace\(href, workspaceHistoryState\(\)\);\s*rememberCanonicalWorkspaceHref\(href\)/);
   assert.match(
     stateUrl,
     /state\.atPackageRoot && state\.package[\s\S]*buildPackageRootStateUrl/);
@@ -2772,6 +2772,9 @@ test("home demos restore the complete parsed location", () => {
   assert.match(
     callGraphDemo,
     /state\.selectedTypeId = type\.id;\s*state\.atPackageRoot = false;\s*state\.lens = "api";\s*state\.packageLens = "overview";\s*resetMemberFilters\(\);\s*resetMemberSectionState\(\);\s*state\.platformStack = \[\];\s*state\.memberBrowseTypeId = type\.id;[\s\S]*state\.selectedMemberKey = member\.key;[\s\S]*state\.selectedOverloadIndex = overloadIndex;[\s\S]*state\.memberSection = "call-graph";[\s\S]*state\.memberCallGraph = result\.callGraph;[\s\S]*await renderMermaidCallGraph\(\)/);
+  assert.match(
+    callGraphDemo,
+    /state\.loading = false;\s*syncCurrentLiveWorkspace\(\);\s*pushCurrentWorkspaceLocation\(buildStateUrl\(\)\.toString\(\)\);\s*render\(\{ synchronizeUrl: false \}\)/);
   const platformHistory =
     appSource.match(/async function restorePlatformScopeThenDeepLink\([\s\S]*?\n}\n\n\/\/ Load and scope/)?.[0]
     ?? "";
@@ -2792,7 +2795,7 @@ test("lens-scoped Platform library changes reset type-specific member state", ()
     ?? "";
   assert.match(
     picker,
-    /originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const pack = selectedPack \|\| platformPackForAssembly\(key\);[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*\(\) => state\.packages\.includes\(originPackage\),[\s\S]*originPackage\.version\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openPlatformLensLibrary\([\s\S]*noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*lens === "integrations"[\s\S]*loadPackageIntegrations\(\)[\s\S]*lens === "opportunities"[\s\S]*loadPackageOpportunities\(\)[\s\S]*lens === "analysis"[\s\S]*loadPackagePerformance\(\)[\s\S]*loadPackageMetadata\(\)/);
+    /originPackage: AppPackage = currentPackage\(\),[\s\S]*noticeRetryState: NoticeRetryState \| null = null[\s\S]*if \(!state\.packages\.includes\(originPackage\)[\s\S]*!packageIdentityEquals\(state\.package, originPackage\)[\s\S]*state\.queryNoticeRetryAction === noticeRetryState\.action[\s\S]*state\.queryNotice = removeAppendedNotice\([\s\S]*state\.queryNoticeRetryAction = null;[\s\S]*const pack = selectedPack \|\| platformPackForAssembly\(key\);[\s\S]*const runtimeResult = await loadRuntimePackAssembly\([\s\S]*isCurrent,[\s\S]*originPackage\.version\);[\s\S]*const loaded = runtimeResult\.packageModel;[\s\S]*previous: state\.queryNotice[\s\S]*const retryAction = \(\) =>\s*openPlatformLensLibrary\([\s\S]*noticeState\);[\s\S]*runtimeResult\.failureMessage[\s\S]*noticeState\.appended = state\.queryNotice;[\s\S]*if \(!isCurrent\(\)\) return;[\s\S]*state\.libraryScope = new Set\(\[key\]\);[\s\S]*normalizeLibrarySelection\(\);[\s\S]*lens === "integrations"[\s\S]*loadPackageIntegrations\(\)[\s\S]*lens === "opportunities"[\s\S]*loadPackageOpportunities\(\)[\s\S]*lens === "analysis"[\s\S]*loadPackagePerformance\(\)[\s\S]*loadPackageMetadata\(\)/);
   assert.doesNotMatch(picker, /select\.isConnected/);
   assert.match(
     appSource,
@@ -2925,10 +2928,10 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /function focusTypeList\([\s\S]*afterCurrentNavigationFrame\(\(\) => \{[\s\S]*"#type-list"/);
   assert.match(
     appSource,
-    /workspaceLocation\.replace\(\s*buildStateUrl\(\)\.toString\(\),\s*workspaceHistoryState\(\)\)/);
+    /const href = buildStateUrl\(\)\.toString\(\);\s*workspaceLocation\.replace\(href, workspaceHistoryState\(\)\);\s*rememberCanonicalWorkspaceHref\(href\)/);
   assert.match(
     appSource,
-    /workspaceLocation\.sync\(snapshot, workspaceHistoryState\(\)\)/);
+    /const href = workspaceLocation\.build\(snapshot\)\.toString\(\);\s*workspaceLocation\.replace\(href, workspaceHistoryState\(\)\);\s*rememberCanonicalWorkspaceHref\(href\)/);
   assert.equal(
     appSource.match(
       /\? withScopeQuery\(state\.packageQueryState\.request, validPrefix\)/g)
@@ -2959,7 +2962,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /workspaceHref: packageQueryWorkspaceHref\(\)/);
   assert.match(
     appSource,
-    /function packageQueryWorkspaceHref\(\): string \{[\s\S]*lastCanonicalWorkspaceHref[\s\S]*buildPackageRootStateUrl/);
+    /const canonicalWorkspaceHrefs = new Map<string, string>\(\);[\s\S]*function packageQueryWorkspaceHref\(\): string \{\s*const rememberedHref = rememberedLiveWorkspaceHref\(\s*state\.workspaceSession,\s*canonicalWorkspaceHrefs\);\s*if \(rememberedHref\) return rememberedHref;[\s\S]*buildPackageRootStateUrl/);
   assert.match(
     appSource,
     /const focusWorkspace = state\.packageQueryOpen;\s*if \(focusWorkspace\) \{\s*state\.packageQueryOpen = false;\s*packageQueryController\.cancel\(\);\s*state\.packageQueryNavigationError = "";\s*\}\s*const navigationSeq = navigationSequence\.begin\(\);\s*if \(focusWorkspace\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*workspaceLocation\.push/);
@@ -5729,10 +5732,25 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /workspaceOperationIsCurrent\(/);
   assert.match(
     appSource,
+    /async function loadRuntimePack\([\s\S]*const operationWorkspaceId = state\.workspaceSession\.selectedWorkspaceId;\s*const operationNavigationSequence = navigationSequence\.current\(\);[\s\S]*navigationSequence\.isCurrent\(operationNavigationSequence\)[\s\S]*packageAcquisition\.loadRuntimePack\(/);
+  assert.match(
+    appSource,
+    /async function loadRuntimePackAssembly\([\s\S]*const operationWorkspaceId = state\.workspaceSession\.selectedWorkspaceId;\s*const operationNavigationSequence = navigationSequence\.current\(\);[\s\S]*navigationSequence\.isCurrent\(operationNavigationSequence\)[\s\S]*packageAcquisition\.loadRuntimePackAssembly\(/);
+  assert.match(
+    appSource,
     /workspaceForHistory\(\s*state\.workspaceSession,\s*history\.state\)/);
   assert.match(
     appSource,
+    /function pushCurrentWorkspaceLocation\(href: string\) \{\s*workspaceLocation\.push\(href, workspaceHistoryState\(null\)\);\s*rememberCanonicalWorkspaceHref\(href\);\s*\}[\s\S]*function selectWorkspace\([\s\S]*pushCurrentWorkspaceLocation\(currentWorkspaceLocation\(\)\)/);
+  assert.match(
+    appSource,
+    /function removeWorkspace\([\s\S]*canonicalWorkspaceHrefs\.delete\(removed\.id\);[\s\S]*pushCurrentWorkspaceLocation\(currentWorkspaceLocation\(\)\)/);
+  assert.match(
+    appSource,
     /function renderEmptyLiveWorkspace\([\s\S]*state\.spotlightOpen \? spotlight\.modalHtml\(\)[\s\S]*restorePackageQueryReturnFocus\(\);[\s\S]*restorePackageQueryWorkspaceFocus\(\)/);
+  assert.match(
+    appSource,
+    /if \(emptyWorkspace\) \{[\s\S]*syncCurrentLiveWorkspace\(\);\s*rememberCanonicalWorkspaceHref\(location\.href\);\s*render\(\{ synchronizeUrl: false \}\)/);
   assert.match(
     appSource,
     /function releasePackageModelCaches\([\s\S]*workspace\.id !== state\.workspaceSession\.selectedWorkspaceId[\s\S]*flatMap\(workspace => workspace\.packages\)[\s\S]*workspaceDependencyKey\(item\) === dependencyKey/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -5684,7 +5684,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /clearWorkspacePackages\(\);\s+render\(\);/);
   assert.match(
     appSource,
-    /if \(loc\.tabs\?\.length && !workspaceCoordinatesMatch\(state\.packages, loc\.tabs\)\) \{\s+observeAsync\(\s*restoreWorkspaceFromLocation/);
+    /if \(loc\.tabs\?\.length\s+&& !workspaceLocationMatchesPackageMembership\(loc, state\.packages\)\) \{\s+observeAsync\(\s*restoreWorkspaceFromLocation/);
   assert.match(
     appSource,
     /for \(const packageModel of discarded\)\s+releasePackageModelCaches\(packageModel\);/);
@@ -5765,7 +5765,10 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /workspaceForHistory\(\s*state\.workspaceSession,\s*history\.state\)/);
   assert.match(
     appSource,
-    /function historyRequestsStaleWorkspaceMembership\([\s\S]*workspaceHistoryMembershipStatus\(\s*state\.workspaceSession,\s*history\.state,[\s\S]*=== "stale"/);
+    /function workspaceLocationMatchesPackageMembership\([\s\S]*workspaceShareTabsMatchResolved\(\s*loc\.shareState\.tabs,\s*resolvedWorkspaceShareTabs\(packages\)\)[\s\S]*function historyRequestsStaleWorkspaceMembership\([\s\S]*workspaceHistoryMembershipStatus\(\s*state\.workspaceSession,\s*history\.state,\s*packages => workspaceLocationMatchesPackageMembership\(loc, packages\)\)[\s\S]*=== "stale"/);
+  assert.match(
+    appSource,
+    /const retainedTarget = workspaceLocationTargetPackage\(loc, state\.packages\);[\s\S]*if \(loc\.tabs\?\.length\) \{[\s\S]*activatePackage\(target, \{ resetAccessibility: true \}\);\s*\} else if \(loc\.package && retainedTarget\) \{\s*activatePackage\(retainedTarget, \{ resetAccessibility: true \}\);\s*\}[\s\S]*const samePackage = retainedTarget\s*\? state\.package === retainedTarget[\s\S]*else \{\s*observeAsync\(\s*loadPackage\(loc\.package/);
   assert.match(
     appSource,
     /function reconcileLiveWorkspaceHistoryMembership\(\) \{[\s\S]*workspaceLocation\.replace\(href, workspaceHistoryState\(history\.state\)\);[\s\S]*syncCurrentLiveWorkspace\(\);[\s\S]*render\(\{ synchronizeUrl: false \}\)/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2648,7 +2648,7 @@ test("malformed package routes use the contained restore failure path", () => {
     ?? "";
   assert.match(
     popstate,
-    /if \(loc\.routeFailure\) \{\s*failWorkspaceRoute\(loc\.routeFailure\.message\);\s*return;\s*\}\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}\s*const canonicalSnapshot = loc\.hasWorkspaceState[\s\S]*state\.queryNotice = loc\.workspaceNotice \|\| "";[\s\S]*const emptyWorkspace[\s\S]*const bareHome/);
+    /if \(loc\.routeFailure\) \{\s*failWorkspaceRoute\(loc\.routeFailure\.message\);\s*return;\s*\}\s*if \(historyRequestsStaleWorkspaceMembership\(loc\)\) \{\s*reconcileLiveWorkspaceHistoryMembership\(\);\s*return;\s*\}\s*if \(!clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}\s*const canonicalSnapshot = loc\.hasWorkspaceState[\s\S]*state\.queryNotice = loc\.workspaceNotice \|\| "";[\s\S]*const emptyWorkspace[\s\S]*const bareHome/);
 
   const failure = appSource.match(
     /function failWorkspaceRoute\([\s\S]*?\n}\n\nfunction failCanonicalWorkspaceRestore/)?.[0]
@@ -5732,6 +5732,30 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /workspaceOperationIsCurrent\(/);
   assert.match(
     appSource,
+    /createWorkspaceProjectionTransactionController\(\s*\(\) => state\.workspaceSession,[\s\S]*currentPackages: \(\) => state\.packages,[\s\S]*synchronize: syncCurrentLiveWorkspace,[\s\S]*restore: adoptLiveWorkspaceProjection,[\s\S]*release: releasePackageModelCaches/);
+  assert.match(
+    appSource,
+    /const navigationSequence = createNavigationSequence\(\s*\(\) => workspaceProjectionTransactions\.abandon\(\)\)/);
+  assert.match(
+    appSource,
+    /function syncCurrentLiveWorkspace\(\) \{\s*if \(workspaceProjectionTransactions\s*\.blocksSelectedWorkspaceSynchronization\(\)\) \{\s*return;/);
+  assert.match(
+    appSource,
+    /beginWorkspaceProjectionTransaction\(operationOwner\);\s*try \{\s*await restoreWorkspaceProjection\([\s\S]*finally \{\s*if \(workspaceProjectionTransactionMatches\(operationOwner\)\) \{\s*workspaceProjectionTransactions\.abandon\(\)/);
+  assert.match(
+    appSource,
+    /commitWorkspaceShareBasis\(loc\.shareState\);\s*state\.loading = false;\s*if \(!commitWorkspaceProjectionTransaction\(operationOwner\)\) return;\s*render\(\)/);
+  assert.match(
+    appSource,
+    /function selectWorkspace\([\s\S]*navigationSequence\.begin\(\);\s*const workspace = adoptWorkspace\(workspaceId\)/);
+  assert.match(
+    appSource,
+    /function createWorkspace\(\): void \{[\s\S]*navigationSequence\.begin\(\);\s*syncCurrentLiveWorkspace\(\)/);
+  assert.match(
+    appSource,
+    /function removeWorkspace\([\s\S]*navigationSequence\.begin\(\);\s*syncCurrentLiveWorkspace\(\)/);
+  assert.match(
+    appSource,
     /async function loadRuntimePack\([\s\S]*const operationWorkspaceId = state\.workspaceSession\.selectedWorkspaceId;\s*const operationNavigationSequence = navigationSequence\.current\(\);[\s\S]*navigationSequence\.isCurrent\(operationNavigationSequence\)[\s\S]*packageAcquisition\.loadRuntimePack\(/);
   assert.match(
     appSource,
@@ -5739,6 +5763,12 @@ test("workspace UI routes replacements and restore notices through bounded paths
   assert.match(
     appSource,
     /workspaceForHistory\(\s*state\.workspaceSession,\s*history\.state\)/);
+  assert.match(
+    appSource,
+    /function historyRequestsStaleWorkspaceMembership\([\s\S]*workspaceHistoryMembershipStatus\(\s*state\.workspaceSession,\s*history\.state,[\s\S]*=== "stale"/);
+  assert.match(
+    appSource,
+    /function reconcileLiveWorkspaceHistoryMembership\(\) \{[\s\S]*workspaceLocation\.replace\(href, workspaceHistoryState\(history\.state\)\);[\s\S]*syncCurrentLiveWorkspace\(\);[\s\S]*render\(\{ synchronizeUrl: false \}\)/);
   assert.match(
     appSource,
     /function pushCurrentWorkspaceLocation\(href: string\) \{\s*workspaceLocation\.push\(href, workspaceHistoryState\(null\)\);\s*rememberCanonicalWorkspaceHref\(href\);\s*\}[\s\S]*function selectWorkspace\([\s\S]*pushCurrentWorkspaceLocation\(currentWorkspaceLocation\(\)\)/);

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -33,6 +33,12 @@ import type {
   BrowserWorkspaceShareEncodeResult,
   BrowserWorkspaceShareState,
 } from "../src/inspect-web-engine.d.ts";
+import {
+  createLiveWorkspaceSession,
+  updateSelectedLiveWorkspace,
+  withWorkspaceHistoryId,
+  workspaceHistoryMembershipStatus,
+} from "../src/workspace-session.ts";
 
 interface TestView {
   id: string;
@@ -605,6 +611,55 @@ test("canonical tabs must remain distinct and ordered after resolution", () => {
       requested,
       [resolved[1]!, resolved[0]!]),
     false);
+});
+
+test("floating canonical tabs match their resolved live Workspace membership", () => {
+  const floating = workspaceState({
+    tabs: [
+      {
+        id: "t0",
+        kind: "package",
+        source: "Example.First",
+        version: null,
+        framework: "net10.0",
+        runtimeIdentifier: null,
+      },
+      {
+        id: "t1",
+        kind: "group",
+        source: ":Platform",
+        version: null,
+        framework: null,
+        runtimeIdentifier: null,
+      },
+    ],
+  });
+  const parsed = parseWorkspaceLocation(
+    locationSnapshot("https://inspect.example/?w=floating"),
+    () => decoded(floating));
+  const resolved = floating.tabs.map(tab => ({
+    ...tab,
+    version: tab.version ?? "10.0.10",
+    framework: tab.framework ?? "net10.0",
+  }));
+  const session =
+    createLiveWorkspaceSession<BrowserWorkspaceShareState["tabs"][number]>(
+      "default-id");
+  updateSelectedLiveWorkspace(session, {
+    packages: resolved,
+    activePackageKey: "t1",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+
+  assert.ok(parsed.shareState);
+  assert.equal(
+    workspaceHistoryMembershipStatus(
+      session,
+      withWorkspaceHistoryId(null, "default-id"),
+      packages =>
+        workspaceShareTabsMatchResolved(parsed.shareState!.tabs, packages)),
+    "current");
 });
 
 test("missing Platform reacquisition retains only an aligned canonical pin", () => {

--- a/prototypes/inspect-web/test/workspace-navigation.test.ts
+++ b/prototypes/inspect-web/test/workspace-navigation.test.ts
@@ -320,14 +320,18 @@ test("navigation history restores a pre-activation transaction snapshot", () => 
 });
 
 test("navigation sequence has one monotonic cancellation authority", () => {
-  const sequence = createNavigationSequence();
+  let superseded = 0;
+  const sequence = createNavigationSequence(() => superseded++);
   assert.equal(sequence.current(), 0);
   const first = sequence.begin();
+  assert.equal(superseded, 1);
   assert.equal(sequence.isCurrent(first), true);
   const second = sequence.begin();
+  assert.equal(superseded, 2);
   assert.equal(sequence.isCurrent(first), false);
   assert.equal(sequence.isCurrent(second), true);
   sequence.invalidate();
+  assert.equal(superseded, 3);
   assert.equal(sequence.isCurrent(second), false);
   assert.equal(sequence.current(), 3);
 });

--- a/prototypes/inspect-web/test/workspace-session.test.ts
+++ b/prototypes/inspect-web/test/workspace-session.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { createNavigationSequence } from "../src/workspace-navigation.ts";
 import {
+  createWorkspaceProjectionTransactionController,
   createLiveWorkspace,
   createLiveWorkspaceSession,
   defaultLiveWorkspace,
@@ -13,6 +15,7 @@ import {
   withWorkspaceHistoryId,
   workspaceForHistory,
   workspaceHistoryId,
+  workspaceHistoryMembershipStatus,
   workspaceOperationIsCurrent,
 } from "../src/workspace-session.ts";
 
@@ -94,6 +97,178 @@ test("an empty Workspace retains its session-only canonical return route", () =>
   assert.equal(
     rememberedLiveWorkspaceHref(session, new Map()),
     null);
+});
+
+test("history cannot restore stale membership into an associated live Workspace", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["Package.A", "Package.B"],
+    activePackageKey: "Package.A",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  const associated = withWorkspaceHistoryId(null, "default-id");
+
+  assert.equal(
+    workspaceHistoryMembershipStatus(
+      session,
+      associated,
+      ["Package.A"],
+      value => value,
+      false),
+    "current");
+  assert.equal(
+    workspaceHistoryMembershipStatus(
+      session,
+      associated,
+      ["Package.A"],
+      value => value,
+      true),
+    "stale");
+  assert.equal(
+    workspaceHistoryMembershipStatus(
+      session,
+      associated,
+      ["Package.Closed"],
+      value => value,
+      false),
+    "stale");
+  assert.equal(
+    workspaceHistoryMembershipStatus(
+      session,
+      withWorkspaceHistoryId(null, "unknown"),
+      ["Package.Closed"],
+      value => value,
+      false),
+    "unassociated");
+});
+
+test("superseded restoration abandons its transient Workspace projection", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["Stable.Package"],
+    activePackageKey: "Stable.Package",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  let visiblePackages = ["Stable.Package"];
+  const released: string[] = [];
+  const transactions = createWorkspaceProjectionTransactionController(
+    () => session,
+    {
+      currentPackages: () => visiblePackages,
+      synchronize: () => {
+        updateSelectedLiveWorkspace(session, {
+          packages: visiblePackages,
+          activePackageKey: visiblePackages[0] ?? null,
+          shareBasis: null,
+          navigation: { stack: [], index: -1 },
+        });
+      },
+      restore: workspace => {
+        visiblePackages = [...workspace.packages];
+      },
+      release: packageModel => released.push(packageModel),
+    });
+  const sequence = createNavigationSequence(() => transactions.abandon());
+  const restorationSequence = sequence.begin();
+  const owner = {
+    workspaceId: session.selectedWorkspaceId,
+    navigationSequence: restorationSequence,
+  };
+  transactions.begin(owner);
+  visiblePackages = ["Partially.Loaded"];
+
+  assert.equal(transactions.blocksSelectedWorkspaceSynchronization(), true);
+  sequence.begin();
+
+  assert.deepEqual(visiblePackages, ["Stable.Package"]);
+  assert.deepEqual(selectedLiveWorkspace(session).packages, ["Stable.Package"]);
+  assert.deepEqual(released, ["Partially.Loaded"]);
+  assert.equal(transactions.commit(owner), false);
+});
+
+test("restoration transactions follow a replaced Workspace session", () => {
+  let session = createLiveWorkspaceSession<string>("original-default");
+  let visiblePackages = ["Original.Package"];
+  const released: string[] = [];
+  const transactions = createWorkspaceProjectionTransactionController(
+    () => session,
+    {
+      currentPackages: () => visiblePackages,
+      synchronize: () => {
+        updateSelectedLiveWorkspace(session, {
+          packages: visiblePackages,
+          activePackageKey: visiblePackages[0] ?? null,
+          shareBasis: null,
+          navigation: { stack: [], index: -1 },
+        });
+      },
+      restore: workspace => {
+        visiblePackages = [...workspace.packages];
+      },
+      release: packageModel => released.push(packageModel),
+    });
+
+  session = createLiveWorkspaceSession<string>("restored-default");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["Restored.Package"],
+    activePackageKey: "Restored.Package",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  const owner = {
+    workspaceId: session.selectedWorkspaceId,
+    navigationSequence: 4,
+  };
+  transactions.begin(owner);
+  visiblePackages = ["Partially.Loaded"];
+
+  assert.equal(transactions.blocksSelectedWorkspaceSynchronization(), true);
+  transactions.abandon();
+
+  assert.deepEqual(visiblePackages, ["Restored.Package"]);
+  assert.deepEqual(released, ["Partially.Loaded"]);
+});
+
+test("committed restoration releases the replaced Workspace projection", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["Replaced.Package"],
+    activePackageKey: "Replaced.Package",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  let visiblePackages = ["Replacement.Package"];
+  const released: string[] = [];
+  const transactions = createWorkspaceProjectionTransactionController(
+    () => session,
+    {
+      currentPackages: () => visiblePackages,
+      synchronize: () => {
+        updateSelectedLiveWorkspace(session, {
+          packages: visiblePackages,
+          activePackageKey: visiblePackages[0] ?? null,
+          shareBasis: null,
+          navigation: { stack: [], index: -1 },
+        });
+      },
+      restore: workspace => {
+        visiblePackages = [...workspace.packages];
+      },
+      release: packageModel => released.push(packageModel),
+    });
+  const owner = {
+    workspaceId: session.selectedWorkspaceId,
+    navigationSequence: 3,
+  };
+  transactions.begin(owner);
+
+  assert.equal(transactions.commit(owner), true);
+  assert.deepEqual(
+    selectedLiveWorkspace(session).packages,
+    ["Replacement.Package"]);
+  assert.deepEqual(released, ["Replaced.Package"]);
 });
 
 test("late operations cannot mutate a newly selected Workspace", () => {

--- a/prototypes/inspect-web/test/workspace-session.test.ts
+++ b/prototypes/inspect-web/test/workspace-session.test.ts
@@ -5,6 +5,7 @@ import {
   createLiveWorkspace,
   createLiveWorkspaceSession,
   defaultLiveWorkspace,
+  rememberedLiveWorkspaceHref,
   removeLiveWorkspace,
   selectLiveWorkspace,
   selectedLiveWorkspace,
@@ -79,6 +80,20 @@ test("browser history preserves Workspace association without dropping other sta
       session,
       withWorkspaceHistoryId(null, "unknown-id")).id,
     "default-id");
+});
+
+test("an empty Workspace retains its session-only canonical return route", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  const canonicalHrefs = new Map([
+    ["default-id", "https://example.test/#workspace"],
+  ]);
+
+  assert.equal(
+    rememberedLiveWorkspaceHref(session, canonicalHrefs),
+    "https://example.test/#workspace");
+  assert.equal(
+    rememberedLiveWorkspaceHref(session, new Map()),
+    null);
 });
 
 test("late operations cannot mutate a newly selected Workspace", () => {

--- a/prototypes/inspect-web/test/workspace-session.test.ts
+++ b/prototypes/inspect-web/test/workspace-session.test.ts
@@ -113,33 +113,27 @@ test("history cannot restore stale membership into an associated live Workspace"
     workspaceHistoryMembershipStatus(
       session,
       associated,
-      ["Package.A"],
-      value => value,
-      false),
+      packages => packages.includes("Package.A")),
     "current");
   assert.equal(
     workspaceHistoryMembershipStatus(
       session,
       associated,
-      ["Package.A"],
-      value => value,
-      true),
+      packages =>
+        packages.length === 1
+        && packages[0] === "Package.A"),
     "stale");
   assert.equal(
     workspaceHistoryMembershipStatus(
       session,
       associated,
-      ["Package.Closed"],
-      value => value,
-      false),
+      packages => packages.includes("Package.Closed")),
     "stale");
   assert.equal(
     workspaceHistoryMembershipStatus(
       session,
       withWorkspaceHistoryId(null, "unknown"),
-      ["Package.Closed"],
-      value => value,
-      false),
+      packages => packages.includes("Package.Closed")),
     "unassociated");
 });
 

--- a/prototypes/inspect-web/test/workspace-session.test.ts
+++ b/prototypes/inspect-web/test/workspace-session.test.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createLiveWorkspace,
+  createLiveWorkspaceSession,
+  defaultLiveWorkspace,
+  removeLiveWorkspace,
+  selectLiveWorkspace,
+  selectedLiveWorkspace,
+  updateSelectedLiveWorkspace,
+  withWorkspaceHistoryId,
+  workspaceForHistory,
+  workspaceHistoryId,
+  workspaceOperationIsCurrent,
+} from "../src/workspace-session.ts";
+
+test("live Workspace session starts with one Default workspace", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+
+  assert.equal(session.workspaces.length, 1);
+  assert.equal(selectedLiveWorkspace(session).name, "Default");
+  assert.equal(defaultLiveWorkspace(session).id, "default-id");
+});
+
+test("created Workspaces retain isolated projections and can be removed", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["System.Text.Json"],
+    activePackageKey: "System.Text.Json",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+  const created = createLiveWorkspace(session, "extensions-id");
+  assert.equal(created?.name, "Workspace 2");
+  updateSelectedLiveWorkspace(session, {
+    packages: ["Microsoft.Extensions.DependencyInjection"],
+    activePackageKey: "Microsoft.Extensions.DependencyInjection",
+    shareBasis: null,
+    navigation: { stack: [], index: -1 },
+  });
+
+  assert.deepEqual(defaultLiveWorkspace(session).packages, ["System.Text.Json"]);
+  assert.deepEqual(selectedLiveWorkspace(session).packages, [
+    "Microsoft.Extensions.DependencyInjection",
+  ]);
+  assert.equal(removeLiveWorkspace(session, "extensions-id")?.id, "extensions-id");
+  assert.equal(selectedLiveWorkspace(session).id, "default-id");
+  assert.equal(removeLiveWorkspace(session, "default-id"), null);
+});
+
+test("session allows at most four live Workspaces", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  assert.ok(createLiveWorkspace(session, "two"));
+  assert.ok(createLiveWorkspace(session, "three"));
+  assert.ok(createLiveWorkspace(session, "four"));
+  assert.equal(createLiveWorkspace(session, "five"), null);
+});
+
+test("browser history preserves Workspace association without dropping other state", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  createLiveWorkspace(session, "second-id");
+  const state = withWorkspaceHistoryId({ entry: "history-id" }, "workspace-id");
+
+  assert.deepEqual(state, {
+    entry: "history-id",
+    dotnetInspectWorkspaceId: "workspace-id",
+  });
+  assert.equal(workspaceHistoryId(state), "workspace-id");
+  assert.equal(workspaceHistoryId({ dotnetInspectWorkspaceId: "" }), null);
+  assert.equal(
+    workspaceForHistory(
+      session,
+      withWorkspaceHistoryId(null, "second-id")).id,
+    "second-id");
+  assert.equal(workspaceForHistory(session, null).id, "default-id");
+  assert.equal(
+    workspaceForHistory(
+      session,
+      withWorkspaceHistoryId(null, "unknown-id")).id,
+    "default-id");
+});
+
+test("late operations cannot mutate a newly selected Workspace", () => {
+  const session = createLiveWorkspaceSession<string>("default-id");
+  const owner = {
+    workspaceId: session.selectedWorkspaceId,
+    navigationSequence: 7,
+  };
+  createLiveWorkspace(session, "extensions-id");
+
+  assert.equal(workspaceOperationIsCurrent(session, owner, 7), false);
+  assert.equal(selectLiveWorkspace(session, "default-id")?.id, "default-id");
+  assert.equal(workspaceOperationIsCurrent(session, owner, 8), false);
+  assert.equal(workspaceOperationIsCurrent(session, owner, 7), true);
+});

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -2,12 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace,
   renderWorkspaceSubject,
-  retainWorkspacePacket,
+  renderWorkspaceView,
+  type WorkspaceSummary,
 } from "../src/workspace-subject.ts";
-import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import type { PackageControlPackage } from "../src/package-controls.ts";
 import { fakeDom } from "./fake-dom.ts";
 
@@ -23,205 +22,196 @@ function packageIdentityKey(pkg: PackageControlPackage) {
   return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
 }
 
-const packet: BrowserHomeDemoResolved = {
-  id: "stj-serialize-callgraph",
-  title: "Serialize call graph",
-  summary: "Dense package-local STJ graph",
-  workspaceMembers: [{
-    kind: "package",
-    id: "System.Text.Json",
-    version: "10.0.0",
-    framework: "net10.0",
-    assembly: null,
-  }],
-  tabs: [{
-    id: "stj",
-    member: {
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    },
-  }],
-  focusTabIndex: 0,
-  view: {
-    library: null,
-    type: "System.Text.Json.JsonSerializer",
-    memberAnchor: "1dc14dd1fb",
-    memberKey: "method:Serialize",
-    section: "Call Graph",
-  },
+const stj: PackageControlPackage = {
+  id: "System.Text.Json",
+  version: "10.0.0",
+  activeFramework: "net10.0",
+  isRuntimePack: false,
+};
+const extensions: PackageControlPackage = {
+  id: "Microsoft.Extensions.DependencyInjection",
+  version: "10.0.0",
+  activeFramework: "net10.0",
+  isRuntimePack: false,
+};
+const platform: PackageControlPackage = {
+  id: "Microsoft.NETCore.App",
+  version: "10.0.0",
+  activeFramework: "net10.0",
+  isRuntimePack: true,
 };
 
-test("Workspace lists independently selectable packets", () => {
-  const sibling = {
-    ...packet,
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-    summary: "STJ number parse path",
-    view: {
-      ...packet.view,
-      type: "System.Text.Json.JsonElement",
-      memberKey: "method:GetDecimal",
-    },
+function workspace(
+  overrides: Partial<WorkspaceSummary<PackageControlPackage>> = {},
+): WorkspaceSummary<PackageControlPackage> {
+  return {
+    id: "default",
+    name: "Default",
+    isDefault: true,
+    packages: [stj],
+    activePackageKey: packageIdentityKey(stj),
+    ...overrides,
   };
+}
 
+test("Workspace inventory lists every live workspace and inferred packages", () => {
   const html = renderWorkspaceSubject({
-    packets: [packet, sibling],
-    selectedPacketId: packet.id,
+    workspaces: [
+      workspace(),
+      workspace({
+        id: "extensions",
+        name: "Workspace 2",
+        isDefault: false,
+        packages: [extensions, platform],
+        activePackageKey: packageIdentityKey(extensions),
+      }),
+    ],
+    selectedWorkspaceId: "extensions",
+    maximumWorkspaces: 4,
     escapeHtml,
   });
 
-  assert.match(html, /WORKSPACE PACKETS[\s\S]*2/);
-  assert.match(html, /workspace-packet active/);
-  assert.match(html, /Serialize call graph[\s\S]*Dense package-local STJ graph/);
-  assert.match(html, /JsonElement\.GetDecimal[\s\S]*STJ number parse path/);
-  assert.doesNotMatch(html, /data-workspace-open/);
+  assert.match(html, /WORKSPACES[\s\S]*2/);
+  assert.match(html, /data-workspace="default"[\s\S]*Default[\s\S]*System\.Text\.Json/);
+  assert.match(html, /workspace-card active[\s\S]*Workspace 2/);
+  assert.match(html, /Microsoft\.Extensions\.DependencyInjection \+ 1/);
+  assert.match(html, /data-workspace-create/);
+  assert.doesNotMatch(html, /workspace packet/i);
 });
 
-test("Workspace packet retention keys scenarios independently of coordinates", () => {
-  const sibling = {
-    ...packet,
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-  };
-  const retained = retainWorkspacePacket(
-    retainWorkspacePacket([], packet),
-    sibling);
+test("Workspace inventory disables creation at the session limit", () => {
+  const html = renderWorkspaceSubject({
+    workspaces: [
+      workspace(),
+      workspace({ id: "two", name: "Workspace 2", isDefault: false }),
+      workspace({ id: "three", name: "Workspace 3", isDefault: false }),
+      workspace({ id: "four", name: "Workspace 4", isDefault: false }),
+    ],
+    selectedWorkspaceId: "default",
+    maximumWorkspaces: 4,
+    escapeHtml,
+  });
 
-  assert.deepEqual(
-    retained.map(item => item.id),
-    ["stj-serialize-callgraph", "stj-getdecimal-callgraph"]);
-  assert.deepEqual(
-    retained.map(item => item.workspaceMembers),
-    [packet.workspaceMembers, packet.workspaceMembers]);
+  assert.match(html, /data-workspace-create disabled/);
 });
 
-test("Workspace packet details distinguish packet data from loaded coordinates", () => {
-  const active: PackageControlPackage = {
-    id: "System.Text.Json",
-    version: "10.0.0",
-    activeFramework: "net10.0",
-    isRuntimePack: false,
-  };
-  const platform: PackageControlPackage = {
-    id: "Microsoft.NETCore.App",
-    version: "10.0.0",
-    activeFramework: "net10.0",
-    isRuntimePack: true,
-  };
-
-  const html = renderWorkspacePacketView({
-    packet,
-    packages: [platform, active],
-    activePackage: active,
+test("Workspace details show live coordinates and remove only non-default workspaces", () => {
+  const nonDefault = workspace({
+    id: "extensions",
+    name: "Workspace 2",
+    isDefault: false,
+    packages: [platform, extensions],
+    activePackageKey: packageIdentityKey(extensions),
+  });
+  const html = renderWorkspaceView({
+    workspace: nonDefault,
+    escapeHtml,
+    packageIdentityKey,
+  });
+  const defaultHtml = renderWorkspaceView({
+    workspace: workspace(),
     escapeHtml,
     packageIdentityKey,
   });
 
-  assert.match(html, /Workspace packet[\s\S]*Serialize call graph/);
-  assert.match(html, /Packet workspace[\s\S]*System\.Text\.Json/);
-  assert.match(html, /Initial view[\s\S]*Call Graph[\s\S]*method:Serialize/);
-  assert.match(html, /Loaded workspace[\s\S]*Microsoft\.NETCore\.App/);
-  assert.match(html, /data-workspace-open="stj-serialize-callgraph"/);
-  assert.match(html, />Open workspace</);
+  assert.match(html, /Inspection workspace[\s\S]*Workspace 2/);
+  assert.match(html, /Microsoft\.NETCore\.App[\s\S]*Microsoft\.Extensions\.DependencyInjection/);
+  assert.match(html, /data-workspace-remove="extensions"/);
+  assert.match(html, /aria-label="Close Microsoft\.Extensions\.DependencyInjection 10\.0\.0 net10\.0"/);
+  assert.doesNotMatch(html, /Close Microsoft\.NETCore\.App/);
+  assert.doesNotMatch(defaultHtml, /data-workspace-remove/);
 });
 
-test("Workspace selection, explicit Open, and Close dispatch separate identities", () => {
+test("Empty workspace remains a visible analysis destination", () => {
+  const html = renderWorkspaceView({
+    workspace: workspace({
+      id: "empty",
+      name: "Workspace 2",
+      isDefault: false,
+      packages: [],
+      activePackageKey: null,
+    }),
+    escapeHtml,
+    packageIdentityKey,
+  });
+
+  assert.match(html, /Workspace 2[\s\S]*No packages loaded/);
+  assert.match(html, /ready for packages/);
+  assert.match(html, /No packages are loaded in this workspace/);
+});
+
+test("Workspace selection, creation, removal, and package close dispatch separately", () => {
   const listeners = new Map<string, EventListener>();
-  const select = {
-    dataset: { workspacePacket: "packet-key" },
-    addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`select:${name}`, listener),
-  };
-  const open = {
-    dataset: { workspaceOpen: "open-key" },
-    addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`open:${name}`, listener),
-  };
-  const close = {
-    dataset: { workspaceClose: "close-key" },
-    addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`close:${name}`, listener),
+  const elements = {
+    select: {
+      dataset: { workspace: "workspace-key" },
+      addEventListener: (name: string, listener: EventListener) =>
+        listeners.set(`select:${name}`, listener),
+    },
+    create: {
+      dataset: {},
+      addEventListener: (name: string, listener: EventListener) =>
+        listeners.set(`create:${name}`, listener),
+    },
+    remove: {
+      dataset: { workspaceRemove: "remove-key" },
+      addEventListener: (name: string, listener: EventListener) =>
+        listeners.set(`remove:${name}`, listener),
+    },
+    close: {
+      dataset: { workspacePackageClose: "package-key" },
+      addEventListener: (name: string, listener: EventListener) =>
+        listeners.set(`close:${name}`, listener),
+    },
   };
   const root = {
     querySelectorAll: (selector: string) =>
-      selector === "[data-workspace-packet]"
-        ? [select]
-        : selector === "[data-workspace-open]"
-          ? [open]
-          : [close],
+      selector === "[data-workspace]"
+        ? [elements.select]
+        : selector === "[data-workspace-create]"
+          ? [elements.create]
+          : selector === "[data-workspace-remove]"
+            ? [elements.remove]
+            : [elements.close],
   };
   const calls: string[] = [];
 
-  bindWorkspaceSubject(
-    fakeDom.parentNode(root),
-    {
-      onSelect: key => calls.push(`select:${key}`),
-      onOpen: key => calls.push(`open:${key}`),
-      onClose: key => calls.push(`close:${key}`),
-    });
+  bindWorkspaceSubject(fakeDom.parentNode(root), {
+    onSelect: key => calls.push(`select:${key}`),
+    onCreate: () => calls.push("create"),
+    onRemove: key => calls.push(`remove:${key}`),
+    onClosePackage: key => calls.push(`close:${key}`),
+  });
 
   listeners.get("select:click")?.(fakeDom.event());
-  listeners.get("open:click")?.(fakeDom.event());
+  listeners.get("create:click")?.(fakeDom.event());
+  listeners.get("remove:click")?.(fakeDom.event());
   listeners.get("close:click")?.(fakeDom.event());
   assert.deepEqual(calls, [
-    "select:packet-key",
-    "open:open-key",
-    "close:close-key",
+    "select:workspace-key",
+    "create",
+    "remove:remove-key",
+    "close:package-key",
   ]);
 });
 
-test("Workspace Close names distinguish matching package ids", () => {
-  const packages: PackageControlPackage[] = [
-    {
-      id: "Example.Package",
-      version: "1.0.0",
-      activeFramework: "net8.0",
-      isRuntimePack: false,
-    },
-    {
-      id: "Example.Package",
-      version: "2.0.0",
-      activeFramework: "net10.0",
-      isRuntimePack: false,
-    },
-  ];
-
-  const html = renderWorkspacePacketView({
-    packet: null,
-    packages,
-    activePackage: packages[0] ?? null,
-    escapeHtml,
-    packageIdentityKey,
-  });
-
-  assert.match(html, /aria-label="Close Example\.Package 1\.0\.0 net8\.0"/);
-  assert.match(html, /aria-label="Close Example\.Package 2\.0\.0 net10\.0"/);
-});
-
-test("Workspace packet focus survives observational selection", () => {
+test("Workspace focus follows selection", () => {
   let focused = "";
   const root = {
     querySelectorAll: () => [{
-      dataset: { workspacePacket: "first" },
+      dataset: { workspace: "first" },
       focus: () => {
         focused = "first";
       },
     }, {
-      dataset: { workspacePacket: "second" },
+      dataset: { workspace: "second" },
       focus: () => {
         focused = "second";
       },
     }],
   };
 
-  assert.equal(
-    focusWorkspacePacket(fakeDom.parentNode(root), "second"),
-    true);
+  assert.equal(focusWorkspace(fakeDom.parentNode(root), "second"), true);
   assert.equal(focused, "second");
-  assert.equal(
-    focusWorkspacePacket(fakeDom.parentNode(root), "missing"),
-    false);
+  assert.equal(focusWorkspace(fakeDom.parentNode(root), "missing"), false);
 });


### PR DESCRIPTION
Build robust, capable Inspect Web features that provide foundational capabilities or compelling user experiences while remaining conventionally sound, delightfully new, or both.

This change replaces the demo-packet interpretation of the Workspace surface with a bounded collection of live browser-session Workspaces. Every Workspace remains visible, derives its presentation from its actual loaded packages, and retains isolated package, navigation, share, history, and asynchronous-operation ownership.

- Start with one non-removable `Default` Workspace and allow creation of up to three additional Workspaces.
- Select, inspect, and remove live Workspaces without acquisition; closing the final package keeps an empty Workspace at `/#workspace`.
- Route ordinary package opening to the selected Workspace and replace only `Default` when running product demos.
- Associate browser history, canonical return URLs, and deferred package/runtime work with the originating Workspace and navigation generation.
- Keep inactive Workspace projections and shared caches resident while resetting Workspace-local object-reference state.
- Preserve browser-session records as the clean boundary for future persistence without claiming product Workspace identity or cross-session storage.

## Demo

1. Open System.Text.Json in `Default`.
2. Create `Workspace 2`, load Microsoft.Extensions packages, and switch back to `Default`.
3. Create another Workspace for Aspire packages.
4. Open Workspace from the subject strip to see every live Workspace, its loaded coordinates, active package, and close/remove actions.
5. Run a product demo and observe that it replaces `Default` without creating another Workspace row or mutating a user-created Workspace.

![Live Workspace inventory and inferred package details](https://github.com/user-attachments/assets/1e4094cd-785f-4aec-9bf0-220f6b89e186)

The selected Workspace name appears in the inspected-target path. Empty Workspaces remain first-class destinations with Search, settings, notices, and package-query focus restoration.

## Validation

- `npm test` — 989 frontend tests
- `npm run analyze` — lint, HTML validation, and Knip
- `npm run build` — production frontend bundle
- `npm run test:browser -- workspace-titlebar.spec.ts` — 31 Firefox tests
- `npx markdownlint-cli docs/design/inspect-web-navigation-consumer.md docs/design/inspect-web-navigation-presentation.md prototypes/inspect-web/README.md`

The Browser gate uses the production Workspace collection and renderer/binder helpers; composition-root assertions pin transactional restoration, live-membership-authoritative history, per-Workspace canonical return URLs, demo history commits, cache ownership, and Workspace/navigation generation authority. This frontend-only slice does not change .NET product or engine code.

Closes #5604.
