### PR TITLE
Make browser cache accounting test exact

### DIFF
--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1971,16 +1971,22 @@ public sealed class BrowserEngineBoundaryTests
 
         BrowserPackageWorkspace.OpenScope(
             [Coordinate("Large.A", Package(image, "lib/net11.0/Large.A.dll", 60 * MiB))]);
+        long expectedResidentBytes = 0;
         foreach (string id in new[] { "Small.B", "Small.C", "Small.D" })
         {
+            byte[] package = Package(
+                image,
+                $"lib/net11.0/{id}.dll",
+                25 * MiB);
+            expectedResidentBytes += package.LongLength;
             BrowserPackageWorkspace.OpenScope(
-                [Coordinate(id, Package(image, $"lib/net11.0/{id}.dll", 25 * MiB))]);
+                [Coordinate(id, package)]);
         }
 
         BrowserPackageCacheSnapshot stats = BrowserPackageWorkspace.Stats();
         Assert.Equal(3, stats.Workspaces);
         Assert.Equal(3, stats.Resident);
-        Assert.InRange(stats.ResidentBytes, 75L * MiB, 76L * MiB);
+        Assert.Equal(expectedResidentBytes, stats.ResidentBytes);
 
         using (BrowserPackageWorkspace.ReservePackageDownload(
             "pending.package@1.0.0",


### PR DESCRIPTION
## Summary

- Replace the browser package cache test's fixed 75-76 MiB range with the exact sum of the generated resident archive lengths.
- Preserve the intended eviction assertion while removing coupling to the size of the growing test assembly.

## Demo

Before:

```text
Expected resident bytes: 75-76 MiB
Actual resident bytes:   79,729,926
Result:                  failure
```

After:

```text
Expected resident bytes: sum(Small.B.nupkg, Small.C.nupkg, Small.D.nupkg)
Actual resident bytes:   exact same sum
Result:                  pass
```

The neighboring 60 MiB package is still evicted, and the test still requires
exactly three resident workspaces and packages.

## Validation

- `npm run build`
- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 218 tests passed

Closes #5744
Unblocks #5734
