### PR TITLE
Declare least-privilege permissions in ci.yml and deep-inspect.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ on:
   merge_group:
     types: [checks_requested]
 
+# Least privilege by default. Jobs needing more declare it themselves; a
+# job-level block replaces this default rather than adding to it.
+permissions:
+  contents: read
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -56,6 +61,11 @@ jobs:
   # ubuntu-26.04 coverage without making it the scheduler for every run.
   changes:
     runs-on: ubuntu-24.04
+    # eng/ci-detect-changes.sh reads the pull request and its file list from
+    # the Pull requests API, which contents:read alone does not cover.
+    permissions:
+      contents: read
+      pull-requests: read
     timeout-minutes: 10
     outputs:
       code: ${{ steps.filter.outputs.code }}

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -25,6 +25,11 @@ on:
     # Weekly discovery: current packages.
     - cron: '0 9 * * 1'
 
+# Least privilege by default. Jobs needing more declare it themselves; a
+# job-level block replaces this default rather than adding to it.
+permissions:
+  contents: read
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
Declares least-privilege `GITHUB_TOKEN` permissions in the only two workflows that lacked them, clearing all 19 `actions/missing-workflow-permissions` alerts that CodeQL default setup reported when it was enabled.

This applies the repository's existing convention rather than setting new policy: 7 of 9 workflows already declare a top-level `permissions:` block. `ci.yml` and `deep-inspect.yml` did not, so their jobs inherited the repository-default token scopes.

## Demo

Before — every job without an explicit block inherits the repository default:

```console
$ gh api '.../code-scanning/alerts?state=open' --jq '.[] | [.rule.id, .most_recent_instance.location.path] | @tsv' | sort | uniq -c
  11 actions/missing-workflow-permissions   .github/workflows/ci.yml
   8 actions/missing-workflow-permissions   .github/workflows/deep-inspect.yml
```

After — every job resolves to an explicit least-privilege set:

```text
#### ci.yml top={'contents': 'read'}
   changes                    -> {'contents': 'read', 'pull-requests': 'read'}
   markdownlint               -> {'contents': 'read'}
   ...
   test                       -> {'contents': 'read', 'packages': 'read'}
   ci-required                -> {'contents': 'read'}

#### deep-inspect.yml top={'contents': 'read'}
   package-sweep              -> {'contents': 'read'}
   ...
   report-scheduled-failure   -> {'issues': 'write'}
```

What to notice: `changes` is **not** plain `contents: read`. `eng/ci-detect-changes.sh` reads `repos/{repo}/pulls/{n}` and `.../files` from the Pull requests API, which `contents: read` does not cover, and the script exits non-zero when those calls fail. A blanket default would have broken path filtering for every PR in the repository. The alert count is 19 rather than 21 because the two jobs that already declared permissions were correctly not flagged.

## What changed

- Both workflows default to `contents: read`.
- `changes` declares `contents: read` + `pull-requests: read` for the API reads above.

## Non-action boundary

No job gains a permission, and no existing job-level block is modified. `test` (`contents`+`packages: read`) and `report-scheduled-failure` (`issues: write`) keep their exact effective sets — a job-level block replaces the workflow default rather than adding to it, so neither changes behavior.

## Validation

- Effective permissions enumerated per job by parsing both workflows; all 21 jobs resolve to an explicit set, listed above.
- `ci-required` on this PR is the direct test of the `changes` grant: that job runs on every pull request and fails closed if the Pull requests API reads are denied.

Follow-up, not in scope here: CodeQL's remaining 9 alerts are 3 `cs/zipslip` (the extractor implements the canonical `GetFullPath` + prefix containment check; the query does not recognize it) and 6 JavaScript alerts, 5 of them in test files.
