### PR TITLE
Require fault-before-request ordering in artifact release model

### DIFF
--- a/docs/models/artifact-session-group-release/ArtifactSessionGroupRelease.tla
+++ b/docs/models/artifact-session-group-release/ArtifactSessionGroupRelease.tla
@@ -658,6 +658,11 @@ ReleaseRequestsCarryOwnerAuthority ==
         /\ (RequestedGroup(g) = NoGroup) = (requestIssuer[g] = "None")
         /\ requestIssuer[g] # "ArtifactCleanup"
 
+RecoveryPrecedesPostFaultRequest ==
+    (/\ groupCloseStatus[DependentTwo] = "Faulted"
+     /\ twoRequestedGroup = DependentTwo)
+        => faultRecoveryRequestObserved
+
 ArtifactCleanupResultRemainsVisible ==
     workspaceState = "Closed"
         => reportedArtifactCleanupResult = artifactCleanupResult

--- a/docs/models/artifact-session-group-release/ArtifactSessionGroupRelease.tla
+++ b/docs/models/artifact-session-group-release/ArtifactSessionGroupRelease.tla
@@ -316,6 +316,8 @@ RequestOwnerRelease(g) ==
     /\ g \in ExactDependentGroups
        \/ /\ g = ForeignGroup
           /\ unrelatedAdmitted
+    /\ ~(g = DependentTwo
+         /\ groupCloseStatus[DependentTwo] = "Faulted")
     /\ IF g = DependentOne
        THEN DependentOneRelease!RequestRelease
        ELSE UNCHANGED oneReleaseVars
@@ -440,6 +442,7 @@ StartWorkspaceGroupClose(g) ==
 FaultSecondWorkspaceGroupClose ==
     /\ workspaceState = "ClosingGroups"
     /\ groupCloseStatus[DependentTwo] = "NotStarted"
+    /\ twoRequestedGroup = NoGroup
     /\ groupCloseStatus' =
         [groupCloseStatus EXCEPT ![DependentTwo] = "Faulted"]
     /\ UNCHANGED <<

--- a/docs/models/artifact-session-group-release/README.md
+++ b/docs/models/artifact-session-group-release/README.md
@@ -64,6 +64,8 @@ The model does not cover:
   owner-supplied boolean per group;
 - a workspace-level result fault after the owner request has started; the
   bounded fault path covers failure before that request;
+- an owner recovery request between that fault and artifact-cleanup start; the
+  bounded recovery transition begins from the retained cleanup wait;
 - exception payloads, cleanup-failure ordering, close-report serialization,
   or thread scheduling;
 - later session-related group rejection, which remains gated by
@@ -100,6 +102,7 @@ terminal receipt cannot authorize release for the second exact dependency.
 | `TransferWaitsForCompletedAdmissions` | Transfer does not compute its exact current set while a group admission remains incomplete. |
 | `ArtifactReleaseWaitsForExactReceipts` | Query-lease/session cleanup starts only after both exact dependent owners issue terminal receipts. |
 | `ReleaseRequestsCarryOwnerAuthority` | Every imported owner request has a recorded issuer, and artifact cleanup is never that issuer. |
+| `RecoveryPrecedesPostFaultRequest` | A requested second group after the modeled fault can arise only through the explicit adjacent-owner recovery transition. |
 | `ArtifactCleanupResultRemainsVisible` | Terminal close publishes the artifact cleanup result, including failure. |
 | `GroupCloseFailureRemainsVisible` | Terminal close preserves whether any workspace-level group close faulted. |
 | `Dependent*CompletionMatchesRequest` and `Dependent*CompletionCarriesResult` | Each exact owner issues a receipt only for its requested group and publishes identity/result together. |
@@ -138,9 +141,12 @@ issued that request.
 
 The reachability configurations intentionally negate their named observations,
 so exit code 12 means TLC reached the required neighboring positive behavior.
-`ReachabilityOwnerRecoveryRequest.cfg` is an exact-outcome gate because its
-fault-before-request ordering is contract-defining. The other reachability
-probes remain unlisted in the sparse manifest.
+`Safety.cfg` enforces fault-before-request ordering through
+`RecoveryPrecedesPostFaultRequest`.
+`ReachabilityOwnerRecoveryRequest.cfg` is an exact-outcome gate proving that
+the required explicit recovery path remains reachable rather than making that
+safety invariant vacuous. The other reachability probes remain unlisted in the
+sparse manifest.
 
 ## Running TLC
 

--- a/docs/models/artifact-session-group-release/README.md
+++ b/docs/models/artifact-session-group-release/README.md
@@ -138,8 +138,9 @@ issued that request.
 
 The reachability configurations intentionally negate their named observations,
 so exit code 12 means TLC reached the required neighboring positive behavior.
-They remain unlisted in the sparse exact-outcome manifest; the positive
-configurations and focused contract mutations are the repository gates.
+`ReachabilityOwnerRecoveryRequest.cfg` is an exact-outcome gate because its
+fault-before-request ordering is contract-defining. The other reachability
+probes remain unlisted in the sparse manifest.
 
 ## Running TLC
 
@@ -182,23 +183,23 @@ SHA-256
 
 | Configuration | Result | Generated states | Distinct states | Maximum depth |
 | --- | --- | ---: | ---: | ---: |
-| `Safety.cfg` | No error | 74,452 | 24,247 | 23 |
-| `Liveness.cfg` | No error | 74,452 | 24,247 | 23 |
-| `ReachabilityFaultedSettlementWait.cfg` | `NoFaultedSettlementWaitObserved` violated | 2,831 | 1,253 | 9 |
-| `ReachabilityOwnerRecoveryRequest.cfg` | `NoOwnerRecoveryRequestObserved` violated | 5,456 | 2,250 | 10 |
-| `ReachabilityAlreadyTerminalTransfer.cfg` | `NoAlreadyTerminalTransferObserved` violated | 143 | 87 | 5 |
+| `Safety.cfg` | No error | 57,596 | 19,429 | 23 |
+| `Liveness.cfg` | No error | 57,596 | 19,429 | 23 |
+| `ReachabilityFaultedSettlementWait.cfg` | `NoFaultedSettlementWaitObserved` violated | 2,570 | 1,161 | 9 |
+| `ReachabilityOwnerRecoveryRequest.cfg` | `NoOwnerRecoveryRequestObserved` violated | 4,819 | 2,038 | 10 |
+| `ReachabilityAlreadyTerminalTransfer.cfg` | `NoAlreadyTerminalTransferObserved` violated | 141 | 86 | 5 |
 | `ReachabilityUnrelatedAfterTransfer.cfg` | `NoUnrelatedAfterTransferObserved` violated | 31 | 23 | 4 |
-| `ReachabilityMixedReceiptResults.cfg` | `NoMixedReceiptCleanupObserved` violated | 26,293 | 8,998 | 13 |
+| `ReachabilityMixedReceiptResults.cfg` | `NoMixedReceiptCleanupObserved` violated | 21,489 | 7,646 | 13 |
 | `BrokenForeignTransfer.cfg` | `TransferUsesCompleteExactSet` violated | 6 | 6 | 2 |
 | `BrokenIncompleteTransfer.cfg` | `TransferUsesCompleteExactSet` violated | 6 | 6 | 2 |
 | `BrokenDuplicateTransfer.cfg` | `TransferUsesDistinctGroups` violated | 6 | 6 | 2 |
 | `BrokenTransferDuringAdmission.cfg` | `TransferWaitsForCompletedAdmissions` violated | 8 | 7 | 3 |
-| `BrokenForeignReceipt.cfg` | `ArtifactReleaseWaitsForExactReceipts` violated | 54,681 | 17,215 | 16 |
-| `BrokenPartialReceipt.cfg` | `ArtifactReleaseWaitsForExactReceipts` violated | 5,457 | 2,251 | 10 |
-| `BrokenArtifactCleanupReleaseAuthority.cfg` | `ReleaseRequestsCarryOwnerAuthority` violated | 5,457 | 2,251 | 10 |
+| `BrokenForeignReceipt.cfg` | `ArtifactReleaseWaitsForExactReceipts` violated | 42,892 | 14,097 | 16 |
+| `BrokenPartialReceipt.cfg` | `ArtifactReleaseWaitsForExactReceipts` violated | 4,820 | 2,039 | 10 |
+| `BrokenArtifactCleanupReleaseAuthority.cfg` | `ReleaseRequestsCarryOwnerAuthority` violated | 4,820 | 2,039 | 10 |
 | `BrokenImportedReceiptLifecycle.cfg` | Imported owner action property violated | 17 | 15 | 3 |
-| `BrokenGroupCloseFaultOmission.cfg` | `GroupCloseFailureRemainsVisible` violated | 37,710 | 12,377 | 14 |
-| `BrokenCleanupOmission.cfg` | `ArtifactCleanupResultRemainsVisible` violated | 37,711 | 12,378 | 14 |
+| `BrokenGroupCloseFaultOmission.cfg` | `GroupCloseFailureRemainsVisible` violated | 30,214 | 10,337 | 14 |
+| `BrokenCleanupOmission.cfg` | `ArtifactCleanupResultRemainsVisible` violated | 30,211 | 10,334 | 14 |
 
 The positive safety and liveness runs explored the complete bounded state
 graph. The fault-recovery trace settles the second workspace-level group close

--- a/docs/models/artifact-session-group-release/Safety.cfg
+++ b/docs/models/artifact-session-group-release/Safety.cfg
@@ -16,6 +16,7 @@ INVARIANTS
   TransferWaitsForCompletedAdmissions
   ArtifactReleaseWaitsForExactReceipts
   ReleaseRequestsCarryOwnerAuthority
+  RecoveryPrecedesPostFaultRequest
   ArtifactCleanupResultRemainsVisible
   GroupCloseFailureRemainsVisible
   DependentOneCompletionMatchesRequest

--- a/eng/tla-expected-exit-codes.txt
+++ b/eng/tla-expected-exit-codes.txt
@@ -22,6 +22,7 @@ docs/models/artifact-session-group-release/BrokenIncompleteTransfer.cfg=12
 docs/models/artifact-session-group-release/BrokenPartialReceipt.cfg=12
 docs/models/artifact-session-group-release/BrokenTransferDuringAdmission.cfg=12
 docs/models/artifact-session-group-release/Liveness.cfg=0
+docs/models/artifact-session-group-release/ReachabilityOwnerRecoveryRequest.cfg=12
 docs/models/artifact-session-group-release/Safety.cfg=0
 docs/models/assembly-context-group-lifecycle/AssemblyContextGroupReleaseBlocked.cfg=0
 docs/models/assembly-context-group-lifecycle/AssemblyContextGroupReleaseLifecycle.cfg=0


### PR DESCRIPTION
#5609 merged while its replacement Round 2 review was still running. This
focused follow-up closes #5638 by making the model's bounded fault path match
its declared contract: the workspace-level fault occurs before the second
owner request, the artifact session remains retained, and only the explicit
adjacent-owner recovery transition may create that missing request.

## Demo

Before this correction, TLC reaches the excluded owner-first ordering:

```text
TransferExactSession
RequestOwnerRelease(DependentTwo)
BeginWorkspaceClose
FaultSecondWorkspaceGroupClose
```

The fault transition only checked that workspace close had not started for the
second group; it did not check that the owner request was still absent.

After this correction:

```text
FaultSecondWorkspaceGroupClose
  requires twoRequestedGroup = NoGroup

RequestOwnerRelease(DependentTwo)
  disabled after that fault

RecoverFaultedGroupRelease
  is the sole post-fault request transition

RecoveryPrecedesPostFaultRequest
  rejects Faulted + requested unless recovery was observed
```

The committed `Safety.cfg` invariant now passes the complete 57,596-generated /
19,429-distinct-state graph at depth 23 and fails against the merged #5609
owner-first behavior. `ReachabilityOwnerRecoveryRequest.cfg` reaches the
intended fault-before-request then adjacent-owner-recovery ordering, and its
exit-12 verdict is registered as the invariant's exact non-vacuity neighbor.

What to notice: the model can no longer satisfy recovered-fault liveness with a
request that predated the modeled fault. The retained wait and later recovery
are ordered exactly as the model guide claims.

## Design

**Normative owner:** `docs/design/artifact-acquisition-and-workspaces.md`,
section `ArtifactSetSession`.

The owner defines the exact transferred artifact-session registration,
dependent-group association, and cleanup only after admission-held physical
settlement. `docs/inspection-space.md` and
`AssemblyContextGroupReleaseLifecycle.tla` continue to own the supporting group
request/receipt lifecycle.

This correction changes only four model-evidence files:

- guard the pre-request fault with `twoRequestedGroup = NoGroup`;
- prevent the generic owner-first action from bypassing the explicit
  post-fault recovery transition; and
- enforce that every faulted-and-requested second group carries the explicit
  recovery witness in `Safety.cfg`;
- require `ReachabilityOwnerRecoveryRequest.cfg=12` in the exact-outcome
  manifest as the non-vacuity neighbor; and
- regenerate deterministic evidence in the model guide.

The two-dependent-plus-one-foreign bound and every other transfer, receipt,
cleanup, reporting, and imported-owner property remain unchanged.

## Applicability

This is a contributor-model correctness repair for an already-shipped product
interaction. It adds no product behavior, API, capability, substrate, host
path, rendering domain, dependency, or platform exception. Package
realization and CLI/browser adoption remain separate #2899 follow-ups.

## Validation

```text
eng/run-tla-checks.sh docs/models/artifact-session-group-release
  1 module, 17 configurations, 13 exact outcomes

eng/run-tla-checks.sh --changed-files0
  8 modules, 88 configurations, 32 exact outcomes

eng/test-tla-checks.sh
  TLA+ runner scope checks passed

npx markdownlint-cli docs/models/artifact-session-group-release/README.md
git diff --check
```

Pinned tool evidence: TLA+ v1.8.0, TLC2 `2026.09.01.002747`
rev `95b800c`, jar SHA-256
`dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94`.
