### PR TITLE
Allow Markout at the presentation boundary

### DIFF
--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -109,8 +109,9 @@ The checked-in rules provide full gate coverage for these dependency claims:
    documented source-neutral `DotnetInspector.Artifacts` exception.
 3. Product libraries use only repository and platform assemblies unless an
    owner-specific rule names an external assembly. Markout is admitted only at
-   the metadata-rendering boundary; package, query, service, and NuGet
-   acquisition libraries retain their explicit narrow exceptions.
+   the metadata-rendering and shared-presentation boundaries; package, query,
+   service, and NuGet acquisition libraries retain their explicit narrow
+   exceptions.
 4. The direct project and compiled dependencies of the CSharp, Metadata,
    Instructions, Analysis, ILDiff, Decompiler, SourceLink, Research,
    JavaScript-export, and TypeScript-generation components stay within their

--- a/eng/dependency-policy.json
+++ b/eng/dependency-policy.json
@@ -75,6 +75,7 @@
         "ILInspector.Analysis.CallerGraph*",
         "DotnetInspector.MetadataRendering",
         "DotnetInspector.Packages",
+        "DotnetInspector.Presentation",
         "DotnetInspector.Queries",
         "DotnetInspector.Services"
       ],
@@ -91,6 +92,21 @@
       ],
       "targets": [
         "DotnetInspector.MetadataRendering"
+      ],
+      "allowOnly": [
+        "$platform",
+        "$repository",
+        "Markout"
+      ]
+    },
+    {
+      "id": "presentation-external-dependencies",
+      "source": "docs/architecture.md#query-and-current-lens-composition",
+      "graphs": [
+        "assembly"
+      ],
+      "targets": [
+        "DotnetInspector.Presentation"
       ],
       "allowOnly": [
         "$platform",


### PR DESCRIPTION
# Allow Markout at the presentation boundary

Keeps dependency governance aligned with the repository architecture so robust,
capable presentation features remain explicitly owned rather than accidentally
blocked by a stale policy snapshot.

## Demo

Before:

```text
error DP0001: product-libraries-use-repository-and-platform-assemblies
[assembly] DotnetInspector.Presentation -> Markout is not permitted
```

After:

```text
Dependency policy passed: 23 rules, 156 evaluated projects, 36 inspected assemblies.
```

## Change

PR #5635 added the documented `DotnetInspector.Presentation -> Markout`
composition edge after dependency-policy PR #5581 had frozen and validated.
The policy PR then merged later without seeing that concurrent edge, causing
the next product-building PR to fail the new gate.

The architecture already defines `DotnetInspector.Presentation` as the
host-neutral lowering from typed contracts into Markout presentation shapes.
This change excludes that project from the broad no-external-dependencies rule
and adds a narrow owner-specific rule admitting only platform assemblies,
repository assemblies, and Markout. The dependency-policy documentation now
names both approved Markout boundaries.

## Validation

- Release solution build completed with zero warnings and errors.
- Dependency-policy tests passed: 24/24.
- Repository dependency policy passed: 23 rules, 156 projects, 36 assemblies.
- Markdown lint and `git diff --check` passed.

Unblocks #5671.
