### PR TITLE
Render exact memory-safety marker states in Library Signals

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
 
 using Microsoft.CodeAnalysis;
@@ -103,7 +104,48 @@ public class CompilerFeatureOptionsTests
             feature => feature.Key == "updated-memory-safety-rules");
     }
 
-    static byte[] BuildMarkedModule(int? version)
+    public static TheoryData<string, byte[]> ReplayModeImages() => new()
+    {
+        { "unmarked", BuildMarkedModule(null) },
+        { "v2 MethodDef ctor", BuildMarkedModule(2) },
+        { "v3 MethodDef ctor", BuildMarkedModule(3) },
+        { "v99 MethodDef ctor", BuildMarkedModule(99) },
+        // ECMA-335 lets a MemberRef name a member of a same-module TypeDef, a
+        // spelling the printer's constructor decode does not recognize. Reading
+        // the marker through any other decoder diverges here.
+        { "v2 MemberRef->TypeDef ctor", BuildMarkedModule(2, memberRefConstructor: true) },
+        // A truncated fixed-arg blob leaves the marker present but its version
+        // undecodable, which version-decoding readers report as absent.
+        { "malformed marker blob", BuildMarkedModule(2, malformedValue: true) },
+    };
+
+    /// <summary>
+    /// The harness must recompile under the exact mode the printer used. This
+    /// pins the two predicates together over marker spellings where an
+    /// independent reader is known to disagree with the printer, so the harness
+    /// cannot silently drift back to deriving the mode on its own.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(ReplayModeImages))]
+    public void HarnessReplayMatchesPrinterMode(string label, byte[] image)
+    {
+        using var pe = new PEReader(new MemoryStream(image));
+        bool printerUsesUpdatedRules =
+            IrImporter.ModuleUsesUpdatedMemorySafetyRules(pe.GetMetadataReader());
+        bool harnessReplaysUpdatedRules = CompilerFeatureOptions.ParseOptions(pe).Features
+            .Any(feature => feature.Key == "updated-memory-safety-rules"
+                && feature.Value == "true");
+
+        Assert.True(
+            printerUsesUpdatedRules == harnessReplaysUpdatedRules,
+            $"{label}: printer replayed updated rules = {printerUsesUpdatedRules}, "
+                + $"harness replayed updated rules = {harnessReplaysUpdatedRules}");
+    }
+
+    static byte[] BuildMarkedModule(
+        int? version,
+        bool memberRefConstructor = false,
+        bool malformedValue = false)
     {
         var metadata = new MetadataBuilder();
         ModuleDefinitionHandle module = metadata.AddModule(
@@ -127,6 +169,8 @@ public class CompilerFeatureOptionsTests
                 1,
                 returnType => returnType.Void(),
                 parameters => parameters.AddParameter().Type().Int32());
+        BlobHandle constructorSignatureHandle =
+            metadata.GetOrAddBlob(constructorSignature);
 
         MethodDefinitionHandle constructor = metadata.AddMethodDefinition(
             System.Reflection.MethodAttributes.Public
@@ -134,7 +178,7 @@ public class CompilerFeatureOptionsTests
                 | System.Reflection.MethodAttributes.RTSpecialName,
             System.Reflection.MethodImplAttributes.Runtime,
             metadata.GetOrAddString(".ctor"),
-            metadata.GetOrAddBlob(constructorSignature),
+            constructorSignatureHandle,
             bodyOffset: -1,
             MetadataTokens.ParameterHandle(1));
 
@@ -145,7 +189,7 @@ public class CompilerFeatureOptionsTests
             default,
             MetadataTokens.FieldDefinitionHandle(1),
             constructor);
-        metadata.AddTypeDefinition(
+        TypeDefinitionHandle markerType = metadata.AddTypeDefinition(
             System.Reflection.TypeAttributes.NotPublic,
             metadata.GetOrAddString("System.Runtime.CompilerServices"),
             metadata.GetOrAddString("MemorySafetyRulesAttribute"),
@@ -153,15 +197,26 @@ public class CompilerFeatureOptionsTests
             MetadataTokens.FieldDefinitionHandle(1),
             constructor);
 
+        EntityHandle constructorToken = memberRefConstructor
+            ? metadata.AddMemberReference(
+                markerType,
+                metadata.GetOrAddString(".ctor"),
+                constructorSignatureHandle)
+            : constructor;
+
         if (version is { } marker)
         {
             var value = new BlobBuilder();
             value.WriteUInt16(1);
-            value.WriteInt32(marker);
-            value.WriteUInt16(0);
+            if (!malformedValue)
+            {
+                value.WriteInt32(marker);
+                value.WriteUInt16(0);
+            }
+
             metadata.AddCustomAttribute(
                 module,
-                constructor,
+                constructorToken,
                 metadata.GetOrAddBlob(value));
         }
 

--- a/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CompilerFeatureOptionsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 using ILInspector.DecompilerHarness;
@@ -70,6 +71,108 @@ public class CompilerFeatureOptionsTests
         const System.Reflection.MethodImplAttributes RuntimeAsync =
             (System.Reflection.MethodImplAttributes)0x2000;
         Assert.True((method.ImplAttributes & RuntimeAsync) != 0);
+    }
+
+    [Theory]
+    // The printer keys on module marker presence, not version, so the harness
+    // must replay updated rules for any marked module. A v2-only harness would
+    // compile printer-emitted `unsafe { }` blocks under legacy rules (CS0214)
+    // and report a false clean.
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(99)]
+    public void AnyModuleMarker_ReplaysUpdatedRules(int version)
+    {
+        using var pe = new PEReader(new MemoryStream(BuildMarkedModule(version)));
+        var options = CompilerFeatureOptions.ParseOptions(pe);
+
+        Assert.Contains(
+            options.Features,
+            feature => feature.Key == "updated-memory-safety-rules"
+                && feature.Value == "true");
+    }
+
+    [Fact]
+    public void UnmarkedModule_CompilesAsLegacy()
+    {
+        using var pe = new PEReader(new MemoryStream(BuildMarkedModule(null)));
+        var options = CompilerFeatureOptions.ParseOptions(pe);
+
+        Assert.DoesNotContain(
+            options.Features,
+            feature => feature.Key == "updated-memory-safety-rules");
+    }
+
+    static byte[] BuildMarkedModule(int? version)
+    {
+        var metadata = new MetadataBuilder();
+        ModuleDefinitionHandle module = metadata.AddModule(
+            0,
+            metadata.GetOrAddString("MarkerProbe.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("MarkerProbe"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+        var constructorSignature = new BlobBuilder();
+        new BlobEncoder(constructorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Int32());
+
+        MethodDefinitionHandle constructor = metadata.AddMethodDefinition(
+            System.Reflection.MethodAttributes.Public
+                | System.Reflection.MethodAttributes.SpecialName
+                | System.Reflection.MethodAttributes.RTSpecialName,
+            System.Reflection.MethodImplAttributes.Runtime,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(constructorSignature),
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+
+        metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            constructor);
+        metadata.AddTypeDefinition(
+            System.Reflection.TypeAttributes.NotPublic,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("MemorySafetyRulesAttribute"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            constructor);
+
+        if (version is { } marker)
+        {
+            var value = new BlobBuilder();
+            value.WriteUInt16(1);
+            value.WriteInt32(marker);
+            value.WriteUInt16(0);
+            metadata.AddCustomAttribute(
+                module,
+                constructor,
+                metadata.GetOrAddBlob(value));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
     }
 
     static CompiledAssembly Compile(string source, CSharpParseOptions options)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -2818,7 +2818,12 @@ public static class IrImporter
     // difference between an old-rules and a new-rules build (an `unsafe` block or
     // member modifier has no IL representation), so it is what the printer keys
     // on to choose explicit `unsafe { }` blocks over the member modifier.
-    static bool ModuleUsesUpdatedMemorySafetyRules(MetadataReader reader)
+    //
+    // Internal rather than private because recompilation must replay the exact
+    // mode the printer used. The decompiler harness calls this same predicate so
+    // the two cannot drift; deriving the harness mode from a separate reader
+    // (however more faithful) reintroduces that drift.
+    internal static bool ModuleUsesUpdatedMemorySafetyRules(MetadataReader reader)
     {
         foreach (var handle in reader.GetModuleDefinition().GetCustomAttributes())
             if (AttributeTypeName(reader, reader.GetCustomAttribute(handle).Constructor)

--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -28,7 +28,14 @@ public record AssemblyAuditMetadata
 {
     public bool? IsTrimmable { get; init; }
     public bool? IsAotCompatible { get; init; }
-    public int? MemorySafetyRulesVersion { get; init; }
+
+    /// <summary>
+    /// The module memory-safety rules state, or null when the image carries no
+    /// metadata. Supplied by <see cref="MemorySafetyMetadataIndex"/> so every
+    /// consumer reads the same typed marker evidence rather than re-deriving a
+    /// model from a raw version integer.
+    /// </summary>
+    public MemorySafetyRulesResult? MemorySafetyRules { get; init; }
     public bool HasDisableRuntimeMarshalling { get; init; }
     public int RequiresUnsafeCount { get; init; }
     public int RequiresUnreferencedCodeCount { get; init; }
@@ -102,7 +109,6 @@ public static class AssemblyDetailScanner
         var reader = peReader.GetMetadataReader();
         bool? isTrimmable = null;
         bool? isAotCompatible = null;
-        int? memorySafetyRulesVersion = null;
         bool hasDisableRuntimeMarshalling = false;
         int requiresUnsafeCount = 0;
         int requiresUnreferencedCodeCount = 0;
@@ -131,10 +137,6 @@ public static class AssemblyDetailScanner
                             else if (metadataValue.Key == "IsAotCompatible")
                                 isAotCompatible = ParseBool(metadataValue.Value);
                         }
-                        break;
-
-                    case KnownAttributeNames.MemorySafetyRulesAttribute:
-                        memorySafetyRulesVersion = TryGetInt32CtorArgument(reader, attr);
                         break;
 
                     case KnownAttributeNames.DisableRuntimeMarshallingAttribute:
@@ -192,7 +194,7 @@ public static class AssemblyDetailScanner
         {
             IsTrimmable = isTrimmable,
             IsAotCompatible = isAotCompatible,
-            MemorySafetyRulesVersion = memorySafetyRulesVersion,
+            MemorySafetyRules = MemorySafetyMetadataIndex.Create(reader).Rules,
             HasDisableRuntimeMarshalling = hasDisableRuntimeMarshalling,
             RequiresUnsafeCount = requiresUnsafeCount,
             RequiresUnreferencedCodeCount = requiresUnreferencedCodeCount,
@@ -289,21 +291,6 @@ public static class AssemblyDetailScanner
             var key = blob.ReadSerializedString();
             var value = blob.ReadSerializedString();
             return key != null && value != null ? (key, value) : null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static int? TryGetInt32CtorArgument(MetadataReader reader, CustomAttribute attr)
-    {
-        try
-        {
-            var blob = reader.GetBlobReader(attr.Value);
-            if (blob.Length < 6) return null;
-            blob.ReadUInt16();
-            return blob.ReadInt32();
         }
         catch
         {

--- a/src/dotnet-inspect.Tests/MemorySafetySignalRenderingTests.cs
+++ b/src/dotnet-inspect.Tests/MemorySafetySignalRenderingTests.cs
@@ -1,0 +1,247 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Gates the Signals projection of the module memory-safety rules state. The
+/// end-to-end cases prove the scanner-to-renderer wiring over real images; the
+/// projection cases cover states whose derivation is already gated in
+/// <c>ILInspector.Metadata.Tests</c> and only need a rendering contract here.
+/// </summary>
+[Collection(ConsoleCollection.Name)]
+public sealed class MemorySafetySignalRenderingTests
+{
+    const string MarkerEvidence = "module MemorySafetyRulesAttribute";
+
+    [Fact]
+    public async Task Signals_RecognizedVersion_ReportsUpdated()
+    {
+        string output = await RunSignalsAsync(BuildMarkerImage(2));
+
+        Assert.Contains(
+            "| Memory safety | Memory safety model | Updated (v2) |",
+            output);
+    }
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(99)]
+    [InlineData(0)]
+    public async Task Signals_UnrecognizedVersion_ReportsUnsupportedWithActualValue(
+        int version)
+    {
+        string output = await RunSignalsAsync(BuildMarkerImage(version));
+
+        Assert.Contains(
+            $"| Memory safety | Memory safety model | Unsupported (v{version}) |",
+            output);
+        Assert.DoesNotContain("Updated", output);
+    }
+
+    [Fact]
+    public async Task Signals_DisagreeingMarkers_ReportConflict()
+    {
+        string output = await RunSignalsAsync(BuildMarkerImage(2, 3));
+
+        Assert.Contains(
+            "| Memory safety | Memory safety model | Conflicting markers |",
+            output);
+        Assert.DoesNotContain("Updated", output);
+    }
+
+    [Fact]
+    public async Task Signals_NoMarker_ReportsNotMarked()
+    {
+        string output = await RunSignalsAsync(BuildMarkerImage(version: null));
+
+        Assert.Contains(
+            "| Memory safety | Memory safety model | Not marked |",
+            output);
+    }
+
+    [Fact]
+    public void Projection_Legacy_RendersNotMarked()
+    {
+        var (value, evidence) = AuditSignalBuilder.FormatMemorySafetyModel(
+            Available(MemorySafetyRulesState.Legacy));
+
+        Assert.Equal("Not marked", value);
+        Assert.Equal(MarkerEvidence, evidence);
+    }
+
+    [Fact]
+    public void Projection_MissingMetadata_RendersNotMarked()
+    {
+        var (value, _) = AuditSignalBuilder.FormatMemorySafetyModel(null);
+
+        Assert.Equal("Not marked", value);
+    }
+
+    [Fact]
+    public void Projection_Malformed_RendersMalformedAndKeepsDetail()
+    {
+        var (value, evidence) = AuditSignalBuilder.FormatMemorySafetyModel(
+            Available(
+                MemorySafetyRulesState.Malformed,
+                new MemorySafetyRulesObservation(
+                    AttributeToken: 0x0C000001,
+                    MemorySafetyRulesObservationState.Malformed,
+                    Version: null,
+                    Detail: "constructor argument could not be decoded")));
+
+        Assert.Equal("Malformed marker", value);
+        Assert.Equal(
+            $"{MarkerEvidence}; constructor argument could not be decoded",
+            evidence);
+    }
+
+    [Fact]
+    public void Projection_Unavailable_RendersUnavailableAndKeepsFailure()
+    {
+        var (value, evidence) = AuditSignalBuilder.FormatMemorySafetyModel(
+            new MemorySafetyRulesResult.Unavailable(
+                new MemorySafetyMetadataFailure(
+                    MemorySafetyMetadataFailureKind.BudgetExceeded,
+                    "Memory-safety module metadata exceeded its scan budget."),
+                ImmutableArray<MemorySafetyRulesObservation>.Empty));
+
+        Assert.Equal("Unavailable", value);
+        Assert.Equal(
+            $"{MarkerEvidence}; Memory-safety module metadata exceeded its scan budget.",
+            evidence);
+    }
+
+    [Fact]
+    public void Projection_Conflicting_ReportsMarkerCount()
+    {
+        var (value, evidence) = AuditSignalBuilder.FormatMemorySafetyModel(
+            Available(
+                MemorySafetyRulesState.Conflicting,
+                Decoded(0x0C000001, 2),
+                Decoded(0x0C000002, 3)));
+
+        Assert.Equal("Conflicting markers", value);
+        Assert.Equal($"{MarkerEvidence}; 2 markers", evidence);
+    }
+
+    static MemorySafetyRulesResult.Available Available(
+        MemorySafetyRulesState state,
+        params MemorySafetyRulesObservation[] observations)
+        => new(state, [.. observations]);
+
+    static MemorySafetyRulesObservation Decoded(int token, int version)
+        => new(token, MemorySafetyRulesObservationState.Decoded, version, null);
+
+    static async Task<string> RunSignalsAsync(byte[] image)
+    {
+        string path = Path.Combine(
+            Path.GetTempPath(),
+            $"memory-safety-signals-{Guid.NewGuid():N}.dll");
+        File.WriteAllBytes(path, image);
+        try
+        {
+            var options = new LibraryOptions
+            {
+                AssemblyName = path,
+                IncludeSections = new HashSet<string>(
+                    StringComparer.OrdinalIgnoreCase) { "Signals" }
+            };
+
+            var (exit, output, _) = await ConsoleCapture.RunAsync(
+                () => LibraryCommand.ExecuteAsync(options));
+
+            Assert.Equal(0, exit);
+            return output;
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Builds a well-formed image whose module optionally carries one or two
+    /// <c>MemorySafetyRulesAttribute</c> markers with the supplied versions.
+    /// </summary>
+    static byte[] BuildMarkerImage(int? version, int? secondVersion = null)
+    {
+        var metadata = new MetadataBuilder();
+        ModuleDefinitionHandle module = metadata.AddModule(
+            0,
+            metadata.GetOrAddString("MarkerProbe.dll"),
+            metadata.GetOrAddGuid(Guid.NewGuid()),
+            default,
+            default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("MarkerProbe"),
+            new Version(1, 0, 0, 0),
+            default,
+            default,
+            default,
+            default);
+
+        var constructorSignature = new BlobBuilder();
+        new BlobEncoder(constructorSignature)
+            .MethodSignature(isInstanceMethod: true)
+            .Parameters(
+                1,
+                returnType => returnType.Void(),
+                parameters => parameters.AddParameter().Type().Int32());
+
+        MethodDefinitionHandle constructor = metadata.AddMethodDefinition(
+            MethodAttributes.Public
+                | MethodAttributes.SpecialName
+                | MethodAttributes.RTSpecialName,
+            MethodImplAttributes.Runtime,
+            metadata.GetOrAddString(".ctor"),
+            metadata.GetOrAddBlob(constructorSignature),
+            bodyOffset: -1,
+            MetadataTokens.ParameterHandle(1));
+
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            constructor);
+        metadata.AddTypeDefinition(
+            TypeAttributes.NotPublic,
+            metadata.GetOrAddString("System.Runtime.CompilerServices"),
+            metadata.GetOrAddString("MemorySafetyRulesAttribute"),
+            default,
+            MetadataTokens.FieldDefinitionHandle(1),
+            constructor);
+
+        foreach (int marker in new[] { version, secondVersion }
+            .Where(candidate => candidate is not null)
+            .Select(candidate => candidate!.Value))
+        {
+            var value = new BlobBuilder();
+            value.WriteUInt16(1);
+            value.WriteInt32(marker);
+            value.WriteUInt16(0);
+            metadata.AddCustomAttribute(
+                module,
+                constructor,
+                metadata.GetOrAddBlob(value));
+        }
+
+        var pe = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            new MetadataRootBuilder(metadata, suppressValidation: true),
+            new BlobBuilder(),
+            flags: CorFlags.ILOnly);
+        var image = new BlobBuilder();
+        pe.Serialize(image);
+        return image.ToArray();
+    }
+}

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -361,10 +361,17 @@ internal static class AuditSignalBuilder
                 ? null
                 : new SignalValue(FormatCount(context.Metadata.DynamicDependencyCount), "DynamicDependencyAttribute");
 
-        private static SignalValue? ResolveMemorySafetyModel(in LibrarySignalContext context) =>
-            context.Metadata == null
-                ? null
-                : new SignalValue(FormatMemorySafetyModel(context.Metadata.MemorySafetyRulesVersion), "module MemorySafetyRulesAttribute");
+        private static SignalValue? ResolveMemorySafetyModel(in LibrarySignalContext context)
+        {
+            if (context.Metadata == null)
+            {
+                return null;
+            }
+
+            var (value, evidence) =
+                FormatMemorySafetyModel(context.Metadata.MemorySafetyRules);
+            return new SignalValue(value, evidence);
+        }
 
         private static SignalValue? ResolveMemorySafetyRequiresUnsafeMembers(in LibrarySignalContext context) =>
             context.Metadata == null
@@ -796,12 +803,75 @@ internal static class AuditSignalBuilder
     private static string FormatCount(int count, string singular)
         => count == 1 ? $"1 {singular}" : $"{count} {singular}s";
 
-    private static string FormatMemorySafetyModel(int? version) => version switch
+    private const string MemorySafetyMarkerEvidence =
+        "module MemorySafetyRulesAttribute";
+
+    /// <summary>
+    /// Projects the typed module rules state onto the Signals row. Every state
+    /// renders distinctly so an unrecognized marker version is never reported
+    /// as the updated model, and unreadable metadata never renders as unmarked.
+    /// </summary>
+    internal static (string Value, string Evidence) FormatMemorySafetyModel(
+        MemorySafetyRulesResult? rules)
     {
-        >= 2 => $"Updated (v{version})",
-        { } marked => $"Marked v{marked}",
-        null => "Not marked"
-    };
+        switch (rules)
+        {
+            case null:
+                return ("Not marked", MemorySafetyMarkerEvidence);
+
+            case MemorySafetyRulesResult.Unavailable unavailable:
+                return (
+                    "Unavailable",
+                    $"{MemorySafetyMarkerEvidence}; {unavailable.Failure.Detail}");
+
+            case MemorySafetyRulesResult.Available available:
+                return available.State switch
+                {
+                    MemorySafetyRulesState.Legacy =>
+                        ("Not marked", MemorySafetyMarkerEvidence),
+                    MemorySafetyRulesState.Updated =>
+                        (
+                            $"Updated{FormatMemorySafetyVersion(available)}",
+                            MemorySafetyMarkerEvidence),
+                    MemorySafetyRulesState.Unsupported =>
+                        (
+                            $"Unsupported{FormatMemorySafetyVersion(available)}",
+                            MemorySafetyMarkerEvidence),
+                    MemorySafetyRulesState.Malformed =>
+                        (
+                            "Malformed marker",
+                            FormatMemorySafetyMarkerDetail(available)),
+                    MemorySafetyRulesState.Conflicting =>
+                        (
+                            "Conflicting markers",
+                            $"{MemorySafetyMarkerEvidence}; {FormatCount(available.Observations.Length, "marker")}"),
+                    _ => ("Unavailable", MemorySafetyMarkerEvidence)
+                };
+
+            default:
+                return ("Unavailable", MemorySafetyMarkerEvidence);
+        }
+    }
+
+    private static string FormatMemorySafetyVersion(
+        MemorySafetyRulesResult.Available available)
+        => available.Observations
+            .Select(observation => observation.Version)
+            .FirstOrDefault(version => version is not null) is { } decoded
+                ? $" (v{decoded})"
+                : string.Empty;
+
+    private static string FormatMemorySafetyMarkerDetail(
+        MemorySafetyRulesResult.Available available)
+    {
+        string? detail = available.Observations
+            .FirstOrDefault(observation =>
+                observation.State == MemorySafetyRulesObservationState.Malformed)
+            ?.Detail;
+        return string.IsNullOrEmpty(detail)
+            ? MemorySafetyMarkerEvidence
+            : $"{MemorySafetyMarkerEvidence}; {detail}";
+    }
 
     private static string FormatNullableBool(bool? value) => value switch
     {

--- a/tools/DecompilerHarness/CompilerFeatureOptions.cs
+++ b/tools/DecompilerHarness/CompilerFeatureOptions.cs
@@ -1,7 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
-using ILInspector.Metadata;
+using ILInspector.Decompiler.Pipeline;
 
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -37,20 +37,17 @@ static class CompilerFeatureOptions
     }
 
     /// <summary>
-    /// Recompilation must replay the mode the printer used, and the printer
-    /// keys on module marker <em>presence</em> rather than the version (see
-    /// <c>IrImporter.ModuleUsesUpdatedMemorySafetyRules</c>). Any observed
-    /// module marker therefore selects the updated-rules feature, so an
-    /// unsupported or conflicting version still compiles back under the same
-    /// rules it was printed with. Only a module with no marker at all
-    /// (<see cref="MemorySafetyRulesState.Legacy"/>) compiles as legacy.
+    /// Recompilation must replay the mode the printer used, so this defers to
+    /// the printer's own predicate rather than deriving the mode independently.
+    /// Any second reader — including the more faithful
+    /// <c>MemorySafetyMetadataIndex</c>, which accepts marker spellings the
+    /// printer ignores — can disagree with the printer and compile output back
+    /// under rules it was not printed with.
+    /// <c>CompilerFeatureOptionsTests.HarnessReplayMatchesPrinterMode</c> is the
+    /// gate.
     /// </summary>
     static bool ModuleUsesUpdatedMemorySafetyRules(PEReader pe)
-        => MemorySafetyMetadataIndex.Create(pe.GetMetadataReader()).Rules
-            is MemorySafetyRulesResult.Available
-            {
-                State: not MemorySafetyRulesState.Legacy
-            };
+        => IrImporter.ModuleUsesUpdatedMemorySafetyRules(pe.GetMetadataReader());
 
     static bool ModuleUsesRuntimeAsync(PEReader pe)
     {

--- a/tools/DecompilerHarness/CompilerFeatureOptions.cs
+++ b/tools/DecompilerHarness/CompilerFeatureOptions.cs
@@ -37,15 +37,19 @@ static class CompilerFeatureOptions
     }
 
     /// <summary>
-    /// Recompilation opts into the updated rules only for the recognized v2
-    /// module marker. An unsupported, malformed, conflicting, or unreadable
-    /// marker is not the updated model and must not enable the feature.
+    /// Recompilation must replay the mode the printer used, and the printer
+    /// keys on module marker <em>presence</em> rather than the version (see
+    /// <c>IrImporter.ModuleUsesUpdatedMemorySafetyRules</c>). Any observed
+    /// module marker therefore selects the updated-rules feature, so an
+    /// unsupported or conflicting version still compiles back under the same
+    /// rules it was printed with. Only a module with no marker at all
+    /// (<see cref="MemorySafetyRulesState.Legacy"/>) compiles as legacy.
     /// </summary>
     static bool ModuleUsesUpdatedMemorySafetyRules(PEReader pe)
         => MemorySafetyMetadataIndex.Create(pe.GetMetadataReader()).Rules
             is MemorySafetyRulesResult.Available
             {
-                State: MemorySafetyRulesState.Updated
+                State: not MemorySafetyRulesState.Legacy
             };
 
     static bool ModuleUsesRuntimeAsync(PEReader pe)

--- a/tools/DecompilerHarness/CompilerFeatureOptions.cs
+++ b/tools/DecompilerHarness/CompilerFeatureOptions.cs
@@ -25,8 +25,7 @@ static class CompilerFeatureOptions
     {
         var options = ParseOptions();
         var features = new List<KeyValuePair<string, string>>();
-        if (pe.HasMetadata
-            && AssemblyDetailScanner.ScanAuditMetadata(pe).MemorySafetyRulesVersion is not null)
+        if (pe.HasMetadata && ModuleUsesUpdatedMemorySafetyRules(pe))
         {
             features.Add(new("updated-memory-safety-rules", "true"));
         }
@@ -36,6 +35,18 @@ static class CompilerFeatureOptions
 
         return features.Count == 0 ? options : options.WithFeatures(features);
     }
+
+    /// <summary>
+    /// Recompilation opts into the updated rules only for the recognized v2
+    /// module marker. An unsupported, malformed, conflicting, or unreadable
+    /// marker is not the updated model and must not enable the feature.
+    /// </summary>
+    static bool ModuleUsesUpdatedMemorySafetyRules(PEReader pe)
+        => MemorySafetyMetadataIndex.Create(pe.GetMetadataReader()).Rules
+            is MemorySafetyRulesResult.Available
+            {
+                State: MemorySafetyRulesState.Updated
+            };
 
     static bool ModuleUsesRuntimeAsync(PEReader pe)
     {


### PR DESCRIPTION
Fixes #5260. Slice of #5555.

The Library **Signals** memory-safety row derived its model from a raw `int?`
marker version and reported *every* value `>= 2` as the updated model. A v3
marker rendered `Updated (v3)`; an image carrying two disagreeing markers
silently rendered whichever the attribute walk happened to see last. The `int?`
representation could not express a malformed, conflicting, or unreadable marker
at all, so unreadable metadata rendered as `Not marked`.

This slice makes the row consume the typed `MemorySafetyRulesResult` from the
`MemorySafetyMetadataIndex` substrate merged in #5285 — the first product
consumer of that substrate.

## Demo

Three synthetic modules, each carrying `MemorySafetyRulesAttribute` on the
module: one v2 marker, one v3 marker, and one with both v2 and v3.

```console
$ dotnet-inspect library MarkedV3.dll -S Signals
```

Before — a v3 marker is announced as the updated memory-safety model:

```text
| Memory safety | Memory safety model | Updated (v3) | module MemorySafetyRulesAttribute |
```

After — the version is reported exactly, and is not claimed as the updated model:

```text
| Memory safety | Memory safety model | Unsupported (v3) | module MemorySafetyRulesAttribute |
```

**What to notice:** `Updated` is a claim about a recognized model, and v3 is not
that model. The tool now reports the integer it actually read.

The neighboring scenario — two disagreeing markers — proves the fix is not
fitted to the single-marker sample. Before, the conflict was invisible and the
last-seen marker won:

```text
| Memory safety | Memory safety model | Updated (v3) | module MemorySafetyRulesAttribute |
```

After, the conflict itself is the answer, and the evidence column carries the
marker count:

```text
| Memory safety | Memory safety model | Conflicting markers | module MemorySafetyRulesAttribute; 2 markers |
```

Unchanged where it should be — a genuine v2 marker still reads `Updated (v2)`,
and a real unmarked assembly (16 MB `System.Private.CoreLib`) still reads
`Not marked`:

```text
| Memory safety | Memory safety model | Updated (v2) | module MemorySafetyRulesAttribute |
| Memory safety | Memory safety model | Not marked   | module MemorySafetyRulesAttribute |
```

## What changed

`AssemblyAuditMetadata` now carries `MemorySafetyRulesResult?` instead of
`int? MemorySafetyRulesVersion`. The audit scan's ad-hoc
`MemorySafetyRulesAttribute` switch case is removed: it read the marker from
assembly, type, *and* member scopes even though the marker is module-only, and
it decoded the constructor blob by hand. The substrate owns both concerns.

Rendering is now total over the typed state:

| State | Value | Evidence |
| --- | --- | --- |
| `Legacy` / no metadata | `Not marked` | marker |
| `Updated` | `Updated (v2)` | marker |
| `Unsupported` | `Unsupported (v<actual>)` | marker |
| `Malformed` | `Malformed marker` | marker + observation detail |
| `Conflicting` | `Conflicting markers` | marker + marker count |
| `Unavailable` | `Unavailable` | marker + failure detail |

`Malformed` and `Unavailable` carry their detail into the evidence column, so
unreadable metadata stays visible instead of collapsing into success-shaped
`Not marked` output.

The decompiler harness previously read the removed `MemorySafetyRulesVersion`,
so it needed a replacement source for the compile-back mode. It now calls the
printer's own predicate, `IrImporter.ModuleUsesUpdatedMemorySafetyRules`, made
`internal` for the purpose. Recompilation must replay the exact mode the printer
used, and any second reader can disagree with it: review found that a module
marker whose constructor token is a `MemberRef` with a same-module `TypeDef`
parent — legal ECMA-335, though Roslyn emits a `MethodDef` — reads as `Updated`
to `MemorySafetyMetadataIndex` and as absent to the printer. That divergence
predates this branch and is unchanged by it (the base harness resolved a
`MemberRef` parent of any kind and diverged on the same image), but sharing one
owned predicate makes the agreement true by construction rather than asserted.

The printer defect behind that divergence — a legal marker spelling read as
absent, so the wrong `unsafe` spelling is printed — is filed as #5670, together
with the related #5662. Changing the printer's mode selection is a decompiler
output-behavior change that needs its own evidence under
`docs/decompiler-correctness-pipeline.md`, so it is deliberately not folded in
here.

## Compatibility and cost

No CLI flag, section, or default-verbosity change. The only value whose spelling
changes for previously-representable input is the mislabeled `>= 2` case, which
is the bug. `Marked v1` becomes `Unsupported (v1)`.

`MemorySafetyMetadataIndex.Create` now runs once per audit scan. Measured
in-process on 16 MB `System.Private.CoreLib`: **10.0 ms**, which is **19%** of
the 52.8 ms audit scan that already walks every type and member attribute. It is
a constant-factor addition to an existing O(metadata) pass, once per command,
not a per-type cost.

## Validation

| Gate | Result |
| --- | --- |
| `dotnet build dotnet-inspect.slnx -c Release` | succeeded, 0 warnings |
| `dotnet run --project src/dotnet-inspect.Tests -c Release` | 5297 total, **0 failed**, 5274 passed, 23 skipped |
| `dotnet run --project tests/ILInspector.Metadata.Tests -c Release` | 2473 total, **0 failed**, 2 skipped |
| `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- --gate no-corpus` | 5514 total, 1 failed — **pre-existing on `main`**, see below |

New gates in `src/dotnet-inspect.Tests/MemorySafetySignalRenderingTests.cs` (11
tests). Four run the real `library ... -S Signals` command end to end over
synthetic images, proving the scanner-to-renderer wiring rather than the
formatter alone:

- v2 → `Updated (v2)`
- **v3, v99, and v0 → `Unsupported (v<n>)`, asserting the output does not contain
  `Updated`** — the direct negative control for this bug
- two disagreeing markers → `Conflicting markers`
- no marker → `Not marked`

Seven more pin the projection contract for `Legacy`, absent metadata,
`Malformed`, `Unavailable`, and `Conflicting`, including that `Malformed` and
`Unavailable` preserve their detail text. State *derivation* stays gated in
`ILInspector.Metadata.Tests`; these gate only the presentation the CLI owns.

The existing `Assembly_Signals_LocalUnsafeAssembly_FocusesOnNewMemorySafetyModel`
gate still passes unchanged.

`CompilerFeatureOptionsTests` gains gates pinning the harness/printer agreement.
Module markers v2, v3, and v99 all replay updated rules and an unmarked module
compiles as legacy — the direct negative control for the round-1 finding.
`HarnessReplayMatchesPrinterMode` then asserts the two predicates agree over six
marker spellings, including the two where an independent reader is known to
diverge: the `MemberRef`→`TypeDef` constructor and a truncated value blob.
Mutation-checked — restoring the substrate-derived predicate fails it with
`v2 MemberRef->TypeDef ctor: printer replayed updated rules = False, harness
replayed updated rules = True`.

### Pre-existing decompiler failure

`SkeletonEmitTests.SkeletonCompilesPastExplicitImplAndConstEnum` fails with
`CS0009` where it expects `CS0101`. Reproduced identically in a clean detached
worktree at `origin/main` (`7383ce274`) with no branch changes present, so it is
not caused by this PR. Filed as #5658 and left unfixed here.
