### PR TITLE
Allow NuGet.Frameworks in query dependency policy

### DIFF
--- a/eng/dependency-policy.json
+++ b/eng/dependency-policy.json
@@ -142,6 +142,7 @@
       "allowOnly": [
         "$platform",
         "$repository",
+        "NuGet.Frameworks",
         "NuGet.Versioning"
       ]
     },


### PR DESCRIPTION
## Summary

Permit `DotnetInspector.Queries` to reference `NuGet.Frameworks`, matching the dependency and query-owned framework-identity semantics already landed in #5623. This is a policy repair only; it changes no product behavior.

## Demo

Before:

```text
error DP0001: query-library-external-dependencies [assembly] DotnetInspector.Queries -> NuGet.Frameworks is not permitted
Dependency policy failed with 1 violation(s).
```

After:

```text
Dependency policy passed.
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project eng/DependencyPolicy.Tests -c Release` — 24 passed
- `dotnet run --project eng/DependencyPolicy -c Release --no-build`
