### PR TITLE
Update Markout to 0.36.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Markout" Version="0.35.2" />
+    <PackageVersion Include="Markout" Version="0.36.0" />
     <PackageVersion Include="Markout.Templates" Version="0.3.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.1" />


### PR DESCRIPTION
## Summary

Adopt the published Markout 0.36.0 package so dotnet-inspect can consume the new `MappedTextDiff` presentation contract in #5527.

- Update the centrally managed `Markout` version from 0.35.2 to 0.36.0.
- Leave `Markout.Templates` unchanged at 0.3.2.
- Make no product behavior change in this package-only handoff.

## Demo

```diff
-<PackageVersion Include="Markout" Version="0.35.2" />
+<PackageVersion Include="Markout" Version="0.36.0" />
```

NuGet restored the released package successfully across all three consuming project paths.

## Compatibility and boundaries

This is the package boundary between the completed Markout implementation and the dotnet-inspect Source Diff adoption. It does not yet change Source Diff output or introduce a local project reference.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release` — 5,281 tests, 33 skipped
- `dotnet run --project tests/DotnetInspector.MetadataRendering.Tests -c Release` — 187 tests
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 6,239 tests, 8 skipped
- Total: 11,707 passed, 0 failed