### PR TITLE
Use full-area Type and Member API surfaces

### DIFF
--- a/docs/design/inspect-web-presentation-language.md
+++ b/docs/design/inspect-web-presentation-language.md
@@ -167,6 +167,8 @@ does not acquire selector selected styling.
 - The summary is not a selector and does not expose `aria-pressed`.
 - Expanding the region does not move keyboard focus automatically. The user
   may continue to the first selector through ordinary tab order.
+- A keyboard command that focuses the member filter first opens the disclosure
+  and then places focus in the text input.
 - Collapsing the region returns focus to the summary when focus was
   inside the region.
 - A restored or deep-linked filter is summarized while collapsed; it does not
@@ -199,6 +201,10 @@ competing with the subject path. Source is the full-area exception governed by
 it adds no local heading, so the subject zone remains the visible owner of the
 complete hierarchy while the active Source inspector labels the lens panel.
 Metadata retains its detailed type heading.
+
+At narrow widths, API header identity and status may elide visually as complete
+strings. Responsive styling does not selectively remove the overload total or
+ordinal from the rendered or accessible status.
 
 When the snapshot has no effective lens, the UI renders no `tabpanel`. A status
 region references the target heading and its visible `Lens unavailable`

--- a/docs/design/inspect-web-presentation-language.md
+++ b/docs/design/inspect-web-presentation-language.md
@@ -133,12 +133,11 @@ Selector rows are hidden by default in the type and member navigation panes.
 The recovered vertical space belongs to the type or member list, which is the
 primary content of each pane.
 
-Each pane provides one compact `Filters` disclosure button beside its text
-filter. The button expands or collapses the complete selector region for that
-pane:
+Each member-filtering surface provides one compact `Filters` disclosure button.
+The button expands or collapses the text filter and complete selector region
+together:
 
-- type kind and accessibility selectors expand together;
-- member kind, accessibility, and trait selectors expand together; and
+- member text, kind, accessibility, and trait filters expand together; and
 - collapsing the region never clears or changes a selection.
 
 The Type navigation pane does not retain a second library filter. The active
@@ -153,39 +152,27 @@ as a user preference across browser sessions.
 
 #### Collapsed summary
 
-Hidden controls must not create hidden state. The disclosure button summarizes
-any selection that restricts the visible result set:
-
-- the visible label becomes `Filters · N`, where `N` is the number of
-  restrictive selector dimensions;
-- the count uses the accent color without giving the button selector selected
-  styling;
-- the accessible name identifies the active restrictions.
-
-For example, a type pane showing only public types has one restrictive
-dimension even though `public` is the product default. Its collapsed control is
-presented as `Filters · 1` with an accessible name such as
-`Filters · 1, accessibility: public`. A member pane with `all kinds`,
-`all access`, and `all traits` has no restrictive dimensions and presents a
-neutral `Filters` button.
-
-The count is by selector dimension, not by selected value. Selecting `public`
-and `protected` in one multi-select accessibility control still contributes
-one restrictive dimension.
+Hidden controls must not create hidden state. A member-filter disclosure shows
+`All members` when no restriction is active. Otherwise its compact trailing
+summary names each active text, kind, accessibility, or trait restriction in
+control order. The summary elides visually when space is exhausted, while its
+accessible name retains the complete active restriction list. The disclosure
+does not acquire selector selected styling.
 
 #### Disclosure semantics
 
-- The disclosure button is not a selector and does not expose `aria-pressed`.
-- The button exposes `aria-expanded` and references the selector region with
-  `aria-controls`.
+- The disclosure uses native `details` and `summary` semantics. A custom
+  equivalent exposes the same expanded state with `aria-expanded` and
+  references the selector region with `aria-controls`.
+- The summary is not a selector and does not expose `aria-pressed`.
 - Expanding the region does not move keyboard focus automatically. The user
   may continue to the first selector through ordinary tab order.
-- Collapsing the region returns focus to the disclosure button when focus was
+- Collapsing the region returns focus to the summary when focus was
   inside the region.
 - A restored or deep-linked filter is summarized while collapsed; it does not
   force the selector region open.
-- The collapsed summary supplements the visible result count. It does not
-  replace result text such as `20 of 84 member groups`.
+- The collapsed summary supplements the live visible/total result count in the
+  owning pane or working-surface header. It does not replace that count.
 
 ## Shared heading rules
 
@@ -203,8 +190,11 @@ underline on hover plus an explicit keyboard focus outline.
 
 ### API, Source, and Metadata lenses
 
-API renders a compact local heading followed by its primary content. Source is
-the full-area exception governed by
+API renders a compact local heading followed by its primary content. Type API
+uses `Members` with the live visible/total member-group count. Member API uses
+the exact local member name with its kind and overload count or ordinal. These
+headings use the same quiet label hierarchy as the navigation pane rather than
+competing with the subject path. Source is the full-area exception governed by
 [Inspect Web Surface Composition](inspect-web-surface-composition.md#source-and-annotated-source):
 it adds no local heading, so the subject zone remains the visible owner of the
 complete hierarchy while the active Source inspector labels the lens panel.
@@ -227,11 +217,14 @@ The compact API heading and full-area Source working surface do not repeat:
 - the kind icon;
 - the namespace eyebrow;
 - the declaration signature;
-- the member count;
 - the accessibility summary;
 - the target framework;
 - the library; or
 - the package and version.
+
+Surface-local status is not repeated subject metadata. Type API may report the
+live visible/total member-group count and overload total; Member API may report
+the selected member kind and overload count or ordinal.
 
 The removed fields do not leave placeholders or reserved vertical space, and
 they are not moved into collapsed duplicate headers on either lens. Page order,

--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -230,6 +230,10 @@ active member filters. The collapsed `Filters` row owns member text, kind,
 accessibility, and trait controls. Member rows use the complete remaining
 scroll area. The bottom guidance does not repeat the count.
 
+If active filters exclude the selected member, the detail pane retains a
+full-area Member empty state with the quiet header and adjustment guidance. It
+does not fall back to the inset Type heading or remove the pane's scroll owner.
+
 Opening a member group preserves the same composition. A group with multiple
 overloads renders the exact member name and overload count in the quiet header,
 then gives the overload rows the remaining scroll area. Opening one overload
@@ -246,6 +250,9 @@ the same full-area scroller.
 Member Source and Annotated Source remain the heading-free full-area exceptions
 defined below. Loading and failure states stay visible and do not become
 success-shaped empty surfaces.
+
+At narrow widths, Type and Member header identity and status may elide, but the
+overload total or selected overload ordinal is not selectively hidden.
 
 ### Package query
 
@@ -550,9 +557,13 @@ with the absence of a synthesized `Default feed` control.
    Confirm that the quiet exact-member header remains stable, each section
    scrolls independently below it, and Overview contains no large duplicate
    hero or package-coordinate summary.
-5. Repeat the Type list, overload picker, and selected-overload checks at a
+5. Apply a filter that excludes the selected member and confirm that the detail
+   pane provides a full-area Member empty state and adjustment guidance without
+   returning to Type scope or restoring the inset Type heading.
+6. Repeat the Type list, overload picker, and selected-overload checks at a
    narrow viewport. Confirm that each surface retains its topology and creates
-   no page-level horizontal overflow.
+   no page-level horizontal overflow while preserving the overload total or
+   selected overload ordinal in the rendered status.
 
 ### Source working surface
 

--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -13,9 +13,9 @@ focused owners; this document places them.
 
 This owner defines:
 
-- which working surfaces exist (Source, Annotated Source, Package query,
-  Diagnostics) and their page-level placement relative to Type/Member
-  navigation;
+- which working surfaces exist (Type API, Member API, Source, Annotated Source,
+  Package query, Diagnostics) and their page-level placement relative to
+  Type/Member navigation;
 - the `/query` route's placement and layout, including placement of its
   per-row `Open in workspace` action;
 - Source and Annotated Source pane placement and independent scrolling;
@@ -199,14 +199,53 @@ these named browser tests in `workspace-titlebar.spec.ts`:
 
 ## Working surfaces
 
-Source, Annotated Source, and Diagnostics are working surfaces rather than
-documents inset inside a general page. This redesign does not change Metadata
-viewer composition.
+Type API, Member API, Source, Annotated Source, and Diagnostics are working
+surfaces rather than documents inset inside a general page. This redesign does
+not change Metadata viewer composition.
 
 The package-query surface's internal query behavior remains owned by
 `package-query-experience.md`; product facet identities, ordering, evidence,
 failures, and completion remain owned by `package-query-cli.md`. Its former
 package-tab placement stays superseded.
+
+### Type and Member API
+
+Type API and Member API use the full area to the right of Type or Member
+navigation. They do not retain a centered document column, a large subject
+hero, or repeated package, library, namespace, and target-framework context.
+The persistent subject path remains the owner of that hierarchy.
+
+The Type API surface contains:
+
+```text
+Members                         visible / total groups · overloads
+Filters                                            active restrictions
+member rows
+                                                  select-row guidance
+```
+
+`Members` and its count use the same quiet label hierarchy as the navigation
+pane rather than competing with the subject path. The count changes with the
+active member filters. The collapsed `Filters` row owns member text, kind,
+accessibility, and trait controls. Member rows use the complete remaining
+scroll area. The bottom guidance does not repeat the count.
+
+Opening a member group preserves the same composition. A group with multiple
+overloads renders the exact member name and overload count in the quiet header,
+then gives the overload rows the remaining scroll area. Opening one overload
+keeps the exact member name in that header with its kind and overload ordinal.
+Overview, Call graph, and Facts scroll below it.
+
+Member Overview retains package documentation, declaration copying, stable
+identity, parameters, returns, exceptions, and applicability. It removes the
+large documentation-style title and the repeated Namespace, Assembly, Package,
+and framework summary because the subject path already supplies that
+orientation. Call graph and Facts retain their owned result semantics and use
+the same full-area scroller.
+
+Member Source and Annotated Source remain the heading-free full-area exceptions
+defined below. Loading and failure states stay visible and do not become
+success-shaped empty surfaces.
 
 ### Package query
 
@@ -495,6 +534,25 @@ outcomes.
 `InspectWebPackageSourceSettingsTests.RendersEnablementAndSelectionWithoutDefaultFeed`
 gates enabled, disabled, selected, and unselected source descriptors together
 with the absence of a synthesized `Default feed` control.
+
+### Type and Member API working surfaces
+
+1. Open a Type API surface with no member filters and confirm that the quiet
+   header, collapsed Filters row, member list, and bottom guidance exactly fill
+   the inspector pane without page overflow.
+2. Apply member text and selector filters and confirm that the header reports
+   the live visible/total group count, the collapsed summary discloses the
+   restrictions, and no second result-count row or footer count appears.
+3. Open a member group with multiple overloads and confirm that the exact
+   member name and overload count remain in the quiet header while the overload
+   rows own the scroll area.
+4. Open one overload and switch between Overview, Call graph, and Facts.
+   Confirm that the quiet exact-member header remains stable, each section
+   scrolls independently below it, and Overview contains no large duplicate
+   hero or package-coordinate summary.
+5. Repeat the Type list, overload picker, and selected-overload checks at a
+   narrow viewport. Confirm that each surface retains its topology and creates
+   no page-level horizontal overflow.
 
 ### Source working surface
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -649,6 +649,7 @@ let homeReadyGlintPending = true;
 const initialState = {
   theme: localStorage.getItem("inspect-theme") === "light" ? "light" : "dark",
   statusBarExpanded: false,
+  memberFiltersExpanded: false,
   packages: [],
   package: null,
   home: false,
@@ -2159,26 +2160,40 @@ function renderMemberFilterControls(type: AppTypeSurface) {
   const kinds = memberKinds(type);
   const accessibilities = memberAccessibilities(type);
   const traits = availableMemberTraits(type);
+  const activeTrait = traits.find(
+    ([property]) => property === state.memberTraitFilter)?.[1];
+  const selectorSummary = [
+    state.memberKindFilter === "all"
+      ? ""
+      : state.memberKindFilter.replaceAll("-", " "),
+    state.memberAccessibilityFilter === "all"
+      ? ""
+      : state.memberAccessibilityFilter,
+    activeTrait ?? "",
+  ].filter(Boolean).join(" · ") || "All members";
   return `
     <div class="type-search member-search">
       <span aria-hidden="true">/</span>
       <input id="member-filter" aria-label="Filter members and signatures" value="${escapeHtml(state.memberTextFilter)}" placeholder="Filter members and signatures" autocomplete="off" spellcheck="false" />
       <button class="tiny-button" id="clear-member-filter" title="Clear member filters" aria-label="Clear member filters">×</button>
     </div>
-    <div class="member-filter-stack">
-      <div class="namespace-chips kind-chips" aria-label="Member kind filters">
-        <button class="${state.memberKindFilter === "all" ? "active" : ""}" data-member-kind-filter="all" aria-pressed="${state.memberKindFilter === "all"}">all kinds</button>
-        ${kinds.map(kind => `<button class="${state.memberKindFilter === kind ? "active" : ""}" data-member-kind-filter="${escapeHtml(kind)}" aria-pressed="${state.memberKindFilter === kind}">${escapeHtml(kind.replaceAll("-", " "))}</button>`).join("")}
+    <details class="member-filter-disclosure" data-member-filter-disclosure${state.memberFiltersExpanded ? " open" : ""}>
+      <summary><span aria-hidden="true">›</span><strong>Selectors</strong><small>${escapeHtml(selectorSummary)}</small></summary>
+      <div class="member-filter-stack">
+        <div class="namespace-chips kind-chips" aria-label="Member kind filters">
+          <button class="${state.memberKindFilter === "all" ? "active" : ""}" data-member-kind-filter="all" aria-pressed="${state.memberKindFilter === "all"}">all kinds</button>
+          ${kinds.map(kind => `<button class="${state.memberKindFilter === kind ? "active" : ""}" data-member-kind-filter="${escapeHtml(kind)}" aria-pressed="${state.memberKindFilter === kind}">${escapeHtml(kind.replaceAll("-", " "))}</button>`).join("")}
+        </div>
+        ${accessibilities.length ? `<div class="namespace-chips access-chips" aria-label="Member accessibility filters">
+          <button class="${state.memberAccessibilityFilter === "all" ? "active" : ""}" data-member-access-filter="all" aria-pressed="${state.memberAccessibilityFilter === "all"}">all access</button>
+          ${accessibilities.map(accessibility => `<button class="${state.memberAccessibilityFilter === accessibility ? "active" : ""}" data-member-access-filter="${escapeHtml(accessibility)}" aria-pressed="${state.memberAccessibilityFilter === accessibility}">${escapeHtml(accessibility)}</button>`).join("")}
+        </div>` : ""}
+        ${traits.length ? `<div class="namespace-chips member-trait-chips" aria-label="Member trait filters">
+          <button class="${!state.memberTraitFilter ? "active" : ""}" data-member-trait-filter="" aria-pressed="${!state.memberTraitFilter}">all traits</button>
+          ${traits.map(([property, label]) => `<button class="${state.memberTraitFilter === property ? "active" : ""}" data-member-trait-filter="${property}" aria-pressed="${state.memberTraitFilter === property}">${label}</button>`).join("")}
+        </div>` : ""}
       </div>
-      ${accessibilities.length ? `<div class="namespace-chips access-chips" aria-label="Member accessibility filters">
-        <button class="${state.memberAccessibilityFilter === "all" ? "active" : ""}" data-member-access-filter="all" aria-pressed="${state.memberAccessibilityFilter === "all"}">all access</button>
-        ${accessibilities.map(accessibility => `<button class="${state.memberAccessibilityFilter === accessibility ? "active" : ""}" data-member-access-filter="${escapeHtml(accessibility)}" aria-pressed="${state.memberAccessibilityFilter === accessibility}">${escapeHtml(accessibility)}</button>`).join("")}
-      </div>` : ""}
-      ${traits.length ? `<div class="namespace-chips member-trait-chips" aria-label="Member trait filters">
-        <button class="${!state.memberTraitFilter ? "active" : ""}" data-member-trait-filter="" aria-pressed="${!state.memberTraitFilter}">all traits</button>
-        ${traits.map(([property, label]) => `<button class="${state.memberTraitFilter === property ? "active" : ""}" data-member-trait-filter="${property}" aria-pressed="${state.memberTraitFilter === property}">${label}</button>`).join("")}
-      </div>` : ""}
-    </div>
+    </details>
     <div class="member-filter-result">${visible.length} of ${groups.length} member groups</div>`;
 }
 
@@ -5153,6 +5168,9 @@ function bindTypePanelEvents() {
       state.memberTextFilter = value;
       normalizeMemberSelection();
       renderPreservingMemberFocus();
+    },
+    onMemberFilterDisclosureToggle: expanded => {
+      state.memberFiltersExpanded = expanded;
     },
     onMemberFilterClear: () => {
       resetMemberFilters();

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2162,7 +2162,8 @@ function renderMemberFilterControls(type: AppTypeSurface) {
   const traits = availableMemberTraits(type);
   const activeTrait = traits.find(
     ([property]) => property === state.memberTraitFilter)?.[1];
-  const selectorSummary = [
+  const filterSummary = [
+    state.memberTextFilter ? `text: ${state.memberTextFilter}` : "",
     state.memberKindFilter === "all"
       ? ""
       : state.memberKindFilter.replaceAll("-", " "),
@@ -2172,13 +2173,13 @@ function renderMemberFilterControls(type: AppTypeSurface) {
     activeTrait ?? "",
   ].filter(Boolean).join(" · ") || "All members";
   return `
-    <div class="type-search member-search">
-      <span aria-hidden="true">/</span>
-      <input id="member-filter" aria-label="Filter members and signatures" value="${escapeHtml(state.memberTextFilter)}" placeholder="Filter members and signatures" autocomplete="off" spellcheck="false" />
-      <button class="tiny-button" id="clear-member-filter" title="Clear member filters" aria-label="Clear member filters">×</button>
-    </div>
     <details class="member-filter-disclosure" data-member-filter-disclosure${state.memberFiltersExpanded ? " open" : ""}>
-      <summary><span aria-hidden="true">›</span><strong>Selectors</strong><small>${escapeHtml(selectorSummary)}</small></summary>
+      <summary><span aria-hidden="true">›</span><strong>Filters</strong><small>${escapeHtml(filterSummary)}</small></summary>
+      <div class="type-search member-search">
+        <span aria-hidden="true">/</span>
+        <input id="member-filter" aria-label="Filter members and signatures" value="${escapeHtml(state.memberTextFilter)}" placeholder="Filter members and signatures" autocomplete="off" spellcheck="false" />
+        <button class="tiny-button" id="clear-member-filter" title="Clear member filters" aria-label="Clear member filters">×</button>
+      </div>
       <div class="member-filter-stack">
         <div class="namespace-chips kind-chips" aria-label="Member kind filters">
           <button class="${state.memberKindFilter === "all" ? "active" : ""}" data-member-kind-filter="all" aria-pressed="${state.memberKindFilter === "all"}">all kinds</button>
@@ -4397,10 +4398,7 @@ function renderApiLens(item: AppTypeSurface) {
   return `
     <section class="api-surface" aria-labelledby="api-surface-title">
       <header class="api-surface-head">
-        <div>
-          <span>Type inspector</span>
-          <h1 id="api-surface-title">Public API</h1>
-        </div>
+        <h1 id="api-surface-title">Members</h1>
         <p><strong>${publicGroups.length}</strong> member groups <span>· ${item.members} overloads</span></p>
       </header>
       <div class="member-browser-controls api-surface-controls">${renderMemberFilterControls(publicSurface)}</div>

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2155,8 +2155,6 @@ function availableMemberTraits(type: AppTypeSurface) {
 }
 
 function renderMemberFilterControls(type: AppTypeSurface) {
-  const groups = publicMemberGroups(type);
-  const visible = visibleMemberGroups(type);
   const kinds = memberKinds(type);
   const accessibilities = memberAccessibilities(type);
   const traits = availableMemberTraits(type);
@@ -2194,8 +2192,7 @@ function renderMemberFilterControls(type: AppTypeSurface) {
           ${traits.map(([property, label]) => `<button class="${state.memberTraitFilter === property ? "active" : ""}" data-member-trait-filter="${property}" aria-pressed="${state.memberTraitFilter === property}">${label}</button>`).join("")}
         </div>` : ""}
       </div>
-    </details>
-    <div class="member-filter-result">${visible.length} of ${groups.length} member groups</div>`;
+    </details>`;
 }
 
 function compositionFilterButton(
@@ -4399,7 +4396,7 @@ function renderApiLens(item: AppTypeSurface) {
     <section class="api-surface" aria-labelledby="api-surface-title">
       <header class="api-surface-head">
         <h1 id="api-surface-title">Members</h1>
-        <p><strong>${publicGroups.length}</strong> member groups <span>· ${item.members} overloads</span></p>
+        <p><strong>${visibleGroups.length} of ${publicGroups.length}</strong> member groups <span>· ${item.members} overloads</span></p>
       </header>
       <div class="member-browser-controls api-surface-controls">${renderMemberFilterControls(publicSurface)}</div>
       <div class="api-surface-scroll">

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -4396,7 +4396,7 @@ function renderApiLens(item: AppTypeSurface) {
     <section class="api-surface" aria-labelledby="api-surface-title">
       <header class="api-surface-head">
         <h1 id="api-surface-title">Members</h1>
-        <p><strong>${visibleGroups.length} of ${publicGroups.length}</strong> member groups <span>· ${item.members} overloads</span></p>
+        <p>${visibleGroups.length} of ${publicGroups.length} member groups <span>· ${item.members} overloads</span></p>
       </header>
       <div class="member-browser-controls api-surface-controls">${renderMemberFilterControls(publicSurface)}</div>
       <div class="api-surface-scroll">

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2759,11 +2759,19 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     sourcePageKind !== null && sourcePageSource !== null;
   const apiWorkingSurface =
     activeScope === "type" && state.lens === "api";
+  const currentMember = current ? selectedMember(current) : undefined;
+  const memberOverloadPicker =
+    currentMember !== undefined
+    && currentMember.overloads.length > 1
+    && !selectedConcreteOverload(
+      currentMember.overloads,
+      state.selectedOverloadIndex);
   const memberWorkingSurface =
     activeScope === "member"
     && current !== null
     && currentPendingGraphMember() === null
-    && memberSectionUsesWorkingSurface(state.memberSection);
+    && (memberOverloadPicker
+      || memberSectionUsesWorkingSurface(state.memberSection));
   const annotatedPageContext =
     activeScope === "member"
     && state.memberSection === "annotated"
@@ -4388,15 +4396,6 @@ function renderApiLens(item: AppTypeSurface) {
   }
   const member = selectedMember(item);
   if (member) return renderMember(item, member);
-  if (state.memberBrowseTypeId === item.id) {
-    return `
-      ${typeHeadingHtml(item)}
-      <section class="document-section empty-document">
-        <span class="large-glyph">⌕</span>
-        <h2>No member selected</h2>
-        <p>Adjust the member filters or choose a member from the list.</p>
-      </section>`;
-  }
   const { publicMembers, graphMembers } =
     partitionGraphMembers(item.api);
   const publicSurface = {
@@ -4404,11 +4403,27 @@ function renderApiLens(item: AppTypeSurface) {
     api: publicMembers
   };
   const publicGroups = memberGroups(publicSurface);
+  const visibleGroups = visibleMemberGroups(publicSurface);
+  if (state.memberBrowseTypeId === item.id) {
+    return `
+      <section class="member-surface member-empty-surface" aria-labelledby="member-surface-title">
+        <header class="api-surface-head member-surface-head">
+          <h1 id="member-surface-title">Members</h1>
+          <p>${visibleGroups.length} of ${publicGroups.length} member groups <span>· no member selected</span></p>
+        </header>
+        <div class="member-surface-scroll">
+          <section class="empty-member-section">
+            <span class="large-glyph">⌕</span>
+            <h2>No member selected</h2>
+            <p>Adjust the member filters or choose a member from the list.</p>
+          </section>
+        </div>
+      </section>`;
+  }
   const graphGroups = memberGroups({
     ...item,
     api: graphMembers
   });
-  const visibleGroups = visibleMemberGroups(publicSurface);
   return `
     <section class="api-surface" aria-labelledby="api-surface-title">
       <header class="api-surface-head">
@@ -6711,6 +6726,12 @@ function focusFilter(
     const input = document.querySelector<HTMLInputElement>(
       "#member-filter, #type-filter");
     if (!input) return;
+    const disclosure = input.closest<HTMLDetailsElement>(
+      "[data-member-filter-disclosure]");
+    if (disclosure && !disclosure.open) {
+      state.memberFiltersExpanded = true;
+      disclosure.open = true;
+    }
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
   };

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -32,7 +32,6 @@ import {
   packageForView,
   packageIdentityKey,
   packageLenses,
-  parameterTitleHtml,
   partitionGraphMembers,
   platformPackForGraphAssembly,
   platformPackFromProvenance,
@@ -2309,6 +2308,12 @@ function memberSourceHasConcreteOverload() {
       state.selectedOverloadIndex));
 }
 
+function memberSectionUsesWorkingSurface(section: MemberSection) {
+  return section === "overview"
+    || section === "call-graph"
+    || section === "facts";
+}
+
 function currentSourceOperationKind() {
   return activeSourceOperationKind(
     state,
@@ -2754,6 +2759,11 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
     sourcePageKind !== null && sourcePageSource !== null;
   const apiWorkingSurface =
     activeScope === "type" && state.lens === "api";
+  const memberWorkingSurface =
+    activeScope === "member"
+    && current !== null
+    && currentPendingGraphMember() === null
+    && memberSectionUsesWorkingSurface(state.memberSection);
   const annotatedPageContext =
     activeScope === "member"
     && state.memberSection === "annotated"
@@ -2843,7 +2853,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
         ${renderNavPane(current, visible)}
 
         <section class="detail-pane">
-          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}"${inspectorPanelSemantics}>
+          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}${memberWorkingSurface ? " member-working-surface" : ""}"${inspectorPanelSemantics}>
             ${renderLens(current)}
           </article>
         </section>
@@ -4341,6 +4351,17 @@ function renderTypeSourceHtml(item: AppTypeSurface) {
   });
 }
 
+function currentPendingGraphMember() {
+  const pending = state.pendingGraphMemberDeepLink;
+  return pending
+    && graphMemberPendingMatchesView(
+      pending,
+      packageIdentityKey(state.package),
+      viewSignature())
+    ? pending
+    : null;
+}
+
 function renderLens(item: AppTypeSurface | null | undefined) {
   if (scope() === "workspace") return renderWorkspaceView();
   if (state.atPackageRoot) return renderPackageView();
@@ -4358,12 +4379,8 @@ function renderLens(item: AppTypeSurface | null | undefined) {
 }
 
 function renderApiLens(item: AppTypeSurface) {
-  const pending = state.pendingGraphMemberDeepLink;
-  if (pending
-    && graphMemberPendingMatchesView(
-      pending,
-      packageIdentityKey(state.package),
-      viewSignature())) {
+  const pending = currentPendingGraphMember();
+  if (pending) {
     const title =
       state.graphMemberNavigationTitle
       || `${typeDisplayName(item)}.${pending.target.memberName}`;
@@ -4429,7 +4446,6 @@ function renderApiLens(item: AppTypeSurface) {
           : ""}
       </div>
       <footer class="api-surface-footer">
-        <span>${visibleGroups.length} of ${publicGroups.length} member groups visible</span>
         <span>Select a row to inspect its API</span>
       </footer>
     </section>`;
@@ -4444,19 +4460,25 @@ function renderMember(type: AppTypeSurface, member: AppMemberGroup) {
     && selectedOverloadIndex < member.overloads.length;
   if (member.overloads.length > 1 && !hasSelectedOverload) {
     return `
-      <button class="member-back" id="member-back">← ${escapeHtml(typeDisplayName(type))}</button>
-      <section class="overload-picker">
-        <p class="eyebrow">${escapeHtml(member.kind)} group</p>
-        <h1>${escapeHtml(member.name)}</h1>
-        <p>Choose a specific overload to inspect.</p>
-        <div class="api-list">
-          ${member.overloads.map((overload, index) => `
-            <button class="api-row overload-row" data-overload="${index}">
-              <span class="member-icon">${index + 1}</span>
-              <code>${highlight(overload.signature)}</code>
-              <small>open →</small>
-            </button>`).join("")}
+      <section class="member-surface member-overload-surface" aria-labelledby="member-surface-title">
+        <header class="api-surface-head member-surface-head">
+          <h1 id="member-surface-title">${escapeHtml(member.name)}</h1>
+          <p>${member.overloads.length} overloads <span>· ${escapeHtml(member.kind)}</span></p>
+        </header>
+        <div class="member-surface-scroll">
+          <div class="api-list api-surface-list member-surface-list">
+            ${member.overloads.map((overload, index) => `
+              <button class="api-row overload-row" data-overload="${index}">
+                <span class="member-icon">${index + 1}</span>
+                <code>${highlight(overload.signature)}</code>
+                <small>open →</small>
+              </button>`).join("")}
+          </div>
         </div>
+        <footer class="api-surface-footer member-surface-footer">
+          <button class="member-back" id="member-back">← ${escapeHtml(typeDisplayName(type))}</button>
+          <span>Choose an overload to inspect</span>
+        </footer>
       </section>`;
   }
   const overloadIndex = hasSelectedOverload ? selectedOverloadIndex ?? 0 : 0;
@@ -4473,21 +4495,10 @@ function renderMember(type: AppTypeSurface, member: AppMemberGroup) {
   const documentationError = documentationState.error;
   let content;
   if (state.memberSection === "overview") {
-    const pageKind = member.kind === "constructor" ? "Constructor" : `${member.kind.slice(0, 1).toUpperCase()}${member.kind.slice(1)}`;
     const parameters = overload.parameters ?? [];
     content = `
       <article class="learn-overview">
-        <header class="learn-title">
-          <p>${escapeHtml(type.namespace)}</p>
-          <h1>${escapeHtml(typeDisplayName(type))}.${escapeHtml(member.name)}${parameterTitleHtml(parameters)} ${escapeHtml(pageKind)}</h1>
-          <span>${escapeHtml(pkg.id)} · ${escapeHtml(pkg.activeFramework)}</span>
-        </header>
-        <section class="learn-section definition-section">
-          <dl class="definition-list">
-            <div><dt>Namespace:</dt><dd>${escapeHtml(type.namespace || "global")}</dd></div>
-            <div><dt>Assembly:</dt><dd>${escapeHtml(type.assembly)}</dd></div>
-            <div><dt>Package:</dt><dd>${escapeHtml(pkg.id)} v${escapeHtml(pkg.version)}</dd></div>
-          </dl>
+        <section class="learn-section member-overview-intro">
           ${documentationLoading
             ? '<p class="docs-loading">Loading package documentation…</p>'
             : documentationError
@@ -4623,9 +4634,17 @@ function renderMember(type: AppTypeSurface, member: AppMemberGroup) {
   } else {
     assertNever(state.memberSection, "member section");
   }
+  if (!memberSectionUsesWorkingSurface(state.memberSection)) return content;
   // The member-mode strip (Overview / Call graph / Facts / Source / Annotated) now lives in
   // the top scope+lens bar, so the detail view renders only the section content itself.
-  return content;
+  return `
+    <section class="member-surface" aria-labelledby="member-surface-title">
+      <header class="api-surface-head member-surface-head">
+        <h1 id="member-surface-title">${escapeHtml(member.name)}</h1>
+        <p>${escapeHtml(member.kind)} <span>· ${overloadIndex + 1} of ${member.overloads.length}</span></p>
+      </header>
+      <div class="member-surface-scroll">${content}</div>
+    </section>`;
 }
 
 // The annotated section renders the product's portable AnnotatedSourceDocument directly: canonical

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2739,6 +2739,8 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
         : null;
   const sourceWorkingSurface =
     sourcePageKind !== null && sourcePageSource !== null;
+  const apiWorkingSurface =
+    activeScope === "type" && state.lens === "api";
   const annotatedPageContext =
     activeScope === "member"
     && state.memberSection === "annotated"
@@ -2828,7 +2830,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
         ${renderNavPane(current, visible)}
 
         <section class="detail-pane">
-          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}"${inspectorPanelSemantics}>
+          <article id="inspector-panel" class="detail-scroll${annotatedWorkingSurface ? " annotated-working-surface" : ""}${sourceWorkingSurface ? " source-working-surface" : ""}${apiWorkingSurface ? " api-working-surface" : ""}"${inspectorPanelSemantics}>
             ${renderLens(current)}
           </article>
         </section>
@@ -4378,11 +4380,17 @@ function renderApiLens(item: AppTypeSurface) {
   });
   const visibleGroups = visibleMemberGroups(publicSurface);
   return `
-    ${typeHeadingHtml(item)}
-    <section class="document-section">
-      <div class="section-title"><h2>Public API</h2><span>${publicGroups.length} member groups · ${item.members} overloads</span></div>
-      <div class="member-browser-controls">${renderMemberFilterControls(publicSurface)}</div>
-      <div class="api-list">${visibleGroups.map(group => {
+    <section class="api-surface" aria-labelledby="api-surface-title">
+      <header class="api-surface-head">
+        <div>
+          <span>Type inspector</span>
+          <h1 id="api-surface-title">Public API</h1>
+        </div>
+        <p><strong>${publicGroups.length}</strong> member groups <span>· ${item.members} overloads</span></p>
+      </header>
+      <div class="member-browser-controls api-surface-controls">${renderMemberFilterControls(publicSurface)}</div>
+      <div class="api-surface-scroll">
+        <div class="api-list api-surface-list">${visibleGroups.map(group => {
         const overload = group.overloads[0];
         if (!overload)
           throw new Error(`Member group '${group.key}' did not contain an overload.`);
@@ -4392,24 +4400,29 @@ function renderApiLens(item: AppTypeSurface) {
           <code>${highlight(overload.signature)}</code>
           <small>${group.overloads.length === 1 ? escapeHtml(group.kind) : `${group.overloads.length} overloads`}</small>
         </button>`;
-      }).join("") || '<div class="empty-list">No declared public members match these filters.</div>'}</div>
-    </section>
-    ${graphGroups.length
-      ? `<section class="document-section">
-          <div class="section-title"><h2>Graph-discovered implementation members</h2><span>${graphGroups.reduce((count, group) => count + group.overloads.length, 0)} projected</span></div>
-          <div class="api-list">${graphGroups.map(group => {
-            const overload = group.overloads[0];
-            if (!overload)
-              throw new Error(`Member group '${group.key}' did not contain an overload.`);
-            return `
-            <button class="api-row" data-member="${escapeHtml(group.key)}">
-              <span class="member-icon">${escapeHtml(group.kind?.slice(0, 1)?.toUpperCase() || "M")}</span>
-              <code>${highlight(overload.signature)}</code>
-              <small>${group.overloads.length === 1 ? "implementation" : `${group.overloads.length} implementations`}</small>
-            </button>`;
-          }).join("")}</div>
-        </section>`
-      : ""}`;
+        }).join("") || '<div class="empty-list">No declared public members match these filters.</div>'}</div>
+        ${graphGroups.length
+          ? `<section class="api-surface-secondary">
+              <div class="section-title"><h2>Graph-discovered implementation members</h2><span>${graphGroups.reduce((count, group) => count + group.overloads.length, 0)} projected</span></div>
+              <div class="api-list">${graphGroups.map(group => {
+                const overload = group.overloads[0];
+                if (!overload)
+                  throw new Error(`Member group '${group.key}' did not contain an overload.`);
+                return `
+                <button class="api-row" data-member="${escapeHtml(group.key)}">
+                  <span class="member-icon">${escapeHtml(group.kind?.slice(0, 1)?.toUpperCase() || "M")}</span>
+                  <code>${highlight(overload.signature)}</code>
+                  <small>${group.overloads.length === 1 ? "implementation" : `${group.overloads.length} implementations`}</small>
+                </button>`;
+              }).join("")}</div>
+            </section>`
+          : ""}
+      </div>
+      <footer class="api-surface-footer">
+        <span>${visibleGroups.length} of ${publicGroups.length} member groups visible</span>
+        <span>Select a row to inspect its API</span>
+      </footer>
+    </section>`;
 }
 
 function renderMember(type: AppTypeSurface, member: AppMemberGroup) {

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -756,7 +756,7 @@ kbd {
   font: 11px var(--mono);
   color: var(--text);
 }
-.member-nav { grid-template-rows: 40px 34px auto 24px minmax(0, 1fr) 27px; }
+.member-nav { grid-template-rows: 40px 34px auto minmax(0, 1fr) 27px; }
 .member-filter-disclosure { min-width: 0; border-top: 1px solid var(--line); }
 .member-filter-disclosure summary { min-width: 0; height: 30px; display: grid; grid-template-columns: 12px max-content minmax(0, 1fr); gap: 7px; align-items: center; padding: 0 10px; cursor: pointer; list-style: none; color: var(--dim); font: 10px var(--mono); }
 .member-filter-disclosure summary::-webkit-details-marker { display: none; }
@@ -767,14 +767,6 @@ kbd {
 .member-filter-disclosure .member-search { border-top: 1px solid var(--line); }
 .member-filter-stack { min-width: 0; }
 .member-filter-stack .namespace-chips:last-child { border-bottom: 0; }
-.member-filter-result {
-  display: flex;
-  align-items: center;
-  padding: 0 10px;
-  border-bottom: 1px solid var(--line);
-  color: var(--dim);
-  font: 10px var(--mono);
-}
 .member-search .tiny-button {
   width: 22px;
   height: 22px;
@@ -870,7 +862,6 @@ kbd {
   background: var(--chrome);
 }
 .member-browser-controls .type-search { height: 38px; }
-.member-browser-controls .member-filter-result { height: 24px; border-bottom: 0; }
 .api-list { border: 1px solid var(--line); }
 .api-row {
   width: 100%;
@@ -891,7 +882,7 @@ kbd {
 .api-row small { color: var(--dim); font: 10px var(--mono); }
 .api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
 .api-surface-head { min-width: 0; min-height: 48px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 8px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
-.api-surface-head h1 { min-width: 0; margin: 0; font-size: 18px; letter-spacing: -.025em; }
+.api-surface-head h1 { min-width: 0; margin: 0; font-size: 17px; letter-spacing: -.025em; }
 .api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); }
 .api-surface-head p strong { color: var(--text); font-size: 13px; font-weight: 500; }
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -881,10 +881,9 @@ kbd {
 .api-row code { overflow: hidden; color: var(--text); font: 12px/1.5 var(--mono); white-space: nowrap; text-overflow: ellipsis; }
 .api-row small { color: var(--dim); font: 10px var(--mono); }
 .api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
-.api-surface-head { min-width: 0; min-height: 48px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 8px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
-.api-surface-head h1 { min-width: 0; margin: 0; font-size: 17px; letter-spacing: -.025em; }
+.api-surface-head { min-width: 0; min-height: 40px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 0 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
+.api-surface-head h1 { min-width: 0; margin: 0; color: var(--muted); font: 10px var(--mono); font-weight: 400; letter-spacing: .12em; text-transform: uppercase; }
 .api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); }
-.api-surface-head p strong { color: var(--text); font-size: 13px; font-weight: 500; }
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
 .api-surface-controls .member-filter-disclosure { border-top: 0; }
 .api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -884,7 +884,8 @@ kbd {
 .api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
 .api-surface-head { min-width: 0; min-height: 40px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 0 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
 .api-surface-head h1 { min-width: 0; overflow: hidden; margin: 0; color: var(--muted); font: 10px var(--mono); font-weight: 400; letter-spacing: .12em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
-.api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); white-space: nowrap; }
+.api-surface-head p { min-width: 0; flex: 0 1 auto; overflow: hidden; margin: 0; color: var(--dim); font: 10px var(--mono); text-overflow: ellipsis; white-space: nowrap; }
+.api-surface-head p span { margin-left: 6px; }
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
 .api-surface-controls .member-filter-disclosure { border-top: 0; }
 .api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
@@ -1468,7 +1469,6 @@ kbd {
   .member-nav { grid-template-rows: 40px 34px auto minmax(0, 1fr); }
   .detail-scroll { padding: 22px 18px 60px; }
   .api-surface-head { min-height: 40px; padding-inline: 12px; }
-  .api-surface-head p span { display: none; }
   .member-surface-scroll { padding: 18px 12px 52px; }
   .member-overload-surface .member-surface-scroll { padding: 0 0 20px; }
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -757,6 +757,13 @@ kbd {
   color: var(--text);
 }
 .member-nav { grid-template-rows: 40px 34px 38px auto 24px minmax(0, 1fr) 27px; }
+.member-filter-disclosure { min-width: 0; border-top: 1px solid var(--line); }
+.member-filter-disclosure summary { min-width: 0; height: 30px; display: grid; grid-template-columns: 12px max-content minmax(0, 1fr); gap: 7px; align-items: center; padding: 0 10px; cursor: pointer; list-style: none; color: var(--dim); font: 10px var(--mono); }
+.member-filter-disclosure summary::-webkit-details-marker { display: none; }
+.member-filter-disclosure summary > span { font-size: 15px; line-height: 1; transition: transform .12s ease; }
+.member-filter-disclosure[open] summary > span { transform: rotate(90deg); }
+.member-filter-disclosure summary strong { color: var(--text); font-weight: 500; }
+.member-filter-disclosure summary small { min-width: 0; overflow: hidden; text-align: right; text-overflow: ellipsis; white-space: nowrap; color: var(--dim); font: inherit; }
 .member-filter-stack { min-width: 0; border-top: 1px solid var(--line); }
 .member-filter-stack .namespace-chips:last-child { border-bottom: 0; }
 .member-filter-result {

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -808,6 +808,7 @@ kbd {
 .detail-scroll.annotated-working-surface {
   display: block;
 }
+.detail-scroll.api-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 
 .type-heading {
   display: grid;
@@ -880,6 +881,19 @@ kbd {
 .api-row:hover { background: var(--panel-raised); }
 .api-row code { overflow: hidden; color: var(--text); font: 12px/1.5 var(--mono); white-space: nowrap; text-overflow: ellipsis; }
 .api-row small { color: var(--dim); font: 10px var(--mono); }
+.api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
+.api-surface-head { min-width: 0; min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
+.api-surface-head > div { min-width: 0; }
+.api-surface-head > div > span { color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
+.api-surface-head h1 { margin: 2px 0 0; font-size: 18px; letter-spacing: -.025em; }
+.api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); }
+.api-surface-head p strong { color: var(--text); font-size: 13px; font-weight: 500; }
+.api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
+.api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
+.api-surface-list { border: 0; }
+.api-surface-list .api-row { padding-inline: 16px; }
+.api-surface-secondary { padding: 24px 16px 0; }
+.api-surface-footer { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 12px; border-top: 1px solid var(--line); background: var(--panel); color: var(--dim); font: 10px var(--mono); }
 .member-icon { border-color: var(--line-strong); color: var(--blue); }
 .member-back {
   margin: 0 0 13px;
@@ -1482,6 +1496,9 @@ kbd {
   .type-browser { grid-template-rows: 40px 38px auto auto minmax(0, 1fr); }
   .member-nav { grid-template-rows: 40px 34px 38px auto 24px minmax(0, 1fr); }
   .detail-scroll { padding: 22px 18px 60px; }
+  .api-surface-head { min-height: 56px; padding-inline: 12px; }
+  .api-surface-head p span,
+  .api-surface-footer span:last-child { display: none; }
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }
   .type-badge { width: 35px; height: 35px; }
   .type-heading p { grid-column: 1 / -1; }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -756,7 +756,7 @@ kbd {
   font: 11px var(--mono);
   color: var(--text);
 }
-.member-nav { grid-template-rows: 40px 34px 38px auto 24px minmax(0, 1fr) 27px; }
+.member-nav { grid-template-rows: 40px 34px auto 24px minmax(0, 1fr) 27px; }
 .member-filter-disclosure { min-width: 0; border-top: 1px solid var(--line); }
 .member-filter-disclosure summary { min-width: 0; height: 30px; display: grid; grid-template-columns: 12px max-content minmax(0, 1fr); gap: 7px; align-items: center; padding: 0 10px; cursor: pointer; list-style: none; color: var(--dim); font: 10px var(--mono); }
 .member-filter-disclosure summary::-webkit-details-marker { display: none; }
@@ -764,7 +764,8 @@ kbd {
 .member-filter-disclosure[open] summary > span { transform: rotate(90deg); }
 .member-filter-disclosure summary strong { color: var(--text); font-weight: 500; }
 .member-filter-disclosure summary small { min-width: 0; overflow: hidden; text-align: right; text-overflow: ellipsis; white-space: nowrap; color: var(--dim); font: inherit; }
-.member-filter-stack { min-width: 0; border-top: 1px solid var(--line); }
+.member-filter-disclosure .member-search { border-top: 1px solid var(--line); }
+.member-filter-stack { min-width: 0; }
 .member-filter-stack .namespace-chips:last-child { border-bottom: 0; }
 .member-filter-result {
   display: flex;
@@ -889,13 +890,12 @@ kbd {
 .api-row code { overflow: hidden; color: var(--text); font: 12px/1.5 var(--mono); white-space: nowrap; text-overflow: ellipsis; }
 .api-row small { color: var(--dim); font: 10px var(--mono); }
 .api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
-.api-surface-head { min-width: 0; min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 10px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
-.api-surface-head > div { min-width: 0; }
-.api-surface-head > div > span { color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
-.api-surface-head h1 { margin: 2px 0 0; font-size: 18px; letter-spacing: -.025em; }
+.api-surface-head { min-width: 0; min-height: 48px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 8px 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
+.api-surface-head h1 { min-width: 0; margin: 0; font-size: 18px; letter-spacing: -.025em; }
 .api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); }
 .api-surface-head p strong { color: var(--text); font-size: 13px; font-weight: 500; }
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
+.api-surface-controls .member-filter-disclosure { border-top: 0; }
 .api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
 .api-surface-list { border: 0; }
 .api-surface-list .api-row { padding-inline: 16px; }

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -808,7 +808,8 @@ kbd {
 .detail-scroll.annotated-working-surface {
   display: block;
 }
-.detail-scroll.api-working-surface { min-height: 0; overflow: hidden; padding: 0; }
+.detail-scroll.api-working-surface,
+.detail-scroll.member-working-surface { min-height: 0; overflow: hidden; padding: 0; }
 
 .type-heading {
   display: grid;
@@ -882,71 +883,44 @@ kbd {
 .api-row small { color: var(--dim); font: 10px var(--mono); }
 .api-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: auto auto minmax(0, 1fr) 34px; background: var(--bg); }
 .api-surface-head { min-width: 0; min-height: 40px; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 0 16px; border-bottom: 1px solid var(--line); background: var(--panel); }
-.api-surface-head h1 { min-width: 0; margin: 0; color: var(--muted); font: 10px var(--mono); font-weight: 400; letter-spacing: .12em; text-transform: uppercase; }
-.api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); }
+.api-surface-head h1 { min-width: 0; overflow: hidden; margin: 0; color: var(--muted); font: 10px var(--mono); font-weight: 400; letter-spacing: .12em; text-overflow: ellipsis; text-transform: uppercase; white-space: nowrap; }
+.api-surface-head p { flex: none; display: flex; align-items: baseline; gap: 6px; margin: 0; color: var(--dim); font: 10px var(--mono); white-space: nowrap; }
 .api-surface-controls { margin: 0; border: 0; border-bottom: 1px solid var(--line); }
 .api-surface-controls .member-filter-disclosure { border-top: 0; }
 .api-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
 .api-surface-list { border: 0; }
 .api-surface-list .api-row { padding-inline: 16px; }
 .api-surface-secondary { padding: 24px 16px 0; }
-.api-surface-footer { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 0 12px; border-top: 1px solid var(--line); background: var(--panel); color: var(--dim); font: 10px var(--mono); }
+.api-surface-footer { min-width: 0; display: flex; align-items: center; justify-content: flex-end; gap: 12px; padding: 0 12px; border-top: 1px solid var(--line); background: var(--panel); color: var(--dim); font: 10px var(--mono); }
+.api-surface-footer span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.member-surface { min-width: 0; min-height: 0; height: 100%; display: grid; grid-template-rows: 40px minmax(0, 1fr); background: var(--bg); }
+.member-surface-scroll { min-width: 0; min-height: 0; overflow: auto; padding: 24px 16px 60px; }
+.member-surface-scroll > .document-section:first-child { padding-top: 0; }
+.member-surface .learn-overview { max-width: 900px; }
+.member-overview-intro { padding-top: 0; }
+.member-overload-surface { grid-template-rows: 40px minmax(0, 1fr) 34px; }
+.member-overload-surface .member-surface-scroll { padding: 0 0 24px; }
+.member-surface-list .api-row { padding-inline: 16px; }
+.member-surface-footer { justify-content: space-between; }
 .member-icon { border-color: var(--line-strong); color: var(--blue); }
-.member-back {
-  margin: 0 0 13px;
+.member-surface-footer .member-back {
+  margin: 0;
   padding: 0;
   border: 0;
   background: transparent;
   color: var(--dim);
-  font: 11px var(--mono);
+  font: 10px var(--mono);
 }
-.member-back:hover { color: var(--text); }
-.overload-picker { max-width: 900px; padding-top: 8px; }
-.overload-picker > .eyebrow { margin: 0 0 7px; color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
-.overload-picker > h1 { margin: 0 0 8px; font-size: clamp(27px, 3vw, 39px); letter-spacing: -.045em; }
-.overload-picker > p:not(.eyebrow) { margin: 0 0 25px; color: var(--muted); font-size: 12px; }
+.member-surface-footer .member-back:hover { color: var(--text); }
 .overload-row { min-height: 52px; }
 .overload-row .member-icon { font-size: 10px; }
-.member-sections {
-  display: flex;
-  gap: 3px;
-  margin-bottom: 30px;
-  border-bottom: 1px solid var(--line);
-}
-.member-sections button {
-  padding: 10px 12px;
-  border: 0;
-  border-bottom: 2px solid transparent;
-  background: transparent;
-  color: var(--dim);
-  font: 11px var(--mono);
-}
-.member-sections button:hover { color: var(--text); }
-.member-sections button.active { border-bottom-color: var(--accent); color: var(--text); }
-.member-summary { padding: 8px 0 28px; border-bottom: 1px solid var(--line); }
-.member-summary .eyebrow { margin: 0 0 7px; color: var(--dim); font: 10px var(--mono); text-transform: uppercase; }
-.member-summary h1 { margin: 0 0 20px; font-size: clamp(27px, 3vw, 39px); letter-spacing: -.045em; }
-.signature-list { display: grid; gap: 7px; }
-.signature-list code {
-  display: block;
-  padding: 10px 12px;
-  border: 1px solid var(--line);
-  background: var(--code-bg);
-  color: var(--code-text);
-  font: 11px/1.55 var(--mono);
-}
 .empty-member-section { padding: 45px 0; color: var(--muted); }
 .empty-member-section h2 { margin: 0 0 8px; color: var(--text); font-size: 15px; }
 .empty-member-section p { margin: 0; font-size: 12px; line-height: 1.6; }
 .learn-overview { max-width: 900px; color: var(--text); font-family: "Segoe UI", system-ui, sans-serif; }
-.learn-title { padding: 8px 0 30px; border-bottom: 1px solid var(--line); }
-.learn-title > p { margin: 0 0 8px; color: var(--blue); font-size: 14px; }
-.learn-title h1 { margin: 0 0 13px; font-size: clamp(28px, 3.3vw, 41px); line-height: 1.15; letter-spacing: -.025em; }
-.learn-title > span { color: var(--dim); font: 11px var(--mono); }
 .learn-section { padding: 30px 0 4px; }
 .learn-section + .learn-section { border-top: 1px solid var(--line); margin-top: 30px; }
 .learn-section h2 { margin: 0 0 20px; font-size: 23px; line-height: 1.25; }
-.definition-section { padding-top: 24px; }
 .member-identity { margin-top: 22px; border-top: 1px solid var(--line); }
 .identity-heading { display: flex; align-items: baseline; gap: 10px; padding: 18px 0 10px; }
 .identity-heading h2 { margin: 0; color: var(--text); font-size: 16px; }
@@ -1491,11 +1465,12 @@ kbd {
   .workspace { grid-template-columns: 44% 56%; }
   .type-browser:not(.member-nav) .namespace-chips, .pane-footer { display: none; }
   .type-browser { grid-template-rows: 40px 38px auto auto minmax(0, 1fr); }
-  .member-nav { grid-template-rows: 40px 34px 38px auto 24px minmax(0, 1fr); }
+  .member-nav { grid-template-rows: 40px 34px auto minmax(0, 1fr); }
   .detail-scroll { padding: 22px 18px 60px; }
-  .api-surface-head { min-height: 56px; padding-inline: 12px; }
-  .api-surface-head p span,
-  .api-surface-footer span:last-child { display: none; }
+  .api-surface-head { min-height: 40px; padding-inline: 12px; }
+  .api-surface-head p span { display: none; }
+  .member-surface-scroll { padding: 18px 12px 52px; }
+  .member-overload-surface .member-surface-scroll { padding: 0 0 20px; }
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }
   .type-badge { width: 35px; height: 35px; }
   .type-heading p { grid-column: 1 / -1; }

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -102,6 +102,7 @@ export interface TypePanelBindingActions {
   onMemberCompositionTraitSelect: (trait: string) => void;
   onMemberFilterChange: (value: string) => void;
   onMemberFilterClear: () => void;
+  onMemberFilterDisclosureToggle: (expanded: boolean) => void;
   onMemberFilterKeyDown: (event: KeyboardEvent, value: string) => boolean;
   onMemberGroupOpen: (memberKey: string) => void;
   onMemberKindFilterSelect: (kind: string | undefined) => void;
@@ -246,6 +247,11 @@ export function bindTypePanel(
   memberFilter?.addEventListener(
     "input",
     () => actions.onMemberFilterChange(memberFilter.value));
+  const memberFilterDisclosure =
+    root.querySelector<HTMLDetailsElement>("[data-member-filter-disclosure]");
+  memberFilterDisclosure?.addEventListener(
+    "toggle",
+    () => actions.onMemberFilterDisclosureToggle(memberFilterDisclosure.open));
   if (memberFilter) {
     keybindings.register({
       id: "member-filter.navigate",

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2236,6 +2236,9 @@ test("global workbench shortcuts respect the topmost modal", () => {
   assert.match(
     appSource,
     /function focusFilter\([\s\S]*\{ immediate = false \}: \{ immediate\?: boolean \} = \{\},[\s\S]*const focus = \(\) => \{[\s\S]*"#member-filter, #type-filter"[\s\S]*if \(immediate\) \{\s*focus\(\);\s*return;\s*}\s*requestAnimationFrame\(focus\);/);
+  assert.match(
+    appSource,
+    /function focusFilter\([\s\S]*input\.closest<HTMLDetailsElement>\(\s*"\[data-member-filter-disclosure\]"\)[\s\S]*state\.memberFiltersExpanded = true;[\s\S]*disclosure\.open = true;[\s\S]*input\.focus\(\)/);
 });
 
 test("Spotlight navigation waits for selection data before restoring focus", () => {
@@ -4765,9 +4768,19 @@ test("type API reports the filtered member count once in its header", () => {
 });
 
 test("member API uses full-area overload and selected-member surfaces", () => {
+  const renderApi =
+    appSource.match(/function renderApiLens\([\s\S]*?\n}\n\nfunction renderMember/)?.[0]
+    ?? "";
   const renderMember =
     appSource.match(/function renderMember\([\s\S]*?\n}\n\n\/\/ The annotated section/)?.[0]
     ?? "";
+  const emptyMember =
+    renderApi.match(/if \(state\.memberBrowseTypeId === item\.id\) \{[\s\S]*?\n  \}/)?.[0]
+    ?? "";
+  assert.match(
+    emptyMember,
+    /class="member-surface member-empty-surface"[\s\S]*?<h1 id="member-surface-title">Members<\/h1>[\s\S]*?No member selected/);
+  assert.doesNotMatch(emptyMember, /typeHeadingHtml/);
   assert.match(
     renderMember,
     /class="member-surface member-overload-surface"[\s\S]*?<h1 id="member-surface-title">\$\{escapeHtml\(member\.name\)}<\/h1>[\s\S]*?\$\{member\.overloads\.length} overloads/);
@@ -4786,13 +4799,19 @@ test("member API uses full-area overload and selected-member surfaces", () => {
     /<dt>Namespace:<\/dt>|<dt>Assembly:<\/dt>|<dt>Package:<\/dt>/);
   assert.match(
     appSource,
-    /const memberWorkingSurface =[\s\S]*?currentPendingGraphMember\(\) === null[\s\S]*?memberSectionUsesWorkingSurface\(state\.memberSection\)/);
+    /const memberOverloadPicker =[\s\S]*?!selectedConcreteOverload\([\s\S]*?const memberWorkingSurface =[\s\S]*?currentPendingGraphMember\(\) === null[\s\S]*?memberOverloadPicker[\s\S]*?memberSectionUsesWorkingSurface\(state\.memberSection\)/);
   assert.match(
     stylesSource,
     /\.detail-scroll\.api-working-surface,\s*\.detail-scroll\.member-working-surface \{[^}]*overflow: hidden;[^}]*padding: 0;/s);
   assert.match(
     stylesSource,
     /\.member-surface \{[^}]*height: 100%;[^}]*grid-template-rows: 40px minmax\(0, 1fr\);/s);
+  assert.match(
+    stylesSource,
+    /\.api-surface-head p \{[^}]*overflow: hidden;[^}]*text-overflow: ellipsis;/s);
+  assert.doesNotMatch(
+    stylesSource,
+    /\.api-surface-head p span \{[^}]*display: none;/s);
 });
 
 test("graph member projections stay transport- and package-bounded", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -4730,7 +4730,6 @@ test("member navigation excludes graph-only projections from ordinary filters", 
   assert.match(
     filters,
     /function publicMemberGroups\([\s\S]*?searchableMemberGroups\(memberGroups\(type\)\)/);
-  assert.match(filters, /const groups = publicMemberGroups\(type\)/);
   assert.match(
     filters,
     /publicMemberGroups\(type\)\s*\.flatMap\(group => group\.overloads\)/);
@@ -4746,6 +4745,19 @@ test("member navigation excludes graph-only projections from ordinary filters", 
     appSource.match(/function renderMemberNavPane\([\s\S]*?\n}\n\n\/\/ The scope switcher/)?.[0]
     ?? "";
   assert.match(pane, /memberCount: publicMemberGroups\(type\)\.length/);
+});
+
+test("type API reports the filtered member count once in its header", () => {
+  const renderApi =
+    appSource.match(/function renderApiLens\([\s\S]*?\n}\n\nfunction renderMember/)?.[0]
+    ?? "";
+  assert.match(
+    renderApi,
+    /<h1 id="api-surface-title">Members<\/h1>/);
+  assert.match(
+    renderApi,
+    /<strong>\$\{visibleGroups\.length} of \$\{publicGroups\.length}<\/strong> member groups/);
+  assert.doesNotMatch(renderApi, /member-filter-result/);
 });
 
 test("graph member projections stay transport- and package-bounded", () => {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -4756,7 +4756,7 @@ test("type API reports the filtered member count once in its header", () => {
     /<h1 id="api-surface-title">Members<\/h1>/);
   assert.match(
     renderApi,
-    /<strong>\$\{visibleGroups\.length} of \$\{publicGroups\.length}<\/strong> member groups/);
+    /<p>\$\{visibleGroups\.length} of \$\{publicGroups\.length} member groups/);
   assert.doesNotMatch(renderApi, /member-filter-result/);
 });
 

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -4264,7 +4264,10 @@ test("pending graph-member restoration is bound to its exact view", () => {
     /else if \(disposition === "graph"[\s\S]*?state\.selectedMemberKey = deep\.member;[\s\S]*?state\.selectedBodyTarget = deep\.graphTarget;[\s\S]*?viewSignature: viewSignature\(\)/);
   assert.match(
     appSource,
-    /function renderLens\([^)]*\) \{[\s\S]*?graphMemberPendingMatchesView\([\s\S]*?return renderGraphMemberPendingHtml\(item, title\)/);
+    /function currentPendingGraphMember\(\) \{[\s\S]*?graphMemberPendingMatchesView\([\s\S]*?viewSignature\(\)/);
+  assert.match(
+    appSource,
+    /function renderApiLens\([^)]*\) \{\s*const pending = currentPendingGraphMember\(\);[\s\S]*?return renderGraphMemberPendingHtml\(item, title\)/);
   assert.match(
     appSource,
     /async function restorePendingGraphMember\([\s\S]*type\.id !== pending\.type[\s\S]*declaring type is no longer available[\s\S]*loadGraphMemberSurface/);
@@ -4758,6 +4761,38 @@ test("type API reports the filtered member count once in its header", () => {
     renderApi,
     /<p>\$\{visibleGroups\.length} of \$\{publicGroups\.length} member groups/);
   assert.doesNotMatch(renderApi, /member-filter-result/);
+  assert.doesNotMatch(renderApi, /member groups visible/);
+});
+
+test("member API uses full-area overload and selected-member surfaces", () => {
+  const renderMember =
+    appSource.match(/function renderMember\([\s\S]*?\n}\n\n\/\/ The annotated section/)?.[0]
+    ?? "";
+  assert.match(
+    renderMember,
+    /class="member-surface member-overload-surface"[\s\S]*?<h1 id="member-surface-title">\$\{escapeHtml\(member\.name\)}<\/h1>[\s\S]*?\$\{member\.overloads\.length} overloads/);
+  assert.match(
+    renderMember,
+    /class="member-surface-scroll"[\s\S]*?class="api-list api-surface-list member-surface-list"/);
+  assert.match(
+    renderMember,
+    /class="api-surface-footer member-surface-footer"[\s\S]*?id="member-back"[\s\S]*?Choose an overload to inspect/);
+  assert.match(
+    renderMember,
+    /if \(!memberSectionUsesWorkingSurface\(state\.memberSection\)\) return content;[\s\S]*?class="member-surface"[\s\S]*?<p>\$\{escapeHtml\(member\.kind\)} <span>· \$\{overloadIndex \+ 1} of \$\{member\.overloads\.length}<\/span><\/p>/);
+  assert.doesNotMatch(renderMember, /class="learn-title"/);
+  assert.doesNotMatch(
+    renderMember,
+    /<dt>Namespace:<\/dt>|<dt>Assembly:<\/dt>|<dt>Package:<\/dt>/);
+  assert.match(
+    appSource,
+    /const memberWorkingSurface =[\s\S]*?currentPendingGraphMember\(\) === null[\s\S]*?memberSectionUsesWorkingSurface\(state\.memberSection\)/);
+  assert.match(
+    stylesSource,
+    /\.detail-scroll\.api-working-surface,\s*\.detail-scroll\.member-working-surface \{[^}]*overflow: hidden;[^}]*padding: 0;/s);
+  assert.match(
+    stylesSource,
+    /\.member-surface \{[^}]*height: 100%;[^}]*grid-template-rows: 40px minmax\(0, 1fr\);/s);
 });
 
 test("graph member projections stay transport- and package-bounded", () => {

--- a/prototypes/inspect-web/test/type-panel.test.ts
+++ b/prototypes/inspect-web/test/type-panel.test.ts
@@ -24,6 +24,7 @@ import { fakeDom } from "./fake-dom.ts";
 class FakeElement {
   readonly dataset: Record<string, string | undefined>;
   value = "";
+  open = false;
   focused = false;
   private readonly listeners = new Map<string, EventListener[]>();
 
@@ -204,6 +205,8 @@ function recordingActions(calls: string[]): TypePanelBindingActions {
       calls.push(`member-jump-trait:${value}`),
     onMemberFilterChange: value => calls.push(`member-filter:${value}`),
     onMemberFilterClear: () => calls.push("member-filter-clear"),
+    onMemberFilterDisclosureToggle: value =>
+      calls.push(`member-filter-disclosure:${value}`),
     onMemberFilterKeyDown: (event, value) => {
       calls.push(`member-filter-key:${event.key}:${value}`);
       return true;
@@ -240,6 +243,9 @@ test("type panel bindings dispatch member filters without eager work", () => {
   root.addAll("[data-member-trait-filter]", allTraits, trait);
   const filter = root.add("#member-filter", new FakeElement());
   filter.value = "parse";
+  const disclosure = root.add(
+    "[data-member-filter-disclosure]",
+    new FakeElement());
   const clear = root.add("#clear-member-filter", new FakeElement());
   const calls: string[] = [];
 
@@ -260,6 +266,8 @@ test("type panel bindings dispatch member filters without eager work", () => {
     "member-trait:isStatic",
   ]);
   filter.dispatch("input");
+  disclosure.open = true;
+  disclosure.dispatch("toggle");
   const arrow = keyboardEvent("ArrowDown");
   dispatchKey(keybindings, filter, arrow);
   clear.dispatch("click");
@@ -268,6 +276,7 @@ test("type panel bindings dispatch member filters without eager work", () => {
     "member-access:protected",
     "member-trait:isStatic",
     "member-filter:parse",
+    "member-filter-disclosure:true",
     "member-filter-key:ArrowDown:parse",
     "member-filter-clear",
   ]);


### PR DESCRIPTION
Type and Member API now use the complete inspector pane with quiet local headers, collapsed filtering controls, and edge-to-edge primary content. This applies the approved Source-style composition without changing Metadata or the existing Source and Annotated Source working surfaces.

## Demo

Open `System.Text.Json.JsonSerializer` in API and notice that `Members` and its live count occupy one quiet 40 px header, filters are collapsed by default, and member rows own the remaining pane. Opening `Deserialize` keeps the same composition through overload selection, Overview, Call graph, and Facts; package coordinates remain in the persistent subject path instead of repeating in a member hero.

### Type API

![Type API full-area surface](https://github.com/user-attachments/assets/56d3d4af-330f-459a-aa01-3486fb8fafcb)

### Member overload selection

![Member overload full-area surface](https://github.com/user-attachments/assets/c0b2930f-803d-40cb-b5b9-8b621d804457)

### Member overview: before and after

| Before | After |
| --- | --- |
| ![Member overview before](https://github.com/user-attachments/assets/b71edc9e-ad67-4f52-8f85-4657c86b7144) | ![Member overview full-area surface](https://github.com/user-attachments/assets/c3f812cd-e424-4283-8a16-75a313c9dae2) |

Follow-up to #5573.

## Design

- Extends the working-surface inventory and acceptance scenarios in `docs/design/inspect-web-surface-composition.md`.
- Defines the shared collapsed-filter and quiet API-heading language in `docs/design/inspect-web-presentation-language.md`.
- Preserves member documentation, declaration copying, stable identity, parameters, returns, exceptions, applicability, Call graph, Facts, Source, and Annotated Source behavior.

## Validation

- `npm test --silent`
- `npm run analyze --silent`
- `npm run build --silent`
- `npx markdownlint-cli docs/design/inspect-web-presentation-language.md docs/design/inspect-web-surface-composition.md`
- Release Wasm publish with .NET SDK `11.0.100-preview.7.26381.103`
- Firefox at 1000 px and 600 px: Type, overload, Overview, Facts, and Call graph surfaces fill the inspector pane with no page overflow or console errors