### PR TITLE
Preserve coordinated artifact release authority

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -307,12 +307,15 @@ workspace-owned group objects whose participants carry registrations minted by
 that session. Ownership transfer requires the complete set of current dependent
 groups; later admission remains available for unrelated work but rejects a new
 group projected from that transferred session. It observes only those groups'
-owner-issued release receipts; an unrelated, foreign, or incomplete group set
-cannot authorize release. Cleanup failures compose with, and never replace,
-group cleanup results in the workspace close report. If coordinated group close
-or its synchronous release request faults, artifact cleanup still runs and its
-failures remain available from the terminal `CloseReport` before the original
-close failure is rethrown.
+exact admission-held physical-release settlements and typed close results; an
+unrelated, foreign, or incomplete group set cannot authorize release. Cleanup
+failures compose with, and never replace, group cleanup results in the workspace
+close report. A coordinated close-result fault cannot authorize artifact
+cleanup before physical group-release settlement, while a fault after
+settlement does not skip cleanup. A synchronous coordinated release-request
+fault before terminal release remains the close failure and keeps the artifact
+session live until the adjacent owner later establishes terminal settlement;
+artifact cleanup never becomes a second physical-release authority.
 
 ### Interaction model
 
@@ -2457,9 +2460,11 @@ The target is complete only when tests equivalent to these exist:
 - `ArtifactSetSession_ReleasesLeasesOnlyAfterOpenArtifactStreamsQuiesce`
 - `WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces`
 - `RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet`
+- `RegisterArtifactSession_RejectsLaterCoordinatedGroup`
 - `WorkspaceClose_ReportsArtifactSessionCleanupFailure`
 - `WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedCloseFaults`
-- `WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedReleaseRequestThrows`
+- `WorkspaceClose_WaitsForPhysicalReleaseWhenCoordinatedCloseFaultsEarly`
+- `WorkspaceClose_WaitsForCoordinatedOwnerAfterReleaseRequestThrows`
 - `ArtifactSetSession_DisposalCancelsInFlightMaterialization`
 - `ArtifactSetSession_CancellationCallbackFailureDoesNotSkipLeaseCleanup`
 - `ArtifactSetSession_PreservesPrimaryFailureWhenCleanupFails`

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -906,6 +906,52 @@ public sealed class InspectionWorkspaceTests
     }
 
     [Fact]
+    public async Task RegisterArtifactSession_RejectsLaterCoordinatedGroup()
+    {
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        AssemblyContextGroup initialGroup =
+            workspace.CreateAssemblyContextGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ]);
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [initialGroup]);
+        var participation =
+            new ControlledWorkspaceParticipation();
+        ImmutableArray<
+            InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
+            admissions =
+                workspace.BeginCoordinatedGroupAdmissions(
+                    [participation]);
+        AssemblyContextGroup lateGroup =
+            admissions[0].CreateGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ],
+                options: null);
+        participation.Group = lateGroup;
+
+        Assert.False(
+            workspace.CompleteCoordinatedGroupAdmissions(
+                admissions,
+                [lateGroup]));
+
+        InspectionWorkspaceCloseReport report =
+            await workspace.CloseAsync();
+        Assert.Equal(2, report.Groups.Length);
+        Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
+    }
+
+    [Fact]
     public async Task WorkspaceClose_ReportsArtifactSessionCleanupFailure()
     {
         ArtifactAssembly artifact =
@@ -941,7 +987,8 @@ public sealed class InspectionWorkspaceTests
         InspectionWorkspace workspace =
             InspectionWorkspace.CreateAsynchronous();
         var participation =
-            new FaultingWorkspaceParticipation();
+            new ControlledWorkspaceParticipation(
+                throwOnCloseResult: true);
         ImmutableArray<
             InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
             admissions =
@@ -977,14 +1024,71 @@ public sealed class InspectionWorkspaceTests
     }
 
     [Fact]
-    public async Task WorkspaceClose_ReleasesArtifactSessionWhenCoordinatedReleaseRequestThrows()
+    public async Task WorkspaceClose_WaitsForPhysicalReleaseWhenCoordinatedCloseFaultsEarly()
     {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
         ArtifactAssembly artifact =
             await CreateArtifactAssemblyAsync();
         InspectionWorkspace workspace =
             InspectionWorkspace.CreateAsynchronous();
         var participation =
-            new FaultingWorkspaceParticipation(
+            new ControlledWorkspaceParticipation(
+                releaseOnRequest: false,
+                throwOnCloseResultBeforeRelease: true);
+        ImmutableArray<
+            InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
+            admissions =
+                workspace.BeginCoordinatedGroupAdmissions(
+                    [participation]);
+        AssemblyContextGroup group =
+            admissions[0].CreateGroup(
+                [
+                    new AssemblyContextParticipant(
+                        artifact.Assembly,
+                        MissingBindingPolicy.Instance),
+                ],
+                options: null);
+        participation.Group = group;
+        Assert.True(
+            workspace.CompleteCoordinatedGroupAdmissions(
+                admissions,
+                [group]));
+        workspace.RegisterArtifactSession(
+            artifact.Session,
+            artifact.QueryLease,
+            [group]);
+
+        Task<InspectionWorkspaceCloseReport> close =
+            workspace.CloseAsync();
+        await participation.ReleaseRequestAttempted.WaitAsync(
+            cancellationToken);
+        Assert.False(close.IsCompleted);
+        Assert.Equal(0, artifact.AcquisitionLease.DisposeCount);
+
+        await participation.ReleaseAsOwnerAsync();
+        InvalidOperationException failure =
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => close);
+
+        Assert.Equal(
+            "Synthetic coordinated close failure.",
+            failure.Message);
+        Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
+        Assert.NotNull(workspace.CloseReport);
+    }
+
+    [Fact]
+    public async Task WorkspaceClose_WaitsForCoordinatedOwnerAfterReleaseRequestThrows()
+    {
+        CancellationToken cancellationToken =
+            TestContext.Current.CancellationToken;
+        ArtifactAssembly artifact =
+            await CreateArtifactAssemblyAsync();
+        InspectionWorkspace workspace =
+            InspectionWorkspace.CreateAsynchronous();
+        var participation =
+            new ControlledWorkspaceParticipation(
                 throwOnReleaseRequest: true);
         ImmutableArray<
             InspectionWorkspace.WorkspaceCoordinatedGroupAdmission>
@@ -1011,6 +1115,12 @@ public sealed class InspectionWorkspaceTests
 
         Task<InspectionWorkspaceCloseReport> close =
             workspace.CloseAsync();
+        await participation.ReleaseRequestAttempted.WaitAsync(
+            cancellationToken);
+        Assert.False(close.IsCompleted);
+        Assert.Equal(0, artifact.AcquisitionLease.DisposeCount);
+
+        await participation.ReleaseAsOwnerAsync();
         InvalidOperationException failure =
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => close);
@@ -1024,7 +1134,14 @@ public sealed class InspectionWorkspaceTests
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => second);
         Assert.Equal(1, artifact.AcquisitionLease.DisposeCount);
-        Assert.NotNull(workspace.CloseReport);
+        InspectionWorkspaceCloseReport report =
+            Assert.IsType<InspectionWorkspaceCloseReport>(
+                workspace.CloseReport);
+        InspectionWorkspaceCoordinatedGroupCloseResult<string> result =
+            Assert.IsType<
+                InspectionWorkspaceCoordinatedGroupCloseResult<string>>(
+                    Assert.Single(report.Groups));
+        Assert.Equal("released", result.Result);
     }
 
     [Fact]
@@ -1717,11 +1834,20 @@ public sealed class InspectionWorkspaceTests
         ResolvedAssemblyReference Assembly,
         TrackingArtifactAcquisitionLease AcquisitionLease);
 
-    sealed class FaultingWorkspaceParticipation(
-        bool throwOnReleaseRequest = false)
+    sealed class ControlledWorkspaceParticipation(
+        bool throwOnReleaseRequest = false,
+        bool throwOnCloseResult = false,
+        bool releaseOnRequest = true,
+        bool throwOnCloseResultBeforeRelease = false)
         : IWorkspaceCoordinatedGroupParticipation
     {
+        readonly TaskCompletionSource _releaseRequestAttempted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         internal AssemblyContextGroup? Group { get; set; }
+
+        internal Task ReleaseRequestAttempted =>
+            _releaseRequestAttempted.Task;
 
         public WorkspaceCoordinatedAdmissionGate WorkspaceAdmission
         {
@@ -1730,11 +1856,14 @@ public sealed class InspectionWorkspaceTests
 
         public void RequestRelease()
         {
+            _releaseRequestAttempted.TrySetResult();
             if (throwOnReleaseRequest)
             {
                 throw new InvalidOperationException(
                     "Synthetic synchronous coordinated release failure.");
             }
+            if (!releaseOnRequest)
+                return;
 
             _ = (Group
                     ?? throw new InvalidOperationException(
@@ -1742,15 +1871,36 @@ public sealed class InspectionWorkspaceTests
                 .RequestReleaseAsync();
         }
 
+        internal Task<AssemblyContextGroupReleaseResult>
+            ReleaseAsOwnerAsync() =>
+                (Group
+                    ?? throw new InvalidOperationException(
+                        "The coordinated group was not attached."))
+                .RequestReleaseAsync();
+
         public async Task<InspectionWorkspaceGroupCloseResult>
             GetCloseResultAsync(int registrationIndex)
         {
+            if (throwOnCloseResultBeforeRelease)
+            {
+                throw new InvalidOperationException(
+                    "Synthetic coordinated close failure.");
+            }
+
             await (Group
                     ?? throw new InvalidOperationException(
                         "The coordinated group was not attached."))
                 .ReleaseCompletion;
-            throw new InvalidOperationException(
-                "Synthetic coordinated close failure.");
+            if (throwOnCloseResult)
+            {
+                throw new InvalidOperationException(
+                    "Synthetic coordinated close failure.");
+            }
+
+            return new InspectionWorkspaceCoordinatedGroupCloseResult<
+                string>(
+                    registrationIndex,
+                    "released");
         }
     }
 

--- a/src/DotnetInspector.Queries/InspectionWorkspace.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspace.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Runtime.ExceptionServices;
 
 using DotnetInspector.Artifacts;
 using DotnetInspector.Artifacts.Workspaces;
@@ -1096,16 +1097,14 @@ public sealed partial class InspectionWorkspace :
         if (published)
             return group;
 
-        admission?.Complete(
-            artifactOwnershipConflict
-                ? null
-                : registration);
         if (artifactOwnershipConflict)
         {
             group.Dispose();
+            admission?.Complete(registration: null);
             throw new InvalidOperationException(
                 "A group projected from a transferred artifact session cannot be admitted later.");
         }
+        admission?.Complete(registration);
         if (_lifetimeMode
             == InspectionWorkspaceLifetimeMode.Synchronous)
         {
@@ -1123,9 +1122,11 @@ public sealed partial class InspectionWorkspace :
     /// The supplied set must contain every current workspace group with at
     /// least one participant projected from this session, and no other group.
     /// A later group projected from a transferred session is rejected. The
-    /// workspace disposes the query lease and session only after all stored
-    /// groups complete release. These properties are gated by
-    /// <c>RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet</c> and
+    /// workspace disposes the query lease and session only after every stored
+    /// admission reaches physical group-release settlement. These properties
+    /// are gated by
+    /// <c>RegisterArtifactSession_RejectsForeignOrIncompleteGroupSet</c>,
+    /// <c>RegisterArtifactSession_RejectsLaterCoordinatedGroup</c>, and
     /// <c>WorkspaceClose_ReleasesArtifactSessionAfterExactDependentGroupQuiesces</c>.
     /// </remarks>
     internal void RegisterArtifactSession(
@@ -1181,6 +1182,9 @@ public sealed partial class InspectionWorkspace :
             var expectedGroups =
                 new HashSet<AssemblyContextGroup>(
                     ReferenceEqualityComparer.Instance);
+            var dependentAdmissions =
+                ImmutableArray.CreateBuilder<
+                    WorkspaceGroupAdmission>();
             foreach (WorkspaceGroupAdmission admission in _admissions)
             {
                 if (!admission.TryGetCompletedGroup(out AssemblyContextGroup? group))
@@ -1196,6 +1200,7 @@ public sealed partial class InspectionWorkspace :
                         && registrations.Contains(registration)))
                 {
                     expectedGroups.Add(group);
+                    dependentAdmissions.Add(admission);
                 }
             }
             if (expectedGroups.Count == 0
@@ -1217,7 +1222,7 @@ public sealed partial class InspectionWorkspace :
                     session,
                     queryLease,
                     [.. registrations],
-                    groups));
+                    dependentAdmissions.ToImmutable()));
         }
     }
 
@@ -1470,7 +1475,16 @@ public sealed partial class InspectionWorkspace :
                 index++)
             {
                 if (completionTasks[index].IsCompletedSuccessfully)
+                {
                     completed[index] = completionTasks[index].Result;
+                }
+                else if (plan.GroupAdmissions[index]
+                    .TryGetTerminalResult(
+                        out InspectionWorkspaceGroupCloseResult?
+                            terminalResult))
+                {
+                    completed[index] = terminalResult;
+                }
             }
         }
         ImmutableArray<Exception>.Builder artifactCleanupFailures =
@@ -1515,12 +1529,13 @@ public sealed partial class InspectionWorkspace :
             ArtifactQueryLease queryLease,
             ImmutableArray<ArtifactAcquisitionRegistration>
                 artifactRegistrations,
-            ImmutableArray<AssemblyContextGroup> dependentGroups)
+            ImmutableArray<WorkspaceGroupAdmission>
+                dependentGroupAdmissions)
         {
             Session = session;
             QueryLease = queryLease;
             ArtifactRegistrations = artifactRegistrations;
-            DependentGroups = dependentGroups;
+            DependentGroupAdmissions = dependentGroupAdmissions;
         }
 
         internal ArtifactSetSession Session { get; }
@@ -1530,7 +1545,8 @@ public sealed partial class InspectionWorkspace :
         ImmutableArray<ArtifactAcquisitionRegistration>
             ArtifactRegistrations { get; }
 
-        ImmutableArray<AssemblyContextGroup> DependentGroups { get; }
+        ImmutableArray<WorkspaceGroupAdmission>
+            DependentGroupAdmissions { get; }
 
         internal bool DependsOn(AssemblyContextGroup group) =>
             group.Participants.Any(participant =>
@@ -1543,8 +1559,9 @@ public sealed partial class InspectionWorkspace :
         internal async Task<IReadOnlyList<Exception>> ReleaseAsync()
         {
             await Task.WhenAll(
-                    DependentGroups.Select(
-                        static group => group.RequestReleaseAsync()))
+                    DependentGroupAdmissions.Select(
+                        static admission =>
+                            admission.TerminalSettlement))
                 .ConfigureAwait(false);
             var failures = new List<Exception>();
             try
@@ -1608,14 +1625,20 @@ public sealed partial class InspectionWorkspace :
         readonly TaskCompletionSource<
             InspectionWorkspaceGroupCloseResult?> _terminalCompletion =
                 new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource _terminalSettlement =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         WorkspaceGroupRegistration? _registration;
         AssemblyContextGroup? _completedGroup;
+        InspectionWorkspaceGroupCloseResult? _terminalResult;
 
         internal int RegistrationIndex { get; } = registrationIndex;
 
         internal IWorkspaceCoordinatedGroupParticipation?
             CoordinatedParticipation { get; } =
                 coordinatedParticipation;
+
+        internal Task TerminalSettlement =>
+            _terminalSettlement.Task;
 
         internal void CloseWorkspaceAdmission() =>
             CoordinatedParticipation?.WorkspaceAdmission.Close();
@@ -1640,7 +1663,30 @@ public sealed partial class InspectionWorkspace :
             RequestReleaseAndGetResultAsync()
         {
             await _constructionCompletion.Task.ConfigureAwait(false);
-            TryRequestRelease();
+            Exception? requestFailure = null;
+            try
+            {
+                TryRequestRelease();
+            }
+            catch (Exception failure)
+            {
+                requestFailure = failure;
+            }
+
+            if (requestFailure is not null)
+            {
+                try
+                {
+                    _ = await _terminalCompletion.Task
+                        .ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    // The release-request failure remains the primary close failure.
+                }
+                ExceptionDispatchInfo.Throw(requestFailure);
+            }
+
             return await _terminalCompletion.Task.ConfigureAwait(false);
         }
 
@@ -1650,6 +1696,7 @@ public sealed partial class InspectionWorkspace :
             if (registration is null)
             {
                 _terminalCompletion.SetResult(result: null);
+                _terminalSettlement.SetResult();
                 _constructionCompletion.SetResult();
                 return;
             }
@@ -1660,6 +1707,7 @@ public sealed partial class InspectionWorkspace :
                 _completedGroup = registration.Group;
             }
 
+            ObserveTerminalSettlement(registration.Group);
             ObserveRelease(registration);
 
             _constructionCompletion.SetResult();
@@ -1678,6 +1726,16 @@ public sealed partial class InspectionWorkspace :
             {
                 group = _completedGroup;
                 return true;
+            }
+        }
+
+        internal bool TryGetTerminalResult(
+            out InspectionWorkspaceGroupCloseResult? result)
+        {
+            lock (_gate)
+            {
+                result = _terminalResult;
+                return result is not null;
             }
         }
 
@@ -1708,8 +1766,23 @@ public sealed partial class InspectionWorkspace :
                         "A workspace group admission has no registration to finish.");
             }
 
+            ObserveTerminalSettlement(registration.Group);
             ObserveRelease(registration);
             _constructionCompletion.SetResult();
+        }
+
+        void ObserveTerminalSettlement(
+            AssemblyContextGroup group)
+        {
+            _ = ObserveTerminalSettlementAsync(
+                group.ReleaseCompletion);
+        }
+
+        async Task ObserveTerminalSettlementAsync(
+            Task<AssemblyContextGroupReleaseResult> completion)
+        {
+            _ = await completion.ConfigureAwait(false);
+            _terminalSettlement.SetResult();
         }
 
         void ObserveRelease(
@@ -1802,6 +1875,7 @@ public sealed partial class InspectionWorkspace :
                 {
                     _registration = null;
                 }
+                _terminalResult = result;
             }
 
             _terminalCompletion.SetResult(result);


### PR DESCRIPTION
## Summary

Preserve coordinated group release authority during artifact-session cleanup.
Artifact registrations now retain exact workspace admissions and wait for
physical group-release settlement without independently requesting coordinated
release. A pre-terminal coordinated request failure remains the primary close
failure after the adjacent owner eventually settles, and a later successful
typed group result remains in the close report.

This corrects the authority defect that landed in #5502 and closes #5611. The
artifact/workspace design remains the normative owner and consumes the
coordinated release contract from `docs/inspection-space.md`; it does not
redefine package-role release. The package consumer and both-host adoption plan
remain #5574 through #5577. Rendering is unaffected.

## Demo

The pathological gate now starts workspace close with a coordinated
participation that records the release request and throws before requesting
physical group release.

**Before:** artifact cleanup called `AssemblyContextGroup.RequestReleaseAsync()`
itself, disposed the acquisition lease, and completed close without an
owner-issued release.

**After:** close remains pending and the acquisition lease remains live. The
adjacent owner later requests release; only after physical settlement does
artifact cleanup run, while the original request failure is rethrown and the
owner's exact successful group result remains in `CloseReport`.

The neighboring gates prove that an early coordinated close-result fault also
cannot release artifact state before physical settlement, while a fault after
settlement still permits cleanup. A later coordinated group projected from an
already transferred artifact session is rejected and drained before cleanup.

## Design basis

- **Normative owner:** `docs/design/artifact-acquisition-and-workspaces.md`
- **Exact claim:** artifact cleanup consumes exact admission-held physical
  settlement and typed close results; it never becomes coordinated physical
  release authority.
- **Adjacent contract:** `docs/inspection-space.md#workspace-close-and-group-release-authority`
- **Formal support:** the group request/receipt/result lifecycle landed in
  #5469; focused composition remains tracked by #5591.
- **Analogous implementation:** direct and package-role paths already separate
  release request authority from completion observation. This change reuses
  that admission boundary instead of adding artifact-specific release logic.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
  - succeeded with 0 warnings and 0 errors
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- -class 'DotnetInspector.Queries.Tests.InspectionWorkspaceTests'`
  - 41 passed
- `dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release`
  - 60 passed, 6 platform-specific skips
- `npx markdownlint-cli docs/design/artifact-acquisition-and-workspaces.md`
- `git diff --check origin/main...HEAD`

The full query suite ran 1,166 tests and failed only the unchanged
`ToPacket_OverCapacityPreflightRemainsNearLinear` wall-clock threshold under
suite load. The same gate passed alone on this head; the deterministic-gate
replacement is tracked by #5622.
