### PR TITLE
Document agent session themes and tmux activity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,7 +578,8 @@ that race in the same files. `docs/stacked-prs.md` owns the mechanics.
   its parent; only the bottom open slice uses `main`. During a GitHub outage,
   branch from the recorded last-known base or parent, then update and
   validate bottom-up on recovery before pushing.
-- Merge bottom-up and confirm each retargeted diff still shows only its slice.
+- Merge bottom-up. After each merge, complete the theme handoff; if another
+  slice remains, propose confirming its retargeted diff as the next task.
 - Restacking your own slices is the exception to the no-force-push rule. Use
   `--force-with-lease` and post a `range-diff` proving only the base changed.
 - Apply review depth and the canonical eligibility table per slice and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,22 +78,23 @@ development model and rationale. The binding summary:
 > [`docs/markout-co-development.md`](docs/markout-co-development.md) before
 > touching either repository.
 
-## Session resume
+## Session theme and resume
 
-The transcript survives a resumed session; repository and PR state may not.
-Follow [Resume a session](docs/agent-session-state.md#resume-a-session) to
-confirm the worktree and PR, refresh the effective base, restore window
-identity, and classify the session. Handle conflicts, failed gates, or moved
-bases first, and do not revisit decisions already settled in the transcript.
+Every session has a theme: use one supplied by the user or infer a concise
+purpose from the work. State it at the start and after every resume, and carry
+it in session-status templates. After a PR merges, restate the theme in one or
+two sentences and propose the next work within it; if none remains, say so and
+ask whether to find a new theme or take on ad-hoc work. Follow
+[Agent session state](docs/agent-session-state.md) for the full lifecycle.
 
 ## Making your work findable
 
 This section is tmux-specific and applies only inside a tmux pane — check
 `[ -n "$TMUX" ]` first; outside tmux there is no window to name or option to
-attach state to, so skip it entirely. Each window must identify its PR,
-current state, and any decision it needs. Full tmux mechanics and rationale
-live in [Agent session state](docs/agent-session-state.md); this section
-states the binding rules.
+attach state to, so skip it entirely. Each window must identify its theme, PR,
+current state, and any decision it needs; its pane title reports current
+activity. Full mechanics live in
+[Agent session state](docs/agent-session-state.md).
 
 - **Rename the window** to `pr<number>` (or `i<number>` before a PR exists),
   always targeting `"${TMUX_PANE:?}"`, and keep it stable except for a
@@ -102,7 +103,7 @@ states the binding rules.
   `"${TMUX_PANE:?}"`. Accept Copilot's startup title only as the initial
   fallback; replace it at the start of work, after every resume, and at
   meaningful phase changes with
-  `tmux select-pane -t "${TMUX_PANE:?}" -T "<current activity>"`.
+  `tmux select-pane -t "${TMUX_PANE:?}" -T "<theme>: <current activity>"`.
 - **Announce PR identity** — the literal token `PR #<number>` or `PR <number>`,
   plus branch or expected head — at the start of work, after every resume, and
   at every round start. Round completions use the
@@ -113,11 +114,11 @@ states the binding rules.
   answer labels — never the report, checkpoint, or evidence itself.
 - **Publish `@agent` and `@agent_state`** after every state change, each as its
   own single command (never inside `if`/`&&`/a loop). `@agent_state` carries
-  `head` and `pr`/`issue`, plus `round`, `reviews`, `blocked`, `waiting`, and
-  `rec` (`continue`, `wait`, `merge`, `split`, `approve`, `stop`); clear both
-  when the window no longer owns the work. `blocked` names an issue/PR a
-  person can act on; `waiting` names tool-evaluable predicates (`check:<name>`,
-  `checks`, `merge`, `review`).
+  `theme`, `head`, and `pr`/`issue`, plus `round`, `reviews`, `blocked`,
+  `waiting`, and `rec` (`continue`, `wait`, `merge`, `split`, `approve`,
+  `stop`); clear both when the window no longer owns the work. `blocked` names
+  an issue/PR a person can act on; `waiting` names tool-evaluable predicates
+  (`check:<name>`, `checks`, `merge`, `review`).
 - **Signal `HELP`** with a persistent state plus one best-effort
   `tmux display-message` nudge when blocked on a human decision; clear it once
   the decision arrives.
@@ -531,22 +532,10 @@ checkpoint and split mechanics:
 
 ## Lead with the demo
 
-Validation proves correctness; a demo shows value. Post the intended demo early
-enough to change the implementation.
-
-For a network-accessible inspect-web demo, follow
-[`docs/runbooks/inspect-web-demo-hosting.md`](docs/runbooks/inspect-web-demo-hosting.md).
-A local HTTP listener or successful `curl` is not a user-visible demo.
-
-A useful demo:
-
-- shows a real canonical invocation and its real output;
-- includes before and after for a fix;
-- says what to notice; and
-- still works for a neighboring scenario, proving the implementation was not
-  fitted to the sample.
-
-Put it under `## Demo` above validation in the PR body.
+Put `## Demo` above validation in every PR body. Show the real scenario and
+output, before and after for a fix, and a neighboring case; use a mockup for
+documentation-only work. [Development Practices](docs/development-practices.md#lead-with-the-demo)
+owns the full contract and the inspect-web hosting pointer.
 
 ## PR and CI discipline
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,11 @@ states the binding rules.
 - **Rename the window** to `pr<number>` (or `i<number>` before a PR exists),
   always targeting `"${TMUX_PANE:?}"`, and keep it stable except for a
   `-blocked` or `-conflict` suffix.
+- **Update the pane title** with concise current activity, always targeting
+  `"${TMUX_PANE:?}"`. Accept Copilot's startup title only as the initial
+  fallback; replace it at the start of work, after every resume, and at
+  meaningful phase changes with
+  `tmux select-pane -t "${TMUX_PANE:?}" -T "<current activity>"`.
 - **Announce PR identity** — the literal token `PR #<number>` or `PR <number>`,
   plus branch or expected head — at the start of work, after every resume, and
   at every round start. Round completions use the

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,7 +147,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [GitHub Status Queries](github-status-queries.md) | Querying PR mergeability and CI status without wasting API quota. |
 | [GitHub API Operations](github-api-operations.md) | Correct `gh api` usage for PR/issue metadata changes. |
 | [Stacked PRs](stacked-prs.md) | Mechanics for stacking multiple PRs for a multi-slice issue. |
-| [Agent Session State](agent-session-state.md) | tmux window naming and `@agent`/`@agent_state` publishing mechanics for concurrent agents. |
+| [Agent Session State](agent-session-state.md) | tmux window identity, live pane activity, and `@agent`/`@agent_state` publishing mechanics for concurrent agents. |
 | [Local Development Environment](dev-environment.md) | NuGet source overrides and file-based throwaway probes. |
 | [Release Workflow](release-workflow.md) | Coordinated package-and-site release process. |
 | [Markout Co-development](markout-co-development.md) | The (rare) peer-checkout workflow for changes spanning Markout and this repo. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -147,7 +147,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [GitHub Status Queries](github-status-queries.md) | Querying PR mergeability and CI status without wasting API quota. |
 | [GitHub API Operations](github-api-operations.md) | Correct `gh api` usage for PR/issue metadata changes. |
 | [Stacked PRs](stacked-prs.md) | Mechanics for stacking multiple PRs for a multi-slice issue. |
-| [Agent Session State](agent-session-state.md) | tmux window identity, live pane activity, and `@agent`/`@agent_state` publishing mechanics for concurrent agents. |
+| [Agent Session State](agent-session-state.md) | Session themes, post-merge handoff, tmux identity, pane activity, and state publishing mechanics. |
 | [Local Development Environment](dev-environment.md) | NuGet source overrides and file-based throwaway probes. |
 | [Release Workflow](release-workflow.md) | Coordinated package-and-site release process. |
 | [Markout Co-development](markout-co-development.md) | The (rare) peer-checkout workflow for changes spanning Markout and this repo. |

--- a/docs/agent-session-state.md
+++ b/docs/agent-session-state.md
@@ -1,29 +1,68 @@
 # Agent session state
 
-[Making your work findable](../AGENTS.md#making-your-work-findable) states the
-binding rules: every window identifies its PR, current state, and any decision
-it needs, while its pane title reports current activity. This document owns the
-tmux mechanics and the reasoning behind them.
+[Session theme and resume](../AGENTS.md#session-theme-and-resume) and
+[Making your work findable](../AGENTS.md#making-your-work-findable) state the
+binding rules. This document owns the session-theme lifecycle, post-merge
+handoff, tmux mechanics, and the reasoning behind them.
+
+## Establish the session theme
+
+Every agent session has one theme: a concise sentence describing the sustained
+purpose of the work. Use the user's wording when they supply one; otherwise
+infer it from the requested work and state it visibly before proceeding:
+
+```text
+Theme: Make long-running agent sessions easy to recognize and continue.
+```
+
+The theme is not the current command, branch, or PR title. Keep it stable across
+related tasks and PRs until the user changes it or confirms that the theme is
+complete. Derive a short, lowercase, hyphenated slug such as
+`agent-session-clarity` for templates that require a space-free value.
 
 ## Resume a session
 
 The transcript survives a resumed session; repository and PR state may not.
 Before continuing:
 
-1. Confirm the worktree, branch, and head from git. Fetch the effective base and
+1. Restate the theme, using the transcript or the user's latest direction.
+2. Confirm the worktree, branch, and head from git. Fetch the effective base and
    re-check the PR per
    [Canonical round flow](../AGENTS.md#canonical-round-flow). Do not pull or
    rebase a pushed branch to catch up.
-2. Rename the window, update the pane title, and re-announce the PR as
+3. Rename the window, update the pane title, and re-announce the PR as
    described below.
-3. State which case applies:
+4. State which case applies:
 
 - **Mid-stream:** continue, but handle conflicts, failed gates, or moved bases
   first. Do not revisit decisions already settled in the transcript.
 - **Waiting on the user:** restate the full question and options, then wait.
-- **Task complete:** state what landed and what proves it, then propose the next
-  task without starting it.
+- **Task complete:** state what landed and what proves it, then perform the
+  [theme handoff](#complete-a-merge-with-a-theme-handoff).
 - **Unclear:** explain what the transcript claims and what git shows, then wait.
+
+## Complete a merge with a theme handoff
+
+After every PR merge, relinquish PR ownership only after a visible theme
+handoff:
+
+1. Restate the theme in one or two sentences.
+2. Propose the next concrete work that advances that theme, without starting it.
+3. If no work remains, state that the theme is complete and ask whether to look
+   for a new theme or take on ad-hoc work unrelated to the completed theme.
+
+Use one of these response shapes:
+
+```text
+Theme: <one- or two-sentence restatement>
+Next: <one concrete task that advances the theme>
+```
+
+```text
+Theme: <one- or two-sentence restatement>
+No work remains on this theme. Should I look for a new theme or take on
+ad-hoc work?
+```
 
 ## Detecting tmux
 
@@ -59,15 +98,18 @@ temporary suffixes:
 ## Set the pane title for current activity
 
 ```sh
-tmux select-pane -t "${TMUX_PANE:?}" -T "reviewing pr<number>"
+tmux select-pane -t "${TMUX_PANE:?}" \
+  -T "agent-session-clarity: reviewing pr<number>"
 ```
 
 The window name is stable identity; the pane title is live activity. Copilot
 sets a title at startup, which is a useful baseline but often becomes stale.
 Replace it at the start of work, after every resume, and at meaningful phase
-changes. Use a short factual phrase such as `reviewing pr4405`, `running tests
-for pr4405`, or `waiting for checks on pr4405`; do not churn the title for
-individual commands.
+changes. Prefix a short factual activity with the theme slug, such as
+`agent-session-clarity: reviewing pr4405`,
+`agent-session-clarity: running tests for pr4405`, or
+`agent-session-clarity: waiting for checks on pr4405`; do not churn the title
+for individual commands.
 
 Always target `"${TMUX_PANE:?}"` for the same ownership reason as
 `rename-window`. The pane title is human-facing status displayed by tmux; tools
@@ -78,8 +120,10 @@ must continue to read `@agent` and `@agent_state` rather than scraping it.
 Update both window-scoped options whenever state changes:
 
 ```sh
-tmux set -w -t "${TMUX_PANE:?}" @agent "round 6 on pr4405, waiting on CI"
-tmux set -w -t "${TMUX_PANE:?}" @agent_state "pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
+tmux set -w -t "${TMUX_PANE:?}" @agent \
+  "theme agent-session-clarity; round 6 on pr4405, waiting on CI"
+tmux set -w -t "${TMUX_PANE:?}" @agent_state \
+  "theme=agent-session-clarity pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
 
 # Clear when this window no longer owns the PR.
 tmux set -w -t "${TMUX_PANE:?}" -u @agent
@@ -94,10 +138,11 @@ reporting that it is blocked, and semi-autonomous work stops dead. A bare
 fi` does not match it, because the command being judged is now the compound.
 That difference has stalled real work.
 
-The state must include `head` and either `pr` or, before a PR exists, `issue`;
-add `round`, `reviews`, `blocked`, `waiting`, and `rec` when applicable. Values
-contain no spaces. `rec` is `continue`, `wait`, `merge`, `split`, `approve`, or
-`stop`. Clear both options when the window no longer owns the work.
+The state must include `theme`, `head`, and either `pr` or, before a PR exists,
+`issue`; add `round`, `reviews`, `blocked`, `waiting`, and `rec` when
+applicable. Values contain no spaces. `rec` is `continue`, `wait`, `merge`,
+`split`, `approve`, or `stop`. Clear both options when the window no longer
+owns the work.
 
 ### `blocked` vs. `waiting`
 
@@ -135,7 +180,8 @@ When blocked on a human decision, set a persistent `HELP` state and send one
 best-effort nudge:
 
 ```sh
-tmux set -w -t "${TMUX_PANE:?}" @agent "HELP: integrate main into pr4405, or close it?"
+tmux set -w -t "${TMUX_PANE:?}" @agent \
+  "theme agent-session-clarity; HELP: integrate main into pr4405, or close it?"
 tmux display-message -d 10000 -t "${TMUX_PANE:?}" \
   "HELP pr4405 in w#{window_index}: integrate main, or close it?"
 ```

--- a/docs/agent-session-state.md
+++ b/docs/agent-session-state.md
@@ -2,7 +2,8 @@
 
 [Making your work findable](../AGENTS.md#making-your-work-findable) states the
 binding rules: every window identifies its PR, current state, and any decision
-it needs. This document owns the tmux mechanics and the reasoning behind them.
+it needs, while its pane title reports current activity. This document owns the
+tmux mechanics and the reasoning behind them.
 
 ## Resume a session
 
@@ -13,7 +14,8 @@ Before continuing:
    re-check the PR per
    [Canonical round flow](../AGENTS.md#canonical-round-flow). Do not pull or
    rebase a pushed branch to catch up.
-2. Rename the window and re-announce the PR as described below.
+2. Rename the window, update the pane title, and re-announce the PR as
+   described below.
 3. State which case applies:
 
 - **Mid-stream:** continue, but handle conflicts, failed gates, or moved bases
@@ -53,6 +55,23 @@ temporary suffixes:
 | --- | --- |
 | `-blocked` | waiting on a human decision |
 | `-conflict` | in conflict recovery |
+
+## Set the pane title for current activity
+
+```sh
+tmux select-pane -t "${TMUX_PANE:?}" -T "reviewing pr<number>"
+```
+
+The window name is stable identity; the pane title is live activity. Copilot
+sets a title at startup, which is a useful baseline but often becomes stale.
+Replace it at the start of work, after every resume, and at meaningful phase
+changes. Use a short factual phrase such as `reviewing pr4405`, `running tests
+for pr4405`, or `waiting for checks on pr4405`; do not churn the title for
+individual commands.
+
+Always target `"${TMUX_PANE:?}"` for the same ownership reason as
+`rename-window`. The pane title is human-facing status displayed by tmux; tools
+must continue to read `@agent` and `@agent_state` rather than scraping it.
 
 ## Publish your state where tooling can read it
 

--- a/docs/agent-session-state.md
+++ b/docs/agent-session-state.md
@@ -123,7 +123,7 @@ Update both window-scoped options whenever state changes:
 tmux set -w -t "${TMUX_PANE:?}" @agent \
   "theme agent-session-clarity; round 6 on pr4405, waiting on CI"
 tmux set -w -t "${TMUX_PANE:?}" @agent_state \
-  "theme=agent-session-clarity pr=4463 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
+  "theme=agent-session-clarity pr=4405 head=595e5d4b round=6 reviews=1/2 blocked=4597,4611 rec=wait"
 
 # Clear when this window no longer owns the PR.
 tmux set -w -t "${TMUX_PANE:?}" -u @agent

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -226,10 +226,14 @@ compatibility contract.
 
 Every PR demonstrates the scenario it serves, using a mockup for documentation
 work when no product output exists yet. Post the intended demo early enough to
-change the design and implementation. A good demo makes the goal accessible,
-shows what to notice, and exercises a neighboring case so the implementation
-is not fitted only to the showcase. Follow
-[Lead with the demo](../AGENTS.md#lead-with-the-demo) for the PR contract.
+change the design and implementation. Put `## Demo` above validation in the PR
+body. A good demo shows a real canonical invocation and its output, includes
+before and after for a fix, says what to notice, and exercises a neighboring
+case so the implementation is not fitted only to the showcase.
+
+For a network-accessible inspect-web demo, follow
+[Inspect Web demo hosting](runbooks/inspect-web-demo-hosting.md). A local HTTP
+listener or successful `curl` is not a user-visible demo.
 
 ## Treat critical review feedback as a design question
 

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -192,7 +192,7 @@ unrelated members such as `review`. In the table, **status members** means
 
 | Status snapshot says | Round transition |
 | --- | --- |
-| PR is merged | Leave the status wait, relinquish ownership, and end. |
+| PR is merged | Leave the status wait, relinquish ownership, perform the [theme handoff](agent-session-state.md#complete-a-merge-with-a-theme-handoff), and end. |
 | PR is closed or draft | Leave the status wait, publish the human action or stopped state, and end. |
 | Base ref changed | Leave the status wait; expire merge authorization and route the unchanged head through candidate formation without inheriting fixed-head evidence. |
 | Head changed | Leave the status wait; disable auto-merge first, handle an already-merged result as terminal, then route the returned head through candidate formation without inheriting fixed-head evidence. |
@@ -430,6 +430,7 @@ prompt:
 
 ```text
 Round <n> is complete for PR <number>.
+- Theme: <one-sentence session theme>.
 - Review models <model-a> and <model-b> were used for adversarial review.
 - Design basis: normative owner <path#section> — <owned claim>; supporting
   <path and role for each model, adjacent contract, constraint, or consumer>.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -192,7 +192,7 @@ unrelated members such as `review`. In the table, **status members** means
 
 | Status snapshot says | Round transition |
 | --- | --- |
-| PR is merged | Leave the status wait, relinquish ownership, perform the [theme handoff](agent-session-state.md#complete-a-merge-with-a-theme-handoff), and end. |
+| PR is merged | Leave the status wait, perform the [theme handoff](agent-session-state.md#complete-a-merge-with-a-theme-handoff), relinquish ownership, and end. |
 | PR is closed or draft | Leave the status wait, publish the human action or stopped state, and end. |
 | Base ref changed | Leave the status wait; expire merge authorization and route the unchanged head through candidate formation without inheriting fixed-head evidence. |
 | Head changed | Leave the status wait; disable auto-merge first, handle an already-merged result as terminal, then route the returned head through candidate formation without inheriting fixed-head evidence. |
@@ -255,6 +255,7 @@ Emit this report as visible session output, never inside an approval prompt:
 
 ```text
 Status not observed for PR <number> at round <n> after <mm> minutes.
+- Theme: <one-sentence session theme>.
 - Head: <40-character SHA>
 - Unresolved: <waiting predicates>
 - Last observation: ci-required=<state|not-observed>,

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -38,9 +38,12 @@ with the fixed-head review rule.
 
 ## Landing the stack
 
-**Merge bottom-up, one at a time.** After each merge, confirm the next PR
-retargeted to `main` and that its diff is still only its own slice. When the
-diff shows work already in `main`, that is the signal to restack, not a defect.
+**Merge bottom-up, one at a time.** After each merge, complete the
+[theme handoff](agent-session-state.md#complete-a-merge-with-a-theme-handoff).
+When another slice remains, propose confirming that the next PR retargeted to
+`main` and that its diff is still only its own slice; do not begin that work
+until the user directs it. When the diff later shows work already in `main`,
+that is the signal to restack, not a defect.
 
 **Restacking is normal, it is usually a button, and it force-pushes.** GitHub's
 *Update with rebase* rebases the slice onto its base and force-pushes the head


### PR DESCRIPTION
## Summary

Advance robust, capable agent workflows by giving every long-running session a
stable theme and separating stable tmux identity from live pane activity.

- Require a user-supplied or agent-inferred session theme at startup and resume.
- Carry the theme through pane-title, `@agent`, `@agent_state`, and round-report
  templates.
- Require a post-merge theme handoff that proposes the next related task or
  states that the theme is complete.
- Apply the same handoff before advancing to the next slice in a stacked PR.
- Keep window names as stable PR identity and pane titles as concise
  human-facing activity.

## Demo

A long-running session begins by making its through-line explicit:

```text
Theme: Make long-running agent sessions easy to recognize and continue.
```

The stable window name remains `pr<number>`, while the pane title and
machine-readable state retain the theme:

```sh
tmux select-pane -t "${TMUX_PANE:?}" \
  -T "agent-session-clarity: reviewing pr<number>"
tmux set -w -t "${TMUX_PANE:?}" @agent_state \
  "theme=agent-session-clarity pr=5702 head=<sha> round=1 reviews=0/2 rec=continue"
```

After a PR merges, the agent closes the loop without losing the session's
purpose:

```text
Theme: Make long-running agent sessions easy to recognize and continue.
Next: Apply the theme to the next session-orientation workflow gap.
```

If no related work remains, the template instead states that the theme is
complete and asks whether to find a new theme or take on ad-hoc work.

## Validation

- `npx markdownlint-cli AGENTS.md docs/README.md docs/agent-session-state.md docs/development-practices.md docs/round-orchestration.md`
- `wc -l AGENTS.md` reports 590 lines
- `tmux 3.7b` reports `select-pane ... [-T title] [-t target-pane]`
