### PR TITLE
Add typed L2 row selection intent

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,9 +90,10 @@ than forming an additional host tier.
 
 These are logical boundaries, not a claim that every layer is already a
 separate reusable assembly. L1 is available through host-neutral projects.
-`DotnetInspector.Sections` contains the first reusable L2 Rows execution
-boundary. Current L2 section pipelines remain in the same namespace inside the
-CLI project; their broader migration is still incomplete.
+`DotnetInspector.Sections` contains the typed unresolved selection-operation
+intent boundary and the first reusable L2 Rows execution boundary. Current L2
+section pipelines remain in the same namespace inside the CLI project; their
+broader migration is still incomplete.
 
 The reusable L1/L2 binding is owned by
 [Compiled inspection domain composition](design/section-pipeline.md#compiled-inspection-domain-composition).
@@ -165,7 +166,7 @@ reaches through Research to redefine the other.
 | ------ | ------------- | -------------- | ----------------- |
 | `DotnetInspector.Vocabulary` | Cross-host catalog | Shared static catalogs for legal rich-query values across hosts. | [Query vocabulary](design/vocabulary.md) |
 | `DotnetInspector.RowSelection` | Shared row-selection contract | Typed `Head`, `Tail`, `Window`, and `Top` declarations plus complete-sequence generic reference evaluation. | [Semantic row selection](design/semantic-row-selection.md) |
-| `DotnetInspector.Sections` | Shared L2 contracts | Typed binding of already-resolved section-row cohorts to semantic selection and L2 result identities. | [L2 section-row shaping](design/section-row-shaping.md) |
+| `DotnetInspector.Sections` | Shared L2 contracts | Typed unresolved row-selection intent plus binding of already-resolved section-row cohorts to semantic selection and L2 result identities. | [L2 section-row shaping](design/section-row-shaping.md) |
 | `DotnetInspector.Queries` | Core L1 | Typed query definitions, immutable catalogs, workspaces, execution plans, and typed results. | [Inspection layers](design/inspection-layers.md), [inspection space](inspection-space.md) |
 | `DotnetInspector.ResearchQueries` | Optional L1 companion | Research-backed queries without pulling Research into the core query assembly. | [Inspection layers](design/inspection-layers.md) |
 | `DotnetInspector.PackageQueries` | Optional L1 companion | Package-aware composition over package-neutral queries and realization proofs. | [Package Root realization](design/artifact-acquisition-and-workspaces.md#package-root-realization) |
@@ -173,9 +174,10 @@ reaches through Research to redefine the other.
 Queries accept content-shaped or context-shaped inputs. They do not choose a
 renderer, parse command lines, or use display strings as identity.
 
-The reusable `DotnetInspector.Sections` project currently contains only the
-one-cohort Rows execution boundary. Existing L2 section pipelines, immutable
-catalogs, schemas, and compiled lenses remain under
+The reusable `DotnetInspector.Sections` project currently contains the
+unresolved selection-operation intent and one-cohort Rows execution
+boundaries. Existing L2 section pipelines, immutable catalogs, schemas, and
+compiled lenses remain under
 `src/dotnet-inspect/Sections` in the CLI assembly. The
 [Section model](design/section-model.md) and
 [section pipeline](design/section-pipeline.md) own those contracts;

--- a/docs/design/inspection-layers.md
+++ b/docs/design/inspection-layers.md
@@ -1679,9 +1679,9 @@ uniformly content-shaped or demand-driven:
 
 Converting the remaining collection into typed, demand-driven, content-shaped
 queries is therefore the migration path for the split, not a follow-up to it.
-`DotnetInspector.Sections` currently contains only the Rows cohort seam; the
-descriptor contract remains in the CLI assembly and is already Markout-free
-apart from its name binding.
+`DotnetInspector.Sections` currently contains the unresolved row-selection
+intent and Rows cohort seams; the descriptor contract remains in the CLI
+assembly and is already Markout-free apart from its name binding.
 
 ## Non-goals
 

--- a/docs/design/section-row-shaping.md
+++ b/docs/design/section-row-shaping.md
@@ -9,11 +9,12 @@ row-selection composition pattern locked by
 
 Implementation is partial. #5557 implements one already-resolved, one-cohort
 Rows path: request-local sequence-key binding, one named semantic invocation,
-and typed success or strict-failure rebinding. Row-intent resolution,
-projection, Count, source outcomes, and multiple-cohort composition remain
-unimplemented.
+and typed success or strict-failure rebinding. #5625 adds the immutable typed
+selection-operation intent received before schema and order resolution.
+Row-intent association and resolution, projection, Count, source outcomes, and
+multiple-cohort composition remain unimplemented.
 
-Only that implemented subset is verified by its four Release gates in
+Only those implemented subsets are verified by their named Release gates in
 [Required gates](#required-gates). Every other asserted behavior remains
 unverified until its named gate lands.
 
@@ -41,6 +42,8 @@ outcomes.
 
 This design owns:
 
+- the typed unresolved semantic-selection operation intent received from
+  higher-level consumers;
 - stable declared-row-set identities and their ordered binding;
 - the mapping between those identities and semantic `RowSequenceKey` tokens;
 - the distinction between membership projection and cell projection;
@@ -66,6 +69,31 @@ This design does not own:
 
 Those adjacent owners provide typed inputs or consume typed results without
 redefining L2 row shaping.
+
+## Unresolved selection-operation intent
+
+Before schema and order resolution, L2 receives one immutable ordered sequence
+of typed `Head`, `Tail`, `Window`, and `Top` operation intent. Counts and present
+one-based inclusive Window bounds are positive, and a closed Window's end does
+not precede its start. A boundless Window remains the semantic identity
+operation; the CLI grammar separately rejects the boundless `--rows ..`
+spelling.
+
+`Top` may carry one opaque caller-issued ranking-order operand or may omit it
+for later default-ranking resolution. The operand is typed but unresolved: its
+value is neither a semantic resolved-order identity nor authority to treat a
+baseline order as ranking. L2 does not infer an operand from display text.
+
+The intent sequence preserves operation order and snapshots its collection
+membership. It contains no row values and can be constructed and inspected
+without semantic execution. This implemented input contract does not yet bind
+intent to row sets, schemas, predicates, effective order, or executable
+`RowSelectionPlan` stages.
+
+This is distinct from the semantic `RowSelectionStage` because unresolved
+intent must represent `Top` without a resolved order identity. It reuses the
+semantic owner's stage-kind identities and matching operand constraints rather
+than redefining their meaning.
 
 ## Declared row sets
 
@@ -533,6 +561,14 @@ path makes no optimization claim and does not satisfy a conditional gate
 vacuously.
 
 ## Required gates
+
+The unresolved selection-intent input contract is enforced by:
+
+| Gate | Contract |
+| --- | --- |
+| `RowSelectionIntentConsumerExercisesDeclaration` | A non-friend consumer constructs and inspects every operation kind, closed, prefix, suffix, and boundless Window shapes, Top with and without an opaque ranking operand, and wrong-kind access without row values or execution. |
+| `RowSelectionIntentRejectsInvalidOperands` | Nonpositive counts or present bounds, reversed Windows, null explicit ranking operands, null operation collections, null entries, and null appends reject at construction. |
+| `RowSelectionIntentSnapshotsAreImmutable` | Intent creation snapshots ordered membership, append leaves the prior intent unchanged, and every exposed operation collection is read-only. |
 
 The one-cohort Rows implementation is enforced by:
 

--- a/src/DotnetInspector.Sections.Tests/RowSelectionIntentContractTests.cs
+++ b/src/DotnetInspector.Sections.Tests/RowSelectionIntentContractTests.cs
@@ -1,0 +1,171 @@
+using System.Collections;
+using DotnetInspector.RowSelection;
+
+namespace DotnetInspector.Sections.Tests;
+
+public sealed class RowSelectionIntentContractTests
+{
+    [Fact]
+    public void RowSelectionIntentConsumerExercisesDeclaration()
+    {
+        RowSelectionIntent<string> intent =
+            RowSelectionIntent<string>.Create(
+                [
+                    RowSelectionIntentOperation<string>.Head(2),
+                    RowSelectionIntentOperation<string>.Tail(3),
+                    RowSelectionIntentOperation<string>.Window(
+                        2,
+                        5),
+                    RowSelectionIntentOperation<string>.Window(
+                        null,
+                        4),
+                    RowSelectionIntentOperation<string>.Window(
+                        3,
+                        null),
+                    RowSelectionIntentOperation<string>.Window(
+                        null,
+                        null),
+                    RowSelectionIntentOperation<string>.Top(6),
+                    RowSelectionIntentOperation<string>.Top(
+                        7,
+                        "confidence")
+                ]);
+
+        Assert.Equal(
+            [
+                RowSelectionStageKind.Head,
+                RowSelectionStageKind.Tail,
+                RowSelectionStageKind.Window,
+                RowSelectionStageKind.Window,
+                RowSelectionStageKind.Window,
+                RowSelectionStageKind.Window,
+                RowSelectionStageKind.Top,
+                RowSelectionStageKind.Top
+            ],
+            intent.Operations.Select(operation => operation.Kind));
+        Assert.Equal(2, intent.Operations[0].Count);
+        Assert.Equal(3, intent.Operations[1].Count);
+        Assert.Equal(2, intent.Operations[2].Start);
+        Assert.Equal(5, intent.Operations[2].End);
+        Assert.Null(intent.Operations[3].Start);
+        Assert.Equal(4, intent.Operations[3].End);
+        Assert.Equal(3, intent.Operations[4].Start);
+        Assert.Null(intent.Operations[4].End);
+        Assert.Null(intent.Operations[5].Start);
+        Assert.Null(intent.Operations[5].End);
+        Assert.Equal(6, intent.Operations[6].Count);
+        Assert.False(
+            intent.Operations[6].HasRankingOrderOperand);
+        Assert.Equal(7, intent.Operations[7].Count);
+        Assert.True(
+            intent.Operations[7].HasRankingOrderOperand);
+        Assert.Equal(
+            "confidence",
+            intent.Operations[7].RankingOrderOperand);
+
+        Assert.Throws<InvalidOperationException>(
+            () => _ = intent.Operations[0].Start);
+        Assert.Throws<InvalidOperationException>(
+            () => _ = intent.Operations[0].End);
+        Assert.Throws<InvalidOperationException>(
+            () => _ = intent.Operations[2].Count);
+        Assert.Throws<InvalidOperationException>(
+            () => _ =
+                intent.Operations[1]
+                    .HasRankingOrderOperand);
+        Assert.Throws<InvalidOperationException>(
+            () => _ =
+                intent.Operations[6]
+                    .RankingOrderOperand);
+    }
+
+    [Fact]
+    public void RowSelectionIntentRejectsInvalidOperands()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Head(0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Tail(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Top(0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Top(
+                0,
+                "confidence"));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Window(
+                0,
+                1));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Window(
+                1,
+                0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => RowSelectionIntentOperation<string>.Window(
+                2,
+                1));
+        Assert.Throws<ArgumentNullException>(
+            () => RowSelectionIntentOperation<string>.Top(
+                1,
+                null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RowSelectionIntent<string>.Create(null!));
+        Assert.Throws<ArgumentNullException>(
+            () => RowSelectionIntent<string>.Create(
+                [
+                    RowSelectionIntentOperation<string>.Head(1),
+                    null!
+                ]));
+        Assert.Throws<ArgumentNullException>(
+            () => RowSelectionIntent<string>.Empty.Append(null!));
+    }
+
+    [Fact]
+    public void RowSelectionIntentSnapshotsAreImmutable()
+    {
+        var operations =
+            new List<RowSelectionIntentOperation<string>>
+            {
+                RowSelectionIntentOperation<string>.Head(2)
+            };
+        RowSelectionIntent<string> intent =
+            RowSelectionIntent<string>.Create(operations);
+
+        operations[0] =
+            RowSelectionIntentOperation<string>.Tail(1);
+        operations.Add(
+            RowSelectionIntentOperation<string>.Top(1));
+
+        Assert.Single(intent.Operations);
+        Assert.Equal(
+            RowSelectionStageKind.Head,
+            intent.Operations[0].Kind);
+
+        RowSelectionIntent<string> appended =
+            intent.Append(
+                RowSelectionIntentOperation<string>.Window(
+                    2,
+                    3));
+        Assert.Single(intent.Operations);
+        Assert.Equal(2, appended.Operations.Count);
+        Assert.Empty(
+            RowSelectionIntent<string>.Empty.Operations);
+        AssertReadOnly(intent.Operations);
+        AssertReadOnly(appended.Operations);
+        AssertReadOnly(
+            RowSelectionIntent<string>.Empty.Operations);
+    }
+
+    private static void AssertReadOnly<T>(
+        IReadOnlyList<T> values)
+    {
+        IList list =
+            Assert.IsAssignableFrom<IList>(values);
+        Assert.True(list.IsReadOnly);
+        if (values.Count > 0)
+        {
+            Assert.Throws<NotSupportedException>(
+                () => list[0] = values[0]);
+        }
+    }
+}

--- a/src/DotnetInspector.Sections/RowSelectionIntent.cs
+++ b/src/DotnetInspector.Sections/RowSelectionIntent.cs
@@ -1,0 +1,217 @@
+using DotnetInspector.RowSelection;
+
+namespace DotnetInspector.Sections;
+
+public sealed class RowSelectionIntentOperation<TOrderOperand>
+    where TOrderOperand : notnull
+{
+    private readonly int _count;
+    private readonly int? _start;
+    private readonly int? _end;
+    private readonly bool _hasRankingOrderOperand;
+    private readonly TOrderOperand _rankingOrderOperand;
+
+    private RowSelectionIntentOperation(
+        RowSelectionStageKind kind,
+        int count,
+        int? start,
+        int? end,
+        bool hasRankingOrderOperand,
+        TOrderOperand rankingOrderOperand)
+    {
+        Kind = kind;
+        _count = count;
+        _start = start;
+        _end = end;
+        _hasRankingOrderOperand = hasRankingOrderOperand;
+        _rankingOrderOperand = rankingOrderOperand;
+    }
+
+    public RowSelectionStageKind Kind { get; }
+
+    public int Count =>
+        Kind is RowSelectionStageKind.Head
+            or RowSelectionStageKind.Tail
+            or RowSelectionStageKind.Top
+            ? _count
+            : throw WrongKind(nameof(Count));
+
+    public int? Start =>
+        Kind is RowSelectionStageKind.Window
+            ? _start
+            : throw WrongKind(nameof(Start));
+
+    public int? End =>
+        Kind is RowSelectionStageKind.Window
+            ? _end
+            : throw WrongKind(nameof(End));
+
+    public bool HasRankingOrderOperand =>
+        Kind is RowSelectionStageKind.Top
+            ? _hasRankingOrderOperand
+            : throw WrongKind(nameof(HasRankingOrderOperand));
+
+    public TOrderOperand RankingOrderOperand =>
+        Kind is not RowSelectionStageKind.Top
+            ? throw WrongKind(nameof(RankingOrderOperand))
+            : _hasRankingOrderOperand
+                ? _rankingOrderOperand
+                : throw new InvalidOperationException(
+                    "The Top operation has no explicit ranking-order operand.");
+
+    public static RowSelectionIntentOperation<TOrderOperand> Head(
+        int count) =>
+        new(
+            RowSelectionStageKind.Head,
+            ValidateCount(count),
+            null,
+            null,
+            false,
+            default!);
+
+    public static RowSelectionIntentOperation<TOrderOperand> Tail(
+        int count) =>
+        new(
+            RowSelectionStageKind.Tail,
+            ValidateCount(count),
+            null,
+            null,
+            false,
+            default!);
+
+    public static RowSelectionIntentOperation<TOrderOperand> Window(
+        int? start,
+        int? end)
+    {
+        if (start is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(start),
+                start,
+                "A present window start must be positive.");
+        }
+
+        if (end is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(end),
+                end,
+                "A present window end must be positive.");
+        }
+
+        if (start is not null
+            && end is not null
+            && end < start)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(end),
+                end,
+                "A closed window end cannot precede its start.");
+        }
+
+        return new(
+            RowSelectionStageKind.Window,
+            0,
+            start,
+            end,
+            false,
+            default!);
+    }
+
+    public static RowSelectionIntentOperation<TOrderOperand> Top(
+        int count) =>
+        new(
+            RowSelectionStageKind.Top,
+            ValidateCount(count),
+            null,
+            null,
+            false,
+            default!);
+
+    public static RowSelectionIntentOperation<TOrderOperand> Top(
+        int count,
+        TOrderOperand rankingOrderOperand)
+    {
+        ArgumentNullException.ThrowIfNull(rankingOrderOperand);
+        return new(
+            RowSelectionStageKind.Top,
+            ValidateCount(count),
+            null,
+            null,
+            true,
+            rankingOrderOperand);
+    }
+
+    private static int ValidateCount(int count)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count),
+                count,
+                "A row-selection count must be positive.");
+        }
+
+        return count;
+    }
+
+    private InvalidOperationException WrongKind(
+        string property) =>
+        new(
+            $"{property} is not valid for a {Kind} row-selection intent operation.");
+}
+
+public sealed class RowSelectionIntent<TOrderOperand>
+    where TOrderOperand : notnull
+{
+    private RowSelectionIntent(
+        IReadOnlyList<RowSelectionIntentOperation<TOrderOperand>>
+            operations)
+    {
+        Operations = operations;
+    }
+
+    public static RowSelectionIntent<TOrderOperand> Empty { get; } =
+        new(
+            SectionContractSnapshot.Empty<
+                RowSelectionIntentOperation<TOrderOperand>>());
+
+    public IReadOnlyList<RowSelectionIntentOperation<TOrderOperand>>
+        Operations { get; }
+
+    public static RowSelectionIntent<TOrderOperand> Create(
+        IReadOnlyList<RowSelectionIntentOperation<TOrderOperand>>
+            operations)
+    {
+        ArgumentNullException.ThrowIfNull(operations);
+
+        var copy =
+            new RowSelectionIntentOperation<TOrderOperand>[
+                operations.Count];
+        for (int index = 0; index < operations.Count; index++)
+        {
+            copy[index] = operations[index]
+                ?? throw new ArgumentNullException(
+                    nameof(operations),
+                    $"Operation {index + 1} is null.");
+        }
+
+        return copy.Length == 0
+            ? Empty
+            : new(SectionContractSnapshot.Own(copy));
+    }
+
+    public RowSelectionIntent<TOrderOperand> Append(
+        RowSelectionIntentOperation<TOrderOperand> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        var copy =
+            new RowSelectionIntentOperation<TOrderOperand>[
+                Operations.Count + 1];
+        for (int index = 0; index < Operations.Count; index++)
+            copy[index] = Operations[index];
+        copy[^1] = operation;
+        return new(SectionContractSnapshot.Own(copy));
+    }
+}

--- a/src/DotnetInspector.Sections/RowsCohortResult.cs
+++ b/src/DotnetInspector.Sections/RowsCohortResult.cs
@@ -57,31 +57,13 @@ public sealed class RowsCohortResult<TIdentity, T>
         SelectedRowSet<TIdentity, T>[] rowSets) =>
         new(
             true,
-            RowsCohortSnapshot.Own(rowSets),
+            SectionContractSnapshot.Own(rowSets),
             null);
 
     internal static RowsCohortResult<TIdentity, T> Failed(
         RowsCohortSemanticFailure<TIdentity> failure) =>
         new(
             false,
-            RowsCohortSnapshot.Empty<SelectedRowSet<TIdentity, T>>(),
+            SectionContractSnapshot.Empty<SelectedRowSet<TIdentity, T>>(),
             failure);
-}
-
-internal static class RowsCohortSnapshot
-{
-    public static IReadOnlyList<T> Empty<T>() =>
-        Array.AsReadOnly(Array.Empty<T>());
-
-    public static IReadOnlyList<T> Copy<T>(
-        IReadOnlyList<T> values)
-    {
-        var copy = new T[values.Count];
-        for (int index = 0; index < values.Count; index++)
-            copy[index] = values[index];
-        return Own(copy);
-    }
-
-    public static IReadOnlyList<T> Own<T>(T[] values) =>
-        Array.AsReadOnly(values);
 }

--- a/src/DotnetInspector.Sections/RowsCohortSequence.cs
+++ b/src/DotnetInspector.Sections/RowsCohortSequence.cs
@@ -23,6 +23,6 @@ public sealed class RowsCohortSequence<TIdentity, T>
         ArgumentNullException.ThrowIfNull(values);
         return new(
             identity,
-            RowsCohortSnapshot.Copy(values));
+            SectionContractSnapshot.Copy(values));
     }
 }

--- a/src/DotnetInspector.Sections/SectionContractSnapshot.cs
+++ b/src/DotnetInspector.Sections/SectionContractSnapshot.cs
@@ -1,0 +1,19 @@
+namespace DotnetInspector.Sections;
+
+internal static class SectionContractSnapshot
+{
+    public static IReadOnlyList<T> Empty<T>() =>
+        Array.AsReadOnly(Array.Empty<T>());
+
+    public static IReadOnlyList<T> Copy<T>(
+        IReadOnlyList<T> values)
+    {
+        var copy = new T[values.Count];
+        for (int index = 0; index < values.Count; index++)
+            copy[index] = values[index];
+        return Own(copy);
+    }
+
+    public static IReadOnlyList<T> Own<T>(T[] values) =>
+        Array.AsReadOnly(values);
+}


### PR DESCRIPTION
Adds the missing host-neutral L2 input boundary between higher-level row gestures and later schema/order resolution. `DotnetInspector.Sections` now exposes immutable typed Head, Tail, Window, and Top operation intent while preserving ranking operands as opaque unresolved caller tokens.

The slice deliberately changes no CLI behavior and does not resolve schemas, predicates, orders, executable plans, Count, projection, source execution, rendering, or line selection.

Closes #5625.

## Demo

A CLI or browser consumer can now declare an ordered request without row values or semantic execution:

```csharp
RowSelectionIntent<string> intent =
    RowSelectionIntent<string>.Create(
        [
            RowSelectionIntentOperation<string>.Window(3, 6),
            RowSelectionIntentOperation<string>.Top(2, "confidence")
        ]);
```

What to notice: the `Top` operand is an opaque unresolved token, not a semantic resolved-order identity. L2 can inspect the declaration before a later focused resolver constructs `RowSelectionPlan<TOrder>`.

The pathological case remains owner-correct: `Window(null, null)` is the valid semantic identity operation, while the CLI grammar separately rejects the user spelling `--rows ..`. Invalid positive-bound and reversed closed-window operands cannot be constructed.

## Validation

- `dotnet run --project src/DotnetInspector.Sections.Tests -c Release` — 7 passed
- `dotnet build dotnet-inspect.slnx -c Release`
- `npx markdownlint-cli docs/design/section-row-shaping.md docs/design/inspection-layers.md docs/architecture.md`
- `git diff --check origin/main...HEAD`