### PR TITLE
Align the Queries dependency policy with NuGet.Frameworks

### DIFF
--- a/eng/dependency-policy.json
+++ b/eng/dependency-policy.json
@@ -142,6 +142,7 @@
       "allowOnly": [
         "$platform",
         "$repository",
+        "NuGet.Frameworks",
         "NuGet.Versioning"
       ]
     },


### PR DESCRIPTION
This restores the dependency gate that protects dotnet-inspect's conventionally
sound layering while preserving the deliberate NuGet framework semantics already
accepted for restored-project queries.

`DotnetInspector.Queries` intentionally gained a direct `NuGet.Frameworks`
assembly dependency in #5623, but its narrow dependency-policy allow-list was
not updated. Current `main` therefore fails its own Release dependency gate and
blocks unrelated PRs such as #5712. This adds only that exact assembly to the
Queries rule.

Closes #5722.

## Demo

Before:

```text
error DP0001: query-library-external-dependencies [assembly]
DotnetInspector.Queries -> NuGet.Frameworks is not permitted
```

After:

```text
Dependency policy passed: 23 rules, 157 evaluated projects,
36 inspected assemblies.
```

The neighboring boundary remains narrow:

```json
"allowOnly": [
  "$platform",
  "$repository",
  "NuGet.Frameworks",
  "NuGet.Versioning"
]
```

No wildcard, package-family prefix, or exception for another product assembly
is added.

## Design basis

`docs/dependency-policy.md#initial-coverage` owns the enforcement model:
product libraries use repository and platform assemblies unless an
owner-specific rule names a narrow external assembly, and an allowed-set change
must be permitted by the cited owner contract.

`docs/design/inspection-layers.md#l1--dotnetinspectorqueries` owns L1 typed
queries. `docs/design/restored-project-dependency-facts.md` requires canonical
NuGet framework identity for restored-project target selection and correlation.
#5623 implemented that contract with `NuGet.Frameworks` and explicitly recorded
the dependency as pure managed, network-free, NativeAOT-compatible, and suitable
for Browser/Wasm consumers.

## Compatibility

This changes no product code, package reference, runtime behavior, platform
support, or dependency graph. It makes the checked-in policy recognize the
already-shipped exact assembly edge and keeps every other Queries dependency
restriction intact.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --nologo`
- `DOTNET_ROOT=/usr/local/share/dotnet dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build` — 24 passed
- `dotnet run --project eng/DependencyPolicy -c Release --no-build` — 23 rules, 157 projects, 36 assemblies
- Confirmed the integrated branch diff against `origin/main` is one insertion
