### PR TITLE
Add atomic binding selection snapshots

### DIFF
--- a/docs/design/models/binding-selection-version/README.md
+++ b/docs/design/models/binding-selection-version/README.md
@@ -91,8 +91,22 @@ Issue #5224 owns miss dispositions; the
 [binding composition-currency model](../binding-composition-currency/README.md)
 owns the complete identity-eligible handoff; #5216 owns workspace generation
 replacement. TLC results establish properties of these state machines under
-the stated bounds, not of the shipped implementation. Formal
-model-to-implementation correspondence is unverified.
+the stated bounds, not of the shipped implementation.
+
+The selection-side implementation introduced by #5646 has focused Release
+correspondence gates in `TypeResolutionContextTests`:
+
+- `ForeignPolicySnapshot_IsRejectedBeforePayloadInterpretation` exercises the
+  atomic-association and foreign-payload exclusion boundary;
+- `FinalPolicyVersionChange_PublishesNoGenerationOrPolicyCache` exercises the
+  final commit comparison and pre-commit publication exclusion; and
+- `NullPolicySnapshot_RemainsInvalidPolicyOutput` keeps invalid output distinct
+  from generation-control evidence.
+
+These tests enforce the named selection-side product transitions, but they are
+not a mechanical refinement proof. Producer token non-reuse, transforming
+composite refresh, workspace retry, and full model-to-implementation
+correspondence remain unverified.
 
 ## Checked configurations
 

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1058,13 +1058,13 @@ public sealed class AssemblyBindingSelectionSnapshot
         AssemblyBindingPolicyVersion policyVersion,
         AssemblyBindingSelection selection)
     {
-        PolicyVersion = policyVersion
+        Version = policyVersion
             ?? throw new ArgumentNullException(nameof(policyVersion));
         Selection = selection
             ?? throw new ArgumentNullException(nameof(selection));
     }
 
-    public AssemblyBindingPolicyVersion PolicyVersion { get; }
+    public AssemblyBindingPolicyVersion Version { get; }
     public AssemblyBindingSelection Selection { get; }
 }
 
@@ -1158,11 +1158,13 @@ internal interface IAssemblyBindingResolver
 
 #### Atomic selection/version snapshots
 
-> **Status: design-only and unverified.** #5264 defines this target contract,
-> and the companion TLA+ model checks it. The product still returns
-> `AssemblyBindingSelection` from `Select` and observes `Version` separately;
-> formal model-to-implementation correspondence and product gates remain
-> unverified.
+> **Status: partially implemented by #5646.** Policies return
+> `AssemblyBindingSelectionSnapshot`, and Metadata validates the returned token
+> before interpreting a cold answer and validates the current token again at
+> the generation commit point. Focused Release tests enforce foreign-snapshot
+> rejection and policy-publication exclusion. Non-reused transforming-policy
+> tokens, delegated-version refresh, supersession retry, and full
+> model-to-implementation correspondence remain unverified.
 
 `AssemblyBindingSelectionSnapshot` is the policy owner's immutable answer for
 one request. It atomically carries the exact
@@ -2584,8 +2586,10 @@ current ownership boundaries.
   frozen manifest does.
 - The focused
   [binding selection/version models](models/binding-selection-version/README.md)
-  are bounded design evidence only; their snapshot contract and product
-  correspondence remain unverified.
+  are bounded design evidence. Focused Release gates implement the
+  selection-side snapshot association, foreign-payload exclusion, and final
+  commit ordering; transforming-policy refresh, workspace retry, producer token
+  non-reuse, and full model-to-product correspondence remain unverified.
 - The focused
   [binding name-ownership model](models/binding-name-ownership/README.md)
   and its mapped Release gates remain the executable evidence for

--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -2993,7 +2993,7 @@ public sealed class BrowserEngineBoundaryTests
                         participant.Assembly.Identity),
                     AssemblyBindingOrigin.FromAssembly(
                         participant.Assembly),
-                    AssemblyResolutionScope.Any));
+                    AssemblyResolutionScope.Any)).Selection;
         AssemblyBindingSelection platform =
             participant.Participant.BindingPolicy.Select(
                 new AssemblyBindingRequest(
@@ -3001,7 +3001,7 @@ public sealed class BrowserEngineBoundaryTests
                         participant.Assembly.Identity),
                     AssemblyBindingOrigin.FromAssembly(
                         participant.Assembly),
-                    AssemblyResolutionScope.Platform));
+                    AssemblyResolutionScope.Platform)).Selection;
 
         Assert.Same(
             participant.Assembly,
@@ -6637,11 +6637,18 @@ public sealed class BrowserEngineBoundaryTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 
 }

--- a/prototypes/inspect-web/engine.Tests/BrowserMetadataOperationsTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserMetadataOperationsTests.cs
@@ -203,10 +203,17 @@ public sealed class BrowserMetadataOperationsTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextAnalysisSourceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextAnalysisSourceTests.cs
@@ -54,7 +54,7 @@ public sealed class AssemblyContextAnalysisSourceTests
                 AssemblyResolutionScope.Any);
 
             Assert.Same(policy.Version, bindingPolicy.Version);
-            Assert.Same(terminal, bindingPolicy.Select(request));
+            Assert.Same(terminal, bindingPolicy.Select(request).Selection);
             Assert.Same(
                 assembly.Registration,
                 Assert.IsType<AssemblyBindingOrigin.RequestingAssembly>(
@@ -62,7 +62,7 @@ public sealed class AssemblyContextAnalysisSourceTests
             Assert.Same(
                 terminal,
                 new AssemblyReferenceBindingPolicy(resolver)
-                    .Select(request));
+                    .Select(request).Selection);
         }
     }
 
@@ -87,7 +87,7 @@ public sealed class AssemblyContextAnalysisSourceTests
             AssemblyContextAnalysisSource.Resolver(group, subject));
 
         var retained = Assert.IsType<AssemblyBindingSelection.Selected>(
-            bindingPolicy.Select(Request(root)));
+            bindingPolicy.Select(Request(root)).Selection);
 
         Assert.Same(
             selected.Registration,
@@ -122,7 +122,7 @@ public sealed class AssemblyContextAnalysisSourceTests
             AssemblyContextAnalysisSource.Resolver(group, subject));
 
         var retained = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-            bindingPolicy.Select(Request(root)));
+            bindingPolicy.Select(Request(root)).Selection);
 
         Assert.Equal(
             [first.Registration, second.Registration],
@@ -155,11 +155,19 @@ public sealed class AssemblyContextAnalysisSourceTests
         public AssemblyBindingPolicyVersion Version { get; } = new();
         internal AssemblyBindingRequest? LastRequest { get; private set; }
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            LastRequest = request;
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                LastRequest = request;
+                return selection;
+
+            }
         }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextApiSurfaceQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextApiSurfaceQueryTests.cs
@@ -1239,10 +1239,17 @@ public sealed class AssemblyContextApiSurfaceQueryTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }
 

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
@@ -606,10 +606,17 @@ public sealed class AssemblyContextIntegrationsQueryTests
         public AssemblyBindingPolicyVersion Version { get; } =
             version;
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextMetadataQueriesTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextMetadataQueriesTests.cs
@@ -165,10 +165,17 @@ public sealed class AssemblyContextMetadataQueriesTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextMethodAnalysisQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextMethodAnalysisQueryTests.cs
@@ -253,11 +253,19 @@ public sealed class AssemblyContextMethodAnalysisQueryTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
-            => AssemblyBindingSelection.CannotSelect(
+
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }
 

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextOptimizationOpportunitiesQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextOptimizationOpportunitiesQueryTests.cs
@@ -457,14 +457,22 @@ public sealed class AssemblyContextOptimizationOpportunitiesQueryTests
         internal IReadOnlyList<AssemblyBindingRequest> Requests =>
             _requests;
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            _requests.Add(request);
-            return AssemblyBindingSelection.CannotSelect(
-                new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind
-                        .CandidateUnavailable));
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                _requests.Add(request);
+                return AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind
+                            .CandidateUnavailable));
+
+            }
         }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextReferencesQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextReferencesQueryTests.cs
@@ -90,9 +90,16 @@ public sealed class AssemblyContextReferencesQueryTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextResearchProjectionQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextResearchProjectionQueryTests.cs
@@ -652,12 +652,20 @@ public sealed class AssemblyContextResearchProjectionQueryTests
 
         internal IReadOnlyList<AssemblyBindingRequest> Requests => _requests;
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
         {
-            _requests.Add(request);
-            return AssemblyBindingSelection.CannotSelect(
-                new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                _requests.Add(request);
+                return AssemblyBindingSelection.CannotSelect(
+                    new AssemblyBindingFailure(
+                        AssemblyBindingFailureKind.CandidateUnavailable));
+
+            }
         }
     }
 
@@ -670,10 +678,18 @@ public sealed class AssemblyContextResearchProjectionQueryTests
 
         internal IReadOnlyList<AssemblyBindingRequest> Requests => _requests;
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
         {
-            _requests.Add(request);
-            return AssemblyBindingSelection.Found(selection);
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                _requests.Add(request);
+                return AssemblyBindingSelection.Found(selection);
+
+            }
         }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextSearchQueryTests.cs
@@ -290,11 +290,18 @@ public sealed class AssemblyContextSearchQueryTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }
 

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextSourceQueryTests.cs
@@ -1001,6 +1001,42 @@ public sealed class AssemblyContextSourceQueryTests
         Assert.True(assembly.Policy.SelectionCount > 0);
     }
 
+    [Fact]
+    public void CancellationObservingBindingPolicy_RejectsForeignSnapshot()
+    {
+        var inner = new FrameworkBindingPolicy();
+        AssemblyBindingPolicyVersion expectedVersion = inner.Version;
+        inner.SnapshotVersion = new AssemblyBindingPolicyVersion();
+        var policy =
+            new AssemblyContextSourceQuery.CancellationObservingBindingPolicy(
+                inner,
+                expectedVersion);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.CoreLibrary(),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        Assert.Throws<InvalidOperationException>(
+            () => policy.Select(request));
+        Assert.Equal(1, inner.SelectionCount);
+    }
+
+    [Fact]
+    public void CancellationObservingBindingPolicy_PreservesNullSnapshot()
+    {
+        var inner = new NullSnapshotPolicy();
+        var policy =
+            new AssemblyContextSourceQuery.CancellationObservingBindingPolicy(
+                inner,
+                inner.Version);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.CoreLibrary(),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        Assert.Null(policy.Select(request));
+    }
+
     [Theory]
     [InlineData(false, false, false)]
     [InlineData(false, true, false)]
@@ -3589,35 +3625,54 @@ public sealed class AssemblyContextSourceQueryTests
         internal Action? BeforeSelection { get; set; }
         internal Func<
             AssemblyBindingRequest,
-            AssemblyBindingSelection?>? SelectOverride { get; set; }
+            AssemblyBindingSelection?>? SelectOverride
+        { get; set; }
+        internal AssemblyBindingPolicyVersion? SnapshotVersion { get; set; }
 
         internal void ChangeVersion() =>
             Version = new AssemblyBindingPolicyVersion();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            Interlocked.Increment(ref _selectionCount);
-            BeforeSelection?.Invoke();
-            if (CancelSelection)
-            {
-                throw new OperationCanceledException(
-                    "Synthetic binding-policy cancellation.");
-            }
-            if (SelectOverride?.Invoke(request)
-                is { } overridden)
-            {
-                return overridden;
-            }
+            return new AssemblyBindingSelectionSnapshot(
+                SnapshotVersion ?? Version,
+                SelectCore());
 
-            return request.Target
-                is AssemblyBindingTarget.AssemblyReference reference
-                && reference.Identity.Name
-                    == _coreLibrary.Identity.Name
-                    ? AssemblyBindingSelection.Found(
-                        _coreLibrary)
-                    : AssemblyBindingSelection.NotFound();
+            AssemblyBindingSelection SelectCore()
+            {
+                Interlocked.Increment(ref _selectionCount);
+                BeforeSelection?.Invoke();
+                if (CancelSelection)
+                {
+                    throw new OperationCanceledException(
+                        "Synthetic binding-policy cancellation.");
+                }
+                if (SelectOverride?.Invoke(request)
+                    is { } overridden)
+                {
+                    return overridden;
+                }
+
+                return request.Target
+                    is AssemblyBindingTarget.AssemblyReference reference
+                    && reference.Identity.Name
+                        == _coreLibrary.Identity.Name
+                        ? AssemblyBindingSelection.Found(
+                            _coreLibrary)
+                        : AssemblyBindingSelection.NotFound();
+
+            }
         }
+    }
+
+    sealed class NullSnapshotPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request) =>
+            null!;
     }
 
     public static class SourceFixture

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextStructuralCloneRetrievalQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextStructuralCloneRetrievalQueryTests.cs
@@ -3687,11 +3687,18 @@ public sealed class AssemblyContextStructuralCloneRetrievalQueryTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind
-                        .CandidateUnavailable));
+                AssemblyBindingFailureKind
+                .CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/ContentShapedWorkspaceParticipantTests.cs
+++ b/src/DotnetInspector.Queries.Tests/ContentShapedWorkspaceParticipantTests.cs
@@ -118,9 +118,16 @@ public sealed class ContentShapedWorkspaceParticipantTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionGraphIntegrationsQueryTests.cs
@@ -14,6 +14,50 @@ namespace DotnetInspector.Queries.Tests;
 public sealed class InspectionGraphIntegrationsQueryTests
 {
     [Fact]
+    public void SelectBindingForVersion_RejectsForeignSnapshot()
+    {
+        var policy = new SnapshotPolicy(
+            AssemblyBindingSelection.NotFound());
+        AssemblyBindingPolicyVersion expectedVersion = policy.Version;
+        policy.SnapshotVersion = new AssemblyBindingPolicyVersion();
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.CoreLibrary(),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        Assert.Throws<InvalidOperationException>(
+            () => InspectionGraphIntegrationsQuery
+                .SelectBindingForVersion(
+                    policy,
+                    expectedVersion,
+                    request));
+    }
+
+    [Fact]
+    public void SelectBindingForVersion_PreservesNullAsInvalidPolicyOutput()
+    {
+        var policy = new SnapshotPolicy(
+            AssemblyBindingSelection.NotFound())
+        {
+            ReturnNull = true,
+        };
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.CoreLibrary(),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Platform);
+
+        var rejected = Assert.IsType<AssemblyBindingSelection.Rejected>(
+            InspectionGraphIntegrationsQuery.SelectBindingForVersion(
+                policy,
+                policy.Version,
+                request));
+
+        Assert.Equal(
+            AssemblyBindingFailureKind.InvalidPolicyResult,
+            rejected.Failure.Kind);
+    }
+
+    [Fact]
     public void Execute_DefaultsToWorkspaceInducedSetWithoutSeeds()
     {
         using var fixture = IntegrationFixture.Create();
@@ -2014,11 +2058,11 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Nodes.Count(node =>
                 node.Subject
                     is InspectionGraphSubject.TypeSubject
-                    {
-                        Identity:
+                {
+                    Identity:
                             InspectionGraphTypeIdentity.AcquiredDefinition
                             identity,
-                    }
+                }
                 && identity.Type.ToMetadataFullName()
                     == "Microsoft.Extensions.AI.IChatClient"));
         Assert.DoesNotContain(
@@ -2104,9 +2148,9 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Failures,
             failure =>
                 failure.Target is
-                    {
-                        Kind: InspectionGraphTargetKind.Node,
-                    } target
+                {
+                    Kind: InspectionGraphTargetKind.Node,
+                } target
                 && AssemblyName(document.Nodes[target.Id].Subject)
                     == "Rejected.Integration");
         var evidence =
@@ -2211,9 +2255,9 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Failures,
             failure =>
                 failure.Target is
-                    {
-                        Kind: InspectionGraphTargetKind.Node,
-                    } target
+                {
+                    Kind: InspectionGraphTargetKind.Node,
+                } target
                 && AssemblyName(document.Nodes[target.Id].Subject)
                     == "UnavailableReferences");
         var evidence =
@@ -2246,9 +2290,9 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Failures,
             failure =>
                 failure.Target is
-                    {
-                        Kind: InspectionGraphTargetKind.Node,
-                    } target
+                {
+                    Kind: InspectionGraphTargetKind.Node,
+                } target
                 && AssemblyName(document.Nodes[target.Id].Subject)
                     == "ReferenceVariants");
         AssemblyReferenceIdentity[] references =
@@ -2404,9 +2448,9 @@ public sealed class InspectionGraphIntegrationsQueryTests
             document.Failures,
             failure =>
                 failure.Target is
-                    {
-                        Kind: InspectionGraphTargetKind.Node,
-                    } target
+                {
+                    Kind: InspectionGraphTargetKind.Node,
+                } target
                 && AssemblyName(document.Nodes[target.Id].Subject)
                     == "Oversized.Logging"
                 && Assert.IsType<
@@ -2434,11 +2478,11 @@ public sealed class InspectionGraphIntegrationsQueryTests
                 node =>
                     node.Subject
                         is InspectionGraphSubject.TypeSubject
-                        {
-                            Identity:
+                    {
+                        Identity:
                                 InspectionGraphTypeIdentity
                                     .AcquiredDefinition identity,
-                        }
+                    }
                     && AcquiredAssemblyName(
                         document,
                         identity.Registration) == assemblyName
@@ -2501,11 +2545,11 @@ public sealed class InspectionGraphIntegrationsQueryTests
                     node =>
                         node.Subject
                             is InspectionGraphSubject.AssemblySubject
-                            {
-                                Identity:
+                        {
+                            Identity:
                                     InspectionGraphAssemblyIdentity.Acquired
                                     identity,
-                            }
+                        }
                         && ReferenceEquals(
                             identity.Registration,
                             registration))
@@ -3354,51 +3398,82 @@ public sealed class InspectionGraphIntegrationsQueryTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            if (request.Target
-                is not AssemblyBindingTarget.AssemblyReference reference)
-            {
-                return AssemblyBindingSelection.NotFound();
-            }
-            if (_unavailableOpenAiBinding
-                && reference.Identity.Name.Equals(
-                    "OpenAI",
-                    StringComparison.OrdinalIgnoreCase))
-            {
-                return AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind
-                            .IdentityPolicyRequired));
-            }
-            if (_multipleUnavailableReferenceBindings
-                && (reference.Identity.Name.Equals(
-                        "Foo",
-                        StringComparison.OrdinalIgnoreCase)
-                    || reference.Identity.Name.Equals(
-                        "Bar",
-                        StringComparison.OrdinalIgnoreCase)))
-            {
-                return AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind
-                            .IdentityPolicyRequired));
-            }
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
 
-            ResolvedAssemblyReference[] candidates =
-            [
-                .. _assemblies.Where(assembly =>
-                    assembly.Identity.IsEquivalentTo(
-                        reference.Identity)),
-            ];
-            return candidates.Length switch
+            AssemblyBindingSelection SelectCore()
             {
-                0 => AssemblyBindingSelection.NotFound(),
-                1 => AssemblyBindingSelection.Found(candidates[0]),
-                _ => AssemblyBindingSelection.Multiple(
-                    [.. candidates]),
-            };
+                if (request.Target
+                    is not AssemblyBindingTarget.AssemblyReference reference)
+                {
+                    return AssemblyBindingSelection.NotFound();
+                }
+                if (_unavailableOpenAiBinding
+                    && reference.Identity.Name.Equals(
+                        "OpenAI",
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind
+                                .IdentityPolicyRequired));
+                }
+                if (_multipleUnavailableReferenceBindings
+                    && (reference.Identity.Name.Equals(
+                            "Foo",
+                            StringComparison.OrdinalIgnoreCase)
+                        || reference.Identity.Name.Equals(
+                            "Bar",
+                            StringComparison.OrdinalIgnoreCase)))
+                {
+                    return AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind
+                                .IdentityPolicyRequired));
+                }
+
+                ResolvedAssemblyReference[] candidates =
+                [
+                    .. _assemblies.Where(assembly =>
+                        assembly.Identity.IsEquivalentTo(
+                            reference.Identity)),
+                ];
+                return candidates.Length switch
+                {
+                    0 => AssemblyBindingSelection.NotFound(),
+                    1 => AssemblyBindingSelection.Found(candidates[0]),
+                    _ => AssemblyBindingSelection.Multiple(
+                        [.. candidates]),
+                };
+
+            }
         }
+    }
+
+    sealed class SnapshotPolicy : IAssemblyBindingPolicy
+    {
+        readonly AssemblyBindingSelection _selection;
+
+        internal SnapshotPolicy(AssemblyBindingSelection selection)
+        {
+            _selection = selection;
+            SnapshotVersion = Version;
+        }
+
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+        internal AssemblyBindingPolicyVersion SnapshotVersion { get; set; }
+        internal bool ReturnNull { get; set; }
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request) =>
+            ReturnNull
+                ? null!
+                : new AssemblyBindingSelectionSnapshot(
+                    SnapshotVersion,
+                    _selection);
     }
 }

--- a/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
+++ b/src/DotnetInspector.Queries.Tests/InspectionWorkspaceTests.cs
@@ -1744,11 +1744,18 @@ public sealed class InspectionWorkspaceTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 
     static async Task<ArtifactAssembly>

--- a/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/MemberCallGraphSessionTests.cs
@@ -1752,8 +1752,15 @@ public sealed class MemberCallGraphSessionTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NotFound();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NotFound();
+        }
     }
 }

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextRolesTests.cs
@@ -34,7 +34,7 @@ public sealed class PackageAssemblyContextRolesTests
                     AssemblyBindingTarget.Reference(
                         implementationOnly.Identity),
                     AssemblyBindingOrigin.FromAssembly(surface),
-                    AssemblyResolutionScope.Any)));
+                    AssemblyResolutionScope.Any)).Selection);
     }
 
     [Fact]
@@ -82,12 +82,12 @@ public sealed class PackageAssemblyContextRolesTests
             new AssemblyBindingRequest(
                 AssemblyBindingTarget.Reference(assembly.Identity),
                 AssemblyBindingOrigin.FromAssembly(assembly),
-                AssemblyResolutionScope.Any));
+                AssemblyResolutionScope.Any)).Selection;
         AssemblyBindingSelection platform = policy.Select(
             new AssemblyBindingRequest(
                 AssemblyBindingTarget.Reference(assembly.Identity),
                 AssemblyBindingOrigin.FromAssembly(assembly),
-                AssemblyResolutionScope.Platform));
+                AssemblyResolutionScope.Platform)).Selection;
 
         Assert.Same(
             assembly,
@@ -99,7 +99,7 @@ public sealed class PackageAssemblyContextRolesTests
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.CoreLibrary(),
                         AssemblyBindingOrigin.FromAssembly(assembly),
-                        AssemblyResolutionScope.Platform)));
+                        AssemblyResolutionScope.Platform)).Selection);
         Assert.Equal(
             AssemblyBindingFailureKind.UnsupportedScope,
             intrinsic.Failure.Kind);

--- a/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
+++ b/src/DotnetInspector.Queries.Tests/WorkspaceContextLoaderTests.cs
@@ -176,7 +176,7 @@ public sealed class WorkspaceContextLoaderTests
             new AssemblyBindingRequest(
                 AssemblyBindingTarget.Reference(target.Assembly.Identity),
                 AssemblyBindingOrigin.FromAssembly(caller.Assembly),
-                AssemblyResolutionScope.Platform));
+                AssemblyResolutionScope.Platform)).Selection;
         Assert.Same(
             target.Assembly,
             Assert.IsType<AssemblyBindingSelection.Selected>(selection)
@@ -1193,7 +1193,7 @@ public sealed class WorkspaceContextLoaderTests
             new AssemblyBindingRequest(
                 AssemblyBindingTarget.Reference(target.Assembly.Identity),
                 AssemblyBindingOrigin.FromAssembly(caller.Assembly),
-                AssemblyResolutionScope.Any));
+                AssemblyResolutionScope.Any)).Selection;
 
         Assert.Same(
             target.Assembly,
@@ -1211,7 +1211,7 @@ public sealed class WorkspaceContextLoaderTests
                         null,
                         null)),
                 AssemblyBindingOrigin.FromAssembly(caller.Assembly),
-                AssemblyResolutionScope.Any));
+                AssemblyResolutionScope.Any)).Selection;
         Assert.IsType<AssemblyBindingSelection.Missing>(outside);
     }
 
@@ -2127,7 +2127,7 @@ public sealed class WorkspaceContextLoaderTests
             new AssemblyBindingRequest(
                 AssemblyBindingTarget.Reference(target.Assembly.Identity),
                 AssemblyBindingOrigin.FromAssembly(caller.Assembly),
-                AssemblyResolutionScope.Any));
+                AssemblyResolutionScope.Any)).Selection;
         Assert.Same(
             target.Assembly,
             Assert.IsType<AssemblyBindingSelection.Selected>(selection).Assembly);
@@ -3031,7 +3031,7 @@ public sealed class WorkspaceContextLoaderTests
                 new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(target.Assembly.Identity),
                     AssemblyBindingOrigin.FromAssembly(caller.Assembly),
-                    AssemblyResolutionScope.Any)));
+                    AssemblyResolutionScope.Any)).Selection);
     }
 
     [Fact]
@@ -3400,7 +3400,7 @@ public sealed class WorkspaceContextLoaderTests
                     AssemblyBindingTarget.Reference(
                         participant.Assembly.Identity),
                     AssemblyBindingOrigin.FromAssembly(first.Assembly),
-                    AssemblyResolutionScope.Any));
+                    AssemblyResolutionScope.Any)).Selection;
             Assert.Same(
                 participant.Assembly,
                 Assert.IsType<AssemblyBindingSelection.Selected>(selection)

--- a/src/DotnetInspector.Queries/AssemblyContextAnalysisSource.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextAnalysisSource.cs
@@ -42,12 +42,13 @@ internal static class AssemblyContextAnalysisSource
                         AssemblyBindingOrigin.FromAssembly(
                             participant.Assembly),
                         scope))
+                ?.Selection
                 is AssemblyBindingSelection.Selected selected
                     ? selected.Assembly
                     : null;
         }
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
@@ -56,12 +57,16 @@ internal static class AssemblyContextAnalysisSource
                 AssemblyBindingOrigin.FromAssembly(
                     participant.Assembly),
                 request.Scope);
+            AssemblyBindingSelectionSnapshot? snapshot =
+                participant.BindingPolicy.Select(
+                    participantRequest);
+            if (snapshot is null)
+                return null!;
             AssemblyBindingSelection selection =
                 AssemblyBindingSelection.ValidateForRequest(
                     participantRequest,
-                    participant.BindingPolicy.Select(
-                        participantRequest));
-            return selection switch
+                    snapshot.Selection);
+            selection = selection switch
             {
                 AssemblyBindingSelection.Selected selected =>
                     RetainSelected(selected),
@@ -69,6 +74,9 @@ internal static class AssemblyContextAnalysisSource
                     RetainAmbiguous(ambiguous),
                 _ => selection,
             };
+            return new AssemblyBindingSelectionSnapshot(
+                snapshot.Version,
+                selection);
         }
 
         AssemblyBindingSelection RetainSelected(

--- a/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextSourceQuery.cs
@@ -282,13 +282,15 @@ public abstract record AssemblyTypeSourceEntry(
 public static class AssemblyContextSourceQuery
 {
     public static InspectionQuery<AssemblyMemberSourceEntry>
-        MemberDefinition { get; } =
+        MemberDefinition
+    { get; } =
         new(
             "Assembly context member source",
             InspectionCost.Moderated);
 
     public static InspectionQuery<AssemblyTypeSourceEntry>
-        TypeDefinition { get; } =
+        TypeDefinition
+    { get; } =
         new(
             "Assembly context type source",
             InspectionCost.Moderated);
@@ -923,7 +925,7 @@ public static class AssemblyContextSourceQuery
         ExceptionDispatchInfo.Capture(disposalFailure).Throw();
     }
 
-    sealed class CancellationObservingBindingPolicy(
+    internal sealed class CancellationObservingBindingPolicy(
         IAssemblyBindingPolicy inner,
         AssemblyBindingPolicyVersion expectedVersion)
         : IAssemblyBindingPolicy
@@ -943,18 +945,32 @@ public static class AssemblyContextSourceQuery
             }
         }
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
             EnsureVersion();
             try
             {
+                AssemblyBindingSelectionSnapshot? snapshot =
+                    inner.Select(request);
+                if (snapshot is null)
+                    return null!;
+                if (!ReferenceEquals(
+                        snapshot.Version,
+                        expectedVersion))
+                {
+                    throw new InvalidOperationException(
+                        "The participant binding-policy snapshot changed during source inspection.");
+                }
+
                 AssemblyBindingSelection selection =
                     AssemblyBindingSelection.ValidateForRequest(
                         request,
-                        inner.Select(request));
+                        snapshot.Selection);
                 EnsureVersion();
-                return ObserveSelectedAssemblies(selection);
+                return new AssemblyBindingSelectionSnapshot(
+                    expectedVersion,
+                    ObserveSelectedAssemblies(selection));
             }
             catch (OperationCanceledException ex)
             {

--- a/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/InspectionGraphIntegrationsQuery.cs
@@ -10,35 +10,37 @@ namespace DotnetInspector.Queries;
 public static class InspectionGraphIntegrationsCatalog
 {
     static InspectionGraphOccurrenceIdentityProjection
-        OccurrenceIdentity { get; } =
+        OccurrenceIdentity
+    { get; } =
         new IntegrationOccurrenceIdentityProjection();
 
     static InspectionGraphEndpointProjection
-        OpportunityEndpointProjection { get; } =
+        OpportunityEndpointProjection
+    { get; } =
         new OpportunityEndpointProjectionImpl();
 
     public static InspectionGraphEvidenceDescriptor ExtensionEvidence { get; } =
         new("metadata.extension-api", InspectionGraphOwner.Metadata);
 
     public static InspectionGraphEvidenceDescriptor IntegrationEvidence
-        { get; } =
+    { get; } =
         new("metadata.integration-api", InspectionGraphOwner.Metadata);
 
     public static InspectionGraphEvidenceDescriptor ReferenceEvidence { get; } =
         new("metadata.assembly-reference", InspectionGraphOwner.Metadata);
 
     public static InspectionGraphEvidenceDescriptor OpportunityEvidence
-        { get; } =
+    { get; } =
         new("metadata.integration-opportunity", InspectionGraphOwner.Metadata);
 
     public static InspectionGraphEvidenceDescriptor CensusObservedEvidence
-        { get; } =
+    { get; } =
         new(
             "queries.integration-census-observed",
             InspectionGraphOwner.Queries);
 
     public static InspectionGraphEvidenceDescriptor CensusOpportunityEvidence
-        { get; } =
+    { get; } =
         new(
             "queries.integration-census-opportunity",
             InspectionGraphOwner.Queries);
@@ -47,7 +49,7 @@ public static class InspectionGraphIntegrationsCatalog
         new("queries.integration-graph-failure", InspectionGraphOwner.Queries);
 
     public static InspectionGraphEvidenceDescriptor CensusFailureEvidence
-        { get; } =
+    { get; } =
         new(
             "queries.integration-census-incomplete",
             InspectionGraphOwner.Queries);
@@ -84,7 +86,7 @@ public static class InspectionGraphIntegrationsCatalog
             [ExtensionEvidence]);
 
     public static InspectionGraphRelationshipDescriptor IntegrationObserved
-        { get; } =
+    { get; } =
         new(
             "integration.observed",
             InspectionGraphOwner.Metadata,
@@ -125,7 +127,7 @@ public static class InspectionGraphIntegrationsCatalog
             ]);
 
     public static InspectionGraphRelationshipDescriptor MetadataReference
-        { get; } =
+    { get; } =
         new(
             "metadata.reference",
             InspectionGraphOwner.Metadata,
@@ -157,7 +159,8 @@ public static class InspectionGraphIntegrationsCatalog
             [ReferenceEvidence]);
 
     public static InspectionGraphRelationshipDescriptor
-        IntegrationOpportunity { get; } =
+        IntegrationOpportunity
+    { get; } =
         new(
             "integration.opportunity",
             InspectionGraphOwner.Metadata,
@@ -201,7 +204,8 @@ public static class InspectionGraphIntegrationsCatalog
             ]);
 
     public static ImmutableArray<InspectionGraphRelationshipDescriptor>
-        Relationships { get; } =
+        Relationships
+    { get; } =
         [
             Extension,
             IntegrationObserved,
@@ -351,35 +355,35 @@ public static class InspectionGraphIntegrationsCatalog
                 return true;
             if (occurrence.SourceSubject
                     is InspectionGraphSubject.TypeSubject
-                    {
-                        Identity:
+                {
+                    Identity:
                             InspectionGraphTypeIdentity.CensusType
                             sourceType,
-                    }
+                }
                 && endpoint
                     is InspectionGraphSubject.AssemblySubject
-                    {
-                        Identity:
+                {
+                    Identity:
                             InspectionGraphAssemblyIdentity
                                 .CensusParticipant sourceAssembly,
-                    })
+                })
             {
                 return sourceType.Identity.Participant.Equals(
                     sourceAssembly.Participant);
             }
             return occurrence.SourceSubject
                     is InspectionGraphSubject.TypeSubject
-                    {
-                        Identity:
+            {
+                Identity:
                             InspectionGraphTypeIdentity.AcquiredDefinition
                             source,
-                    }
+            }
                 && endpoint
                     is InspectionGraphSubject.AssemblySubject
-                    {
-                        Identity:
+                {
+                    Identity:
                             InspectionGraphAssemblyIdentity.Acquired assembly,
-                    }
+                }
                 && ReferenceEquals(
                     source.Registration,
                     assembly.Registration);
@@ -660,11 +664,12 @@ public sealed record InspectionGraphIntegrationCensusFailureEvidence :
     }
 
     public ImmutableArray<IntegrationSourceParticipantAttempt> SourceAttempts
-        { get; }
+    { get; }
     public ImmutableArray<IntegrationProducerPolicyAttempt>
-        ProducerPolicyAttempts { get; }
+        ProducerPolicyAttempts
+    { get; }
     public ImmutableArray<IntegrationCandidateAttempt.Failed> CandidateAttempts
-        { get; }
+    { get; }
 
     public InspectionGraphEvidenceDescriptor Descriptor =>
         InspectionGraphIntegrationsCatalog.CensusFailureEvidence;
@@ -695,7 +700,7 @@ public sealed record InspectionGraphIntegrationFailureEvidence :
     }
 
     public ImmutableArray<InspectionGraphIntegrationFailureDetail> Details
-        { get; }
+    { get; }
 
     public InspectionGraphEvidenceDescriptor Descriptor =>
         InspectionGraphIntegrationsCatalog.FailureEvidence;
@@ -984,6 +989,33 @@ public static class InspectionGraphIntegrationsQuery
             request);
     }
 
+    internal static AssemblyBindingSelection SelectBindingForVersion(
+        IAssemblyBindingPolicy policy,
+        AssemblyBindingPolicyVersion expectedVersion,
+        AssemblyBindingRequest request)
+    {
+        if (!ReferenceEquals(policy.Version, expectedVersion))
+        {
+            throw new InvalidOperationException(
+                "The participant binding-policy snapshot changed during Integration graph construction.");
+        }
+
+        AssemblyBindingSelectionSnapshot? snapshot =
+            policy.Select(request);
+        if (snapshot is not null
+            && !ReferenceEquals(
+                snapshot.Version,
+                expectedVersion))
+        {
+            throw new InvalidOperationException(
+                "The participant binding-policy snapshot changed during Integration graph construction.");
+        }
+
+        return AssemblyBindingSelection.ValidateForRequest(
+            request,
+            snapshot?.Selection);
+    }
+
     static InspectionGraphDocument CreateSelectedSource(
         WorkspaceContextLoadOutcome.Loaded context,
         InspectionGraphModeRequest modeRequest,
@@ -1072,6 +1104,7 @@ public static class InspectionGraphIntegrationsQuery
     sealed class Builder
     {
         readonly WorkspaceContextLoadOutcome.Loaded _context;
+        readonly AssemblyBindingPolicyVersion _bindingPolicyVersion;
         readonly InspectionGraphPackageBoundary _boundary;
         readonly List<InspectionGraphNode> _nodes;
         readonly ImmutableArray<InspectionGraphGroup> _groups;
@@ -1105,6 +1138,7 @@ public static class InspectionGraphIntegrationsQuery
             InspectionGraphPackageBoundary boundary)
         {
             _context = context;
+            _bindingPolicyVersion = context.Group.BindingPolicyVersion;
             _boundary = boundary;
             InspectionGraphDocument packageDocument = boundary.Project(
                 InspectionGraphPackageBoundaryLens.PackageGroups);
@@ -1714,6 +1748,7 @@ public static class InspectionGraphIntegrationsQuery
         internal InspectionGraphDocument Build(
             InspectionGraphModeRequest modeRequest)
         {
+            EnsureBindingPolicyVersions();
             InspectionGraphEdge[] edges =
             [
                 .. _edges.Select((edge, id) =>
@@ -2034,9 +2069,10 @@ public static class InspectionGraphIntegrationsQuery
                     source.Assembly),
                 AssemblyResolutionScope.Any);
             AssemblyBindingSelection selection =
-                AssemblyBindingSelection.ValidateForRequest(
-                    request,
-                    source.BindingPolicy.Select(request));
+                SelectBindingForVersion(
+                    source.BindingPolicy,
+                    _bindingPolicyVersion,
+                    request);
             if (selection
                 is AssemblyBindingSelection.Selected selected)
             {
@@ -2073,6 +2109,27 @@ public static class InspectionGraphIntegrationsQuery
                     .BindingUnavailable,
             };
             return false;
+        }
+
+        void EnsureBindingPolicyVersions()
+        {
+            foreach (AssemblyContextParticipant participant
+                in _participants.Values)
+            {
+                EnsureBindingPolicyVersion(participant);
+            }
+        }
+
+        void EnsureBindingPolicyVersion(
+            AssemblyContextParticipant participant)
+        {
+            if (!ReferenceEquals(
+                    participant.BindingPolicy.Version,
+                    _bindingPolicyVersion))
+            {
+                throw new InvalidOperationException(
+                    "The participant binding-policy snapshot changed during Integration graph construction.");
+            }
         }
 
         int AddNode(
@@ -2246,7 +2303,7 @@ public static class InspectionGraphIntegrationsQuery
             internal int FromNodeId { get; } = fromNodeId;
             internal int ToNodeId { get; } = toNodeId;
             internal InspectionGraphRelationshipDescriptor Relationship
-                { get; } = relationship;
+            { get; } = relationship;
             internal List<int> OccurrenceIds { get; } = [];
         }
 
@@ -2254,7 +2311,7 @@ public static class InspectionGraphIntegrationsQuery
         {
             internal int TargetId { get; } = targetId;
             internal List<InspectionGraphIntegrationFailureDetail> Details
-                { get; } = [];
+            { get; } = [];
         }
 
         readonly record struct FailureKey(

--- a/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
+++ b/src/DotnetInspector.Queries/PackageAssemblyContextRoles.cs
@@ -412,27 +412,36 @@ public sealed class PackageAssemblyContextRoles : IDisposable
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
             ArgumentNullException.ThrowIfNull(request);
+            AssemblyBindingSelection selection;
             if (request.Target
                 is AssemblyBindingTarget.IntrinsicCoreLibrary)
             {
-                return AssemblyBindingSelection.CannotSelect(
+                selection = AssemblyBindingSelection.CannotSelect(
                     new AssemblyBindingFailure(
                         AssemblyBindingFailureKind.UnsupportedScope));
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
             }
             if (request.Target
                     is not AssemblyBindingTarget.AssemblyReference reference)
             {
-                return AssemblyBindingSelection.Invalid(
+                selection = AssemblyBindingSelection.Invalid(
                     new AssemblyBindingFailure(
                         AssemblyBindingFailureKind.InvalidPolicyResult));
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
             }
             if (request.Scope == AssemblyResolutionScope.Platform)
             {
-                return AssemblyBindingSelection.NameNotOwned();
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    AssemblyBindingSelection.NameNotOwned());
             }
 
             ImmutableArray<ResolvedAssemblyReference> matches =
@@ -441,7 +450,7 @@ public sealed class PackageAssemblyContextRoles : IDisposable
                     assembly => assembly.Identity.IsEquivalentTo(
                         reference.Identity)),
             ];
-            return matches.Length switch
+            selection = matches.Length switch
             {
                 0 => assemblies.Any(assembly =>
                         string.Equals(
@@ -453,6 +462,9 @@ public sealed class PackageAssemblyContextRoles : IDisposable
                 1 => AssemblyBindingSelection.Found(matches[0]),
                 _ => AssemblyBindingSelection.Multiple(matches),
             };
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                selection);
         }
     }
 }

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -151,7 +151,7 @@ public class AssemblyDependencyResolverTests
                                     Culture: null,
                                     PublicKeyToken: null)),
                             AssemblyBindingOrigin.Global(),
-                            AssemblyResolutionScope.Any)));
+                            AssemblyResolutionScope.Any)).Selection);
 
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
@@ -199,7 +199,7 @@ public class AssemblyDependencyResolverTests
                                     Culture: null,
                                     PublicKeyToken: null)),
                             AssemblyBindingOrigin.Global(),
-                            AssemblyResolutionScope.Any)));
+                            AssemblyResolutionScope.Any)).Selection);
 
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
@@ -256,7 +256,7 @@ public class AssemblyDependencyResolverTests
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(platformIdentity),
                         AssemblyBindingOrigin.Global(),
-                        AssemblyResolutionScope.Any)));
+                        AssemblyResolutionScope.Any)).Selection);
 
             Assert.Equal(
                 AssemblyBindingMissDisposition.NameOwnedNoMatch,
@@ -293,7 +293,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var missing = Assert.IsType<AssemblyBindingSelection.Missing>(
-            resolver.Select(request));
+            resolver.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingMissDisposition.NoNameOwner,
@@ -326,7 +326,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var missing = Assert.IsType<AssemblyBindingSelection.Missing>(
-            resolver.Select(request));
+            resolver.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingMissDisposition.NoNameOwner,
@@ -350,7 +350,7 @@ public class AssemblyDependencyResolverTests
             AssemblyBindingOrigin.Global(),
             AssemblyResolutionScope.Any);
         var owned = Assert.IsType<AssemblyBindingSelection.Missing>(
-            resolver.Select(ownedRequest));
+            resolver.Select(ownedRequest).Selection);
 
         Assert.Equal(
             AssemblyBindingMissDisposition.NameOwnedNoMatch,
@@ -382,7 +382,7 @@ public class AssemblyDependencyResolverTests
                 new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(platformIdentity),
                     AssemblyBindingOrigin.Global(),
-                    AssemblyResolutionScope.Any)));
+                    AssemblyResolutionScope.Any)).Selection);
 
         Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
             selected.Assembly.Provenance);
@@ -441,7 +441,7 @@ public class AssemblyDependencyResolverTests
                                     AssemblyReferenceIdentity
                                         .ComputePublicKeyToken(selectedKey))),
                             AssemblyBindingOrigin.Global(),
-                            AssemblyResolutionScope.Any)));
+                            AssemblyResolutionScope.Any)).Selection);
 
             Assert.Equal(candidates[1], selection.Assembly.Path);
         }
@@ -497,10 +497,10 @@ public class AssemblyDependencyResolverTests
 
         var selected = Assert.IsType<
             AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
         var repeated = Assert.IsType<
             AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
         Assert.Same(selected.Assembly, repeated.Assembly);
 
@@ -580,8 +580,8 @@ public class AssemblyDependencyResolverTests
 
         var selected = Assert.IsType<
             AssemblyBindingSelection.Selected>(
-                group.Select(request));
-        _ = group.Select(request);
+                group.Select(request).Selection);
+        _ = group.Select(request).Selection;
 
         Assert.Same(coreLibrary, selected.Assembly);
         Assert.Equal(0, firstOpens);
@@ -666,14 +666,14 @@ public class AssemblyDependencyResolverTests
             ]);
         AssemblyBindingPolicyVersion version = group.Version;
 
-        Task<AssemblyBindingSelection> firstSelection = Task.Run(
+        Task<AssemblyBindingSelectionSnapshot> firstSelection = Task.Run(
             () => group.Select(
                 new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(
                         firstCandidate.Identity),
                     AssemblyBindingOrigin.FromAssembly(firstOwner),
                     AssemblyResolutionScope.Any)));
-        Task<AssemblyBindingSelection> secondSelection = Task.Run(
+        Task<AssemblyBindingSelectionSnapshot> secondSelection = Task.Run(
             () => group.Select(
                 new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(
@@ -681,17 +681,20 @@ public class AssemblyDependencyResolverTests
                     AssemblyBindingOrigin.FromAssembly(secondOwner),
                     AssemblyResolutionScope.Any)));
 
-        AssemblyBindingSelection[] selections =
+        AssemblyBindingSelectionSnapshot[] snapshots =
             await Task.WhenAll(firstSelection, secondSelection);
 
         Assert.Same(
             firstCandidate,
             Assert.IsType<AssemblyBindingSelection.Selected>(
-                selections[0]).Assembly);
+                snapshots[0].Selection).Assembly);
         Assert.Same(
             secondCandidate,
             Assert.IsType<AssemblyBindingSelection.Selected>(
-                selections[1]).Assembly);
+                snapshots[1].Selection).Assembly);
+        Assert.All(
+            snapshots,
+            snapshot => Assert.Same(version, snapshot.Version));
 
         var probe = new AssemblyReferenceIdentity(
             "Probe",
@@ -704,14 +707,14 @@ public class AssemblyDependencyResolverTests
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(probe),
                         AssemblyBindingOrigin.FromAssembly(firstCandidate),
-                        AssemblyResolutionScope.Any)));
+                        AssemblyResolutionScope.Any)).Selection);
         var secondProbe = Assert.IsType<
             AssemblyBindingSelection.Selected>(
                 group.Select(
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(probe),
                         AssemblyBindingOrigin.FromAssembly(secondCandidate),
-                        AssemblyResolutionScope.Any)));
+                        AssemblyResolutionScope.Any)).Selection);
 
         Assert.Same(firstCandidate, firstProbe.Assembly);
         Assert.Same(secondCandidate, secondProbe.Assembly);
@@ -834,7 +837,7 @@ public class AssemblyDependencyResolverTests
 
         var unavailable = Assert.IsType<
             AssemblyBindingSelection.Unavailable>(
-                group.Select(request));
+                group.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.IdentityPolicyRequired,
@@ -878,7 +881,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal([first, second], ambiguous.Assemblies);
     }
@@ -916,7 +919,7 @@ public class AssemblyDependencyResolverTests
 
         var unavailable = Assert.IsType<
             AssemblyBindingSelection.Unavailable>(
-                group.Select(request));
+                group.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.IdentityPolicyRequired,
@@ -953,7 +956,7 @@ public class AssemblyDependencyResolverTests
 
         var selected = Assert.IsType<
             AssemblyBindingSelection.Selected>(
-                group.Select(request));
+                group.Select(request).Selection);
 
         Assert.Same(root, selected.Assembly);
     }
@@ -992,7 +995,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var result = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(selected, result.Assembly);
     }
@@ -1036,7 +1039,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Same(platform, Assert.Single(selected.ShadowedAssemblies));
@@ -1077,7 +1080,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var missing = Assert.IsType<AssemblyBindingSelection.Missing>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(disposition, missing.Disposition);
         Assert.Equal(1, policy.SelectionCount);
@@ -1115,7 +1118,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var missing = Assert.IsType<AssemblyBindingSelection.Missing>(
-            group.Select(request));
+            group.Select(request).Selection);
         Assert.Equal(
             AssemblyBindingMissDisposition.Undifferentiated,
             missing.Disposition);
@@ -1154,7 +1157,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Equal(1, policy.SelectionCount);
@@ -1183,7 +1186,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var missing = Assert.IsType<AssemblyBindingSelection.Missing>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingMissDisposition.NoNameOwner,
@@ -1224,7 +1227,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(2, ambiguous.Assemblies.Length);
         Assert.Contains(first, ambiguous.Assemblies);
@@ -1252,7 +1255,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Empty(selected.ShadowedAssemblies);
@@ -1287,7 +1290,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Empty(selected.ShadowedAssemblies);
@@ -1327,7 +1330,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.IdentityPolicyRequired,
@@ -1372,7 +1375,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Same(platform, Assert.Single(selected.ShadowedAssemblies));
@@ -1419,7 +1422,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.CandidateUnavailable,
@@ -1468,7 +1471,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(2, ambiguous.Assemblies.Length);
         Assert.Contains(root, ambiguous.Assemblies);
@@ -1512,7 +1515,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Equal(2, ambiguous.Assemblies.Length);
         Assert.Contains(root, ambiguous.Assemblies);
@@ -1565,7 +1568,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(designated, selected.Assembly);
         Assert.Equal(2, selected.ShadowedAssemblies.Length);
@@ -1612,7 +1615,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            group.Select(request));
+            group.Select(request).Selection);
 
         Assert.Same(platform, selected.Assembly);
         Assert.Empty(selected.ShadowedAssemblies);
@@ -1683,7 +1686,7 @@ public class AssemblyDependencyResolverTests
                 scope);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(designatedPath, selected.Assembly.Path);
             Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
@@ -1729,7 +1732,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            resolver.Select(request));
+            resolver.Select(request).Selection);
 
         Assert.Equal(platformPath, selected.Assembly.Path);
         Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
@@ -1779,7 +1782,7 @@ public class AssemblyDependencyResolverTests
 
             var unavailable =
                 Assert.IsType<AssemblyBindingSelection.Unavailable>(
-                    resolver.Select(request));
+                    resolver.Select(request).Selection);
 
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
@@ -1829,7 +1832,7 @@ public class AssemblyDependencyResolverTests
 
             var unavailable =
                 Assert.IsType<AssemblyBindingSelection.Unavailable>(
-                    resolver.Select(request));
+                    resolver.Select(request).Selection);
 
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
@@ -1875,7 +1878,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Platform);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(designatedPath, selected.Assembly.Path);
             Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
@@ -1915,7 +1918,7 @@ public class AssemblyDependencyResolverTests
             AssemblyResolutionScope.Platform);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            resolver.Select(request));
+            resolver.Select(request).Selection);
 
         Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
             selected.Assembly.Provenance);
@@ -1959,7 +1962,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Platform);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(platformPath, selected.Assembly.Path);
             Assert.IsType<AssemblyResolutionProvenance.PlatformAsset>(
@@ -2008,7 +2011,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Platform);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(platformPath, selected.Assembly.Path);
             Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
@@ -2062,7 +2065,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Any);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.IsType<AssemblyResolutionProvenance.DesignatedAsset>(
                 selected.Assembly.Provenance);
@@ -2138,7 +2141,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Any);
 
             var ambiguous = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(2, ambiguous.Assemblies.Length);
             Assert.All(
@@ -2194,7 +2197,7 @@ public class AssemblyDependencyResolverTests
                 AssemblyResolutionScope.Any);
 
             var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-                resolver.Select(request));
+                resolver.Select(request).Selection);
 
             Assert.Equal(siblingPath, selected.Assembly.Path);
             Assert.IsType<AssemblyResolutionProvenance.LocalAsset>(
@@ -2251,11 +2254,19 @@ public class AssemblyDependencyResolverTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            SelectionCount++;
-            return AssemblyBindingSelection.Found(selected);
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                SelectionCount++;
+                return AssemblyBindingSelection.Found(selected);
+
+            }
         }
     }
 
@@ -2270,18 +2281,26 @@ public class AssemblyDependencyResolverTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            if (Interlocked.Increment(ref _selectionCount) == 1
-                && !firstSelectionBarrier.SignalAndWait(
-                    TimeSpan.FromSeconds(30)))
-            {
-                throw new TimeoutException(
-                    "Concurrent binding selections did not rendezvous.");
-            }
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
 
-            return AssemblyBindingSelection.Found(selected);
+            AssemblyBindingSelection SelectCore()
+            {
+                if (Interlocked.Increment(ref _selectionCount) == 1
+                    && !firstSelectionBarrier.SignalAndWait(
+                        TimeSpan.FromSeconds(30)))
+                {
+                    throw new TimeoutException(
+                        "Concurrent binding selections did not rendezvous.");
+                }
+
+                return AssemblyBindingSelection.Found(selected);
+
+            }
         }
     }
 
@@ -2291,9 +2310,16 @@ public class AssemblyDependencyResolverTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NameNotOwned();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NameNotOwned();
+        }
     }
 
     static AssemblyBindingSelection Missing(
@@ -2316,11 +2342,19 @@ public class AssemblyDependencyResolverTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            SelectionCount++;
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                SelectionCount++;
+                return selection;
+
+            }
         }
     }
 

--- a/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
+++ b/src/DotnetInspector.Services/AssemblyDependencyResolver.cs
@@ -132,16 +132,18 @@ public sealed partial class AssemblyDependencyResolver :
 
     public AssemblyBindingPolicyVersion Version { get; } = new();
 
-    public AssemblyBindingSelection Select(
+    public AssemblyBindingSelectionSnapshot Select(
         AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
         var key = AssemblyBindingRequestKey.From(request);
-        return _bindingSelections.GetOrAdd(
-            key,
-            _ => new Lazy<AssemblyBindingSelection>(
-                () => SelectCore(request),
-                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+        return new AssemblyBindingSelectionSnapshot(
+            Version,
+            _bindingSelections.GetOrAdd(
+                key,
+                _ => new Lazy<AssemblyBindingSelection>(
+                    () => SelectCore(request),
+                    LazyThreadSafetyMode.ExecutionAndPublication)).Value);
     }
 
     public IReadOnlyList<ResolvedAssemblyDependency> ResolveAll()

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -58,13 +58,14 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
     public AssemblyBindingPolicyVersion Version =>
         Volatile.Read(ref _state).Version;
 
-    public AssemblyBindingSelection Select(
+    public AssemblyBindingSelectionSnapshot Select(
         AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        return Select(
-            Volatile.Read(ref _state),
-            request);
+        BindingPolicyState state = Volatile.Read(ref _state);
+        return new AssemblyBindingSelectionSnapshot(
+            state.Version,
+            Select(state, request));
     }
 
     AssemblyBindingSelection Select(
@@ -141,10 +142,12 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             }
         }
 
+        AssemblyBindingSelectionSnapshot? snapshot =
+            policy.Select(request);
         AssemblyBindingSelection selection =
             AssemblyBindingSelection.ValidateForRequest(
                 request,
-                policy.Select(request));
+                snapshot?.Selection);
         if (reference is not null
             && pendingDesignated is not null)
         {
@@ -156,10 +159,10 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
         if (reference is not null
             && (selection
                     is AssemblyBindingSelection.Missing
-                    {
-                        Disposition:
+            {
+                Disposition:
                             AssemblyBindingMissDisposition.NoNameOwner,
-                    }
+            }
                 || selection
                     is AssemblyBindingSelection.Selected)
             && IdentityMismatchSelection(
@@ -461,7 +464,8 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             defaultPolicy;
         internal ImmutableDictionary<
             AssemblyAcquisitionRegistration,
-            AssemblyRoute> Routes { get; } =
+            AssemblyRoute> Routes
+        { get; } =
                 routes;
         internal IntrinsicSelectionCache IntrinsicSelections { get; } =
             intrinsicSelections;

--- a/src/ILInspector.Analysis.Tests/CallerScopeReachabilityPlanTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallerScopeReachabilityPlanTests.cs
@@ -166,7 +166,7 @@ public class CallerScopeReachabilityPlanTests
                     target,
                     []);
 
-            Assert.Same(terminal, policy.Select(request));
+            Assert.Same(terminal, policy.Select(request).Selection);
         }
     }
 
@@ -190,7 +190,7 @@ public class CallerScopeReachabilityPlanTests
 
         var unavailable =
             Assert.IsType<AssemblyBindingSelection.Unavailable>(
-                policy.Select(request));
+                policy.Select(request).Selection);
         Assert.Equal(
             AssemblyBindingFailureKind.IdentityPolicyRequired,
             unavailable.Failure.Kind);
@@ -216,7 +216,7 @@ public class CallerScopeReachabilityPlanTests
             AssemblyResolutionScope.Any);
 
         var selected = Assert.IsType<AssemblyBindingSelection.Selected>(
-            policy.Select(request));
+            policy.Select(request).Selection);
 
         Assert.Same(root, selected.Assembly);
         Assert.Equal(0, fallback.CallCount);
@@ -247,7 +247,7 @@ public class CallerScopeReachabilityPlanTests
 
         var ambiguous =
             Assert.IsType<AssemblyBindingSelection.Ambiguous>(
-                policy.Select(request));
+                policy.Select(request).Selection);
 
         Assert.Equal([target, root], ambiguous.Assemblies);
         Assert.Equal(1, fallback.CallCount);
@@ -280,7 +280,7 @@ public class CallerScopeReachabilityPlanTests
 
         var unavailable =
             Assert.IsType<AssemblyBindingSelection.Unavailable>(
-                policy.Select(request));
+                policy.Select(request).Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.IdentityPolicyRequired,
@@ -558,15 +558,22 @@ public class CallerScopeReachabilityPlanTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && _assemblies.TryGetValue(
-                    reference.Identity,
-                    out ResolvedAssemblyReference? assembly)
-                    ? AssemblyBindingSelection.Found(assembly)
-                    : AssemblyBindingSelection.NotFound();
+                reference.Identity,
+                out ResolvedAssemblyReference? assembly)
+                ? AssemblyBindingSelection.Found(assembly)
+                : AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class SelectedPolicy(
@@ -575,9 +582,16 @@ public class CallerScopeReachabilityPlanTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.Found(selected);
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.Found(selected);
+        }
     }
 
     sealed class FixedPolicy(AssemblyBindingSelection selection)
@@ -587,11 +601,19 @@ public class CallerScopeReachabilityPlanTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            CallCount++;
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                CallCount++;
+                return selection;
+
+            }
         }
     }
 }

--- a/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogCallGraphScopeTests.cs
@@ -735,17 +735,25 @@ public class CatalogCallGraphScopeTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            SelectionCount++;
-            return request.Target
-                is AssemblyBindingTarget.AssemblyReference reference
-                && _roots.TryGetValue(
-                    reference.Identity,
-                    out ResolvedAssemblyReference? root)
-                        ? AssemblyBindingSelection.Found(root)
-                        : inner.Select(request);
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                SelectionCount++;
+                return request.Target
+                    is AssemblyBindingTarget.AssemblyReference reference
+                    && _roots.TryGetValue(
+                        reference.Identity,
+                        out ResolvedAssemblyReference? root)
+                            ? AssemblyBindingSelection.Found(root)
+                            : inner.Select(request).Selection;
+
+            }
         }
     }
 
@@ -755,10 +763,17 @@ public class CatalogCallGraphScopeTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/ILInspector.Analysis.Tests/CatalogDirectCallerQueryTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogDirectCallerQueryTests.cs
@@ -499,37 +499,45 @@ public class CatalogDirectCallerQueryTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            if (request.Target
-                is not AssemblyBindingTarget.AssemblyReference reference)
-            {
-                return AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.CandidateUnavailable));
-            }
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
 
-            string path = Path.Combine(
-                _frameworkDirectory,
-                reference.Identity.Name + ".dll");
-            if (!File.Exists(path))
+            AssemblyBindingSelection SelectCore()
             {
-                return AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.CandidateUnavailable));
-            }
+                if (request.Target
+                    is not AssemblyBindingTarget.AssemblyReference reference)
+                {
+                    return AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind.CandidateUnavailable));
+                }
 
-            ResolvedAssemblyReference assembly =
-                ResolvedAssemblyReference.CreateFromPath(
-                    path,
-                    AssemblyResolutionProvenance.Local(
-                        "framework direct-caller test"));
-            return assembly.Identity == reference.Identity
-                ? AssemblyBindingSelection.Found(assembly)
-                : AssemblyBindingSelection.CannotSelect(
-                    new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.IdentityPolicyRequired));
+                string path = Path.Combine(
+                    _frameworkDirectory,
+                    reference.Identity.Name + ".dll");
+                if (!File.Exists(path))
+                {
+                    return AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind.CandidateUnavailable));
+                }
+
+                ResolvedAssemblyReference assembly =
+                    ResolvedAssemblyReference.CreateFromPath(
+                        path,
+                        AssemblyResolutionProvenance.Local(
+                            "framework direct-caller test"));
+                return assembly.Identity == reference.Identity
+                    ? AssemblyBindingSelection.Found(assembly)
+                    : AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind.IdentityPolicyRequired));
+
+            }
         }
     }
 
@@ -540,13 +548,22 @@ public class CatalogDirectCallerQueryTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            AssemblyBindingSelection selection = inner.Select(request);
-            if (selection is AssemblyBindingSelection.Selected)
-                SelectedCount++;
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                AssemblyBindingSelection selection =
+                    inner.Select(request).Selection;
+                if (selection is AssemblyBindingSelection.Selected)
+                    SelectedCount++;
+                return selection;
+
+            }
         }
     }
 
@@ -562,15 +579,22 @@ public class CatalogDirectCallerQueryTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && _assemblies.TryGetValue(
-                    reference.Identity,
-                    out ResolvedAssemblyReference? assembly)
-                    ? AssemblyBindingSelection.Found(assembly)
-                    : AssemblyBindingSelection.NotFound();
+                reference.Identity,
+                out ResolvedAssemblyReference? assembly)
+                ? AssemblyBindingSelection.Found(assembly)
+                : AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class UnavailablePolicy : IAssemblyBindingPolicy
@@ -579,10 +603,17 @@ public class CatalogDirectCallerQueryTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.CandidateUnavailable));
+                AssemblyBindingFailureKind.CandidateUnavailable));
+        }
     }
 }

--- a/src/ILInspector.Analysis.Tests/CatalogMemberCorrespondencePlanTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogMemberCorrespondencePlanTests.cs
@@ -1780,9 +1780,16 @@ public class CatalogMemberCorrespondencePlanTests
         internal static MissingPolicy Instance { get; } = new();
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NotFound();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class CoreLibraryPolicy(
@@ -1790,11 +1797,18 @@ public class CatalogMemberCorrespondencePlanTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
                 ? AssemblyBindingSelection.Found(coreLibrary)
                 : AssemblyBindingSelection.NameNotOwned();
+        }
     }
 
     sealed class UnavailablePolicy : IAssemblyBindingPolicy
@@ -1802,11 +1816,18 @@ public class CatalogMemberCorrespondencePlanTests
         internal static UnavailablePolicy Instance { get; } = new();
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.CannotSelect(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.CannotSelect(
                 new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.IdentityPolicyRequired));
+                AssemblyBindingFailureKind.IdentityPolicyRequired));
+        }
     }
 
     sealed class ExactPolicy : IAssemblyBindingPolicy
@@ -1822,13 +1843,20 @@ public class CatalogMemberCorrespondencePlanTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target is AssemblyBindingTarget.AssemblyReference reference
-            && _assemblies.TryGetValue(
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target is AssemblyBindingTarget.AssemblyReference reference
+                && _assemblies.TryGetValue(
                 reference.Identity,
                 out ResolvedAssemblyReference? assembly)
                 ? AssemblyBindingSelection.Found(assembly)
                 : AssemblyBindingSelection.NotFound();
+        }
     }
 }

--- a/src/ILInspector.Analysis.Tests/CatalogMethodDefinitionCorrespondencePlanTests.cs
+++ b/src/ILInspector.Analysis.Tests/CatalogMethodDefinitionCorrespondencePlanTests.cs
@@ -375,10 +375,10 @@ public sealed class CatalogMethodDefinitionCorrespondencePlanTests
             failure => failure
                 is CatalogMethodDefinitionCorrespondenceFailure
                     .ImageOwnerMismatch
-                {
-                    Side:
+            {
+                Side:
                         CatalogMethodDefinitionCorrespondenceSide.Source,
-                });
+            });
     }
 
     [Fact]
@@ -407,10 +407,10 @@ public sealed class CatalogMethodDefinitionCorrespondencePlanTests
             failure => failure
                 is CatalogMethodDefinitionCorrespondenceFailure
                     .InvalidMethodToken
-                {
-                    Side:
+            {
+                Side:
                         CatalogMethodDefinitionCorrespondenceSide.Source,
-                });
+            });
     }
 
     [Fact]
@@ -478,11 +478,11 @@ public sealed class CatalogMethodDefinitionCorrespondencePlanTests
             failure => failure
                 is CatalogMethodDefinitionCorrespondenceFailure
                     .ResourceLimitExceeded
-                {
-                    Limit:
+            {
+                Limit:
                         CatalogMethodDefinitionCorrespondenceLimit
                             .SameNameCandidates,
-                });
+            });
     }
 
     [Fact]
@@ -690,13 +690,20 @@ public sealed class CatalogMethodDefinitionCorrespondencePlanTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && target.Identity.IsEquivalentTo(reference.Identity)
-                    ? AssemblyBindingSelection.Found(target)
-                    : fallback.Select(request);
+                ? AssemblyBindingSelection.Found(target)
+                : fallback.Select(request).Selection;
+        }
     }
 
 }

--- a/src/ILInspector.Analysis/CallerScopeReachabilityPlan.cs
+++ b/src/ILInspector.Analysis/CallerScopeReachabilityPlan.cs
@@ -567,18 +567,29 @@ public sealed class CallerScopeReachabilityPlan
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
         {
+            AssemblyBindingSelection selection;
             if (request.Target
                 is not AssemblyBindingTarget.AssemblyReference reference)
             {
-                return AssemblyBindingSelection.ValidateForRequest(
+                AssemblyBindingSelectionSnapshot? nonReferenceSnapshot =
+                    _fallback.Select(request);
+                selection = AssemblyBindingSelection.ValidateForRequest(
                     request,
-                    _fallback.Select(request));
+                    nonReferenceSnapshot?.Selection);
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
             }
 
             if (_target.Identity.IsEquivalentTo(reference.Identity))
-                return AssemblyBindingSelection.Found(_target);
+            {
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    AssemblyBindingSelection.Found(_target));
+            }
 
             ImmutableArray<ResolvedAssemblyReference> matches = _roots
                 .Where(
@@ -587,15 +598,20 @@ public sealed class CallerScopeReachabilityPlan
                 .ToImmutableArray();
             if (matches.Length > 0)
             {
-                return matches.Length == 1
+                selection = matches.Length == 1
                     ? AssemblyBindingSelection.Found(matches[0])
                     : AssemblyBindingSelection.Multiple(matches);
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
             }
 
+            AssemblyBindingSelectionSnapshot? referenceSnapshot =
+                _fallback.Select(request);
             AssemblyBindingSelection delegated =
                 AssemblyBindingSelection.ValidateForRequest(
                     request,
-                    _fallback.Select(request));
+                    referenceSnapshot?.Selection);
             if (delegated
                 is not AssemblyBindingSelection.Missing
                 {
@@ -603,7 +619,9 @@ public sealed class CallerScopeReachabilityPlan
                         AssemblyBindingMissDisposition.NoNameOwner,
                 })
             {
-                return delegated;
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    delegated);
             }
 
             bool targetOwnsName = string.Equals(
@@ -623,7 +641,7 @@ public sealed class CallerScopeReachabilityPlan
             if (targetOwnsName)
                 nameOwners = nameOwners.Insert(0, _target);
 
-            return nameOwners.Length switch
+            selection = nameOwners.Length switch
             {
                 0 => delegated,
                 1 => AssemblyBindingSelection.CannotSelect(
@@ -631,6 +649,9 @@ public sealed class CallerScopeReachabilityPlan
                         AssemblyBindingFailureKind.IdentityPolicyRequired)),
                 _ => AssemblyBindingSelection.Multiple(nameOwners),
             };
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                selection);
         }
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ReferenceEqualityMetadataFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceEqualityMetadataFactsTests.cs
@@ -1151,30 +1151,38 @@ public class ReferenceEqualityMetadataFactsTests
         public bool ReceiverRequested { get; private set; }
         public bool BaseRequestedFromReceiver { get; private set; }
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            if (request.Target is not
-                AssemblyBindingTarget.AssemblyReference reference)
-            {
-                return _runtime.Select(request);
-            }
-            if (reference.Identity.Name == receiver.Identity.Name)
-            {
-                ReceiverRequested = true;
-                return AssemblyBindingSelection.Found(receiver);
-            }
-            if (reference.Identity.Name != rootBase.Identity.Name)
-                return _runtime.Select(request);
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
 
-            bool fromReceiver = request.Origin is
-                AssemblyBindingOrigin.RequestingAssembly origin
-                && ReferenceEquals(
-                origin.Registration,
-                receiver.Registration);
-            BaseRequestedFromReceiver |= fromReceiver;
-            return AssemblyBindingSelection.Found(
-                fromReceiver ? receiverBase : rootBase);
+            AssemblyBindingSelection SelectCore()
+            {
+                if (request.Target is not
+                    AssemblyBindingTarget.AssemblyReference reference)
+                {
+                    return _runtime.Select(request).Selection;
+                }
+                if (reference.Identity.Name == receiver.Identity.Name)
+                {
+                    ReceiverRequested = true;
+                    return AssemblyBindingSelection.Found(receiver);
+                }
+                if (reference.Identity.Name != rootBase.Identity.Name)
+                    return _runtime.Select(request).Selection;
+
+                bool fromReceiver = request.Origin is
+                    AssemblyBindingOrigin.RequestingAssembly origin
+                    && ReferenceEquals(
+                    origin.Registration,
+                    receiver.Registration);
+                BaseRequestedFromReceiver |= fromReceiver;
+                return AssemblyBindingSelection.Found(
+                    fromReceiver ? receiverBase : rootBase);
+
+            }
         }
     }
 

--- a/src/ILInspector.Metadata/AssemblyBinding.cs
+++ b/src/ILInspector.Metadata/AssemblyBinding.cs
@@ -63,6 +63,29 @@ public sealed record AssemblyBindingFailure
 public sealed class AssemblyBindingPolicyVersion;
 
 /// <summary>
+/// One immutable policy answer paired with the exact policy-state version that
+/// produced it.
+/// </summary>
+public sealed class AssemblyBindingSelectionSnapshot
+{
+    public AssemblyBindingSelectionSnapshot(
+        AssemblyBindingPolicyVersion version,
+        AssemblyBindingSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+        ArgumentNullException.ThrowIfNull(selection);
+        Version = version;
+        Selection = selection;
+    }
+
+    /// <summary>Gets the policy-state version that produced the selection.</summary>
+    public AssemblyBindingPolicyVersion Version { get; }
+
+    /// <summary>Gets the structured selection produced by that state.</summary>
+    public AssemblyBindingSelection Selection { get; }
+}
+
+/// <summary>
 /// The thing a binding policy is asked to select. This is deliberately
 /// separate from <see cref="TypeResolutionStart"/>, which describes where
 /// type resolution begins, and <see cref="TypeResolutionRequest"/>, which
@@ -364,8 +387,11 @@ public interface IAssemblyBindingPolicy
     /// <summary>Gets the identity of the policy snapshot in use.</summary>
     AssemblyBindingPolicyVersion Version { get; }
 
-    /// <summary>Selects descriptor candidates for one structured request.</summary>
-    AssemblyBindingSelection Select(AssemblyBindingRequest request);
+    /// <summary>
+    /// Selects descriptor candidates and atomically identifies the policy state
+    /// that produced the answer.
+    /// </summary>
+    AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request);
 }
 
 /// <summary>
@@ -381,7 +407,7 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
     readonly AssemblyBindingPolicyVersion _version = new();
     readonly ConcurrentDictionary<
         SelectionKey,
-        Lazy<AssemblyBindingSelection>> _selections = new();
+        Lazy<AssemblyBindingSelectionSnapshot>> _selections = new();
 
     public AssemblyReferenceBindingPolicy(IAssemblyReferenceResolver resolver)
     {
@@ -395,7 +421,8 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
             ? bindingPolicy.Version
             : _version;
 
-    public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+    public AssemblyBindingSelectionSnapshot Select(
+        AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (_bindingPolicy is { } bindingPolicy)
@@ -404,8 +431,10 @@ public sealed class AssemblyReferenceBindingPolicy : IAssemblyBindingPolicy
         var key = SelectionKey.From(request);
         return _selections.GetOrAdd(
             key,
-            _ => new Lazy<AssemblyBindingSelection>(
-                () => SelectLegacy(request),
+            _ => new Lazy<AssemblyBindingSelectionSnapshot>(
+                () => new AssemblyBindingSelectionSnapshot(
+                    _version,
+                    SelectLegacy(request)),
                 LazyThreadSafetyMode.ExecutionAndPublication)).Value;
     }
 

--- a/src/ILInspector.Metadata/NoResolverAssemblyBindingPolicy.cs
+++ b/src/ILInspector.Metadata/NoResolverAssemblyBindingPolicy.cs
@@ -14,20 +14,23 @@ public sealed class NoResolverAssemblyBindingPolicy : IAssemblyBindingPolicy
 
     public AssemblyBindingPolicyVersion Version { get; } = new();
 
-    public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+    public AssemblyBindingSelectionSnapshot Select(
+        AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        return request.Target switch
-        {
-            AssemblyBindingTarget.AssemblyReference =>
-                AssemblyBindingSelection.NameNotOwned(),
-            AssemblyBindingTarget.IntrinsicCoreLibrary =>
-                AssemblyBindingSelection.CannotSelect(
+        return new AssemblyBindingSelectionSnapshot(
+            Version,
+            request.Target switch
+            {
+                AssemblyBindingTarget.AssemblyReference =>
+                    AssemblyBindingSelection.NameNotOwned(),
+                AssemblyBindingTarget.IntrinsicCoreLibrary =>
+                    AssemblyBindingSelection.CannotSelect(
+                        new AssemblyBindingFailure(
+                            AssemblyBindingFailureKind.UnsupportedScope)),
+                _ => AssemblyBindingSelection.Invalid(
                     new AssemblyBindingFailure(
-                        AssemblyBindingFailureKind.UnsupportedScope)),
-            _ => AssemblyBindingSelection.Invalid(
-                new AssemblyBindingFailure(
-                    AssemblyBindingFailureKind.InvalidPolicyResult)),
-        };
+                        AssemblyBindingFailureKind.InvalidPolicyResult)),
+            });
     }
 }

--- a/src/ILInspector.Metadata/TypeResolutionContext.cs
+++ b/src/ILInspector.Metadata/TypeResolutionContext.cs
@@ -12,6 +12,25 @@ sealed record CachedBindingEvaluation(
     CandidateOpenFailure? OpenFailure = null,
     ImmutableArray<ResolvedAssemblyReference> Registrations = default);
 
+abstract record TypeResolutionContextBuildResult
+{
+    internal sealed record Completed(TypeResolutionContext Context)
+        : TypeResolutionContextBuildResult;
+
+    internal sealed record PolicyVersionChanged(
+        AssemblyBindingPolicyVersion Expected,
+        AssemblyBindingPolicyVersion? Observed)
+        : TypeResolutionContextBuildResult;
+}
+
+sealed class PolicyVersionChangedException(
+    AssemblyBindingPolicyVersion expected,
+    AssemblyBindingPolicyVersion? observed) : Exception
+{
+    internal AssemblyBindingPolicyVersion Expected { get; } = expected;
+    internal AssemblyBindingPolicyVersion? Observed { get; } = observed;
+}
+
 readonly record struct PolicyCacheKey(
     AssemblyBindingPolicyVersion PolicyVersion,
     object RequestKey);
@@ -514,7 +533,8 @@ public sealed class TypeResolutionCatalog : IDisposable
             lock (_gate)
                 ObjectDisposedException.ThrowIf(_disposed, this);
 
-            return TypeResolutionContext.Build(
+            TypeResolutionContextBuildResult result =
+                TypeResolutionContext.Build(
                 this,
                 policy,
                 roots,
@@ -524,6 +544,16 @@ public sealed class TypeResolutionCatalog : IDisposable
                 ownsCatalog,
                 allowRootAdjacencyDegradation,
                 cancellationToken);
+            return result switch
+            {
+                TypeResolutionContextBuildResult.Completed completed =>
+                    completed.Context,
+                TypeResolutionContextBuildResult.PolicyVersionChanged =>
+                    throw new InvalidOperationException(
+                        "The binding policy changed version during discovery."),
+                _ => throw new InvalidOperationException(
+                    "Unknown type-resolution context build result."),
+            };
         }
         finally
         {
@@ -980,7 +1010,7 @@ public sealed class TypeResolutionContext : IDisposable
         }
     }
 
-    internal static TypeResolutionContext Build(
+    internal static TypeResolutionContextBuildResult Build(
         TypeResolutionCatalog catalog,
         IAssemblyBindingPolicy policy,
         IEnumerable<ResolvedAssemblyReference> roots,
@@ -991,35 +1021,44 @@ public sealed class TypeResolutionContext : IDisposable
         bool allowRootAdjacencyDegradation,
         CancellationToken cancellationToken)
     {
-        var builder = new Builder(
-            catalog,
-            policy,
-            options.MaxForwarderHops,
-            options.MaxCandidates,
-            options.MaxTypeResolutionRequests,
-            ownsCatalog,
-            cancellationToken);
-        foreach (ResolvedAssemblyReference root in roots)
+        try
         {
-            ArgumentNullException.ThrowIfNull(root);
-            builder.Register(
-                root,
-                allowRootAdjacencyDegradation);
-        }
+            var builder = new Builder(
+                catalog,
+                policy,
+                options.MaxForwarderHops,
+                options.MaxCandidates,
+                options.MaxTypeResolutionRequests,
+                ownsCatalog,
+                cancellationToken);
+            foreach (ResolvedAssemblyReference root in roots)
+            {
+                ArgumentNullException.ThrowIfNull(root);
+                builder.Register(
+                    root,
+                    allowRootAdjacencyDegradation);
+            }
 
-        foreach (AssemblyBindingRequest request in bindingRequests)
+            foreach (AssemblyBindingRequest request in bindingRequests)
+            {
+                ArgumentNullException.ThrowIfNull(request);
+                builder.Add(request);
+            }
+
+            foreach (TypeResolutionRequest request in requests)
+            {
+                ArgumentNullException.ThrowIfNull(request);
+                builder.Add(request);
+            }
+
+            return builder.Freeze();
+        }
+        catch (PolicyVersionChangedException changed)
         {
-            ArgumentNullException.ThrowIfNull(request);
-            builder.Add(request);
+            return new TypeResolutionContextBuildResult.PolicyVersionChanged(
+                changed.Expected,
+                changed.Observed);
         }
-
-        foreach (TypeResolutionRequest request in requests)
-        {
-            ArgumentNullException.ThrowIfNull(request);
-            builder.Add(request);
-        }
-
-        return builder.Freeze();
     }
 
     /// <summary>
@@ -1698,10 +1737,17 @@ public sealed class TypeResolutionContext : IDisposable
             }
         }
 
-        internal TypeResolutionContext Freeze()
+        internal TypeResolutionContextBuildResult Freeze()
         {
             _cancellationToken.ThrowIfCancellationRequested();
-            EnsurePolicyVersion();
+            AssemblyBindingPolicyVersion? observedVersion = _policy.Version;
+            if (!ReferenceEquals(_policyVersion, observedVersion))
+            {
+                return new TypeResolutionContextBuildResult
+                    .PolicyVersionChanged(
+                        _policyVersion,
+                        observedVersion);
+            }
 
             // Policy-dependent work is promoted only after the whole
             // generation completes under the policy version captured at its
@@ -1739,19 +1785,20 @@ public sealed class TypeResolutionContext : IDisposable
                 _generation,
                 _candidates,
                 _inventories);
-            return new TypeResolutionContext(
-                _catalog,
-                _ownsCatalog,
-                _generation,
-                _candidates,
-                _registrationFailures,
-                _descriptors,
-                _outcomes.ToImmutableDictionary(),
-                _projectionFailures.ToImmutableDictionary(),
-                _bindings.ToImmutableDictionary(
-                    static pair => pair.Key,
-                    static pair => pair.Value.Outcome),
-                _inventories.ToImmutableDictionary());
+            return new TypeResolutionContextBuildResult.Completed(
+                new TypeResolutionContext(
+                    _catalog,
+                    _ownsCatalog,
+                    _generation,
+                    _candidates,
+                    _registrationFailures,
+                    _descriptors,
+                    _outcomes.ToImmutableDictionary(),
+                    _projectionFailures.ToImmutableDictionary(),
+                    _bindings.ToImmutableDictionary(
+                        static pair => pair.Key,
+                        static pair => pair.Value.Outcome),
+                    _inventories.ToImmutableDictionary()));
         }
 
         bool TryProjectRequest(
@@ -2284,10 +2331,10 @@ public sealed class TypeResolutionContext : IDisposable
         {
             MetadataTypeDefinitionKind kind =
                 outcome is TypeResolutionOutcome.Resolved
-            {
-                Definition.Kind:
+                {
+                    Definition.Kind:
                     MetadataTypeDefinitionKind.Class,
-            } resolved
+                } resolved
                 && resolved.Definition.GenericParameterCount
                     == genericArgumentCount
                 && !(resolved.Definition
@@ -2451,14 +2498,39 @@ public sealed class TypeResolutionContext : IDisposable
             }
 
             _cancellationToken.ThrowIfCancellationRequested();
-            if (!HasPolicyVersion())
-                return CacheInvalidBinding(key);
-            AssemblyBindingSelection? selection = _policy.Select(request);
-            if (!HasPolicyVersion())
-                return CacheInvalidBinding(key);
-            selection = AssemblyBindingSelection.ValidateForRequest(
-                request,
-                selection);
+            AssemblyBindingPolicyVersion? observedVersion =
+                _policy.Version;
+            if (!ReferenceEquals(_policyVersion, observedVersion))
+            {
+                throw new PolicyVersionChangedException(
+                    _policyVersion,
+                    observedVersion);
+            }
+
+            AssemblyBindingSelectionSnapshot? snapshot =
+                _policy.Select(request);
+            AssemblyBindingSelection selection;
+            if (snapshot is null)
+            {
+                selection = AssemblyBindingSelection.ValidateForRequest(
+                    request,
+                    selection: null);
+            }
+            else
+            {
+                if (!ReferenceEquals(
+                        _policyVersion,
+                        snapshot.Version))
+                {
+                    throw new PolicyVersionChangedException(
+                        _policyVersion,
+                        snapshot.Version);
+                }
+
+                selection = AssemblyBindingSelection.ValidateForRequest(
+                    request,
+                    snapshot.Selection);
+            }
 
             // Policy returns public descriptors. Registration turns those
             // selections into catalog candidates and a frozen Metadata-owned
@@ -2485,13 +2557,6 @@ public sealed class TypeResolutionContext : IDisposable
                             rejected.Failure)),
                 _ => InvalidBinding(),
             };
-            _bindings.Add(key, evaluation);
-            return evaluation;
-        }
-
-        CachedBindingEvaluation CacheInvalidBinding(BindingKey key)
-        {
-            CachedBindingEvaluation evaluation = InvalidBinding();
             _bindings.Add(key, evaluation);
             return evaluation;
         }
@@ -2652,18 +2717,6 @@ public sealed class TypeResolutionContext : IDisposable
                 new TypeResolutionFailure.UnregisteredAssembly(registration);
             candidate = null!;
             return false;
-        }
-
-        bool HasPolicyVersion() =>
-            ReferenceEquals(_policyVersion, _policy.Version);
-
-        void EnsurePolicyVersion()
-        {
-            if (!HasPolicyVersion())
-            {
-                throw new InvalidOperationException(
-                    "The binding policy changed version during discovery.");
-            }
         }
 
         static AssemblyResolutionScope TightenScope(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -972,11 +972,11 @@ public static class ResearchDiff
                             ? ResearchChangeKind.Removed
                             : ResearchChangeKind.Changed;
                     string descriptorId = kind switch
-                        {
-                            ResearchChangeKind.Added => "il.operation.added",
-                            ResearchChangeKind.Removed => "il.operation.removed",
-                            _ => "il.hunk.changed",
-                        };
+                    {
+                        ResearchChangeKind.Added => "il.operation.added",
+                        ResearchChangeKind.Removed => "il.operation.removed",
+                        _ => "il.hunk.changed",
+                    };
                     builder.Add(new ResearchChange(
                         subject,
                         ResearchChangeMechanism.IlBody,
@@ -1530,15 +1530,19 @@ public static class ResearchDiff
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
+            AssemblyBindingSelection selection;
             if (request.Target
                 is not AssemblyBindingTarget.AssemblyReference reference)
             {
-                return AssemblyBindingSelection.CannotSelect(
+                selection = AssemblyBindingSelection.CannotSelect(
                     new AssemblyBindingFailure(
                         AssemblyBindingFailureKind.UnsupportedScope));
+                return new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
             }
 
             ImmutableArray<ResolvedAssemblyReference> matches =
@@ -1547,7 +1551,7 @@ public static class ResearchDiff
                         assembly.Identity
                             .IsEquivalentTo(reference.Identity))
                     .ToImmutableArray();
-            return matches.Length switch
+            selection = matches.Length switch
             {
                 0 => assemblies.Any(assembly =>
                         string.Equals(
@@ -1560,6 +1564,9 @@ public static class ResearchDiff
                     matches[0]),
                 _ => AssemblyBindingSelection.Multiple(matches),
             };
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                selection);
         }
     }
 

--- a/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/ApiOutputFormatterTests.cs
@@ -81,10 +81,10 @@ public class ApiOutputFormatterTests
                 .Single(constructor =>
                     constructor.GetParameters() is
                     [
-                        {
-                            ParameterType:
+                    {
+                        ParameterType:
                             var parameterType
-                        },
+                    },
                     ]
                     && parameterType
                         == typeof(AssemblyReferenceIdentity))
@@ -3311,22 +3311,36 @@ public class ApiOutputFormatterTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && reference.Identity == assembly.Identity
                 ? AssemblyBindingSelection.Found(assembly)
                 : AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class MissingBindingPolicy : IAssemblyBindingPolicy
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NotFound();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class AmbiguousBindingPolicy(
@@ -3336,13 +3350,20 @@ public class ApiOutputFormatterTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && reference.Identity == first.Identity
                 ? AssemblyBindingSelection.Multiple([first, second])
                 : AssemblyBindingSelection.NotFound();
+        }
     }
 }
 

--- a/src/dotnet-inspect.Tests/CallerBindingPolicyTests.cs
+++ b/src/dotnet-inspect.Tests/CallerBindingPolicyTests.cs
@@ -89,8 +89,8 @@ public class CallerBindingPolicyTests
                 });
         AssemblyBindingPolicyVersion version = policy.Version;
 
-        AssemblyBindingSelection? firstSelection = null;
-        AssemblyBindingSelection? secondSelection = null;
+        AssemblyBindingSelectionSnapshot? firstSnapshot = null;
+        AssemblyBindingSelectionSnapshot? secondSnapshot = null;
         Exception? firstFailure = null;
         Exception? secondFailure = null;
         var firstThread = new Thread(
@@ -98,7 +98,7 @@ public class CallerBindingPolicyTests
             {
                 try
                 {
-                    firstSelection = policy.Select(
+                    firstSnapshot = policy.Select(
                         Request(firstOwner, firstCandidate.Identity));
                 }
                 catch (Exception ex)
@@ -114,7 +114,7 @@ public class CallerBindingPolicyTests
             {
                 try
                 {
-                    secondSelection = policy.Select(
+                    secondSnapshot = policy.Select(
                         Request(secondOwner, secondCandidate.Identity));
                 }
                 catch (Exception ex)
@@ -137,22 +137,25 @@ public class CallerBindingPolicyTests
         Assert.Same(
             firstCandidate,
             Assert.IsType<AssemblyBindingSelection.Selected>(
-                firstSelection).Assembly);
+                firstSnapshot!.Selection).Assembly);
         Assert.Same(
             secondCandidate,
             Assert.IsType<AssemblyBindingSelection.Selected>(
-                secondSelection).Assembly);
+                secondSnapshot!.Selection).Assembly);
+        Assert.Same(version, firstSnapshot.Version);
+        Assert.Same(version, secondSnapshot.Version);
 
         AssemblyReferenceIdentity probe = Identity("Probe");
         Assert.IsType<AssemblyBindingSelection.Missing>(
-            policy.Select(Request(firstCandidate, probe)));
+            policy.Select(Request(firstCandidate, probe)).Selection);
         Assert.IsType<AssemblyBindingSelection.Missing>(
-            policy.Select(Request(secondCandidate, probe)));
+            policy.Select(Request(secondCandidate, probe)).Selection);
 
         Assert.IsType<AssemblyBindingSelection.Selected>(
-            policy.Select(Request(firstOwner, firstCandidate.Identity)));
+            policy.Select(
+                Request(firstOwner, firstCandidate.Identity)).Selection);
         Assert.IsType<AssemblyBindingSelection.Missing>(
-            policy.Select(Request(firstCandidate, probe)));
+            policy.Select(Request(firstCandidate, probe)).Selection);
 
         Assert.Same(version, policy.Version);
         Assert.Equal(0, defaultPolicy.CallCount);
@@ -201,11 +204,19 @@ public class CallerBindingPolicyTests
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            Interlocked.Increment(ref _callCount);
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                Interlocked.Increment(ref _callCount);
+                return selection;
+
+            }
         }
     }
 

--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -664,10 +664,17 @@ public class MethodBodyInspectionSessionTests
             AssemblyResolutionScope scope) =>
             null;
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
                 ? AssemblyBindingSelection.Found(_coreLibrary)
                 : AssemblyBindingSelection.NameNotOwned();
+        }
     }
 }

--- a/src/dotnet-inspect.Tests/PlatformResolverTests.cs
+++ b/src/dotnet-inspect.Tests/PlatformResolverTests.cs
@@ -1239,7 +1239,7 @@ public class PlatformResolverTests
                                 Culture: null,
                                 PublicKeyToken: null)),
                         AssemblyBindingOrigin.Global(),
-                        AssemblyResolutionScope.Any)));
+                        AssemblyResolutionScope.Any)).Selection);
     }
 
     /// <summary>

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1896,12 +1896,19 @@ public class SourceForwarderResolutionTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && reference.Identity == dependency.Identity
                 ? AssemblyBindingSelection.Found(dependency)
                 : AssemblyBindingSelection.NotFound();
+        }
     }
 }

--- a/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
+++ b/src/dotnet-inspect/Inspectors/ApiMemberAnalysisInspection.cs
@@ -602,7 +602,7 @@ internal sealed class ApiMemberAnalysisInspection
         public AssemblyBindingPolicyVersion Version =>
             Volatile.Read(ref _state).Version;
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
             BindingPolicyState state = Volatile.Read(ref _state);
@@ -618,10 +618,12 @@ internal sealed class ApiMemberAnalysisInspection
                 }
             }
 
+            AssemblyBindingSelectionSnapshot? snapshot =
+                policy.Value.Select(request);
             AssemblyBindingSelection selection =
                 AssemblyBindingSelection.ValidateForRequest(
                     request,
-                    policy.Value.Select(request));
+                    snapshot?.Selection);
             switch (selection)
             {
                 case AssemblyBindingSelection.Selected selected:
@@ -632,7 +634,9 @@ internal sealed class ApiMemberAnalysisInspection
                     break;
             }
 
-            return selection;
+            return new AssemblyBindingSelectionSnapshot(
+                state.Version,
+                selection);
         }
 
         static Func<
@@ -725,7 +729,8 @@ internal sealed class ApiMemberAnalysisInspection
                 defaultPolicy;
             internal ImmutableDictionary<
                 AssemblyAcquisitionRegistration,
-                Lazy<IAssemblyBindingPolicy>> Routes { get; } =
+                Lazy<IAssemblyBindingPolicy>> Routes
+            { get; } =
                     routes;
 
             internal BindingPolicyState WithLearnedRoutes(

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -900,7 +900,7 @@ internal static class LibraryMetadataService
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(reference),
                         AssemblyBindingOrigin.Global(),
-                        AssemblyResolutionScope.Any));
+                        AssemblyResolutionScope.Any)).Selection;
             ResolvedAssemblyReference? resolved =
                 (selection as AssemblyBindingSelection.Selected)
                     ?.Assembly;
@@ -1088,7 +1088,7 @@ internal static class LibraryMetadataService
                 new AssemblyBindingRequest(
                     AssemblyBindingTarget.Reference(reference),
                     AssemblyBindingOrigin.Global(),
-                    AssemblyResolutionScope.Any));
+                    AssemblyResolutionScope.Any)).Selection;
             ResolvedAssemblyReference? resolved =
                 (selection as AssemblyBindingSelection.Selected)?.Assembly;
             if (selection is AssemblyBindingSelection.Unavailable unavailable)
@@ -1496,7 +1496,7 @@ internal static class LibraryMetadataService
                     ?.EvidenceMethodToken),
             SupportingIL =
                 opportunity.SupportingCallSite is
-                    { ILOffset: var supportingOffset }
+                { ILOffset: var supportingOffset }
                     ? $"IL_{supportingOffset:X4}"
                     : null,
             Evidence = opportunity.Evidence,

--- a/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyReferenceBindingPolicyTests.cs
@@ -30,13 +30,15 @@ public class AssemblyReferenceBindingPolicyTests
         var firstRequest = Request(AssemblyBindingTarget.Reference(Reference));
         var equivalentRequest = Request(AssemblyBindingTarget.Reference(Reference));
 
-        AssemblyBindingSelection first = policy.Select(firstRequest);
-        AssemblyBindingSelection second = policy.Select(equivalentRequest);
+        AssemblyBindingSelectionSnapshot first = policy.Select(firstRequest);
+        AssemblyBindingSelectionSnapshot second =
+            policy.Select(equivalentRequest);
 
         Assert.Same(first, second);
+        Assert.Same(version, first.Version);
         Assert.Equal(
             AssemblyBindingMissDisposition.Undifferentiated,
-            Assert.IsType<AssemblyBindingSelection.Missing>(first)
+            Assert.IsType<AssemblyBindingSelection.Missing>(first.Selection)
                 .Disposition);
         Assert.Equal(Reference, Assert.Single(resolver.Requests).Identity);
         Assert.Same(version, policy.Version);
@@ -62,6 +64,19 @@ public class AssemblyReferenceBindingPolicyTests
     }
 
     [Fact]
+    public void AssemblyBindingSelectionSnapshot_RequiresBothComponents()
+    {
+        var version = new AssemblyBindingPolicyVersion();
+        AssemblyBindingSelection selection =
+            AssemblyBindingSelection.NameNotOwned();
+
+        Assert.Throws<ArgumentNullException>(
+            () => new AssemblyBindingSelectionSnapshot(null!, selection));
+        Assert.Throws<ArgumentNullException>(
+            () => new AssemblyBindingSelectionSnapshot(version, null!));
+    }
+
+    [Fact]
     public void Select_MapsRecoverableResolverFailuresToUnavailable()
     {
         Exception[] failures =
@@ -82,7 +97,8 @@ public class AssemblyReferenceBindingPolicyTests
                 Assert.IsType<AssemblyBindingSelection.Unavailable>(
                     policy.Select(
                         Request(
-                            AssemblyBindingTarget.Reference(Reference))));
+                            AssemblyBindingTarget.Reference(Reference)))
+                        .Selection);
 
             Assert.Equal(
                 AssemblyBindingFailureKind.CandidateUnavailable,
@@ -97,7 +113,8 @@ public class AssemblyReferenceBindingPolicyTests
         var policy = new AssemblyReferenceBindingPolicy(resolver);
 
         var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
-            policy.Select(Request(AssemblyBindingTarget.CoreLibrary())));
+            policy.Select(Request(AssemblyBindingTarget.CoreLibrary()))
+                .Selection);
 
         Assert.Equal(
             AssemblyBindingFailureKind.UnsupportedScope,
@@ -127,13 +144,18 @@ public class AssemblyReferenceBindingPolicyTests
         AssemblyBindingRequest coreRequest =
             Request(AssemblyBindingTarget.CoreLibrary());
 
-        AssemblyBindingSelection first = policy.Select(referenceRequest);
-        AssemblyBindingSelection second = policy.Select(referenceRequest);
-        AssemblyBindingSelection core = policy.Select(coreRequest);
+        AssemblyBindingSelectionSnapshot first =
+            policy.Select(referenceRequest);
+        AssemblyBindingSelectionSnapshot second =
+            policy.Select(referenceRequest);
+        AssemblyBindingSelectionSnapshot core = policy.Select(coreRequest);
 
-        Assert.Same(referenceSelection, first);
-        Assert.Same(referenceSelection, second);
-        Assert.Same(coreSelection, core);
+        Assert.Same(referenceSelection, first.Selection);
+        Assert.Same(referenceSelection, second.Selection);
+        Assert.Same(coreSelection, core.Selection);
+        Assert.Same(resolver.Version, first.Version);
+        Assert.Same(resolver.Version, second.Version);
+        Assert.Same(resolver.Version, core.Version);
         Assert.Equal(
             [referenceRequest, referenceRequest, coreRequest],
             resolver.Requests);
@@ -154,7 +176,8 @@ public class AssemblyReferenceBindingPolicyTests
         var policy = new AssemblyReferenceBindingPolicy(resolver);
 
         var result = Assert.IsType<AssemblyBindingSelection.Selected>(
-            policy.Select(Request(AssemblyBindingTarget.CoreLibrary())));
+            policy.Select(Request(AssemblyBindingTarget.CoreLibrary()))
+                .Selection);
 
         Assert.Same(selected, result.Assembly);
         Assert.Equal(1, resolver.SelectionCount);
@@ -177,7 +200,8 @@ public class AssemblyReferenceBindingPolicyTests
 
         var result = Assert.IsType<AssemblyBindingSelection.Selected>(
             policy.Select(
-                Request(AssemblyBindingTarget.Reference(Reference))));
+                Request(AssemblyBindingTarget.Reference(Reference)))
+                .Selection);
 
         Assert.Same(selected, result.Assembly);
         Assert.Same(shadow, Assert.Single(result.ShadowedAssemblies));
@@ -198,7 +222,8 @@ public class AssemblyReferenceBindingPolicyTests
 
         var result = Assert.IsType<AssemblyBindingSelection.Ambiguous>(
             policy.Select(
-                Request(AssemblyBindingTarget.Reference(Reference))));
+                Request(AssemblyBindingTarget.Reference(Reference)))
+                .Selection);
 
         Assert.Equal([first, second], result.Assemblies);
         Assert.Equal(1, resolver.SelectionCount);
@@ -309,13 +334,14 @@ public class AssemblyReferenceBindingPolicyTests
         AssemblyBindingRequest request =
             Request(AssemblyBindingTarget.CoreLibrary());
 
-        AssemblyBindingSelection selection = policy.Select(request);
+        AssemblyBindingSelectionSnapshot snapshot = policy.Select(request);
 
-        Assert.Same(missing, selection);
+        Assert.Same(missing, snapshot.Selection);
+        Assert.Same(resolver.LastSnapshot, snapshot);
         var rejected = Assert.IsType<AssemblyBindingSelection.Rejected>(
             AssemblyBindingSelection.ValidateForRequest(
                 request,
-                selection));
+                snapshot.Selection));
         Assert.Equal(
             AssemblyBindingFailureKind.InvalidPolicyResult,
             rejected.Failure.Kind);
@@ -329,10 +355,11 @@ public class AssemblyReferenceBindingPolicyTests
         var missing =
             Assert.IsType<AssemblyBindingSelection.Missing>(
                 NoResolverAssemblyBindingPolicy.Instance.Select(
-                    Request(AssemblyBindingTarget.Reference(Reference))));
+                    Request(AssemblyBindingTarget.Reference(Reference)))
+                    .Selection);
         var unavailable = Assert.IsType<AssemblyBindingSelection.Unavailable>(
             NoResolverAssemblyBindingPolicy.Instance.Select(
-                Request(AssemblyBindingTarget.CoreLibrary())));
+                Request(AssemblyBindingTarget.CoreLibrary())).Selection);
 
         Assert.Equal(
             AssemblyBindingMissDisposition.NoNameOwner,
@@ -384,6 +411,11 @@ public class AssemblyReferenceBindingPolicyTests
         public List<AssemblyBindingRequest> Requests { get; } = [];
         public int ResolutionCount { get; private set; }
         public int SelectionCount { get; private set; }
+        public AssemblyBindingSelectionSnapshot? LastSnapshot
+        {
+            get;
+            private set;
+        }
 
         public ResolvedAssemblyReference? Resolve(
             AssemblyReferenceIdentity identity,
@@ -393,12 +425,21 @@ public class AssemblyReferenceBindingPolicyTests
             return null;
         }
 
-        public AssemblyBindingSelection Select(
+        public AssemblyBindingSelectionSnapshot Select(
             AssemblyBindingRequest request)
         {
-            SelectionCount++;
-            Requests.Add(request);
-            return select(request);
+            LastSnapshot = new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+            return LastSnapshot;
+
+            AssemblyBindingSelection SelectCore()
+            {
+                SelectionCount++;
+                Requests.Add(request);
+                return select(request);
+
+            }
         }
 
         public void AdvanceVersion() =>

--- a/tests/ILInspector.Metadata.Tests/ConstraintResolutionHardeningTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ConstraintResolutionHardeningTests.cs
@@ -2776,15 +2776,22 @@ public class ConstraintResolutionHardeningTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
-                    is AssemblyBindingTarget.AssemblyReference reference
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
+                is AssemblyBindingTarget.AssemblyReference reference
                 && map.TryGetValue(
-                    reference.Identity.Name,
-                    out ResolvedAssemblyReference? assembly)
-                    ? AssemblyBindingSelection.Found(assembly)
-                    : AssemblyBindingSelection.NotFound();
+                reference.Identity.Name,
+                out ResolvedAssemblyReference? assembly)
+                ? AssemblyBindingSelection.Found(assembly)
+                : AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class MissingPolicy : IAssemblyBindingPolicy
@@ -2792,8 +2799,15 @@ public class ConstraintResolutionHardeningTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NotFound();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NotFound();
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataRowReferenceSearchTests.cs
@@ -452,11 +452,16 @@ public class MetadataRowReferenceSearchTests
         // row counter still reaches RowCount + 1 on the way out, which looks
         // exactly like an ordinary completed table. Truncation is the only thing
         // that separates the two.
-        using var peReader = OpenSelfFromBytes();
+        using var peReader = new PEReader(
+            new MemoryStream(BuildTruncationBoundaryImage()));
         var reader = peReader.GetMetadataReader();
-        int popular = MostReferencedTypeRef(FullProjection(peReader));
+        const int targetTypeRef = 1;
 
-        var full = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, int.MaxValue);
+        var full = MetadataTableProjector.FindReferences(
+            peReader,
+            TableIndex.TypeRef,
+            targetTypeRef,
+            int.MaxValue);
         Assert.False(full.Truncated);
 
         // Find a match that sits on the last row of a multi-row table. Budgeting
@@ -478,7 +483,11 @@ public class MetadataRowReferenceSearchTests
 
         Assert.True(budget >= 0, "No match sat on the last row of a multi-row table.");
 
-        var capped = MetadataTableProjector.FindReferences(peReader, TableIndex.TypeRef, popular, budget);
+        var capped = MetadataTableProjector.FindReferences(
+            peReader,
+            TableIndex.TypeRef,
+            targetTypeRef,
+            budget);
         Assert.True(capped.Truncated, "Expected the budget to stop this scan.");
         Assert.Equal(budget, capped.References.Length);
 
@@ -502,7 +511,8 @@ public class MetadataRowReferenceSearchTests
         // though the scan ended inside it. Reporting it unscanned would be a
         // false blind spot: it would claim an unread row could hide an edge when
         // no row went unread.
-        using var peReader = OpenSelfFromBytes();
+        using var peReader = new PEReader(
+            new MemoryStream(BuildTruncationBoundaryImage()));
         var reader = peReader.GetMetadataReader();
 
         int typeDefRows = reader.GetTableRowCount(TableIndex.TypeDef);
@@ -742,6 +752,66 @@ public class MetadataRowReferenceSearchTests
             methodList: MetadataTokens.MethodDefinitionHandle(1));
 
         var rootBuilder = new MetadataRootBuilder(metadata, suppressValidation: true);
+        var peBuilder = new ManagedPEBuilder(
+            PEHeaderBuilder.CreateLibraryHeader(),
+            rootBuilder,
+            ilStream: new BlobBuilder());
+        var image = new BlobBuilder();
+        peBuilder.Serialize(image);
+        return image.ToArray();
+    }
+
+    static byte[] BuildTruncationBoundaryImage()
+    {
+        var metadata = new MetadataBuilder();
+        ModuleDefinitionHandle module = metadata.AddModule(
+            generation: 0,
+            moduleName: metadata.GetOrAddString("Boundary.dll"),
+            mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
+            encId: default,
+            encBaseId: default);
+        metadata.AddAssembly(
+            metadata.GetOrAddString("Boundary"),
+            new Version(1, 0, 0, 0),
+            culture: default,
+            publicKey: default,
+            flags: default,
+            hashAlgorithm: default);
+        TypeReferenceHandle baseType = metadata.AddTypeReference(
+            module,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("Base"));
+
+        metadata.AddTypeDefinition(
+            default,
+            default,
+            metadata.GetOrAddString("<Module>"),
+            baseType: default,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+        metadata.AddTypeDefinition(
+            TypeAttributes.Public | TypeAttributes.Abstract,
+            metadata.GetOrAddString("N"),
+            metadata.GetOrAddString("Derived"),
+            baseType,
+            fieldList: MetadataTokens.FieldDefinitionHandle(1),
+            methodList: MetadataTokens.MethodDefinitionHandle(1));
+
+        var signature = new BlobBuilder();
+        new BlobEncoder(signature)
+            .MethodSignature()
+            .Parameters(0, result => result.Void(), _ => { });
+        metadata.AddMethodDefinition(
+            MethodAttributes.Public | MethodAttributes.Abstract,
+            MethodImplAttributes.IL,
+            metadata.GetOrAddString("M"),
+            metadata.GetOrAddBlob(signature),
+            bodyOffset: -1,
+            parameterList: MetadataTokens.ParameterHandle(1));
+
+        var rootBuilder = new MetadataRootBuilder(
+            metadata,
+            suppressValidation: true);
         var peBuilder = new ManagedPEBuilder(
             PEHeaderBuilder.CreateLibraryHeader(),
             rootBuilder,

--- a/tests/ILInspector.Metadata.Tests/TypeParameterKindClassifierTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeParameterKindClassifierTests.cs
@@ -1890,15 +1890,22 @@ public class TypeParameterKindClassifierTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            request.Target
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                request.Target
                 is AssemblyBindingTarget.AssemblyReference reference
                 && _assemblies.TryGetValue(
-                    reference.Identity.Name,
-                    out ResolvedAssemblyReference? assembly)
+                reference.Identity.Name,
+                out ResolvedAssemblyReference? assembly)
                 ? AssemblyBindingSelection.Found(assembly)
                 : AssemblyBindingSelection.NotFound();
+        }
     }
 
     sealed class MissingPolicy : IAssemblyBindingPolicy
@@ -1906,8 +1913,15 @@ public class TypeParameterKindClassifierTests
         public AssemblyBindingPolicyVersion Version { get; } =
             new();
 
-        public AssemblyBindingSelection Select(
-            AssemblyBindingRequest request) =>
-            AssemblyBindingSelection.NotFound();
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                AssemblyBindingSelection.NotFound();
+        }
     }
 }

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionContextTests.cs
@@ -2236,7 +2236,7 @@ public class TypeResolutionContextTests
     }
 
     [Fact]
-    public void PolicyVersionChange_DuringDiscoveryRejectsFreeze()
+    public void PolicyVersionChange_AfterMatchingSelectionRejectsFreeze()
     {
         byte[] facadeImage = BuildAssembly(
             "Facade",
@@ -2255,6 +2255,160 @@ public class TypeResolutionContextTests
                 [facade],
                 [request]));
         Assert.Equal(1, policy.CallCount);
+    }
+
+    [Fact]
+    public void PolicyVersionChange_StopsBeforeNextSelection()
+    {
+        var first = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(Identity("First")),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+        var second = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(Identity("Second")),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+        var policy = new VersionChangingPolicy();
+        using var catalog = new TypeResolutionCatalog();
+
+        Assert.Throws<InvalidOperationException>(
+            () => catalog.CreateContext(
+                policy,
+                roots: [],
+                bindingRequests: [first, second],
+                requests: []));
+
+        Assert.Equal(1, policy.CallCount);
+    }
+
+    [Fact]
+    public void ForeignPolicySnapshot_IsRejectedBeforePayloadInterpretation()
+    {
+        int openCount = 0;
+        ResolvedAssemblyReference selected = Descriptor(
+            BuildAssembly("Selected", definesType: true),
+            () => openCount++);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(selected.Identity),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+        var policy = new ScriptedSnapshotPolicy(
+            currentVersion: new AssemblyBindingPolicyVersion(),
+            snapshotVersion: new AssemblyBindingPolicyVersion(),
+            AssemblyBindingSelection.Found(selected));
+        using var catalog = new TypeResolutionCatalog();
+
+        Assert.Throws<InvalidOperationException>(
+            () => catalog.CreateContext(
+                policy,
+                roots: [],
+                bindingRequests: [request],
+                requests: []));
+
+        Assert.Equal(1, policy.CallCount);
+        Assert.Equal(0, openCount);
+
+        policy.SetState(
+            policy.Version,
+            policy.Version,
+            AssemblyBindingSelection.NameNotOwned());
+        using TypeResolutionContext context = catalog.CreateContext(
+            policy,
+            roots: [],
+            bindingRequests: [request],
+            requests: []);
+
+        Assert.Equal(2, policy.CallCount);
+        Assert.Equal(
+            AssemblyBindingMissDisposition.NoNameOwner,
+            Assert.IsType<AssemblyBindingOutcome.Missing>(
+                context.Bind(request)).Disposition);
+    }
+
+    [Fact]
+    public void FinalPolicyVersionChange_PublishesNoGenerationOrPolicyCache()
+    {
+        byte[] baselineImage =
+            BuildAssembly("Baseline", definesType: true);
+        ResolvedAssemblyReference baseline = Descriptor(baselineImage);
+        TypeResolutionRequest baselineRequest =
+            TypeResolutionRequest.FromAssembly(
+                baseline,
+                AssemblyResolutionScope.Any,
+                TypeName());
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext baselineContext =
+            catalog.CreateContext(
+                NoResolverAssemblyBindingPolicy.Instance,
+                [baseline],
+                [baselineRequest]);
+        ResolvedTypeDefinitionKey baselineKey =
+            Assert.IsType<TypeResolutionOutcome.Resolved>(
+                baselineContext.Resolve(baselineRequest)).Definition.Key;
+
+        byte[] targetImage = BuildAssembly("Target", definesType: true);
+        byte[] facadeImage = BuildAssembly(
+            "Facade",
+            definesType: false,
+            forwardTarget: ReadIdentity(targetImage));
+        ResolvedAssemblyReference target = Descriptor(targetImage);
+        ResolvedAssemblyReference facade = Descriptor(facadeImage);
+        TypeResolutionRequest request = TypeResolutionRequest.FromAssembly(
+            facade,
+            AssemblyResolutionScope.Any,
+            TypeName());
+        var version = new AssemblyBindingPolicyVersion();
+        var policy = new ScriptedSnapshotPolicy(
+            version,
+            version,
+            AssemblyBindingSelection.Found(target),
+            nextVersion: new AssemblyBindingPolicyVersion());
+
+        Assert.Throws<InvalidOperationException>(
+            () => catalog.CreateContext(
+                policy,
+                [facade],
+                [request]));
+
+        Assert.Equal(1, policy.CallCount);
+        Assert.IsType<DefinitionCorrespondence.Same>(
+            catalog.Compare(baselineKey, baselineKey));
+
+        AssemblyBindingPolicyVersion retryVersion = policy.Version;
+        Assert.NotSame(version, retryVersion);
+        policy.SetState(
+            retryVersion,
+            retryVersion,
+            AssemblyBindingSelection.NameNotOwned());
+        using TypeResolutionContext retry = catalog.CreateContext(
+            policy,
+            [facade],
+            [request]);
+
+        Assert.Equal(2, policy.CallCount);
+        Assert.IsNotType<TypeResolutionOutcome.Resolved>(
+            retry.Resolve(request));
+    }
+
+    [Fact]
+    public void NullPolicySnapshot_RemainsInvalidPolicyOutput()
+    {
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.Reference(Identity("Missing")),
+            AssemblyBindingOrigin.Global(),
+            AssemblyResolutionScope.Any);
+        using var catalog = new TypeResolutionCatalog();
+        using TypeResolutionContext context = catalog.CreateContext(
+            new NullSnapshotPolicy(),
+            roots: [],
+            bindingRequests: [request],
+            requests: []);
+
+        var rejected = Assert.IsType<AssemblyBindingOutcome.Rejected>(
+            context.Bind(request));
+        Assert.Equal(
+            AssemblyBindingFailureKind.InvalidPolicyResult,
+            rejected.Failure.Kind);
     }
 
     [Theory]
@@ -2964,7 +3118,7 @@ public class TypeResolutionContextTests
     }
 
     sealed class RecordingPolicy(
-        Func<AssemblyBindingRequest, AssemblyBindingSelection> select)
+        Func<AssemblyBindingRequest, AssemblyBindingSelection?> select)
         : IAssemblyBindingPolicy
     {
         readonly object _gate = new();
@@ -2972,11 +3126,17 @@ public class TypeResolutionContextTests
         public AssemblyBindingPolicyVersion Version { get; } = new();
         public List<AssemblyBindingRequest> Requests { get; } = [];
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
         {
             lock (_gate)
                 Requests.Add(request);
-            return select(request);
+            AssemblyBindingSelection? selection = select(request);
+            return selection is null
+                ? null!
+                : new AssemblyBindingSelectionSnapshot(
+                    Version,
+                    selection);
         }
     }
 
@@ -2986,11 +3146,15 @@ public class TypeResolutionContextTests
             new();
         public int CallCount { get; private set; }
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
         {
+            AssemblyBindingPolicyVersion version = Version;
             CallCount++;
             Version = new AssemblyBindingPolicyVersion();
-            return AssemblyBindingSelection.NotFound();
+            return new AssemblyBindingSelectionSnapshot(
+                version,
+                AssemblyBindingSelection.NotFound());
         }
     }
 
@@ -3004,10 +3168,18 @@ public class TypeResolutionContextTests
             new();
         public int CallCount { get; private set; }
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
         {
-            CallCount++;
-            return Missing(_disposition);
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore()
+            {
+                CallCount++;
+                return Missing(_disposition);
+
+            }
         }
 
         public void Advance(AssemblyBindingMissDisposition next)
@@ -3015,5 +3187,63 @@ public class TypeResolutionContextTests
             _disposition = next;
             Version = new AssemblyBindingPolicyVersion();
         }
+    }
+
+    sealed class ScriptedSnapshotPolicy : IAssemblyBindingPolicy
+    {
+        AssemblyBindingPolicyVersion _snapshotVersion;
+        AssemblyBindingSelection _selection;
+        AssemblyBindingPolicyVersion? _nextVersion;
+
+        internal ScriptedSnapshotPolicy(
+            AssemblyBindingPolicyVersion currentVersion,
+            AssemblyBindingPolicyVersion snapshotVersion,
+            AssemblyBindingSelection selection,
+            AssemblyBindingPolicyVersion? nextVersion = null)
+        {
+            Version = currentVersion;
+            _snapshotVersion = snapshotVersion;
+            _selection = selection;
+            _nextVersion = nextVersion;
+        }
+
+        public AssemblyBindingPolicyVersion Version { get; private set; }
+        internal int CallCount { get; private set; }
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request)
+        {
+            CallCount++;
+            var snapshot = new AssemblyBindingSelectionSnapshot(
+                _snapshotVersion,
+                _selection);
+            if (_nextVersion is { } nextVersion)
+            {
+                Version = nextVersion;
+                _nextVersion = null;
+            }
+
+            return snapshot;
+        }
+
+        internal void SetState(
+            AssemblyBindingPolicyVersion currentVersion,
+            AssemblyBindingPolicyVersion snapshotVersion,
+            AssemblyBindingSelection selection,
+            AssemblyBindingPolicyVersion? nextVersion = null)
+        {
+            Version = currentVersion;
+            _snapshotVersion = snapshotVersion;
+            _selection = selection;
+            _nextVersion = nextVersion;
+        }
+    }
+
+    sealed class NullSnapshotPolicy : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+
+        public AssemblyBindingSelectionSnapshot Select(
+            AssemblyBindingRequest request) => null!;
     }
 }

--- a/tests/ILInspector.Metadata.Tests/TypeResolutionEnumWidthTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeResolutionEnumWidthTests.cs
@@ -1172,7 +1172,15 @@ public sealed class TypeResolutionEnumWidthTests
     {
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
-            => select(request);
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
+
+            AssemblyBindingSelection SelectCore() =>
+                select(request);
+        }
     }
 }

--- a/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
+++ b/tools/DecompilerHarness/ReturnToSenderTypePlanner.cs
@@ -35,7 +35,7 @@ internal abstract record ArtifactRequest(
     internal RoundTripBodyPolicy BodyPolicy { get; init; } = RoundTripBodyPolicy.Selected;
     internal MetadataSource? BodySource { get; init; }
     internal ReturnToSender.CompilationClosure? CompilationClosure
-        { get; set; }
+    { get; set; }
 }
 
 internal sealed record MethodArtifactRequest(
@@ -2238,23 +2238,31 @@ public static class CompileBackSourceComposer
 
         public AssemblyBindingPolicyVersion Version { get; } = new();
 
-        public AssemblyBindingSelection Select(AssemblyBindingRequest request)
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
         {
-            if (request.Target
-                    is AssemblyBindingTarget.AssemblyReference reference)
-            {
-                return _references.TryGetValue(
-                    reference.Identity.Name,
-                    out ResolvedAssemblyReference? selected)
-                        ? AssemblyBindingSelection.Found(selected)
-                        : AssemblyBindingSelection.NotFound();
-            }
+            return new AssemblyBindingSelectionSnapshot(
+                Version,
+                SelectCore());
 
-            return _resolver.Select(
-                new AssemblyBindingRequest(
-                    request.Target,
-                    request.Origin,
-                    AssemblyResolutionScope.Any));
+            AssemblyBindingSelection SelectCore()
+            {
+                if (request.Target
+                        is AssemblyBindingTarget.AssemblyReference reference)
+                {
+                    return _references.TryGetValue(
+                        reference.Identity.Name,
+                        out ResolvedAssemblyReference? selected)
+                            ? AssemblyBindingSelection.Found(selected)
+                            : AssemblyBindingSelection.NotFound();
+                }
+
+                return _resolver.Select(
+                    new AssemblyBindingRequest(
+                        request.Target,
+                        request.Origin,
+                        AssemblyResolutionScope.Any)).Selection;
+
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds producer-issued atomic assembly-binding selection snapshots and makes
Metadata treat policy-version drift as generation control rather than a binding
answer.

- `IAssemblyBindingPolicy.Select` now returns an immutable
  `AssemblyBindingSelectionSnapshot` pairing the selection with the exact
  producer state that created it.
- Metadata rejects a foreign snapshot before interpreting or opening its
  descriptors, and validates the current token again before publishing binding
  caches, resolution caches, or the generation.
- Structured `AssemblyReferenceBindingPolicy` remains transparent by forwarding
  the delegated snapshot instance unchanged; legacy resolver mode keeps its
  fixed-token cached behavior.
- Production policies, direct consumers, tests, and browser/Wasm consumers are
  migrated to the compile-breaking contract.

This implements #5646 under #5274. Transforming-policy token refresh and
workspace retry remain separate owner adoptions.

## Demo

The pathological Metadata fixture gives the policy current token `V1`, then
returns a selected descriptor in a snapshot carrying foreign token `V2`:

```text
policy.Version                     V1
policy.Select(request).Version     V2
policy.Select(request).Selection   Selected(descriptor)
```

`TypeResolutionContext.Create` now fails through the existing public
`InvalidOperationException` boundary before the descriptor is opened:

```text
policy calls   1
image opens    0
context        not published
```

The companion final-drift fixture returns a matching `V1` snapshot, advances
the current policy to `V2` before commit, and likewise publishes no generation
or reusable policy cache. A later request under `V2` is evaluated again.

## Design

The normative owner is
`docs/design/type-forwarding-resolution.md#atomic-selectionversion-snapshots`.
The selection-side transitions correspond to
`BindingSelectionVersion.tla`: atomic answer association, foreign-payload
exclusion, final current-token validation, and no policy-dependent publication
before commit.

`CompositeBindingVersion.tla` remains a target for later Services, CLI,
Analysis, and Queries transforming-policy adoptions. This PR deliberately does
not activate fresh route tokens or automatic retry because route learning
currently occurs during selection.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
  - 2,478 total, 2 expected skips
- `dotnet run --project src/DotnetInspector.Queries.Tests -c Release`
  - 1,176 total
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release`
  - 1,055 total
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
  - 1,347 total
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
  - 5,286 total, 23 expected skips
- `dotnet run --project prototypes/inspect-web/engine.Tests/InspectWeb.Engine.Tests.csproj -c Release`
  - 213 total using the repository-required Node 24 runtime
- `npx markdownlint-cli docs/design/type-forwarding-resolution.md docs/design/models/binding-selection-version/README.md`

The fast decompiler suite's existing
`SkeletonEmitTests.SkeletonCompilesPastExplicitImplAndConstEnum` failure
reproduces unchanged on `origin/main`.

Closes #5646
