### PR TITLE
Make release certification tests portable

### DIFF
--- a/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
+++ b/src/DotnetInspector.Services.Tests/LocalFolderSourceTests.cs
@@ -34,7 +34,7 @@ public class LocalFolderSourceTests : IDisposable
     {
         @"D:\some\local\packages",
         "/var/local/packages",
-        "file:///var/packages",
+        new Uri(Path.Combine(Path.GetTempPath(), "packages")).AbsoluteUri,
         @"C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\",
         // Also unparseable / non-absolute should be skipped, not crash:
         "local-packages",

--- a/src/DotnetInspector.Services.Tests/PackageCoordinateResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageCoordinateResolverTests.cs
@@ -1420,9 +1420,14 @@ public sealed class PackageCoordinateResolverTests
             StringComparison.Ordinal);
     }
 
+    public static TheoryData<string> NonHttpSources() => new()
+    {
+        Path.Combine(Path.GetTempPath(), "packages"),
+        new Uri(Path.Combine(Path.GetTempPath(), "packages")).AbsoluteUri,
+    };
+
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(NonHttpSources))]
     public async Task ListVersions_SkipsNonHttpSource(
         string localSourceUrl)
     {
@@ -1448,8 +1453,7 @@ public sealed class PackageCoordinateResolverTests
     }
 
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(NonHttpSources))]
     public async Task FloatingCoordinate_SkipsNonHttpSource(
         string localSourceUrl)
     {

--- a/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionVectorTests.cs
@@ -18,6 +18,12 @@ public class PackageVersionVectorTests
         "2.0.0",
     ];
 
+    public static TheoryData<string> NonHttpSources() => new()
+    {
+        Path.Combine(Path.GetTempPath(), "packages"),
+        new Uri(Path.Combine(Path.GetTempPath(), "packages")).AbsoluteUri,
+    };
+
     [Fact]
     public void Create_ResolvesAnInclusiveVectorInCallerDirection()
     {
@@ -173,8 +179,7 @@ public class PackageVersionVectorTests
     }
 
     [Theory]
-    [InlineData("/tmp/packages")]
-    [InlineData("file:///tmp/packages")]
+    [MemberData(nameof(NonHttpSources))]
     public async Task ResolveAsync_SkipsNonHttpSource(
         string localSource)
     {

--- a/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
+++ b/src/dotnet-inspect.Tests/WorkspaceCommandTests.cs
@@ -63,7 +63,7 @@ public sealed class WorkspaceCommandTests
 
             No package occurrences.
 
-            """,
+            """.ReplaceLineEndings(),
             captured.Output);
         Assert.Empty(captured.Error);
     }


### PR DESCRIPTION
## Summary

Unblock 0.24.0 release certification by preserving the existing non-HTTP-source and workspace-rendering contracts with platform-native test fixtures.

- derive local package paths and `file://` URIs from the current platform instead of hard-coding Unix paths
- compare workspace output using the platform-native newline sequence
- leave product behavior unchanged

## Demo

Before, the Windows Deep Inspect lane rejected `file:///tmp/packages` and `file:///var/packages` as unusable Windows paths, and the workspace assertion expected LF while the renderer emitted CRLF. After, the same cases use a valid local path/URI pair for the executing platform and normalize only the expected newline sequence.

## Validation

- `dotnet restore dotnet-inspect.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- 2 `PackageVersionVectorTests.ResolveAsync_SkipsNonHttpSource` cases
- `WorkspaceCommandTests.EmptyWorkspace_RendersTheTypedEmptyInventory`
- 19 affected services test cases across `LocalFolderSourceTests` and `PackageCoordinateResolverTests`
- `git diff --check`