### PR TITLE
Adopt MTP for IL roundtrip tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,7 +763,7 @@ jobs:
 
       - name: Run IL round-trip tests (fast)
         if: matrix.rid == 'linux-x64' && fromJSON(needs.changes.outputs.plan).validations.ilRoundTrip
-        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trait- "Speed=Slow"
+        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- --filter-not-trait "Speed=Slow"
 
       # Terminal checks: the suites above still report their results when
       # acquisition fails, but the lane must not go green having silently

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -210,7 +210,7 @@ Notes:
   prove the slow suite is green; run the full suite locally before review.
 - The IL round-trip oracle follows the same shape: PR CI runs
   `dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release --
-  -trait- "Speed=Slow"` when IL round-trip inputs change, while the unfiltered
+  --filter-not-trait "Speed=Slow"` when IL round-trip inputs change, while the unfiltered
   `DotnetInspector.ILRoundtrip.Tests` command keeps the assembly-wide sweep in
   Deep Inspect / full local coverage. Mark new broad/corpus-style
   round-trip checks `[Trait("Speed", "Slow")]`.

--- a/docs/design/xunit-test-host.md
+++ b/docs/design/xunit-test-host.md
@@ -167,6 +167,12 @@ test contract records the corresponding explicit live selection. These paths
 reuse the pinned outcome-level host gate and preserve the test partition owned
 by `docs/design/nuget-authentication.md`.
 
+`DotnetInspector.ILRoundtrip.Tests` is the fourth adopter. Its required PR lane
+exercises the fast `Speed=Slow` exclusion through MTP, while Deep Inspect and
+the suite's focused README preserve the unfiltered vendored-assembler sweep.
+These paths reuse the pinned outcome-level host gate without weakening the
+round-trip oracle or moving broad sweep work into PR CI.
+
 If the selected MTP version cannot produce the independent discovery and
 execution identities required by the decompiler completeness receipt, that
 suite remains on its transitional host until its owner has an equally strong

--- a/tests/DotnetInspector.ILRoundtrip.Tests/DotnetInspector.ILRoundtrip.Tests.csproj
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/DotnetInspector.ILRoundtrip.Tests.csproj
@@ -9,6 +9,7 @@
     <IsTestProject>true</IsTestProject>
     <IsAotCompatible>false</IsAotCompatible>
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
 
     <!-- IlasmScaffold captures the IL assembler's in-process stderr with
          Console.SetError so a parse failure becomes a test diagnostic rather

--- a/tests/DotnetInspector.ILRoundtrip.Tests/README.md
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/README.md
@@ -19,7 +19,7 @@ Run the fast subset used for pull-request validation:
 
 ```bash
 dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- \
-  -trait- "Speed=Slow"
+  --filter-not-trait "Speed=Slow"
 ```
 
 The fast suite includes canonical array-bound signatures and requires the


### PR DESCRIPTION
## Summary

Adopt Microsoft Testing Platform for
`DotnetInspector.ILRoundtrip.Tests`, the fourth ordinary xUnit executable
migrated under #5379.

- select MTP through the existing transitive xUnit integration;
- migrate the required PR `Speed=Slow` exclusion;
- migrate the focused README and correctness-pipeline command; and
- preserve the unfiltered vendored-ILAssembler sweep in Deep Inspect.

The suite's `OwnsItsOwnStderr` setting remains unchanged: it governs
ILAssembler diagnostics, not test-host execution. The custom
`ILInspector.Decompiler.Tests` host remains deferred until MTP can preserve
its independent discovery/execution identities and exactly-once completeness
receipt.

## Demo

On `main`, a stale native selector silently succeeds:

```console
$ dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests \
    -c Release -- -method "*DefinitelyNoSuchTest5379*"
...
DotnetInspector.ILRoundtrip.Tests  Total: 0
$ status=$?; echo "process exit code: $status"
process exit code: 0
```

With this change, the same zero-execution mistake fails through MTP:

```console
$ dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests \
    -c Release -- --filter-method "*DefinitelyNoSuchTest5379*"
...
Test run summary: Zero tests ran
$ status=$?; echo "process exit code: $status"
process exit code: 8
```

The `8` is the command's process exit code, not a test count. It makes a stale
focused invocation fail instead of producing success-shaped evidence.

The required fast lane preserves its existing partition:

```console
$ dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests \
    -c Release -- --filter-not-trait "Speed=Slow"
...
total: 22
failed: 0
succeeded: 22
```

The neighboring unfiltered command still exercises the two slow
assembly-sweep cases through the vendored assembler:

```console
$ dotnet run --no-build \
    --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
...
total: 24
failed: 0
succeeded: 24
```

## Design basis

Normative owner:
`docs/design/xunit-test-host.md#execution-contract` requires adopted suites to
use MTP grammar and preserve aggregate zero-test failure.

Supporting owner:
`docs/decompiler-correctness-pipeline.md` defines the fast/full
`Speed=Slow` partition for the IL round-trip oracle. PR CI continues to run
the 22-test fast complement; the unfiltered two-case assembly sweep remains in
Deep Inspect and explicit local validation.

## Validation

- `bash eng/restore-ilassembler.sh`
- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- --filter-not-trait "Speed=Slow"`
  - 22/22 passed
- valid focused MTP selector: 1/1 passed
- unmatched focused MTP selector: zero tests, exit `8`
- slow MTP discovery: two assembly-sweep cases selected without execution
- unfiltered vendored-assembler sweep: 24/24 passed
- `npx markdownlint-cli docs/decompiler-correctness-pipeline.md docs/design/xunit-test-host.md tests/DotnetInspector.ILRoundtrip.Tests/README.md`
- `git diff --check`

Part of #5379.
