### PR TITLE
Define ecosystem-owned product demos

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,7 @@ referencing the CLI assembly.
 
 | Host | Place in flow | Role | Primary guide |
 | ---- | ------------- | ---- | ------------- |
-| `src/DotnetInspector.Ecosystems` | Application catalog | Static package-set identity, audited membership, discovery, and lookup shared by the product front ends without entering reusable infrastructure. | [Package Set Registry](design/package-set-registry.md), [Static Ecosystem Packs](design/ecosystem-packs.md) |
+| `src/DotnetInspector.Ecosystems` | Application catalog | Static package-set identity and membership today; target ecosystem-pack metadata and product-demo sources shared by the product front ends without entering reusable infrastructure. | [Package Set Registry](design/package-set-registry.md), [Static Ecosystem Packs](design/ecosystem-packs.md), [Workspace Definitions](design/workspace-definitions.md#product-demos-are-closed-section-presets) |
 | `src/dotnet-inspect` | Product host | Complete command-line host, including source resolution, command orchestration, section selection, output models, and rendering. | [CLI host architecture](cli-architecture.md) |
 | `prototypes/inspect-web` | Product host | Browser/Wasm host and product UI over reusable engine and focused UI-control contracts. | [Inspect Web UI](design/inspect-web-ui.md) composition map, [SlideStrip](design/inspect-web-slide-strip.md) reusable control, [operation authority](design/inspect-web-operation-authority.md) |
 | `tools/DecompilerHarness` | Correctness harness | Decompiler correctness, compile-back, corpus, and independent-oracle orchestration. | [Decompiler correctness pipeline](decompiler-correctness-pipeline.md) |

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -396,14 +396,15 @@ Workspace Definitions retains:
 
 The pack registration stores one owner-issued binding and does not copy or
 reinterpret its records. Workspace Definitions exposes the public minting seam
-`ProductDemoSourceBinding.Create(scenarioId, static createRecords)`. The static
-lambda or method-group requirement is the source-level noncapture boundary;
-construction also rejects a delegate with a non-null target before publication.
-The binding stores the delegate privately and exposes no delegate or factory
-property. Its resolve operation requires the returned records to contain
-exactly one `ScenarioDefinition`, requires that record's ID to equal the
-binding scenario ID, constructs the registry, resolves that exact ID, and
-enforces the demo section contract.
+`ProductDemoSourceBinding.Create(scenarioId, CreateRecords)`. Only a static
+method group is admitted; construction rejects a delegate with a non-null
+target before publication. Static lambdas are intentionally not the authoring
+form because the compiler may represent a noncapturing lambda with a cached
+target object. The binding stores the delegate privately and exposes no
+delegate or factory property. Its resolve operation requires the returned
+records to contain exactly one `ScenarioDefinition`, requires that record's ID
+to equal the binding scenario ID, constructs the registry, resolves that exact
+ID, and enforces the demo section contract.
 
 Complete ecosystem-manifest validation rejects duplicate scenario IDs,
 duplicate demo orders, empty title or summary, and a pack-local demo sequence
@@ -508,8 +509,7 @@ Integration concept IDs.
 The binding is statically rooted and noncapturing:
 
 ```text
-EcosystemIntegrationScannerBinding.Create(
-  static observations => AspireIntegrationScanner.Scan(observations))
+EcosystemIntegrationScannerBinding.Create(AspireIntegrationScanner.Scan)
 ```
 
 The concrete binding, context, invocation, and result types belong to the

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -397,14 +397,16 @@ Workspace Definitions retains:
 The pack registration stores one owner-issued binding and does not copy or
 reinterpret its records. Workspace Definitions exposes the public minting seam
 `ProductDemoSourceBinding.Create(scenarioId, CreateRecords)`. Only a static
-method group is admitted; construction rejects a delegate with a non-null
-target before publication. Static lambdas are intentionally not the authoring
-form because the compiler may represent a noncapturing lambda with a cached
-target object. The binding stores the delegate privately and exposes no
-delegate or factory property. Its resolve operation requires the returned
-records to contain exactly one `ScenarioDefinition`, requires that record's ID
-to equal the binding scenario ID, constructs the registry, resolves that exact
-ID, and enforces the demo section contract.
+method group is admitted; construction requires a one-entry invocation list and
+rejects a delegate with a non-null target before publication. Static lambdas are
+intentionally not the authoring form because the compiler may represent a
+noncapturing lambda with a cached target object. A multicast combination of
+static method groups is also rejected because invoking one binding would
+otherwise execute every combined source. The binding stores the delegate
+privately and exposes no delegate or factory property. Its resolve operation
+requires the returned records to contain exactly one `ScenarioDefinition`,
+requires that record's ID to equal the binding scenario ID, constructs the
+registry, resolves that exact ID, and enforces the demo section contract.
 
 Complete ecosystem-manifest validation rejects duplicate scenario IDs,
 duplicate demo orders, empty title or summary, and a pack-local demo sequence

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -18,12 +18,19 @@ inventories are implemented. The pack registry, demo contribution, and their
 novel registry and application-adoption gates remain unimplemented. The
 assembly-friend tests and solution dependency-policy rule already landed with
 the application shell and remain applicable. The inspect-web facade boundary
-gate still names the former host facade; application adoption must retarget its
-sole ecosystem-catalog exception to the catalog facade.
+gate still names the former host facade and inspects only declared references;
+application adoption must retarget its sole ecosystem-catalog exception to the
+catalog facade and add compiled-reference coverage.
 Existing product demos remain in the `DotnetInspector.Queries` donor registry
 until the transfer described here lands. Every asserted target property is
 unverified until its named Release gate lands; existing package membership,
 demo behavior, and search behavior remain unchanged.
+
+Participating normative owner:
+
+- [Static workspaces: definitions, assembly groups, and projections](workspace-definitions.md#product-demos-are-closed-section-presets)
+  solely owns `ProductDemoSourceBinding` construction, validation, resolution,
+  execution handoff, and failures.
 
 Supporting owners:
 
@@ -37,9 +44,6 @@ Supporting owners:
   package discovery, paging, failures, and payload acquisition.
 - [Artifact acquisition and workspace composition](artifact-acquisition-and-workspaces.md)
   owns realization and workspace generations.
-- [Static workspaces: definitions, assembly groups, and projections](workspace-definitions.md#product-demos-are-closed-section-presets)
-  owns demo definition records, lazy source bindings, resolution, section
-  admission, run plans, execution semantics, and failures.
 - [Inspection bundles and demos](../inspection-space.md#inspection-bundles-and-demos)
   owns the bundle and runtime-workspace composition boundary.
 - [Capability-driven section registry spike](capability-section-registry-spike.md)
@@ -55,6 +59,18 @@ Supporting owners:
   Workspace viewer.
 - [#5772](https://github.com/richlander/dotnet-inspect/issues/5772) is the
   three-slice Aspire and ecosystem-demo delivery stack.
+
+## Approved composition scope
+
+The operator approved #5772 as one bounded two-owner composition: this owner
+defines the static product-demo inventory and exact dispatch, while Workspace
+Definitions issues the one lazy source-binding currency required to transfer
+application-authored demo sources out of Queries. The handoff is
+`ProductDemoSourceBinding` in and `ResolvedScenario` or an owner-domain failure
+out. This approval does not transfer record, validation, resolution, section,
+run-plan, execution, or failure semantics to the catalog and does not admit
+changes to any other Workspace Definitions contract. Package-set, prefix, and
+scanner owner tracks remain separate efforts.
 
 ## Authority and exact claim
 
@@ -178,10 +194,10 @@ EcosystemDemoSelection
 ```
 
 `ProductDemoSourceBinding` is issued by Workspace Definitions. It carries the
-exact scenario ID and one noncapturing source for that scenario's peer
-definition records. The scenario ID is the product-demo identity; the
-ecosystem catalog does not mint a parallel demo ID or infer identity from
-title, order, package coordinate, or ecosystem.
+exact scenario ID and an opaque owner-defined resolution operation. The
+scenario ID is the product-demo identity; the ecosystem catalog does not mint
+a parallel demo ID or infer identity from title, order, package coordinate, or
+ecosystem.
 
 The public discovery boundary exposes immutable pack, prefix-action, and demo
 descriptor metadata, package-set identity, and whether a scanner is available.
@@ -307,13 +323,16 @@ production target except `dotnet-inspect`.
 The dependency-policy solution does not include inspect-web, so it does not
 claim to prove that boundary. The browser owner separately adds
 `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly`, which reads the
-evaluated MSBuild `ProjectReference` and assembly `Reference` items for the
-inspect-web production projects. Its current implementation permits either
-reference only from the former managed host facade, `InspectWeb.Engine`;
-application adoption retargets that sole exception to
-`InspectWeb.Engine.CatalogExports`. `InspectWeb.Engine.Core`, the host and
-sibling export facades, and every other inspect-web production project reject
-it. Test projects and the focused
+evaluated direct MSBuild `ProjectReference` items and each Release-built
+production assembly's metadata `AssemblyRef` rows. Its current implementation
+inspects only declared references and permits the former managed host facade,
+`InspectWeb.Engine`; application adoption adds compiled-reference coverage and
+retargets the sole exception to `InspectWeb.Engine.CatalogExports`. The
+compiled check rejects host source that consumes the catalog through the
+transitive host-to-catalog-facade project graph.
+`InspectWeb.Engine.Core`, the host and sibling export facades, and every other
+inspect-web production project reject both a declared edge and a compiled
+catalog reference. Test projects and the focused
 `DotnetInspector.Ecosystems.Consumer.Tests` non-friend canary may reference the
 catalog, but only `DotnetInspector.Ecosystems.Tests` may be an assembly friend.
 
@@ -400,28 +419,19 @@ Workspace Definitions retains:
 - execution semantics; and
 - visible failures.
 
-The pack registration stores one owner-issued binding and does not copy or
-reinterpret its records. Workspace Definitions exposes the public minting seam
-`ProductDemoSourceBinding.Create(scenarioId, CreateRecords)`. Only a static
-method group is admitted; construction requires a one-entry invocation list and
-rejects a delegate with a non-null target before publication. Static lambdas are
-intentionally not the authoring form because the compiler may represent a
-noncapturing lambda with a cached target object. A multicast combination of
-static method groups is also rejected because invoking one binding would
-otherwise execute every combined source. The binding stores the delegate
-privately and exposes no delegate or factory property. Its resolve operation
-requires the returned records to contain exactly one `ScenarioDefinition`,
-requires that record's ID to equal the binding scenario ID, constructs the
-registry, resolves that exact ID, and enforces the demo section contract.
+The pack registration stores one owner-issued binding and does not copy,
+inspect, or reinterpret its source or records. Workspace Definitions solely
+owns binding construction, admission, private source storage, record
+validation, exact resolution, section admission, and failures. The catalog
+consumes only the binding's public scenario identity and resolution result.
 
 Complete ecosystem-manifest validation rejects duplicate scenario IDs,
 duplicate demo orders, empty title or summary, and a pack-local demo sequence
 whose orders are not strictly ascending. It does not invoke a source to
 validate its records. Catalog selection dispatches only the chosen binding;
 record construction, single-scenario validation, exact resolution, and
-owner-domain failure remain Workspace Definitions behavior. A mismatch,
-malformed record graph, unsupported section, or other owner-domain failure is
-visible rather than becoming an empty or default demo.
+owner-domain failure remain Workspace Definitions behavior. An owner-domain
+failure remains visible rather than becoming an empty or default demo.
 
 Demo order is global across the product rather than derived from pack order.
 Grouped discovery presents packs in pack order and each pack's demos in their
@@ -784,7 +794,7 @@ ordinary non-friend consumer.
 | `EcosystemPackAssemblyBoundaryTests.FriendsOnlyDedicatedTests` | `DotnetInspector.Ecosystems.Tests` is the assembly's only `InternalsVisibleTo`; the CLI, inspect-web facade, non-friend canary, and all other assemblies are absent. |
 | `EcosystemPackAssemblyBoundaryTests.OwnerContractsRequireNoFriendAccess` | Repository-owned lower assemblies derived from the ecosystem assembly's compiled references omit `DotnetInspector.Ecosystems` from `InternalsVisibleTo`; compiling the ecosystem assembly therefore exercises only public owner contracts. |
 | `eng/dependency-policy.json` rule `ecosystem-catalog-stays-in-approved-hosts` | Within `dotnet-inspect.slnx`, project and compiled assembly graphs reject every production dependency on `DotnetInspector.Ecosystems` except direct use by `dotnet-inspect`; existing IL rules independently reject the reusable IL-library edges they select. |
-| `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly` | After application adoption retargets the existing gate, evaluated inspect-web `ProjectReference` and assembly `Reference` items permit `DotnetInspector.Ecosystems` only in `InspectWeb.Engine.CatalogExports` and reject it from `InspectWeb.Engine.Core`, the host and sibling export facades, and every other browser production project. |
+| `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly` | After application adoption strengthens and retargets the existing gate, evaluated direct inspect-web `ProjectReference` items and Release-built metadata `AssemblyRef` rows permit `DotnetInspector.Ecosystems` only in `InspectWeb.Engine.CatalogExports`; they reject declared catalog edges or compiled catalog consumption through transitive availability from `InspectWeb.Engine.Core`, the host and sibling export facades, and every other browser production project. |
 
 Application adoption adds
 `ProductEcosystemPackTests.ShippedManifestMatchesLiteralPolicy` and
@@ -835,13 +845,13 @@ The owner tracks may advance independently:
 
 1. Lock this focused pack pattern.
 2. Advance whichever independent owner track is needed for the first real pack.
-3. In one implementation slice, issue the Workspace-Definitions-owned lazy
-   source binding; transfer the eight application-authored donor sources; add
-   the two Aspire sources; implement pack identity, descriptors, private
-   manifest, package-set and demo slots, grouped and flattened discovery, exact
-   lookup and selection; and publish the four-pack, ten-demo manifest with its
-   focused gates. Do not change current package membership, existing demo
-   execution, or search behavior.
+3. Under the approved #5772 two-owner composition, issue the
+   Workspace-Definitions-owned lazy source binding; transfer the eight
+   application-authored donor sources; add the two Aspire sources; implement
+   pack identity, descriptors, private manifest, package-set and demo slots,
+   grouped and flattened discovery, exact lookup and selection; and publish the
+   four-pack, ten-demo manifest with its focused gates. Do not change current
+   package membership, existing demo execution, or search behavior.
 4. Add each remaining action slot independently when its owner track lands; no
    later slot reopens already implemented action semantics.
 5. Adopt CLI and browser actions through the same implementation slice's

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -14,12 +14,14 @@ Integration scanner implementation, plus product demos that exercise ordinary
 shipping sections over exact pinned inputs.
 
 The Package Set Registry and its Microsoft.Extensions and ASP.NET Core
-inventories are implemented. The pack pattern, demo contribution, and all
-pack-level target gates remain unimplemented. Existing product demos remain in
-the `DotnetInspector.Queries` donor registry until the transfer described here
-lands. Every asserted target property is unverified until its named Release
-gate lands; existing package membership, demo behavior, and search behavior
-remain unchanged.
+inventories are implemented. The pack registry, demo contribution, and their
+novel registry and application-adoption gates remain unimplemented. The
+assembly-friend tests, solution dependency-policy rule, and inspect-web facade
+boundary gate already landed with the application shell and remain applicable.
+Existing product demos remain in the `DotnetInspector.Queries` donor registry
+until the transfer described here lands. Every asserted target property is
+unverified until its named Release gate lands; existing package membership,
+demo behavior, and search behavior remain unchanged.
 
 Supporting owners:
 
@@ -849,8 +851,9 @@ coherent.
 The package-set donor transfer already created
 `DotnetInspector.Ecosystems`, limited friendship to
 `DotnetInspector.Ecosystems.Tests`, and landed the solution dependency-policy
-gate. The demo track adds the Queries dependency and inspect-web project-graph
-gate while preserving those boundaries.
+and inspect-web project-graph gates. The demo track adds the Queries dependency
+and must keep those existing boundaries green; it does not add parallel
+boundary mechanisms.
 
 ## Non-claims
 

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -16,8 +16,10 @@ shipping sections over exact pinned inputs.
 The Package Set Registry and its Microsoft.Extensions and ASP.NET Core
 inventories are implemented. The pack registry, demo contribution, and their
 novel registry and application-adoption gates remain unimplemented. The
-assembly-friend tests, solution dependency-policy rule, and inspect-web facade
-boundary gate already landed with the application shell and remain applicable.
+assembly-friend tests and solution dependency-policy rule already landed with
+the application shell and remain applicable. The inspect-web facade boundary
+gate still names the former host facade; application adoption must retarget its
+sole ecosystem-catalog exception to the catalog facade.
 Existing product demos remain in the `DotnetInspector.Queries` donor registry
 until the transfer described here lands. Every asserted target property is
 unverified until its named Release gate lands; existing package membership,
@@ -203,12 +205,13 @@ The intended host-neutral application component is
 `DotnetInspector.Ecosystems`. It sits above Packages and
 Queries/Workspace Definitions and Metadata/Integrations and contains the
 application manifest and concrete pack source. Its only production consumers
-are the `dotnet-inspect` CLI front end and the `InspectWeb.Engine` managed
-browser facade. `InspectWeb.Engine.Core`, Packages, Metadata, Queries,
-Services, Presentation, Vocabulary, and other reusable infrastructure do not
-reference it. Selected owner-issued package, demo, or scanner currencies flow
-from the catalog or two front ends into existing infrastructure; the catalog
-itself does not flow downward.
+are the `dotnet-inspect` CLI front end and the
+`InspectWeb.Engine.CatalogExports` managed browser facade.
+`InspectWeb.Engine.Core`, the host and sibling export facades, Packages,
+Metadata, Queries, Services, Presentation, Vocabulary, and other reusable
+infrastructure do not reference it. Selected owner-issued package, demo, or
+scanner currencies flow from the catalog or two front ends into existing
+infrastructure; the catalog itself does not flow downward.
 
 ## Identity
 
@@ -305,15 +308,17 @@ The dependency-policy solution does not include inspect-web, so it does not
 claim to prove that boundary. The browser owner separately adds
 `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly`, which reads the
 evaluated MSBuild `ProjectReference` and assembly `Reference` items for the
-inspect-web production projects and permits either reference only from the
-current managed front-end facade, `InspectWeb.Engine`.
-`InspectWeb.Engine.Core` and every other inspect-web production project reject
+inspect-web production projects. Its current implementation permits either
+reference only from the former managed host facade, `InspectWeb.Engine`;
+application adoption retargets that sole exception to
+`InspectWeb.Engine.CatalogExports`. `InspectWeb.Engine.Core`, the host and
+sibling export facades, and every other inspect-web production project reject
 it. Test projects and the focused
 `DotnetInspector.Ecosystems.Consumer.Tests` non-friend canary may reference the
 catalog, but only `DotnetInspector.Ecosystems.Tests` may be an assembly friend.
 
-Together, the solution dependency policy and browser project-graph gate provide
-full coverage for the current production dependency claim.
+Together, the solution dependency policy and retargeted browser project-graph
+gate provide full coverage for the production dependency claim.
 `DotnetInspector.Ecosystems` consumes package-coordinate, prefix, and scanner
 currencies through their public owner-issued surfaces. Demo adoption adds a
 normal public reference from `DotnetInspector.Ecosystems` to
@@ -332,10 +337,9 @@ application concepts in owner-domain records and evidence, and such a scan
 would conflate semantic content with an application-catalog dependency.
 
 `DotnetInspector.Ecosystems.csproj` declares exactly one friend,
-`DotnetInspector.Ecosystems.Tests`. The CLI, `InspectWeb.Engine`, the non-friend
+`DotnetInspector.Ecosystems.Tests`. The CLI, inspect-web facades, the non-friend
 canary, and all other production and test assemblies receive no friend access.
-Friendship is not an alternate registration, publication, or selection
-channel.
+Friendship is not an alternate registration, publication, or selection channel.
 
 ## Materialization
 
@@ -590,8 +594,9 @@ explicit selections.
 ## Host plan
 
 The static manifest is host-neutral application product data directly consumed
-only by the CLI and `InspectWeb.Engine` front ends. Neither copies the pack
-list, package-set identity, prefix metadata, or scanner availability.
+only by the CLI and `InspectWeb.Engine.CatalogExports` front ends. Neither
+copies the pack list, package-set identity, prefix metadata, or scanner
+availability.
 
 The CLI may later expose ecosystem discovery or map existing source selectors
 to pack capabilities. It retains token grammar, command policy, diagnostics,
@@ -605,9 +610,9 @@ and run plan through the existing type/member section pipeline. Product-facing
 title and summary come from the selected catalog descriptor, not from the
 resolved scenario's portable metadata.
 
-`InspectWeb.Engine` may project an ecosystem action surface from the same
-descriptors through its generated facade. The TypeScript front end retains
-interaction and browser presentation. Browser infrastructure retains
+`InspectWeb.Engine.CatalogExports` projects an ecosystem action surface from
+the same descriptors through its generated facade. The TypeScript front end
+retains interaction and browser presentation. Browser infrastructure retains
 asynchronous acquisition, budget reservation, workspace replacement, rollback,
 and disposal without referencing the ecosystem catalog.
 
@@ -624,14 +629,14 @@ Integration-owned orchestration. Browser Core may carry the Integration value
 through an Integration-typed parameter, but it does not reference the ecosystem
 catalog or rediscover the pack.
 
-The current browser exception names `InspectWeb.Engine`. If the proposed
-JSExport facade partition lands first, its owner must designate exactly one
-managed export facade as the replacement exception and assign the complete
-ecosystem discovery, selection, execution adaptation, and facade-local DTO
-closure to it. Sibling export facades neither consume that facade nor reference
-the catalog. The TypeScript application composes the separate facade result
-into its application model. Core and every other reusable browser project
-remain forbidden.
+The implemented
+[JSExport facade partition](inspect-web-jsexport-partitioning.md) designates
+`InspectWeb.Engine.CatalogExports` as the sole managed ecosystem-catalog
+consumer and assigns the complete discovery, selection, execution adaptation,
+and facade-local DTO closure to it. Sibling export facades neither consume that
+facade nor reference the catalog. The TypeScript application composes the
+separate facade result into its application model. Core and every other
+reusable browser project remain forbidden.
 
 The registry preserves typed data through both host boundaries. This design
 defines no broad report or output format; hosts render focused discovery and
@@ -779,7 +784,7 @@ ordinary non-friend consumer.
 | `EcosystemPackAssemblyBoundaryTests.FriendsOnlyDedicatedTests` | `DotnetInspector.Ecosystems.Tests` is the assembly's only `InternalsVisibleTo`; the CLI, inspect-web facade, non-friend canary, and all other assemblies are absent. |
 | `EcosystemPackAssemblyBoundaryTests.OwnerContractsRequireNoFriendAccess` | Repository-owned lower assemblies derived from the ecosystem assembly's compiled references omit `DotnetInspector.Ecosystems` from `InternalsVisibleTo`; compiling the ecosystem assembly therefore exercises only public owner contracts. |
 | `eng/dependency-policy.json` rule `ecosystem-catalog-stays-in-approved-hosts` | Within `dotnet-inspect.slnx`, project and compiled assembly graphs reject every production dependency on `DotnetInspector.Ecosystems` except direct use by `dotnet-inspect`; existing IL rules independently reject the reusable IL-library edges they select. |
-| `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly` | Evaluated inspect-web `ProjectReference` and assembly `Reference` items permit `DotnetInspector.Ecosystems` only in the current managed front-end facade and reject it from `InspectWeb.Engine.Core` and every other browser production project. |
+| `BrowserEngineLayeringTests.EcosystemCatalogIsFacadeOnly` | After application adoption retargets the existing gate, evaluated inspect-web `ProjectReference` and assembly `Reference` items permit `DotnetInspector.Ecosystems` only in `InspectWeb.Engine.CatalogExports` and reject it from `InspectWeb.Engine.Core`, the host and sibling export facades, and every other browser production project. |
 
 Application adoption adds
 `ProductEcosystemPackTests.ShippedManifestMatchesLiteralPolicy` and

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -411,7 +411,7 @@ Workspace-Definitions-owned source binding. The application catalog owns:
 Workspace Definitions retains:
 
 - the exact scenario ID carried by the binding;
-- peer `InspectionDefinitionRecord` construction;
+- `InspectionDefinitionRecord` types and the peer-graph contract;
 - record and reference validation;
 - exact scenario resolution;
 - section or facet admission;
@@ -429,7 +429,8 @@ Complete ecosystem-manifest validation rejects duplicate scenario IDs,
 duplicate demo orders, empty title or summary, and a pack-local demo sequence
 whose orders are not strictly ascending. It does not invoke a source to
 validate its records. Catalog selection dispatches only the chosen binding;
-record construction, single-scenario validation, exact resolution, and
+the selected application factory constructs the records, while record and
+reference validation, single-scenario admission, exact resolution, and
 owner-domain failure remain Workspace Definitions behavior. An owner-domain
 failure remains visible rather than becoming an empty or default demo.
 

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -3,16 +3,22 @@
 ## Status
 
 Focused cross-cutting pattern proposal for
-[#5710](https://github.com/richlander/dotnet-inspect/issues/5710).
+[#5710](https://github.com/richlander/dotnet-inspect/issues/5710), extended by
+the demo-content stack in
+[#5772](https://github.com/richlander/dotnet-inspect/issues/5772).
 
 This document defines the source-level structure by which the product can
 elevate a .NET ecosystem coherently through discovery metadata, an optional
 curated package set, recorded package-prefix queries, and an optional
-Integration scanner implementation.
+Integration scanner implementation, plus product demos that exercise ordinary
+shipping sections over exact pinned inputs.
 
-The pattern and all target gates are unimplemented. Every asserted target
-property is unverified until its named Release gate lands. Existing
-Microsoft.Extensions and ASP.NET Core package membership and search behavior
+The Package Set Registry and its Microsoft.Extensions and ASP.NET Core
+inventories are implemented. The pack pattern, demo contribution, and all
+pack-level target gates remain unimplemented. Existing product demos remain in
+the `DotnetInspector.Queries` donor registry until the transfer described here
+lands. Every asserted target property is unverified until its named Release
+gate lands; existing package membership, demo behavior, and search behavior
 remain unchanged.
 
 Supporting owners:
@@ -27,6 +33,11 @@ Supporting owners:
   package discovery, paging, failures, and payload acquisition.
 - [Artifact acquisition and workspace composition](artifact-acquisition-and-workspaces.md)
   owns realization and workspace generations.
+- [Static workspaces: definitions, assembly groups, and projections](workspace-definitions.md#product-demos-are-closed-section-presets)
+  owns demo definition records, lazy source bindings, resolution, section
+  admission, run plans, execution semantics, and failures.
+- [Inspection bundles and demos](../inspection-space.md#inspection-bundles-and-demos)
+  owns the bundle and runtime-workspace composition boundary.
 - [Capability-driven section registry spike](capability-section-registry-spike.md)
   supplies comparative evidence for a static table of noncapturing execution
   bindings rather than runtime registration or an object graph.
@@ -35,6 +46,11 @@ Supporting owners:
 - [#5728](https://github.com/richlander/dotnet-inspect/issues/5728) is the
   non-normative end-to-end delivery tracker joining the focused owner work,
   application catalog, both front ends, and first complete ecosystem adoption.
+- [#5770](https://github.com/richlander/dotnet-inspect/issues/5770) is the
+  inspect-web consumer for one flat, inert product-demo list in the singular
+  Workspace viewer.
+- [#5772](https://github.com/richlander/dotnet-inspect/issues/5772) is the
+  three-slice Aspire and ecosystem-demo delivery stack.
 
 ## Authority and exact claim
 
@@ -47,13 +63,17 @@ One pack registration may contain:
 - stable ecosystem identity and product-owned discovery metadata;
 - one optional package-set identity;
 - zero or more ordered package-prefix discovery entries; and
-- one optional Integration-owned static scanner binding.
+- one optional Integration-owned static scanner binding; and
+- zero or more ordered Workspace-Definitions-owned product-demo source
+  bindings with application-owned display metadata.
 
 The owner also defines:
 
 - pack and prefix-entry identity;
 - intrinsic registration and manifest-table validation;
 - deterministic manifest discovery and exact lookup;
+- demo-to-pack grouping, global product-demo order, grouped demo discovery, and
+  flattened product-demo discovery;
 - selection-time materialization boundaries; and
 - the rule that adding a manifest registration adds no ecosystem-specific
   name, enum, switch arm, parser branch, or query path to reusable
@@ -66,6 +86,8 @@ It does not own:
 - Integration concepts, scanning evidence, currency, or results;
 - package acquisition, artifact admission, workspace construction, or
   lifetime;
+- demo record shape, scenario identity, validation, resolution, section or
+  facet admission, run-plan lowering, execution, or failure semantics;
 - source-selection defaults or cross-source deduplication;
 - CLI or browser actions, rendering, or recommendations; or
 - runtime plugins, registration, discovery, unloading, or mutation.
@@ -74,18 +96,22 @@ The exact claim is:
 
 > The host-neutral application catalog defines how one ecosystem contribution
 > is described, discovered, and selected. Source in that catalog defines which
-> static contributions ship and supplies their data and scanner
-> implementations. The co-located Package Set Registry remains a separate
-> owner, while lower package-coordinate, query, and Integration infrastructure
-> remains independent and subject to its owners' separate contracts.
+> static contributions ship and supplies their data, product-demo sources, and
+> scanner implementations. Product-demo inventory, grouping, display metadata,
+> and product order are application-catalog concerns; demo records, resolution,
+> section admission, run plans, and execution remain Workspace Definitions
+> concerns. The co-located Package Set Registry remains a separate owner, while
+> lower package-coordinate, query, and Integration infrastructure remains
+> independent and subject to its owners' separate contracts.
 
 ## Why a pack is the product unit
 
-A package set alone answers which exact package coordinates the product has
-selected. A package prefix answers which live source query a user may run. An
-Integration scanner answers how realized package APIs are interpreted. Users
-experience those capabilities as one ecosystem even though their semantics
-belong to different owners.
+A package set alone answers which package IDs the product has selected. A
+package prefix answers which live source query a user may run. An Integration
+scanner answers how realized package APIs are interpreted. A product demo fixes
+exact package versions and a normal product view that demonstrates the
+ecosystem. Users experience those capabilities as one ecosystem even though
+their semantics belong to different owners.
 
 The pack is the smallest composition unit that keeps those capabilities
 discoverable together without merging their contracts:
@@ -96,10 +122,13 @@ ecosystem pack
   optional PackageSetId
   zero or more package-prefix entries
   optional Integration scanner binding
+  zero or more product-demo contributions
 ```
 
 The registration contains references and application bindings. It does not
-copy package membership, prefix execution, or Integration result semantics.
+copy package membership, prefix execution, Integration result semantics, or
+Workspace Definitions semantics. Selecting any one capability does not select
+or execute its neighbors.
 
 ## Contract shape
 
@@ -111,6 +140,7 @@ EcosystemPackRegistration
   PackageSet   PackageSetId?
   Prefixes     immutable ordered EcosystemPackagePrefix sequence
   Scanner      EcosystemIntegrationScannerBinding?
+  Demos        immutable ordered EcosystemDemoRegistration sequence
 
 EcosystemPackDescriptor
   Id           EcosystemPackId
@@ -124,12 +154,41 @@ EcosystemPackagePrefix
   Title        string
   Summary      string
   Order        int
+
+EcosystemDemoRegistration
+  Title        string
+  Summary      string
+  Order        int
+  Source       ProductDemoSourceBinding
+
+EcosystemDemoDescriptor
+  Ecosystem    EcosystemPackId
+  ScenarioId   string
+  Title        string
+  Summary      string
+  Order        int
+
+EcosystemDemoSelection
+  Descriptor   EcosystemDemoDescriptor
+  Scenario     ResolvedScenario
 ```
 
-The public discovery boundary exposes immutable descriptor and prefix-action
-metadata, package-set identity, and whether a scanner is available. Typed
-selection returns the chosen owner-issued request or binding. It does not
-expose a mutable application manifest or a scanner implementation object.
+`ProductDemoSourceBinding` is issued by Workspace Definitions. It carries the
+exact scenario ID and one noncapturing source for that scenario's peer
+definition records. The scenario ID is the product-demo identity; the
+ecosystem catalog does not mint a parallel demo ID or infer identity from
+title, order, package coordinate, or ecosystem.
+
+The public discovery boundary exposes immutable pack, prefix-action, and demo
+descriptor metadata, package-set identity, and whether a scanner is available.
+Exact demo selection returns one `EcosystemDemoSelection`, retaining the
+catalog descriptor beside the Workspace-Definitions-owned resolved scenario.
+Hosts use descriptor title and summary for product discovery and display;
+`ScenarioDefinition.Title` and `Description` remain portable definition fields,
+not a second product-catalog metadata authority. Other typed selections return
+only the chosen owner-issued request or binding. No discovery or selection
+surface exposes a mutable application manifest, demo record factory, delegate,
+or scanner implementation object.
 
 There is no `Ecosystem`, `IEcosystemModule`, pack factory, catalog builder,
 service registration, or per-pack runtime object. Registration construction is
@@ -140,13 +199,14 @@ and no external construction path can add a pack to product discovery.
 
 The intended host-neutral application component is
 `DotnetInspector.Ecosystems`. It sits above Packages and
-Metadata/Integrations and contains the application manifest and concrete pack
-source. Its only production consumers are the `dotnet-inspect` CLI front end
-and the `InspectWeb.Engine` managed browser facade. `InspectWeb.Engine.Core`,
-Packages, Metadata, Queries, Services, Presentation, Vocabulary, and other
-reusable infrastructure do not reference it. Selected owner-issued package or
-scanner currencies flow from the two front ends into existing infrastructure;
-the catalog itself does not flow downward.
+Queries/Workspace Definitions and Metadata/Integrations and contains the
+application manifest and concrete pack source. Its only production consumers
+are the `dotnet-inspect` CLI front end and the `InspectWeb.Engine` managed
+browser facade. `InspectWeb.Engine.Core`, Packages, Metadata, Queries,
+Services, Presentation, Vocabulary, and other reusable infrastructure do not
+reference it. Selected owner-issued package, demo, or scanner currencies flow
+from the catalog or two front ends into existing infrastructure; the catalog
+itself does not flow downward.
 
 ## Identity
 
@@ -186,6 +246,7 @@ One application-owned static table names the packs compiled into the product:
 
 ```text
 ProductEcosystemPacks
+  PlatformPack.Registration
   MicrosoftExtensionsPack.Registration
   AspNetCorePack.Registration
   AspirePack.Registration
@@ -207,11 +268,13 @@ validated sequence.
 
 Generic catalog mechanics in `DotnetInspector.Ecosystems` consume the
 registration contract but do not name a shipped ecosystem. A new application
-pack supplies its own descriptor, prefix data, package-set reference, scanner
-implementation, tests, and manifest row. It does not add an enum member,
-switch arm, parser branch, or special-case query path to lower infrastructure.
-Separate Integration adoption may add owner-issued concept or policy names
-under that owner's contract; adding the manifest registration itself does not.
+pack supplies its own descriptor, prefix data, package-set reference, demo
+sources, scanner implementation, tests, and manifest row as applicable. It
+does not add an enum member, switch arm, parser branch, or special-case query
+path to lower infrastructure. Separate Workspace Definitions or Integration
+adoption may add owner-issued bindings, records, concepts, or policy names
+under those owners' contracts; adding the manifest registration itself does
+not.
 
 Packs do not reference, invoke, order, or inherit from other packs. Shared
 algorithms belong to their owning infrastructure or a separately justified
@@ -250,12 +313,21 @@ catalog, but only `DotnetInspector.Ecosystems.Tests` may be an assembly friend.
 Together, the solution dependency policy and browser project-graph gate provide
 full coverage for the current production dependency claim.
 `DotnetInspector.Ecosystems` consumes package-coordinate, prefix, and scanner
-currencies through their public owner-issued surfaces; those lower assemblies
-do not grant it `InternalsVisibleTo`. The non-friend front-end canary separately
-proves that discovery and selection require only the ecosystem assembly's
-public surface. No source-text or string-constant scan is needed: Integrations
-already names concepts such as Aspire legitimately, and such a scan would
-conflate semantic evidence policy with an application-pack dependency.
+currencies through their public owner-issued surfaces. Demo adoption adds a
+normal public reference from `DotnetInspector.Ecosystems` to
+`DotnetInspector.Queries` so application source can construct definition
+records and consume its `ProductDemoSourceBinding` and resolution surface.
+Queries and all other lower assemblies still do not reference the ecosystem
+assembly or grant it `InternalsVisibleTo`. This direction preserves L1
+ownership: the application catalog supplies fixed inputs to the owner rather
+than reimplementing record validation, scenario resolution, section admission,
+or run-plan lowering.
+
+The non-friend front-end canary separately proves that discovery and selection
+require only the ecosystem assembly's public surface. No source-text or
+string-constant scan is needed: Queries and Integrations may legitimately name
+application concepts in owner-domain records and evidence, and such a scan
+would conflate semantic content with an application-catalog dependency.
 
 `DotnetInspector.Ecosystems.csproj` declares exactly one friend,
 `DotnetInspector.Ecosystems.Tests`. The CLI, `InspectWeb.Engine`, the non-friend
@@ -274,7 +346,12 @@ The application manifest follows the repository's static-registry pattern:
 - selecting a package-set action returns only that referenced package-set
   identity;
 - selecting a prefix action returns only that prefix request to the front end;
-  and
+- grouped or flattened demo discovery returns only immutable metadata and does
+  not invoke a demo source;
+- selecting one demo dispatches only that demo's
+  Workspace-Definitions-owned source binding; the binding constructs and
+  validates only its returned peer records, resolves its exact scenario ID,
+  and returns the resolved scenario beside the selected catalog descriptor; and
 - selecting Integration analysis returns only the selected pack's static
   scanner binding to Integration orchestration.
 
@@ -294,6 +371,70 @@ discovery and exact lookup reuse it. The implementation should remain a direct
 ordered table while the shipped pack count is small; it must not introduce a
 runtime registration graph, dependency resolver, or factory layer to optimize
 a scale the product does not have.
+
+## Product demos
+
+A demo contribution is application-authored content over a
+Workspace-Definitions-owned source binding. The application catalog owns:
+
+- which product demos ship in one build;
+- the pack that groups each demo;
+- title and summary;
+- one globally unique explicit `Order`; and
+- grouped and flattened metadata discovery.
+
+Workspace Definitions retains:
+
+- the exact scenario ID carried by the binding;
+- peer `InspectionDefinitionRecord` construction;
+- record and reference validation;
+- exact scenario resolution;
+- section or facet admission;
+- `ProductDemoRunPlan`;
+- execution semantics; and
+- visible failures.
+
+The pack registration stores one owner-issued binding and does not copy or
+reinterpret its records. Workspace Definitions exposes the public minting seam
+`ProductDemoSourceBinding.Create(scenarioId, static createRecords)`. The static
+lambda or method-group requirement is the source-level noncapture boundary;
+construction also rejects a delegate with a non-null target before publication.
+The binding stores the delegate privately and exposes no delegate or factory
+property. Its resolve operation requires the returned records to contain
+exactly one `ScenarioDefinition`, requires that record's ID to equal the
+binding scenario ID, constructs the registry, resolves that exact ID, and
+enforces the demo section contract.
+
+Complete ecosystem-manifest validation rejects duplicate scenario IDs,
+duplicate demo orders, empty title or summary, and a pack-local demo sequence
+whose orders are not strictly ascending. It does not invoke a source to
+validate its records. Catalog selection dispatches only the chosen binding;
+record construction, single-scenario validation, exact resolution, and
+owner-domain failure remain Workspace Definitions behavior. A mismatch,
+malformed record graph, unsupported section, or other owner-domain failure is
+visible rather than becoming an empty or default demo.
+
+Demo order is global across the product rather than derived from pack order.
+Grouped discovery presents packs in pack order and each pack's demos in their
+ascending demo order. Flattened discovery performs one bounded metadata-only
+merge into ascending global demo order. This lets the application preserve the
+current interleaved product order while retaining literal ecosystem grouping.
+The flat and grouped surfaces project the same registrations; there is no
+second demo manifest.
+
+Demo inputs are exact and pinned. A demo contribution may reference a package
+that also appears in its pack's curated package set, but the two statements
+have different semantics: the package set is an unversioned source-selection
+snapshot, while the demo is one reproducible scenario over exact coordinates.
+Selecting a demo does not select, resolve, count, or update the package set,
+does not expand a prefix, and does not return or invoke the scanner. Selecting
+another pack capability does not construct demo records.
+
+`ecosystem.platform` is an application grouping for basic .NET product demos,
+not a source-coordinate inference rule. A Platform demo may retain an exact
+package coordinate when that is the existing reproducible scenario. The
+catalog never infers grouping from package IDs, namespaces, titles, or
+workspace coordinate kinds.
 
 ## Package-set composition
 
@@ -422,6 +563,15 @@ Exact lookup accepts `EcosystemPackId` and returns the matching registration
 view or typed unknown. It does not use titles, prefix text, package-set identity,
 scanner identity, or neighboring values as aliases.
 
+Grouped demo discovery returns each pack's immutable demo descriptors without
+invoking sources. Flattened demo discovery returns the same descriptors in
+global demo order and retains each descriptor's exact `EcosystemPackId`.
+Exact demo selection uses the owner-issued scenario ID with ordinal,
+case-sensitive equality. Unknown text does not alias by title, package,
+ecosystem, or order and does not select a default. A known selection returns
+its catalog descriptor and owner-resolved scenario together so a host never
+re-derives product display metadata from definition records.
+
 Discovery answers:
 
 ```text
@@ -443,11 +593,26 @@ The CLI may later expose ecosystem discovery or map existing source selectors
 to pack capabilities. It retains token grammar, command policy, diagnostics,
 Markout lowering, and progressive disclosure.
 
+The existing `demo list` and `demo <scenario-id>` surfaces move to the
+application catalog without changing their output or execution semantics.
+`demo list` consumes flattened metadata only. Running a demo selects its exact
+scenario ID, then consumes the Workspace-Definitions-owned resolved scenario
+and run plan through the existing type/member section pipeline. Product-facing
+title and summary come from the selected catalog descriptor, not from the
+resolved scenario's portable metadata.
+
 `InspectWeb.Engine` may project an ecosystem action surface from the same
 descriptors through its generated facade. The TypeScript front end retains
 interaction and browser presentation. Browser infrastructure retains
 asynchronous acquisition, budget reservation, workspace replacement, rollback,
 and disposal without referencing the ecosystem catalog.
+
+For [#5770](https://github.com/richlander/dotnet-inspect/issues/5770), the
+managed facade projects the flattened demo metadata as one inert list. The
+TypeScript application may ignore ecosystem grouping for that view while
+dispatching the exact stable scenario ID. Listing performs no package
+acquisition or demo resolution, and opening one demo continues to replace the
+singular live Workspace through the existing browser path.
 
 For Integration execution, the facade selects the opaque binding and passes
 that owner-issued value with the realized operation inputs to
@@ -470,19 +635,41 @@ action metadata through their existing presentation owners.
 
 ## Initial packs and staged adoption
 
-The first application adoption may describe the two product selections that
-already exist:
+The first application adoption describes four packs from already-owned
+currencies and content:
 
-| Pack identity | Package-set identity | Recorded prefix | Scanner |
+| Pack identity | Package-set identity | Product demos | Residual capabilities |
 | --- | --- | --- | --- |
-| `ecosystem.microsoft-extensions` | `package-set.microsoft-extensions` | `Microsoft.Extensions.` | absent until focused Integration adoption |
-| `ecosystem.aspnetcore` | `package-set.aspnetcore` | `Microsoft.AspNetCore.` | absent until focused Integration adoption |
+| `ecosystem.platform` | absent | `stj-serializer`, `stj-serialize-callgraph`, `stj-getdecimal-callgraph` | no prefix or scanner planned by this slice |
+| `ecosystem.microsoft-extensions` | `package-set.microsoft-extensions` | `extensions-callgraph`, `config-bind-callgraph`, `options-add-callgraph`, `di-tryadd-callgraph`, `http-addhttpclient-callgraph` | prefix waits for #5602; scanner waits for #5719 |
+| `ecosystem.aspnetcore` | `package-set.aspnetcore` | none initially | prefix waits for #5602; scanner waits for #5719 |
+| `ecosystem.aspire` | `package-set.aspire` | `aspire-postgres-callgraph`, `aspire-redis-callgraph` | prefixes wait for #5602; scanner waits for #5719 |
+
+The eight existing demo IDs, metadata, global order, records, pins, and run
+plans remain unchanged. Their global orders are assigned in their current
+product sequence. The two new Aspire demos follow them. The literal
+demo-to-pack mapping is application policy and is not inferred from their
+package coordinates or titles.
+
+| Global order | Scenario ID | Pack |
+| ---: | --- | --- |
+| 100 | `stj-serializer` | `ecosystem.platform` |
+| 200 | `extensions-callgraph` | `ecosystem.microsoft-extensions` |
+| 300 | `stj-serialize-callgraph` | `ecosystem.platform` |
+| 400 | `config-bind-callgraph` | `ecosystem.microsoft-extensions` |
+| 500 | `options-add-callgraph` | `ecosystem.microsoft-extensions` |
+| 600 | `di-tryadd-callgraph` | `ecosystem.microsoft-extensions` |
+| 700 | `http-addhttpclient-callgraph` | `ecosystem.microsoft-extensions` |
+| 800 | `stj-getdecimal-callgraph` | `ecosystem.platform` |
+| 900 | `aspire-postgres-callgraph` | `ecosystem.aspire` |
+| 1000 | `aspire-redis-callgraph` | `ecosystem.aspire` |
 
 Such registrations must not change package membership, search defaults,
-source order, limits, or existing Integration behavior.
+source order, limits, existing Integration behavior, or demo execution
+semantics.
 
-Aspire is the first intended new-pack candidate. A complete Aspire pack depends
-on separately approved owner work:
+Aspire is the first intended new-pack candidate. The eventual full Aspire
+capability set depends on separately approved owner work:
 
 1. package/API evidence defines a complete current `aspire`-co-owned Aspire API
    package set;
@@ -490,49 +677,79 @@ on separately approved owner work:
    the pack source under its separate static manifest; and
 3. Integrations defines and adopts the static scanner binding.
 
+The initial Aspire row does not wait for the prefix or scanner tracks. Its
+package-set and demo capabilities are independently coherent; later owner-issued
+slots extend the same registration without changing those semantics.
+
 An Aspire pack may then expose:
 
 ```text
 ecosystem.aspire
   package-set.aspire
+  demos     -> AddPostgres call graph, AddRedis call graph
   official  -> Aspire.
   community -> CommunityToolkit.Aspire.
   scanner   -> AspireIntegrationScanner.Scan
 ```
+
+The first Aspire demo sources are exact package-local Call Graph presets:
+
+| Scenario ID | Package | Type and member | Stable anchor |
+| --- | --- | --- | --- |
+| `aspire-postgres-callgraph` | `Aspire.Hosting.PostgreSQL@13.5.3` | `Aspire.Hosting.PostgresBuilderExtensions.AddPostgres` | `e5a66a2bd9` |
+| `aspire-redis-callgraph` | `Aspire.Hosting.Redis@13.5.3` | `Aspire.Hosting.RedisBuilderExtensions.AddRedis` | `7618364a03` |
+
+Production `dotnet-inspect` resolves both packages to `net8.0` and emits
+nonempty ordinary Call Graph sections. `AddPostgres` reaches the PostgreSQL
+resource and eventing path; the selected four-parameter `AddRedis` overload
+retains both inbound overload delegation and outbound resource, eventing, and
+health-check paths. The implementation gates exact pins and anchors rather
+than re-discovering a member by display name.
 
 Entity Framework Core, OpenTelemetry, gRPC, Orleans, and other ecosystems are
 candidate packs, not registrations authorized by this design.
 
 ## Demo
 
-The product mockup demonstrates the intended application adoption without
-package or scanner work:
+The flat product-demo projection preserves current order and appends Aspire:
 
 ```text
-Ecosystems
+Demos
+
+System.Text.Json                     Browse a real package API
+Cross-package call graph             Trace calls across three packages
+Serialize call graph                 Dense package-local STJ graph
+Configuration Bind                  Recursive binder call graph
+Options hub                         Inbound fan-in at AddOptions
+DI TryAdd hub                       Keyed/scoped Try* fan-in
+AddHttpClient                       HttpClient factory registration
+JsonElement.GetDecimal              STJ number parse path
+Aspire AddPostgres                  PostgreSQL resource registration graph
+Aspire AddRedis                     Redis resource registration graph
+```
+
+The grouped ecosystem projection uses the same registrations:
+
+```text
+Platform
+  3 demos
 
 Microsoft.Extensions
   Add curated packages
-  Search Microsoft.Extensions packages
+  5 demos
 
 ASP.NET Core
   Add curated packages
-  Search Microsoft.AspNetCore packages
+
+Aspire
+  Add curated packages
+  2 demos
 ```
 
-The pattern implementation demo uses two synthetic registrations:
-
-```text
-Example Data
-  Search Example.Data packages
-
-Example Compute
-  Inspect integrations
-```
-
-Discovery shows only each declared action. Selecting the first pack returns
-its prefix intent and does not return, construct, or invoke the neighboring
-scanner binding.
+Listing either projection constructs no definition records. Selecting
+`aspire-postgres-callgraph` constructs and resolves only that scenario and
+does not resolve `package-set.aspire`, expand a prefix, construct the Redis
+demo, or return a scanner binding.
 
 ## Required gates
 
@@ -544,12 +761,17 @@ ordinary non-friend consumer.
 | `EcosystemPackRegistryTests.SyntheticManifestIsDiscoverableInDeclaredOrder` | Static discovery returns a literal expected synthetic descriptor and action sequence in unique explicit order. |
 | `EcosystemPackRegistryTests.ExactLookupUsesOnlyTypedIdentity` | Exact ID lookup returns the enumerated registration view; labels, prefix text, package-set IDs, case variants, and unknown IDs do not alias a pack. |
 | `EcosystemPackRegistryTests.InvalidStaticRegistrationsFailBeforePublication` | Malformed or duplicate IDs, duplicate pack order, out-of-order pack sequences, duplicate prefix-entry IDs/order, out-of-order prefix sequences, and empty registrations reject the complete static manifest before publishing any view rather than publishing a shortened view. |
-| `EcosystemPackRegistryTests.CatalogMaterializationPerformsNoObservableWork` | Materializing and discovering a synthetic manifest perform no package-set resolution, package-source or workspace work, scanner invocation, or pack/scanner instance construction; initialization timing itself is not asserted. |
-| `EcosystemPackRegistryTests.DiscoveryDoesNotResolveOrExecuteCapabilities` | Discovery performs no package-set membership resolution, package-source work, artifact/workspace work, or scanner invocation. |
+| `EcosystemPackRegistryTests.InvalidDemoRegistrationsFailBeforePublication` | Duplicate global scenario IDs/order, empty display metadata, and non-ascending pack-local demo order reject the complete manifest without invoking a demo source. |
+| `EcosystemPackRegistryTests.CatalogMaterializationPerformsNoObservableWork` | Materializing and discovering a synthetic manifest perform no package-set resolution, package-source or workspace work, demo-source invocation, scanner invocation, or pack/scanner instance construction; initialization timing itself is not asserted. |
+| `EcosystemPackRegistryTests.DiscoveryDoesNotResolveOrExecuteCapabilities` | Pack, grouped-demo, and flat-demo discovery perform no package-set membership resolution, package-source work, demo resolution, artifact/workspace work, or scanner invocation. |
+| `EcosystemPackRegistryTests.FlattenedDemoDiscoveryPreservesGlobalProductOrder` | A synthetic interleaved manifest returns one descriptor per registration in unique global demo order while retaining literal pack identity; grouped and flattened views contain the same descriptor instances. |
+| `EcosystemPackRegistryTests.DemoSelectionInvokesOnlyTheSelectedSource` | Exact scenario-ID selection dispatches only that binding and returns its catalog descriptor beside the Workspace-Definitions-owned resolved scenario; neighboring sources and capabilities remain untouched. |
+| `EcosystemPackRegistryTests.DemoSelectionPreservesOwnerFailures` | Unknown IDs produce typed unknown without invoking a source, while a selected source's absent, duplicate, or mismatched scenario record, invalid record graph, or unsupported section remains an owner-domain failure rather than an empty or default demo. |
+| `EcosystemPackRegistryTests.DemoSelectionRetainsCatalogMetadata` | A synthetic descriptor whose title and summary differ from its portable scenario metadata is returned unchanged beside the resolved scenario. |
 | `EcosystemPackRegistryTests.ScannerSelectionReturnsOnlyTheSelectedBinding` | Selecting one synthetic pack returns only its scanner binding and leaves every neighboring binding unreturned and uninvoked. |
 | `EcosystemPackRegistryTests.PrefixSelectionPreservesExactValidatedIntent` | After the prefix owner issues its currency, selecting a prefix returns that typed request unchanged and does not expand, combine, count, or execute it. |
 | `EcosystemPackRegistryTests.PackageSetSelectionPreservesExactTypedIdentity` | Selecting a curated set returns only its `PackageSetId` and does not copy membership or activate another pack capability. |
-| `EcosystemPackConsumerTests.PublicSurfaceSupportsStaticDiscoveryAndSelection` | An ordinary non-friend front-end consumer discovers and selects available actions through only the public surface, without registration construction, manifest publication, scanner implementation, CLI types, package clients, or workspaces. |
+| `EcosystemPackConsumerTests.PublicSurfaceSupportsStaticDiscoveryAndSelection` | An ordinary non-friend front-end consumer discovers and selects available actions through only the public surface, without registration construction, manifest publication, demo factories, scanner implementation, CLI types, package clients, or workspaces. |
 | `EcosystemPackAssemblyBoundaryTests.FriendsOnlyDedicatedTests` | `DotnetInspector.Ecosystems.Tests` is the assembly's only `InternalsVisibleTo`; the CLI, inspect-web facade, non-friend canary, and all other assemblies are absent. |
 | `EcosystemPackAssemblyBoundaryTests.OwnerContractsRequireNoFriendAccess` | Repository-owned lower assemblies derived from the ecosystem assembly's compiled references omit `DotnetInspector.Ecosystems` from `InternalsVisibleTo`; compiling the ecosystem assembly therefore exercises only public owner contracts. |
 | `eng/dependency-policy.json` rule `ecosystem-catalog-stays-in-approved-hosts` | Within `dotnet-inspect.slnx`, project and compiled assembly graphs reject every production dependency on `DotnetInspector.Ecosystems` except direct use by `dotnet-inspect`; existing IL rules independently reject the reusable IL-library edges they select. |
@@ -562,9 +784,26 @@ descriptor and reference expectations, plus
 `ProductEcosystemPackTests.ShippedPackManifestCarriesOnlyPackageSetIdentity` to
 prove compiled shipped pack fields and construction paths carry no package-set
 descriptor, registration, coordinate sequence, registry lookup, or
-registry-enumeration reference. Integration adoption owns scanner invocation
-and witness gates. Generic catalog tests use synthetic pack names and do not
-establish built-in ecosystem policy.
+registry-enumeration reference.
+`ProductEcosystemPackTests.ShippedDemoManifestMatchesLiteralPolicy` fixes the
+ten scenario IDs, pack mapping, metadata, and global order without deriving
+expectations from source records.
+`ProductEcosystemPackTests.ExistingDemoSourcesPreserveDonorRecordsAndRunPlans`
+resolves the transferred eight sources and compares their records and run plans
+with the locked donor fixtures.
+`ProductEcosystemPackTests.AspireDemoSourcesMatchLiteralPinsAndAnchors` gates
+the two exact package IDs, versions, TFMs, types, member anchors, and Call Graph
+bindings.
+`DemoCommandTests.ExecuteAspireScenarios_ReturnsCallGraphSection` gates
+nonempty ordinary CLI Call Graph execution through the existing section
+pipeline.
+`DemoCommandTests.ListUsesCatalogDescriptorMetadata` and
+`BrowserProductHomeDemosTests.CatalogProjectionUsesEcosystemDescriptorMetadata`
+prove both hosts use application-catalog title and summary even when the
+portable scenario metadata differs.
+Integration adoption owns scanner invocation and witness gates. Generic
+catalog tests use synthetic pack names and do not establish built-in ecosystem
+policy.
 
 The implementation must also retain existing NativeAOT and Browser/Wasm build
 coverage. Static binding values root their target methods in published output.
@@ -581,34 +820,35 @@ The owner tracks may advance independently:
 | Independent track | Owner work |
 | --- | --- |
 | Curated package set | #5720 places source-authored membership in the separate private application Package Set Registry, followed by registry implementation. |
+| Product demo | Workspace Definitions issues the lazy source binding; #5772 transfers application-authored sources and host discovery to the ecosystem catalog. |
 | Recorded prefix | #5602 issues the typed package-prefix request currency. |
 | Semantic scanner | #5719 issues the opaque binding and decoded observation-context contract. |
 
 1. Lock this focused pack pattern.
 2. Advance whichever independent owner track is needed for the first real pack.
-3. Implement `DotnetInspector.Ecosystems` when any one owner-issued action
-   currency supports a coherent real application row. The first slice includes
-   identity, descriptors, the private manifest, discovery, exact lookup, the
-   available optional action slot or slots, and their focused gates.
-4. Add Microsoft.Extensions and ASP.NET Core rows without changing current
-   package membership or search behavior.
-5. Add each remaining action slot independently when its owner track lands; no
+3. In one implementation slice, issue the Workspace-Definitions-owned lazy
+   source binding; transfer the eight application-authored donor sources; add
+   the two Aspire sources; implement pack identity, descriptors, private
+   manifest, package-set and demo slots, grouped and flattened discovery, exact
+   lookup and selection; and publish the four-pack, ten-demo manifest with its
+   focused gates. Do not change current package membership, existing demo
+   execution, or search behavior.
+4. Add each remaining action slot independently when its owner track lands; no
    later slot reopens already implemented action semantics.
-6. Measure Aspire APIs and propose Aspire through its package-set, Integration,
-   and application-pack owner changes.
-7. Adopt CLI and browser actions through their separately owned slices.
+5. Adopt CLI and browser actions through the same implementation slice's
+   application-catalog handoff; Integration remains independently adoptable.
 
-The three owner tracks remain separately owned; #5720 records the package-set
+The four owner tracks remain separately owned; #5720 records the package-set
 composition decision, while prefix and scanner contracts remain residual. No
 implementation slice waits for every optional slot: each lands only when its
 owner-issued currency exists and one real application scenario makes that slice
 coherent.
 
-Whichever action track first creates `DotnetInspector.Ecosystems` also creates
-the project, grants friendship only to `DotnetInspector.Ecosystems.Tests`, and
-lands the solution dependency-policy and inspect-web project-graph gates. The
-package-set donor transfer is the intended first track; another track may pay
-that one-time application-shell cost if it lands first.
+The package-set donor transfer already created
+`DotnetInspector.Ecosystems`, limited friendship to
+`DotnetInspector.Ecosystems.Tests`, and landed the solution dependency-policy
+gate. The demo track adds the Queries dependency and inspect-web project-graph
+gate while preserving those boundaries.
 
 ## Non-claims
 
@@ -622,6 +862,11 @@ This design does not define:
 - package-set membership or prefix-query results;
 - a new Integration concept, classifier, evidence shape, or query;
 - package acquisition or workspace behavior;
+- demo definition-record, resolution, section, run-plan, or execution
+  semantics;
+- inference of demo grouping from package, namespace, title, or source kind;
+- an implication that a demo uses, exhausts, or activates its pack's curated
+  package set;
 - automatic execution of every capability exposed by a pack;
 - recommendation, ranking, popularity, or compatibility policy;
 - generic CLI syntax or browser interaction details;
@@ -629,5 +874,5 @@ This design does not define:
   front ends project the application catalog directly, and any future generic
   query-value adoption requires a separately owned design; or
 - a requirement that every ecosystem have any particular one of package set,
-  prefix, or scanner; every shipped pack must still expose at least one of
-  those capabilities.
+  prefix, scanner, or demos; every shipped pack must still expose at least one
+  capability.

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -724,7 +724,9 @@ Hard constraints:
    and generated TypeScript bindings for the engine surface project that
    preset; they are not a second demo system.
 
-This revision transfers one cohesive application responsibility to
+Under the operator-approved two-owner composition recorded by
+[#5772](https://github.com/richlander/dotnet-inspect/issues/5772), this revision
+transfers one cohesive application responsibility to
 [Static Ecosystem Packs](ecosystem-packs.md#product-demos): which product demos
 ship, their ecosystem grouping and display metadata, their global product
 order, and the source-authored record factories. Workspace Definitions retains
@@ -742,6 +744,11 @@ noncapturing lambda with a cached target object. A multicast combination of
 static method groups is also rejected because one resolve would otherwise
 execute every combined source. The binding stores the source privately and
 exposes no delegate or factory property.
+
+This section is the sole authority for the binding's construction, admission,
+source lifetime, validation, resolution, execution handoff, and failure
+semantics. The ecosystem design names only the opaque handoff and the
+catalog-owned dispatch obligations.
 
 The application catalog stores that opaque owner-issued binding beside its
 application metadata. Listing is metadata-only and cannot invoke the source.

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -734,11 +734,12 @@ admission, run plans, execution semantics, and failures.
 Workspace Definitions issues `ProductDemoSourceBinding`, one static
 noncapturing source paired with the exact scenario ID it must resolve. The
 public minting seam is
-`ProductDemoSourceBinding.Create(scenarioId, static createRecords)`. A static
-lambda or method group is the source-level noncapture boundary, and
-construction rejects a delegate with a non-null target before publication.
-The binding stores the source privately and exposes no delegate or factory
-property.
+`ProductDemoSourceBinding.Create(scenarioId, CreateRecords)`. Only a static
+method group is admitted, and construction rejects a delegate with a non-null
+target before publication. Static lambdas are intentionally not the authoring
+form because the compiler may represent a noncapturing lambda with a cached
+target object. The binding stores the source privately and exposes no delegate
+or factory property.
 
 The application catalog stores that opaque owner-issued binding beside its
 application metadata. Listing is metadata-only and cannot invoke the source.
@@ -781,7 +782,8 @@ schema version 2 and the explicit legacy table below settle versioned migration
 and complete view composition. `ecosystem.platform` is application grouping,
 not workspace-coordinate inference: the current System.Text.Json demos retain
 their exact package pins even when the ecosystem catalog groups them as basic
-Platform demos.
+Platform demos. Platform-coordinate workspaces remain a product capability but
+are not admitted as home demos by this slice.
 
 A schema-version-2 home demo persists only `ViewState.Facet` and version-2
 query records. The resolved facet and query owners reach their ordinary
@@ -1902,8 +1904,9 @@ Implementation must add, at minimum:
   invokes its source exactly once, allocates only the records returned by that
   source, requires exactly one scenario record, resolves the declared scenario
   ID exactly, and keeps absent, duplicate, mismatched, record-reference, and
-  section-admission failures visible; a separate constructor case rejects a
-  capturing source before publication —
+  section-admission failures visible; constructor cases accept a static method
+  group and reject instance, capturing-lambda, and cached static-lambda targets
+  before publication —
   `ProductDemoSourceBindingTests` owns these Workspace Definitions properties;
   application inventory, grouping, catalog display metadata, and
   neighboring-source isolation remain ecosystem-catalog gates;

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -796,16 +796,18 @@ their exact canonical facet IDs before Registry resolution.
 **CLI run** lowers the resolved plan to `TypeCommand` / `MemberCommand` options
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
-package members as `--caller-package` for the call-graph demo. **inspect-web**
-loads flattened home-demo metadata and exact scenario IDs from the application
-ecosystem catalog through the browser engine (`ListHomeDemos` /
-`ResolveHomeDemo` / `RunHomeDemo`). `RunHomeDemo` accepts both
-type-only `Methods` and member-bound `Call Graph` presets: the engine resolves
-the workspace, focus, section, and optional member anchor, opens one aggregate
-browser workspace, and returns its package surfaces plus exact activation
-identity. The focused `BrowserTypeSurface.Api` rows are the browser's ordinary
-Methods-section output; a member-bound run additionally returns the ordinary
-Call Graph projection. The engine rejects other product sections,
+package members as `--caller-package` for the call-graph demo. **inspect-web** currently loads home-demo metadata and exact scenario IDs from
+`ProductInspectionDemos` through the browser engine (`ListHomeDemos` /
+`ResolveHomeDemo` / `RunHomeDemo`). The transfer replaces only that
+application-inventory source with the ecosystem catalog's flattened
+descriptors and exact selection; Workspace Definitions execution remains
+unchanged. `RunHomeDemo` accepts both type-only `Methods` and member-bound
+`Call Graph` presets: the engine resolves the workspace, focus, section, and
+optional member anchor, opens one aggregate browser workspace, and returns its
+package surfaces plus exact activation identity. The focused
+`BrowserTypeSurface.Api` rows are the browser's ordinary Methods-section
+output; a member-bound run additionally returns the ordinary Call Graph
+projection. The engine rejects other product sections,
 library-scoped views, and runtime-identifier-scoped package workspaces until
 Browser has explicit execution support rather than silently dropping those
 bindings. These properties are gated by

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -758,9 +758,10 @@ record's ID to equal the declared scenario ID, builds
 `InspectionDefinitionRegistry`, resolves that exact ID, and enforces the normal
 demo section binding. An absent, second, or mismatched scenario, malformed peer
 graph, or unsupported section fails visibly; it does not return an empty or
-neighboring demo. Record construction, validation, resolution, and failure
-therefore remain wholly owned here, while Ecosystems owns only exact dispatch
-isolation and the application inventory.
+neighboring demo. Record types, graph validation, scenario admission,
+resolution, and failure therefore remain wholly owned here, while the
+application-authored factory body constructs those records and Ecosystems owns
+only exact dispatch isolation and the application inventory.
 
 Catalog selection retains the application descriptor beside
 `ResolvedScenario`. Product-facing title and summary come from that descriptor.

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -724,13 +724,44 @@ Hard constraints:
    and generated TypeScript bindings for the engine surface project that
    preset; they are not a second demo system.
 
-The product registry (`ProductInspectionDemos`) stays a static id→metadata
-table plus peer definition records lowered to a `ResolvedScenario`. Listing
-remains metadata-only. `ProductDemoRunPlan` is the host-neutral lowering of a
-resolved scenario into its selected context, navigation focus, type/member
-selection, and section; CLI and browser encodings consume that plan rather than
-parsing the member selection independently. **The current schema-version-1
-home demos bind legacy product section display names** through
+This revision transfers one cohesive application responsibility to
+[Static Ecosystem Packs](ecosystem-packs.md#product-demos): which product demos
+ship, their ecosystem grouping and display metadata, their global product
+order, and the source-authored record factories. Workspace Definitions retains
+scenario identity, record shape, validation, resolution, section or facet
+admission, run plans, execution semantics, and failures.
+
+Workspace Definitions issues `ProductDemoSourceBinding`, one static
+noncapturing source paired with the exact scenario ID it must resolve. The
+public minting seam is
+`ProductDemoSourceBinding.Create(scenarioId, static createRecords)`. A static
+lambda or method group is the source-level noncapture boundary, and
+construction rejects a delegate with a non-null target before publication.
+The binding stores the source privately and exposes no delegate or factory
+property.
+
+The application catalog stores that opaque owner-issued binding beside its
+application metadata. Listing is metadata-only and cannot invoke the source.
+Selecting one demo dispatches only that binding. Its resolve operation requires
+the returned records to contain exactly one `ScenarioDefinition`, requires that
+record's ID to equal the declared scenario ID, builds
+`InspectionDefinitionRegistry`, resolves that exact ID, and enforces the normal
+demo section binding. An absent, second, or mismatched scenario, malformed peer
+graph, or unsupported section fails visibly; it does not return an empty or
+neighboring demo. Record construction, validation, resolution, and failure
+therefore remain wholly owned here, while Ecosystems owns only exact dispatch
+isolation and the application inventory.
+
+Catalog selection retains the application descriptor beside
+`ResolvedScenario`. Product-facing title and summary come from that descriptor.
+`ScenarioDefinition.Title` and `Description` remain portable definition fields
+and may differ without becoming a second product-catalog metadata authority.
+
+`ProductDemoRunPlan` remains the host-neutral lowering of a resolved scenario
+into its selected context, navigation focus, type/member selection, and
+section; CLI and browser encodings consume that plan rather than parsing the
+member selection independently. **The current schema-version-1 home demos bind
+legacy product section display names** through
 `ProductDemoSections` (today: `Methods` for the STJ API tour; `Call
 Graph` primary bind for multi-package and package-local graph demos, expanded
 at run via `ExpandRunSections` / `DemoScenarioRunner`: Markdown keeps
@@ -741,15 +772,16 @@ select `Call Graph` when it does not, so package-local entry points with empty
 Callers still emit rows; standalone `--mermaid` keeps `Call Graph`; document
 `--json` fails closed for Call Graph demos until graph sections project into
 that payload.
-`ResolveHomeScenario` fails when a home demo omits `View.Section` or names a
+Demo-source resolution fails when a home demo omits `View.Section` or names a
 section outside that allow list (`ProductHomeDemos_AllBindKnownProductSections`,
 `ProductDemoSections_AreProductSectionNames`). Methods demos reject standalone
 mermaid rather than falling through to the type shape tree. The
 [View Facet Registry](view-facet-registry.md) settles minted facet identity;
 schema version 2 and the explicit legacy table below settle versioned migration
-and complete view composition. Platform workspaces remain product capability;
-they are not a home-demo entry (home catalog is package- and graph-shaped
-scenarios).
+and complete view composition. `ecosystem.platform` is application grouping,
+not workspace-coordinate inference: the current System.Text.Json demos retain
+their exact package pins even when the ecosystem catalog groups them as basic
+Platform demos.
 
 A schema-version-2 home demo persists only `ViewState.Facet` and version-2
 query records. The resolved facet and query owners reach their ordinary
@@ -761,9 +793,9 @@ their exact canonical facet IDs before Registry resolution.
 (`DemoScenarioRunner`) so `dotnet-inspect demo <id>` returns ordinary section
 output from the existing pipelines; multi-package workspaces encode extra
 package members as `--caller-package` for the call-graph demo. **inspect-web**
-loads home-demo catalog and coordinates from the product registry through the
-browser engine (`ListHomeDemos` / `ResolveHomeDemo` /
-`RunHomeDemo` over `ProductInspectionDemos`). `RunHomeDemo` accepts both
+loads flattened home-demo metadata and exact scenario IDs from the application
+ecosystem catalog through the browser engine (`ListHomeDemos` /
+`ResolveHomeDemo` / `RunHomeDemo`). `RunHomeDemo` accepts both
 type-only `Methods` and member-bound `Call Graph` presets: the engine resolves
 the workspace, focus, section, and optional member anchor, opens one aggregate
 browser workspace, and returns its package surfaces plus exact activation
@@ -1866,6 +1898,15 @@ Implementation must add, at minimum:
   `BrowserEngineBoundaryTests.HomeDemoRunCore_ProjectsTheAnchoredMemberAndItsGraph`
   gates aggregate workspace projection, non-first focus consumption,
   digest-prefix selection, and graph execution;
+- a demo-source binding gate proving construction is inert, selected resolution
+  invokes its source exactly once, allocates only the records returned by that
+  source, requires exactly one scenario record, resolves the declared scenario
+  ID exactly, and keeps absent, duplicate, mismatched, record-reference, and
+  section-admission failures visible; a separate constructor case rejects a
+  capturing source before publication —
+  `ProductDemoSourceBindingTests` owns these Workspace Definitions properties;
+  application inventory, grouping, catalog display metadata, and
+  neighboring-source isolation remain ecosystem-catalog gates;
 - a demo-section constraint (design rule under
   [Product demos are closed section presets](#product-demos-are-closed-section-presets)):
   each product home demo names only existing section ids and runs through the
@@ -1907,12 +1948,13 @@ Definition records and product demos (this slice):
   expressions and filesystem coordinates are typed failures in this slice).
   Each resolved context retains its activation-relative
   `WorkspaceContextAddress` and compact target descriptor;
-- `ProductInspectionDemos` is a static id→factory registry (smooth-markdown-table
-  `RendererRegistry` style) of the product home scenarios (Methods tour plus
-  multiple Call Graph shapes); listing is metadata-only and
-  `ResolveHomeScenario` allocates only that demo's peer records and enforces
-  `ProductDemoSections` binding; JSON remains the portable load path for external
-  definitions;
+- `ProductInspectionDemos` is the current static id→factory donor registry
+  (smooth-markdown-table `RendererRegistry` style) of the product home
+  scenarios (Methods tour plus multiple Call Graph shapes); listing is
+  metadata-only and `ResolveHomeScenario` allocates only that demo's peer
+  records and enforces `ProductDemoSections` binding. The ecosystem-catalog
+  transfer and `ProductDemoSourceBinding` remain unimplemented and unverified;
+  JSON remains the portable load path for external definitions;
 - `ProductDemoRunPlan` lowers the resolved context, focus, type/member
   selection, and section once for host encodings;
 - `ProductDemoSections` is the closed allow list of product section display names

--- a/docs/design/workspace-definitions.md
+++ b/docs/design/workspace-definitions.md
@@ -735,11 +735,13 @@ Workspace Definitions issues `ProductDemoSourceBinding`, one static
 noncapturing source paired with the exact scenario ID it must resolve. The
 public minting seam is
 `ProductDemoSourceBinding.Create(scenarioId, CreateRecords)`. Only a static
-method group is admitted, and construction rejects a delegate with a non-null
-target before publication. Static lambdas are intentionally not the authoring
-form because the compiler may represent a noncapturing lambda with a cached
-target object. The binding stores the source privately and exposes no delegate
-or factory property.
+method group is admitted. Construction requires a one-entry invocation list and
+rejects a delegate with a non-null target before publication. Static lambdas are
+intentionally not the authoring form because the compiler may represent a
+noncapturing lambda with a cached target object. A multicast combination of
+static method groups is also rejected because one resolve would otherwise
+execute every combined source. The binding stores the source privately and
+exposes no delegate or factory property.
 
 The application catalog stores that opaque owner-issued binding beside its
 application metadata. Listing is metadata-only and cannot invoke the source.
@@ -1906,7 +1908,7 @@ Implementation must add, at minimum:
   ID exactly, and keeps absent, duplicate, mismatched, record-reference, and
   section-admission failures visible; constructor cases accept a static method
   group and reject instance, capturing-lambda, and cached static-lambda targets
-  before publication —
+  plus multicast static-method-group combinations before publication —
   `ProductDemoSourceBindingTests` owns these Workspace Definitions properties;
   application inventory, grouping, catalog display metadata, and
   neighboring-source isolation remain ecosystem-catalog gates;

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1075,26 +1075,36 @@ a typed query result to instantiate a workspace in a later authorized stage.
 Several scenarios may reuse one workspace definition, and a host may inspect
 the definition without running a preset or acquiring its inputs.
 
-Product-resident home demos ship as a static id→factory registry
-(`DotnetInspector.Queries.Definitions.ProductInspectionDemos`, smooth-markdown-table
-`RendererRegistry` style); hosts resolve one demo via
-`ProductInspectionDemos.ResolveHomeScenario`, which allocates only that demo's
-peer records and requires a `ProductDemoSections` binding. Home demos are closed
-presets over the open query/section product: the registry fixes inputs and names
-**existing product section(s)** (`ProductDemoSections.ExpandRunSections` expands
-Call Graph presets format-aware: Markdown keeps Call Graph + Callers;
-table/tsv/jsonl keep Callers when the demo has caller scope so the re-add stays
-one section, otherwise Call Graph so package-local entry points still emit rows;
-mermaid keeps Call Graph; document JSON fails closed until graph projection
-lands); the CLI host runs them through the normal type/member section pipelines
-(`DemoScenarioRunner` → `TypeCommand` / `MemberCommand`) and returns those
-sections in ordinary formats. Demos must not call past sections into ad hoc
-inspection APIs; a capability that is not a product section is not a home demo
-until the section exists. CLI argv, definition plans, and browser engine
-operations (including a generated TypeScript binding of that engine surface)
-must be encodings of the same preset—not parallel demo systems. Residual:
-minted view-facet ids, `WorkspaceContextLoader` as the shared group-run owner,
-and Call Graph structured-JSON projection (see
+Target product-resident home demos ship through the static application
+ecosystem catalog. `DotnetInspector.Ecosystems` owns which sources ship,
+ecosystem grouping, display metadata, and global product order. Workspace
+Definitions owns `ProductDemoSourceBinding`, peer records, exact scenario
+resolution, section admission, run plans, execution, and failures. Grouped and
+flat discovery expose only immutable metadata; selecting one exact scenario ID
+dispatches only that source, whose binding requires exactly one matching
+scenario record. Selection retains the catalog descriptor beside the resolved
+scenario, and hosts use that descriptor as product display metadata. The current
+`DotnetInspector.Queries.Definitions.ProductInspectionDemos` registry remains
+the donor until that transfer lands.
+
+Home demos are closed presets over the open query/section product: each source
+fixes inputs and names **existing product section(s)**
+(`ProductDemoSections.ExpandRunSections` expands Call Graph presets
+format-aware: Markdown keeps Call Graph + Callers; table/tsv/jsonl keep Callers
+when the demo has caller scope so the re-add stays one section, otherwise Call
+Graph so package-local entry points still emit rows; mermaid keeps Call Graph;
+document JSON fails closed until graph projection lands). The CLI host runs
+them through the normal type/member section pipelines (`DemoScenarioRunner` →
+`TypeCommand` / `MemberCommand`) and returns those sections in ordinary
+formats. Demos must not call past sections into ad hoc inspection APIs; a
+capability that is not a product section is not a home demo until the section
+exists. CLI argv, definition plans, and browser engine operations (including a
+generated TypeScript binding of that engine surface) must be encodings of the
+same preset—not parallel demo systems. Ecosystem grouping does not select or
+activate the pack's package set, prefixes, or scanner, and is never inferred
+from package coordinates or display text. Residual: the ecosystem-catalog
+donor transfer, minted view-facet ids, `WorkspaceContextLoader` as the shared
+group-run owner, and Call Graph structured-JSON projection (see
 workspace-definitions). Detail:
 [workspace-definitions.md — Product demos are closed section
 presets](design/workspace-definitions.md#product-demos-are-closed-section-presets).

--- a/docs/inspection-space.md
+++ b/docs/inspection-space.md
@@ -1078,14 +1078,15 @@ the definition without running a preset or acquiring its inputs.
 Target product-resident home demos ship through the static application
 ecosystem catalog. `DotnetInspector.Ecosystems` owns which sources ship,
 ecosystem grouping, display metadata, and global product order. Workspace
-Definitions owns `ProductDemoSourceBinding`, peer records, exact scenario
-resolution, section admission, run plans, execution, and failures. Grouped and
-flat discovery expose only immutable metadata; selecting one exact scenario ID
-dispatches only that source, whose binding requires exactly one matching
-scenario record. Selection retains the catalog descriptor beside the resolved
-scenario, and hosts use that descriptor as product display metadata. The current
-`DotnetInspector.Queries.Definitions.ProductInspectionDemos` registry remains
-the donor until that transfer lands.
+Definitions owns `ProductDemoSourceBinding`, record types and peer-graph
+validation, exact scenario resolution, section admission, run plans, execution,
+and failures. The selected application-authored factory constructs the records.
+Grouped and flat discovery expose only immutable metadata; selecting one exact
+scenario ID dispatches only that source, whose binding requires exactly one
+matching scenario record. Selection retains the catalog descriptor beside the
+resolved scenario, and hosts use that descriptor as product display metadata.
+The current `DotnetInspector.Queries.Definitions.ProductInspectionDemos`
+registry remains the donor until that transfer lands.
 
 Home demos are closed presets over the open query/section product: each source
 fixes inputs and names **existing product section(s)**

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -83,13 +83,17 @@ substrates, and inspection producers that will extend that space.
 - `src/ILInspector.Text/` provides the reusable `TextFindings` API for exact, ordered line inspection and generic text comparison on the shared Finding spine.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction,
   package/source caches, feeds, symbol package acquisition, and version
-  resolution. The
-  [Package Set Registry](design/package-set-registry.md) reuses this package
-  owner's coordinate currency and validation while stable set identity, the
-  private shipped inventory, discovery, and lookup live in the front-end-only
-  `DotnetInspector.Ecosystems` application assembly. The CLI consumes that
-  application catalog and passes only package IDs into reusable scope
   resolution.
+- `src/DotnetInspector.Ecosystems/` is the static front-end application
+  catalog. The [Package Set Registry](design/package-set-registry.md) reuses
+  Packages-owned coordinate currency and validation while stable set identity,
+  private shipped inventory, discovery, and lookup live here today. The
+  [Ecosystem Pack](design/ecosystem-packs.md) pattern targets shipped pack
+  metadata and product-demo source content for this assembly while Workspace
+  Definitions retains demo records, resolution, run plans, and execution. Only
+  the CLI and the managed inspect-web facade may consume this application
+  assembly; reusable Queries, Packages, Services, Metadata, and browser Core do
+  not reference it.
 - `src/DotnetInspector.PackageQueries/` is the optional package-aware query
   companion. It consumes package realization proofs and package-neutral core
   queries without adding package identity or acquisition policy to those core


### PR DESCRIPTION
## Summary

Define product demos as static ecosystem-pack contributions while preserving Workspace Definitions as the owner of records, validation, exact resolution, section admission, run plans, execution, and failures.

This is slice 2 of 3 in #5772, stacked on #5763. This is an operator-approved two-owner composition: `docs/design/ecosystem-packs.md` owns which demos ship, literal ecosystem grouping, display metadata, global product order, and exact dispatch; `docs/design/workspace-definitions.md` solely owns `ProductDemoSourceBinding` construction, validation, resolution, execution handoff, and failures. The same registrations project grouped discovery and the flat inert list required by #5770.

The design preserves all eight current IDs and order, adds `ecosystem.platform`, and specifies two exact Aspire Call Graph demos:

- `Aspire.Hosting.PostgreSQL@13.5.3` `AddPostgres~e5a66a2bd9`
- `Aspire.Hosting.Redis@13.5.3` `AddRedis~7618364a03`

## Demo

```text
Demos

System.Text.Json                     Browse a real package API
Cross-package call graph             Trace calls across three packages
Serialize call graph                 Dense package-local STJ graph
Configuration Bind                  Recursive binder call graph
Options hub                         Inbound fan-in at AddOptions
DI TryAdd hub                       Keyed/scoped Try* fan-in
AddHttpClient                       HttpClient factory registration
JsonElement.GetDecimal              STJ number parse path
Aspire AddPostgres                  PostgreSQL resource registration graph
Aspire AddRedis                     Redis resource registration graph
```

The grouped projection retains Platform, Microsoft.Extensions, ASP.NET Core, and Aspire identity. Listing constructs no definition records. Selecting one demo returns its catalog descriptor beside the Queries-owned resolved scenario and does not activate the pack package set, prefixes, scanner, or neighboring demo sources.

## Compatibility and boundaries

- No runtime behavior changes in this documentation slice.
- Existing demo IDs, metadata, order, records, pins, and run plans remain the implementation compatibility boundary.
- `ProductDemoSourceBinding.Create(scenarioId, CreateRecords)` is public owner-issued currency; it keeps the delegate private, rejects targeted or multicast delegates, requires exactly one matching scenario record, and preserves owner-domain failures.
- The ecosystem catalog may reference Queries; Queries and every other reusable component remain forbidden from referencing Ecosystems.
- Product display metadata comes from the catalog descriptor, not portable scenario title/description.

## Validation

- `npx markdownlint-cli docs/architecture.md docs/design/ecosystem-packs.md docs/design/workspace-definitions.md docs/inspection-space.md docs/overview.md`
- Production `dotnet-inspect` resolved both Aspire pins to `net8.0`, confirmed the stable anchors, and emitted nonempty ordinary Call Graph sections.

## Stack

- Slice 1: #5763 — audited 82-package Aspire set, targets `main`.
- Slice 2: this PR — ecosystem demo-content contract, targets `measure/aspire-package-set`.
- Slice 3: implementation and donor transfer, will target `design/ecosystem-demo-catalog`.

Remaining work is confined to slice 3: implement the four-pack/ten-demo catalog, transfer donor sources, adapt CLI and `InspectWeb.Engine.CatalogExports`, and land the named dependency and behavior gates.