### PR TITLE
Use host-valid local source fixtures

### DIFF
--- a/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
@@ -30,15 +30,19 @@ public class LocalFolderSourceTests : IDisposable
         CoreCache.Clear(VersionCacheCategory);
     }
 
-    public static TheoryData<string> LocalFolderUrls() => new()
+    public static TheoryData<string> LocalFolderUrls()
     {
-        @"D:\some\local\packages",
-        "/var/local/packages",
-        "file:///var/packages",
-        @"C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\",
-        // Also unparseable / non-absolute should be skipped, not crash:
-        "local-packages",
-    };
+        string hostPath = Path.GetFullPath("local-packages");
+        return new()
+        {
+            @"D:\some\local\packages",
+            "/var/local/packages",
+            hostPath,
+            new Uri(hostPath).AbsoluteUri,
+            @"C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\",
+            "local-packages",
+        };
+    }
 
     [Theory]
     [MemberData(nameof(LocalFolderUrls))]

--- a/src/DotnetInspector.Services.Tests/PackageCoordinateResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCoordinateResolverTests.cs
@@ -15,6 +15,16 @@ public sealed class PackageCoordinateResolverTests
 {
     static readonly PackageSource NuGetOrg = PackageSource.NuGetOrg;
 
+    public static TheoryData<string> LocalSourceSpellings()
+    {
+        string path = Path.GetFullPath("packages");
+        return new()
+        {
+            path,
+            new Uri(path).AbsoluteUri,
+        };
+    }
+
     [Fact]
     public async Task TypedExactPin_DoesNotEscapeExpiredOperationContext()
     {
@@ -1421,8 +1431,7 @@ public sealed class PackageCoordinateResolverTests
     }
 
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(LocalSourceSpellings))]
     public async Task ListVersions_SkipsNonHttpSource(
         string localSourceUrl)
     {
@@ -1448,8 +1457,7 @@ public sealed class PackageCoordinateResolverTests
     }
 
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(LocalSourceSpellings))]
     public async Task FloatingCoordinate_SkipsNonHttpSource(
         string localSourceUrl)
     {

--- a/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
@@ -18,6 +18,16 @@ public class PackageVersionVectorTests
         "2.0.0",
     ];
 
+    public static TheoryData<string> LocalSourceSpellings()
+    {
+        string path = Path.GetFullPath("packages");
+        return new()
+        {
+            path,
+            new Uri(path).AbsoluteUri,
+        };
+    }
+
     [Fact]
     public void Create_ResolvesAnInclusiveVectorInCallerDirection()
     {
@@ -173,8 +183,7 @@ public class PackageVersionVectorTests
     }
 
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(LocalSourceSpellings))]
     public async Task ResolveAsync_SkipsNonHttpSource(
         string localSource)
     {


### PR DESCRIPTION
Closes #5613 by making local package-source test data follow the current
host's path semantics. The product continues to reject a `file:` URI whose
local path is not fully qualified.

**Owner:** `docs/design/local-package-source-identity.md`, explicit file-URI
admission.
**Claim:** Tests that exercise a valid local path and its `file:` URI spelling
use a pair that is valid on the host running the test.

## Demo

The scheduled Windows platform gate received Unix-only fixture values:

```text
Before
  path:     /tmp/packages
  file URI: file:///tmp/packages
  Windows:  file URI local path has no drive -> rejected as unusable

After
  path:     Path.GetFullPath("packages")
  file URI: new Uri(path).AbsoluteUri
  Windows:  C:\...\packages and file:///C:/.../packages
  Unix:     /.../packages and file:///.../packages
```

What to notice: both forms still name the same lexical local source, but the
runtime now supplies the host root instead of the fixture assuming a Unix
root. The neighboring malformed and relative-source owner gates remain
unchanged.

## Change

- Generate a host-qualified local path and matching absolute `file:` URI in
  `PackageVersionVectorTests` and `PackageCoordinateResolverTests`.
- Add the same host-valid pair to `LocalFolderSourceTests`, preserving its
  existing legacy path spellings.
- Do not change `LocalPackageSourceIdentity`, source admission, or production
  behavior.

This is the simplest sufficient repair: the invalid assumption belongs to
test data, and each affected test class owns its small data set. A shared test
abstraction would add indirection without strengthening the contract.

This exact diff adds no product capability, substrate, host path, or rendering
domain. Consumer/host planning and rendering strategy are therefore not
applicable; the changed surfaces are three existing test classes.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `PackageVersionVectorTests.ResolveAsync_SkipsNonHttpSource`: 2/2
- `PackageCoordinateResolverTests.*SkipsNonHttpSource` and
  `LocalFolderSourceTests.*LocalFolderSource_DoesNotThrowAndReturnsNull`: 22/22
- Complete `DotnetInspector.Services.Tests`: 1,058/1,058
- SDK: `11.0.100-preview.7.26381.103`

A complete local CLI run reached all 5,286 tests but reported 23 unrelated
`CommandExecutionTests` failures after current `main` enabled the
Microsoft.Testing.Platform runner. None involved the changed theory, which
passes its exact MTP filter. Current-head CI and the replacement Windows
platform run are the decisive broader gates for this cross-platform fixture
repair.
