### PR TITLE
Adopt MTP for NuGetFetch tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,7 @@ jobs:
       # token that CI — and any fork PR — does not have. Everything that can be proven with an
       # in-memory transport, including the whole credential-mechanism matrix, runs here.
       - name: Run NuGetFetch tests (offline)
-        run: dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
+        run: dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-not-trait "Network=Live"
 
       # InertText sits below every other project, so a regression here reaches every assembly
       # that prints artifact-derived text. The gates are pure and fast — a full BMP sweep and a

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Run NuGetFetch tests (offline)
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}
-        run: dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
+        run: dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-not-trait "Network=Live"
 
       - name: Run metadata tests
         if: ${{ !cancelled() && steps.build.outcome == 'success' }}

--- a/docs/design/nuget-authentication.md
+++ b/docs/design/nuget-authentication.md
@@ -861,7 +861,7 @@ Two tiers, in `src/NuGetFetch.Tests`:
 CI runs the offline tier only:
 
 ```bash
-dotnet run --project src/NuGetFetch.Tests -c Release -- -trait- "Network=Live"
+dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-not-trait "Network=Live"
 ```
 
 The live tier needs a private feed, which CI and fork PRs do not have. To run it locally, mint a
@@ -872,7 +872,7 @@ PAT:
 export DOTNET_INSPECT_TEST_AZDO_FEED=https://pkgs.dev.azure.com/ORG/PROJECT/_packaging/FEED/nuget/v3/index.json
 export DOTNET_INSPECT_TEST_AZDO_TOKEN=$(az account get-access-token \
   --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-dotnet run --project src/NuGetFetch.Tests -c Release -- -trait "Network=Live"
+dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-trait "Network=Live"
 ```
 
 The token is read from the environment and never written to a config file.

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -161,6 +161,12 @@ the migrated filter syntax. These paths use the same pinned xUnit integration
 as the outcome-level host gate rather than duplicating that self-spawn harness
 in every adopting suite.
 
+`NuGetFetch.Tests` is the third adopter. Its CI and Deep Inspect lanes exercise
+the offline `Network=Live` exclusion through MTP, while the NuGet authentication
+test contract records the corresponding explicit live selection. These paths
+reuse the pinned outcome-level host gate and preserve the test partition owned
+by `docs/design/nuget-authentication.md`.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/src/NuGetFetch.Tests/AzureDevOpsCredentialProviderTests.cs
+++ b/src/NuGetFetch.Tests/AzureDevOpsCredentialProviderTests.cs
@@ -24,7 +24,7 @@ namespace NuGetFetch.Tests;
 /// export DOTNET_INSPECT_TEST_AZDO_FEED=https://pkgs.dev.azure.com/ORG/PROJECT/_packaging/FEED/nuget/v3/index.json
 /// export ARTIFACTS_CREDENTIALPROVIDER_ACCESSTOKEN=&lt;PAT with Packaging read, or an Entra access token&gt;
 /// export ARTIFACTS_CREDENTIALPROVIDER_URI_PREFIXES=https://pkgs.dev.azure.com/ORG/
-/// dotnet run --project src/NuGetFetch.Tests -c Release -- -trait "Network=Live"
+/// dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-trait "Network=Live"
 /// </code>
 /// <para>
 /// The provider is fed its token through the environment rather than a prompt because these run

--- a/src/NuGetFetch.Tests/AzureDevOpsFeedTests.cs
+++ b/src/NuGetFetch.Tests/AzureDevOpsFeedTests.cs
@@ -25,7 +25,7 @@ namespace NuGetFetch.Tests;
 /// export DOTNET_INSPECT_TEST_AZDO_FEED=https://pkgs.dev.azure.com/ORG/PROJECT/_packaging/FEED/nuget/v3/index.json
 /// export DOTNET_INSPECT_TEST_AZDO_TOKEN=&lt;PAT with Packaging read, or an Entra access token&gt;
 /// export DOTNET_INSPECT_TEST_AZDO_PACKAGE=Markout          # optional
-/// dotnet run --project src/NuGetFetch.Tests -c Release -- -trait "Network=Live"
+/// dotnet run --project src/NuGetFetch.Tests -c Release -- --filter-trait "Network=Live"
 /// </code>
 /// <para>
 /// The token is read from the environment and never written to a config file, so no secret

--- a/src/NuGetFetch.Tests/NuGetFetch.Tests.csproj
+++ b/src/NuGetFetch.Tests/NuGetFetch.Tests.csproj
@@ -10,6 +10,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adopt Microsoft Testing Platform for `NuGetFetch.Tests`, the third ordinary
xUnit executable migrated under #5379.

- select MTP through the existing transitive xUnit integration;
- migrate the required CI and Deep Inspect `Network=Live` exclusions;
- migrate the documented live/offline commands; and
- preserve the NuGet authentication test partition without adding a
  repository-owned filter parser or a direct runner dependency.

The custom `ILInspector.Decompiler.Tests` host remains deferred until MTP can
preserve its independent discovery/execution identities and exactly-once
completeness receipt.

## Demo

On `main`, a stale native selector silently succeeds:

```console
$ dotnet run --project src/NuGetFetch.Tests -c Release -- \
    -method "*DefinitelyNoSuchTest5379*"
...
NuGetFetch.Tests  Total: 0
$ status=$?; echo "process exit code: $status"
process exit code: 0
```

With this change, the same zero-execution mistake fails through MTP:

```console
$ dotnet run --project src/NuGetFetch.Tests -c Release -- \
    --filter-method "*DefinitelyNoSuchTest5379*"
...
Test run summary: Zero tests ran
$ status=$?; echo "process exit code: $status"
process exit code: 8
```

The `8` is the command's process exit code, not a test count. It makes a stale
focused invocation fail instead of producing success-shaped evidence.

The required hermetic lane continues to run the full offline partition:

```console
$ dotnet run --project src/NuGetFetch.Tests -c Release -- \
    --filter-not-trait "Network=Live"
...
total: 921
failed: 0
succeeded: 919
skipped: 2
```

MTP discovery confirms that the explicit live selector addresses 27 tests
without executing network work:

```console
$ dotnet run --no-build --project src/NuGetFetch.Tests -c Release -- \
    --list-tests --filter-trait "Network=Live"
...
Test discovery summary: found 27 test(s)
```

## Design basis

Normative owner:
`docs/design/xunit-test-host.md#execution-contract` requires adopted suites to
use MTP grammar and preserve aggregate zero-test failure.

Supporting owner:
`docs/design/nuget-authentication.md#tests` defines the hermetic/live
`Network=Live` partition. CI and Deep Inspect continue to execute only its
hermetic complement; live execution remains explicit.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --no-build --project src/NuGetFetch.Tests -c Release -- --filter-not-trait "Network=Live"`
  - 921 total, 919 passed, two platform skips
- valid focused MTP selector: 1/1 passed
- unmatched focused MTP selector: zero tests, exit `8`
- live MTP discovery: 27 tests selected without execution
- `npx markdownlint-cli docs/design/nuget-authentication.md docs/design/xunit-test-host.md`
- `git diff --check`

Part of #5379.
