### PR TITLE
Pin an immutable TLA+ v1.8.0 tool build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,30 +203,29 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/share/tlaplus/tla2tools.jar
-          # Include the asset digest so a recreated tagged release cannot
-          # reuse cached bytes from the prior asset.
-          key: tla2tools-v1.8.0-16b8cd970e07147f
+          # Include the asset digest so a later pin cannot reuse cached bytes
+          # from a different build.
+          key: tla2tools-v1.8.0-ab323b79802aedc3
 
-      # Pinned per docs/runbooks/tla-plus-setup.md: v1.8.0 is a GitHub
-      # prerelease, so it is never resolved by a "latest" alias -- always
-      # fetch this exact tagged asset URL.
+      # Pinned per docs/runbooks/tla-plus-setup.md: upstream v1.8.0 is a
+      # rolling channel whose prior assets disappear. Fetch the immutable
+      # mirrored build instead of the mutable upstream tag.
       - name: Download tla2tools.jar
         if: steps.cache-tla.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p ~/.local/share/tlaplus
           curl -fLo ~/.local/share/tlaplus/tla2tools.jar \
-            https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+            https://github.com/zactionsz/tla-tools/releases/download/tla2tools-2026.08.11.125311/tla2tools.jar
 
-      # A cache key alone is not an integrity check: a substituted release
-      # asset served under the same tag, or a poisoned cache entry, would
-      # otherwise execute unverified bytecode via the "Run TLA+ checks"
-      # step below with no diagnostic. Verify on every run -- cache hits
-      # included -- not only right after a fresh download.
+      # A cache key alone is not an integrity check: substituted release bytes
+      # or a poisoned cache entry would otherwise execute unverified bytecode
+      # via the "Run TLA+ checks" step below with no diagnostic. Verify on
+      # every run -- cache hits included -- not only after a fresh download.
       - name: Verify tla2tools.jar checksum
         run: |
           set -euo pipefail
-          echo "16b8cd970e07147ff91f126baecba7edd98202e5ab33220a42f8f4358ee94b2b  $HOME/.local/share/tlaplus/tla2tools.jar" \
+          echo "ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f  $HOME/.local/share/tlaplus/tla2tools.jar" \
             | sha256sum -c -
 
       - name: Run TLA+ checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           path: ~/.local/share/tlaplus/tla2tools.jar
           # Include the asset digest so a recreated tagged release cannot
           # reuse cached bytes from the prior asset.
-          key: tla2tools-v1.8.0-dbcc75552f21978a
+          key: tla2tools-v1.8.0-16b8cd970e07147f
 
       # Pinned per docs/runbooks/tla-plus-setup.md: v1.8.0 is a GitHub
       # prerelease, so it is never resolved by a "latest" alias -- always
@@ -226,7 +226,7 @@ jobs:
       - name: Verify tla2tools.jar checksum
         run: |
           set -euo pipefail
-          echo "dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94  $HOME/.local/share/tlaplus/tla2tools.jar" \
+          echo "16b8cd970e07147ff91f126baecba7edd98202e5ab33220a42f8f4358ee94b2b  $HOME/.local/share/tlaplus/tla2tools.jar" \
             | sha256sum -c -
 
       - name: Run TLA+ checks

--- a/docs/runbooks/tla-plus-setup.md
+++ b/docs/runbooks/tla-plus-setup.md
@@ -34,12 +34,12 @@ pinned release is:
 
 - **Version:** `v1.8.0` ("The Clarke" release) — currently a GitHub
   **prerelease**, not the "latest" stable tag. Agents in this repository are
-  standardized on it (confirmed TLC build `2026.09.01.002747`, rev
-  `95b800c`), so pin to it rather than the older
+  standardized on it (confirmed TLC build `2026.09.03.193042`, rev
+  `1239539`), so pin to it rather than the older
   stable `v1.7.4` to stay consistent with work already done.
 - **Source:** <https://github.com/tlaplus/tlaplus/releases/tag/v1.8.0>
 - **Asset:** `tla2tools.jar`
-- **SHA-256:** `dbcc75552f21978a4846688b8e23be1a6b6c0b3fcee35d78fec2df167958ec94` —
+- **SHA-256:** `16b8cd970e07147ff91f126baecba7edd98202e5ab33220a42f8f4358ee94b2b` —
   CI verifies this on every run (cache hit or fresh download), since a
   cache key alone is not an integrity check against a substituted release
   asset. Update it alongside the version when the pin changes.

--- a/docs/runbooks/tla-plus-setup.md
+++ b/docs/runbooks/tla-plus-setup.md
@@ -23,7 +23,7 @@ apply to `tla2tools.jar`: no mainstream package manager (`apt`, `brew`,
 `winget`, `choco`, `scoop`) carries the CLI jar. Homebrew's only TLA+ artifact
 is the `tla+-toolbox` cask — the GUI IDE, not the CLI tools, and macOS-only —
 so it does not give a cross-platform, scriptable install and is not used here.
-Pin and download `tla2tools.jar` directly from the project's GitHub releases
+Pin and download `tla2tools.jar` from the immutable mirror release named below
 on every OS instead.
 
 ## Pin one TLA+ version across every OS
@@ -32,17 +32,22 @@ Use the same `tla2tools.jar` release on every machine so model-checking
 results are reproducible across contributors and OSes. As of this writing the
 pinned release is:
 
-- **Version:** `v1.8.0` ("The Clarke" release) — currently a GitHub
-  **prerelease**, not the "latest" stable tag. Agents in this repository are
-  standardized on it (confirmed TLC build `2026.09.03.193042`, rev
-  `1239539`), so pin to it rather than the older
-  stable `v1.7.4` to stay consistent with work already done.
-- **Source:** <https://github.com/tlaplus/tlaplus/releases/tag/v1.8.0>
+- **Upstream version:** `v1.8.0` ("The Clarke" release), currently published
+  as a rolling GitHub prerelease channel rather than an immutable release.
+- **TLC build:** `2026.08.11.125311`
+- **Upstream source:** <https://github.com/tlaplus/tlaplus/releases/tag/v1.8.0>
+- **Immutable distribution:**
+  <https://github.com/zactionsz/tla-tools/releases/tag/tla2tools-2026.08.11.125311>
 - **Asset:** `tla2tools.jar`
-- **SHA-256:** `16b8cd970e07147ff91f126baecba7edd98202e5ab33220a42f8f4358ee94b2b` —
-  CI verifies this on every run (cache hit or fresh download), since a
-  cache key alone is not an integrity check against a substituted release
-  asset. Update it alongside the version when the pin changes.
+- **SHA-256:** `ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f`
+
+The upstream `v1.8.0` channel continuously replaces its asset and deletes the
+previous bytes, so its tag-relative URL is not a durable pin. The mirror
+preserves the upstream build under a build-specific tag and records the
+original upstream asset identity and digest. It is a distribution point, not a
+trust root: CI verifies the repository-pinned SHA-256 on every run, including
+cache hits. Update the build-specific URL, cache key, and digest together when
+the pin changes.
 
 Model READMEs retain the tool hashes and build identities used for their
 recorded historical runs; updating the repository's current pin does not
@@ -53,18 +58,22 @@ rewrite that evidence.
 the install path used here, on top of being macOS-only and installing the GUI
 app rather than the jar.)
 
-Because `v1.8.0` is a prerelease, `.../releases/latest` (used by both the
-GitHub UI default view and tools that resolve "latest") will not surface it —
-always fetch the exact tagged asset URL below, never a "latest" alias:
+Always fetch the exact build-specific mirror URL, never the rolling upstream
+tag or a `latest` alias:
 
 ```bash
-curl -fLO https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+curl -fLO https://github.com/zactionsz/tla-tools/releases/download/tla2tools-2026.08.11.125311/tla2tools.jar
+echo "ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f  tla2tools.jar" \
+  | sha256sum -c -
 ```
 
 Put `tla2tools.jar` somewhere stable (for example `~/.local/share/tlaplus/` on
 Linux/macOS or `%LOCALAPPDATA%\tlaplus\` on Windows) and reference it by full
 path or via `CLASSPATH`/`java -jar`, rather than copying it per-worktree. When
 the pinned version changes, update this file and re-download on every OS.
+On macOS, use `shasum -a 256 -c -` in place of `sha256sum -c -`. On Windows,
+compare `(Get-FileHash .\tla2tools.jar -Algorithm SHA256).Hash` with the pinned
+digest before using the jar.
 
 ## Java prerequisite
 


### PR DESCRIPTION
This keeps dotnet-inspect's model-backed engineering foundation reproducible:
a cold machine can obtain and verify the exact tool bytes before checking the
robust Workspace capabilities built above them.

## Summary

- replace the mutable upstream `v1.8.0` URL with immutable mirror build
  `2026.08.11.125311`;
- pin the build-specific URL and SHA-256
  `ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f`;
- keep digest-bearing cache identity and unconditional checksum verification;
  and
- document why the upstream rolling tag is not a durable pin while preserving
  every model README's historical build evidence.

Fixes #5804.

## Demo

The original candidate refreshed one rolling asset. Upstream replaced it again
during exact-head review, so a cold download no longer matched:

```text
reviewed  16b8cd970e07147f...
current   b658b4e504fdf0b...
```

The replacement downloads one build-specific mirror release and verifies the
consumer-owned digest before TLC runs:

```text
/tmp/tla2tools-2026.08.11.125311.jar: OK
TLC - provides model checking and simulation of TLA+ specifications
- Version 2026.08.11.125311
```

That exact jar also checks the neighboring repository-wide corpus:

```text
Checked 49 module(s) and 495 configuration(s) (35 exact outcomes).
0 exact-outcome or semantic-verdict mismatches.
```

Five unlisted exhaustive configurations were not verified within the
reviewer's deliberately reduced 180-second budget; every contract-defining
exact outcome completed.

## Compatibility

This changes no product or TLA+ model contract. The complete current model
corpus passes with the pinned build, and historical model evidence retains the
exact tool build and hash that originally produced it.

## Validation

- cold mirror download and SHA-256 verification
- all 49 TLA+ modules and 495 configurations at a reduced review budget
- `npx markdownlint-cli docs/runbooks/tla-plus-setup.md`
- `git diff --check`
