### PR TITLE
Prepare 0.24.0 release

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -21,9 +21,10 @@ and `--` sends remaining options to dotnet-inspect rather than `dnx`.
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
 | Discover legal query values or demos | `vocabulary -D`; select values with `vocabulary -S Accessibility`, `-S "C# Style Choices" --json`, or `-S "C# Body Kinds"`; use `demo list` for product-home scenarios. |
 | Find rendered body syntax | `library path/to.dll --where "Kind=ObjectCreationExpression"`, `type Type --library path/to.dll --where "Kind=InvocationExpression"`, or `member Type Method:1 --library path/to.dll --where "Kind=InvocationExpression"`; load `skill decompiler` for stable kinds and coordinates. |
-| Compare APIs or implementations | `diff --package Foo@old..new --breaking` (`--additive` new APIs; `--alloc-regressions` for allocation regressions); `match Type.MethodA Type.MethodB --package Foo --implementation` compares two unambiguously named methods with C#/IL. |
+| Compare APIs or implementations | `diff --package Foo@old..new --breaking` (`--additive` new APIs; `--alloc-regressions` for allocation regressions); `match Type.MethodA Type.MethodB --package Foo --implementation` compares two methods with C#/IL; `match Type.Method --similar --package Foo` ranks structural candidates for discovery. |
 | Trace API evolution | `timeline --package Foo@old..new --type Type --members --at all`; omit `--at` to inspect the vector without acquiring packages. |
 | Inspect packages | `package Foo`; use `-D` to discover sections and `-S "Signals,Audit: Findings"` to audit text-bearing files and SourceLink mappings. Load `skill private-feeds` for custom/authenticated sources. |
+| Inspect a Workspace | `workspace --package Foo@version --tfm net10.0`; repeat `--package` to preserve an ordered package occurrence set. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; use `-D` to discover sections and `-S "Unsafe Members"` for standalone unsafe evidence. Load `skill metadata` for raw ECMA-335 tables/heaps. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.23.0
+version: 0.24.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -12,8 +12,10 @@ structured sections, with the broadest shared query surface on `type`, `member`,
 field/column projection. `find` supports `-D` discovery and field/column
 projection but not `-S` selection. `diff` supports `-D` and `-S` but not
 field/column projection. `timeline` supports section selection and projection
-but not `-D` discovery. Relationship commands render fixed output without `-D`
-or `-S`. Discover the shape first where available, then select and project.
+but not `-D` discovery. `workspace` supports output formats, `--count`, and
+`--rows`, but not discovery, section selection, or field projection.
+Relationship commands render fixed output without `-D` or `-S`. Discover the
+shape first where available, then select and project.
 
 ```bash
 dnx dotnet-inspect -y -- <command>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -20,7 +20,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.23.0</VersionPrefix>
+    <VersionPrefix>0.24.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Prepares dotnet-inspect 0.24.0 by synchronizing the package
`VersionPrefix`, embedded router-skill version, and shipped guidance for the
release's new CLI surfaces. Version 0.23.0 is already published, and 0.24.0 is
currently unclaimed on NuGet.

This is a trivial release-metadata and documentation change: it alters no
command, package shape, runtime behavior, or compatibility contract, so it
requires no adversarial review.

## Demo

The Release apphost reports the intended package version, and the embedded
router carries the same version:

```text
$ dotnet-inspect --version
0.24.0+e5ce539

$ dotnet-inspect skill | head -4
---
name: dotnet-inspect
version: 0.24.0
description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
```

The router now points agents at `match --similar` and `workspace`; the query
skill records that `workspace` supports output formats, `--count`, and
`--rows`, but not discovery, section selection, or field projection.

## Shipped documentation checkpoint

- `README.md` already reflects the release's current user-visible command
  surface, including seeded `match --similar` discovery, runtime Workspace
  package occurrences, SourceLink clone precedence, and package-skill
  containment behavior.
- The affected focused product skills were updated with their owning features:
  `package-skills`, `relationships`, and `sourcelink`.
- This release checkpoint updates the router for `match --similar` and
  `workspace`, and updates the query skill's command-applicability summary for
  `workspace`.
- No tracked product skill was added or removed since 0.23.0. The runtime
  registry and embedded-resource set still agree with the tracked focused
  skills.
- GitHub release notes remain generated from the tag range by `release.yml`;
  no separate authored release-note input is required.

## Validation

- .NET SDK `11.0.100-preview.7.26381.103`.
- Release solution build.
- `FocusedSkillFilesRegistryAndEmbeddedResourcesAgree`: 1 passed.
- Release apphost `--version`, router-skill frontmatter, and `skill list`
  smoke checks.
- `markdownlint` on the changed `SKILL.md`.
- NuGet confirms `dotnet-inspect` 0.24.0 is unpublished.

The local restore used nuget.org explicitly because this machine's enabled
Azure feed proxy had not yet mirrored Markout 0.36.0.
