### PR TITLE
Stop gating merges on npm's advisories endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,16 +314,6 @@ jobs:
           grep -q '<script type="importmap"></script>' dist/index.html
           grep -Eq '<link rel="preload" id="webassembly"[[:space:]]*/?>' dist/index.html
 
-      - name: Audit shipped browser dependencies
-        working-directory: prototypes/inspect-web
-        # The runtime libraries are lockfile dependencies, so advisories against the code that
-        # reaches a user's browser are visible to `npm audit`. `--audit-level=info` is the
-        # strictest setting and is not the default: npm falls back to `low`, which passes a
-        # package whose advisories are all `info`. No `--omit=dev`, because that filters by
-        # where a package is declared rather than by whether it ships -- Vite is a
-        # devDependency and its helpers are in the bundle.
-        run: npm audit --audit-level=info
-
       - name: Check generated inspect-web TypeScript facade for drift
         run: eng/generate-inspect-web-engine-facade.sh --check
 

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -1061,9 +1061,11 @@ and 5 against that mermaid build. The code comment asserting that DOMPurify
 makes package Markdown safe had been resting on that build. None of it was
 hidden; nothing was in a position to look.
 
-CI runs `npm audit --audit-level=info` over the whole tree. Three review rounds
-went into that one line, and each found the same shape of mistake: a flag, or
-the absence of one, meaning something narrower than it appeared to.
+Auditing that lockfile is what makes the difference visible, and `npm audit` is
+still the way to run it by hand. Three review rounds went into the one CI line
+that used to run it, and each found the same shape of mistake: a flag, or the
+absence of one, meaning something narrower than it appeared to. That analysis is
+worth keeping even though the line is gone.
 
 `--audit-level` reads as a severity filter over advisories. npm applies it to
 *packages*, bucketing each by the highest severity affecting it. Of the 24
@@ -1081,11 +1083,21 @@ declared, not by whether its code reaches a browser. Vite is a devDependency and
 its `__vite__mapDeps` helper is in the shipped bundle, so that split was never
 the boundary it resembled.
 
-What remains is the strictest available check over all 168 packages, which is
-what lets the sanitization comment name its gate without qualification. It is
-clean today. It will sometimes fail for a build tool rather than for shipped
-code; that is the accepted trade against a narrower gate whose description has
-to be exactly right, and three times was not.
+That check no longer runs in CI. `npm audit` needs npm's advisories endpoint,
+and it exits non-zero both when it finds an advisory and when it cannot reach
+that endpoint, so the merge gate could not tell a vulnerable dependency from an
+npm outage. On 2026-09-04 the endpoint returned 503s and timeouts for over two
+hours and turned `ci-required` red on unrelated pull requests; a gate that
+blocks merges on a third party's uptime is not measuring this repository.
+
+What watches the lockfile now is Dependabot: the same 168 packages against the
+same advisory database, with vulnerability alerts enabled and a weekly npm
+update schedule for `/prototypes/inspect-web`. The honest difference is timing.
+`npm audit` blocked the merge that introduced an advisory; Dependabot reports
+one after it lands and opens a security update. That is weaker, and it is what
+lets the sanitization comment name a gate that is monitoring rather than
+enforcement. Run `npm audit --audit-level=info` locally to get the old answer on
+demand.
 
 What remains on a CDN is the three Prism scripts in `index.html`. Those are
 markup, they carry digests, and the freshness check reads them -- so the

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -9799,8 +9799,10 @@ function closeGraphSource() {
 //
 // That sanitization claim is only as good as the DOMPurify build behind it, and a CDN URL had
 // no gate at all: the pinned version was never checked against any advisory feed. The gate is
-// now the lockfile pin plus CI's `npm audit --audit-level=info`, which fails the build when
-// any dependency in the lockfile has a known advisory at any severity.
+// now the lockfile pin plus Dependabot vulnerability alerts, which watch that lockfile against
+// the same advisory database and open a security update when one lands. That is monitoring
+// rather than a merge gate: an advisory is reported after the fact instead of failing a build,
+// because `npm audit` reaching the registry is not something a merge can depend on.
 async function markdownLibs() {
   markdownModule ??= Promise.all([
     import("marked"),


### PR DESCRIPTION
## Claim

`npm audit` cannot tell a vulnerable dependency from an npm outage, so it does
not belong in a merge gate. This removes it from the merge-gating `inspect-web`
job and points the two claims that named it at what actually enforces them now.

## Demo

**Before** — the same command, three times in two hours, on unrelated PRs:

```text
02:09  npm error audit endpoint returned an error
03:54  npm warn audit 503 Service Unavailable - POST
       https://registry.npmjs.org/-/npm/v1/security/advisories/bulk
04:09  npm warn audit network timeout at:
       https://registry.npmjs.org/-/npm/v1/security/advisories/bulk
```

Verified independently of CI, from a workstation:

```console
$ curl -s -o /dev/null -w "HTTP %{http_code} in %{time_total}s\n" -X POST \
    -H 'Content-Type: application/json' -d '{"npm":["10.0.0"]}' \
    https://registry.npmjs.org/-/npm/v1/security/advisories/bulk --max-time 30
HTTP 000 in 30.007252s
```

`ci-required` was red on #5703 and #5679 the whole time. Neither changed an npm
dependency. #5679 was re-run once and failed the same way.

**What to notice:** `npm audit` exits `1` for "found an advisory" *and* for
"could not ask", and the job cannot distinguish them. The red says a security
gate failed when what actually happened is that a third party was unreachable.

**After** — the step is gone, so an npm outage cannot fail an unrelated merge.
Running it by hand still gives the old answer:

```console
$ cd prototypes/inspect-web && npm audit --audit-level=info
found 0 vulnerabilities
```

**Neighboring case:** this is not specific to the outage that prompted it. Any
registry unavailability — rate limiting, a network policy change on the runner,
a regional failure — produced the same false red for any PR touching
`prototypes/inspect-web`.

## What replaces it

Dependabot already watches the same 168 packages against the same advisory
database: vulnerability alerts are enabled (`/vulnerability-alerts` → HTTP 204)
and `.github/dependabot.yml` schedules weekly npm updates for
`/prototypes/inspect-web`.

**This is weaker, and the PR says so rather than presenting it as equivalent.**
`npm audit` blocked the merge that introduced an advisory. Dependabot reports
one after it lands and opens a security update. The trade is a real reduction in
gating strength for a gate that could not run reliably.

Because two places named the CI check as their enforcing gate, both were
updated rather than left stale:

- `src/dotnet-inspect.ts:9800` — the DOMPurify sanitization comment now names
  the lockfile pin plus Dependabot alerts, and says plainly that this is
  monitoring rather than enforcement.
- `prototypes/inspect-web/README.md` — the "CI runs `npm audit`" claim is
  corrected. The `--audit-level` analysis is kept: it is still true, still
  explains why moving CDN libraries into the lockfile mattered, and is still how
  to run the check by hand.

## Boundary

No dependency, lockfile, or shipped code changes. The only behavior change is
that CI no longer contacts npm's advisories endpoint.

## Validation

- `npx markdownlint-cli prototypes/inspect-web/README.md` — clean.
- Workflow parses; the `inspect-web` job keeps its remaining 23 steps and the
  audit step is absent.
- `grep -rn 'npm audit'` — every surviving mention is accurate.
