### PR TITLE
Add explicit CLI row-selection lowering

### DIFF
--- a/docs/design/cli-row-selection.md
+++ b/docs/design/cli-row-selection.md
@@ -8,8 +8,18 @@ Focused L3 design proposal for
 
 This document owns the `dotnet-inspect` command-line grammar and lowering
 boundary for semantic row selection and rendered-line selection. The current
-product has not adopted this contract. All asserted behavior is unverified
-until the gates in [Required gates](#required-gates) land.
+product has not adopted this contract.
+
+Implementation is partial. #5644 implements value parsing, ordered lowering,
+modifier composition, Top-order attachment, typed capability rejection, and
+structured failure selection over already-owned explicit-command option
+occurrences. Raw argv ownership, System.CommandLine integration, bare
+shorthand, implicit routing, diagnostics, command adoption, and guidance remain
+unimplemented.
+
+Only that explicit-occurrence subset is verified by its named Release gates in
+[Required gates](#required-gates). Every other asserted behavior remains
+unverified until its named gate lands.
 
 Related owners:
 
@@ -54,6 +64,38 @@ This design does not own:
 L3 may reject a combination because its command has not adopted the required
 adjacent capability. It may not invent that capability or define the adjacent
 owner's behavior to make the combination succeed.
+
+## Explicit-command lowering boundary
+
+The first implemented slice begins after an explicit command has assigned each
+row-selection occurrence its option identity, value where applicable, and argv
+position. It does not split attached tokens, classify option arity, rewrite bare
+`-N`, or participate in command routing.
+
+The lowerer parses count, Window, and Top values; applies direction and line
+modifiers; preserves the argv order of semantic gestures; attaches the one
+typed opaque `--order-by` operand to Top when Top is present; otherwise
+preserves it as baseline-order input; and checks the active command's typed
+capability declaration. Success contains L2-owned `RowSelectionIntent` plus
+optional L3 rendered-line intent. Failure is structured and content-free; this
+slice does not render a diagnostic or echo argv text.
+
+Capabilities follow the lowered unit. A count that survives as semantic Head
+or Tail requires the semantic Head/Tail capability. A count redirected by
+`--lines` or `--tail-lines` requires only the rendered-line capability, because
+it contributes no semantic operation.
+
+Value failures are selected before repetition and modifier conflicts, which are
+selected before capability failures. Within each category, argv position
+selects the first failure except that absence conflicts complete at end of argv
+and use the first modifier's position. Token, arity, routing, L2-resolution, and
+diagnostic precedence remain unimplemented.
+
+The CLI project and reusable L2 project temporarily contain types in the same
+`DotnetInspector.Sections` namespace while existing section pipelines remain in
+the CLI assembly. This slice introduces no colliding type and uses only the
+L2-owned intent contract; the broader namespace migration remains owned by
+[Inspection layers](inspection-layers.md).
 
 ## Convention and deliberate divergence
 
@@ -450,6 +492,18 @@ All gates run in Release. New gates are **unverified** until implemented.
 `UntrustedArgumentDiagnosticContainmentTests` already exists and remains the
 enforcing gate for argv-derived diagnostic containment; each implemented
 spelling adds its new diagnostic channels to that gate.
+
+The implemented explicit-command occurrence lowerer is enforced by:
+
+| Gate | Property |
+| --- | --- |
+| `CliRowSelectionExplicitValueTests` | Positive ASCII-decimal Count and Top values plus closed, prefix, and suffix Window values lower to typed intent; empty, signed, non-ASCII, zero, overflowing, integer, start-plus-count, boundless, repeated-operator, reversed, and internally spaced forms return their structured value failure. |
+| `CliRowSelectionExplicitOrderTests` | Count, Window, and Top preserve argv order; one order operand attaches only to Top when Top is present and otherwise remains typed baseline-order input. |
+| `CliRowSelectionExplicitModifierTests` | Direction modifiers lower the limit count to Head or Tail intent, line modifiers remove that count while preserving neighboring semantic operations, exact modifier repeats and equivalent tail/line redundancy are tolerated, conflicting directions reject at the completing token, and absence conflicts name the first modifier. |
+| `CliRowSelectionExplicitCapabilityTests` | An explicit request succeeds with exactly its lowered semantic, order, and line capabilities; line-unit counts do not require the Head/Tail capability, missing capabilities reject in argv order, and an empty request requires none. |
+| `CliRowSelectionExplicitFailurePrecedenceTests` | Value failure precedes repetition/conflict, repetition/conflict precedes capability rejection, each category uses the specified position rule, and structured failure publishes no success value. |
+
+The remaining implementation must satisfy:
 
 | Gate | Property |
 | --- | --- |

--- a/src/dotnet-inspect.Tests/CliRowSelectionLoweringTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionLoweringTests.cs
@@ -1,0 +1,464 @@
+using DotnetInspector.CommandLine;
+using DotnetInspector.RowSelection;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+public sealed class CliRowSelectionLoweringTests
+{
+    [Fact]
+    public void CliRowSelectionExplicitValueTests()
+    {
+        CliRowSelectionLowering<string> value =
+            Success(
+                All,
+                Limit(0, "12"),
+                Rows(1, "2..5"));
+
+        Assert.Equal(2, value.SemanticIntent.Operations.Count);
+        Assert.Equal(
+            RowSelectionStageKind.Head,
+            value.SemanticIntent.Operations[0].Kind);
+        Assert.Equal(
+            12,
+            value.SemanticIntent.Operations[0].Count);
+        Assert.Equal(
+            RowSelectionStageKind.Window,
+            value.SemanticIntent.Operations[1].Kind);
+        Assert.Equal(
+            2,
+            value.SemanticIntent.Operations[1].Start);
+        Assert.Equal(
+            5,
+            value.SemanticIntent.Operations[1].End);
+
+        AssertWindow("..5", null, 5);
+        AssertWindow("3..", 3, null);
+        AssertWindow("7..7", 7, 7);
+        AssertCount(Top(0, "4"), 4);
+
+        AssertFailure(
+            Limit(0, ""),
+            CliRowSelectionFailureReason.MalformedValue);
+        AssertFailure(
+            Limit(0, "-1"),
+            CliRowSelectionFailureReason.MalformedValue);
+        AssertFailure(
+            Limit(0, "٠١"),
+            CliRowSelectionFailureReason.MalformedValue);
+        AssertFailure(
+            Limit(0, "0"),
+            CliRowSelectionFailureReason.NonPositiveValue);
+        AssertFailure(
+            Limit(0, "99999999999999999999"),
+            CliRowSelectionFailureReason.OverflowValue);
+        AssertFailure(
+            Rows(0, "5"),
+            CliRowSelectionFailureReason.InvalidWindowForm);
+        AssertFailure(
+            Rows(0, "2+3"),
+            CliRowSelectionFailureReason.InvalidWindowForm);
+        AssertFailure(
+            Rows(0, ".."),
+            CliRowSelectionFailureReason.InvalidWindowForm);
+        AssertFailure(
+            Rows(0, "1..2..3"),
+            CliRowSelectionFailureReason.InvalidWindowForm);
+        AssertFailure(
+            Rows(0, "4..2"),
+            CliRowSelectionFailureReason.ReversedWindow);
+        AssertFailure(
+            Rows(0, "0..2"),
+            CliRowSelectionFailureReason.NonPositiveValue);
+        AssertFailure(
+            Rows(0, "1.. 2"),
+            CliRowSelectionFailureReason.MalformedValue);
+    }
+
+    [Fact]
+    public void CliRowSelectionExplicitOrderTests()
+    {
+        CliRowSelectionLowering<string> ordered =
+            Success(
+                All,
+                Top(8, "2"),
+                Rows(2, "3..6"),
+                Limit(5, "4"));
+
+        Assert.Equal(
+            [
+                RowSelectionStageKind.Window,
+                RowSelectionStageKind.Head,
+                RowSelectionStageKind.Top
+            ],
+            ordered.SemanticIntent.Operations.Select(
+                operation => operation.Kind));
+
+        CliRowSelectionLowering<string> ranked =
+            Success(
+                All,
+                OrderBy(9, "confidence"),
+                Top(2, "3"));
+        RowSelectionIntentOperation<string> top =
+            Assert.Single(ranked.SemanticIntent.Operations);
+        Assert.True(top.HasRankingOrderOperand);
+        Assert.Equal(
+            "confidence",
+            top.RankingOrderOperand);
+        Assert.False(ranked.HasBaselineOrderOperand);
+
+        CliRowSelectionLowering<string> defaultRanked =
+            Success(
+                All,
+                Top(2, "3"));
+        Assert.False(
+            Assert.Single(defaultRanked.SemanticIntent.Operations)
+                .HasRankingOrderOperand);
+
+        CliRowSelectionLowering<string> baseline =
+            Success(
+                All,
+                OrderBy(1, "name"),
+                Limit(3, "2"));
+        Assert.True(baseline.HasBaselineOrderOperand);
+        Assert.Equal("name", baseline.BaselineOrderOperand);
+        Assert.Throws<InvalidOperationException>(
+            () => _ = ranked.BaselineOrderOperand);
+    }
+
+    [Fact]
+    public void CliRowSelectionExplicitModifierTests()
+    {
+        CliRowSelectionLowering<string> tail =
+            Success(
+                All,
+                Limit(0, "4"),
+                Tail(2),
+                Tail(3));
+        Assert.Equal(
+            RowSelectionStageKind.Tail,
+            Assert.Single(tail.SemanticIntent.Operations).Kind);
+
+        CliRowSelectionLowering<string> head =
+            Success(
+                CliRowSelectionCapabilities.HeadTail,
+                Limit(0, "3"),
+                Head(1),
+                Head(2));
+        Assert.Equal(
+            RowSelectionStageKind.Head,
+            Assert.Single(head.SemanticIntent.Operations).Kind);
+
+        CliRowSelectionLowering<string> lines =
+            Success(
+                All,
+                Limit(0, "4"),
+                Lines(1),
+                Tail(2),
+                TailLines(3),
+                Lines(4));
+        Assert.Empty(lines.SemanticIntent.Operations);
+        Assert.NotNull(lines.LineIntent);
+        Assert.Equal(4, lines.LineIntent.Count);
+        Assert.Equal(
+            CliLineSelectionDirection.Tail,
+            lines.LineIntent.Direction);
+
+        CliRowSelectionLowering<string> windowAndLines =
+            Success(
+                CliRowSelectionCapabilities.Window
+                    | CliRowSelectionCapabilities.Lines,
+                Rows(0, "3..6"),
+                Limit(1, "2"),
+                Lines(2));
+        RowSelectionIntentOperation<string> survivingWindow =
+            Assert.Single(
+                windowAndLines.SemanticIntent.Operations);
+        Assert.Equal(
+            RowSelectionStageKind.Window,
+            survivingWindow.Kind);
+        Assert.Equal(3, survivingWindow.Start);
+        Assert.Equal(6, survivingWindow.End);
+        Assert.NotNull(windowAndLines.LineIntent);
+        Assert.Equal(2, windowAndLines.LineIntent.Count);
+        Assert.Equal(
+            CliLineSelectionDirection.Head,
+            windowAndLines.LineIntent.Direction);
+
+        AssertConflict(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            3,
+            Limit(0, "2"),
+            Head(1),
+            Tail(3));
+        AssertConflict(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            4,
+            Limit(0, "2"),
+            TailLines(1),
+            Head(4));
+        AssertConflict(
+            CliRowSelectionFailureReason.ModifierRequiresCount,
+            1,
+            Top(0, "2"),
+            Lines(1),
+            Tail(2));
+    }
+
+    [Fact]
+    public void CliRowSelectionExplicitCapabilityTests()
+    {
+        AssertCapabilityFailure(
+            CliRowSelectionCapabilities.Window,
+            Rows(2, "1..2"));
+        AssertCapabilityFailure(
+            CliRowSelectionCapabilities.Top,
+            Top(2, "3"));
+        AssertCapabilityFailure(
+            CliRowSelectionCapabilities.OrderBy,
+            OrderBy(2, "confidence"));
+        AssertCapabilityFailure(
+            CliRowSelectionCapabilities.Lines,
+            Limit(0, "2"),
+            Lines(2));
+
+        CliRowSelectionLowering<string> lineOnly =
+            Success(
+                CliRowSelectionCapabilities.Lines,
+                TailLines(0),
+                Limit(1, "2"));
+        Assert.Empty(lineOnly.SemanticIntent.Operations);
+        Assert.NotNull(lineOnly.LineIntent);
+        Assert.Equal(
+            CliLineSelectionDirection.Tail,
+            lineOnly.LineIntent.Direction);
+
+        CliRowSelectionLowering<string> exact =
+            Success(
+                CliRowSelectionCapabilities.Window
+                    | CliRowSelectionCapabilities.Top
+                    | CliRowSelectionCapabilities.OrderBy,
+                Rows(0, "1..2"),
+                Top(1, "3"),
+                OrderBy(2, "confidence"));
+        Assert.Equal(2, exact.SemanticIntent.Operations.Count);
+
+        Assert.True(
+            CliRowSelectionLowerer.Lower(
+                Array.Empty<
+                    CliRowSelectionOccurrence<string>>(),
+                CliRowSelectionCapabilities.None)
+                .IsSuccess);
+    }
+
+    [Fact]
+    public void CliRowSelectionExplicitFailurePrecedenceTests()
+    {
+        CliRowSelectionFailure malformedBeforeRepeat =
+            Failure(
+                All,
+                Limit(0, "2"),
+                Limit(1, "3"),
+                Rows(4, "bad"));
+        Assert.Equal(
+            CliRowSelectionFailureReason.InvalidWindowForm,
+            malformedBeforeRepeat.Reason);
+        Assert.Equal(4, malformedBeforeRepeat.Position);
+
+        CliRowSelectionFailure firstMalformedByPosition =
+            Failure(
+                All,
+                Top(8, "bad"),
+                Rows(3, "0..2"));
+        Assert.Equal(
+            CliRowSelectionFailureReason.NonPositiveValue,
+            firstMalformedByPosition.Reason);
+        Assert.Equal(3, firstMalformedByPosition.Position);
+
+        CliRowSelectionFailure repeatBeforeCapability =
+            Failure(
+                CliRowSelectionCapabilities.None,
+                Limit(0, "2"),
+                Limit(6, "3"));
+        Assert.Equal(
+            CliRowSelectionFailureReason.RepeatedGesture,
+            repeatBeforeCapability.Reason);
+        Assert.Equal(6, repeatBeforeCapability.Position);
+
+        CliRowSelectionFailure conflictBeforeAbsence =
+            Failure(
+                All,
+                Lines(0),
+                Head(1),
+                Tail(5));
+        Assert.Equal(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            conflictBeforeAbsence.Reason);
+        Assert.Equal(5, conflictBeforeAbsence.Position);
+
+        CliRowSelectionFailure firstAbsenceModifier =
+            Failure(
+                All,
+                Tail(7),
+                Lines(2));
+        Assert.Equal(
+            CliRowSelectionFailureReason.ModifierRequiresCount,
+            firstAbsenceModifier.Reason);
+        Assert.Equal(2, firstAbsenceModifier.Position);
+
+        CliRowSelectionFailure firstCapability =
+            Failure(
+                CliRowSelectionCapabilities.HeadTail,
+                Top(8, "2"),
+                Rows(2, "1..2"));
+        Assert.Equal(
+            CliRowSelectionFailureReason.UnsupportedCapability,
+            firstCapability.Reason);
+        Assert.Equal(2, firstCapability.Position);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            firstCapability.OccurrenceKind);
+    }
+
+    private const CliRowSelectionCapabilities All =
+        CliRowSelectionCapabilities.All;
+
+    private static CliRowSelectionOccurrence<string> Limit(
+        int position,
+        string value) =>
+        CliRowSelectionOccurrence<string>.Limit(
+            position,
+            value);
+
+    private static CliRowSelectionOccurrence<string> Rows(
+        int position,
+        string value) =>
+        CliRowSelectionOccurrence<string>.Rows(
+            position,
+            value);
+
+    private static CliRowSelectionOccurrence<string> Top(
+        int position,
+        string value) =>
+        CliRowSelectionOccurrence<string>.Top(
+            position,
+            value);
+
+    private static CliRowSelectionOccurrence<string> OrderBy(
+        int position,
+        string value) =>
+        CliRowSelectionOccurrence<string>.OrderBy(
+            position,
+            value);
+
+    private static CliRowSelectionOccurrence<string> Head(
+        int position) =>
+        CliRowSelectionOccurrence<string>.Head(position);
+
+    private static CliRowSelectionOccurrence<string> Tail(
+        int position) =>
+        CliRowSelectionOccurrence<string>.Tail(position);
+
+    private static CliRowSelectionOccurrence<string> Lines(
+        int position) =>
+        CliRowSelectionOccurrence<string>.Lines(position);
+
+    private static CliRowSelectionOccurrence<string> TailLines(
+        int position) =>
+        CliRowSelectionOccurrence<string>.TailLines(position);
+
+    private static void AssertWindow(
+        string value,
+        int? start,
+        int? end)
+    {
+        RowSelectionIntentOperation<string> operation =
+            Assert.Single(
+                Success(
+                    All,
+                    Rows(0, value))
+                    .SemanticIntent.Operations);
+        Assert.Equal(start, operation.Start);
+        Assert.Equal(end, operation.End);
+    }
+
+    private static void AssertCount(
+        CliRowSelectionOccurrence<string> occurrence,
+        int count)
+    {
+        Assert.Equal(
+            count,
+            Assert.Single(
+                Success(All, occurrence)
+                    .SemanticIntent.Operations)
+                .Count);
+    }
+
+    private static void AssertFailure(
+        CliRowSelectionOccurrence<string> occurrence,
+        CliRowSelectionFailureReason reason)
+    {
+        CliRowSelectionFailure failure =
+            Failure(All, occurrence);
+        Assert.Equal(reason, failure.Reason);
+        Assert.Equal(
+            occurrence.Kind,
+            failure.OccurrenceKind);
+        Assert.Equal(
+            occurrence.Position,
+            failure.Position);
+    }
+
+    private static void AssertConflict(
+        CliRowSelectionFailureReason reason,
+        int position,
+        params CliRowSelectionOccurrence<string>[] occurrences)
+    {
+        CliRowSelectionFailure failure =
+            Failure(All, occurrences);
+        Assert.Equal(reason, failure.Reason);
+        Assert.Equal(position, failure.Position);
+    }
+
+    private static void AssertCapabilityFailure(
+        CliRowSelectionCapabilities missing,
+        params CliRowSelectionOccurrence<string>[] occurrences)
+    {
+        CliRowSelectionFailure failure =
+            Failure(
+                All & ~missing,
+                occurrences);
+        Assert.Equal(
+            CliRowSelectionFailureReason.UnsupportedCapability,
+            failure.Reason);
+        Assert.Equal(missing, failure.MissingCapabilities);
+    }
+
+    private static CliRowSelectionLowering<string> Success(
+        CliRowSelectionCapabilities capabilities,
+        params CliRowSelectionOccurrence<string>[] occurrences)
+    {
+        CliRowSelectionLoweringResult<string> result =
+            CliRowSelectionLowerer.Lower(
+                occurrences,
+                capabilities);
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Failure);
+        return Assert.IsType<CliRowSelectionLowering<string>>(
+            result.Value);
+    }
+
+    private static CliRowSelectionFailure Failure(
+        CliRowSelectionCapabilities capabilities,
+        params CliRowSelectionOccurrence<string>[] occurrences)
+    {
+        CliRowSelectionLoweringResult<string> result =
+            CliRowSelectionLowerer.Lower(
+                occurrences,
+                capabilities);
+        Assert.False(result.IsSuccess);
+        Assert.Null(result.Value);
+        return Assert.IsType<CliRowSelectionFailure>(
+            result.Failure);
+    }
+}

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionLowerer.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionLowerer.cs
@@ -1,0 +1,694 @@
+using System.Globalization;
+using DotnetInspector.RowSelection;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.CommandLine;
+
+[Flags]
+internal enum CliRowSelectionCapabilities
+{
+    None = 0,
+    HeadTail = 1,
+    Window = 2,
+    Top = 4,
+    OrderBy = 8,
+    Lines = 16,
+    All = HeadTail | Window | Top | OrderBy | Lines
+}
+
+internal enum CliLineSelectionDirection
+{
+    Head,
+    Tail
+}
+
+internal sealed class CliLineSelectionIntent
+{
+    public CliLineSelectionIntent(
+        int count,
+        CliLineSelectionDirection direction)
+    {
+        Count = count;
+        Direction = direction;
+    }
+
+    public int Count { get; }
+
+    public CliLineSelectionDirection Direction { get; }
+}
+
+internal enum CliRowSelectionFailureReason
+{
+    MalformedValue,
+    NonPositiveValue,
+    OverflowValue,
+    InvalidWindowForm,
+    ReversedWindow,
+    RepeatedGesture,
+    ConflictingDirection,
+    ModifierRequiresCount,
+    UnsupportedCapability
+}
+
+internal sealed class CliRowSelectionFailure
+{
+    public CliRowSelectionFailure(
+        CliRowSelectionFailureReason reason,
+        CliRowSelectionOccurrenceKind occurrenceKind,
+        int position,
+        CliRowSelectionCapabilities missingCapabilities =
+            CliRowSelectionCapabilities.None)
+    {
+        Reason = reason;
+        OccurrenceKind = occurrenceKind;
+        Position = position;
+        MissingCapabilities = missingCapabilities;
+    }
+
+    public CliRowSelectionFailureReason Reason { get; }
+
+    public CliRowSelectionOccurrenceKind OccurrenceKind { get; }
+
+    public int Position { get; }
+
+    public CliRowSelectionCapabilities MissingCapabilities { get; }
+}
+
+internal sealed class CliRowSelectionLowering<TOrderOperand>
+    where TOrderOperand : notnull
+{
+    private readonly bool _hasBaselineOrderOperand;
+    private readonly TOrderOperand _baselineOrderOperand;
+
+    public CliRowSelectionLowering(
+        RowSelectionIntent<TOrderOperand> semanticIntent,
+        CliLineSelectionIntent? lineIntent,
+        bool hasBaselineOrderOperand,
+        TOrderOperand baselineOrderOperand)
+    {
+        SemanticIntent = semanticIntent;
+        LineIntent = lineIntent;
+        _hasBaselineOrderOperand = hasBaselineOrderOperand;
+        _baselineOrderOperand = baselineOrderOperand;
+    }
+
+    public RowSelectionIntent<TOrderOperand> SemanticIntent { get; }
+
+    public CliLineSelectionIntent? LineIntent { get; }
+
+    public bool HasBaselineOrderOperand =>
+        _hasBaselineOrderOperand;
+
+    public TOrderOperand BaselineOrderOperand =>
+        _hasBaselineOrderOperand
+            ? _baselineOrderOperand
+            : throw new InvalidOperationException(
+                "The CLI row-selection request has no baseline-order operand.");
+}
+
+internal sealed class CliRowSelectionLoweringResult<TOrderOperand>
+    where TOrderOperand : notnull
+{
+    private CliRowSelectionLoweringResult(
+        CliRowSelectionLowering<TOrderOperand>? value,
+        CliRowSelectionFailure? failure)
+    {
+        Value = value;
+        Failure = failure;
+    }
+
+    public bool IsSuccess => Value is not null;
+
+    public CliRowSelectionLowering<TOrderOperand>? Value { get; }
+
+    public CliRowSelectionFailure? Failure { get; }
+
+    public static CliRowSelectionLoweringResult<TOrderOperand> Success(
+        CliRowSelectionLowering<TOrderOperand> value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(value, null);
+    }
+
+    public static CliRowSelectionLoweringResult<TOrderOperand> Failed(
+        CliRowSelectionFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new(null, failure);
+    }
+}
+
+internal static class CliRowSelectionLowerer
+{
+    public static CliRowSelectionLoweringResult<TOrderOperand> Lower<
+        TOrderOperand>(
+        IReadOnlyList<CliRowSelectionOccurrence<TOrderOperand>>
+            occurrences,
+        CliRowSelectionCapabilities capabilities)
+        where TOrderOperand : notnull
+    {
+        ArgumentNullException.ThrowIfNull(occurrences);
+
+        ParsedOccurrence<TOrderOperand>[] ordered =
+            ParseAndOrder(
+                occurrences,
+                out CliRowSelectionFailure? valueFailure);
+        if (valueFailure is not null)
+        {
+            return CliRowSelectionLoweringResult<TOrderOperand>.Failed(
+                valueFailure);
+        }
+
+        CliRowSelectionFailure? conflict =
+            FindConflict(ordered);
+        if (conflict is not null)
+        {
+            return CliRowSelectionLoweringResult<TOrderOperand>.Failed(
+                conflict);
+        }
+
+        CliRowSelectionFailure? capabilityFailure =
+            FindCapabilityFailure(
+                ordered,
+                capabilities);
+        if (capabilityFailure is not null)
+        {
+            return CliRowSelectionLoweringResult<TOrderOperand>.Failed(
+                capabilityFailure);
+        }
+
+        return CliRowSelectionLoweringResult<TOrderOperand>.Success(
+            Build(ordered));
+    }
+
+    private static ParsedOccurrence<TOrderOperand>[] ParseAndOrder<
+        TOrderOperand>(
+        IReadOnlyList<CliRowSelectionOccurrence<TOrderOperand>>
+            occurrences,
+        out CliRowSelectionFailure? failure)
+        where TOrderOperand : notnull
+    {
+        var indexed =
+            new (
+                CliRowSelectionOccurrence<TOrderOperand> Occurrence,
+                int Index)[occurrences.Count];
+        for (int index = 0; index < occurrences.Count; index++)
+        {
+            indexed[index] =
+                (
+                    occurrences[index]
+                        ?? throw new ArgumentNullException(
+                            nameof(occurrences),
+                            $"Occurrence {index + 1} is null."),
+                    index
+                );
+        }
+
+        Array.Sort(
+            indexed,
+            static (left, right) =>
+            {
+                int position =
+                    left.Occurrence.Position.CompareTo(
+                        right.Occurrence.Position);
+                return position != 0
+                    ? position
+                    : left.Index.CompareTo(right.Index);
+            });
+
+        var parsed =
+            new ParsedOccurrence<TOrderOperand>[indexed.Length];
+        for (int index = 0; index < indexed.Length; index++)
+        {
+            CliRowSelectionOccurrence<TOrderOperand> occurrence =
+                indexed[index].Occurrence;
+            if (!TryParse(
+                    occurrence,
+                    out parsed[index],
+                    out CliRowSelectionFailureReason reason))
+            {
+                failure =
+                    new(
+                        reason,
+                        occurrence.Kind,
+                        occurrence.Position);
+                return parsed;
+            }
+        }
+
+        failure = null;
+        return parsed;
+    }
+
+    private static bool TryParse<TOrderOperand>(
+        CliRowSelectionOccurrence<TOrderOperand> occurrence,
+        out ParsedOccurrence<TOrderOperand> parsed,
+        out CliRowSelectionFailureReason failure)
+        where TOrderOperand : notnull
+    {
+        switch (occurrence.Kind)
+        {
+            case CliRowSelectionOccurrenceKind.Limit:
+            case CliRowSelectionOccurrenceKind.Top:
+                if (!TryParsePositiveInteger(
+                        occurrence.Value,
+                        out int count,
+                        out failure))
+                {
+                    parsed = default;
+                    return false;
+                }
+
+                parsed =
+                    new(
+                        occurrence,
+                        count,
+                        null,
+                        null);
+                return true;
+
+            case CliRowSelectionOccurrenceKind.Rows:
+                if (!TryParseWindow(
+                        occurrence.Value,
+                        out int? start,
+                        out int? end,
+                        out failure))
+                {
+                    parsed = default;
+                    return false;
+                }
+
+                parsed =
+                    new(
+                        occurrence,
+                        0,
+                        start,
+                        end);
+                return true;
+
+            default:
+                parsed =
+                    new(
+                        occurrence,
+                        0,
+                        null,
+                        null);
+                failure = default;
+                return true;
+        }
+    }
+
+    private static bool TryParsePositiveInteger(
+        string value,
+        out int parsed,
+        out CliRowSelectionFailureReason failure)
+    {
+        parsed = 0;
+        if (value.Length == 0)
+        {
+            failure = CliRowSelectionFailureReason.MalformedValue;
+            return false;
+        }
+
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (!char.IsAsciiDigit(value[index]))
+            {
+                failure =
+                    CliRowSelectionFailureReason.MalformedValue;
+                return false;
+            }
+        }
+
+        if (!int.TryParse(
+                value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out parsed))
+        {
+            failure = CliRowSelectionFailureReason.OverflowValue;
+            return false;
+        }
+
+        if (parsed == 0)
+        {
+            failure =
+                CliRowSelectionFailureReason.NonPositiveValue;
+            return false;
+        }
+
+        failure = default;
+        return true;
+    }
+
+    private static bool TryParseWindow(
+        string value,
+        out int? start,
+        out int? end,
+        out CliRowSelectionFailureReason failure)
+    {
+        start = null;
+        end = null;
+
+        int separator =
+            value.IndexOf(
+                "..",
+                StringComparison.Ordinal);
+        if (separator < 0
+            || value.IndexOf(
+                "..",
+                separator + 2,
+                StringComparison.Ordinal) >= 0)
+        {
+            failure =
+                CliRowSelectionFailureReason.InvalidWindowForm;
+            return false;
+        }
+
+        string startText = value[..separator];
+        string endText = value[(separator + 2)..];
+        if (startText.Length == 0
+            && endText.Length == 0)
+        {
+            failure =
+                CliRowSelectionFailureReason.InvalidWindowForm;
+            return false;
+        }
+
+        if (startText.Length > 0)
+        {
+            if (!TryParsePositiveInteger(
+                    startText,
+                    out int parsedStart,
+                    out failure))
+            {
+                return false;
+            }
+
+            start = parsedStart;
+        }
+
+        if (endText.Length > 0)
+        {
+            if (!TryParsePositiveInteger(
+                    endText,
+                    out int parsedEnd,
+                    out failure))
+            {
+                return false;
+            }
+
+            end = parsedEnd;
+        }
+
+        if (start is not null
+            && end is not null
+            && end < start)
+        {
+            failure =
+                CliRowSelectionFailureReason.ReversedWindow;
+            return false;
+        }
+
+        failure = default;
+        return true;
+    }
+
+    private static CliRowSelectionFailure? FindConflict<
+        TOrderOperand>(
+        IReadOnlyList<ParsedOccurrence<TOrderOperand>> ordered)
+        where TOrderOperand : notnull
+    {
+        bool countSeen = false;
+        bool rowsSeen = false;
+        bool topSeen = false;
+        bool orderSeen = false;
+        bool headSeen = false;
+        bool tailSeen = false;
+        bool tailLinesSeen = false;
+        ParsedOccurrence<TOrderOperand>? firstModifier = null;
+
+        for (int index = 0; index < ordered.Count; index++)
+        {
+            ParsedOccurrence<TOrderOperand> parsed =
+                ordered[index];
+            CliRowSelectionOccurrence<TOrderOperand> occurrence =
+                parsed.Occurrence;
+
+            switch (occurrence.Kind)
+            {
+                case CliRowSelectionOccurrenceKind.Limit:
+                    if (countSeen)
+                        return Repeated(occurrence);
+                    countSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Rows:
+                    if (rowsSeen)
+                        return Repeated(occurrence);
+                    rowsSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Top:
+                    if (topSeen)
+                        return Repeated(occurrence);
+                    topSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.OrderBy:
+                    if (orderSeen)
+                        return Repeated(occurrence);
+                    orderSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Head:
+                    firstModifier ??= parsed;
+                    if (!headSeen && (tailSeen || tailLinesSeen))
+                        return DirectionConflict(occurrence);
+                    headSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Tail:
+                    firstModifier ??= parsed;
+                    if (!tailSeen && headSeen)
+                        return DirectionConflict(occurrence);
+                    tailSeen = true;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Lines:
+                    firstModifier ??= parsed;
+                    break;
+
+                case CliRowSelectionOccurrenceKind.TailLines:
+                    firstModifier ??= parsed;
+                    if (!tailLinesSeen && headSeen)
+                        return DirectionConflict(occurrence);
+                    tailLinesSeen = true;
+                    break;
+            }
+        }
+
+        if (!countSeen && firstModifier is not null)
+        {
+            CliRowSelectionOccurrence<TOrderOperand> occurrence =
+                firstModifier.Value.Occurrence;
+            return new(
+                CliRowSelectionFailureReason.ModifierRequiresCount,
+                occurrence.Kind,
+                occurrence.Position);
+        }
+
+        return null;
+    }
+
+    private static CliRowSelectionFailure Repeated<TOrderOperand>(
+        CliRowSelectionOccurrence<TOrderOperand> occurrence)
+        where TOrderOperand : notnull =>
+        new(
+            CliRowSelectionFailureReason.RepeatedGesture,
+            occurrence.Kind,
+            occurrence.Position);
+
+    private static CliRowSelectionFailure DirectionConflict<
+        TOrderOperand>(
+        CliRowSelectionOccurrence<TOrderOperand> occurrence)
+        where TOrderOperand : notnull =>
+        new(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            occurrence.Kind,
+            occurrence.Position);
+
+    private static CliRowSelectionFailure? FindCapabilityFailure<
+        TOrderOperand>(
+        IReadOnlyList<ParsedOccurrence<TOrderOperand>> ordered,
+        CliRowSelectionCapabilities capabilities)
+        where TOrderOperand : notnull
+    {
+        bool lineSelection = false;
+        for (int index = 0; index < ordered.Count; index++)
+        {
+            CliRowSelectionOccurrenceKind kind =
+                ordered[index].Occurrence.Kind;
+            if (kind is CliRowSelectionOccurrenceKind.Lines
+                or CliRowSelectionOccurrenceKind.TailLines)
+            {
+                lineSelection = true;
+                break;
+            }
+        }
+
+        for (int index = 0; index < ordered.Count; index++)
+        {
+            CliRowSelectionOccurrence<TOrderOperand> occurrence =
+                ordered[index].Occurrence;
+            CliRowSelectionCapabilities required =
+                RequiredCapabilities(
+                    occurrence.Kind,
+                    lineSelection);
+            CliRowSelectionCapabilities missing =
+                required & ~capabilities;
+            if (missing != CliRowSelectionCapabilities.None)
+            {
+                return new(
+                    CliRowSelectionFailureReason.UnsupportedCapability,
+                    occurrence.Kind,
+                    occurrence.Position,
+                    missing);
+            }
+        }
+
+        return null;
+    }
+
+    private static CliRowSelectionCapabilities RequiredCapabilities(
+        CliRowSelectionOccurrenceKind kind,
+        bool lineSelection) =>
+        kind switch
+        {
+            CliRowSelectionOccurrenceKind.Limit
+                or CliRowSelectionOccurrenceKind.Head
+                or CliRowSelectionOccurrenceKind.Tail =>
+                lineSelection
+                    ? CliRowSelectionCapabilities.Lines
+                    : CliRowSelectionCapabilities.HeadTail,
+            CliRowSelectionOccurrenceKind.Rows =>
+                CliRowSelectionCapabilities.Window,
+            CliRowSelectionOccurrenceKind.Top =>
+                CliRowSelectionCapabilities.Top,
+            CliRowSelectionOccurrenceKind.OrderBy =>
+                CliRowSelectionCapabilities.OrderBy,
+            CliRowSelectionOccurrenceKind.Lines =>
+                CliRowSelectionCapabilities.Lines,
+            CliRowSelectionOccurrenceKind.TailLines =>
+                CliRowSelectionCapabilities.Lines,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(kind),
+                kind,
+                null)
+        };
+
+    private static CliRowSelectionLowering<TOrderOperand> Build<
+        TOrderOperand>(
+        IReadOnlyList<ParsedOccurrence<TOrderOperand>> ordered)
+        where TOrderOperand : notnull
+    {
+        ParsedOccurrence<TOrderOperand>? count = null;
+        ParsedOccurrence<TOrderOperand>? top = null;
+        ParsedOccurrence<TOrderOperand>? order = null;
+        bool tail = false;
+        bool lines = false;
+
+        for (int index = 0; index < ordered.Count; index++)
+        {
+            ParsedOccurrence<TOrderOperand> parsed =
+                ordered[index];
+            switch (parsed.Occurrence.Kind)
+            {
+                case CliRowSelectionOccurrenceKind.Limit:
+                    count = parsed;
+                    break;
+                case CliRowSelectionOccurrenceKind.Top:
+                    top = parsed;
+                    break;
+                case CliRowSelectionOccurrenceKind.OrderBy:
+                    order = parsed;
+                    break;
+                case CliRowSelectionOccurrenceKind.Tail:
+                    tail = true;
+                    break;
+                case CliRowSelectionOccurrenceKind.Lines:
+                    lines = true;
+                    break;
+                case CliRowSelectionOccurrenceKind.TailLines:
+                    tail = true;
+                    lines = true;
+                    break;
+            }
+        }
+
+        var operations =
+            new List<RowSelectionIntentOperation<TOrderOperand>>();
+        for (int index = 0; index < ordered.Count; index++)
+        {
+            ParsedOccurrence<TOrderOperand> parsed =
+                ordered[index];
+            switch (parsed.Occurrence.Kind)
+            {
+                case CliRowSelectionOccurrenceKind.Limit
+                    when !lines:
+                    operations.Add(
+                        tail
+                            ? RowSelectionIntentOperation<TOrderOperand>
+                                .Tail(parsed.Count)
+                            : RowSelectionIntentOperation<TOrderOperand>
+                                .Head(parsed.Count));
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Rows:
+                    operations.Add(
+                        RowSelectionIntentOperation<TOrderOperand>
+                            .Window(
+                                parsed.Start,
+                                parsed.End));
+                    break;
+
+                case CliRowSelectionOccurrenceKind.Top:
+                    operations.Add(
+                        order is not null
+                            ? RowSelectionIntentOperation<TOrderOperand>
+                                .Top(
+                                    parsed.Count,
+                                    order.Value.Occurrence.OrderOperand)
+                            : RowSelectionIntentOperation<TOrderOperand>
+                                .Top(parsed.Count));
+                    break;
+            }
+        }
+
+        CliLineSelectionIntent? lineIntent =
+            lines
+                ? new(
+                    count!.Value.Count,
+                    tail
+                        ? CliLineSelectionDirection.Tail
+                        : CliLineSelectionDirection.Head)
+                : null;
+        bool hasBaselineOrder =
+            order is not null && top is null;
+
+        return new(
+            RowSelectionIntent<TOrderOperand>.Create(operations),
+            lineIntent,
+            hasBaselineOrder,
+            hasBaselineOrder
+                ? order!.Value.Occurrence.OrderOperand
+                : default!);
+    }
+
+    private readonly record struct ParsedOccurrence<TOrderOperand>(
+        CliRowSelectionOccurrence<TOrderOperand> Occurrence,
+        int Count,
+        int? Start,
+        int? End)
+        where TOrderOperand : notnull;
+}

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionOccurrence.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionOccurrence.cs
@@ -1,0 +1,143 @@
+namespace DotnetInspector.CommandLine;
+
+internal enum CliRowSelectionOccurrenceKind
+{
+    Limit,
+    Rows,
+    Top,
+    OrderBy,
+    Head,
+    Tail,
+    Lines,
+    TailLines
+}
+
+internal sealed class CliRowSelectionOccurrence<TOrderOperand>
+    where TOrderOperand : notnull
+{
+    private readonly string? _value;
+    private readonly TOrderOperand _orderOperand;
+
+    private CliRowSelectionOccurrence(
+        CliRowSelectionOccurrenceKind kind,
+        int position,
+        string? value,
+        TOrderOperand orderOperand)
+    {
+        if (position < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(position),
+                position,
+                "An argv position cannot be negative.");
+        }
+
+        Kind = kind;
+        Position = position;
+        _value = value;
+        _orderOperand = orderOperand;
+    }
+
+    public CliRowSelectionOccurrenceKind Kind { get; }
+
+    public int Position { get; }
+
+    public string Value =>
+        Kind is CliRowSelectionOccurrenceKind.Limit
+            or CliRowSelectionOccurrenceKind.Rows
+            or CliRowSelectionOccurrenceKind.Top
+            ? _value!
+            : throw WrongKind(nameof(Value));
+
+    public TOrderOperand OrderOperand =>
+        Kind is CliRowSelectionOccurrenceKind.OrderBy
+            ? _orderOperand
+            : throw WrongKind(nameof(OrderOperand));
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Limit(
+        int position,
+        string value) =>
+        WithValue(
+            CliRowSelectionOccurrenceKind.Limit,
+            position,
+            value);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Rows(
+        int position,
+        string value) =>
+        WithValue(
+            CliRowSelectionOccurrenceKind.Rows,
+            position,
+            value);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Top(
+        int position,
+        string value) =>
+        WithValue(
+            CliRowSelectionOccurrenceKind.Top,
+            position,
+            value);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> OrderBy(
+        int position,
+        TOrderOperand orderOperand)
+    {
+        ArgumentNullException.ThrowIfNull(orderOperand);
+        return new(
+            CliRowSelectionOccurrenceKind.OrderBy,
+            position,
+            null,
+            orderOperand);
+    }
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Head(
+        int position) =>
+        Modifier(
+            CliRowSelectionOccurrenceKind.Head,
+            position);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Tail(
+        int position) =>
+        Modifier(
+            CliRowSelectionOccurrenceKind.Tail,
+            position);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> Lines(
+        int position) =>
+        Modifier(
+            CliRowSelectionOccurrenceKind.Lines,
+            position);
+
+    public static CliRowSelectionOccurrence<TOrderOperand> TailLines(
+        int position) =>
+        Modifier(
+            CliRowSelectionOccurrenceKind.TailLines,
+            position);
+
+    private static CliRowSelectionOccurrence<TOrderOperand> WithValue(
+        CliRowSelectionOccurrenceKind kind,
+        int position,
+        string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(
+            kind,
+            position,
+            value,
+            default!);
+    }
+
+    private static CliRowSelectionOccurrence<TOrderOperand> Modifier(
+        CliRowSelectionOccurrenceKind kind,
+        int position) =>
+        new(
+            kind,
+            position,
+            null,
+            default!);
+
+    private InvalidOperationException WrongKind(
+        string property) =>
+        new(
+            $"{property} is not valid for a {Kind} CLI row-selection occurrence.");
+}

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -100,6 +100,7 @@
     <ProjectReference Include="..\DotnetInspector.MetadataRendering\DotnetInspector.MetadataRendering.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\DotnetInspector.Vocabulary\DotnetInspector.Vocabulary.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Sections\DotnetInspector.Sections.csproj" />
     <ProjectReference Include="..\InertText\InertText.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Add the first CLI-owned L3 row-selection lowering slice. It consumes
already-owned explicit-command option occurrences and returns typed L2
row-selection intent, optional rendered-line intent, optional baseline-order
input, or one structured failure.

The slice implements only the smallest contract needed before argv and
System.CommandLine integration:

- positive ASCII-decimal limit and Top values;
- closed, prefix, and suffix Window values;
- argv-ordered Head, Tail, Window, and Top lowering;
- direction and rendered-line modifier composition;
- Top-only order attachment with baseline-order preservation otherwise;
- capabilities evaluated from the lowered semantic or rendered-line unit; and
- deterministic value, conflict, and capability failure precedence.

Current commands and user-visible behavior are unchanged. Raw argv ownership,
bare `-N`, System.CommandLine wiring, routing, diagnostics, command adoption,
and L2 resolution remain later slices.

## Demo

Before this change, L3 had no typed lowering boundary between owned CLI option
occurrences and L2 `RowSelectionIntent`.

After this change, an explicit-command adapter can lower:

```text
Capabilities: Window | Lines
Occurrences:  --rows 3..6, -n 2, --lines

Semantic intent: Window(3, 6)
Rendered-line intent: Head(2)
```

What to notice: `--lines` changes only the unit of `-n`; it does not discard
the neighboring semantic Window and does not require the Head/Tail capability.

The pathological range spelling remains an L3 failure:

```text
Occurrence: --rows ..
Failure: InvalidWindowForm at that occurrence
```

L2 still permits a boundless Window as semantic identity; only this CLI
spelling is rejected.

## In-flight compatibility

Candidate `abbfa669646981de2dad9a709f6f4c9f60c0afb8` has no file overlap with
exact #5465 head `0538f7d397142108ffe654eb2a7685a3e8add05a`, and their merge tree is clean.

The candidate also merges cleanly with exact #5635 head
`a37843eb97bf2500694b99893234039f76d14b2c`. The merged
`src/dotnet-inspect/dotnet-inspect.csproj` contains both
`DotnetInspector.Presentation` and `DotnetInspector.Sections` references.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- --filter-class 'DotnetInspector.Tests.CliRowSelectionLoweringTests'`
  - 5 passed
- `dotnet build dotnet-inspect.slnx -c Release --tl:off --nologo -v:minimal`
  - 0 warnings, 0 errors
- `npx markdownlint-cli docs/design/cli-row-selection.md`
- `git diff --check`

Closes #5644
