### PR TITLE
Gate dependency policy after main merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           fi
           jq -e '
             type == "object"
-            and .schemaVersion == 1
+            and .schemaVersion == 2
             and .status == "planned"
           ' <<< "$plan" > /dev/null
           printf 'plan=%s\n' "$plan" >> "$GITHUB_OUTPUT"
@@ -776,6 +776,39 @@ jobs:
           echo "This lane cannot certify hosted fixture consumption. See the fixture test step." >&2
           exit 1
 
+  # Pull-request and merge-group candidates validate dependency policy in the
+  # full test job above. Pushes to main need a focused second look at the
+  # composed tree: two independently green PRs can introduce a forbidden edge
+  # only when both are present, and the full test matrix intentionally skips
+  # post-merge runs.
+  dependency-policy:
+    needs: changes
+    if: fromJSON(needs.changes.outputs.plan).validations.dependencyPolicy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build
+        run: dotnet build dotnet-inspect.slnx -c Release
+
+      - name: Validate dependency policy
+        run: dotnet run --project eng/DependencyPolicy -c Release --no-build
+
   # net10.0 fallback build coverage. The official non-AOT "any" package targets
   # the net10.0 LTS floor (Directory.Build.props), but the full test lane builds
   # net11 only — so net11-only API usage on the fallback path is invisible until
@@ -1357,10 +1390,11 @@ jobs:
       - inspect-web
       - skill-gate
       - test
+      - dependency-policy
       - tla-plus
       # Path-gated jobs report `skipped` when their input class is absent; all
-      # expensive jobs except inspect-web also skip on pushes to main. That
-      # passes the gate by design; the allow list below distinguishes
+      # expensive jobs except inspect-web and dependency-policy skip on pushes
+      # to main. That passes the gate by design; the allow list below distinguishes
       # "correctly not run" from "ran and failed".
       - build-net10
       - decompiler-gates

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -139,6 +139,12 @@ project closure and the fail-closed collision, target-output, metadata, and
 reference-decoding boundaries. The final command evaluates the real Release
 project and assembly graphs.
 
+Pull-request and merge-group candidates run both the tests and real policy in
+the Release test job. Every push to `main` also builds the Release graph and
+runs the real policy in a focused post-merge job. That post-merge gate catches
+interactions between independently validated PRs without repeating the complete
+test suite, and `ci-required` includes its result.
+
 ## Non-claims
 
 The tool does not inspect source text, public API ownership beyond assembly

--- a/docs/design/ci-change-plan.md
+++ b/docs/design/ci-change-plan.md
@@ -187,6 +187,11 @@ policy input cannot silently remove validation. A deliberately conservative
 selection must be represented in a valid plan and tested as policy, not
 reached through an accidental parsing fallback.
 
+Every push selects `dependencyPolicy` independently of changed paths. The
+focused consumer rebuilds and checks the composed Release graph after merge;
+pull-request and merge-group candidates instead run the same policy inside
+their selected pre-merge test job.
+
 Two conservative inventory policies are current and named. When
 `eng/inspect-web-gate-projects.txt` is missing or malformed, every `src`
 change broadens to the Browser/Wasm lane. When
@@ -229,7 +234,7 @@ Conceptually:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "status": "planned",
   "provenance": {
     "kind": "pullRequestSyntheticCandidate",
@@ -242,6 +247,7 @@ Conceptually:
   },
   "validations": {
     "test": true,
+    "dependencyPolicy": false,
     "markdownlint": false,
     "ilRoundtrip": true,
     "tla": true
@@ -264,8 +270,9 @@ Path corpora and refusal diagnostics remain outside the plan.
 Concretely, the serialized plan is one compact UTF-8 JSON object containing
 only printable ASCII, with deterministic property order, lower camel member
 names, no newline, and lowercase digests. Its `validations` member always
-carries every field — `test`, `csharpDiffSmoke`, `decompilerGates`,
-`markdownlint`, `ilDiffSmoke`, `ilRoundTrip`, `pack`, `buildNet10`,
+carries every field — `test`, `dependencyPolicy`, `csharpDiffSmoke`,
+`decompilerGates`, `markdownlint`, `ilDiffSmoke`, `ilRoundTrip`, `pack`,
+`buildNet10`,
 `inspectWeb`, `skillGate`, and `tla` — so a consumer never distinguishes
 "false" from "absent". `ilRoundTrip` implies `test` as a construction
 invariant. A scope descriptor names its artifact, record framing, record

--- a/eng/CiChangeDetection/Planning/ChangePlan.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlan.cs
@@ -163,7 +163,7 @@ internal sealed class ChangePlan
     /// <summary>
     /// The only schema version this repository produces or consumes.
     /// </summary>
-    internal const int CurrentSchemaVersion = 1;
+    internal const int CurrentSchemaVersion = 2;
 
     /// <summary>
     /// The only status valid in a serialized plan.

--- a/eng/CiChangeDetection/Planning/ChangePlanParity.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanParity.cs
@@ -103,6 +103,11 @@ internal static class ChangePlanParity
             effective.Test,
             scenario);
         AssertEffective(
+            "dependencyPolicy",
+            kind == PlanEventKind.Push,
+            effective.DependencyPolicy,
+            scenario);
+        AssertEffective(
             "csharpDiffSmoke",
             Raw(values, "csharpdiff") && preMerge,
             effective.CSharpDiffSmoke,

--- a/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanSerializer.cs
@@ -14,6 +14,7 @@ internal static class ChangePlanSerializer
     private static readonly string[] ValidationNames =
     [
         "test",
+        "dependencyPolicy",
         "csharpDiffSmoke",
         "decompilerGates",
         "markdownlint",
@@ -238,7 +239,8 @@ internal static class ChangePlanSerializer
                 values[7],
                 values[8],
                 values[9],
-                values[10]);
+                values[10],
+                values[11]);
 
             JsonElement scopesElement =
                 RequireObject(root.GetProperty("scopes"), "scopes");
@@ -303,6 +305,7 @@ internal static class ChangePlanSerializer
     private static bool[] ValidationValues(ValidationSelections validations) =>
     [
         validations.Test,
+        validations.DependencyPolicy,
         validations.CSharpDiffSmoke,
         validations.DecompilerGates,
         validations.Markdownlint,

--- a/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
+++ b/eng/CiChangeDetection/Planning/ChangePlanTestSuite.cs
@@ -322,6 +322,7 @@ internal static class ChangePlanTestSuite
             ValidationSelections selections =
                 ValidationSelections.FromRouting(all, kind);
             if (!(selections.Test
+                && !selections.DependencyPolicy
                 && selections.CSharpDiffSmoke
                 && selections.DecompilerGates
                 && selections.Markdownlint
@@ -342,6 +343,7 @@ internal static class ChangePlanTestSuite
         ValidationSelections pushed =
             ValidationSelections.FromRouting(all, PlanEventKind.Push);
         if (pushed.Test
+            || !pushed.DependencyPolicy
             || pushed.CSharpDiffSmoke
             || pushed.DecompilerGates
             || pushed.IlDiffSmoke
@@ -408,6 +410,7 @@ internal static class ChangePlanTestSuite
             PlanRefusalCategory.PlanSerialization,
             () => new ValidationSelections(
                 test: false,
+                dependencyPolicy: false,
                 cSharpDiffSmoke: false,
                 decompilerGates: false,
                 markdownlint: false,
@@ -515,7 +518,7 @@ internal static class ChangePlanTestSuite
             policy);
 
         const string Golden =
-            "{\"schemaVersion\":1,\"status\":\"planned\",\"provenance\":"
+            "{\"schemaVersion\":2,\"status\":\"planned\",\"provenance\":"
             + "{\"kind\":\"pullRequestSyntheticCandidate\",\"baseObjectId\":"
             + "\"1111111111111111111111111111111111111111\","
             + "\"candidateObjectId\":"
@@ -523,6 +526,7 @@ internal static class ChangePlanTestSuite
             + "{\"recordCount\":2,\"sha256\":"
             + "\"e2942177c268e91967eeb66ed6c48b8e8e426158f30a8f3371de8322"
             + "439a2a05\"},\"validations\":{\"test\":false,"
+            + "\"dependencyPolicy\":false,"
             + "\"csharpDiffSmoke\":false,\"decompilerGates\":false,"
             + "\"markdownlint\":true,\"ilDiffSmoke\":false,"
             + "\"ilRoundTrip\":false,\"pack\":false,\"buildNet10\":false,"
@@ -622,12 +626,12 @@ internal static class ChangePlanTestSuite
                     "\"status\": \"planned\"")),
             ("non-canonical property order",
                 text.Replace(
-                    "{\"schemaVersion\":1,\"status\":\"planned\"",
-                    "{\"status\":\"planned\",\"schemaVersion\":1")),
+                    "{\"schemaVersion\":2,\"status\":\"planned\"",
+                    "{\"status\":\"planned\",\"schemaVersion\":2")),
             ("escaped member name",
                 text.Replace("schemaVersion", "schema\\u0056ersion")),
             ("non-canonical number",
-                text.Replace("\"schemaVersion\":1", "\"schemaVersion\":1e0")),
+                text.Replace("\"schemaVersion\":2", "\"schemaVersion\":2e0")),
             ("control character", $"\n{text}"),
             ("truncated document", text[..^1]),
             ("unknown member",
@@ -635,13 +639,13 @@ internal static class ChangePlanTestSuite
             ("missing member", text.Replace(",\"diagnostics\":[]", "")),
             ("duplicate member",
                 text.Replace(
-                    "\"schemaVersion\":1",
-                    "\"schemaVersion\":1,\"schemaVersion\":1")),
+                    "\"schemaVersion\":2",
+                    "\"schemaVersion\":2,\"schemaVersion\":2")),
             ("mistyped boolean", text.Replace("\"test\":false", "\"test\":0")),
             ("mistyped count",
                 text.Replace("\"recordCount\":1", "\"recordCount\":\"1\"")),
             ("unsupported version",
-                text.Replace("\"schemaVersion\":1", "\"schemaVersion\":2")),
+                text.Replace("\"schemaVersion\":2", "\"schemaVersion\":3")),
             ("unsupported status",
                 text.Replace("\"planned\"", "\"refused\"")),
             ("invalid digest",

--- a/eng/CiChangeDetection/Planning/ValidationSelections.cs
+++ b/eng/CiChangeDetection/Planning/ValidationSelections.cs
@@ -33,6 +33,7 @@ internal sealed class ValidationSelections
 {
     internal ValidationSelections(
         bool test,
+        bool dependencyPolicy,
         bool cSharpDiffSmoke,
         bool decompilerGates,
         bool markdownlint,
@@ -52,6 +53,7 @@ internal sealed class ValidationSelections
         }
 
         Test = test;
+        DependencyPolicy = dependencyPolicy;
         CSharpDiffSmoke = cSharpDiffSmoke;
         DecompilerGates = decompilerGates;
         Markdownlint = markdownlint;
@@ -65,6 +67,8 @@ internal sealed class ValidationSelections
     }
 
     internal bool Test { get; }
+
+    internal bool DependencyPolicy { get; }
 
     internal bool CSharpDiffSmoke { get; }
 
@@ -88,9 +92,9 @@ internal sealed class ValidationSelections
 
     /// <summary>
     /// Applies the repository's event rules to raw routing selections. A push
-    /// runs neither the pre-merge test matrix nor the validations placed
-    /// behind it; documentation lint, the Browser/Wasm lane, and the TLA+ lane
-    /// have no event gate.
+    /// runs the focused dependency-policy composition gate rather than the
+    /// pre-merge test matrix; documentation lint, the Browser/Wasm lane, and
+    /// the TLA+ lane have no event gate.
     /// </summary>
     /// <param name="selections">The raw routing selections.</param>
     /// <param name="kind">The provenance kind supplying the event rule.</param>
@@ -102,6 +106,7 @@ internal sealed class ValidationSelections
         bool preMerge = kind != PlanEventKind.Push;
         return new ValidationSelections(
             test: selections.Code && preMerge,
+            dependencyPolicy: kind == PlanEventKind.Push,
             cSharpDiffSmoke: selections.CSharpDiff && preMerge,
             decompilerGates: selections.Decompiler && preMerge,
             markdownlint: selections.Docs,

--- a/eng/CiChangeDetection/WorkflowContract.Consumers.cs
+++ b/eng/CiChangeDetection/WorkflowContract.Consumers.cs
@@ -12,6 +12,7 @@ internal static partial class WorkflowContract
             "markdownlint",
             "skill-gate",
             "test",
+            "dependency-policy",
             "build-net10",
             "decompiler-gates",
             "csharp-diff-smoke",
@@ -35,7 +36,78 @@ internal static partial class WorkflowContract
         }
 
         ValidateConsumerStepGuards(jobs, jobNames);
+        ValidateDependencyPolicyJob(jobs);
         ValidateIlDiffTestStep(jobs);
+    }
+
+    private static void ValidateDependencyPolicyJob(YamlMappingNode jobs)
+    {
+        YamlMappingNode job = GetRequiredMapping(
+            jobs,
+            "dependency-policy",
+            "jobs");
+        RequireExactKeys(
+            job,
+            ["needs", "if", "runs-on", "timeout-minutes", "steps"],
+            "jobs.dependency-policy");
+        RequireScalarValue(
+            job,
+            "needs",
+            "changes",
+            "jobs.dependency-policy");
+        RequireScalarValue(
+            job,
+            "if",
+            "fromJSON(needs.changes.outputs.plan).validations.dependencyPolicy",
+            "jobs.dependency-policy");
+        RequireScalarValue(
+            job,
+            "runs-on",
+            "ubuntu-24.04",
+            "jobs.dependency-policy");
+        RequireScalarValue(
+            job,
+            "timeout-minutes",
+            "20",
+            "jobs.dependency-policy");
+
+        YamlSequenceNode steps = GetRequiredSequence(
+            job,
+            "steps",
+            "jobs.dependency-policy");
+        if (steps.Children.Count != 5)
+        {
+            throw new InvalidOperationException(
+                "jobs.dependency-policy must contain exactly five steps.");
+        }
+
+        YamlMappingNode build = RequireMapping(
+            steps.Children[3],
+            "jobs.dependency-policy Build step");
+        RequireScalarValue(
+            build,
+            "name",
+            "Build",
+            "jobs.dependency-policy Build step");
+        RequireScalarValue(
+            build,
+            "run",
+            "dotnet build dotnet-inspect.slnx -c Release",
+            "jobs.dependency-policy Build step");
+
+        YamlMappingNode validate = RequireMapping(
+            steps.Children[4],
+            "jobs.dependency-policy Validate dependency policy step");
+        RequireScalarValue(
+            validate,
+            "name",
+            "Validate dependency policy",
+            "jobs.dependency-policy Validate dependency policy step");
+        RequireScalarValue(
+            validate,
+            "run",
+            "dotnet run --project eng/DependencyPolicy -c Release --no-build",
+            "jobs.dependency-policy Validate dependency policy step");
     }
 
     private static void ValidateIlDiffTestStep(YamlMappingNode jobs)


### PR DESCRIPTION
Prevent a green `main` build from hiding dependency-policy failures introduced
only by composing independently validated PRs.

PR #5635 intentionally added `DotnetInspector.Presentation -> Markout` after
PR #5581's final pull-request run. PR #5581 then merged the validator onto that
newer tree, but push CI skipped the full `test` job containing the policy gate.
PR #5688 repaired the policy exception; this change closes the CI visibility
gap that allowed the false green.

## Demo

The old merge-time run reported `ci-required` success while skipping `test`,
and a Release build of the resulting tree produced:

```text
error DP0001: product-libraries-use-repository-and-platform-assemblies
  [assembly] DotnetInspector.Presentation -> Markout is not permitted
```

The typed plan now selects a focused dependency-policy job for every push while
continuing to skip the complete test matrix:

```json
{
  "test": false,
  "dependencyPolicy": true
}
```

The job builds the Release solution and runs the real checked-in policy. Its
result is a required input to `ci-required`. Pull-request and merge-group
candidates continue to run policy tests and the real policy in the existing
pre-merge `test` job.

## Design

- `docs/design/ci-change-plan.md` is the normative owner of the push event
  rule; workflow YAML only projects `validations.dependencyPolicy`.
- `docs/dependency-policy.md` supplies the supporting validation contract and
  now names its pre-merge and post-merge composition coverage.
- Plan schema version 2 adds that required field with strict serialization and
  event-semantic coverage.
- The workflow contract fixes the post-merge job's selection, build, and
  validation commands; the aggregate contract requires every workflow job in
  `ci-required`.
- The focused push job does not repeat the complete test suite.

## Validation

```text
dotnet build dotnet-inspect.slnx -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)

dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build
Total: 24, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project eng/DependencyPolicy -c Release --no-build
Dependency policy passed: 23 rules, 156 evaluated projects, 36 inspected assemblies.

dotnet run eng/test-ci-change-detection.cs
CI aggregate fail-safe, legacy classifier parity, path canaries, provenance pin mutations, and change-planner construction passed.

npx markdownlint-cli docs/dependency-policy.md docs/design/ci-change-plan.md
```

Closes #5689.
