### PR TITLE
Add ordered Workspace package occurrence views

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ stderr rather than mixed into structured output.
 | Performance analysis *(experimental)* | `library -S @Performance`, `type`/`member -S "Performance Triage"`, `"Top Leverage"`, `"Resource Triage"`, `"Call Graph"` | Whole-assembly leverage ranking, actionable rewrite-shape detection, and exception-path resource-lifecycle candidates. |
 | Decompiler *(experimental)* | `member -S @Source`, `member -S "Fidelity Causes"`, `member`/`type`/`library --where "Kind=<ID>"` | Decompiled C#, annotated source, IL, body-shape queries, and typed `DEC####` fidelity causes. |
 | Raw metadata | `library -S @Metadata`, `--heap "#Strings:0x1a4"` | Decoded ECMA-335 metadata tables and heap addressing. |
+| Workspace package occurrences | `workspace --package X --tfm TFM` | Render the exact ordered package occurrences of one runtime Workspace through the same product-owned view used by Inspect Web. Repeat `--package` to compose the Workspace. |
 | Workspace sharing | `workspace-state encode` / `decode` | Convert the canonical browser/CLI base64url workspace packet to or from its bounded JSON shape without acquisition or execution. |
 | Agent-friendly output | global flags | Markdown by default, compact `--table`, normalized `--tsv`, `--jsonl`, `--json`, Mermaid diagrams, section/field projection, `--count`, and row limiting. |
 
@@ -130,6 +131,7 @@ stderr rather than mixed into structured output.
 | `implements X` | Find concrete implementors or subclasses. |
 | `match A B` | Compare two unambiguous `Type.Member` names by identity-agnostic structural equivalence; add `--implementation` for side-by-side decompiled C# and IL. |
 | `vocabulary` | Discover product-owned query vocabularies such as `Accessibility`, `C# Style Choices`, and `C# Body Kinds`. |
+| `workspace` | Render an ordered runtime Workspace package-occurrence view for packages with selected managed assemblies. Repeat `--package ID@VERSION` coordinates and supply `--tfm`; omit packages for a typed empty Workspace. |
 | `workspace-state encode` / `decode` | Convert validated workspace-state JSON and canonical base64url packets; pass `-` for stdin or use `--file`. |
 | `skill` | Print the base LLM skill and route to focused built-in guidance (`skill list`, `skill query`, `skill decompiler`, `skill relationships`, and more). |
 | `demo [id]` | List or run product-home inspection demos backed by real section output. |

--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -2256,17 +2256,39 @@ The currency contract is:
 | Rebinding | No value can reconstruct or rebind it in another Workspace | Only future Workspace membership operations may associate it with retained state |
 | Correspondence | Reference equality proves the same runtime Workspace | Reference equality proves the same issuance; package correspondence additionally uses the exact carried `PackageRootBinding` |
 
-This first slice issues the currencies and enforces their construction
-lifetime. It does not yet claim that an issued occurrence is admitted or
-retained, expose ordered descriptors, define membership transition semantics,
-or implement Navigation adoption. Those remain later slices of #5508, #5583,
-and #5584. The gates are
+`InspectionWorkspace.CreatePackageOccurrenceView` composes an immutable
+ordered view from acquisition-issued package Root bindings. Input order is the
+view order; equal or repeated bindings remain distinct occurrences. An empty
+input produces a typed empty view. Each descriptor exposes package, version,
+and selected framework presentation facts from its exact Root binding and
+carries an opaque action issued for that exact view. Activating the action
+returns the exact `PackageRootOccurrenceBinding` only while the Workspace is
+open and the action belongs to that view. A foreign-view action returns
+`ViewMismatch`; an action whose Workspace has closed returns
+`WorkspaceClosed`.
+
+The action and both runtime identities remain process-local. Browser/Wasm
+lowers an action to an opaque random transport token and resolves that token
+back to the product action before selecting or projecting a package. The CLI
+lowers the same ordered descriptors through Markout. Neither host derives
+activation identity from package text, version, framework, row position, or a
+cache key.
+
+This slice does not define retained membership, add/remove transitions,
+successor selection, persistence, general Navigation snapshots, or
+concurrency semantics. It also does not project non-package Root occurrences
+through this package view. The first CLI acquisition adapter requires a
+package with at least one selected managed assembly; root-only, analyzer-only,
+and tools-only package acquisition is not yet a supported CLI input. Those
+remain consumer-led slices of #5634, #5583, and #5584. The gates are
 `WorkspaceIdentity_IsStableAndExactPerInstance`,
 `PackageOccurrence_IsExactPerIssuanceAndCarriesBinding`,
 `PackageOccurrence_DistinguishesWorkspaceAndBindingGeneration`,
 `NonPackageOccurrence_IsExactAndWorkspaceScoped`,
 `SynchronousClose_StopsOccurrenceIssuanceButKeepsIdentity`, and
-`AsynchronousClose_StopsOccurrenceIssuanceImmediately`.
+`AsynchronousClose_StopsOccurrenceIssuanceImmediately`, plus the
+`PackageOccurrenceView_*` gates for ordering, empty input, repeated bindings,
+exact activation, foreign-view rejection, and closed-Workspace rejection.
 
 ### Workspace composition and query execution
 

--- a/docs/design/inspection-subject-navigation.md
+++ b/docs/design/inspection-subject-navigation.md
@@ -34,11 +34,15 @@ standalone exact-lens activation is implemented by
 `StandaloneLensActivation_RejectsDifferentExactSubjectBeforeRegistryResolution`,
 `ExplicitLensResolution_MapsEveryRegistryOutcomeWithoutFallback`, and
 `ExplicitLensResolution_RetainsExactRegistryEvidence`. Workspace and Package
-identity, descriptor composition, subject activation, snapshot installation,
-reconciliation, revision behavior, retained sessions, synchronization, and
-restoration remain unverified until their implementation gates in
+identity as a Navigation subject, snapshot installation, reconciliation,
+revision behavior, retained sessions, synchronization, and restoration remain
+unverified until their implementation gates in
 [Verification](#verification) land. The workspace-owned identity prerequisite
-is tracked by #5508, Registry adoption by #5509, and portable
+is implemented by `InspectionWorkspaceIdentity`; the first package descriptor
+composition and exact view-scoped activation slice is implemented by
+`InspectionWorkspacePackageOccurrenceView` for the Inspect Web and CLI
+consumers. This slice does not install or mutate Navigation state. Registry
+adoption is tracked by #5509, and portable
 Workspace/Package subject projection by #5525.
 
 The concurrency claims are specified separately as executable TLA+ models under

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -29,7 +29,6 @@ import {
   type WorkbenchShellBindingActions,
   workbenchShellHtml,
 } from "../src/shell-controls.ts";
-import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import { KeybindingRegistry } from "../src/keybinding-registry.ts";
 import {
   bindSettingsPanel,

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -41,10 +41,9 @@ import {
 } from "../src/type-panel.ts";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace,
   renderWorkspaceSubject,
-  retainWorkspacePacket,
+  renderWorkspaceView,
 } from "../src/workspace-subject.ts";
 
 declare global {
@@ -149,97 +148,28 @@ const coordinates = [
     isRuntimePack: false,
   },
 ];
-const packetDefinitions: readonly BrowserHomeDemoResolved[] = [
-  {
-    id: "stj-serializer",
-    title: "System.Text.Json",
-    summary: "Browse a real package API",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonSerializer",
-      memberAnchor: null,
-      memberKey: null,
-      section: "Methods",
-    },
-  },
-  {
-    id: "stj-serialize-callgraph",
-    title: "Serialize call graph",
-    summary: "Dense package-local STJ graph",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonSerializer",
-      memberAnchor: "1dc14dd1fb",
-      memberKey: "method:Serialize",
-      section: "Call Graph",
-    },
-  },
-  {
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-    summary: "STJ number parse path",
-    workspaceMembers: [{
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    }],
-    tabs: [],
-    focusTabIndex: 0,
-    view: {
-      library: null,
-      type: "System.Text.Json.JsonElement",
-      memberAnchor: "cfd9980a6c",
-      memberKey: "method:GetDecimal",
-      section: "Call Graph",
-    },
-  },
-];
-let workspacePackets: BrowserHomeDemoResolved[] = [];
-for (const packet of packetDefinitions)
-  workspacePackets = retainWorkspacePacket(workspacePackets, packet);
-let selectedWorkspacePacketId = workspacePackets[0]?.id ?? "";
-
-function selectedWorkspacePacket(): BrowserHomeDemoResolved | null {
-  return workspacePackets.find(
-    packet => packet.id === selectedWorkspacePacketId) ?? null;
-}
-
 function workspaceNavigationHtml(): string {
   return renderWorkspaceSubject({
-    packets: workspacePackets,
-    selectedPacketId: selectedWorkspacePacketId,
+    packageCount: coordinates.length,
+    selected: true,
     escapeHtml,
   });
 }
 
 function workspaceDetailHtml(): string {
-  return renderWorkspacePacketView({
-    packet: selectedWorkspacePacket(),
-    packages: coordinates.slice(0, 1),
-    activePackage: coordinates[0] ?? null,
+  return renderWorkspaceView({
+    occurrences: coordinates
+      .filter(item => !item.isRuntimePack)
+      .map((item, index) => ({
+        action: `occurrence-${index}`,
+        package: item.id,
+        version: item.version,
+        framework: item.activeFramework,
+      })),
+    packages: coordinates,
+    loading: false,
+    error: "",
     escapeHtml,
-    packageIdentityKey: item =>
-      `${item.id}@${item.version}::${item.activeFramework}`,
   });
 }
 
@@ -675,9 +605,7 @@ function bindHarnessScopeBar() {
   }, scopeBarState);
 }
 
-function renderHarnessWorkspace(packetId: string) {
-  if (!workspacePackets.some(packet => packet.id === packetId)) return;
-  selectedWorkspacePacketId = packetId;
+function renderHarnessWorkspace() {
   const navigation =
     document.querySelector<HTMLElement>(".workspace-nav");
   const detail =
@@ -690,27 +618,25 @@ function renderHarnessWorkspace(packetId: string) {
     throw new Error("The workspace packet harness is incomplete.");
   navigation.outerHTML = workspaceNavigationHtml();
   detail.innerHTML = workspaceDetailHtml();
-  const title = selectedWorkspacePacket()?.title ?? "Current workspace";
+  const title = "Default Workspace";
   path.setAttribute("aria-label", title);
   path.title = title;
   pathSegment.textContent = title;
   bindHarnessWorkspace();
   requestAnimationFrame(() =>
-    focusWorkspacePacket(document, packetId));
+    focusWorkspace(document));
 }
 
 function bindHarnessWorkspace() {
   if (!workspaceMode) return;
   bindWorkspaceSubject(document, {
     onSelect: renderHarnessWorkspace,
-    onOpen: packetId => {
+    onActivate: action => {
       const count = Number(document.body.dataset.workspaceExecutionCount ?? "0");
       document.body.dataset.workspaceExecutionCount = String(count + 1);
-      document.body.dataset.workspaceExecution = packetId;
+      document.body.dataset.workspaceExecution = action;
     },
-    onClose: packageKey => {
-      document.body.dataset.workspaceClose = packageKey;
-    },
+    onRetry: () => {},
   });
 }
 

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -1378,18 +1378,18 @@ test("the title line advertises the typed Package, Type, and Member path", async
   expect(zone.y + zone.height).toBeLessThanOrEqual(workspace.y);
 });
 
-test("Workspace gives retained packets the pane and keeps the menu fixed", async ({
+test("Workspace keeps the Default Workspace visible and menu fixed", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
 
-  const list = await box(page, ".workspace-packet-list");
-  const lastPacket = await box(page, ".workspace-packet:last-child");
+  const list = await box(page, ".workspace-list");
+  const defaultWorkspace = await box(page, ".workspace-card");
   const applicationMenu = await box(page, "#application-menu-button");
 
   expect(list.height).toBeGreaterThan(200);
-  expect(lastPacket.y + lastPacket.height)
+  expect(defaultWorkspace.y + defaultWorkspace.height)
     .toBeLessThanOrEqual(list.y + list.height);
   expect(applicationMenu.width).toBeCloseTo(30, 0);
   await page.locator("#application-menu-button").click();
@@ -1398,47 +1398,30 @@ test("Workspace gives retained packets the pane and keeps the menu fixed", async
   await expect(page.locator("[data-subject-copy]")).toHaveCount(0);
 });
 
-test("Workspace packet selection is observational and Open executes", async ({
+test("Workspace selection is observational and occurrence activation executes", async ({
   page,
 }) => {
   await page.goto("/browser/workspace-titlebar.html?workspace=1");
 
-  const packets = page.locator("[data-workspace-packet]");
-  await expect(packets).toHaveCount(3);
-  expect(await packets.evaluateAll(elements =>
-    elements.map(element => element.getAttribute("data-workspace-packet"))))
-    .toEqual([
-    "stj-serializer",
-    "stj-serialize-callgraph",
-    "stj-getdecimal-callgraph",
-  ]);
+  const workspace = page.locator("[data-workspace-default]");
+  await expect(workspace).toHaveCount(1);
   const href = page.url();
-  const serialize = page.locator(
-    '[data-workspace-packet="stj-serialize-callgraph"]');
-  await serialize.click();
+  await workspace.click();
 
-  await expect(serialize).toBeFocused();
+  await expect(workspace).toBeFocused();
   await expect(page.locator(".workspace-heading h1"))
-    .toHaveText("Serialize call graph");
+    .toHaveText("Default Workspace");
   await expect(page.locator(".subject-path-segment"))
-    .toHaveText("Serialize call graph");
+    .toHaveText("Default Workspace");
   await expect(page.locator("body"))
     .toHaveAttribute("data-workspace-execution-count", "0");
   expect(page.url()).toBe(href);
 
-  const getDecimal = page.locator(
-    '[data-workspace-packet="stj-getdecimal-callgraph"]');
-  await getDecimal.click();
-  await expect(getDecimal).toBeFocused();
-  await expect(page.locator(".workspace-heading h1"))
-    .toHaveText("JsonElement.GetDecimal");
-  expect(page.url()).toBe(href);
-
-  await page.getByRole("button", { name: "Open workspace" }).click();
+  await page.locator('[data-workspace-activate="occurrence-0"]').click();
   await expect(page.locator("body"))
     .toHaveAttribute("data-workspace-execution-count", "1");
   await expect(page.locator("body"))
     .toHaveAttribute(
       "data-workspace-execution",
-      "stj-getdecimal-callgraph");
+      "occurrence-0");
 });

--- a/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserPackageWorkspace.cs
@@ -1259,6 +1259,12 @@ internal static class BrowserPackageWorkspace
     {
         HashSet<string>? _packageKeys = new(StringComparer.Ordinal);
 
+        internal void Lease(BrowserPackageCoordinate coordinate)
+        {
+            ArgumentNullException.ThrowIfNull(coordinate);
+            Lease(PackageKey(coordinate));
+        }
+
         internal void Lease(string packageKey)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(packageKey);
@@ -1609,7 +1615,8 @@ internal sealed class BrowserPackage
             _acquiredPayload
             ?? throw new InvalidOperationException(
                 "Only an acquisition-issued Browser package can create a bound package Root."),
-            targetFramework);
+            targetFramework,
+            displayPackageId: PackageId);
 
     /// <summary>
     /// The package's browsable Markdown: a root <c>README.md</c>/<c>PACKAGE.md</c> and any

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5334,7 +5334,7 @@ public sealed class BrowserEngineBoundaryTests
     }
 
     [Fact]
-    public async Task WorkspaceOccurrences_RevokedInflightQueryReturnsSupersededView()
+    public async Task WorkspaceOccurrences_ReplacedInflightQueryCannotRetireReplacement()
     {
         string packageId = $"Gallery.Workspace.Race.{Guid.NewGuid():N}";
         const string version = "1.2.3";
@@ -5368,23 +5368,93 @@ public sealed class BrowserEngineBoundaryTests
                         version,
                         "net11.0"),
                 ],
-                async _ =>
+                async (_, _) =>
                 {
                     resolutionStarted.SetResult();
                     await continueResolution.Task;
                     return coordinate;
                 });
         await resolutionStarted.Task;
-        BrowserWorkspaceOccurrenceOperations.ClearCurrent();
+        BrowserWorkspacePackageOccurrenceView replacement =
+            BrowserWorkspaceOccurrenceOperations.ReplaceCurrent(
+                [coordinate]);
         continueResolution.SetResult();
 
         BrowserWorkspacePackageOccurrenceView view = await query;
 
         Assert.True(view.Superseded);
-        Assert.Single(view.Occurrences);
-        Assert.Null(
+        Assert.Empty(view.Occurrences);
+        Assert.NotNull(
             BrowserWorkspaceOccurrenceOperations.Activate(
-                view.Occurrences[0].Action));
+                replacement.Occurrences[0].Action));
+    }
+
+    [Fact]
+    public async Task WorkspaceOccurrences_RevocationReleasesLeasesBeforeAStalledResolutionCompletes()
+    {
+        string packageId = $"Gallery.Workspace.LeaseRace.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            Package(
+                [0x01],
+                $"lib/net11.0/{packageId}.dll"));
+        using IPackageSourceClient source = Gallery(handler);
+        BrowserPackageCoordinate coordinate =
+            await BrowserPackageWorkspace.ResolveAsync(
+                packageId,
+                version,
+                "net11.0",
+                source,
+                PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+        var secondResolutionStarted =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueResolution =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        int resolution = 0;
+
+        Task<BrowserWorkspacePackageOccurrenceView> query =
+            BrowserWorkspaceOccurrenceOperations.QueryAsync(
+                [
+                    new BrowserPackageRequest(
+                        packageId,
+                        version,
+                        "net11.0"),
+                    new BrowserPackageRequest(
+                        packageId,
+                        version,
+                        "net11.0"),
+                ],
+                async (_, cancellationToken) =>
+                {
+                    if (Interlocked.Increment(ref resolution) == 1)
+                        return coordinate;
+
+                    secondResolutionStarted.SetResult();
+                    await continueResolution.Task;
+                    return coordinate;
+                });
+        await secondResolutionStarted.Task;
+
+        BrowserWorkspaceOccurrenceOperations.ClearCurrent();
+        using (
+            BrowserPackageWorkspace.ReservePackageDownload(
+                $"workspace.lease.pressure.{Guid.NewGuid():N}@1.0.0",
+                128L * MiB))
+        {
+            Assert.Equal(
+                0,
+                BrowserPackageWorkspace.Stats().Resident);
+        }
+        continueResolution.SetResult();
+
+        BrowserWorkspacePackageOccurrenceView view = await query;
+        Assert.True(view.Superseded);
+        Assert.Empty(view.Occurrences);
     }
 
     [Fact]

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -5258,6 +5258,7 @@ public sealed class BrowserEngineBoundaryTests
         PackageRootBinding binding = Assert.IsType<PackageRootBinding>(
             coordinate.Binding);
         Assert.Same(binding.Root, coordinate.Root);
+        Assert.Equal(packageId, binding.Root.PackageId);
         Assert.Equal(packageId.ToLowerInvariant(), binding.Coordinate.PackageId);
         Assert.Equal(version, binding.Coordinate.Version);
         Assert.Equal("net11.0", binding.Coordinate.Framework);
@@ -5266,6 +5267,124 @@ public sealed class BrowserEngineBoundaryTests
             NuGetCache.GetSourceKey(PackageSourceIdentity.NuGetOrg.Value),
             binding.Coordinate.Producer);
         Assert.True(binding.Root.ReferencesContent(coordinate.Package.Content));
+    }
+
+    [Fact]
+    public async Task WorkspaceOccurrences_PreserveOrderAndSupersedeOldActions()
+    {
+        string packageId = $"Gallery.Workspace.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        byte[] archive = Package(
+            [0x01],
+            $"lib/net11.0/{packageId}.dll");
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            archive);
+        using IPackageSourceClient source = Gallery(handler);
+        BrowserPackageCoordinate coordinate =
+            await BrowserPackageWorkspace.ResolveAsync(
+                packageId,
+                version,
+                "net11.0",
+                source,
+                PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+
+        BrowserWorkspacePackageOccurrenceView view =
+            BrowserWorkspaceOccurrenceOperations.ReplaceCurrent(
+                [coordinate, coordinate]);
+
+        Assert.Equal(2, view.Occurrences.Length);
+        Assert.All(
+            view.Occurrences,
+            occurrence =>
+            {
+                Assert.Equal(packageId, occurrence.Package);
+                Assert.Equal(version, occurrence.Version);
+                Assert.Equal("net11.0", occurrence.Framework);
+                Assert.DoesNotContain(
+                    packageId,
+                    occurrence.Action,
+                    StringComparison.OrdinalIgnoreCase);
+            });
+        Assert.NotEqual(
+            view.Occurrences[0].Action,
+            view.Occurrences[1].Action);
+        BrowserWorkspaceOccurrenceSelection selection = Assert.IsType<
+            BrowserWorkspaceOccurrenceSelection>(
+                BrowserWorkspaceOccurrenceOperations.Activate(
+                    view.Occurrences[1].Action));
+        Assert.Same(coordinate, selection.Coordinate);
+
+        BrowserWorkspaceOccurrenceOperations.ReplaceCurrent([]);
+
+        Assert.Null(
+            BrowserWorkspaceOccurrenceOperations.Activate(
+                view.Occurrences[0].Action));
+
+        BrowserWorkspacePackageOccurrenceView replacement =
+            BrowserWorkspaceOccurrenceOperations.ReplaceCurrent(
+                [coordinate]);
+        BrowserWorkspaceOccurrenceOperations.ClearCurrent();
+
+        Assert.Null(
+            BrowserWorkspaceOccurrenceOperations.Activate(
+                replacement.Occurrences[0].Action));
+    }
+
+    [Fact]
+    public async Task WorkspaceOccurrences_RevokedInflightQueryReturnsSupersededView()
+    {
+        string packageId = $"Gallery.Workspace.Race.{Guid.NewGuid():N}";
+        const string version = "1.2.3";
+        var handler = new GalleryPackageHandler(
+            packageId,
+            version,
+            Package(
+                [0x01],
+                $"lib/net11.0/{packageId}.dll"));
+        using IPackageSourceClient source = Gallery(handler);
+        BrowserPackageCoordinate coordinate =
+            await BrowserPackageWorkspace.ResolveAsync(
+                packageId,
+                version,
+                "net11.0",
+                source,
+                PackageSourceIdentity.NuGetOrg,
+                TimeSpan.FromSeconds(5));
+        var resolutionStarted =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueResolution =
+            new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<BrowserWorkspacePackageOccurrenceView> query =
+            BrowserWorkspaceOccurrenceOperations.QueryAsync(
+                [
+                    new BrowserPackageRequest(
+                        packageId,
+                        version,
+                        "net11.0"),
+                ],
+                async _ =>
+                {
+                    resolutionStarted.SetResult();
+                    await continueResolution.Task;
+                    return coordinate;
+                });
+        await resolutionStarted.Task;
+        BrowserWorkspaceOccurrenceOperations.ClearCurrent();
+        continueResolution.SetResult();
+
+        BrowserWorkspacePackageOccurrenceView view = await query;
+
+        Assert.True(view.Superseded);
+        Assert.Single(view.Occurrences);
+        Assert.Null(
+            BrowserWorkspaceOccurrenceOperations.Activate(
+                view.Occurrences[0].Action));
     }
 
     [Fact]

--- a/prototypes/inspect-web/engine/BrowserContracts.cs
+++ b/prototypes/inspect-web/engine/BrowserContracts.cs
@@ -1052,6 +1052,21 @@ public sealed record BrowserWorkspacePackage(
     string Version,
     string Framework);
 
+public sealed record BrowserWorkspacePackageOccurrence(
+    string Action,
+    string Package,
+    string Version,
+    string Framework);
+
+public sealed record BrowserWorkspacePackageOccurrenceView(
+    BrowserWorkspacePackageOccurrence[] Occurrences,
+    bool Superseded);
+
+public sealed record BrowserWorkspacePackageOccurrenceActivation(
+    bool Activated,
+    bool Superseded,
+    BrowserPackageSurface? Package);
+
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(BrowserPackageSurface))]
 [JsonSerializable(typeof(BrowserMemberSurface))]
@@ -1077,6 +1092,8 @@ public sealed record BrowserWorkspacePackage(
 [JsonSerializable(typeof(BrowserSource))]
 [JsonSerializable(typeof(BrowserCallGraph))]
 [JsonSerializable(typeof(BrowserWorkspacePackage[]))]
+[JsonSerializable(typeof(BrowserWorkspacePackageOccurrenceView))]
+[JsonSerializable(typeof(BrowserWorkspacePackageOccurrenceActivation))]
 [JsonSerializable(typeof(BrowserTypeCandidate[]))]
 [JsonSerializable(typeof(BrowserTypeSearchHit[]))]
 [JsonSerializable(typeof(string[]))]

--- a/prototypes/inspect-web/engine/BrowserWorkspaceOccurrenceOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserWorkspaceOccurrenceOperations.cs
@@ -21,45 +21,56 @@ internal sealed record BrowserWorkspaceOccurrenceSelection(
 internal static class BrowserWorkspaceOccurrenceOperations
 {
     static BrowserWorkspaceOccurrenceSession? _current;
+    static InFlightQuery? _inFlight;
     static long _generation;
 
     internal static async Task<BrowserWorkspacePackageOccurrenceView>
         QueryAsync(IReadOnlyList<BrowserPackageRequest> requests)
         => await QueryAsync(
             requests,
-            static request => BrowserPackageWorkspace.ResolveAsync(
+            static (request, cancellationToken) =>
+                BrowserPackageWorkspace.ResolveAsync(
                 request.PackageId,
                 request.Version,
-                request.TargetFramework));
+                request.TargetFramework,
+                cancellationToken));
 
     internal static async Task<BrowserWorkspacePackageOccurrenceView>
         QueryAsync(
             IReadOnlyList<BrowserPackageRequest> requests,
-            Func<BrowserPackageRequest, Task<BrowserPackageCoordinate>>
-                resolveAsync)
+            Func<
+                BrowserPackageRequest,
+                CancellationToken,
+                Task<BrowserPackageCoordinate>> resolveAsync)
     {
         ArgumentNullException.ThrowIfNull(requests);
         ArgumentNullException.ThrowIfNull(resolveAsync);
-        long generation = BeginReplacement();
+        InFlightQuery query = BeginQuery();
         var coordinates =
             new List<BrowserPackageCoordinate>(requests.Count);
-        var leases = new BrowserPackageWorkspace.PackageLeaseSet();
         try
         {
             foreach (BrowserPackageRequest request in requests)
             {
                 BrowserPackageCoordinate coordinate =
-                    await resolveAsync(request);
-                leases.Lease(coordinate);
+                    await resolveAsync(request, query.CancellationToken);
+                query.Lease(coordinate);
                 coordinates.Add(coordinate);
             }
 
-            return ReplaceCurrent(coordinates, leases, generation);
+            return ReplaceCurrent(
+                coordinates,
+                query.TakeLeases(),
+                query.Generation);
         }
-        catch
+        catch (OperationCanceledException)
+            when (query.CancellationToken.IsCancellationRequested)
         {
-            leases.Dispose();
-            throw;
+            return SupersededView();
+        }
+        finally
+        {
+            EndQuery(query);
         }
     }
 
@@ -100,13 +111,39 @@ internal static class BrowserWorkspaceOccurrenceOperations
     static long BeginReplacement()
     {
         long generation = ++_generation;
+        CancelInFlight();
         ClearCurrentCore();
         return generation;
+    }
+
+    static InFlightQuery BeginQuery()
+    {
+        long generation = ++_generation;
+        CancelInFlight();
+        ClearCurrentCore();
+        var query = new InFlightQuery(generation);
+        _inFlight = query;
+        return query;
+    }
+
+    static void EndQuery(InFlightQuery query)
+    {
+        if (ReferenceEquals(_inFlight, query))
+            _inFlight = null;
+        query.Dispose();
+    }
+
+    static void CancelInFlight()
+    {
+        InFlightQuery? query = _inFlight;
+        _inFlight = null;
+        query?.Cancel();
     }
 
     internal static void ClearCurrent()
     {
         _generation++;
+        CancelInFlight();
         ClearCurrentCore();
     }
 
@@ -117,11 +154,83 @@ internal static class BrowserWorkspaceOccurrenceOperations
         previous?.Dispose();
     }
 
+    static BrowserWorkspacePackageOccurrenceView SupersededView() =>
+        new([], Superseded: true);
+
     internal static BrowserWorkspaceOccurrenceSelection? Activate(
         string action)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(action);
         return _current?.Activate(action);
+    }
+
+    sealed class InFlightQuery : IDisposable
+    {
+        readonly object _gate = new();
+        readonly CancellationTokenSource _cancellation = new();
+        BrowserPackageWorkspace.PackageLeaseSet? _leases = new();
+        bool _disposed;
+
+        internal InFlightQuery(long generation)
+        {
+            Generation = generation;
+        }
+
+        internal long Generation { get; }
+
+        internal CancellationToken CancellationToken =>
+            _cancellation.Token;
+
+        internal void Lease(BrowserPackageCoordinate coordinate)
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                CancellationToken.ThrowIfCancellationRequested();
+                _leases!.Lease(coordinate);
+            }
+        }
+
+        internal BrowserPackageWorkspace.PackageLeaseSet TakeLeases()
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+            lock (_gate)
+            {
+                CancellationToken.ThrowIfCancellationRequested();
+                BrowserPackageWorkspace.PackageLeaseSet leases = _leases
+                    ?? throw new InvalidOperationException(
+                        "The in-flight Workspace occurrence leases were already transferred.");
+                _leases = null;
+                return leases;
+            }
+        }
+
+        internal void Cancel()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+                BrowserPackageWorkspace.PackageLeaseSet? leases = _leases;
+                _leases = null;
+                leases?.Dispose();
+                _cancellation.Cancel();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                BrowserPackageWorkspace.PackageLeaseSet? leases = _leases;
+                _leases = null;
+                leases?.Dispose();
+                _cancellation.Dispose();
+            }
+        }
     }
 
     sealed class BrowserWorkspaceOccurrenceSession : IDisposable

--- a/prototypes/inspect-web/engine/BrowserWorkspaceOccurrenceOperations.cs
+++ b/prototypes/inspect-web/engine/BrowserWorkspaceOccurrenceOperations.cs
@@ -1,0 +1,339 @@
+using System.Collections.Immutable;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using System.Runtime.InteropServices.JavaScript;
+using DotnetInspector.Queries;
+
+namespace InspectWeb.Engine
+{
+
+internal sealed record BrowserWorkspaceOccurrenceSnapshot(
+    BrowserWorkspacePackageOccurrenceView View,
+    ImmutableDictionary<
+        string,
+        BrowserWorkspaceOccurrenceSelection> Selections);
+
+internal sealed record BrowserWorkspaceOccurrenceSelection(
+    InspectionWorkspacePackageOccurrenceAction Action,
+    BrowserPackageCoordinate Coordinate);
+
+[SupportedOSPlatform("browser")]
+internal static class BrowserWorkspaceOccurrenceOperations
+{
+    static BrowserWorkspaceOccurrenceSession? _current;
+    static long _generation;
+
+    internal static async Task<BrowserWorkspacePackageOccurrenceView>
+        QueryAsync(IReadOnlyList<BrowserPackageRequest> requests)
+        => await QueryAsync(
+            requests,
+            static request => BrowserPackageWorkspace.ResolveAsync(
+                request.PackageId,
+                request.Version,
+                request.TargetFramework));
+
+    internal static async Task<BrowserWorkspacePackageOccurrenceView>
+        QueryAsync(
+            IReadOnlyList<BrowserPackageRequest> requests,
+            Func<BrowserPackageRequest, Task<BrowserPackageCoordinate>>
+                resolveAsync)
+    {
+        ArgumentNullException.ThrowIfNull(requests);
+        ArgumentNullException.ThrowIfNull(resolveAsync);
+        long generation = BeginReplacement();
+        var coordinates =
+            new List<BrowserPackageCoordinate>(requests.Count);
+        var leases = new BrowserPackageWorkspace.PackageLeaseSet();
+        try
+        {
+            foreach (BrowserPackageRequest request in requests)
+            {
+                BrowserPackageCoordinate coordinate =
+                    await resolveAsync(request);
+                leases.Lease(coordinate);
+                coordinates.Add(coordinate);
+            }
+
+            return ReplaceCurrent(coordinates, leases, generation);
+        }
+        catch
+        {
+            leases.Dispose();
+            throw;
+        }
+    }
+
+    internal static BrowserWorkspacePackageOccurrenceView ReplaceCurrent(
+        IReadOnlyList<BrowserPackageCoordinate> coordinates)
+    {
+        long generation = BeginReplacement();
+        return ReplaceCurrent(
+            coordinates,
+            new BrowserPackageWorkspace.PackageLeaseSet(),
+            generation);
+    }
+
+    static BrowserWorkspacePackageOccurrenceView ReplaceCurrent(
+        IReadOnlyList<BrowserPackageCoordinate> coordinates,
+        BrowserPackageWorkspace.PackageLeaseSet leases,
+        long generation)
+    {
+        ArgumentNullException.ThrowIfNull(coordinates);
+        ArgumentNullException.ThrowIfNull(leases);
+
+        BrowserWorkspaceOccurrenceSession replacement =
+            BrowserWorkspaceOccurrenceSession.Create(
+                coordinates,
+                leases);
+        if (generation != _generation)
+        {
+            replacement.Dispose();
+            return replacement.View with { Superseded = true };
+        }
+
+        BrowserWorkspaceOccurrenceSession? previous = _current;
+        _current = replacement;
+        previous?.Dispose();
+        return replacement.View;
+    }
+
+    static long BeginReplacement()
+    {
+        long generation = ++_generation;
+        ClearCurrentCore();
+        return generation;
+    }
+
+    internal static void ClearCurrent()
+    {
+        _generation++;
+        ClearCurrentCore();
+    }
+
+    static void ClearCurrentCore()
+    {
+        BrowserWorkspaceOccurrenceSession? previous = _current;
+        _current = null;
+        previous?.Dispose();
+    }
+
+    internal static BrowserWorkspaceOccurrenceSelection? Activate(
+        string action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(action);
+        return _current?.Activate(action);
+    }
+
+    sealed class BrowserWorkspaceOccurrenceSession : IDisposable
+    {
+        readonly InspectionWorkspace _workspace;
+        readonly BrowserPackageWorkspace.PackageLeaseSet _leases;
+        readonly InspectionWorkspacePackageOccurrenceView _productView;
+        readonly ImmutableDictionary<
+            string,
+            BrowserWorkspaceOccurrenceSelection> _selections;
+
+        BrowserWorkspaceOccurrenceSession(
+            InspectionWorkspace workspace,
+            BrowserPackageWorkspace.PackageLeaseSet leases,
+            InspectionWorkspacePackageOccurrenceView productView,
+            BrowserWorkspaceOccurrenceSnapshot snapshot)
+        {
+            _workspace = workspace;
+            _leases = leases;
+            _productView = productView;
+            View = snapshot.View;
+            _selections = snapshot.Selections;
+        }
+
+        internal BrowserWorkspacePackageOccurrenceView View { get; }
+
+        internal static BrowserWorkspaceOccurrenceSession Create(
+            IReadOnlyList<BrowserPackageCoordinate> coordinates,
+            BrowserPackageWorkspace.PackageLeaseSet leases)
+        {
+            var workspace = new InspectionWorkspace();
+            try
+            {
+                PackageRootBinding[] bindings =
+                [
+                    .. coordinates.Select(coordinate =>
+                        coordinate.Binding
+                        ?? throw new InvalidOperationException(
+                            "A browser Workspace occurrence requires an acquisition-issued package Root binding.")),
+                ];
+                InspectionWorkspacePackageOccurrenceView productView =
+                    workspace.CreatePackageOccurrenceView(bindings);
+                BrowserWorkspaceOccurrenceSnapshot snapshot =
+                    Project(productView, coordinates);
+                return new BrowserWorkspaceOccurrenceSession(
+                    workspace,
+                    leases,
+                    productView,
+                    snapshot);
+            }
+            catch
+            {
+                workspace.Dispose();
+                leases.Dispose();
+                throw;
+            }
+        }
+
+        internal BrowserWorkspaceOccurrenceSelection? Activate(
+            string action)
+        {
+            if (!_selections.TryGetValue(
+                    action,
+                    out BrowserWorkspaceOccurrenceSelection? selection))
+            {
+                return null;
+            }
+
+            if (_productView.Activate(selection.Action)
+                is not InspectionWorkspacePackageOccurrenceActivation.Activated
+                activated)
+            {
+                return null;
+            }
+            if (!ReferenceEquals(
+                    activated.Occurrence.RootBinding,
+                    selection.Coordinate.Binding))
+            {
+                throw new InvalidOperationException(
+                    "The activated product occurrence does not match its browser coordinate.");
+            }
+
+            return selection;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _workspace.Dispose();
+            }
+            finally
+            {
+                _leases.Dispose();
+            }
+        }
+
+        static BrowserWorkspaceOccurrenceSnapshot Project(
+            InspectionWorkspacePackageOccurrenceView view,
+            IReadOnlyList<BrowserPackageCoordinate> coordinates)
+        {
+            var rows =
+                ImmutableArray.CreateBuilder<
+                    BrowserWorkspacePackageOccurrence>(
+                        view.Occurrences.Length);
+            var selections =
+                ImmutableDictionary.CreateBuilder<
+                    string,
+                    BrowserWorkspaceOccurrenceSelection>(
+                        StringComparer.Ordinal);
+            for (int index = 0; index < view.Occurrences.Length; index++)
+            {
+                InspectionWorkspacePackageOccurrenceDescriptor descriptor =
+                    view.Occurrences[index];
+                BrowserPackageCoordinate coordinate = coordinates[index];
+                if (!ReferenceEquals(
+                        coordinate.Binding,
+                        descriptor.Occurrence.RootBinding))
+                {
+                    throw new InvalidOperationException(
+                        "The product occurrence order did not preserve its package Root inputs.");
+                }
+                string action = Guid.NewGuid().ToString("N");
+                rows.Add(
+                    new BrowserWorkspacePackageOccurrence(
+                        action,
+                        descriptor.PackageId,
+                        descriptor.Version,
+                        descriptor.Framework ?? ""));
+                selections.Add(
+                    action,
+                    new BrowserWorkspaceOccurrenceSelection(
+                        descriptor.Action,
+                        coordinate));
+            }
+
+            return new BrowserWorkspaceOccurrenceSnapshot(
+                new BrowserWorkspacePackageOccurrenceView(
+                    rows.ToArray(),
+                    Superseded: false),
+                selections.ToImmutable());
+        }
+    }
+}
+
+}
+
+[SupportedOSPlatform("browser")]
+public static partial class InspectionEngine
+{
+    [JSExport]
+    public static void ClearWorkspacePackageOccurrences() =>
+        InspectWeb.Engine.BrowserWorkspaceOccurrenceOperations.ClearCurrent();
+
+    [JSExport]
+    public static async Task<string> QueryWorkspacePackageOccurrences(
+        string workspaceJson)
+    {
+        InspectWeb.Engine.BrowserWorkspacePackage[] workspace =
+            JsonSerializer.Deserialize(
+                workspaceJson,
+                InspectWeb.Engine.BrowserJsonContext.Default
+                    .BrowserWorkspacePackageArray)
+            ?? [];
+        InspectWeb.Engine.BrowserPackageRequest[] requests =
+        [
+            .. workspace.Select(entry =>
+                new InspectWeb.Engine.BrowserPackageRequest(
+                entry.Package,
+                entry.Version,
+                string.IsNullOrWhiteSpace(entry.Framework)
+                    ? null
+                    : entry.Framework)),
+        ];
+        InspectWeb.Engine.BrowserWorkspacePackageOccurrenceView view =
+            await InspectWeb.Engine.BrowserWorkspaceOccurrenceOperations
+                .QueryAsync(requests);
+        return JsonSerializer.Serialize(
+            view,
+            InspectWeb.Engine.BrowserJsonContext.Default
+                .BrowserWorkspacePackageOccurrenceView);
+    }
+
+    [JSExport]
+    public static string ActivateWorkspacePackageOccurrence(string action)
+    {
+        InspectWeb.Engine.BrowserWorkspaceOccurrenceSelection? selection =
+            InspectWeb.Engine.BrowserWorkspaceOccurrenceOperations
+                .Activate(action);
+        if (selection is null)
+        {
+            return JsonSerializer.Serialize(
+                new InspectWeb.Engine
+                    .BrowserWorkspacePackageOccurrenceActivation(
+                    Activated: false,
+                    Superseded: true,
+                    Package: null),
+                InspectWeb.Engine.BrowserJsonContext.Default
+                    .BrowserWorkspacePackageOccurrenceActivation);
+        }
+
+        InspectWeb.Engine.BrowserInspectionScope scope =
+            InspectWeb.Engine.BrowserPackageWorkspace.OpenScope(
+                [selection.Coordinate]);
+        InspectWeb.Engine.BrowserPackageSurface package =
+            ProjectPackageSurface(scope, scope.Coordinate(selection.Coordinate));
+        return JsonSerializer.Serialize(
+            new InspectWeb.Engine.BrowserWorkspacePackageOccurrenceActivation(
+                Activated: true,
+                Superseded: false,
+                package),
+            InspectWeb.Engine.BrowserJsonContext.Default
+                .BrowserWorkspacePackageOccurrenceActivation);
+    }
+}

--- a/prototypes/inspect-web/engine/inspect-web-engine.ts
+++ b/prototypes/inspect-web/engine/inspect-web-engine.ts
@@ -776,6 +776,30 @@ export interface BrowserVocabularySection {
   readonly values: ReadonlyArray<unknown>;
 }
 
+export interface BrowserWorkspacePackage {
+  readonly package: string;
+  readonly version: string;
+  readonly framework: string;
+}
+
+export interface BrowserWorkspacePackageOccurrence {
+  readonly action: string;
+  readonly package: string;
+  readonly version: string;
+  readonly framework: string;
+}
+
+export interface BrowserWorkspacePackageOccurrenceActivation {
+  readonly activated: boolean;
+  readonly superseded: boolean;
+  readonly package: BrowserPackageSurface | null;
+}
+
+export interface BrowserWorkspacePackageOccurrenceView {
+  readonly occurrences: ReadonlyArray<BrowserWorkspacePackageOccurrence>;
+  readonly superseded: boolean;
+}
+
 export interface BrowserWorkspaceShareContext {
   readonly id: string;
   readonly tabIds: ReadonlyArray<string>;
@@ -827,10 +851,12 @@ export interface BrowserWorkspaceShareView {
 
 type $ManagedExports = {
   readonly "InspectionEngine": {
+    readonly "ActivateWorkspacePackageOccurrence.304094707": (action: string) => string;
     readonly "AsyncLoweringCanary.1684317047": () => Promise<string>;
     readonly "BuildIdentity.1310674786": () => string;
     readonly "CancelPackageQuery.19325221": () => void;
     readonly "CancelSourceQuery.19325221": () => void;
+    readonly "ClearWorkspacePackageOccurrences.19325221": () => void;
     readonly "ConfigureHost.92020726": (origin: string) => void;
     readonly "DecodeWorkspaceShareState.304094707": (encoded: string) => string;
     readonly "EncodeWorkspaceShareState.304094707": (stateJson: string) => string;
@@ -867,6 +893,7 @@ type $ManagedExports = {
     readonly "QueryTypeMemberSource.641907440": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
     readonly "QueryTypeProjection.1330709314": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeId: string) => Promise<string>;
     readonly "QueryTypeSource.649160465": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string) => Promise<string>;
+    readonly "QueryWorkspacePackageOccurrences.976702342": (workspaceJson: string) => Promise<string>;
     readonly "ResolveHomeDemo.304094707": (scenarioId: string) => string;
     readonly "ResolvePackageDependencyVersion.451505237": (packageId: string, declaredRange: string | null) => Promise<string>;
     readonly "RunHomeDemo.976702342": (scenarioId: string) => Promise<string>;
@@ -912,6 +939,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "InspectionEngine");
+    value = $ownDataProperty(value, "ActivateWorkspacePackageOccurrence.304094707");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027InspectionEngine.ActivateWorkspacePackageOccurrence.304094707\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "InspectionEngine");
     value = $ownDataProperty(value, "AsyncLoweringCanary.1684317047");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027InspectionEngine.AsyncLoweringCanary.1684317047\u0027 is not callable.");
@@ -939,6 +974,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
     value = $ownDataProperty(value, "CancelSourceQuery.19325221");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027InspectionEngine.CancelSourceQuery.19325221\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "InspectionEngine");
+    value = $ownDataProperty(value, "ClearWorkspacePackageOccurrences.19325221");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027InspectionEngine.ClearWorkspacePackageOccurrences.19325221\u0027 is not callable.");
     }
   }
   {
@@ -1232,6 +1275,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "InspectionEngine");
+    value = $ownDataProperty(value, "QueryWorkspacePackageOccurrences.976702342");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027InspectionEngine.QueryWorkspacePackageOccurrences.976702342\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "InspectionEngine");
     value = $ownDataProperty(value, "ResolveHomeDemo.304094707");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027InspectionEngine.ResolveHomeDemo.304094707\u0027 is not callable.");
@@ -1298,6 +1349,12 @@ export function runEntryPoint(
   return $requireRuntime().runMain(mainAssemblyName, args);
 }
 
+export function activateWorkspacePackageOccurrence(action: string): BrowserWorkspacePackageOccurrenceActivation {
+  const $result = $requireManagedExports()["InspectionEngine"]["ActivateWorkspacePackageOccurrence.304094707"](action);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserWorkspacePackageOccurrenceActivation;
+}
+
 export async function asyncLoweringCanary(): Promise<string> {
   return await $requireManagedExports()["InspectionEngine"]["AsyncLoweringCanary.1684317047"]();
 }
@@ -1314,6 +1371,10 @@ export function cancelPackageQuery(): void {
 
 export function cancelSourceQuery(): void {
   return $requireManagedExports()["InspectionEngine"]["CancelSourceQuery.19325221"]();
+}
+
+export function clearWorkspacePackageOccurrences(): void {
+  return $requireManagedExports()["InspectionEngine"]["ClearWorkspacePackageOccurrences.19325221"]();
 }
 
 export function configureHost(origin: string): void {
@@ -1522,6 +1583,12 @@ export async function queryTypeSource(packageId: string, version: string, target
   const $result = await $requireManagedExports()["InspectionEngine"]["QueryTypeSource.649160465"](packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
   const $parsed: unknown = JSON.parse($result);
   return $parsed as BrowserSource;
+}
+
+export async function queryWorkspacePackageOccurrences(workspaceJson: string): Promise<BrowserWorkspacePackageOccurrenceView> {
+  const $result = await $requireManagedExports()["InspectionEngine"]["QueryWorkspacePackageOccurrences.976702342"](workspaceJson);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserWorkspacePackageOccurrenceView;
 }
 
 export function resolveHomeDemo(scenarioId: string): BrowserHomeDemoResolveResult {

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-engine.js
@@ -39,6 +39,14 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "InspectionEngine");
+        value = $ownDataProperty(value, "ActivateWorkspacePackageOccurrence.304094707");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027InspectionEngine.ActivateWorkspacePackageOccurrence.304094707\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "InspectionEngine");
         value = $ownDataProperty(value, "AsyncLoweringCanary.1684317047");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027InspectionEngine.AsyncLoweringCanary.1684317047\u0027 is not callable.");
@@ -66,6 +74,14 @@ function $validateManagedExports(exports) {
         value = $ownDataProperty(value, "CancelSourceQuery.19325221");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027InspectionEngine.CancelSourceQuery.19325221\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "InspectionEngine");
+        value = $ownDataProperty(value, "ClearWorkspacePackageOccurrences.19325221");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027InspectionEngine.ClearWorkspacePackageOccurrences.19325221\u0027 is not callable.");
         }
     }
     {
@@ -359,6 +375,14 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "InspectionEngine");
+        value = $ownDataProperty(value, "QueryWorkspacePackageOccurrences.976702342");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027InspectionEngine.QueryWorkspacePackageOccurrences.976702342\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "InspectionEngine");
         value = $ownDataProperty(value, "ResolveHomeDemo.304094707");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027InspectionEngine.ResolveHomeDemo.304094707\u0027 is not callable.");
@@ -418,6 +442,11 @@ export function initializeRuntime() {
 export function runEntryPoint(mainAssemblyName, args) {
     return $requireRuntime().runMain(mainAssemblyName, args);
 }
+export function activateWorkspacePackageOccurrence(action) {
+    const $result = $requireManagedExports()["InspectionEngine"]["ActivateWorkspacePackageOccurrence.304094707"](action);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
 export async function asyncLoweringCanary() {
     return await $requireManagedExports()["InspectionEngine"]["AsyncLoweringCanary.1684317047"]();
 }
@@ -431,6 +460,9 @@ export function cancelPackageQuery() {
 }
 export function cancelSourceQuery() {
     return $requireManagedExports()["InspectionEngine"]["CancelSourceQuery.19325221"]();
+}
+export function clearWorkspacePackageOccurrences() {
+    return $requireManagedExports()["InspectionEngine"]["ClearWorkspacePackageOccurrences.19325221"]();
 }
 export function configureHost(origin) {
     return $requireManagedExports()["InspectionEngine"]["ConfigureHost.92020726"](origin);
@@ -601,6 +633,11 @@ export async function queryTypeProjection(packageId, version, targetFramework, a
 }
 export async function queryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
     const $result = await $requireManagedExports()["InspectionEngine"]["QueryTypeSource.649160465"](packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
+export async function queryWorkspacePackageOccurrences(workspaceJson) {
+    const $result = await $requireManagedExports()["InspectionEngine"]["QueryWorkspacePackageOccurrences.976702342"](workspaceJson);
     const $parsed = JSON.parse($result);
     return $parsed;
 }

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -165,7 +165,6 @@ import {
   productHomeDemoLocationHref,
   setProductHomeDemoCatalog,
   type ProductHomeDemoId,
-  type ProductHomeDemoResolved,
 } from "./product-home-demos.ts";
 import {
   createSourceInspectionCoordinator,

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -36,7 +36,6 @@ import {
   partitionGraphMembers,
   platformPackForGraphAssembly,
   platformPackFromProvenance,
-  removeWorkspacePackage,
   removeAppendedNotice,
   retainGraphMemberProjection,
   retainWorkspacePackage,
@@ -246,10 +245,9 @@ import {
 } from "./scope-bar.ts";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace,
   renderWorkspaceSubject,
-  retainWorkspacePacket as retainWorkspacePacketInList,
+  renderWorkspaceView as renderWorkspaceViewPure,
 } from "./workspace-subject.ts";
 import {
   bindDocViewer,
@@ -387,6 +385,8 @@ import type {
   BrowserTypeMetadata,
   BrowserTypeSurface,
   BrowserWorkspaceShareState,
+  BrowserWorkspacePackageOccurrenceActivation,
+  BrowserWorkspacePackageOccurrenceView,
 } from "./inspect-web-engine.d.ts";
 
 type EngineModule = typeof import("./inspect-web-engine.d.ts");
@@ -421,6 +421,12 @@ let inspectPackageMetadataTable: EngineModule["queryPackageMetadataTable"];
 let inspectPackageOpportunities: EngineModule["queryPackageOpportunities"];
 let inspectPackagePerformance: EngineModule["queryPackagePerformance"];
 let inspectPackageVersions: EngineModule["queryPackageVersions"];
+let inspectQueryWorkspacePackageOccurrences:
+  EngineModule["queryWorkspacePackageOccurrences"];
+let inspectActivateWorkspacePackageOccurrence:
+  EngineModule["activateWorkspacePackageOccurrence"];
+let inspectClearWorkspacePackageOccurrences:
+  EngineModule["clearWorkspacePackageOccurrences"];
 let inspectPlatformHeapEntries: EngineModule["queryPlatformHeapEntries"];
 let inspectPlatformIntegrations: EngineModule["queryPlatformIntegrations"];
 let inspectPlatformMetadata: EngineModule["queryPlatformMetadata"];
@@ -475,6 +481,12 @@ async function loadEngineModule() {
     queryPackageOpportunities: inspectPackageOpportunities,
     queryPackagePerformance: inspectPackagePerformance,
     queryPackageVersions: inspectPackageVersions,
+    queryWorkspacePackageOccurrences:
+      inspectQueryWorkspacePackageOccurrences,
+    activateWorkspacePackageOccurrence:
+      inspectActivateWorkspacePackageOccurrence,
+    clearWorkspacePackageOccurrences:
+      inspectClearWorkspacePackageOccurrences,
     queryPlatformHeapEntries: inspectPlatformHeapEntries,
     queryPlatformIntegrations: inspectPlatformIntegrations,
     queryPlatformMetadata: inspectPlatformMetadata,
@@ -749,8 +761,10 @@ const initialState = {
   memberDocumentationKey: "",
   lens: "api" as const,
   packageLens: "overview" as const,
-  workspacePackets: [],
-  selectedWorkspacePacketId: "",
+  workspaceOccurrences: null,
+  workspaceOccurrenceSignature: "",
+  workspaceOccurrenceLoading: false,
+  workspaceOccurrenceError: "",
   workspaceSubjectOpen: false,
   atPackageRoot: false,
   typeFilter: "",
@@ -815,7 +829,7 @@ const initialState = {
 interface StateOverrides {
   packages: AppPackage[];
   package: AppPackage | null;
-  workspacePackets: ProductHomeDemoResolved[];
+  workspaceOccurrences: BrowserWorkspacePackageOccurrenceView | null;
   workspaceShareBasis: BrowserWorkspaceShareState | null;
   platformIndex: PlatformIndex | null;
   queryNoticeRetryAction: RetryAction;
@@ -1934,29 +1948,94 @@ function selectWorkspacePackage(
   render();
 }
 
-function closeWorkspacePackage(packageKey: string) {
-  const removal = removeWorkspacePackage(state.packages, state.package, packageKey);
-  if (!removal.closed) return;
-  const activeChanged =
-    !packageIdentityEquals(removal.active, state.package);
-  if (!removal.active && !clearWorkspaceRouteFailure()) {
-    render();
-    return;
-  }
+function workspaceOccurrenceRequest() {
+  return state.packages
+    .filter(item => !item.isRuntimePack)
+    .map(item => ({
+      package: item.id,
+      version: item.version,
+      framework: item.activeFramework,
+    }));
+}
 
-  state.packages = removal.packages;
-  releasePackageModelCaches(removal.closed);
-  if (removal.active) {
-    if (activeChanged) {
-      selectWorkspacePackage(removal.active, { stayInWorkspace: true });
-    } else {
-      render();
+function ensureWorkspaceOccurrenceView() {
+  if (!state.engineReady) return;
+  const signature = JSON.stringify(workspaceOccurrenceRequest());
+  if (signature === state.workspaceOccurrenceSignature) return;
+
+  state.workspaceOccurrenceSignature = signature;
+  if (state.workspaceOccurrenceLoading) return;
+  void queryWorkspaceOccurrenceView();
+}
+
+let workspaceOccurrenceRevision = 0;
+
+async function queryWorkspaceOccurrenceView() {
+  const signature = state.workspaceOccurrenceSignature;
+  const revision = workspaceOccurrenceRevision;
+  let superseded = false;
+  state.workspaceOccurrenceLoading = true;
+  state.workspaceOccurrenceError = "";
+  try {
+    const view = await inspectQueryWorkspacePackageOccurrences(signature);
+    superseded = view.superseded;
+    if (!superseded
+      && revision === workspaceOccurrenceRevision
+      && signature === state.workspaceOccurrenceSignature) {
+      state.workspaceOccurrences = view;
     }
+  } catch (error: unknown) {
+    if (revision === workspaceOccurrenceRevision
+      && signature === state.workspaceOccurrenceSignature) {
+      state.workspaceOccurrences = null;
+      state.workspaceOccurrenceError =
+        error instanceof Error ? error.message : String(error);
+    }
+  } finally {
+    state.workspaceOccurrenceLoading = false;
+    if (scope() === "workspace"
+      && (superseded
+        || revision !== workspaceOccurrenceRevision
+        || signature !== state.workspaceOccurrenceSignature)) {
+      state.workspaceOccurrenceSignature =
+        JSON.stringify(workspaceOccurrenceRequest());
+      void queryWorkspaceOccurrenceView();
+    }
+    render();
+  }
+}
+
+function retryWorkspaceOccurrenceView() {
+  state.workspaceOccurrenceSignature = "";
+  ensureWorkspaceOccurrenceView();
+  render();
+}
+
+function clearWorkspaceOccurrenceView() {
+  inspectClearWorkspacePackageOccurrences();
+  workspaceOccurrenceRevision++;
+  state.workspaceOccurrenceSignature = "";
+  state.workspaceOccurrences = null;
+  state.workspaceOccurrenceError = "";
+}
+
+function activateWorkspacePackageOccurrence(action: string) {
+  const result: BrowserWorkspacePackageOccurrenceActivation =
+    inspectActivateWorkspacePackageOccurrence(action);
+  if (!result.activated || !result.package) {
+    state.workspaceOccurrenceSignature = "";
+    ensureWorkspaceOccurrenceView();
+    showToast(
+      result.superseded
+        ? "That Workspace view was replaced. Package actions have been refreshed."
+        : "The package occurrence could not be activated.",
+    );
     return;
   }
 
-  state.package = null;
-  goHome();
+  const packageModel = createNuGetPackageModel(result.package);
+  retainPackageModel(packageModel);
+  selectWorkspacePackage(packageModel);
 }
 
 function activatePackage(
@@ -2632,6 +2711,12 @@ function typeDisplayName(
 
 function render(options: { synchronizeUrl?: boolean } = {}) {
   sourceInspection.cancelHiddenRequest();
+  if (state.engineReady
+    && scope() !== "workspace"
+    && (state.workspaceOccurrenceSignature
+      || state.workspaceOccurrences)) {
+    clearWorkspaceOccurrenceView();
+  }
   document.body.classList.remove("package-query-route");
   const applicationMenuHadFocus = applicationMenuOwnsFocus(document);
   const focusedElement = document.activeElement instanceof HTMLElement
@@ -2988,7 +3073,7 @@ function inspectedSubjectPath(
   if (scope() === "workspace") {
     return [{
       kind: "workspace",
-      label: selectedWorkspacePacket()?.title ?? "Current workspace",
+      label: "Default Workspace",
       copyable: false,
     }];
   }
@@ -3041,8 +3126,8 @@ function renderInspectedSubjectPath(
 
 function renderWorkspaceNavPane() {
   return renderWorkspaceSubject({
-    packets: state.workspacePackets,
-    selectedPacketId: state.selectedWorkspacePacketId || null,
+    packageCount: state.packages.length,
+    selected: state.workspaceSubjectOpen,
     escapeHtml,
   });
 }
@@ -3263,12 +3348,13 @@ function renderPackageView() {
 }
 
 function renderWorkspaceView() {
-  return renderWorkspacePacketView({
-    packet: selectedWorkspacePacket(),
+  ensureWorkspaceOccurrenceView();
+  return renderWorkspaceViewPure({
+    occurrences: state.workspaceOccurrences?.occurrences ?? [],
     packages: state.packages,
-    activePackage: state.package,
+    loading: state.workspaceOccurrenceLoading,
+    error: state.workspaceOccurrenceError,
     escapeHtml,
-    packageIdentityKey,
   });
 }
 
@@ -5535,9 +5621,12 @@ const graphBackActions: GraphBackBindingActions = {
 
 function bindWorkspaceSubjectEvents() {
   bindWorkspaceSubject(document, {
-    onSelect: selectWorkspacePacket,
-    onOpen: runHomeDemo,
-    onClose: closeWorkspacePackage,
+    onSelect: openDefaultWorkspace,
+    onActivate: action =>
+      observeAction(
+        () => activateWorkspacePackageOccurrence(action),
+        "Opening the Workspace package"),
+    onRetry: retryWorkspaceOccurrenceView,
   });
 }
 
@@ -7507,26 +7596,12 @@ function bindHomeEvents() {
 // deep links built from the resolved projection; member-bound Call Graph demos
 // execute through one generated engine operation over the product-resolved
 // workspace and view.
-function selectedWorkspacePacket(): ProductHomeDemoResolved | null {
-  return state.workspacePackets.find(
-    packet => packet.id === state.selectedWorkspacePacketId) ?? null;
-}
-
-function selectWorkspacePacket(packetId: string): void {
-  if (!state.workspacePackets.some(packet => packet.id === packetId)) return;
-  state.selectedWorkspacePacketId = packetId;
+function openDefaultWorkspace(): void {
   state.workspaceSubjectOpen = true;
   state.atPackageRoot = true;
   render();
   afterCurrentNavigationFrame(() =>
-    focusWorkspacePacket(document, packetId));
-}
-
-function retainWorkspacePacket(packet: ProductHomeDemoResolved): void {
-  state.workspacePackets = retainWorkspacePacketInList(
-    state.workspacePackets,
-    packet);
-  state.selectedWorkspacePacketId = packet.id;
+    focusWorkspace(document));
 }
 
 function runHomeDemo(kind: ProductHomeDemoId) {
@@ -7539,7 +7614,6 @@ function runHomeDemo(kind: ProductHomeDemoId) {
     render();
     return;
   }
-  retainWorkspacePacket(resolved);
   state.home = false;
   const link = productHomeDemoLocationHref(
     resolved,
@@ -9955,6 +10029,9 @@ async function loadPackage(
   framework: string,
   options: LoadPackageOptions = {},
 ): Promise<AppPackage | null> {
+  if (state.engineReady)
+    clearWorkspaceOccurrenceView();
+
   // Background restores load a tab's data into state.packages (for the tab bar and
   // cross-package edges) WITHOUT stealing the main view: no focus switch, no selection
   // reset, no loading toggle, no render. The caller (workspace restore) keeps the loading
@@ -10884,14 +10961,14 @@ function navigateInAppUrl(url: URL) {
     goHome();
     return;
   }
-  const focusWorkspace = state.packageQueryOpen;
-  if (focusWorkspace) {
+  const focusWorkspaceAfterQuery = state.packageQueryOpen;
+  if (focusWorkspaceAfterQuery) {
     state.packageQueryOpen = false;
     packageQueryController.cancel();
     state.packageQueryNavigationError = "";
   }
   const navigationSeq = navigationSequence.begin();
-  if (focusWorkspace) {
+  if (focusWorkspaceAfterQuery) {
     packageQueryWorkspaceFocusNavigationSeq = navigationSeq;
   }
   workspaceLocation.push(url.toString());

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -247,6 +247,7 @@ import {
   focusWorkspace,
   renderWorkspaceSubject,
   renderWorkspaceView as renderWorkspaceViewPure,
+  workspaceOccurrenceActionsAreVisible,
 } from "./workspace-subject.ts";
 import {
   bindDocViewer,
@@ -1992,7 +1993,7 @@ async function queryWorkspaceOccurrenceView() {
     }
   } finally {
     state.workspaceOccurrenceLoading = false;
-    if (scope() === "workspace"
+    if (workspaceOccurrenceViewIsVisible()
       && (superseded
         || revision !== workspaceOccurrenceRevision
         || signature !== state.workspaceOccurrenceSignature)) {
@@ -2016,6 +2017,20 @@ function clearWorkspaceOccurrenceView() {
   state.workspaceOccurrenceSignature = "";
   state.workspaceOccurrences = null;
   state.workspaceOccurrenceError = "";
+}
+
+function workspaceOccurrenceViewIsVisible() {
+  return workspaceOccurrenceActionsAreVisible({
+    engineReady: state.engineReady,
+    scope: scope(),
+    explorerOpen: state.explorer?.open === true,
+    creditsOpen: state.credits,
+    packageQueryOpen: state.packageQueryOpen,
+    loading: state.loading,
+    error: state.error,
+    home: state.home,
+    hasPackage: state.package !== null,
+  });
 }
 
 function activateWorkspacePackageOccurrence(action: string) {
@@ -2710,8 +2725,7 @@ function typeDisplayName(
 
 function render(options: { synchronizeUrl?: boolean } = {}) {
   sourceInspection.cancelHiddenRequest();
-  if (state.engineReady
-    && scope() !== "workspace"
+  if (!workspaceOccurrenceViewIsVisible()
     && (state.workspaceOccurrenceSignature
       || state.workspaceOccurrences)) {
     clearWorkspaceOccurrenceView();

--- a/prototypes/inspect-web/src/inspect-web-engine.d.ts
+++ b/prototypes/inspect-web/src/inspect-web-engine.d.ts
@@ -675,6 +675,26 @@ export interface BrowserVocabularySection {
     readonly fields: ReadonlyArray<BrowserVocabularyField>;
     readonly values: ReadonlyArray<unknown>;
 }
+export interface BrowserWorkspacePackage {
+    readonly package: string;
+    readonly version: string;
+    readonly framework: string;
+}
+export interface BrowserWorkspacePackageOccurrence {
+    readonly action: string;
+    readonly package: string;
+    readonly version: string;
+    readonly framework: string;
+}
+export interface BrowserWorkspacePackageOccurrenceActivation {
+    readonly activated: boolean;
+    readonly superseded: boolean;
+    readonly package: BrowserPackageSurface | null;
+}
+export interface BrowserWorkspacePackageOccurrenceView {
+    readonly occurrences: ReadonlyArray<BrowserWorkspacePackageOccurrence>;
+    readonly superseded: boolean;
+}
 export interface BrowserWorkspaceShareContext {
     readonly id: string;
     readonly tabIds: ReadonlyArray<string>;
@@ -719,10 +739,12 @@ export interface BrowserWorkspaceShareView {
 }
 export declare function initializeRuntime(): Promise<void>;
 export declare function runEntryPoint(mainAssemblyName?: string, args?: string[]): Promise<number>;
+export declare function activateWorkspacePackageOccurrence(action: string): BrowserWorkspacePackageOccurrenceActivation;
 export declare function asyncLoweringCanary(): Promise<string>;
 export declare function buildIdentity(): BrowserBuildIdentity;
 export declare function cancelPackageQuery(): void;
 export declare function cancelSourceQuery(): void;
+export declare function clearWorkspacePackageOccurrences(): void;
 export declare function configureHost(origin: string): void;
 export declare function decodeWorkspaceShareState(encoded: string): BrowserWorkspaceShareDecodeResult;
 export declare function encodeWorkspaceShareState(stateJson: string): BrowserWorkspaceShareEncodeResult;
@@ -759,6 +781,7 @@ export declare function queryPlatformPerformance(targetFramework: string, platfo
 export declare function queryTypeMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
 export declare function queryTypeProjection(packageId: string, version: string, targetFramework: string, assemblyName: string, typeId: string): Promise<BrowserTypeMetadata>;
 export declare function queryTypeSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserSource>;
+export declare function queryWorkspacePackageOccurrences(workspaceJson: string): Promise<BrowserWorkspacePackageOccurrenceView>;
 export declare function resolveHomeDemo(scenarioId: string): BrowserHomeDemoResolveResult;
 export declare function resolvePackageDependencyVersion(packageId: string, declaredRange: string | null): Promise<string>;
 export declare function runHomeDemo(scenarioId: string): Promise<BrowserHomeDemoRunResult>;

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -315,8 +315,8 @@ body {
 .scope-switch button.scope-seg:hover { color: var(--text); background: rgba(127,127,127,.12); }
 .scope-switch button.scope-seg.active { color: #fff; background: var(--accent); border-bottom-color: transparent; }
 .lens-separator { flex: none; width: 1px; height: 17px; background: var(--line); margin: 0 4px; }
-.workspace-packet-list { min-height: 0; overflow: auto; padding: 8px; }
-.workspace-packet {
+.workspace-list { min-height: 0; overflow: auto; padding: 8px; }
+.workspace-card {
   display: block;
   width: 100%;
   padding: 10px;
@@ -325,27 +325,18 @@ body {
   color: var(--muted);
   text-align: left;
 }
-.workspace-packet:hover { border-color: var(--line); background: rgba(127,127,127,.08); }
-.workspace-packet.active { border-color: var(--line-strong); background: var(--panel-active); }
-.workspace-packet strong,
-.workspace-packet span,
-.workspace-packet small { display: block; overflow: hidden; text-overflow: ellipsis; }
-.workspace-packet strong { color: var(--text); font: 11px var(--mono); }
-.workspace-packet span { margin-top: 4px; color: var(--muted); font-size: 11px; }
-.workspace-packet small { margin-top: 5px; color: var(--dim); font: 9px var(--mono); }
-.workspace-packet-empty { margin: 12px 8px; color: var(--dim); font-size: 11px; line-height: 1.5; }
+.workspace-card:hover { border-color: var(--line); background: rgba(127,127,127,.08); }
+.workspace-card.active { border-color: var(--line-strong); background: var(--panel-active); }
+.workspace-card strong,
+.workspace-card span,
+.workspace-card small { display: block; overflow: hidden; text-overflow: ellipsis; }
+.workspace-card strong { color: var(--text); font: 11px var(--mono); }
+.workspace-card span { margin-top: 4px; color: var(--muted); font-size: 11px; }
+.workspace-card small { margin-top: 5px; color: var(--dim); font: 9px var(--mono); }
+.workspace-empty { margin: 12px 8px; color: var(--dim); font-size: 11px; line-height: 1.5; }
 .workspace-overview { max-width: 900px; margin-top: 28px; }
 .workspace-overview p { color: var(--muted); line-height: 1.6; }
-.workspace-packet-introduction {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 20px;
-}
-.workspace-packet-introduction p { margin: 0; font-size: 14px; }
-.workspace-packet-introduction button { flex: none; padding: 8px 14px; }
-.workspace-packet-section { margin-top: 14px; }
+.workspace-section { margin-top: 14px; }
 .workspace-detail-list { list-style: none; margin: 0; padding: 0; }
 .workspace-detail-list li {
   display: grid;
@@ -362,6 +353,24 @@ body {
 .workspace-detail-list.loaded li { grid-template-columns: 110px minmax(0, 1fr) auto auto; }
 .workspace-detail-list.loaded li.active > strong { color: var(--accent); }
 .workspace-detail-list.loaded button { padding: 3px 7px; }
+.workspace-detail-list.loaded li.workspace-occurrence-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.workspace-occurrence {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr) auto;
+  align-items: baseline;
+  gap: 12px;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+.workspace-occurrence:hover > strong { color: var(--accent); }
+.workspace-occurrence > span { color: var(--dim); font: 9px var(--mono); text-transform: uppercase; }
+.workspace-occurrence > strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; font: 12px var(--mono); }
+.workspace-occurrence > small { color: var(--muted); font: 10px var(--mono); }
 .workspace-view-details { margin: 0; }
 .workspace-view-details div {
   display: grid;
@@ -1485,7 +1494,6 @@ kbd {
   .type-heading { grid-template-columns: 35px minmax(0, 1fr); }
   .type-badge { width: 35px; height: 35px; }
   .type-heading p { grid-column: 1 / -1; }
-  .workspace-packet-introduction { align-items: flex-start; flex-direction: column; gap: 10px; }
   .workspace-detail-list li,
   .workspace-detail-list.loaded li {
     grid-template-columns: minmax(0, 1fr) auto;
@@ -1493,6 +1501,12 @@ kbd {
   }
   .workspace-detail-list li > span { grid-column: 1 / -1; }
   .workspace-detail-list li > small { grid-column: 1; }
+  .workspace-occurrence {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 5px 10px;
+  }
+  .workspace-occurrence > span { grid-column: 1 / -1; }
+  .workspace-occurrence > small { grid-column: 1; }
   .workspace-view-details div { grid-template-columns: 80px minmax(0, 1fr); }
 }
 

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -1,164 +1,98 @@
 import type { PackageControlPackage } from "./package-controls.ts";
 import type {
-  BrowserHomeDemoMember,
-  BrowserHomeDemoResolved,
+  BrowserWorkspacePackageOccurrence,
 } from "./inspect-web-engine.d.ts";
 
 export interface WorkspaceSubjectRenderOptions {
-  packets: readonly BrowserHomeDemoResolved[];
-  selectedPacketId: string | null;
+  packageCount: number;
+  selected: boolean;
   escapeHtml: (value: unknown) => string;
 }
 
-export interface WorkspacePacketViewRenderOptions {
-  packet: BrowserHomeDemoResolved | null;
+export interface WorkspaceViewRenderOptions {
+  occurrences: readonly BrowserWorkspacePackageOccurrence[];
   packages: readonly PackageControlPackage[];
-  activePackage: PackageControlPackage | null;
+  loading: boolean;
+  error: string;
   escapeHtml: (value: unknown) => string;
-  packageIdentityKey: (pkg: PackageControlPackage) => string;
 }
 
 export interface WorkspaceSubjectBindingActions {
-  onSelect: (packetId: string) => void;
-  onOpen: (packetId: string) => void;
-  onClose: (packageKey: string) => void;
-}
-
-export function retainWorkspacePacket(
-  packets: readonly BrowserHomeDemoResolved[],
-  packet: BrowserHomeDemoResolved,
-): BrowserHomeDemoResolved[] {
-  const index = packets.findIndex(candidate => candidate.id === packet.id);
-  if (index < 0) return [...packets, packet];
-  const retained = packets.slice();
-  retained[index] = packet;
-  return retained;
+  onSelect: () => void;
+  onActivate: (action: string) => void;
+  onRetry: () => void;
 }
 
 export function renderWorkspaceSubject(
   options: WorkspaceSubjectRenderOptions,
 ): string {
   const {
-    packets,
-    selectedPacketId,
+    packageCount,
+    selected,
     escapeHtml,
   } = options;
-  const rows = packets.map(packet => {
-    const active = packet.id === selectedPacketId;
-    const target = [packet.view.section, packet.view.type]
-      .filter((value): value is string => Boolean(value))
-      .join(" · ") || "Workspace";
-    return `<button class="workspace-packet${active ? " active" : ""}" type="button" data-workspace-packet="${escapeHtml(packet.id)}" aria-current="${active ? "true" : "false"}">
-      <strong>${escapeHtml(packet.title)}</strong>
-      <span>${escapeHtml(packet.summary)}</span>
-      <small>${escapeHtml(target)}</small>
-    </button>`;
-  }).join("");
-  const content = rows
-    || `<p class="workspace-packet-empty">Open a demo to retain its workspace packet here.</p>`;
   return `<aside class="type-browser workspace-nav">
-    <header class="browser-head"><span>WORKSPACE PACKETS</span><small>${packets.length}</small></header>
-    <div class="workspace-packet-list">${content}</div>
+    <header class="browser-head"><span>WORKSPACES</span><small>1</small></header>
+    <div class="workspace-list">
+      <button class="workspace-card${selected ? " active" : ""}" type="button" data-workspace-default aria-current="${selected ? "true" : "false"}">
+        <strong>Default Workspace</strong>
+        <span>${escapeHtml(packageCount)} loaded coordinate${packageCount === 1 ? "" : "s"}</span>
+        <small>Browser session</small>
+      </button>
+    </div>
   </aside>`;
 }
 
-function coordinateDetail(
-  member: BrowserHomeDemoMember,
-  escapeHtml: (value: unknown) => string,
-): string {
-  const details = [member.version, member.framework, member.assembly]
-    .filter((value): value is string => Boolean(value))
-    .map(escapeHtml)
-    .join(" · ");
-  const kind = member.kind === "package"
-    ? "NuGet package"
-    : member.kind === "platform"
-      ? "Platform"
-      : member.kind;
-  return `<li>
-    <span>${escapeHtml(kind)}</span>
-    <strong>${escapeHtml(member.id)}</strong>
-    ${details ? `<small>${details}</small>` : ""}
-  </li>`;
-}
-
-export function renderWorkspacePacketView(
-  options: WorkspacePacketViewRenderOptions,
+export function renderWorkspaceView(
+  options: WorkspaceViewRenderOptions,
 ): string {
   const {
-    packet,
+    occurrences,
     packages,
-    activePackage,
+    loading,
+    error,
     escapeHtml,
-    packageIdentityKey,
   } = options;
-  const title = packet?.title ?? "Current workspace";
-  const summary = packet?.summary
-    ?? "Live coordinates retained by this browser session.";
-  const declaredMembers = packet?.workspaceMembers.map(member =>
-    coordinateDetail(member, escapeHtml)).join("") ?? "";
-  const focusedTab = packet
-    ? packet.tabs[Math.min(
-        Math.max(packet.focusTabIndex, 0),
-        Math.max(packet.tabs.length - 1, 0))]
-    : null;
-  const viewRows = packet
-    ? [
-        ["Starts at", focusedTab?.member.id ?? null],
-        ["Section", packet.view.section],
-        ["Library", packet.view.library],
-        ["Type", packet.view.type],
-        ["Member", packet.view.memberKey ?? packet.view.memberAnchor],
-      ].filter((row): row is [string, string] => Boolean(row[1]))
-    : [];
-  const loadedCoordinates = packages.map(item => {
-    const key = packageIdentityKey(item);
-    const active = Boolean(
-      activePackage
-      && packageIdentityKey(activePackage) === key);
-    const label = `${item.id} ${item.version} ${item.activeFramework}`;
-    return `<li class="${active ? "active" : ""}">
-      <span>${item.isRuntimePack ? "Platform" : "Loaded package"}</span>
-      <strong>${escapeHtml(item.id)}</strong>
-      <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
-      ${item.isRuntimePack
-        ? ""
-        : `<button type="button" data-workspace-close="${escapeHtml(key)}" aria-label="Close ${escapeHtml(label)}">Close</button>`}
+  const packageRows = occurrences.map(occurrence => {
+    const label = `${occurrence.package} ${occurrence.version} ${occurrence.framework}`;
+    return `<li class="workspace-occurrence-row">
+      <button class="workspace-occurrence" type="button" data-workspace-activate="${escapeHtml(occurrence.action)}" aria-label="Inspect ${escapeHtml(label)}">
+        <span>NuGet package</span>
+        <strong>${escapeHtml(occurrence.package)}</strong>
+        <small>${escapeHtml(occurrence.version)} · ${escapeHtml(occurrence.framework)}</small>
+      </button>
     </li>`;
   }).join("");
-  const packetDetails = packet
-    ? `<section class="document-section workspace-packet-section">
-        <div class="section-title"><h2>Packet workspace</h2><span>${packet.workspaceMembers.length} member${packet.workspaceMembers.length === 1 ? "" : "s"}</span></div>
-        <ul class="workspace-detail-list">${declaredMembers}</ul>
-      </section>
-      <section class="document-section workspace-packet-section">
-        <div class="section-title"><h2>Initial view</h2><span>selection only</span></div>
-        <dl class="workspace-view-details">${viewRows.map(([label, value]) =>
-          `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`).join("")}</dl>
-      </section>`
-    : "";
+  const platformRows = packages.filter(item => item.isRuntimePack).map(item =>
+    `<li>
+      <span>Platform</span>
+      <strong>${escapeHtml(item.id)}</strong>
+      <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
+    </li>`).join("");
+  const rows = `${packageRows}${platformRows}`;
+  const content = loading
+    ? `<p class="workspace-empty">Reading Workspace package occurrences…</p>`
+    : error
+      ? `<div class="workspace-empty">
+          <p>${escapeHtml(error)}</p>
+          <button type="button" data-workspace-retry>Retry</button>
+        </div>`
+      : rows
+        ? `<ul class="workspace-detail-list loaded">${rows}</ul>`
+        : `<p class="workspace-empty">No packages are loaded in this Workspace.</p>`;
   return `<header class="type-heading workspace-heading">
     <div class="type-badge">W</div>
     <div>
-      <div class="type-namespace">${packet ? "Workspace packet" : "Inspection workspace"}</div>
-      <h1>${escapeHtml(title)}</h1>
-      <code class="type-signature">${packet
-        ? `${packet.workspaceMembers.length} workspace member${packet.workspaceMembers.length === 1 ? "" : "s"} · ${packet.tabs.length} navigation target${packet.tabs.length === 1 ? "" : "s"}`
-        : `${packages.length} loaded coordinate${packages.length === 1 ? "" : "s"}`}</code>
+      <div class="type-namespace">Workspace</div>
+      <h1>Default Workspace</h1>
+      <code class="type-signature">${packages.length} loaded coordinate${packages.length === 1 ? "" : "s"}</code>
     </div>
   </header>
   <div class="workspace-overview">
-    <div class="workspace-packet-introduction">
-      <p>${escapeHtml(summary)}</p>
-      ${packet
-        ? `<button class="primary-action" type="button" data-workspace-open="${escapeHtml(packet.id)}">Open workspace</button>`
-        : ""}
-    </div>
-    ${packetDetails}
-    <section class="document-section workspace-packet-section">
-      <div class="section-title"><h2>Loaded workspace</h2><span>${packages.length} coordinate${packages.length === 1 ? "" : "s"}</span></div>
-      <p>Workspace packets may share these loaded coordinates without becoming the same packet.</p>
-      <ul class="workspace-detail-list loaded">${loadedCoordinates}</ul>
+    <section class="document-section workspace-section">
+      <div class="section-title"><h2>Packages</h2><span>${packages.length} coordinate${packages.length === 1 ? "" : "s"}</span></div>
+      <p>Choose a package to inspect it. The Workspace keeps every loaded coordinate available.</p>
+      ${content}
     </section>
   </div>`;
 }
@@ -167,31 +101,21 @@ export function bindWorkspaceSubject(
   root: ParentNode,
   actions: WorkspaceSubjectBindingActions,
 ): void {
-  root.querySelectorAll<HTMLElement>("[data-workspace-packet]").forEach(button =>
+  root.querySelector<HTMLElement>("[data-workspace-default]")
+    ?.addEventListener("click", actions.onSelect);
+  root.querySelectorAll<HTMLElement>("[data-workspace-activate]").forEach(button =>
     button.addEventListener("click", () => {
-      const id = button.dataset.workspacePacket;
-      if (id !== undefined) actions.onSelect(id);
+      const action = button.dataset.workspaceActivate;
+      if (action !== undefined) actions.onActivate(action);
     }));
-  root.querySelectorAll<HTMLElement>("[data-workspace-open]").forEach(button =>
-    button.addEventListener("click", () => {
-      const id = button.dataset.workspaceOpen;
-      if (id !== undefined) actions.onOpen(id);
-    }));
-  root.querySelectorAll<HTMLElement>("[data-workspace-close]").forEach(button =>
-    button.addEventListener("click", () => {
-      const key = button.dataset.workspaceClose;
-      if (key !== undefined) actions.onClose(key);
-    }));
+  root.querySelector<HTMLElement>("[data-workspace-retry]")
+    ?.addEventListener("click", actions.onRetry);
 }
 
-export function focusWorkspacePacket(
+export function focusWorkspace(
   root: ParentNode,
-  packetId: string,
 ): boolean {
-  for (const button of root.querySelectorAll<HTMLElement>("[data-workspace-packet]")) {
-    if (button.dataset.workspacePacket !== packetId) continue;
-    button.focus();
-    return true;
-  }
-  return false;
+  const button = root.querySelector<HTMLElement>("[data-workspace-default]");
+  button?.focus();
+  return Boolean(button);
 }

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -23,6 +23,32 @@ export interface WorkspaceSubjectBindingActions {
   onRetry: () => void;
 }
 
+export interface WorkspaceOccurrenceVisibility {
+  engineReady: boolean;
+  scope: string;
+  explorerOpen: boolean;
+  creditsOpen: boolean;
+  packageQueryOpen: boolean;
+  loading: boolean;
+  error: string;
+  home: boolean;
+  hasPackage: boolean;
+}
+
+export function workspaceOccurrenceActionsAreVisible(
+  state: WorkspaceOccurrenceVisibility,
+): boolean {
+  return state.engineReady
+    && state.scope === "workspace"
+    && !state.explorerOpen
+    && !state.creditsOpen
+    && !state.packageQueryOpen
+    && !state.loading
+    && !state.error
+    && !state.home
+    && state.hasPackage;
+}
+
 export function renderWorkspaceSubject(
   options: WorkspaceSubjectRenderOptions,
 ): string {

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2727,34 +2727,11 @@ test("member entry controls move focus into the resulting member navigation", ()
 
 test("workspace package selection resets type-specific member filters", () => {
   const selection =
-    appSource.match(/function selectWorkspacePackage\([\s\S]*?\n}\n\nfunction closeWorkspacePackage/)?.[0]
+    appSource.match(/function selectWorkspacePackage\([\s\S]*?\n}\n\nfunction activatePackage/)?.[0]
     ?? "";
   assert.match(
     selection,
     /state\.selectedTypeId = defaultVisibleTypeId\(packageModel\);[\s\S]*resetMemberFilters\(\);[\s\S]*resetMemberSectionState\(\)/);
-});
-
-test("last package close recovers a route before releasing the workspace", () => {
-  const close =
-    appSource.match(/function closeWorkspacePackage\([\s\S]*?\n}\n\nfunction activatePackage/)?.[0]
-    ?? "";
-
-  assert.match(
-    close,
-    /const removal = removeWorkspacePackage\([\s\S]*if \(!removal\.closed\) return;[\s\S]*if \(!removal\.active && !clearWorkspaceRouteFailure\(\)\) \{\s*render\(\);\s*return;\s*\}[\s\S]*state\.packages = removal\.packages;\s*releasePackageModelCaches\(removal\.closed\);[\s\S]*state\.package = null;\s*goHome\(\);/);
-});
-
-test("Workspace close preserves the subject unless the active coordinate changes", () => {
-  const close =
-    appSource.match(/function closeWorkspacePackage\([\s\S]*?\n}\n\nfunction activatePackage/)?.[0]
-    ?? "";
-
-  assert.match(
-    close,
-    /const activeChanged =\s*!packageIdentityEquals\(removal\.active, state\.package\)/);
-  assert.match(
-    close,
-    /if \(removal\.active\) \{\s*if \(activeChanged\) \{\s*selectWorkspacePackage\(removal\.active, \{ stayInWorkspace: true \}\);\s*\} else \{\s*render\(\);/);
 });
 
 test("loaded-package Spotlight selection resets type-specific member filters", () => {
@@ -2877,7 +2854,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
   assert.doesNotMatch(route, /packageQueryController\.run/);
   assert.match(
     appSource,
-    /function render\(options: \{ synchronizeUrl\?: boolean \} = \{\}\) \{\s*sourceInspection\.cancelHiddenRequest\(\);\s*document\.body\.classList\.remove\("package-query-route"\);[\s\S]*if \(state\.packageQueryOpen\s*&& state\.engineReady\s*&& !state\.loading\s*&& !state\.error\) \{\s*document\.body\.classList\.add\("package-query-route"\)/);
+    /function render\(options: \{ synchronizeUrl\?: boolean \} = \{\}\) \{\s*sourceInspection\.cancelHiddenRequest\(\);[\s\S]*?document\.body\.classList\.remove\("package-query-route"\);[\s\S]*if \(state\.packageQueryOpen\s*&& state\.engineReady\s*&& !state\.loading\s*&& !state\.error\) \{\s*document\.body\.classList\.add\("package-query-route"\)/);
   assert.match(
     stylesSource,
     /@media \(max-width: 860px\) \{\s*body\.package-query-route \{ min-width: 0; \}/);
@@ -2985,7 +2962,7 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /function packageQueryWorkspaceHref\(\): string \{[\s\S]*lastCanonicalWorkspaceHref[\s\S]*buildPackageRootStateUrl/);
   assert.match(
     appSource,
-    /const focusWorkspace = state\.packageQueryOpen;\s*if \(focusWorkspace\) \{\s*state\.packageQueryOpen = false;\s*packageQueryController\.cancel\(\);\s*state\.packageQueryNavigationError = "";\s*\}\s*const navigationSeq = navigationSequence\.begin\(\);\s*if \(focusWorkspace\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*workspaceLocation\.push/);
+    /const focusWorkspaceAfterQuery = state\.packageQueryOpen;\s*if \(focusWorkspaceAfterQuery\) \{\s*state\.packageQueryOpen = false;\s*packageQueryController\.cancel\(\);\s*state\.packageQueryNavigationError = "";\s*\}\s*const navigationSeq = navigationSequence\.begin\(\);\s*if \(focusWorkspaceAfterQuery\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*workspaceLocation\.push/);
   assert.match(
     appSource,
     /function restorePackageQueryWorkspaceFocus\(\) \{\s*const navigationSeq = packageQueryWorkspaceFocusNavigationSeq;[\s\S]*navigationSequence\.isCurrent\(navigationSeq\)[\s\S]*afterCurrentNavigationFrame\(\(\) => \{\s*if \(!focusLevelOneHeading\(\)\) \{\s*document\.querySelector<HTMLElement>\("#type-list"\)\?\.focus\(\)/);
@@ -5735,15 +5712,21 @@ test("workspace UI routes replacements and restore notices through bounded paths
   assert.match(
     appSource,
     /appendQueryNotice\(\s+friendly\.message,\s+options\.retryAction/);
-  assert.match(
+  assert.doesNotMatch(
     workspaceSubjectSource,
     /data-workspace-close=/);
-  assert.match(
+  assert.doesNotMatch(
     appSource,
     /onClose: closeWorkspacePackage/);
   assert.match(
     appSource,
-    /onSelect: selectWorkspacePacket,\s+onOpen: runHomeDemo/);
+    /onSelect: openDefaultWorkspace,\s+onActivate: action =>\s+observeAction\(\s+\(\) => activateWorkspacePackageOccurrence\(action\)/);
+  assert.match(
+    appSource,
+    /const revision = workspaceOccurrenceRevision;[\s\S]*superseded = view\.superseded;[\s\S]*revision === workspaceOccurrenceRevision[\s\S]*\(superseded[\s\S]*\|\| revision !== workspaceOccurrenceRevision[\s\S]*\|\| signature !== state\.workspaceOccurrenceSignature\)/);
+  assert.match(
+    appSource,
+    /if \(state\.engineReady\s*&& scope\(\) !== "workspace"\s*&& \(state\.workspaceOccurrenceSignature\s*\|\| state\.workspaceOccurrences\)\) \{\s*clearWorkspaceOccurrenceView\(\)/);
   assert.match(
     appSource,
     /const key = assemblyId \|\| `legacy:\$\{asm\}`/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -5726,7 +5726,7 @@ test("workspace UI routes replacements and restore notices through bounded paths
     /const revision = workspaceOccurrenceRevision;[\s\S]*superseded = view\.superseded;[\s\S]*revision === workspaceOccurrenceRevision[\s\S]*\(superseded[\s\S]*\|\| revision !== workspaceOccurrenceRevision[\s\S]*\|\| signature !== state\.workspaceOccurrenceSignature\)/);
   assert.match(
     appSource,
-    /if \(state\.engineReady\s*&& scope\(\) !== "workspace"\s*&& \(state\.workspaceOccurrenceSignature\s*\|\| state\.workspaceOccurrences\)\) \{\s*clearWorkspaceOccurrenceView\(\)/);
+    /if \(!workspaceOccurrenceViewIsVisible\(\)\s*&& \(state\.workspaceOccurrenceSignature\s*\|\| state\.workspaceOccurrences\)\) \{\s*clearWorkspaceOccurrenceView\(\)/);
   assert.match(
     appSource,
     /const key = assemblyId \|\| `legacy:\$\{asm\}`/);

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -5,6 +5,7 @@ import {
   focusWorkspace,
   renderWorkspaceSubject,
   renderWorkspaceView,
+  workspaceOccurrenceActionsAreVisible,
 } from "../src/workspace-subject.ts";
 import type { PackageControlPackage } from "../src/package-controls.ts";
 import { fakeDom } from "./fake-dom.ts";
@@ -27,6 +28,40 @@ test("Workspace navigation always displays the Default Workspace", () => {
   assert.match(html, /WORKSPACES[\s\S]*1/);
   assert.match(html, /workspace-card active/);
   assert.match(html, /Default Workspace[\s\S]*2 loaded coordinates/);
+});
+
+test("Workspace occurrence actions are visible only in the rendered Workspace view", () => {
+  const visible = {
+    engineReady: true,
+    scope: "workspace" as const,
+    explorerOpen: false,
+    creditsOpen: false,
+    packageQueryOpen: false,
+    loading: false,
+    error: "",
+    home: false,
+    hasPackage: true,
+  };
+
+  assert.equal(workspaceOccurrenceActionsAreVisible(visible), true);
+  for (const hidden of [
+    { engineReady: false },
+    { explorerOpen: true },
+    { creditsOpen: true },
+    { packageQueryOpen: true },
+    { loading: true },
+    { error: "failed" },
+    { home: true },
+    { hasPackage: false },
+    { scope: "type" as const },
+  ]) {
+    assert.equal(
+      workspaceOccurrenceActionsAreVisible({
+        ...visible,
+        ...hidden,
+      }),
+      false);
+  }
 });
 
 test("Workspace details render product occurrences as opaque actions", () => {

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -2,12 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindWorkspaceSubject,
-  focusWorkspacePacket,
-  renderWorkspacePacketView,
+  focusWorkspace,
   renderWorkspaceSubject,
-  retainWorkspacePacket,
+  renderWorkspaceView,
 } from "../src/workspace-subject.ts";
-import type { BrowserHomeDemoResolved } from "../src/inspect-web-engine.d.ts";
 import type { PackageControlPackage } from "../src/package-controls.ts";
 import { fakeDom } from "./fake-dom.ts";
 
@@ -19,209 +17,122 @@ function escapeHtml(value: unknown) {
     .replaceAll('"', "&quot;");
 }
 
-function packageIdentityKey(pkg: PackageControlPackage) {
-  return `${pkg.id}@${pkg.version}::${pkg.activeFramework}`;
-}
-
-const packet: BrowserHomeDemoResolved = {
-  id: "stj-serialize-callgraph",
-  title: "Serialize call graph",
-  summary: "Dense package-local STJ graph",
-  workspaceMembers: [{
-    kind: "package",
-    id: "System.Text.Json",
-    version: "10.0.0",
-    framework: "net10.0",
-    assembly: null,
-  }],
-  tabs: [{
-    id: "stj",
-    member: {
-      kind: "package",
-      id: "System.Text.Json",
-      version: "10.0.0",
-      framework: "net10.0",
-      assembly: null,
-    },
-  }],
-  focusTabIndex: 0,
-  view: {
-    library: null,
-    type: "System.Text.Json.JsonSerializer",
-    memberAnchor: "1dc14dd1fb",
-    memberKey: "method:Serialize",
-    section: "Call Graph",
-  },
-};
-
-test("Workspace lists independently selectable packets", () => {
-  const sibling = {
-    ...packet,
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-    summary: "STJ number parse path",
-    view: {
-      ...packet.view,
-      type: "System.Text.Json.JsonElement",
-      memberKey: "method:GetDecimal",
-    },
-  };
-
+test("Workspace navigation always displays the Default Workspace", () => {
   const html = renderWorkspaceSubject({
-    packets: [packet, sibling],
-    selectedPacketId: packet.id,
+    packageCount: 2,
+    selected: true,
     escapeHtml,
   });
 
-  assert.match(html, /WORKSPACE PACKETS[\s\S]*2/);
-  assert.match(html, /workspace-packet active/);
-  assert.match(html, /Serialize call graph[\s\S]*Dense package-local STJ graph/);
-  assert.match(html, /JsonElement\.GetDecimal[\s\S]*STJ number parse path/);
-  assert.doesNotMatch(html, /data-workspace-open/);
+  assert.match(html, /WORKSPACES[\s\S]*1/);
+  assert.match(html, /workspace-card active/);
+  assert.match(html, /Default Workspace[\s\S]*2 loaded coordinates/);
 });
 
-test("Workspace packet retention keys scenarios independently of coordinates", () => {
-  const sibling = {
-    ...packet,
-    id: "stj-getdecimal-callgraph",
-    title: "JsonElement.GetDecimal",
-  };
-  const retained = retainWorkspacePacket(
-    retainWorkspacePacket([], packet),
-    sibling);
-
-  assert.deepEqual(
-    retained.map(item => item.id),
-    ["stj-serialize-callgraph", "stj-getdecimal-callgraph"]);
-  assert.deepEqual(
-    retained.map(item => item.workspaceMembers),
-    [packet.workspaceMembers, packet.workspaceMembers]);
-});
-
-test("Workspace packet details distinguish packet data from loaded coordinates", () => {
-  const active: PackageControlPackage = {
+test("Workspace details render product occurrences as opaque actions", () => {
+  const packages: PackageControlPackage[] = [{
     id: "System.Text.Json",
     version: "10.0.0",
     activeFramework: "net10.0",
     isRuntimePack: false,
-  };
-  const platform: PackageControlPackage = {
+  }, {
     id: "Microsoft.NETCore.App",
     version: "10.0.0",
     activeFramework: "net10.0",
     isRuntimePack: true,
-  };
+  }];
 
-  const html = renderWorkspacePacketView({
-    packet,
-    packages: [platform, active],
-    activePackage: active,
+  const html = renderWorkspaceView({
+    occurrences: [{
+      action: "opaque-action",
+      package: "system.text.json",
+      version: "10.0.0",
+      framework: "net10.0",
+    }],
+    packages,
+    loading: false,
+    error: "",
     escapeHtml,
-    packageIdentityKey,
   });
 
-  assert.match(html, /Workspace packet[\s\S]*Serialize call graph/);
-  assert.match(html, /Packet workspace[\s\S]*System\.Text\.Json/);
-  assert.match(html, /Initial view[\s\S]*Call Graph[\s\S]*method:Serialize/);
-  assert.match(html, /Loaded workspace[\s\S]*Microsoft\.NETCore\.App/);
-  assert.match(html, /data-workspace-open="stj-serialize-callgraph"/);
-  assert.match(html, />Open workspace</);
+  assert.match(html, /Workspace[\s\S]*Default Workspace/);
+  assert.match(
+    html,
+    /data-workspace-activate="opaque-action"[\s\S]*system\.text\.json/);
+  assert.match(html, /Platform[\s\S]*Microsoft\.NETCore\.App/);
+  assert.doesNotMatch(html, /data-workspace-close/);
 });
 
-test("Workspace selection, explicit Open, and Close dispatch separate identities", () => {
+test("Workspace details distinguish loading, empty, and failure", () => {
+  const render = (loading: boolean, error = "") => renderWorkspaceView({
+    occurrences: [],
+    packages: [],
+    loading,
+    error,
+    escapeHtml,
+  });
+
+  assert.match(render(true), /Reading Workspace package occurrences/);
+  assert.match(render(false), /No packages are loaded/);
+  assert.match(render(false, "Acquisition failed"), /Acquisition failed/);
+});
+
+test("Workspace selection and activation dispatch separate actions", () => {
   const listeners = new Map<string, EventListener>();
   const select = {
-    dataset: { workspacePacket: "packet-key" },
     addEventListener: (name: string, listener: EventListener) =>
       listeners.set(`select:${name}`, listener),
   };
-  const open = {
-    dataset: { workspaceOpen: "open-key" },
+  const activate = {
+    dataset: { workspaceActivate: "opaque-action" },
     addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`open:${name}`, listener),
+      listeners.set(`activate:${name}`, listener),
   };
-  const close = {
-    dataset: { workspaceClose: "close-key" },
+  const retry = {
     addEventListener: (name: string, listener: EventListener) =>
-      listeners.set(`close:${name}`, listener),
+      listeners.set(`retry:${name}`, listener),
   };
   const root = {
-    querySelectorAll: (selector: string) =>
-      selector === "[data-workspace-packet]"
-        ? [select]
-        : selector === "[data-workspace-open]"
-          ? [open]
-          : [close],
+    querySelector: (selector: string) =>
+      selector === "[data-workspace-default]" ? select : retry,
+    querySelectorAll: () => [activate],
   };
   const calls: string[] = [];
 
   bindWorkspaceSubject(
     fakeDom.parentNode(root),
     {
-      onSelect: key => calls.push(`select:${key}`),
-      onOpen: key => calls.push(`open:${key}`),
-      onClose: key => calls.push(`close:${key}`),
+      onSelect: () => {
+        calls.push("select");
+      },
+      onActivate: action => {
+        calls.push(`activate:${action}`);
+      },
+      onRetry: () => {
+        calls.push("retry");
+      },
     });
 
   listeners.get("select:click")?.(fakeDom.event());
-  listeners.get("open:click")?.(fakeDom.event());
-  listeners.get("close:click")?.(fakeDom.event());
+  listeners.get("activate:click")?.(fakeDom.event());
+  listeners.get("retry:click")?.(fakeDom.event());
   assert.deepEqual(calls, [
-    "select:packet-key",
-    "open:open-key",
-    "close:close-key",
+    "select",
+    "activate:opaque-action",
+    "retry",
   ]);
 });
 
-test("Workspace Close names distinguish matching package ids", () => {
-  const packages: PackageControlPackage[] = [
-    {
-      id: "Example.Package",
-      version: "1.0.0",
-      activeFramework: "net8.0",
-      isRuntimePack: false,
-    },
-    {
-      id: "Example.Package",
-      version: "2.0.0",
-      activeFramework: "net10.0",
-      isRuntimePack: false,
-    },
-  ];
-
-  const html = renderWorkspacePacketView({
-    packet: null,
-    packages,
-    activePackage: packages[0] ?? null,
-    escapeHtml,
-    packageIdentityKey,
-  });
-
-  assert.match(html, /aria-label="Close Example\.Package 1\.0\.0 net8\.0"/);
-  assert.match(html, /aria-label="Close Example\.Package 2\.0\.0 net10\.0"/);
-});
-
-test("Workspace packet focus survives observational selection", () => {
-  let focused = "";
+test("Workspace focus targets the always-visible Workspace", () => {
+  let focused = false;
   const root = {
-    querySelectorAll: () => [{
-      dataset: { workspacePacket: "first" },
+    querySelector: () => ({
       focus: () => {
-        focused = "first";
+        focused = true;
       },
-    }, {
-      dataset: { workspacePacket: "second" },
-      focus: () => {
-        focused = "second";
-      },
-    }],
+    }),
   };
 
-  assert.equal(
-    focusWorkspacePacket(fakeDom.parentNode(root), "second"),
-    true);
-  assert.equal(focused, "second");
-  assert.equal(
-    focusWorkspacePacket(fakeDom.parentNode(root), "missing"),
-    false);
+  assert.equal(focusWorkspace(fakeDom.parentNode(root)), true);
+  assert.equal(focused, true);
 });

--- a/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
+++ b/src/DotnetInspector.Packages/PackageCompileAssetSelector.cs
@@ -190,12 +190,25 @@ public static class PackageCompileAssetSelector
                     TfmResolver.GetTfmPriority(framework.ToLowerInvariant()))
                 .ThenBy(framework => framework, StringComparer.OrdinalIgnoreCase),
         ];
-        string? selectedFramework = string.IsNullOrWhiteSpace(targetFramework)
-            ? frameworks[0]
-            : frameworks.FirstOrDefault(
+        string? selectedFramework;
+        if (string.IsNullOrWhiteSpace(targetFramework))
+        {
+            selectedFramework = frameworks[0];
+        }
+        else
+        {
+            selectedFramework = frameworks.FirstOrDefault(
                 framework => framework.Equals(
                     targetFramework,
                     StringComparison.OrdinalIgnoreCase));
+            if (selectedFramework is null
+                && emptyReferenceGroups.Contains(
+                    targetFramework,
+                    StringComparer.OrdinalIgnoreCase))
+            {
+                selectedFramework = targetFramework;
+            }
+        }
         if (selectedFramework is null)
         {
             return new PackageCompileAssetSelection(

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceIdentityTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceIdentityTests.cs
@@ -137,4 +137,121 @@ public sealed class InspectionWorkspaceIdentityTests
             () => workspace.IssueNonPackageRootOccurrence());
         await close;
     }
+
+    [Fact]
+    public void PackageOccurrenceView_PreservesOrderAndBindingFacts()
+    {
+        PackageRootBinding first =
+            PackageAssemblyContextCompletionTests.SharedBinding(
+                "First.View");
+        PackageRootBinding second =
+            PackageAssemblyContextCompletionTests.SharedBinding(
+                "Second.View");
+        using var workspace = new InspectionWorkspace();
+
+        InspectionWorkspacePackageOccurrenceView view =
+            workspace.CreatePackageOccurrenceView([second, first]);
+
+        Assert.Same(workspace.Identity, view.Workspace);
+        Assert.Collection(
+            view.Occurrences,
+            descriptor =>
+            {
+                Assert.Equal("second.view", descriptor.PackageId);
+                Assert.Same(second, descriptor.Occurrence.RootBinding);
+                Assert.Same(
+                    workspace.Identity,
+                    descriptor.Occurrence.WorkspaceIdentity);
+            },
+            descriptor =>
+            {
+                Assert.Equal("first.view", descriptor.PackageId);
+                Assert.Same(first, descriptor.Occurrence.RootBinding);
+                Assert.Same(
+                    workspace.Identity,
+                    descriptor.Occurrence.WorkspaceIdentity);
+            });
+    }
+
+    [Fact]
+    public void PackageOccurrenceView_EmptyInputProducesTypedEmptyView()
+    {
+        using var workspace = new InspectionWorkspace();
+
+        InspectionWorkspacePackageOccurrenceView view =
+            workspace.CreatePackageOccurrenceView([]);
+
+        Assert.Same(workspace.Identity, view.Workspace);
+        Assert.Empty(view.Occurrences);
+    }
+
+    [Fact]
+    public void PackageOccurrenceView_RepeatedBindingIssuesDistinctOccurrences()
+    {
+        PackageRootBinding binding =
+            PackageAssemblyContextCompletionTests.SharedBinding(
+                "Repeated.View");
+        using var workspace = new InspectionWorkspace();
+
+        InspectionWorkspacePackageOccurrenceView view =
+            workspace.CreatePackageOccurrenceView([binding, binding]);
+
+        Assert.Equal(2, view.Occurrences.Length);
+        Assert.NotSame(
+            view.Occurrences[0].Occurrence,
+            view.Occurrences[1].Occurrence);
+        Assert.Same(
+            binding,
+            view.Occurrences[0].Occurrence.RootBinding);
+        Assert.Same(
+            binding,
+            view.Occurrences[1].Occurrence.RootBinding);
+    }
+
+    [Fact]
+    public void PackageOccurrenceView_ActivationResolvesOnlyItsOwnAction()
+    {
+        PackageRootBinding binding =
+            PackageAssemblyContextCompletionTests.SharedBinding(
+                "Activation.View");
+        using var workspace = new InspectionWorkspace();
+        InspectionWorkspacePackageOccurrenceView first =
+            workspace.CreatePackageOccurrenceView([binding]);
+        InspectionWorkspacePackageOccurrenceView second =
+            workspace.CreatePackageOccurrenceView([binding]);
+
+        var activated = Assert.IsType<
+            InspectionWorkspacePackageOccurrenceActivation.Activated>(
+                first.Activate(first.Occurrences[0].Action));
+        var rejected = Assert.IsType<
+            InspectionWorkspacePackageOccurrenceActivation.Rejected>(
+                first.Activate(second.Occurrences[0].Action));
+
+        Assert.Same(first.Occurrences[0].Occurrence, activated.Occurrence);
+        Assert.Equal(
+            InspectionWorkspacePackageOccurrenceActivationRejection
+                .ViewMismatch,
+            rejected.Reason);
+    }
+
+    [Fact]
+    public void PackageOccurrenceView_ActivationRejectsClosedWorkspace()
+    {
+        PackageRootBinding binding =
+            PackageAssemblyContextCompletionTests.SharedBinding(
+                "Closed.View");
+        var workspace = new InspectionWorkspace();
+        InspectionWorkspacePackageOccurrenceView view =
+            workspace.CreatePackageOccurrenceView([binding]);
+
+        workspace.Dispose();
+
+        var rejected = Assert.IsType<
+            InspectionWorkspacePackageOccurrenceActivation.Rejected>(
+                view.Activate(view.Occurrences[0].Action));
+        Assert.Equal(
+            InspectionWorkspacePackageOccurrenceActivationRejection
+                .WorkspaceClosed,
+            rejected.Reason);
+    }
 }

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRealizationTests.cs
@@ -430,8 +430,12 @@ public sealed class PackageAssemblyContextRealizationTests
             PackagePayloadOrigin.Download);
 
         PackageRootBinding binding =
-            PackageRootBinding.CreateFromResolved(payload, "net10.0");
+            PackageRootBinding.CreateFromResolved(
+                payload,
+                "net10.0",
+                "Resolved.Sample");
 
+        Assert.Equal("Resolved.Sample", binding.Root.PackageId);
         Assert.Equal("net11.0", binding.Coordinate.Framework);
         Assert.Equal("linux-x64", binding.Coordinate.RuntimeIdentifier);
         Assert.Equal("net10.0", binding.Root.RequestedTargetFramework);
@@ -449,6 +453,11 @@ public sealed class PackageAssemblyContextRealizationTests
         Assert.Equal(
             "linux-x64",
             binding.Root.RequestedRuntimeIdentifier);
+        Assert.Throws<ArgumentException>(
+            () => PackageRootBinding.CreateFromResolved(
+                payload,
+                "net10.0",
+                "Different.Package"));
     }
 
     [Fact]

--- a/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
@@ -63,7 +63,10 @@ public sealed class WorkspaceContextLoaderTests
                     Framework = Framework,
                     Members = [PackageMember(Version)],
                 },
-                Options(client, store),
+                Options(client, store) with
+                {
+                    IncludePackageRootBindings = true,
+                },
                 TestContext.Current.CancellationToken);
 
         var loaded = Loaded(outcome);
@@ -71,6 +74,17 @@ public sealed class WorkspaceContextLoaderTests
         Assert.Equal(Framework, loaded.Framework);
         Assert.Null(loaded.RuntimeIdentifier);
         Assert.Equal(2, loaded.Group.Participants.Length);
+        PackageRootBinding packageRoot =
+            Assert.Single(loaded.PackageRoots);
+        Assert.Equal(PackageId, packageRoot.Root.PackageId);
+        Assert.Equal(Version, packageRoot.Root.PackageVersion);
+        Assert.Equal(
+            Framework,
+            packageRoot.Root.AssetSelection.TargetFramework);
+        Assert.Equal(
+            Assert.IsType<RealizedMemberCoordinate.Package>(
+                loaded.Members[0].Realized),
+            packageRoot.Coordinate);
         Assert.Equal(
             [
                 Path.GetFileNameWithoutExtension(CallerPath),

--- a/src/DotnetInspector.Queries/InspectionWorkspacePackageOccurrenceView.cs
+++ b/src/DotnetInspector.Queries/InspectionWorkspacePackageOccurrenceView.cs
@@ -1,0 +1,180 @@
+using System.Collections.Immutable;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>
+/// One package occurrence in an ordered Workspace view.
+/// </summary>
+public sealed class InspectionWorkspacePackageOccurrenceDescriptor
+{
+    internal InspectionWorkspacePackageOccurrenceDescriptor(
+        PackageRootOccurrenceBinding occurrence,
+        InspectionWorkspacePackageOccurrenceAction action)
+    {
+        Occurrence = occurrence;
+        Action = action;
+    }
+
+    /// <summary>The exact Workspace-bound package occurrence.</summary>
+    public PackageRootOccurrenceBinding Occurrence { get; }
+
+    /// <summary>An opaque request to activate this exact occurrence.</summary>
+    public InspectionWorkspacePackageOccurrenceAction Action { get; }
+
+    public string PackageId => Occurrence.RootBinding.Root.PackageId;
+
+    public string Version => Occurrence.RootBinding.Root.PackageVersion;
+
+    public string? Framework =>
+        Occurrence.RootBinding.Root.AssetSelection.TargetFramework
+        ?? Occurrence.RootBinding.Root.RequestedTargetFramework
+        ?? Occurrence.RootBinding.Coordinate.Framework;
+}
+
+/// <summary>
+/// Opaque request to activate one exact package occurrence in one exact view.
+/// </summary>
+public sealed class InspectionWorkspacePackageOccurrenceAction
+{
+    internal InspectionWorkspacePackageOccurrenceAction(
+        InspectionWorkspacePackageOccurrenceView view,
+        PackageRootOccurrenceBinding occurrence)
+    {
+        View = view;
+        Occurrence = occurrence;
+    }
+
+    internal InspectionWorkspacePackageOccurrenceView View { get; }
+
+    internal PackageRootOccurrenceBinding Occurrence { get; }
+}
+
+public enum InspectionWorkspacePackageOccurrenceActivationRejection
+{
+    ViewMismatch,
+    WorkspaceClosed,
+}
+
+public abstract record InspectionWorkspacePackageOccurrenceActivation
+{
+    private protected InspectionWorkspacePackageOccurrenceActivation()
+    {
+    }
+
+    public sealed record Activated(
+        PackageRootOccurrenceBinding Occurrence)
+        : InspectionWorkspacePackageOccurrenceActivation;
+
+    public sealed record Rejected(
+        InspectionWorkspacePackageOccurrenceActivationRejection Reason)
+        : InspectionWorkspacePackageOccurrenceActivation;
+}
+
+/// <summary>
+/// Immutable ordered package-occurrence view for one exact Workspace.
+/// </summary>
+public sealed class InspectionWorkspacePackageOccurrenceView
+{
+    readonly InspectionWorkspace _workspace;
+
+    internal InspectionWorkspacePackageOccurrenceView(
+        InspectionWorkspace workspace,
+        ImmutableArray<PackageRootOccurrenceBinding> occurrences)
+    {
+        _workspace = workspace;
+        Workspace = workspace.Identity;
+
+        var descriptors =
+            ImmutableArray.CreateBuilder<
+                InspectionWorkspacePackageOccurrenceDescriptor>(
+                    occurrences.Length);
+        foreach (PackageRootOccurrenceBinding occurrence in occurrences)
+        {
+            var action =
+                new InspectionWorkspacePackageOccurrenceAction(
+                    this,
+                    occurrence);
+            descriptors.Add(
+                new InspectionWorkspacePackageOccurrenceDescriptor(
+                    occurrence,
+                    action));
+        }
+        Occurrences = descriptors.MoveToImmutable();
+    }
+
+    public InspectionWorkspaceIdentity Workspace { get; }
+
+    public ImmutableArray<InspectionWorkspacePackageOccurrenceDescriptor>
+        Occurrences { get; }
+
+    public InspectionWorkspacePackageOccurrenceActivation Activate(
+        InspectionWorkspacePackageOccurrenceAction action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return _workspace.ActivatePackageOccurrence(this, action);
+    }
+}
+
+public sealed partial class InspectionWorkspace
+{
+    /// <summary>
+    /// Issues an immutable ordered view over already-acquired package Roots.
+    /// </summary>
+    public InspectionWorkspacePackageOccurrenceView
+        CreatePackageOccurrenceView(
+            IEnumerable<PackageRootBinding> rootBindings)
+    {
+        ArgumentNullException.ThrowIfNull(rootBindings);
+        ImmutableArray<PackageRootBinding> bindings = [.. rootBindings];
+        if (bindings.Any(static binding => binding is null))
+        {
+            throw new ArgumentException(
+                "A package occurrence view cannot contain a null Root binding.",
+                nameof(rootBindings));
+        }
+
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(
+                _state != InspectionWorkspaceState.Open,
+                this);
+            ImmutableArray<PackageRootOccurrenceBinding> occurrences =
+            [
+                .. bindings.Select(binding =>
+                    new PackageRootOccurrenceBinding(
+                        _identity,
+                        binding)),
+            ];
+            return new InspectionWorkspacePackageOccurrenceView(
+                this,
+                occurrences);
+        }
+    }
+
+    internal InspectionWorkspacePackageOccurrenceActivation
+        ActivatePackageOccurrence(
+            InspectionWorkspacePackageOccurrenceView view,
+            InspectionWorkspacePackageOccurrenceAction action)
+    {
+        lock (_gate)
+        {
+            if (_state != InspectionWorkspaceState.Open)
+            {
+                return new InspectionWorkspacePackageOccurrenceActivation
+                    .Rejected(
+                        InspectionWorkspacePackageOccurrenceActivationRejection
+                            .WorkspaceClosed);
+            }
+            if (!ReferenceEquals(action.View, view))
+            {
+                return new InspectionWorkspacePackageOccurrenceActivation
+                    .Rejected(
+                        InspectionWorkspacePackageOccurrenceActivationRejection
+                            .ViewMismatch);
+            }
+
+            return new InspectionWorkspacePackageOccurrenceActivation
+                .Activated(action.Occurrence);
+        }
+    }
+}

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRealization.cs
@@ -81,7 +81,8 @@ public sealed class PackageRootBinding
     public static PackageRootBinding CreateFromSource(
         AcquiredPackageSourcePayload payload,
         string? selectionTargetFramework = null,
-        string? runtimeIdentifier = null)
+        string? runtimeIdentifier = null,
+        string? displayPackageId = null)
     {
         ArgumentNullException.ThrowIfNull(payload);
         if (runtimeIdentifier is not null
@@ -105,6 +106,7 @@ public sealed class PackageRootBinding
         return Create(
             payload,
             payload.Coordinate.PackageId,
+            displayPackageId ?? payload.Coordinate.PackageId,
             payload.Coordinate.Version,
             payload.Content,
             payload.ProducerKey,
@@ -118,12 +120,14 @@ public sealed class PackageRootBinding
     /// </summary>
     public static PackageRootBinding CreateFromResolved(
         AcquiredPackagePayload payload,
-        string? selectionTargetFramework = null)
+        string? selectionTargetFramework = null,
+        string? displayPackageId = null)
     {
         ArgumentNullException.ThrowIfNull(payload);
         return Create(
             payload,
             payload.Coordinate.PackageId,
+            displayPackageId ?? payload.Coordinate.PackageId,
             payload.Coordinate.Version,
             payload.Content,
             payload.ProducerKey,
@@ -134,7 +138,8 @@ public sealed class PackageRootBinding
 
     static PackageRootBinding Create(
         object acquiredPayload,
-        string packageId,
+        string coordinatePackageId,
+        string displayPackageId,
         string packageVersion,
         IPackageContent content,
         string producerKey,
@@ -142,6 +147,14 @@ public sealed class PackageRootBinding
         string? targetFramework,
         string? runtimeIdentifier)
     {
+        if (!displayPackageId.Equals(
+                coordinatePackageId,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                "A package Root display id must identify the acquired package.",
+                nameof(displayPackageId));
+        }
         if (!content.ProducerKey.Equals(producerKey, StringComparison.Ordinal))
         {
             throw new ArgumentException(
@@ -151,7 +164,7 @@ public sealed class PackageRootBinding
 
         var root = new PackageRootRealization(
             content,
-            packageId,
+            displayPackageId,
             packageVersion,
             targetFramework,
             runtimeIdentifier);
@@ -163,7 +176,7 @@ public sealed class PackageRootBinding
         string? effectiveRuntimeIdentifier =
             runtimeIdentifier;
         if (!RealizedMemberCoordinate.Package.TryCreate(
-                packageId,
+                coordinatePackageId,
                 packageVersion,
                 producerKey,
                 effectiveFramework,

--- a/src/DotnetInspector.Queries/WorkspaceAcquisitionCoordinates.cs
+++ b/src/DotnetInspector.Queries/WorkspaceAcquisitionCoordinates.cs
@@ -880,9 +880,28 @@ public abstract record WorkspaceContextLoadOutcome
                 availablePlatformAssemblies,
             string? framework,
             string? runtimeIdentifier)
+            : this(
+                group,
+                members,
+                [],
+                availablePlatformAssemblies,
+                framework,
+                runtimeIdentifier)
+        {
+        }
+
+        internal Loaded(
+            AssemblyContextGroup group,
+            ImmutableArray<WorkspaceContextMember> members,
+            ImmutableArray<PackageRootBinding> packageRoots,
+            ImmutableArray<RealizedMemberCoordinate.Platform>
+                availablePlatformAssemblies,
+            string? framework,
+            string? runtimeIdentifier)
         {
             Group = group;
             Members = members;
+            PackageRoots = packageRoots;
             AvailablePlatformAssemblies = availablePlatformAssemblies;
             Framework = framework;
             RuntimeIdentifier = runtimeIdentifier;
@@ -895,6 +914,11 @@ public abstract record WorkspaceContextLoadOutcome
         /// contribute several participants.
         /// </summary>
         public ImmutableArray<WorkspaceContextMember> Members { get; }
+
+        /// <summary>
+        /// Acquisition-issued package Roots in context declaration order.
+        /// </summary>
+        public ImmutableArray<PackageRootBinding> PackageRoots { get; }
 
         /// <summary>
         /// Metadata-derived assembly selection coordinates observed in the

--- a/src/DotnetInspector.Queries/WorkspaceContextLoader.cs
+++ b/src/DotnetInspector.Queries/WorkspaceContextLoader.cs
@@ -77,6 +77,16 @@ public sealed record WorkspaceContextLoadOptions
     public bool UseVersionCache { get; init; }
 
     /// <summary>
+    /// Whether package realizations should also issue package Root bindings.
+    /// </summary>
+    /// <remarks>
+    /// This remains opt-in because creating a Root binding freezes a separate
+    /// compile-asset selection needed by Workspace occurrence consumers.
+    /// Ordinary assembly-context loads do not pay for that projection.
+    /// </remarks>
+    public bool IncludePackageRootBindings { get; init; }
+
+    /// <summary>
     /// The bounds a downloaded package payload must respect before it may be
     /// published into <see cref="PackageStore"/>.
     /// </summary>
@@ -262,7 +272,8 @@ public static class WorkspaceContextLoader
                     new RealizedMember(
                         member,
                         realization.Realized!,
-                        assembly));
+                        assembly,
+                        realization.PackageRoot));
             }
         }
 
@@ -429,7 +440,8 @@ public static class WorkspaceContextLoader
                     new RealizedMember(
                         declared,
                         realization.Realized!,
-                        assembly));
+                        assembly,
+                        realization.PackageRoot));
             }
         }
 
@@ -994,9 +1006,17 @@ public static class WorkspaceContextLoader
                     participants[index]));
         }
 
+        ImmutableArray<PackageRootBinding> packageRoots =
+        [
+            .. realized
+                .Select(static entry => entry.PackageRoot)
+                .OfType<PackageRootBinding>()
+                .Distinct(),
+        ];
         return new WorkspaceContextLoadOutcome.Loaded(
             group,
             members.MoveToImmutable(),
+            packageRoots,
             [
                 .. availablePlatformAssemblies
                     .OrderBy(assembly => assembly.Family, StringComparer.Ordinal)
@@ -1902,6 +1922,7 @@ public static class WorkspaceContextLoader
             acquired,
             framework,
             runtimeIdentifier,
+            options.IncludePackageRootBindings,
             cancellationToken);
     }
 
@@ -2024,12 +2045,16 @@ public static class WorkspaceContextLoader
             acquired,
             framework,
             pinned.RuntimeIdentifier,
+            options.IncludePackageRootBindings,
             cancellationToken);
 
         // A re-acquired member reports the coordinate it was asked for, so a
         // caller can compare the round trip by value.
         return realization.Failure is null
-            ? new MemberRealization(pinned, realization.Assemblies)
+            ? new MemberRealization(
+                pinned,
+                realization.Assemblies,
+                realization.PackageRoot)
             : realization;
     }
 
@@ -2038,6 +2063,7 @@ public static class WorkspaceContextLoader
         AcquiredPackagePayload acquired,
         string framework,
         string? runtimeIdentifier,
+        bool includePackageRootBinding,
         CancellationToken cancellationToken)
     {
         ResolvedPackageCoordinate coordinate = acquired.Coordinate;
@@ -2150,9 +2176,44 @@ public static class WorkspaceContextLoader
                     $"The acquired package could not be named by a canonical realized coordinate: {problem}."));
         }
 
+        PackageRootBinding? packageRoot = null;
+        if (includePackageRootBinding)
+        {
+            try
+            {
+                packageRoot = PackageRootBinding.CreateFromResolved(
+                    acquired,
+                    framework,
+                    ((WorkspaceMemberCoordinate.PackageMember)member)
+                        .PackageId);
+            }
+            catch (Exception ex) when (
+                ex is ArgumentException
+                    or IOException
+                    or InvalidOperationException
+                    or NotSupportedException
+                    or ObjectDisposedException)
+            {
+                return new MemberRealization(
+                    Failure(
+                        WorkspaceContextLoadFailureKind.InvalidCoordinate,
+                        member,
+                        $"The package Root for '{coordinate.PackageId}' could not be bound to its acquired content."));
+            }
+            if (packageRoot.Coordinate != realizedCoordinate)
+            {
+                return new MemberRealization(
+                    Failure(
+                        WorkspaceContextLoadFailureKind.InvalidCoordinate,
+                        member,
+                        $"The package Root for '{coordinate.PackageId}' disagrees with the context's realized coordinate."));
+            }
+        }
+
         return new MemberRealization(
             realizedCoordinate,
-            assemblies.ToImmutable());
+            assemblies.ToImmutable(),
+            packageRoot);
     }
 
     static MemberRealization RealizeEmbedded(
@@ -2355,8 +2416,9 @@ public static class WorkspaceContextLoader
     {
         internal MemberRealization(
             RealizedMemberCoordinate realized,
-            ImmutableArray<ResolvedAssemblyReference> assemblies)
-            : this(realized, assemblies, [])
+            ImmutableArray<ResolvedAssemblyReference> assemblies,
+            PackageRootBinding? packageRoot = null)
+            : this(realized, assemblies, [], packageRoot)
         {
         }
 
@@ -2364,11 +2426,13 @@ public static class WorkspaceContextLoader
             RealizedMemberCoordinate realized,
             ImmutableArray<ResolvedAssemblyReference> assemblies,
             ImmutableArray<RealizedMemberCoordinate.Platform>
-                availablePlatformAssemblies)
+                availablePlatformAssemblies,
+            PackageRootBinding? packageRoot = null)
         {
             Realized = realized;
             Assemblies = assemblies;
             AvailablePlatformAssemblies = availablePlatformAssemblies;
+            PackageRoot = packageRoot;
             Failure = null;
         }
 
@@ -2377,6 +2441,7 @@ public static class WorkspaceContextLoader
             Realized = null;
             Assemblies = [];
             AvailablePlatformAssemblies = [];
+            PackageRoot = null;
             Failure = failure;
         }
 
@@ -2384,11 +2449,13 @@ public static class WorkspaceContextLoader
         internal ImmutableArray<ResolvedAssemblyReference> Assemblies { get; }
         internal ImmutableArray<RealizedMemberCoordinate.Platform>
             AvailablePlatformAssemblies { get; }
+        internal PackageRootBinding? PackageRoot { get; }
         internal WorkspaceContextLoadFailure? Failure { get; }
     }
 
     readonly record struct RealizedMember(
         WorkspaceMemberCoordinate Declared,
         RealizedMemberCoordinate Realized,
-        ResolvedAssemblyReference Assembly);
+        ResolvedAssemblyReference Assembly,
+        PackageRootBinding? PackageRoot = null);
 }

--- a/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCompileAssetSelectorTests.cs
@@ -306,6 +306,28 @@ public class PackageCompileAssetSelectorTests : IDisposable
     }
 
     [Fact]
+    public void EmptyReferenceGroup_AtRequestedFramework_SuppressesCompatibleLibraryFallback()
+    {
+        IPackageContent content = InMemory(
+            "ref/net10.0/_._",
+            "lib/net8.0/Example.dll");
+
+        PackageCompileAssetSelection selection =
+            PackageCompileAssetSelector.Select(content, "Example", "net10.0");
+
+        Assert.False(selection.IsSelected);
+        Assert.Equal(
+            PackageCompileAssetSelectionStatus.EmptyCompileGroup,
+            selection.Status);
+        Assert.Equal("net10.0", selection.TargetFramework);
+        Assert.Empty(selection.Assets);
+        Assert.Null(selection.DefaultAsset);
+        Assert.Equal(
+            ["lib/net8.0/Example.dll"],
+            selection.CandidateAssets.Select(asset => asset.Path));
+    }
+
+    [Fact]
     public void EmptyReferenceGroup_NearestCompatibleGroupSuppressesLibraryFallback()
     {
         IPackageContent content = InMemory(

--- a/src/NuGetFetch.Tests/LegacyPackageSourceIdentityMigrationTests.cs
+++ b/src/NuGetFetch.Tests/LegacyPackageSourceIdentityMigrationTests.cs
@@ -60,7 +60,7 @@ public sealed class LegacyPackageSourceIdentityMigrationTests
             new(
                 "#4805",
                 "prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs",
-                ExplicitReferences: 19,
+                ExplicitReferences: 20,
                 ImplicitReferences: 0),
         ];
 

--- a/src/NuGetFetch.Tests/LegacyPackageSourceIdentityMigrationTests.cs
+++ b/src/NuGetFetch.Tests/LegacyPackageSourceIdentityMigrationTests.cs
@@ -60,7 +60,7 @@ public sealed class LegacyPackageSourceIdentityMigrationTests
             new(
                 "#4805",
                 "prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs",
-                ExplicitReferences: 17,
+                ExplicitReferences: 19,
                 ImplicitReferences: 0),
         ];
 

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -167,9 +167,55 @@ public sealed class WorkspaceCommandTests
         Assert.Equal(1, captured.ExitCode);
         Assert.Empty(captured.Output);
         Assert.Contains(
-            "requires each package to select at least one managed compile assembly",
+            "does not support packages with an explicit empty compile group",
             captured.Error);
         Assert.Contains("EmptyCompileGroup", captured.Error);
+    }
+
+    [Fact]
+    public async Task CompatibleCompileGroup_RendersTheRequestedFramework()
+    {
+        const string assetFramework = "net8.0";
+        var store = new InMemoryPackageStore();
+        string sourceKey = NuGetCache.GetSourceKey(Source.Url);
+        byte[] assembly =
+            await File.ReadAllBytesAsync(
+                typeof(WorkspaceCommandTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{PackageId}.nuspec", "<package />"u8.ToArray()),
+            ($"lib/{assetFramework}/dotnet-inspect.Tests.dll", assembly));
+        using (var stream = new MemoryStream(package))
+        {
+            await store.CommitAsync(
+                PackageId,
+                Version,
+                sourceKey,
+                stream,
+                TestContext.Current.CancellationToken);
+        }
+
+        using var client = new HttpClient(new FailingHandler());
+        var captured = await ConsoleCapture.RunAsync(
+            () => WorkspaceCommand.ExecuteAsync(
+                new WorkspaceOptions
+                {
+                    Packages = [$"{PackageId}@{Version}"],
+                    Tfm = Framework,
+                },
+                new WorkspaceContextLoadOptions
+                {
+                    HttpClient = client,
+                    SourceAuthorization =
+                        new UniformPackageSourceAuthorization([Source]),
+                    PackageStore = store,
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, captured.ExitCode);
+        Assert.Contains(PackageId, captured.Output);
+        Assert.Contains(Framework, captured.Output);
+        Assert.Empty(captured.Error);
     }
 
     sealed class FailingHandler : HttpMessageHandler

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -124,6 +124,54 @@ public sealed class WorkspaceCommandTests
         Assert.Empty(captured.Error);
     }
 
+    [Fact]
+    public async Task EmptyCompileGroup_IsReportedAsUnsupported()
+    {
+        var store = new InMemoryPackageStore();
+        string sourceKey = NuGetCache.GetSourceKey(Source.Url);
+        byte[] assembly =
+            await File.ReadAllBytesAsync(
+                typeof(WorkspaceCommandTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{PackageId}.nuspec", "<package />"u8.ToArray()),
+            ($"ref/{Framework}/_._", []),
+            ($"lib/{Framework}/dotnet-inspect.Tests.dll", assembly));
+        using (var stream = new MemoryStream(package))
+        {
+            await store.CommitAsync(
+                PackageId,
+                Version,
+                sourceKey,
+                stream,
+                TestContext.Current.CancellationToken);
+        }
+
+        using var client = new HttpClient(new FailingHandler());
+        var captured = await ConsoleCapture.RunAsync(
+            () => WorkspaceCommand.ExecuteAsync(
+                new WorkspaceOptions
+                {
+                    Packages = [$"{PackageId}@{Version}"],
+                    Tfm = Framework,
+                },
+                new WorkspaceContextLoadOptions
+                {
+                    HttpClient = client,
+                    SourceAuthorization =
+                        new UniformPackageSourceAuthorization([Source]),
+                    PackageStore = store,
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(1, captured.ExitCode);
+        Assert.Empty(captured.Output);
+        Assert.Contains(
+            "requires each package to select at least one managed compile assembly",
+            captured.Error);
+        Assert.Contains("EmptyCompileGroup", captured.Error);
+    }
+
     sealed class FailingHandler : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -1,0 +1,138 @@
+using System.Net;
+
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Packages;
+using DotnetInspector.Queries;
+using DotnetInspector.Services;
+using ILInspector.Metadata;
+using NuGetFetch;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public sealed class WorkspaceCommandTests
+{
+    const string PackageId = "Workspace.Command.Fixture";
+    const string Version = "1.0.0";
+    const string Framework = "net10.0";
+
+    static readonly PackageSource Source =
+        new("fixture", "https://fixture.invalid/v3/index.json");
+
+    [Fact]
+    public void WorkspaceCommand_IsReservedFromImplicitPackageRouting()
+    {
+        string[] arguments =
+            CommandLineBuilder.PreprocessArgs(["workspace", "--help"]);
+
+        Assert.Equal("workspace", arguments[0]);
+        Assert.Contains("workspace", CommandLineBuilder.KnownCommands);
+    }
+
+    [Fact]
+    public void WorkspaceCommand_RegistersSharedOutputOptions()
+    {
+        string[] arguments =
+            ["workspace", "--json", "--rows", "1", "--verbose"];
+
+        var result = CommandLineBuilder.CreateRootCommand().Parse(arguments);
+
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task EmptyWorkspace_RendersTheTypedEmptyInventory()
+    {
+        using var client = new HttpClient(new FailingHandler());
+        var captured = await ConsoleCapture.RunAsync(
+            () => WorkspaceCommand.ExecuteAsync(
+                new WorkspaceOptions(),
+                new WorkspaceContextLoadOptions
+                {
+                    HttpClient = client,
+                    SourceAuthorization =
+                        new UniformPackageSourceAuthorization([Source]),
+                    PackageStore = new InMemoryPackageStore(),
+                }));
+
+        Assert.Equal(0, captured.ExitCode);
+        Assert.Equal(
+            """
+            # Workspace
+
+            No package occurrences.
+
+            """,
+            captured.Output);
+        Assert.Empty(captured.Error);
+    }
+
+    [Fact]
+    public async Task PopulatedWorkspace_RendersProductOccurrenceOrder()
+    {
+        var store = new InMemoryPackageStore();
+        string sourceKey = NuGetCache.GetSourceKey(Source.Url);
+        byte[] assembly =
+            await File.ReadAllBytesAsync(
+                typeof(WorkspaceCommandTests).Assembly.Location,
+                TestContext.Current.CancellationToken);
+        byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
+            ($"{PackageId}.nuspec", "<package />"u8.ToArray()),
+            ($"lib/{Framework}/dotnet-inspect.Tests.dll", assembly));
+        using (var stream = new MemoryStream(package))
+        {
+            await store.CommitAsync(
+                PackageId,
+                Version,
+                sourceKey,
+                stream,
+                TestContext.Current.CancellationToken);
+        }
+
+        using var client = new HttpClient(new FailingHandler());
+        var captured = await ConsoleCapture.RunAsync(
+            () => WorkspaceCommand.ExecuteAsync(
+                new WorkspaceOptions
+                {
+                    Packages =
+                    [
+                        $"{PackageId}@{Version}",
+                        $"{PackageId}@{Version}",
+                    ],
+                    Tfm = Framework,
+                },
+                new WorkspaceContextLoadOptions
+                {
+                    HttpClient = client,
+                    SourceAuthorization =
+                        new UniformPackageSourceAuthorization([Source]),
+                    PackageStore = store,
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, captured.ExitCode);
+        Assert.Contains("# Workspace", captured.Output);
+        Assert.Contains(PackageId, captured.Output);
+        Assert.Contains(Version, captured.Output);
+        Assert.Contains(Framework, captured.Output);
+        Assert.Equal(
+            2,
+            captured.Output.Split(
+                PackageId,
+                StringSplitOptions.None).Length - 1);
+        Assert.Empty(captured.Error);
+    }
+
+    sealed class FailingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.NotFound)
+                {
+                    RequestMessage = request,
+                });
+    }
+}

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -125,8 +125,9 @@ public sealed class WorkspaceCommandTests
     }
 
     [Fact]
-    public async Task EmptyCompileGroup_IsReportedAsUnsupported()
+    public async Task EmptyCompileGroup_WithCompatibleLibrary_IsReportedAsUnsupported()
     {
+        const string assetFramework = "net8.0";
         var store = new InMemoryPackageStore();
         string sourceKey = NuGetCache.GetSourceKey(Source.Url);
         byte[] assembly =
@@ -136,7 +137,7 @@ public sealed class WorkspaceCommandTests
         byte[] package = SnupkgPdbReaderTests.MakeSnupkg(
             ($"{PackageId}.nuspec", "<package />"u8.ToArray()),
             ($"ref/{Framework}/_._", []),
-            ($"lib/{Framework}/dotnet-inspect.Tests.dll", assembly));
+            ($"lib/{assetFramework}/dotnet-inspect.Tests.dll", assembly));
         using (var stream = new MemoryStream(package))
         {
             await store.CommitAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/WorkspaceCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/WorkspaceCommandDefinitions.cs
@@ -1,0 +1,81 @@
+using System.CommandLine;
+
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.CommandLine;
+
+public static class WorkspaceCommandDefinitions
+{
+    public static Command CreateWorkspaceCommand(SharedOptions opts)
+    {
+        var command = new Command(
+            WorkspaceCommand.Name,
+            "Show the ordered package occurrences in an inspection Workspace");
+        var packageOption = new Option<string[]>("--package")
+        {
+            Description =
+                "Package in the Workspace (name or name@version). Repeat for each package.",
+            AllowMultipleArgumentsPerToken = false,
+        };
+        var tfmOption = new Option<string?>("--tfm")
+        {
+            Description =
+                "Shared target framework for the package set (for example net10.0)",
+        };
+        var prereleaseOption = new Option<bool>("--preview")
+        {
+            Description =
+                "Allow prerelease versions when an unversioned package floats",
+        };
+        prereleaseOption.Aliases.Add("--prerelease");
+
+        command.Options.Add(packageOption);
+        command.Options.Add(tfmOption);
+        command.Options.Add(prereleaseOption);
+        command.Options.Add(opts.Markdown);
+        command.Options.Add(opts.PlainText);
+        command.Options.Add(opts.Json);
+        opts.AddTableOptionsTo(command);
+        opts.AddOutputOptionsTo(command);
+        opts.AddCountOptionTo(command);
+        opts.AddNuGetOptionsTo(command);
+
+        command.SetAction(async (parseResult, cancellationToken) =>
+        {
+            string[] packages =
+                parseResult.GetValue(packageOption) ?? [];
+            string? tfm = parseResult.GetValue(tfmOption);
+            if (packages.Length > 0
+                && string.IsNullOrWhiteSpace(tfm))
+            {
+                CommandError.Write(
+                    "A shared --tfm is required when the Workspace contains packages.");
+                CommandError.WriteLine(
+                    "Run 'dotnet-inspect workspace --help' for usage.");
+                return 1;
+            }
+
+            return await WorkspaceCommand.ExecuteAsync(
+                new WorkspaceOptions
+                {
+                    Packages = packages,
+                    Tfm = tfm,
+                    IncludePrerelease =
+                        parseResult.GetValue(prereleaseOption),
+                    Format = opts.ResolveFormat(parseResult),
+                    Count = parseResult.GetValue(opts.Count),
+                    Rows = opts.ParseRows(parseResult),
+                    NoHeader = parseResult.GetValue(opts.NoHeaders),
+                    Verbose = parseResult.GetValue(opts.Verbose),
+                    SourceOptions =
+                        opts.ParseNuGetSourceOptions(parseResult),
+                },
+                cancellationToken);
+        });
+
+        return command;
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -106,7 +106,7 @@ public static class ArgumentPreprocessor
     public static readonly HashSet<string> KnownCommands = new(StringComparer.OrdinalIgnoreCase)
     {
         "audit", // removed command, reserved so it is not treated as an implicit package target
-        "package", "project", "library", "api", "type", "member", "diff", "timeline", "graph", "find", "vocabulary", "source", "list", "ls", "skill", "demo", "extensions", "implements", "match", "depends", "cache", "workspace-state", "help", "--help", "-h", "-?", "--version", "--flavor"
+        "package", "project", "library", "api", "type", "member", "diff", "timeline", "graph", "find", "vocabulary", "source", "list", "ls", "skill", "demo", "extensions", "implements", "match", "depends", "cache", "workspace", "workspace-state", "help", "--help", "-h", "-?", "--version", "--flavor"
     };
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLineBuilder.cs
+++ b/src/dotnet-inspect/CommandLineBuilder.cs
@@ -402,6 +402,10 @@ public static class CommandLineBuilder
         rootCommand.Subcommands.Add(
             UtilityCommandDefinitions.CreateWorkspaceStateCommand());
 
+        // Product-owned runtime Workspace inventory
+        rootCommand.Subcommands.Add(
+            WorkspaceCommandDefinitions.CreateWorkspaceCommand(opts));
+
         // Router command (hidden, implicit default for bare names)
         rootCommand.Subcommands.Add(RouterCommandDefinition.Create(rootCommand, opts));
 

--- a/src/dotnet-inspect/Commands/InspectionGraphCommand.cs
+++ b/src/dotnet-inspect/Commands/InspectionGraphCommand.cs
@@ -117,7 +117,7 @@ public static class InspectionGraphCommand
                 : null,
         };
 
-    static bool TryCreateMembers(
+    internal static bool TryCreateMembers(
         IReadOnlyList<string> packageSpecs,
         out WorkspaceMemberCoordinate[] members)
     {

--- a/src/dotnet-inspect/Commands/WorkspaceCommand.cs
+++ b/src/dotnet-inspect/Commands/WorkspaceCommand.cs
@@ -76,10 +76,11 @@ public static class WorkspaceCommand
                 var loaded = (WorkspaceContextLoadOutcome.Loaded)outcome;
                 PackageRootBinding packageRoot =
                     loaded.PackageRoots.Single();
-                if (!packageRoot.Root.AssetSelection.IsSelected)
+                if (packageRoot.Root.AssetSelection.Status
+                    == PackageCompileAssetSelectionStatus.EmptyCompileGroup)
                 {
                     CommandError.Write(
-                        "The Workspace command requires each package to select at least one managed compile assembly.",
+                        "The Workspace command does not support packages with an explicit empty compile group for the target framework.",
                         [
                             $"{packageRoot.Root.PackageId}@{packageRoot.Root.PackageVersion}: "
                             + packageRoot.Root.AssetSelection.Status,

--- a/src/dotnet-inspect/Commands/WorkspaceCommand.cs
+++ b/src/dotnet-inspect/Commands/WorkspaceCommand.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+using DotnetInspector.Queries;
+using DotnetInspector.Views;
+using Markout;
+
+namespace DotnetInspector.Commands;
+
+public static class WorkspaceCommand
+{
+    public const string Name = "workspace";
+
+    public static Task<int> ExecuteAsync(
+        WorkspaceOptions options,
+        CancellationToken cancellationToken = default) =>
+        ExecuteAsync(
+            options,
+            CreateLoadOptions(options),
+            cancellationToken);
+
+    internal static async Task<int> ExecuteAsync(
+        WorkspaceOptions options,
+        WorkspaceContextLoadOptions loadOptions,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(loadOptions);
+        loadOptions = loadOptions with
+        {
+            IncludePackageRootBindings = true,
+        };
+
+        using var workspace = new InspectionWorkspace();
+        InspectionWorkspacePackageOccurrenceView occurrenceView;
+        if (options.Packages.Length == 0)
+        {
+            occurrenceView = workspace.CreatePackageOccurrenceView([]);
+        }
+        else
+        {
+            if (!InspectionGraphCommand.TryCreateMembers(
+                    options.Packages,
+                    out WorkspaceMemberCoordinate[] members))
+            {
+                return 1;
+            }
+            var packageRoots =
+                new List<PackageRootBinding>(members.Length);
+            foreach (WorkspaceMemberCoordinate member in members)
+            {
+                WorkspaceContextLoadOutcome outcome =
+                    await WorkspaceContextLoader.LoadAsync(
+                        workspace,
+                        new WorkspaceContextInput
+                        {
+                            Framework = options.Tfm,
+                            Members = [member],
+                        },
+                        loadOptions,
+                        cancellationToken).ConfigureAwait(false);
+                if (outcome is WorkspaceContextLoadOutcome.Failed failed)
+                {
+                    CommandError.Write(
+                        "The Workspace package inventory could not be loaded.",
+                        [
+                            .. failed.Failures.Select(static failure =>
+                                $"{failure.Kind}: {failure.Message}"),
+                        ]);
+                    return 1;
+                }
+
+                var loaded = (WorkspaceContextLoadOutcome.Loaded)outcome;
+                packageRoots.Add(
+                    loaded.PackageRoots.Single());
+            }
+
+            occurrenceView =
+                workspace.CreatePackageOccurrenceView(
+                    packageRoots);
+        }
+
+        Write(occurrenceView, options);
+        return 0;
+    }
+
+    internal static void Write(
+        InspectionWorkspacePackageOccurrenceView occurrenceView,
+        WorkspaceOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(occurrenceView);
+        ArgumentNullException.ThrowIfNull(options);
+
+        IReadOnlyList<
+            InspectionWorkspacePackageOccurrenceDescriptor> occurrences =
+            RowWindow.Apply(
+                options.Rows,
+                occurrenceView.Occurrences);
+        if (options.Count)
+        {
+            CountOutput.WriteCount(occurrences.Count);
+            return;
+        }
+
+        var view = new WorkspacePackageOccurrenceView
+        {
+            Packages =
+            [
+                .. occurrences.Select(static occurrence =>
+                    new WorkspacePackageOccurrenceRow(
+                        occurrence.PackageId,
+                        occurrence.Version,
+                        occurrence.Framework ?? "")),
+            ],
+        };
+        switch (options.Format)
+        {
+            case OutputFormat.Json:
+                Console.WriteLine(
+                    JsonSerializer.Serialize(
+                        view.Packages.ToArray(),
+                        WorkspaceCommandJsonContext.Default
+                            .WorkspacePackageOccurrenceRowArray));
+                break;
+            case OutputFormat.Table:
+            case OutputFormat.Tsv:
+            case OutputFormat.Jsonl:
+                MarkoutSerializer.Serialize(
+                    view,
+                    Console.Out,
+                    new TableFormatter(!options.NoHeader),
+                    WorkspaceViewContext.Default,
+                    OutputFormatter.CreateTableWriterOptions(
+                        tsv: options.Format == OutputFormat.Tsv,
+                        jsonl: options.Format == OutputFormat.Jsonl));
+                break;
+            case OutputFormat.PlainText:
+                MarkoutSerializer.Serialize(
+                    view,
+                    Console.Out,
+                    new PlainTextFormatter(),
+                    WorkspaceViewContext.Default);
+                break;
+            default:
+                MarkoutSerializer.Serialize(
+                    view,
+                    Console.Out,
+                    WorkspaceViewContext.Default);
+                break;
+        }
+    }
+
+    static WorkspaceContextLoadOptions CreateLoadOptions(
+        WorkspaceOptions options) =>
+        new()
+        {
+            HttpClient = HttpClientFactory.Shared,
+            SourceAuthorization =
+                new SourcePolicyPackageSourceAuthorization(
+                    options.SourceOptions),
+            PackageStore = new FileSystemPackageStore(),
+            IncludePrerelease = options.IncludePrerelease,
+            UseVersionCache = true,
+            Log = options.Verbose
+                ? CommandError.WriteLine
+                : null,
+            IncludePackageRootBindings = true,
+        };
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(WorkspacePackageOccurrenceRow[]))]
+internal partial class WorkspaceCommandJsonContext : JsonSerializerContext;

--- a/src/dotnet-inspect/Commands/WorkspaceCommand.cs
+++ b/src/dotnet-inspect/Commands/WorkspaceCommand.cs
@@ -74,8 +74,20 @@ public static class WorkspaceCommand
                 }
 
                 var loaded = (WorkspaceContextLoadOutcome.Loaded)outcome;
-                packageRoots.Add(
-                    loaded.PackageRoots.Single());
+                PackageRootBinding packageRoot =
+                    loaded.PackageRoots.Single();
+                if (!packageRoot.Root.AssetSelection.IsSelected)
+                {
+                    CommandError.Write(
+                        "The Workspace command requires each package to select at least one managed compile assembly.",
+                        [
+                            $"{packageRoot.Root.PackageId}@{packageRoot.Root.PackageVersion}: "
+                            + packageRoot.Root.AssetSelection.Status,
+                        ]);
+                    return 1;
+                }
+
+                packageRoots.Add(packageRoot);
             }
 
             occurrenceView =

--- a/src/dotnet-inspect/Options/WorkspaceOptions.cs
+++ b/src/dotnet-inspect/Options/WorkspaceOptions.cs
@@ -1,0 +1,18 @@
+using DotnetInspector.Output;
+using DotnetInspector.Packages;
+
+namespace DotnetInspector.Options;
+
+public sealed record WorkspaceOptions
+{
+    public string[] Packages { get; init; } = [];
+    public string? Tfm { get; init; }
+    public bool IncludePrerelease { get; init; }
+    public OutputFormat Format { get; init; } = OutputFormat.Markdown;
+    public bool Count { get; init; }
+    public RowWindow? Rows { get; init; }
+    public bool NoHeader { get; init; }
+    public bool Verbose { get; init; }
+    public NuGetSourceOptions SourceOptions { get; init; } =
+        NuGetSourceOptions.Default;
+}

--- a/src/dotnet-inspect/Views/WorkspaceViews.cs
+++ b/src/dotnet-inspect/Views/WorkspaceViews.cs
@@ -1,0 +1,44 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    DescriptionProperty = nameof(Description))]
+public sealed class WorkspacePackageOccurrenceView
+{
+    [MarkoutIgnore]
+    public string Title => "Workspace";
+
+    [MarkoutIgnore]
+    public string? Description =>
+        Packages.Count == 0
+            ? "No package occurrences."
+            : null;
+
+    [MarkoutSection(Headless = true)]
+    public List<WorkspacePackageOccurrenceRow> Packages { get; init; } = [];
+}
+
+[MarkoutSerializable]
+public sealed record WorkspacePackageOccurrenceRow
+{
+    public WorkspacePackageOccurrenceRow(
+        string package,
+        string version,
+        string framework)
+    {
+        Package = LibraryViewText.Contain(package) ?? "";
+        Version = LibraryViewText.Contain(version) ?? "";
+        Framework = LibraryViewText.Contain(framework) ?? "";
+    }
+
+    public string Package { get; }
+
+    public string Version { get; }
+
+    public string Framework { get; }
+}
+
+[MarkoutContext(typeof(WorkspacePackageOccurrenceView))]
+public partial class WorkspaceViewContext : MarkoutSerializerContext;


### PR DESCRIPTION
This builds the first robust, host-neutral Workspace experience: product code
owns exact package-occurrence identity and ordering, while both Inspect Web and
the CLI consume that contract without reconstructing identity from display
text, row position, or cache keys.

## Demo

Load an exact package coordinate into Inspect Web, then choose **Workspace**:

![Inspect Web Default Workspace showing System.Text.Json](https://github.com/user-attachments/assets/622633e2-e174-4caf-81ce-43bfe2b771af)

What to notice:

- **Default Workspace** is always available as a real Workspace, not a demo
  packet.
- The content pane shows the package ID, version, and selected framework.
- Selecting the Workspace is observational; selecting a package occurrence
  activates an opaque product-issued action.

The CLI consumes the same ordered product view:

```console
$ dotnet-inspect workspace --package System.Text.Json@10.0.0 --tfm net10.0
# Workspace

| Package | Version | Framework |
| ------- | ------- | --------- |
| System.Text.Json | 10.0.0 | net10.0 |
```

Repeating `--package` preserves repeated occurrences and input order rather
than collapsing coordinates.

## Design basis

**Normative owner:** `docs/design/artifact-acquisition-and-workspaces.md`,
Runtime identity and lifecycle. It owns the claim that a live
`InspectionWorkspace` issues exact, process-local package occurrences over
acquisition-issued `PackageRootBinding` values.

The landed acquisition coordinates and Root bindings supply package
correspondence. `docs/design/inspection-subject-navigation.md` records this
view as a prerequisite for later Navigation adoption. Inspect Web is one thin
consumer with opaque transport tokens; the CLI is the second consumer and
lowers the same descriptors through Markout.

## What changed

- Added an immutable ordered package-occurrence view with view-scoped opaque
  activation and typed rejection for foreign or closed Workspaces.
- Preserved acquisition-issued Root identity, repeated occurrences, input
  order, display package casing, and selected-framework facts.
- Added `dotnet-inspect workspace` with Markdown, plain text, table, TSV,
  JSONL, JSON, count, and row-window output.
- Replaced demo packet presentation in Inspect Web with one visible Default
  Workspace whose package rows activate exact opaque occurrences.
- Kept inventory lightweight: it does not open composite inspection scopes,
  and hidden or superseded views revoke actions and package-cache leases.

## Scope

This slice intentionally does not define retained membership mutation,
multiple-Workspace creation, removal/successor semantics, persistence, or
complete Navigation state. The first CLI adapter also requires a selected
managed assembly; root-only, analyzer-only, and tools-only packages remain
unsupported until a consumer requires that acquisition shape.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release --no-build`
  — 1,177 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- --filter-class '*WorkspaceCommandTests'`
  — 6 passed
- Full CLI suite — 5,268 passed, 21 skipped; one endpoint-failover timing
  assertion failed during the 29-minute run and passed immediately in isolation
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release`
  — 216 passed
- `npm test` — 984 passed
- `npm run analyze`
- `npm run build`
- Firefox `workspace-titlebar.spec.ts --grep Workspace` — 35 passed
- generated Inspect Web facade check
- `markdownlint` on changed Markdown

Part of #5634.
