### PR TITLE
Preserve annotated source fact occurrence multiplicity

### DIFF
--- a/docs/design/member-body-substrate.md
+++ b/docs/design/member-body-substrate.md
@@ -402,6 +402,12 @@ the original `PrintedRangeMap` slot — because that map promises only
 descendants-before-ancestors, and ids taken from emission order would be
 reproducible by accident.
 
+While an owning caller composes a document, the printer projection may also
+retain that caller's producer-issued Finding instance key beside an annotation.
+The key is an internal association tag, not part of the public map constructor
+or serialized document. Decompiler carries it through placement without
+minting, parsing, or validating Finding identity.
+
 #### The portable document: text, nodes, regions, facts, targets
 
 `AnnotatedSourceDocument` is the transport envelope, and it is a **text buffer
@@ -552,16 +558,21 @@ body with no facts still has a full node plane. The separation is what lets
 future syntax/trivia/XML-doc producers add nodes without touching the fact
 vocabulary.
 
-**`Targets` is the only join, and it is why a cross-medium fact is stated once.**
+**`Targets` is the only placement join.**
 `Fact → target → node → spans → text` is the whole walk, in one shape, with no
-polymorphic target kind to switch on. A fact observed on a C# node and on its
-exact-offset instruction is one row in `Facts` with two rows in `Targets` —
-unambiguously one observation, where the old shape repeated it on two lines and
-left a consumer to compare tuples and guess. Facts are deduplicated on their full
-semantic identity (descriptor, category, conditionality, detail, source offset,
-origin) *after* portable escaping, and the constructor enforces that uniqueness
-along with contiguous ids, resolvable and non-duplicated target pairs, and — for
-a target on an IL node — an `IlOffset` equal to the fact's own `SourceOffset`.
+polymorphic target kind to switch on. A caller-distinguished fact observed on a
+C# node and on its exact-offset instruction is one row in `Facts` with two rows
+in `Targets` — unambiguously one observation, where the old shape repeated it on
+two lines and left a consumer to compare tuples and guess.
+
+Fact content is not occurrence identity. Two observations may agree on
+descriptor, category, conditionality, detail, source offset, and origin and
+still retain separate document-local fact ids. The constructor therefore
+preserves visible-value multiplicity rather than deduplicating or rejecting it;
+the producer must establish any cross-medium sameness while it still holds an
+owner-issued association. The constructor continues to enforce contiguous ids,
+resolvable and non-duplicated target pairs, and — for a target on an IL node —
+an `IlOffset` equal to the fact's own `SourceOffset`.
 
 A graph overlay does not add an edge-to-node join.
 `AnnotatedMemberDocument` pairs the unchanged document with an
@@ -606,9 +617,13 @@ covers the span rules, text bounds, and the overflowing `int.MaxValue` span;
 `...RejectsMisplacedIlOffsets` covers the `Instruction`-kind invariant in both
 directions, offsets belonging to IL nodes only, being unique and strictly
 increasing, and staying optional for a future structural IL node;
-`...RejectsBrokenIdentity` and `...RejectsFalseTargetClaims` cover
-contiguous ids, fact deduplication, dangling and duplicated targets, the
-instruction-offset agreement, and the header-fact rules;
+`...AnnotatedSourceDocumentPreservesDisplayIdenticalFactMultiplicity` proves
+equal visible values retain separate document-local observations;
+`...PrintedBodyMapPreservesCallerIssuedFindingInstanceKey` proves the printer
+projection retains an owner-issued association through placement;
+`...RejectsBrokenIdentity` and `...RejectsFalseTargetClaims` cover contiguous
+ids, dangling and duplicated targets, the instruction-offset agreement, and
+the header-fact rules;
 `...AnnotatedSourceDocumentSnapshotsValidatesAndReplays` covers the input
 snapshot, structural equality, and JSON replay. On the producer side,
 `AnnotatedSourceDocumentProjectionTests.MultiLineCSharpStructureIsSpannedAroundTheInterleavedIl`

--- a/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrintedBodyMapTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -1694,14 +1695,6 @@ public class PrintedBodyMapTests
             [fact with { Id = 5 }],
             [new AnnotatedSourceTarget(5, 0)]));
 
-        // Facts are deduplicated, so restating one makes "how many times" unanswerable.
-        Assert.Throws<ArgumentException>(() => new AnnotatedSourceDocument(
-            DocumentText,
-            [node],
-            [],
-            [fact, fact with { Id = 1 }],
-            []));
-
         // ... and so is restating a target.
         Assert.Throws<ArgumentException>(() => new AnnotatedSourceDocument(
             DocumentText,
@@ -1729,6 +1722,54 @@ public class PrintedBodyMapTests
             [],
             [fact],
             [new AnnotatedSourceTarget(0, -1)]));
+    }
+
+    [Fact]
+    public void AnnotatedSourceDocumentPreservesDisplayIdenticalFactMultiplicity()
+    {
+        var fact = AllocationFact();
+        var document = new AnnotatedSourceDocument(
+            DocumentText,
+            [AllocationNode()],
+            [],
+            [fact, fact with { Id = 1 }],
+            []);
+
+        Assert.Equal(2, document.Facts.Count);
+        Assert.Equal(document.Facts[0] with { Id = 1 }, document.Facts[1]);
+    }
+
+    [Fact]
+    public void PrintedBodyMapPreservesCallerIssuedFindingInstanceKey()
+    {
+        using var source = MetadataSource.Open(
+            typeof(AllocSampleClass).Assembly.Location);
+        var function = Assert.IsType<IrFunction>(IrImporter.Import(
+            source,
+            typeof(AllocSampleClass).FullName!,
+            nameof(AllocSampleClass.MakeArray)));
+        var result = CSharpPrinter.PrintRaised(function, out var ranges);
+        Assert.NotNull(result.Output);
+
+        IAnnotation annotation = new Annotation(Alloc, 0, "array");
+        FindingCensus<IAnnotation> census = FindingCensus<IAnnotation>.Seal(
+        [
+            new Finding<IAnnotation>(
+                new FindingSubject("test", "test"),
+                new FindingDescriptor("alloc.new", "allocation"),
+                new FindingKey("one"),
+                annotation),
+        ]);
+        FindingInstanceKey key = Assert.Single(census.Entries).Key;
+
+        PrintedBodyMap map = PrintedBodyMap.Create(
+            ranges,
+            function,
+            [annotation],
+            provenanceOffsetAllowList: null,
+            instanceKey: _ => key);
+
+        Assert.Equal(key, Assert.Single(map.Annotations).InstanceKey);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/AnnotatedSourceDocument.cs
+++ b/src/ILInspector.Decompiler/AnnotatedSourceDocument.cs
@@ -469,7 +469,7 @@ public sealed record AnnotatedSourceDocument
     /// <param name="Text">The rendered interleaved C#/IL text, newline-separated, and the coordinate space every span indexes. Must be well-formed UTF-16: every high surrogate followed by a low surrogate, and no lone surrogate of either half.</param>
     /// <param name="Nodes">Text structure over <paramref name="Text"/>, ids contiguous from <c>0</c> in list order.</param>
     /// <param name="Regions">Named construct and clause regions over <paramref name="Text"/>.</param>
-    /// <param name="Facts">Every distinct observation about the member, ids contiguous from <c>0</c> in list order.</param>
+    /// <param name="Facts">Every observation about the member, ids contiguous from <c>0</c> in list order.</param>
     /// <param name="Targets">Which node each fact is about; a fact with none is unanchored.</param>
     public AnnotatedSourceDocument(
         string Text,
@@ -519,7 +519,7 @@ public sealed record AnnotatedSourceDocument
     /// <summary>Named construct and clause regions over <see cref="Text"/>.</summary>
     public IReadOnlyList<AnnotatedSourceRegion> Regions { get; }
 
-    /// <summary>Every distinct observation about the member.</summary>
+    /// <summary>Every observation about the member.</summary>
     public IReadOnlyList<AnnotatedSourceFact> Facts { get; }
 
     /// <summary>Which node each fact is about; a fact with no row here is unanchored.</summary>
@@ -593,13 +593,6 @@ public sealed record AnnotatedSourceDocument
 
     static void ValidateFacts(AnnotatedSourceFact[] facts)
     {
-        var identities = new HashSet<(
-            string Descriptor,
-            string Category,
-            AnnotationConditionality Conditionality,
-            string? Detail,
-            int SourceOffset,
-            AnnotatedSourceFactOrigin Origin)>();
         for (int index = 0; index < facts.Length; index++)
         {
             var fact = facts[index];
@@ -641,23 +634,6 @@ public sealed record AnnotatedSourceDocument
             {
                 throw new ArgumentException(
                     $"Member-header fact {fact.Descriptor} is about the member, not an instruction, so its source offset must be -1.",
-                    "Facts");
-            }
-
-            // Facts are deduplicated, so two rows that agree on everything a
-            // consumer can observe are the same observation stated twice --
-            // which would make "how many times does this happen" unanswerable
-            // from the payload.
-            if (!identities.Add((
-                    fact.Descriptor,
-                    fact.Category,
-                    fact.Conditionality,
-                    fact.Detail,
-                    fact.SourceOffset,
-                    fact.Origin)))
-            {
-                throw new ArgumentException(
-                    $"Fact {fact.Descriptor} is stated more than once; facts are deduplicated and targeted instead.",
                     "Facts");
             }
         }

--- a/src/ILInspector.Decompiler/PrintedBodyMap.cs
+++ b/src/ILInspector.Decompiler/PrintedBodyMap.cs
@@ -1,5 +1,6 @@
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 
 namespace ILInspector.Decompiler;
 
@@ -58,7 +59,10 @@ public readonly record struct PrintedAnnotationSpan(
     PrintedExtent? Extent,
     string? Detail,
     int SourceOffset,
-    int? NodeId);
+    int? NodeId)
+{
+    internal FindingInstanceKey? InstanceKey { get; init; }
+}
 
 /// <summary>Which syntactic part of a compound construct a printed region represents.</summary>
 public enum PrintedRegionRole
@@ -269,8 +273,18 @@ public sealed record PrintedBodyMap
         if (c != 0) return c;
         c = string.CompareOrdinal(a.Detail, b.Detail);
         if (c != 0) return c;
-        return Nullable.Compare(a.NodeId, b.NodeId);
+        c = Nullable.Compare(a.NodeId, b.NodeId);
+        return c != 0 ? c : Compare(a.InstanceKey, b.InstanceKey);
     }
+
+    static int Compare(
+        FindingInstanceKey? left,
+        FindingInstanceKey? right)
+        => left is null
+            ? right is null ? 0 : 1
+            : right is null
+                ? -1
+                : left.Value.Value.CompareTo(right.Value.Value);
 
     /// <summary>An empty map.</summary>
     public static PrintedBodyMap Empty { get; } = new([], [], [], []);
@@ -463,6 +477,19 @@ public sealed record PrintedBodyMap
         IrFunction function,
         IReadOnlyList<IAnnotation> annotations,
         IReadOnlySet<int>? provenanceOffsetAllowList = null)
+        => Create(
+            ranges,
+            function,
+            annotations,
+            provenanceOffsetAllowList,
+            instanceKey: null);
+
+    internal static PrintedBodyMap Create(
+        PrintedRangeMap ranges,
+        IrFunction function,
+        IReadOnlyList<IAnnotation> annotations,
+        IReadOnlySet<int>? provenanceOffsetAllowList,
+        Func<IAnnotation, FindingInstanceKey?>? instanceKey)
     {
         ArgumentNullException.ThrowIfNull(ranges);
         ArgumentNullException.ThrowIfNull(function);
@@ -507,7 +534,10 @@ public sealed record PrintedBodyMap
                 extent,
                 annotation.Detail,
                 annotation.SourceOffset,
-                nodeId));
+                nodeId)
+            {
+                InstanceKey = instanceKey?.Invoke(annotation),
+            });
         }
         facts.Sort(Compare);
 


### PR DESCRIPTION
Closes #5626

## Stack

Slice 1 of 2. Child: #5630. This bottom slice targets `main`; the Research census adopter follows on `feature/research-finding-census-projection`.

## Claim

`ILInspector.Decompiler` now preserves caller-distinguished fact occurrences through printer placement and document-local fact ids. Equal visible fact values no longer cause `AnnotatedSourceDocument` construction to fail, while existing coordinate, topology, target, UTF-16, and JSON replay invariants remain unchanged.

The internal printer association carries an owner-issued Finding instance key only while composing the document. It does not mint, parse, serialize, or validate census identity.

## Demo

Before, constructing a document with two equal visible observations failed as a duplicate:

```csharp
new AnnotatedSourceDocument(
    text, nodes, regions,
    [fact, fact with { Id = 1 }],
    targets); // ArgumentException
```

After, both occurrences survive with local ids `0` and `1`; a separate gate still rejects duplicate target pairs. The neighboring one-observation/two-target shape is unchanged.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PrintedBodyMapTests` — 78 passed
- `npx markdownlint-cli docs/design/member-body-substrate.md`

## Residual

#4717 owns the upper Research projection that seals one census and supplies the caller-issued receipt/key associations. CLI and Inspect Web transport remain in #4718, #5516, and #5517.