### PR TITLE
Clarify Gallery search paging boundary

### DIFF
--- a/docs/design/package-query-cli.md
+++ b/docs/design/package-query-cli.md
@@ -213,8 +213,30 @@ requests. The two profile passes ran concurrently from separate networks, so
 the values characterize observed end-to-end service latency rather than
 isolated CPU throughput. The probe used a 30-minute operation ceiling so the
 source boundary could be measured; the CLI default is 120 seconds. The 5,000
-request did not produce 5,000 candidates: NuGet Gallery
-reached its documented 3,000-skip boundary after 2,933 matching package IDs.
+request did not produce 5,000 candidates. NuGet Gallery's
+[Search Query Service](https://learn.microsoft.com/nuget/api/search-query-service-resource)
+permits `skip` values only through 3,000 and `take` values only through 1,000.
+Its response contains `totalHits` and `data`, not a continuation cursor or
+next-page link that can cross that offset boundary.
+
+The current prefix client requests fixed 100-row pages. In this measurement it
+therefore examined the ranked search rows at offsets 0 through 3,000, at most
+3,100 raw rows, before returning `SourcePageLimit`. The Gallery query is
+broader ranked text search; the client then applies exact case-insensitive
+prefix matching and package-ID deduplication. Those steps yielded 2,933
+accepted `Microsoft.` package IDs. That number is neither the source's maximum
+package count nor the maximum legal offset.
+
+A client could use the documented maximum `take` on the final legal offset and
+inspect up to the first 4,000 ranked rows, but it still could not request the
+next offset. The current fixed-page path leaves that final-page capacity
+unused. Exhaustive enumeration beyond the bounded Search window requires a
+different source mechanism, such as a maintained view over the append-only
+NuGet Catalog; it is not another Search page. The measured 500 default and
+1,000 CLI maximum remain below this distinction and continue to be selected
+from end-to-end latency and operation-deadline evidence rather than from the
+largest theoretically reachable search window.
+
 The profile issued 2,964 HTTP requests, produced 2,931 matches and two visible
 manifest failures, and retained `SourcePageLimit` truncation. CPU time remained
 below 1.3 seconds in every profile run, so wall time was network-bound rather


### PR DESCRIPTION
## Summary

Clarifies that the NuGet Gallery Search Query Service limit is a maximum legal `skip` offset, not a package-count ceiling or a continuation boundary. Separates the 3,000 offset, 3,100 rows examined by the current client, and 2,933 accepted exact-prefix package IDs.

Records that `take=1000` could widen the final legal page to a 4,000-row search window, but no next link can continue beyond it. The measured 500 default and 1,000 CLI maximum remain unchanged because latency and the operation deadline, not maximum search-window capacity, select them.

## Demo

Before:

> NuGet Gallery reached its documented 3,000-skip boundary after 2,933 matching package IDs.

After, the design distinguishes:

- maximum legal offset: 3,000;
- maximum page size: 1,000;
- current fixed-page search window: 3,100 ranked rows;
- accepted exact `Microsoft.` prefix matches: 2,933; and
- exhaustive enumeration: a separate Catalog-backed mechanism, not another Search page.

## Validation

- `npx markdownlint-cli docs/design/package-query-cli.md`
- `git diff --check`

Closes #5674