### PR TITLE
Adopt MTP for analysis tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,7 +629,7 @@ jobs:
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
 
       - name: Run analysis tests (fast)
-        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -trait- "Speed=Slow"
+        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- --filter-not-trait "Speed=Slow"
 
       # The runtime-async compiler switch changes IL lowering without changing
       # whether the fixture builds. Run the focused owner gates so CI proves

--- a/.github/workflows/windows-pr.yml
+++ b/.github/workflows/windows-pr.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run analysis tests
         if: inputs.suite == 'analysis'
-        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -trait- "Speed=Slow"
+        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- --filter-not-trait "Speed=Slow"
 
       - name: Run decompiler tests
         if: inputs.suite == 'decompiler'

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -154,6 +154,13 @@ unmatched, valid, and mixed valid/stale filter outcomes. The suite's workflow
 contract tests pin its MTP call sites and preserve the authenticated package
 fixture's stronger not-skipped receipt.
 
+`ILInspector.Analysis.Tests` is the second adopter. Its required Linux and
+Windows lanes exercise exclusion-filtered execution through MTP, while Deep
+Inspect exercises the unfiltered suite. The Windows workflow contract test pins
+the migrated filter syntax. These paths use the same pinned xUnit integration
+as the outcome-level host gate rather than duplicating that self-spawn harness
+in every adopting suite.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -12,6 +12,7 @@
     <IsAotCompatible>false</IsAotCompatible>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
+++ b/src/dotnet-inspect.Tests/IlToolsActivationTests.cs
@@ -816,7 +816,7 @@ public class IlToolsActivationTests
             (
                 "analysis",
                 "dotnet run --project src/ILInspector.Analysis.Tests " +
-                "-c Release -- -trait- \"Speed=Slow\""),
+                "-c Release -- --filter-not-trait \"Speed=Slow\""),
             (
                 "decompiler",
                 "dotnet run --project src/ILInspector.Decompiler.Tests " +

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -296,7 +296,7 @@ from the fast PR lane — like the decompiler generated-fixture catalogue. Run i
 
 ```bash
 dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll \
-  -method "*SeedCatalogue*"
+  --filter-method "*SeedCatalogue*"
 ```
 
 ## Layers above this


### PR DESCRIPTION
## Summary

Adopt Microsoft Testing Platform for `ILInspector.Analysis.Tests`, the second
ordinary xUnit executable migrated under #5379.

- select the MTP runner already packaged by the pinned `xunit.v3` dependency;
- translate the required Linux and Windows `Speed=Slow` exclusion filters to
  MTP syntax;
- migrate the documented seed-catalogue focused invocation to MTP syntax;
- update the Windows workflow contract assertion; and
- record the staged adoption in the xUnit host design.

This adds no direct runner dependency and does not change the deferred
decompiler host or its stronger discovery-to-execution completeness receipt.

## Demo

Before this change, a stale focused selector in the Analysis suite was
successful despite executing nothing:

```console
$ dotnet run --project src/ILInspector.Analysis.Tests -c Release -- \
    -method '*DefinitelyNoSuchTest5379*'
...
ILInspector.Analysis.Tests  Total: 0
$ echo $?
0
```

With the suite configured for MTP, the equivalent selector fails:

```console
$ dotnet run --project src/ILInspector.Analysis.Tests -c Release -- \
    --filter-method 'ILInspector.Analysis.Tests.DefinitelyNoSuchTest5379'
...
Test run summary: Zero tests ran
$ echo $?
8
```

The neighboring valid method filter exits `0`, and the workflow-equivalent
`--filter-not-trait 'Speed=Slow'` command runs the fixture-heavy fast suite
successfully: 1,345/1,345 tests pass.

## Validation

```console
dotnet build dotnet-inspect.slnx -c Release
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- \
  --filter-not-trait 'Speed=Slow'
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- \
  --filter-method \
  'ILInspector.Analysis.Tests.AnalysisFindingsTests.InspectAllocations_ProducesCompleteIlOrderedCensus'
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- \
  --filter-method '*IlToolsActivationTests*'
dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll \
  --filter-method '*SeedCatalogue*'
npx markdownlint-cli docs/design/xunit-test-host.md
git diff --check origin/main...HEAD
```

The corrected seed-catalogue command passes 1/1. The unmatched MTP filter was
separately asserted to return exit code `8`.
