### PR TITLE
Stabilize inspect-web workspace budget fixture size

### DIFF
--- a/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserEngineBoundaryTests.cs
@@ -1968,13 +1968,23 @@ public sealed class BrowserEngineBoundaryTests
     public void WorkspaceOwnership_AccountsArchivesAndCarriesSelectedFailures()
     {
         byte[] image = File.ReadAllBytes(typeof(BrowserEngineBoundaryTests).Assembly.Location);
+        int largePackagePadding = 60 * MiB - image.Length;
+        int smallPackagePadding = 25 * MiB - image.Length;
+        Assert.True(smallPackagePadding > 0);
 
         BrowserPackageWorkspace.OpenScope(
-            [Coordinate("Large.A", Package(image, "lib/net11.0/Large.A.dll", 60 * MiB))]);
+            [Coordinate(
+                "Large.A",
+                Package(image, "lib/net11.0/Large.A.dll", largePackagePadding))]);
         foreach (string id in new[] { "Small.B", "Small.C", "Small.D" })
         {
             BrowserPackageWorkspace.OpenScope(
-                [Coordinate(id, Package(image, $"lib/net11.0/{id}.dll", 25 * MiB))]);
+                [Coordinate(
+                    id,
+                    Package(
+                        image,
+                        $"lib/net11.0/{id}.dll",
+                        smallPackagePadding))]);
         }
 
         BrowserPackageCacheSnapshot stats = BrowserPackageWorkspace.Stats();


### PR DESCRIPTION
Makes the workspace-cache budget fixture model nominal package content sizes instead of adding the growing test assembly on top of every nominal size.

## Demo

Before, the unchanged product failed once `InspectWeb.Engine.Tests.dll` grew beyond the fixture’s incidental allowance:

```text
Assert.InRange() Failure: Value not in range
Range:  (78643200 - 79691776)
Actual: 79742214
```

After, the same Release suite passes while retaining the original 75-76 MiB resident-byte assertion:

```text
InspectWeb.Engine.Tests  Total: 218, Errors: 0, Failed: 0, Skipped: 0
```

What to notice: the packages still contain the real valid test assembly, but the padding is reduced by that assembly’s byte length so the nominal 25 MiB and 60 MiB fixture content no longer drifts as unrelated tests are added. The neighboring malformed, reference-only, expanded-size, and assembly-count cases remain in the same test.

## Design basis

- **Owner:** the existing workspace cache budget gate in `BrowserEngineBoundaryTests` and the 128 MiB cache policy in `BrowserPackageWorkspace`.
- **Exact claim:** nominal package-size fixtures must measure cache behavior rather than growth of the test runner assembly used as valid package content.
- **Scope:** one test-only correction; no product limit, cache algorithm, package parser, or user-visible behavior changes.
- **Pathological case:** a valid fixture assembly grows large enough that three nominal 25 MiB packages exceed the fixed 76 MiB test ceiling.

## Validation

- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release` — 218 passed
- `git diff --check`

Head: `3f39d67d499219bcbdd9ef114cc363cba1546132`

Effective base: `d7b5fe1f0b07745962cccb5dc9bd0d684c4af05c`

Closes #5749. Unblocks #5737.