### PR TITLE
Preserve Finding census identity through Research projections

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Finding Nomenclature](design/finding-nomenclature.md) | Canonical observation/change vocabulary, arity ladder, operation outcomes, and Research composition boundary. |
 | [Finding Producer Design](design/finding-producers.md) | Choosing producer ownership, payloads, identities, result shapes, matching modes, and higher-rung boundaries. |
 | [Finding Instance Census](design/finding-instance-census.md) | Producer-issued receipt and per-instance keys for one sealed Finding census, including exact-association validation. |
+| [Research Finding Census Projection](design/research-finding-census-projection.md) | Preserving one producer-sealed body-fact census through Facts and Annotated Source without shape-derived identity. |
 | [Finding Value Semantics](design/finding-value-equality.md) | Equality and hashing for Finding-owned structural values, ordered collections, identity sets, union cases, and operation objects. |
 | [Analysis Diff Format](design/analysis-diff.md) | Complete immutable two-version item sequences and exhaustive producer-issued N:M relations for shared CLI and browser/Wasm analysis. |
 | [Comparison Document](design/comparison-document.md) | Portable root and subject composition for shared CLI/browser diffs and clone payloads, including referenced rename/move descriptions. |

--- a/docs/design/research-finding-census-projection.md
+++ b/docs/design/research-finding-census-projection.md
@@ -1,0 +1,168 @@
+# Research Finding census projection
+
+This document owns how `ILInspector.Research` preserves one producer-issued
+Finding census through its member-body Facts and Annotated Source projections.
+It consumes the receipt, instance-key, sealing, and validation contract from
+[Finding instance census](finding-instance-census.md) without redefining it.
+
+The end-to-end adoption is tracked by
+[issue #5515](https://github.com/richlander/dotnet-inspect/issues/5515).
+This focused first-adopter slice is
+[issue #4717](https://github.com/richlander/dotnet-inspect/issues/4717).
+
+## Problem
+
+Research already collects one body-fact set and shares it across member
+projections, but the projections retain only rendered annotation shape.
+Annotated Source consequently treats equal descriptor, category,
+conditionality, detail, and offset values as one observation. Two distinct
+Findings with equal visible values can collapse, and Facts and Annotated Source
+cannot prove that their rows came from the same producer execution.
+
+Descriptor text, detail, offsets, Finding correspondence keys, producer
+ordinals, collection positions, and value equality answer other questions.
+None may be reconstructed into Finding instance identity.
+
+## Contract
+
+The Research fact registry is the Finding producer for its heterogeneous
+body-fact stream. Each registered producer returns
+`Finding<IAnnotation>` observations:
+
+- the Finding subject identifies the member being inspected;
+- the Finding descriptor identifies the Research fact vocabulary entry;
+- the Finding key retains producer-owned cross-version correspondence;
+- the annotation payload retains category, conditionality, detail, and typed
+  domain evidence; and
+- the optional Finding ordinal retains producer order where one exists.
+
+The registry orders the complete producer result once and seals exactly one
+`FindingCensus<IAnnotation>`. The sealed census is the only assignment
+authority for instance keys. Research then projects the canonical entries; it
+does not reseal a filtered view or reconstruct a key from projection order.
+
+### Projection identity
+
+Every projected body fact carries the pair:
+
+```text
+(FindingCensusReceipt, FindingInstanceKey)
+```
+
+Facts rows and Annotated Source facts produced by one member operation carry
+the same receipt. A body Finding retains the same instance key in every
+requested projection. The member result also carries the receipt independently
+of its rows, so a successful empty body census remains identified.
+
+Annotated Source keeps its document-local fact id for fact-to-node targets.
+That id is presentation structure, not Finding identity. Research returns a
+sidecar joining each body fact id to its retained receipt/key pair. Equal
+visible fact values therefore remain separate document facts with separate
+sidecar entries, while the same Finding observed on C# and IL remains one fact
+with multiple targets. The Decompiler-owned multiplicity and internal placement
+contract is the stacked prerequisite tracked by
+[issue #5626](https://github.com/richlander/dotnet-inspect/issues/5626).
+
+Member-header facts are outside this first adoption. They retain their existing
+unanchored presentation and carry no body-census instance key. A later header
+Finding adoption must define its own producer census rather than inserting
+header rows into this one implicitly.
+
+### Admission and filtering
+
+Research admits the complete registry projection with
+`FindingCensus<T>.Validate`. A view that filters or reorders canonical entries
+retains the original receipt and validates each retained association with
+`ValidateEntry`.
+
+A default or wrong receipt, an invalid key, or a substituted Finding is a
+visible projection failure. Research does not fall back to descriptor, detail,
+offset, annotation equality, or list position. Projection construction
+finishes only after the retained associations pass the Finding-owned
+validation.
+
+Research enforces the lowered identity shape before returning the document and
+sidecar:
+
+- every sidecar row carries the operation's non-default census receipt;
+- every body fact id has exactly one non-default instance key;
+- body keys are unique within the projection;
+- header fact ids have no body-census sidecar row; and
+- no sidecar row names a missing document fact.
+
+These checks validate the portable join without making
+`AnnotatedSourceDocument` own Finding identity or deserialization. Exact
+Finding-reference association is validated before lowering, while the
+references are still available.
+
+## Composition boundaries
+
+Research owns:
+
+- producing the heterogeneous body Finding stream;
+- sealing one member-operation census;
+- preserving canonical receipt/key associations through filtering, ordering,
+  Facts rows, and Annotated Source; and
+- rejecting invalid associations before portable lowering.
+
+Adjacent owners remain separate:
+
+- [Finding instance census](finding-instance-census.md) owns receipt and key
+  construction, exact-association validation, and failure precedence;
+- [Member body substrate](member-body-substrate.md) owns portable document fact
+  multiplicity and the printer's internal preservation of a caller-issued
+  occurrence discriminator;
+- [Finding coordinates](finding-coordinates.md) owns subject, correspondence,
+  producer order, and typed provenance meanings;
+- the CLI adoption in
+  [issue #4718](https://github.com/richlander/dotnet-inspect/issues/4718) owns
+  command and structured-output presentation;
+- Inspect Web transport in
+  [issue #5516](https://github.com/richlander/dotnet-inspect/issues/5516) owns
+  managed result envelopes and wire field names; and
+- Inspect Web interaction in
+  [issue #5517](https://github.com/richlander/dotnet-inspect/issues/5517) owns
+  cross-view selection and stale-result behavior.
+
+The total Research projection-outcome lifecycle remains tracked by
+[issue #5608](https://github.com/richlander/dotnet-inspect/issues/5608).
+Method-qualified Research evidence locations remain tracked by
+[issue #5610](https://github.com/richlander/dotnet-inspect/issues/5610).
+
+## Evidence
+
+The Release executable gates in `src/ILInspector.Research.Tests` verify:
+
+- `MemberProjection_PreservesOneCensusAcrossFactsAndAnnotatedSource` proves one
+  producer collection and one receipt shared by both projections;
+- `MemberProjection_PreservesDisplayIdenticalFindingMultiplicity` proves equal
+  visible values retain distinct keys and document facts;
+- `MemberProjection_ReceiptsSuccessfulEmptyBodyCensus` proves a successful
+  empty body projection retains its non-default operation receipt;
+- `ResearchFactProjection_PreservesKeysThroughFilteringAndReordering` proves
+  subset projections retain canonical associations;
+- `ResearchFactProjection_RejectsWrongReceiptAndSubstitution` proves invalid
+  associations fail before lowering;
+- `ProjectionIsOptInAndFactsAgreeAcrossMedia` proves C# and IL targets refer to
+  the same keyed document facts without shape-derived `Distinct()`; and
+- the existing Research projection and Annotated Source suites preserve
+  neighboring rendering, header-fact, and opt-in behavior.
+
+The contract is immutable composition inside one member operation. It has no
+concurrent replacement, scheduling, retry, or asynchronous admission lifecycle,
+so executable Release gates are the appropriate oracle; no TLA+ model is
+required.
+
+## Non-claims
+
+This design does not:
+
+- redefine Finding census construction, validation, equality, or
+  correspondence;
+- make receipt/key identity durable across operations, processes, or sessions;
+- define JSON, TSV, Markout, TypeScript, or browser packet fields;
+- define CLI wording, browser selection, modal, focus, or history behavior;
+- adopt member-header facts into a Finding census;
+- define total requested, unrequested, successful, or failed projection
+  outcomes; or
+- define method-qualified evidence locations.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -94,7 +94,13 @@ substrates, and inspection producers that will extend that space.
   `AsyncCache`), the single `HttpClientFactory` seam with offline and
   network-policy enforcement, network telemetry, and hardened XML/JSON readers.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
-- `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
+- `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis
+  and Decompiler: its registry orders fact producers, joins R1 analysis
+  occurrences with R2 decompiler projections, and projects facts into the
+  Annotated Source, annotated IL, and Facts views used by `member`.
+  [Research Finding census projection](design/research-finding-census-projection.md)
+  owns preservation of one producer-sealed body-fact receipt and its instance
+  keys across those projections.
 - `prototypes/annotated-source-viewer/` is the dependency-free browser consumer
   for `AnnotatedSourceDocument`: it derives lines from the canonical text buffer,
   resolves facts through targets to multi-span nodes, filters the stable node-kind
@@ -297,6 +303,9 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Finding instance census](design/finding-instance-census.md): producer-issued
   receipt and per-instance keys for one sealed execution census, with
   bijection and exact-association validation.
+- [Research Finding census projection](design/research-finding-census-projection.md):
+  Research preservation of one body-fact census through Facts and Annotated
+  Source.
 - [Finding value semantics](design/finding-value-equality.md): .NET equality
   and hashing for Finding-owned structural values, ordered collections,
   identity sets, union cases, and reference-identity operation objects.

--- a/src/ILInspector.Research.Tests/AnnotatedSourceDocumentProjectionTests.cs
+++ b/src/ILInspector.Research.Tests/AnnotatedSourceDocumentProjectionTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 
 namespace ILInspector.Research.Tests;
 
@@ -22,6 +23,7 @@ public class AnnotatedSourceDocumentProjectionTests
             source,
             typeof(ResearchFixture).FullName!,
             nameof(ResearchFixture.BoxInt),
+            FactRows: true,
             SourceDocument: true));
         var document = Assert.IsType<AnnotatedSourceDocument>(projection.SourceDocument);
 
@@ -32,8 +34,14 @@ public class AnnotatedSourceDocumentProjectionTests
         Assert.Contains(document.Nodes, node => node.Medium == SourceLineKind.CSharp);
         Assert.Contains(document.Nodes, node => node.Medium == SourceLineKind.Il);
 
-        var csharpFacts = Facts(document, SourceLineKind.CSharp);
-        var ilFacts = Facts(document, SourceLineKind.Il);
+        var csharpFacts = InstanceKeys(
+            document,
+            projection.SourceDocumentFactIdentities,
+            SourceLineKind.CSharp);
+        var ilFacts = InstanceKeys(
+            document,
+            projection.SourceDocumentFactIdentities,
+            SourceLineKind.Il);
         Assert.NotEmpty(csharpFacts);
         Assert.Equal(csharpFacts, ilFacts);
 
@@ -57,13 +65,11 @@ public class AnnotatedSourceDocumentProjectionTests
         Assert.Equal(box.SourceOffset, boxIl.IlOffset);
         Assert.Contains(Lines(document), line => line.Il && line.Text == Selected(document, boxIl));
 
-        var expected = ResearchViews.CollectFacts(
-                source,
-                typeof(ResearchFixture).FullName!,
-                nameof(ResearchFixture.BoxInt))
-            .Select(FactKey.From)
-            .Distinct()
-            .Order()
+        var expected = Assert.IsAssignableFrom<IReadOnlyList<ResearchViews.FactRow>>(
+                projection.Facts)
+            .Where(row => row.InstanceKey is not null)
+            .Select(row => row.InstanceKey!.Value)
+            .OrderBy(key => key.Value)
             .ToArray();
         Assert.Equal(expected, ilFacts);
 
@@ -73,6 +79,147 @@ public class AnnotatedSourceDocumentProjectionTests
         Assert.Equal(ilOffsets.Length, ilOffsets.Distinct().Count());
 
         AssertNormalized(document);
+    }
+
+    [Fact]
+    public void MemberProjection_PreservesOneCensusAcrossFactsAndAnnotatedSource()
+    {
+        var producer = new CountingFindingsProducer(
+        [
+            Finding(new Annotation(
+                new AnnotationDescriptor(
+                    "test.first",
+                    AnnotationCategory.Cost,
+                    "first"),
+                SourceOffset: 0,
+                Detail: "first"),
+                identity: "first"),
+            Finding(new Annotation(
+                new AnnotationDescriptor(
+                    "test.second",
+                    AnnotationCategory.Semantics,
+                    "second"),
+                SourceOffset: 0,
+                Detail: "second"),
+                identity: "second"),
+        ]);
+        using var source = MetadataSource.Open(
+            typeof(ResearchFixture).Assembly.Location);
+
+        var projection = ResearchViews.ProjectMember(
+            new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(ResearchFixture).FullName!,
+                nameof(ResearchFixture.BoxInt),
+                FactRows: true,
+                Registry: new ResearchFactRegistry(producer),
+                SourceDocument: true));
+
+        Assert.Equal(1, producer.ProduceCount);
+        var rows = Assert.IsAssignableFrom<IReadOnlyList<ResearchViews.FactRow>>(
+            projection.Facts);
+        var identities = Assert.IsAssignableFrom<
+            IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>>(
+                projection.SourceDocumentFactIdentities);
+        FindingCensusReceipt receipt = Assert.Single(
+            rows.Select(row => Assert.IsType<FindingCensusReceipt>(
+                    row.CensusReceipt))
+                .Distinct());
+        Assert.False(receipt.IsDefault);
+        Assert.Equal(receipt, projection.FactCensusReceipt);
+        Assert.All(identities, identity =>
+            Assert.Equal(receipt, identity.CensusReceipt));
+        Assert.Equal(
+            rows.Select(row => Assert.IsType<FindingInstanceKey>(
+                    row.InstanceKey))
+                .OrderBy(key => key.Value),
+            identities.Select(identity => identity.InstanceKey)
+                .OrderBy(key => key.Value));
+    }
+
+    [Fact]
+    public void MemberProjection_ReceiptsSuccessfulEmptyBodyCensus()
+    {
+        using var source = MetadataSource.Open(
+            typeof(ResearchFixture).Assembly.Location);
+
+        var projection = ResearchViews.ProjectMember(
+            new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(ResearchFixture).FullName!,
+                nameof(ResearchFixture.BoxInt),
+                Registry: new ResearchFactRegistry(),
+                SourceDocument: true));
+
+        FindingCensusReceipt receipt = Assert.IsType<FindingCensusReceipt>(
+            projection.FactCensusReceipt);
+        Assert.False(receipt.IsDefault);
+        Assert.Empty(Assert.IsType<AnnotatedSourceDocument>(
+            projection.SourceDocument).Facts);
+        Assert.Empty(Assert.IsAssignableFrom<
+            IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>>(
+                projection.SourceDocumentFactIdentities));
+    }
+
+    [Fact]
+    public void MemberProjection_PreservesDisplayIdenticalFindingMultiplicity()
+    {
+        var descriptor = new AnnotationDescriptor(
+            "test.duplicate",
+            AnnotationCategory.Cost,
+            "duplicate");
+        var subject = new FindingSubject("test-member", "test member");
+        var key = new FindingKey("same-correspondence");
+        Finding<IAnnotation> first = ResearchFactFinding.Create(
+            subject,
+            new Annotation(descriptor, SourceOffset: 0, Detail: "same"),
+            key,
+            ordinal: 0);
+        Finding<IAnnotation> second = ResearchFactFinding.Create(
+            subject,
+            new Annotation(descriptor, SourceOffset: 0, Detail: "same"),
+            key,
+            ordinal: 0);
+        Assert.Equal(first, second);
+        Assert.NotSame(first, second);
+
+        using var source = MetadataSource.Open(
+            typeof(ResearchFixture).Assembly.Location);
+        var projection = ResearchViews.ProjectMember(
+            new ResearchViews.MemberProjectionRequest(
+                source,
+                typeof(ResearchFixture).FullName!,
+                nameof(ResearchFixture.BoxInt),
+                FactRows: true,
+                Registry: new ResearchFactRegistry(
+                    new CountingFindingsProducer([first, second])),
+                SourceDocument: true));
+        Assert.True(
+            projection.SourceDocumentFailure is null,
+            projection.SourceDocumentFailure is null
+                ? null
+                : string.Join(
+                    "; ",
+                    projection.SourceDocumentFailure.Diagnostics));
+        var document = Assert.IsType<AnnotatedSourceDocument>(
+            projection.SourceDocument);
+        var rows = Assert.IsAssignableFrom<IReadOnlyList<ResearchViews.FactRow>>(
+            projection.Facts);
+        var identities = Assert.IsAssignableFrom<
+            IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>>(
+                projection.SourceDocumentFactIdentities);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(2, rows.Select(row => row.InstanceKey).Distinct().Count());
+        Assert.Equal(
+            2,
+            document.Facts.Count(fact =>
+                fact.Descriptor == descriptor.Id
+                && fact.Detail == "same"
+                && fact.SourceOffset == 0));
+        Assert.Equal(2, identities.Count);
+        Assert.Equal(2, identities.Select(identity => identity.FactId).Distinct().Count());
+        Assert.Equal(2, identities.Select(identity => identity.InstanceKey).Distinct().Count());
     }
 
     [Fact]
@@ -179,7 +326,9 @@ public class AnnotatedSourceDocumentProjectionTests
         Assert.Contains(AllFacts(document), fact => fact.Descriptor == "cost.document-test");
         Assert.Equal(overlaysOnly.CostOverlay?.Body.Output, withDocument.CostOverlay?.Body.Output);
         Assert.Equal(overlaysOnly.SemanticsOverlay?.Output, withDocument.SemanticsOverlay?.Output);
-        Assert.Equal(overlaysOnly.Facts, withDocument.Facts);
+        Assert.Equal(
+            WithoutIdentity(overlaysOnly.Facts),
+            WithoutIdentity(withDocument.Facts));
         Assert.DoesNotContain("a ? b : c", Assert.IsType<string>(withDocument.CostOverlay?.Body.Output));
         Assert.DoesNotContain("a ? b : c", Assert.IsType<string>(withDocument.SemanticsOverlay?.Output));
     }
@@ -215,7 +364,9 @@ public class AnnotatedSourceDocumentProjectionTests
         Assert.Equal(withoutDocument.AnnotatedSource?.Output, withDocument.AnnotatedSource?.Output);
         Assert.Equal(withoutDocument.CostOverlay?.Body.Output, withDocument.CostOverlay?.Body.Output);
         Assert.Equal(withoutDocument.SemanticsOverlay?.Output, withDocument.SemanticsOverlay?.Output);
-        Assert.Equal(withoutDocument.Facts, withDocument.Facts);
+        Assert.Equal(
+            WithoutIdentity(withoutDocument.Facts),
+            WithoutIdentity(withDocument.Facts));
     }
 
     [Fact]
@@ -380,6 +531,7 @@ public class AnnotatedSourceDocumentProjectionTests
             source,
             typeof(ResearchFixture).FullName!,
             nameof(ResearchFixture.HighLoopLeverageCallee),
+            FactRows: true,
             SourceDocument: true));
         var document = Assert.IsType<AnnotatedSourceDocument>(projection.SourceDocument);
 
@@ -389,6 +541,18 @@ public class AnnotatedSourceDocumentProjectionTests
                 && candidate.Origin == AnnotatedSourceFactOrigin.MemberHeader);
         Assert.Equal(-1, fact.SourceOffset);
         Assert.Empty(Targets(document, fact));
+        Assert.DoesNotContain(
+            Assert.IsAssignableFrom<
+                IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>>(
+                projection.SourceDocumentFactIdentities),
+            identity => identity.FactId == fact.Id);
+
+        ResearchViews.FactRow row = Assert.Single(
+            Assert.IsAssignableFrom<IReadOnlyList<ResearchViews.FactRow>>(
+                projection.Facts),
+            candidate => candidate.Id == "cost.method");
+        Assert.Null(row.CensusReceipt);
+        Assert.Null(row.InstanceKey);
     }
 
     [Fact]
@@ -659,6 +823,39 @@ public class AnnotatedSourceDocumentProjectionTests
     static AnnotatedSourceTarget[] Targets(AnnotatedSourceDocument document, AnnotatedSourceFact fact) =>
         [.. document.Targets.Where(target => target.FactId == fact.Id)];
 
+    static FindingInstanceKey[] InstanceKeys(
+        AnnotatedSourceDocument document,
+        IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>? identities,
+        SourceLineKind medium)
+    {
+        var byFact = Assert.IsAssignableFrom<
+                IReadOnlyList<ResearchViews.AnnotatedSourceFactIdentity>>(
+                identities)
+            .ToDictionary(identity => identity.FactId);
+        return
+        [
+            .. document.Targets
+                .Where(target =>
+                    document.Nodes[target.NodeId].Medium == medium)
+                .Select(target => byFact[target.FactId].InstanceKey)
+                .Distinct()
+                .OrderBy(key => key.Value),
+        ];
+    }
+
+    static ResearchViews.FactRow[] WithoutIdentity(
+        IReadOnlyList<ResearchViews.FactRow>? facts)
+        => facts is null
+            ? []
+            :
+            [
+                .. facts.Select(fact => fact with
+                {
+                    CensusReceipt = null,
+                    InstanceKey = null,
+                }),
+            ];
+
     /// <summary>
     /// The facts a medium actually shows, derived by joining targets back to
     /// their nodes. Facts are deduplicated, so an observation seen in both media
@@ -768,7 +965,8 @@ public class AnnotatedSourceDocumentProjectionTests
         public string Name => "document-marker";
         public IReadOnlyList<string> Produces => [marker.Descriptor.Id];
         public IReadOnlyList<string> DependsOn => [];
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => [marker];
+        public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
+            => [TestFinding(marker)];
     }
 
     sealed class MarkersProducer(IReadOnlyList<IAnnotation> markers) : IResearchFactProducer
@@ -776,7 +974,25 @@ public class AnnotatedSourceDocumentProjectionTests
         public string Name => "document-markers";
         public IReadOnlyList<string> Produces => [.. markers.Select(marker => marker.Descriptor.Id)];
         public IReadOnlyList<string> DependsOn => [];
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => markers;
+        public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
+            => [.. markers.Select(TestFinding)];
+    }
+
+    sealed class CountingFindingsProducer(
+        IReadOnlyList<Finding<IAnnotation>> findings) : IResearchFactProducer
+    {
+        public int ProduceCount { get; private set; }
+        public string Name => "counting-findings";
+        public IReadOnlyList<string> Produces =>
+            [.. findings.Select(finding => finding.Payload.Descriptor.Id)];
+        public IReadOnlyList<string> DependsOn => [];
+
+        public IReadOnlyList<Finding<IAnnotation>> Produce(
+            ResearchFactContext context)
+        {
+            ProduceCount++;
+            return findings;
+        }
     }
 
     sealed class ThrowingHeaderProducer : IResearchFactProducer
@@ -784,7 +1000,7 @@ public class AnnotatedSourceDocumentProjectionTests
         public string Name => "throwing-header";
         public IReadOnlyList<string> Produces => [];
         public IReadOnlyList<string> DependsOn => [];
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => [];
+        public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context) => [];
         public IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context)
             => throw new InvalidOperationException("header failed");
     }
@@ -803,14 +1019,40 @@ public class AnnotatedSourceDocumentProjectionTests
         public string Name => "malformed-text";
         public IReadOnlyList<string> Produces => [Body.Id, Placed.Id, Literal.Id, Header.Id];
         public IReadOnlyList<string> DependsOn => [];
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+        public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
             =>
             [
-                new Annotation(Body, SourceOffset: -1, Detail: "body.\U0001F600\uDC00"),
-                new Annotation(Placed, SourceOffset: 0, Detail: "placed.\U0001F600\uDC00"),
-                new Annotation(Literal, SourceOffset: -1, Detail: "literal.\\uD800"),
+                TestFinding(new Annotation(
+                    Body,
+                    SourceOffset: -1,
+                    Detail: "body.\U0001F600\uDC00")),
+                TestFinding(new Annotation(
+                    Placed,
+                    SourceOffset: 0,
+                    Detail: "placed.\U0001F600\uDC00")),
+                TestFinding(new Annotation(
+                    Literal,
+                    SourceOffset: -1,
+                    Detail: "literal.\\uD800")),
             ];
         public IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context)
             => [new ResearchHeaderFact(Header, "header.\uD800")];
     }
+
+    static Finding<IAnnotation> TestFinding(
+        IAnnotation annotation,
+        int ordinal = 0)
+        => ResearchFactFinding.Create(
+            new FindingSubject("test-member", "test member"),
+            annotation,
+            new FindingKey($"{annotation.Descriptor.Id}|{ordinal}"),
+            ordinal);
+
+    static Finding<IAnnotation> Finding(
+        IAnnotation annotation,
+        string identity)
+        => ResearchFactFinding.Create(
+            new FindingSubject("test-member", "test member"),
+            annotation,
+            new FindingKey(identity));
 }

--- a/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchFactRegistryTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 using ILInspector.Metadata;
 
 namespace ILInspector.Research.Tests;
@@ -748,6 +749,94 @@ public class ResearchFactRegistryTests
     }
 
     [Fact]
+    public void ResearchFactProjection_PreservesKeysThroughFilteringAndReordering()
+    {
+        Finding<IAnnotation>[] findings =
+        [
+            TestFinding(
+                new Annotation(
+                    new AnnotationDescriptor(
+                        "test.first",
+                        AnnotationCategory.Cost,
+                        "first"),
+                    SourceOffset: 0),
+                ordinal: 0),
+            TestFinding(
+                new Annotation(
+                    new AnnotationDescriptor(
+                        "test.second",
+                        AnnotationCategory.Semantics,
+                        "second"),
+                    SourceOffset: 1),
+                ordinal: 1),
+            TestFinding(
+                new Annotation(
+                    new AnnotationDescriptor(
+                        "test.third",
+                        AnnotationCategory.Cost,
+                        "third"),
+                    SourceOffset: 2),
+                ordinal: 2),
+        ];
+        FindingCensus<IAnnotation> census =
+            FindingCensus<IAnnotation>.Seal(findings);
+
+        ResearchFactProjection projection =
+            ResearchFactProjection.AdmitSubset(
+                census,
+                census.Receipt,
+                [census.Entries[2], census.Entries[0]]);
+
+        Assert.Equal(
+            [census.Entries[2].Key, census.Entries[0].Key],
+            projection.Annotations.Select(annotation => annotation.Entry.Key));
+        Assert.Same(
+            census.Entries[2].Finding,
+            projection.Annotations[0].Entry.Finding);
+        Assert.Same(
+            census.Entries[0].Finding,
+            projection.Annotations[1].Entry.Finding);
+    }
+
+    [Fact]
+    public void ResearchFactProjection_RejectsWrongReceiptAndSubstitution()
+    {
+        var descriptor = new AnnotationDescriptor(
+            "test.same",
+            AnnotationCategory.Cost,
+            "same");
+        Finding<IAnnotation> finding = TestFinding(
+            new Annotation(descriptor, SourceOffset: 0, Detail: "same"),
+            ordinal: 0);
+        FindingCensus<IAnnotation> census =
+            FindingCensus<IAnnotation>.Seal([finding]);
+        FindingCensus<IAnnotation> other =
+            FindingCensus<IAnnotation>.Seal([finding]);
+
+        var wrongReceipt = Assert.Throws<InvalidOperationException>(() =>
+            ResearchFactProjection.AdmitSubset(
+                census,
+                other.Receipt,
+                census.Entries));
+        Assert.Contains("WrongReceipt", wrongReceipt.Message);
+
+        Finding<IAnnotation> substitute = TestFinding(
+            new Annotation(descriptor, SourceOffset: 0, Detail: "same"),
+            ordinal: 0);
+        Assert.Equal(finding, substitute);
+        Assert.NotSame(finding, substitute);
+        var substitutedEntry = new FindingCensusEntry<IAnnotation>(
+            census.Entries[0].Key,
+            substitute);
+        var substituted = Assert.Throws<InvalidOperationException>(() =>
+            ResearchFactProjection.AdmitSubset(
+                census,
+                census.Receipt,
+                [substitutedEntry]));
+        Assert.Contains("SubstitutedFinding", substituted.Message);
+    }
+
+    [Fact]
     public void DefaultAllocationProducer_ProjectsAnalysisFindingCensus()
     {
         using var source = MetadataSource.Open(typeof(ResearchFixture).Assembly.Location);
@@ -922,7 +1011,11 @@ public class ResearchFactRegistryTests
         public string Name => name;
         public IReadOnlyList<string> Produces { get; } = produces ?? [];
         public IReadOnlyList<string> DependsOn { get; } = dependsOn ?? [];
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => facts ?? [];
+        public IReadOnlyList<Finding<IAnnotation>> Produce(
+            ResearchFactContext context)
+            => facts is null
+                ? []
+                : [.. facts.Select((fact, ordinal) => TestFinding(fact, ordinal))];
     }
 
     sealed class CountingProducer : IResearchFactProducer
@@ -938,20 +1031,31 @@ public class ResearchFactRegistryTests
             ResearchFactRequirements.ForAssembly(
                 LibraryBodyAnalysisFeatures.MethodEvidence);
 
-        public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+        public IReadOnlyList<Finding<IAnnotation>> Produce(
+            ResearchFactContext context)
         {
             FactCollectCount++;
             AssemblyContext = context.Assembly;
             return
             [
-                new Annotation(
-                    new AnnotationDescriptor("cost.test", AnnotationCategory.Cost, "test cost"),
-                    SourceOffset: 0,
-                    Detail: "shared"),
-                new Annotation(
-                    new AnnotationDescriptor("semantics.test", AnnotationCategory.Semantics, "test semantics"),
-                    SourceOffset: 0,
-                    Detail: "shared")
+                TestFinding(
+                    new Annotation(
+                        new AnnotationDescriptor(
+                            "cost.test",
+                            AnnotationCategory.Cost,
+                            "test cost"),
+                        SourceOffset: 0,
+                        Detail: "shared"),
+                    ordinal: 0),
+                TestFinding(
+                    new Annotation(
+                        new AnnotationDescriptor(
+                            "semantics.test",
+                            AnnotationCategory.Semantics,
+                            "test semantics"),
+                        SourceOffset: 0,
+                        Detail: "shared"),
+                    ordinal: 1),
             ];
         }
 
@@ -983,7 +1087,7 @@ public class ResearchFactRegistryTests
         public IReadOnlyList<string> Produces => [];
         public IReadOnlyList<string> DependsOn => [];
 
-        public IReadOnlyList<IAnnotation> Produce(
+        public IReadOnlyList<Finding<IAnnotation>> Produce(
             ResearchFactContext context)
         {
             WasInvoked = true;
@@ -991,6 +1095,15 @@ public class ResearchFactRegistryTests
             return [];
         }
     }
+
+    static Finding<IAnnotation> TestFinding(
+        IAnnotation annotation,
+        int ordinal)
+        => ResearchFactFinding.Create(
+            new FindingSubject("test-member", "test member"),
+            annotation,
+            new FindingKey($"{annotation.Descriptor.Id}|{ordinal}"),
+            ordinal);
 }
 
 public static class ResearchFixture

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -21,7 +21,7 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         ResearchFactRequirements.ForMember(
             LibraryBodyAnalysisFeatures.Allocations);
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
     {
         var function = context.Imported;
         if (context.Assembly is not { } assembly || function.MetadataToken == 0)
@@ -35,7 +35,9 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         return
         [
             .. AnalysisFindings.InspectAllocations(occurrences, subject)
-                .Select(finding => ToAnnotation(finding.Payload)),
+                .Select(finding => ResearchFactFinding.Project(
+                    finding,
+                    ToAnnotation(finding.Payload))),
         ];
     }
 

--- a/src/ILInspector.Research/CallSiteCostFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteCostFactProducer.cs
@@ -1,5 +1,6 @@
 using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
@@ -19,7 +20,7 @@ sealed class CallSiteCostFactProducer : IResearchFactProducer
         ResearchFactRequirements.ForAssembly(
             LibraryBodyAnalysisFeatures.Allocations);
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
     {
         if (context.Assembly is not { } assembly || context.Imported.MetadataToken == 0)
             return [];
@@ -27,7 +28,7 @@ sealed class CallSiteCostFactProducer : IResearchFactProducer
         if (callSites.IsEmpty)
             return [];
 
-        var facts = new List<Annotation>();
+        var facts = new List<Finding<IAnnotation>>();
         foreach (var finding in callSites)
         {
             var call = finding.Payload;
@@ -39,7 +40,12 @@ sealed class CallSiteCostFactProducer : IResearchFactProducer
             assembly.LeverageByToken.TryGetValue(calleeToken, out var leverage);
             if (!IsHighValue(call, signals, leverage))
                 continue;
-            facts.Add(new Annotation(CalleeCost, call.ILOffset, Detail(call.Callee, signals, leverage, call.InLoop)));
+            facts.Add(ResearchFactFinding.Project(
+                finding,
+                new Annotation(
+                    CalleeCost,
+                    call.ILOffset,
+                    Detail(call.Callee, signals, leverage, call.InLoop))));
         }
         return facts;
     }

--- a/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
+++ b/src/ILInspector.Research/CallSiteSemanticsFactProducer.cs
@@ -1,5 +1,6 @@
 using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
@@ -17,7 +18,7 @@ sealed class CallSiteSemanticsFactProducer : IResearchFactProducer
         ResearchFactRequirements.ForAssembly(
             LibraryBodyAnalysisFeatures.MethodEvidence);
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
     {
         if (context.Assembly is not { } assembly || context.Imported.MetadataToken == 0)
             return [];
@@ -25,7 +26,7 @@ sealed class CallSiteSemanticsFactProducer : IResearchFactProducer
         if (callSites.IsEmpty)
             return [];
 
-        var facts = new List<Annotation>();
+        var facts = new List<Finding<IAnnotation>>();
         foreach (var finding in callSites)
         {
             var call = finding.Payload;
@@ -36,11 +37,22 @@ sealed class CallSiteSemanticsFactProducer : IResearchFactProducer
             var signals = assembly.Signals.GetValueOrDefault(calleeToken, MethodSignals.None);
             var exceptionTypes = DomainExceptionTypes(signals);
             if (exceptionTypes.Count > 0)
-                facts.Add(new Annotation(CalleeSemantics, call.ILOffset, ExceptionDetail(exceptionTypes)));
+            {
+                facts.Add(ResearchFactFinding.Project(
+                    finding,
+                    new Annotation(
+                        CalleeSemantics,
+                        call.ILOffset,
+                        ExceptionDetail(exceptionTypes))));
+            }
 
             var unsafeDetail = UnsafeDetail(assembly, calleeToken);
             if (unsafeDetail is not null)
-                facts.Add(new Annotation(CalleeSafety, call.ILOffset, unsafeDetail));
+            {
+                facts.Add(ResearchFactFinding.Project(
+                    finding,
+                    new Annotation(CalleeSafety, call.ILOffset, unsafeDetail)));
+            }
         }
         return facts;
     }

--- a/src/ILInspector.Research/DirectCallFactProducer.cs
+++ b/src/ILInspector.Research/DirectCallFactProducer.cs
@@ -1,5 +1,6 @@
 using ILInspector.Analysis;
 using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
@@ -16,24 +17,28 @@ sealed class DirectCallFactProducer : IResearchFactProducer
         [ResearchFactRegistry.CallRelationshipDescriptorId];
     public IReadOnlyList<string> DependsOn => [];
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
     {
         IReadOnlyList<DirectCall> calls = context.CallSites
             ?? throw new InvalidOperationException(
                 "Direct call relationship facts require supplied call-site evidence.");
-        return calls.Count == 0
-            ? []
-            :
-            [
-                .. calls
-                    .OrderBy(call => call.ILOffset)
-                    .ThenBy(call => call.OperandToken)
-                    .Select(call => new Annotation<DirectCall>(
+        if (calls.Count == 0)
+            return [];
+
+        var subject = ResearchMemberIdentity.SubjectFromMethod(calls[0].Caller);
+        return
+        [
+            .. AnalysisFindings.InspectCallSites(
+                    calls,
+                    new FindingSubject(subject.Id, subject.Display))
+                .Select(finding => ResearchFactFinding.Project(
+                    finding,
+                    new Annotation<DirectCall>(
                         CallEdge,
-                        call.ILOffset,
-                        call,
+                        finding.Payload.ILOffset,
+                        finding.Payload,
                         Formatter: static occurrence =>
-                            occurrence.Callee.ToQualifiedDisplayString())),
-            ];
+                            occurrence.Callee.ToQualifiedDisplayString()))),
+        ];
     }
 }

--- a/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
+++ b/src/ILInspector.Research/MethodHeaderLeverageFactProducer.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
 
 namespace ILInspector.Research;
 
@@ -18,7 +19,7 @@ sealed class MethodHeaderLeverageFactProducer : IResearchFactProducer
         ResearchFactRequirements.ForAssembly(
             ILInspector.Analysis.LibraryBodyAnalysisFeatures.MethodEvidence);
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context) => [];
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context) => [];
 
     public IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context)
     {

--- a/src/ILInspector.Research/ResearchFactFinding.cs
+++ b/src/ILInspector.Research/ResearchFactFinding.cs
@@ -1,0 +1,52 @@
+using ILInspector.Decompiler.Annotations;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+
+namespace ILInspector.Research;
+
+static class ResearchFactFinding
+{
+    public static Finding<IAnnotation> Project<T>(
+        Finding<T> source,
+        IAnnotation annotation)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(annotation);
+        return new Finding<IAnnotation>(
+            source.Subject,
+            Descriptor(annotation.Descriptor),
+            source.Key,
+            annotation,
+            source.Ordinal,
+            annotation.Detail);
+    }
+
+    public static Finding<IAnnotation> Create(
+        FindingSubject subject,
+        IAnnotation annotation,
+        FindingKey key,
+        int? ordinal = null)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(annotation);
+        return new Finding<IAnnotation>(
+            subject,
+            Descriptor(annotation.Descriptor),
+            key,
+            annotation,
+            ordinal,
+            annotation.Detail);
+    }
+
+    public static FindingSubject Subject(IrFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        return new FindingSubject(
+            $"{function.AssemblyPath}|{function.MetadataToken:X8}",
+            function.Name);
+    }
+
+    static FindingDescriptor Descriptor(AnnotationDescriptor descriptor)
+        => new(descriptor.Id, descriptor.Title);
+}

--- a/src/ILInspector.Research/ResearchFactProjection.cs
+++ b/src/ILInspector.Research/ResearchFactProjection.cs
@@ -1,0 +1,117 @@
+using ILInspector.Decompiler.Annotations;
+using ILInspector.Findings;
+
+namespace ILInspector.Research;
+
+sealed class ResearchFactProjection
+{
+    readonly FindingCensus<IAnnotation> _census;
+
+    ResearchFactProjection(
+        FindingCensus<IAnnotation> census,
+        FindingCensusReceipt receipt,
+        IReadOnlyList<ResearchFactAnnotation> annotations)
+    {
+        _census = census;
+        Receipt = receipt;
+        Annotations = annotations;
+    }
+
+    public FindingCensusReceipt Receipt { get; }
+    public IReadOnlyList<ResearchFactAnnotation> Annotations { get; }
+
+    public static ResearchFactProjection AdmitComplete(
+        FindingCensus<IAnnotation> census,
+        FindingCensusReceipt receipt,
+        IEnumerable<FindingCensusEntry<IAnnotation>> entries)
+    {
+        ArgumentNullException.ThrowIfNull(census);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        FindingCensusEntry<IAnnotation>[] retained = [.. entries];
+        RequireValid(census.Validate(receipt, retained));
+        return new ResearchFactProjection(
+            census,
+            receipt,
+            [.. retained.Select(entry => new ResearchFactAnnotation(entry))]);
+    }
+
+    public ResearchFactProjection Where(
+        Func<IAnnotation, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        FindingCensusEntry<IAnnotation>[] retained =
+        [
+            .. Annotations
+                .Where(annotation => predicate(annotation))
+                .Select(annotation => annotation.Entry),
+        ];
+        foreach (FindingCensusEntry<IAnnotation> entry in retained)
+            RequireValid(_census.ValidateEntry(Receipt, entry));
+        return new ResearchFactProjection(
+            _census,
+            Receipt,
+            [.. retained.Select(entry => new ResearchFactAnnotation(entry))]);
+    }
+
+    internal static ResearchFactProjection AdmitSubset(
+        FindingCensus<IAnnotation> census,
+        FindingCensusReceipt receipt,
+        IEnumerable<FindingCensusEntry<IAnnotation>> entries)
+    {
+        ArgumentNullException.ThrowIfNull(census);
+        ArgumentNullException.ThrowIfNull(entries);
+
+        FindingCensusEntry<IAnnotation>[] retained = [.. entries];
+        foreach (FindingCensusEntry<IAnnotation> entry in retained)
+            RequireValid(census.ValidateEntry(receipt, entry));
+
+        FindingInstanceKey duplicate = retained
+            .GroupBy(entry => entry.Key)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .OrderBy(key => key.Value)
+            .FirstOrDefault();
+        if (!duplicate.IsDefault)
+        {
+            throw new InvalidOperationException(
+                $"Research Finding projection rejected DuplicateKey at key {duplicate}.");
+        }
+        return new ResearchFactProjection(
+            census,
+            receipt,
+            [.. retained.Select(entry => new ResearchFactAnnotation(entry))]);
+    }
+
+    static void RequireValid(FindingCensusValidation validation)
+    {
+        FindingCensusValidationFailure? failure = validation switch
+        {
+            FindingCensusValidation.Valid => null,
+            FindingCensusValidation.Invalid invalid => invalid.Failure,
+        };
+        if (failure is null)
+            return;
+
+        throw new InvalidOperationException(
+            $"Research Finding projection rejected {failure.Kind}"
+                + (failure.Key.IsDefault ? "" : $" at key {failure.Key}")
+                + (failure.InputIndex is null
+                    ? "."
+                    : $" at input index {failure.InputIndex}."));
+    }
+}
+
+sealed class ResearchFactAnnotation(
+    FindingCensusEntry<IAnnotation> entry) : IAnnotation
+{
+    public FindingCensusEntry<IAnnotation> Entry { get; } =
+        entry ?? throw new ArgumentNullException(nameof(entry));
+
+    IAnnotation Annotation => Entry.Finding.Payload;
+
+    public AnnotationDescriptor Descriptor => Annotation.Descriptor;
+    public int SourceOffset => Annotation.SourceOffset;
+    public AnnotationConditionality Conditionality => Annotation.Conditionality;
+    public string? Detail => Annotation.Detail;
+}

--- a/src/ILInspector.Research/ResearchFactRegistry.cs
+++ b/src/ILInspector.Research/ResearchFactRegistry.cs
@@ -155,7 +155,7 @@ public interface IResearchFactProducer
     IReadOnlyList<string> Produces { get; }
     IReadOnlyList<string> DependsOn { get; }
     ResearchFactRequirements Requirements => ResearchFactRequirements.None;
-    IReadOnlyList<IAnnotation> Produce(ResearchFactContext context);
+    IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context);
     IReadOnlyList<ResearchHeaderFact> ProduceHeaderFacts(ResearchFactContext context) => [];
 }
 
@@ -200,8 +200,28 @@ public sealed class ResearchFactRegistry
     public static ResearchFactRegistry CallRelationships { get; } = new(
         new DirectCallFactProducer());
 
+    public FindingCensus<IAnnotation> CollectCensus(ResearchFactContext context)
+    {
+        Finding<IAnnotation>[] findings =
+        [
+            .. _producers.SelectMany(producer => producer.Produce(context)),
+        ];
+        if (findings.Any(finding => finding is null))
+        {
+            throw new InvalidOperationException(
+                "Research fact producers must not return null Findings.");
+        }
+
+        return FindingCensus<IAnnotation>.Seal(
+            findings
+                .OrderBy(finding => finding.Payload.SourceOffset)
+                .ThenBy(
+                    finding => finding.Payload.Descriptor.Id,
+                    StringComparer.Ordinal));
+    }
+
     public IReadOnlyList<IAnnotation> Collect(ResearchFactContext context)
-        => [.. _producers.SelectMany(producer => producer.Produce(context)).OrderBy(fact => fact.SourceOffset).ThenBy(fact => fact.Descriptor.Id, StringComparer.Ordinal)];
+        => [.. CollectCensus(context).Findings.Select(finding => finding.Payload)];
 
     public IReadOnlyList<ResearchHeaderFact> CollectHeaderFacts(ResearchFactContext context)
         => [.. _producers.SelectMany(producer => producer.ProduceHeaderFacts(context)).OrderBy(fact => fact.Descriptor.Id, StringComparer.Ordinal)];
@@ -239,6 +259,20 @@ sealed class DecompilerLifetimeFactProducer : IResearchFactProducer
     public IReadOnlyList<string> Produces { get; } = ["lifetime.*"];
     public IReadOnlyList<string> DependsOn => [];
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
-        => new Decompiler.Annotations.LifetimeClassifier().Classify(context.Imported);
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
+    {
+        var subject = ResearchFactFinding.Subject(context.Imported);
+        return
+        [
+            .. new Decompiler.Annotations.LifetimeClassifier()
+                .Classify(context.Imported)
+                .Select((annotation, ordinal) =>
+                    ResearchFactFinding.Create(
+                        subject,
+                        annotation,
+                        new FindingKey(
+                            $"{annotation.Descriptor.Id}|{annotation.SourceOffset:X8}"),
+                        ordinal)),
+        ];
+    }
 }

--- a/src/ILInspector.Research/ResearchViews.cs
+++ b/src/ILInspector.Research/ResearchViews.cs
@@ -5,6 +5,7 @@ using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
 using ILInspector.Instructions;
 using ILInspector.Text;
 
@@ -20,7 +21,36 @@ public static partial class ResearchViews
         string Category,
         string Id,
         string? Detail,
-        string Conditionality);
+        string Conditionality,
+        FindingCensusReceipt? CensusReceipt = null,
+        FindingInstanceKey? InstanceKey = null);
+
+    public sealed record AnnotatedSourceFactIdentity
+    {
+        public AnnotatedSourceFactIdentity(
+            int factId,
+            FindingCensusReceipt censusReceipt,
+            FindingInstanceKey instanceKey)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(factId);
+            if (censusReceipt.IsDefault)
+                throw new ArgumentException(
+                    "Census receipt must be producer-issued and non-default.",
+                    nameof(censusReceipt));
+            if (instanceKey.IsDefault)
+                throw new ArgumentException(
+                    "Instance key must be producer-issued and non-default.",
+                    nameof(instanceKey));
+
+            FactId = factId;
+            CensusReceipt = censusReceipt;
+            InstanceKey = instanceKey;
+        }
+
+        public int FactId { get; }
+        public FindingCensusReceipt CensusReceipt { get; }
+        public FindingInstanceKey InstanceKey { get; }
+    }
 
     public sealed record CostOverlayResult(
         DecompilerResult Body,
@@ -84,7 +114,19 @@ public static partial class ResearchViews
         DecompilerResult? SourceDocumentFailure = null,
 
         /// <summary>The MethodDef token selected for this projection.</summary>
-        int? SelectedMethodToken = null);
+        int? SelectedMethodToken = null,
+
+        /// <summary>
+        /// Research-owned Finding identities for body facts in
+        /// <see cref="SourceDocument"/>, joined by document-local fact id.
+        /// </summary>
+        IReadOnlyList<AnnotatedSourceFactIdentity>? SourceDocumentFactIdentities = null,
+
+        /// <summary>
+        /// Receipt for the one body Finding census successfully collected by
+        /// this member operation, including a successful empty census.
+        /// </summary>
+        FindingCensusReceipt? FactCensusReceipt = null);
 
     public static MemberProjectionResult ProjectMember(MemberProjectionRequest request)
     {
@@ -116,7 +158,12 @@ public static partial class ResearchViews
                 imported,
                 assembly,
                 request.CallSites);
-            var facts = effectiveRegistry.Collect(context);
+            var factCensus = effectiveRegistry.CollectCensus(context);
+            var factProjection = ResearchFactProjection.AdmitComplete(
+                factCensus,
+                factCensus.Receipt,
+                factCensus.Entries);
+            IReadOnlyList<IAnnotation> facts = factProjection.Annotations;
             IReadOnlyList<ResearchHeaderFact> headerFacts = [];
             DecompilerResult? headerFactsFailure = null;
             if (request.FactRows)
@@ -138,6 +185,7 @@ public static partial class ResearchViews
             }
 
             AnnotatedSourceDocument? sourceDocument = null;
+            IReadOnlyList<AnnotatedSourceFactIdentity>? sourceDocumentFactIdentities = null;
             DecompilerResult? sourceDocumentFailure = null;
             if (request.SourceDocument)
             {
@@ -156,18 +204,22 @@ public static partial class ResearchViews
                     var documentHeaderFacts = request.FactRows || request.CostOverlay
                         ? headerFacts
                         : effectiveRegistry.CollectHeaderFacts(context);
-                    return BuildAnnotatedSourceDocument(
+                    AnnotatedSourceProjection sourceProjection =
+                        BuildAnnotatedSourceDocument(
                         request.Source,
                         request.Type,
                         request.Method,
                         documentFunction,
-                        facts,
+                        factProjection,
                         documentHeaderFacts,
                         request.AnnotatedStage,
                         request.OverloadIndex,
                         request.PublicOnly,
                         request.MethodToken,
                         request.PrinterOptions);
+                    sourceDocumentFactIdentities =
+                        sourceProjection.FactIdentities;
+                    return sourceProjection.Document;
                 });
             }
 
@@ -211,9 +263,10 @@ public static partial class ResearchViews
                 }
                 else
                 {
-                    var costAnnotations = facts
-                        .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Cost)
-                        .ToList();
+                    IReadOnlyList<IAnnotation> costAnnotations = factProjection
+                        .Where(annotation =>
+                            annotation.Descriptor.Category == AnnotationCategory.Cost)
+                        .Annotations;
                     var costHeaderFacts = headerFacts
                         .Where(fact => fact.Descriptor.Category == AnnotationCategory.Cost)
                         .ToList();
@@ -232,9 +285,10 @@ public static partial class ResearchViews
             DecompilerResult? semanticsOverlay = null;
             if (request.SemanticsOverlay)
             {
-                var semanticsAnnotations = facts
-                    .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Semantics)
-                    .ToList();
+                IReadOnlyList<IAnnotation> semanticsAnnotations = factProjection
+                    .Where(annotation =>
+                        annotation.Descriptor.Category == AnnotationCategory.Semantics)
+                    .Annotations;
                 semanticsOverlay = WithTrace(
                     RunProjection(() => RenderRaisedOverlay(
                         imported,
@@ -247,7 +301,13 @@ public static partial class ResearchViews
 
             IReadOnlyList<FactRow>? factRows = null;
             if (request.FactRows)
-                factRows = BuildFactRows(request.Type, request.Method, imported, facts, headerFacts, request.Source);
+                factRows = BuildFactRows(
+                    request.Type,
+                    request.Method,
+                    imported,
+                    factProjection,
+                    headerFacts,
+                    request.Source);
 
             return new MemberProjectionResult(
                 annotatedSource,
@@ -258,7 +318,9 @@ public static partial class ResearchViews
                 UnmatchedFocusAlternatives(request.CaretFocus, gestures, facts),
                 sourceDocument,
                 sourceDocumentFailure,
-                imported.MetadataToken);
+                imported.MetadataToken,
+                sourceDocumentFactIdentities,
+                factProjection.Receipt);
         }
         catch (Exception ex)
         {
@@ -348,7 +410,11 @@ public static partial class ResearchViews
 
     public static IReadOnlyList<IAnnotation> CollectFacts(
         MetadataSource source, IrFunction imported, ResearchAssemblyContext? assembly, ResearchFactRegistry? registry = null)
-        => (registry ?? ResearchFactRegistry.Default).Collect(new ResearchFactContext(source, imported, assembly));
+        => (registry ?? ResearchFactRegistry.Default)
+            .CollectCensus(new ResearchFactContext(source, imported, assembly))
+            .Findings
+            .Select(finding => finding.Payload)
+            .ToArray();
 
     public static IReadOnlyList<FactRow> CollectFactRows(
         MetadataSource source, string type, string method, int overloadIndex = 0, bool publicOnly = false,
@@ -363,7 +429,11 @@ public static partial class ResearchViews
             ResolveAssemblyContext(
                 imported,
                 effectiveRegistry.Requirements));
-        var facts = effectiveRegistry.Collect(context);
+        var census = effectiveRegistry.CollectCensus(context);
+        var facts = ResearchFactProjection.AdmitComplete(
+            census,
+            census.Receipt,
+            census.Entries);
         var headerFacts = effectiveRegistry.CollectHeaderFacts(context);
         return BuildFactRows(type, method, imported, facts, headerFacts, source);
     }
@@ -428,12 +498,12 @@ public static partial class ResearchViews
         return csResult with { Output = RenderMixedStream(stream, gestures ?? AnnotationGestureSelector.SideOnly, extents) };
     }
 
-    static AnnotatedSourceDocument BuildAnnotatedSourceDocument(
+    static AnnotatedSourceProjection BuildAnnotatedSourceDocument(
         MetadataSource source,
         string type,
         string method,
         IrFunction imported,
-        IReadOnlyList<IAnnotation> annotations,
+        ResearchFactProjection facts,
         IReadOnlyList<ResearchHeaderFact> headerFacts,
         AnnotationStage stage,
         int overloadIndex,
@@ -441,6 +511,7 @@ public static partial class ResearchViews
         int? methodToken,
         PrinterOptions? printerOptions)
     {
+        IReadOnlyList<IAnnotation> annotations = facts.Annotations;
         IrFunction? ImportMethodBody(MethodRef target) => IrImporter.Import(source, target);
         var csResult = stage == AnnotationStage.Lowered
             ? CSharpPrinter.PrintLowered(
@@ -495,8 +566,14 @@ public static partial class ResearchViews
             printedRanges,
             imported,
             annotations,
-            provenanceOffsetAllowList);
-        return MakeDocument(stream, csharpMap, headerFacts, documentSource);
+            provenanceOffsetAllowList,
+            InstanceKey);
+        return MakeDocument(
+            stream,
+            csharpMap,
+            headerFacts,
+            documentSource,
+            facts.Receipt);
     }
 
     internal static string RequireSuccessfulDocumentOutput(DecompilerResult result)
@@ -630,20 +707,20 @@ public static partial class ResearchViews
     /// join established before those identities were discarded.
     /// </para>
     /// <para>
-    /// Facts are deduplicated on their full semantic identity, including origin,
-    /// after portable escaping — escaping first, because two descriptors that
-    /// differ only in an unpaired surrogate must not merge after they are
-    /// encoded the same way. One fact observed in both media therefore becomes
-    /// one fact row targeting a C# node and an instruction node, which is what
-    /// makes "this is one observation" readable from the payload. A fact neither
-    /// medium could anchor simply has no target.
+    /// Body facts are joined by producer-issued instance key after portable
+    /// escaping; equal rendered values therefore retain multiplicity. One
+    /// instance observed in both media becomes one fact row targeting a C# node
+    /// and an instruction node. Header facts remain outside the body census and
+    /// retain their visible-value identity. A fact neither medium could anchor
+    /// simply has no target.
     /// </para>
     /// </remarks>
-    static AnnotatedSourceDocument MakeDocument(
+    static AnnotatedSourceProjection MakeDocument(
         IReadOnlyList<BoundSourceLine> stream,
         PrintedBodyMap csharpMap,
         IReadOnlyList<ResearchHeaderFact> headerFacts,
-        AnnotatedSourceDocumentSource? source)
+        AnnotatedSourceDocumentSource? source,
+        FindingCensusReceipt censusReceipt)
     {
         int csharpLineCount = stream.Count(line => line.Kind == SourceLineKind.CSharp);
         if (csharpLineCount != csharpMap.Lines.Count)
@@ -698,8 +775,9 @@ public static partial class ResearchViews
             .Select(region => new AnnotatedSourceRegion(region.Role, ToSpans(region.Extent)))
             .ToArray();
 
-        // Keyed by semantic identity so the same observation seen on a C# node
-        // and on its instruction collapses to one fact carrying both targets.
+        // Body identity includes the producer-issued instance key, so equal
+        // visible values remain separate while one instance seen on C# and IL
+        // collapses to one fact carrying both targets.
         var collected = new Dictionary<FactIdentity, SortedSet<int>>();
         SortedSet<int> Anchors(FactIdentity identity)
         {
@@ -732,7 +810,8 @@ public static partial class ResearchViews
                     annotation.Conditionality,
                     annotation.Detail is null ? null : MakePortableText(annotation.Detail),
                     annotation.SourceOffset,
-                    AnnotatedSourceFactOrigin.Body);
+                    AnnotatedSourceFactOrigin.Body,
+                    InstanceKey(annotation));
                 Anchors(identity).Add(nodeId);
             }
         }
@@ -745,7 +824,8 @@ public static partial class ResearchViews
                 AnnotationConditionality.Always,
                 fact.Detail is null ? null : MakePortableText(fact.Detail),
                 SourceOffset: -1,
-                AnnotatedSourceFactOrigin.MemberHeader);
+                Origin: AnnotatedSourceFactOrigin.MemberHeader,
+                InstanceKey: null);
 
             // A header fact is about the member, so it is stated and left
             // unanchored rather than given somewhere in the body to point at.
@@ -756,6 +836,7 @@ public static partial class ResearchViews
         ordered.Sort(CompareFactIdentities);
 
         var facts = new AnnotatedSourceFact[ordered.Count];
+        var factIdentities = new List<AnnotatedSourceFactIdentity>();
         var targets = new List<AnnotatedSourceTarget>(ordered.Count);
         for (int id = 0; id < ordered.Count; id++)
         {
@@ -769,6 +850,14 @@ public static partial class ResearchViews
                 identity.SourceOffset,
                 identity.Origin);
 
+            if (identity.InstanceKey is { } instanceKey)
+            {
+                factIdentities.Add(new AnnotatedSourceFactIdentity(
+                    id,
+                    censusReceipt,
+                    instanceKey));
+            }
+
             foreach (int nodeId in collected[identity])
                 targets.Add(new AnnotatedSourceTarget(id, nodeId));
         }
@@ -779,7 +868,16 @@ public static partial class ResearchViews
             return c != 0 ? c : a.NodeId.CompareTo(b.NodeId);
         });
 
-        return new AnnotatedSourceDocument(text, nodes, regions, facts, targets, source);
+        ValidateFactIdentities(facts, factIdentities, censusReceipt);
+        return new AnnotatedSourceProjection(
+            new AnnotatedSourceDocument(
+                text,
+                nodes,
+                regions,
+                facts,
+                targets,
+                source),
+            factIdentities);
 
         IReadOnlyList<AnnotatedSourceSpan> ToSpans(PrintedExtent extent)
         {
@@ -839,6 +937,45 @@ public static partial class ResearchViews
         }
     }
 
+    static void ValidateFactIdentities(
+        IReadOnlyList<AnnotatedSourceFact> facts,
+        IReadOnlyList<AnnotatedSourceFactIdentity> identities,
+        FindingCensusReceipt censusReceipt)
+    {
+        if (censusReceipt.IsDefault)
+            throw new InvalidOperationException(
+                "Research cannot lower a default Finding census receipt.");
+
+        var factIds = new HashSet<int>();
+        var keys = new HashSet<FindingInstanceKey>();
+        foreach (AnnotatedSourceFactIdentity identity in identities)
+        {
+            if (identity.CensusReceipt != censusReceipt)
+                throw new InvalidOperationException(
+                    $"Annotated Source fact {identity.FactId} carries the wrong Finding census receipt.");
+            if (identity.FactId >= facts.Count)
+                throw new InvalidOperationException(
+                    $"Annotated Source Finding identity names missing fact {identity.FactId}.");
+            if (facts[identity.FactId].Origin != AnnotatedSourceFactOrigin.Body)
+                throw new InvalidOperationException(
+                    $"Annotated Source member-header fact {identity.FactId} cannot carry body Finding identity.");
+            if (!factIds.Add(identity.FactId))
+                throw new InvalidOperationException(
+                    $"Annotated Source fact {identity.FactId} carries more than one Finding identity.");
+            if (!keys.Add(identity.InstanceKey))
+                throw new InvalidOperationException(
+                    $"Annotated Source Finding instance key {identity.InstanceKey} is projected more than once.");
+        }
+
+        int bodyFactCount = facts.Count(
+            fact => fact.Origin == AnnotatedSourceFactOrigin.Body);
+        if (factIds.Count != bodyFactCount)
+        {
+            throw new InvalidOperationException(
+                $"Annotated Source projected {factIds.Count} Finding identities for {bodyFactCount} body facts.");
+        }
+    }
+
     static int CompareFactIdentities(FactIdentity left, FactIdentity right)
     {
         int c = left.SourceOffset.CompareTo(right.SourceOffset);
@@ -850,8 +987,21 @@ public static partial class ResearchViews
         c = left.Conditionality.CompareTo(right.Conditionality);
         if (c != 0) return c;
         c = string.CompareOrdinal(left.Detail, right.Detail);
-        return c != 0 ? c : left.Origin.CompareTo(right.Origin);
+        if (c != 0) return c;
+        c = left.Origin.CompareTo(right.Origin);
+        return c != 0
+            ? c
+            : CompareInstanceKeys(left.InstanceKey, right.InstanceKey);
     }
+
+    static int CompareInstanceKeys(
+        FindingInstanceKey? left,
+        FindingInstanceKey? right)
+        => left is null
+            ? right is null ? 0 : 1
+            : right is null
+                ? -1
+                : left.Value.Value.CompareTo(right.Value.Value);
 
     static PrintedAnnotationSpan MakePortable(PrintedAnnotationSpan annotation)
         => annotation with
@@ -900,7 +1050,8 @@ public static partial class ResearchViews
         AnnotationConditionality Conditionality,
         string? Detail,
         int SourceOffset,
-        AnnotatedSourceFactOrigin Origin)
+        AnnotatedSourceFactOrigin Origin,
+        FindingInstanceKey? InstanceKey)
     {
         internal static FactIdentity From(
             PrintedAnnotationSpan annotation,
@@ -910,8 +1061,13 @@ public static partial class ResearchViews
             annotation.Conditionality,
             annotation.Detail,
             annotation.SourceOffset,
-            origin);
+            origin,
+            annotation.InstanceKey);
     }
+
+    sealed record AnnotatedSourceProjection(
+        AnnotatedSourceDocument Document,
+        IReadOnlyList<AnnotatedSourceFactIdentity> FactIdentities);
 
     // The correlation layer: fold the printed C# body, its statement-line map, the
     // resolved annotations, and the IL instruction lines into one ordered
@@ -1095,13 +1251,14 @@ public static partial class ResearchViews
         string type,
         string method,
         IrFunction imported,
-        IReadOnlyList<IAnnotation> facts,
+        ResearchFactProjection facts,
         IReadOnlyList<ResearchHeaderFact> headerFacts,
         MetadataSource source)
     {
-        var linesByFact = CSharpLinesByFact(imported, facts, source);
+        IReadOnlyList<IAnnotation> annotations = facts.Annotations;
+        var linesByFact = CSharpLinesByFact(imported, annotations, source);
         string member = $"{type}::{method}";
-        var rows = facts.Select(fact => new FactRow(
+        var rows = facts.Annotations.Select(fact => new FactRow(
             member,
             fact.SourceOffset >= 0 ? fact.SourceOffset : null,
             linesByFact.TryGetValue(fact, out int line) ? line + 1 : null,
@@ -1109,7 +1266,9 @@ public static partial class ResearchViews
             fact.Descriptor.Category.ToString(),
             fact.Descriptor.Id,
             fact.Detail,
-            fact.Conditionality.ToString()));
+            fact.Conditionality.ToString(),
+            facts.Receipt,
+            fact.Entry.Key));
         var headerRows = headerFacts.Select(fact => new FactRow(
             member,
             ILOffset: null,
@@ -1118,9 +1277,16 @@ public static partial class ResearchViews
             fact.Descriptor.Category.ToString(),
             fact.Descriptor.Id,
             fact.Detail,
-            Conditionality: "Always"));
+            Conditionality: "Always",
+            CensusReceipt: null,
+            InstanceKey: null));
         return [.. rows.Concat(headerRows)];
     }
+
+    static FindingInstanceKey? InstanceKey(IAnnotation annotation)
+        => annotation is ResearchFactAnnotation projected
+            ? projected.Entry.Key
+            : null;
 
     static DecompilerResult WithTrace(DecompilerResult result, MetadataSource source)
         => result with

--- a/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/UnsafetyOccurrenceFactProducer.cs
@@ -17,7 +17,7 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
         ResearchFactRequirements.ForMember(
             LibraryBodyAnalysisFeatures.MethodEvidence);
 
-    public IReadOnlyList<IAnnotation> Produce(ResearchFactContext context)
+    public IReadOnlyList<Finding<IAnnotation>> Produce(ResearchFactContext context)
     {
         var function = context.Imported;
         if (context.Assembly is not { } assembly || function.MetadataToken == 0)
@@ -31,7 +31,9 @@ sealed class UnsafetyOccurrenceFactProducer : IResearchFactProducer
             .. AnalysisFindings.InspectUnsafety(
                     occurrences,
                     new FindingSubject(subject.Id, subject.Display))
-                .Select(finding => ToAnnotation(finding.Payload)),
+                .Select(finding => ResearchFactFinding.Project(
+                    finding,
+                    ToAnnotation(finding.Payload))),
         ];
     }
 


### PR DESCRIPTION
Closes #4717

## Stack

Slice 2 of 2. Parent: #5629. This PR targets `feature/annotated-source-fact-multiplicity`; merge the stack bottom-up.

## Claim

Research now preserves one producer-issued Finding census through one member operation. Facts rows and Annotated Source sidecars carry the same receipt/key pair, filtered projections retain canonical entries, display-identical Findings remain distinct, and invalid receipt or exact-reference associations fail visibly.

Header facts remain outside this first body census. CLI formatting and Inspect Web transport/interaction remain deferred to #4718, #5516, and #5517.

## Demo

A fixture emits two distinct Findings with identical visible values (`test.same`, same category, detail, conditionality, and offset). The projection now retains:

| Surface | Occurrence 1 | Occurrence 2 |
| --- | --- | --- |
| Facts | same receipt, key `1` | same receipt, key `2` |
| Annotated Source | local fact `0` → key `1` | local fact `1` → key `2` |

The same keyed Finding placed on both C# and IL remains one document fact with multiple targets. A successful empty body census still returns a non-default operation receipt.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build` — 259 passed
- `npx markdownlint-cli docs/design/research-finding-census-projection.md docs/README.md docs/overview.md`

## Compatibility and boundaries

`IResearchFactProducer.Produce` now returns `Finding<IAnnotation>` so the producer boundary cannot discard identity before sealing. `ILInspector.Research` is not a packed public artifact, and all in-repository implementations and consumers move together in this focused owner adoption. The portable document itself does not serialize or deserialize census identity.