### PR TITLE
Activate subjects during arrow navigation

### DIFF
--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -313,17 +313,17 @@ sequence plus subject-policy version. The inspector strip's key is the active
 subject identity, ordered inspector identity sequence, and inspector-policy
 version. Width and focus movement do not replace either key.
 
-The subject tablist uses one tab stop and manual activation. Left and Right
-Arrow move focus through the complete installed subject order, sliding the
-window by the smallest amount needed when focus reaches a hidden item. Home and
-End move to the first and last subject. Focus movement does not select a
-subject until Enter or Space activates it. Every subject references the shared
-subject panel, which is labelled by the active subject. The inspector tablist
-retains the equivalent lens semantics below. Allocation-button activation
-changes only allocation and focus remains on the button. Each strip's leading
-and trailing highlights disclose hidden items but add no tab stop. Any sliding
-animation preserves the focused element and is omitted when reduced motion is
-requested.
+The subject tablist uses one tab stop and automatic keyboard activation. Left
+and Right Arrow move focus through the complete installed subject order and
+activate the destination, sliding the window by the smallest amount needed when
+focus reaches a hidden item. Home and End move to and activate the first and
+last subject. Enter or Space also activates the focused subject. Every subject
+references the shared subject panel, which is labelled by the active subject.
+The inspector tablist retains the manual lens semantics below.
+Allocation-button activation changes only allocation and focus remains on the
+button. Each strip's leading and trailing highlights disclose hidden items but
+add no tab stop. Any sliding animation preserves the focused element and is
+omitted when reduced motion is requested.
 
 When a window, mode, or allocation change excludes the sole roving-tab-stop
 holder while that tablist is unfocused, the adopter moves `tabindex="0"` without
@@ -798,6 +798,7 @@ add and pass these named Inspect Web tests:
 - `scope-bar.test.ts` and `workspace-titlebar.spec.ts`:
   `slideable subject strip composes reusable strips without losing navigation`
   cover the separate subject and inspector whole-strip mode policies,
+  automatic subject activation with destination focus restoration,
   contiguous windows and edge indicators, inspector-first width allocation,
   stable Pareto-ladder construction, duplicate and dominated result removal,
   exact selected-window slack return, adjacent non-no-op allocation controls,
@@ -896,12 +897,13 @@ are proved by the gates in
    result. Confirm that focus remains on the allocation button. At each bound,
    confirm that the corresponding mounted button is `aria-disabled="true"` and
    activation has no effect.
-7. Rove focus to an inactive subject and inspector and replace the shell
-   asynchronously. Confirm that the focused typed tab remains the sole tab
-   stop in its tablist, each retained window still contains its focus, and
-   allocation bias survives while the subject and ordered inspector identity
-   sequence remain installed. Change that sequence without changing the
-   subject and confirm that allocation resets to inspector-first.
+7. Use Arrow navigation to focus and activate another subject, then rove focus
+   to an inactive inspector and replace the shell asynchronously. Confirm that
+   each focused typed tab remains the sole tab stop in its tablist, each
+   retained window still contains its focus, and allocation bias survives while
+   the subject and ordered inspector identity sequence remain installed.
+   Change that sequence without changing the subject and confirm that
+   allocation resets to inspector-first.
    Then move focus outside each tablist and change its window so the previous
    tab-stop holder is hidden. Confirm that focus and selection do not move and
    that the active visible tab, or otherwise the nearest visible item, becomes

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -668,8 +668,6 @@ test("keyboard tab activation preserves focus across shell replacement", async (
   await type.focus();
   await page.keyboard.press("ArrowLeft");
   await expect(packageSubject).toBeFocused();
-  await expect(packageSubject).toHaveAttribute("aria-selected", "false");
-  await page.keyboard.press("Enter");
   await expect(packageSubject).toHaveAttribute("aria-selected", "true");
   await expect(packageSubject).toBeFocused();
 });
@@ -786,7 +784,11 @@ test("row-one controls yield in order before Subject and Inspector navigation", 
   await expect(memberSubject).toHaveAttribute("aria-selected", "true");
   await memberSubject.focus();
   await page.keyboard.press("ArrowLeft");
-  await expect(page.locator('[data-scope="type"]')).toBeFocused();
+  const typeSubject = page.locator('[data-scope="type"]');
+  await expect(typeSubject).toBeFocused();
+  await expect(typeSubject).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("ArrowRight");
+  await expect(memberSubject).toBeFocused();
   await expect(memberSubject).toHaveAttribute("aria-selected", "true");
   await overview.focus();
   await page.keyboard.press("ArrowRight");
@@ -1267,7 +1269,6 @@ test("manual windows survive resize and reset with inspector inventory", async (
   await page.keyboard.press("ArrowLeft");
   const typeSubject = page.locator('[data-scope="type"]');
   await expect(typeSubject).toBeFocused();
-  await page.keyboard.press("Enter");
   await expect(typeSubject).toHaveAttribute("aria-selected", "true");
   await expect(page.locator(".slide-strip-inspector")).toHaveAttribute(
     "data-mode",

--- a/prototypes/inspect-web/src/scope-bar.ts
+++ b/prototypes/inspect-web/src/scope-bar.ts
@@ -205,6 +205,7 @@ function targetStrip(target: ScopeBarFocusTarget): "subject" | "inspector" {
 function bindRovingTabs(
   tabs: readonly HTMLButtonElement[],
   reveal: (target: HTMLButtonElement) => void,
+  activateOnNavigation = false,
 ): void {
   tabs.forEach((tab, index) =>
     tab.addEventListener("keydown", event => {
@@ -232,6 +233,7 @@ function bindRovingTabs(
       });
       target.tabIndex = 0;
       target.focus();
+      if (activateOnNavigation) target.click();
     }));
 }
 
@@ -253,7 +255,7 @@ export function bindScopeBar(
   bindRovingTabs([
     ...root.querySelectorAll<HTMLButtonElement>(
       "[data-subject-tab]"),
-  ], target => controller?.reveal(target));
+  ], target => controller?.reveal(target), true);
   bindRovingTabs([
     ...root.querySelectorAll<HTMLButtonElement>("[data-inspector-tab]"),
   ], target => controller?.reveal(target));

--- a/prototypes/inspect-web/test/scope-bar.test.ts
+++ b/prototypes/inspect-web/test/scope-bar.test.ts
@@ -47,6 +47,10 @@ class FakeElement {
     this.focused = true;
   }
 
+  click() {
+    this.dispatch("click");
+  }
+
   checkVisibility() {
     return this.rendered;
   }
@@ -258,23 +262,26 @@ test("scope bar binding tolerates an empty strip", () => {
     recordingActions([])));
 });
 
-test("subject tabs use manual roving keyboard focus", () => {
+test("subject tab navigation focuses and activates the destination", () => {
   const root = new FakeRoot();
-  const workspace = new FakeElement();
-  const packageSubject = new FakeElement();
-  const type = new FakeElement();
+  const workspace = new FakeElement({ scope: "workspace" });
+  const packageSubject = new FakeElement({ scope: "package" });
+  const type = new FakeElement({ scope: "type" });
   workspace.tabIndex = -1;
   packageSubject.tabIndex = 0;
   type.tabIndex = -1;
   root.add("[data-subject-tab]", workspace, packageSubject, type);
+  root.add("[data-scope]", workspace, packageSubject, type);
+  const calls: string[] = [];
 
-  bindScopeBar(fakeDom.parentNode(root), recordingActions([]));
+  bindScopeBar(fakeDom.parentNode(root), recordingActions(calls));
 
   assert.equal(packageSubject.dispatch("keydown", { key: "ArrowRight" }), true);
   assert.equal(type.focused, true);
   assert.deepEqual(
     [workspace.tabIndex, packageSubject.tabIndex, type.tabIndex],
     [-1, -1, 0]);
+  assert.deepEqual(calls, ["scope:type"]);
 });
 
 test("scope bar bindings ignore missing and unknown dataset values", () => {


### PR DESCRIPTION
Build robust, capable Inspect Web navigation by making the keyboard-driven subject strip complete the action it visually announces.

## Demo

**Before:** Left/Right moved focus from Member to Type or Type to Package, but the prior subject stayed selected until Enter or Space.

**After:** A single Left/Right, Home, or End keypress focuses the destination subject and activates it. Focus survives the resulting shell replacement. Inspector tabs retain manual activation, so arrow keys still preview them without starting lens work.

## Summary

- activate only subject-strip destinations after roving focus moves
- preserve manual keyboard activation for inspector and application-scope strips
- update the navigation-presentation contract and focused unit/browser evidence

## Validation

- `npm run typecheck --silent`
- `node --test test/scope-bar.test.ts`
- `npm run lint --silent`
- `playwright test` for keyboard activation, row-one navigation, and resized manual windows in Firefox
- `npx markdownlint-cli docs/design/inspect-web-navigation-presentation.md`

Closes #5802