### PR TITLE
Make Inspect Web cache budget fixture-relative

### DIFF
--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1971,16 +1971,19 @@ public sealed class BrowserEngineBoundaryTests
 
         BrowserPackageWorkspace.OpenScope(
             [Coordinate("Large.A", Package(image, "lib/net11.0/Large.A.dll", 60 * MiB))]);
+        long expectedResidentBytes = 0;
         foreach (string id in new[] { "Small.B", "Small.C", "Small.D" })
         {
+            byte[] package = Package(image, $"lib/net11.0/{id}.dll", 25 * MiB);
+            expectedResidentBytes += package.LongLength;
             BrowserPackageWorkspace.OpenScope(
-                [Coordinate(id, Package(image, $"lib/net11.0/{id}.dll", 25 * MiB))]);
+                [Coordinate(id, package)]);
         }
 
         BrowserPackageCacheSnapshot stats = BrowserPackageWorkspace.Stats();
         Assert.Equal(3, stats.Workspaces);
         Assert.Equal(3, stats.Resident);
-        Assert.InRange(stats.ResidentBytes, 75L * MiB, 76L * MiB);
+        Assert.Equal(expectedResidentBytes, stats.ResidentBytes);
 
         using (BrowserPackageWorkspace.ReservePackageDownload(
             "pending.package@1.0.0",


### PR DESCRIPTION
Make the Inspect Web cache-ownership gate compare resident bytes with the exact generated package payloads instead of a fixed allowance for the test assembly.

## Demo

Before, ordinary test-assembly growth broke the unchanged ownership behavior:

```text
Assert.InRange() Failure: Value not in range
Range:  (78643200 - 79691776)
Actual: 79729926
```

After, the fixture records each uncompressed package length and asserts that the three resident cache entries account for exactly their combined bytes:

```csharp
Assert.Equal(expectedResidentBytes, stats.ResidentBytes);
```

The same assertion remains exact if the test assembly later grows or shrinks; package-count and workspace-count assertions continue to gate eviction.

## Compatibility

This changes only test evidence. Browser cache limits, eviction, package construction, and production behavior are unchanged.

## Validation

- `git diff --check`
- Focused local execution was blocked because the centrally managed SDK lacks the required `wasm-tools` workload; the existing Inspect Web CI job provides the Release gate.

Fixes #5745