### PR TITLE
Implement implicit-route row-selection envelope

### DIFF
--- a/docs/design/cli-row-selection.md
+++ b/docs/design/cli-row-selection.md
@@ -369,6 +369,8 @@ require platform or package resolution.
 Before an implicit router performs observable resolution, it uses a pure
 route-independent envelope over candidate command declarations:
 
+- `-n N` has the same default meaning for every adopting command: select the
+  first *N* declared semantic items; rendered lines require explicit `--lines`;
 - the required-value arity union protects a following negative token whenever
   any candidate route must consume it as that option's value;
 - an invocation with no row-selection request follows ordinary routing;
@@ -402,6 +404,15 @@ Envelope activation is evaluated per owned row-selection request: a semantic
 gesture or one of its direction/unit modifiers. A candidate that does not
 declare the request makes the candidate set non-uniform; L3 does not infer
 support from shared option objects or display behavior.
+
+Bare `-N` is the one declaration-sensitive exception because it has no explicit
+option identity until normalization. It is route-independent only when every
+candidate binds `-n`; mixed binding defers the shorthand to the authoritative
+child rather than manufacturing an explicit-command requirement. When no
+candidate binds `-n`, bare `-N` is not a route-envelope request at all.
+Explicit `-n N` already carries option identity, so mixed declaration remains
+a non-uniform request and uniform non-declaration remains a common unsupported
+gesture.
 
 ## L3 conflicts and failure
 

--- a/docs/design/cli-row-selection.md
+++ b/docs/design/cli-row-selection.md
@@ -20,8 +20,9 @@ shorthand, preserves raw positions, extracts those occurrences, and invokes
 the lowerer. #5786 installs that adapter for plural package-version listings,
 renders its L3 failures before package acquisition, and carries typed intent
 through L2 row-cohort selection after source aggregation. The general implicit
-route envelope, remaining command adoptions, and shared universal guidance
-remain unimplemented.
+route envelope is implemented by #5784 as a pure pre-acquisition classifier;
+candidate-set construction, router wiring, remaining command adoptions, and
+shared universal guidance remain unimplemented.
 
 Only the implemented subsets are verified by their named Release gates in
 [Required gates](#required-gates). Every other asserted behavior remains
@@ -637,6 +638,12 @@ The plural package-version adoption is enforced by:
 | `CoordinateVersionListing_PreservesPartialEvidence` and `SingularCoordinateVersionListing_PreservesSourceFailureDisclosure` | Adopted coordinates preserve source-failure evidence before selection and count projection, with or without listing status: observed pins disclose partial results, latest/range queries fail without rows, and singular pins retain the source owner's disclosure. |
 | `PackageVersionListing_LocalFolderReadsVersionsWithoutHttpTransport` | Local-directory and file-URI sources enumerate versions without HTTP/plugin authentication under semantic Head(1). |
 
+The implemented implicit-route envelope is enforced by:
+
+| Gate | Property |
+| --- | --- |
+| `CliRowSelectionRouterPreflightTests` | Request-free invocations preserve ordinary routing; common row grammar failures and uniformly unsupported requests survive unrelated route deferral; mixed declaration or capability requires an explicit command; required-value disagreement defers dependent decisions; bare `-N` is common only when every candidate binds `-n`; original raw-argv positions are preserved. |
+
 The remaining implementation must satisfy:
 
 | Gate | Property |
@@ -645,7 +652,6 @@ The remaining implementation must satisfy:
 | `CliRowSelectionOrderTests` | `-n`, `--rows`, and `--top` preserve argv order; modifiers change unit or direction without becoming operation-intent positions. |
 | `CliRowSelectionBareShorthandTests` | Required, optional, boolean, attached, positional, router, parent-option, and `--` cases classify bare `-N` by parsed arity and ownership; normalization precedes duplicate-gesture lowering. |
 | `CliRowSelectionCapabilityTests` | Only the active adopted leaf command accepts its declared gestures; shared helpers and parent commands do not imply adoption. |
-| `CliRowSelectionRouterPreflightTests` | Request-free invocations route ordinarily; a determinate request across non-uniform candidate declarations requires an explicit command; uniform non-support rejects before routing; uniform support handles common token, arity, value, repetition, and modifier failures before target resolution; arity-union-indeterminate cases defer dependent decisions while preserving required negative option values; every envelope failure returns nonzero and emits no success-shaped result. |
 | `CliRowSelectionTopOrderBindingTests` | One explicit `--order-by` attaches only as the one `TopIntent`'s unresolved ranking-order operation; no explicit order leaves that operation absent for L2 default resolution; L3 never emits a resolved ranking identity or infers baseline order as ranking. |
 | `CliRowSelectionPreExecutionFailureTests` | L3-decidable explicit-command failures occur before command execution or command-owned acquisition, return nonzero, and emit no success-shaped result; L2 ranking failures follow L2-owned timing. |
 | `CliRowSelectionFailurePrecedenceTests` | Explicit and implicit multi-fault invocations, token/arity failures, malformed values, token-completed conflicts, tied end-of-argv absence conflicts, multiple capability rejections, and L2 failures produce the one diagnostic selected by their applicable precedence. |

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -1294,6 +1294,117 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void ChildScopeOptionRecognitionDefersRowArguments()
+    {
+        foreach (string valueAlias in new[] { "-n", "--rows", "--top", "--order-by" })
+        {
+            foreach (bool childOnly in new[] { false, true })
+            {
+                CandidateFixture first =
+                    new("first", parentName: "scope", childName: "Target",
+                        childDeclarations: RowDeclarations.All,
+                        extraOptionName: childOnly ? null : "--other",
+                        childOptionName: childOnly ? "--other" : null);
+                CandidateFixture second =
+                    new("second", childName: "Target", childDeclarations: RowDeclarations.All,
+                        extraOptionName: childOnly ? null : "--other",
+                        childOptionName: childOnly ? "--other" : null);
+                foreach (string following in new[] { "--other", "--other=payload", "--other:payload" })
+                {
+                    CliRowSelectionRouteEnvelopeResult result =
+                        Evaluate(["Target", valueAlias, following], first, second);
+                    CliRowSelectionRouteEnvelopeResult reversed =
+                        Evaluate(["Target", valueAlias, following], second, first);
+                    Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                    Assert.Equal(result.Outcome, reversed.Outcome);
+                    Assert.Equal([0], result.DeferredPositions);
+                    Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+                }
+
+                CliRowSelectionRouteEnvelopeResult laterValue =
+                    Evaluate(["Target", valueAlias, "--other", "--rows", "bad"], first, second);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, laterValue.Outcome);
+                Assert.Equal(CliRowSelectionFailureReason.InvalidWindowForm, laterValue.Failure!.Reason);
+                Assert.Equal(3, laterValue.Position);
+
+                CliRowSelectionRouteEnvelopeResult laterArity =
+                    Evaluate(["Target", valueAlias, "--other", "--rows"], first, second);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure, laterArity.Outcome);
+                Assert.Equal(CliRowSelectionArgumentFailureReason.MissingValue, laterArity.ArgumentFailure!.Reason);
+                Assert.Equal(CliRowSelectionOccurrenceKind.Rows, laterArity.RequestKind);
+                Assert.Equal(3, laterArity.Position);
+
+                CliRowSelectionRouteEnvelopeResult attached =
+                    Evaluate(["Target", $"{valueAlias}=--other"], first, second);
+                if (valueAlias == "--order-by")
+                {
+                    Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, attached.Outcome);
+                }
+                else
+                {
+                    Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, attached.Outcome);
+                    Assert.Equal(
+                        valueAlias == "--rows"
+                            ? CliRowSelectionFailureReason.InvalidWindowForm
+                            : CliRowSelectionFailureReason.MalformedValue,
+                        attached.Failure!.Reason);
+                    Assert.Equal(1, attached.Position);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void RowArityUsesTheTokenScope()
+    {
+        CandidateFixture first =
+            new("first", childName: "Target", childDeclarations: RowDeclarations.All,
+                extraOptionName: "--other");
+        CandidateFixture second =
+            new("second", childName: "Target", childDeclarations: RowDeclarations.All,
+                extraOptionName: "--other");
+
+        CliRowSelectionRouteEnvelopeResult absence =
+            Evaluate(["Target", "--head", "-n", "--other"], first, second);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, absence.Outcome);
+        Assert.Equal([0], absence.DeferredPositions);
+
+        CliRowSelectionRouteEnvelopeResult prefix =
+            Evaluate(["-n", "--other", "Target"], first, second);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure, prefix.Outcome);
+        Assert.Equal(CliRowSelectionArgumentFailureReason.MissingValue, prefix.ArgumentFailure!.Reason);
+        Assert.Equal(0, prefix.Position);
+
+        CliRowSelectionArgumentResult explicitChild =
+            CliRowSelectionArgumentAdapter.LowerExplicit(
+                first.Candidate.ParserRoot,
+                [.. first.Candidate.CommandPrefix, "Target", "-n", "--other"],
+                first.Candidate.Bindings,
+                CliRowSelectionCapabilities.All);
+        Assert.Empty(explicitChild.ArgumentFailures);
+        Assert.Empty(explicitChild.ParseErrors);
+        Assert.Equal(CliRowSelectionFailureReason.MalformedValue, explicitChild.LoweringResult!.Failure!.Reason);
+
+        CandidateFixture recursiveFirst =
+            new("recursive-first", childName: "Target", childDeclarations: RowDeclarations.All,
+                extraOptionName: "--other", extraOptionRecursive: true);
+        CandidateFixture recursiveSecond =
+            new("recursive-second", childName: "Target", childDeclarations: RowDeclarations.All,
+                extraOptionName: "--other", extraOptionRecursive: true);
+        CliRowSelectionRouteEnvelopeResult commonArity =
+            Evaluate(["Target", "-n", "--other"], recursiveFirst, recursiveSecond);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure, commonArity.Outcome);
+        Assert.Equal(CliRowSelectionArgumentFailureReason.MissingValue, commonArity.ArgumentFailure!.Reason);
+        Assert.Equal(1, commonArity.Position);
+
+        CliRowSelectionRouteEnvelopeResult commonValue =
+            Evaluate(["Target", "-n", "--unknown"], first, second);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, commonValue.Outcome);
+        Assert.Equal(CliRowSelectionFailureReason.MalformedValue, commonValue.Failure!.Reason);
+        Assert.Equal(1, commonValue.Position);
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =
@@ -1655,7 +1766,8 @@ public sealed class CliRowSelectionRouterPreflightTests
             string tailName = "--tail",
             string linesName = "--lines",
             string tailLinesName = "--tail-lines",
-            string? childOptionName = null)
+            string? childOptionName = null,
+            bool extraOptionRecursive = false)
         {
             Option<string[]> limit =
                 RowValueOption(limitName);
@@ -1735,9 +1847,9 @@ public sealed class CliRowSelectionRouterPreflightTests
             command.Options.Add(required);
             if (extraOptionName is not null)
             {
-                command.Options.Add(
-                    ModifierOption(
-                        extraOptionName));
+                Option<bool> extraOption = ModifierOption(extraOptionName);
+                extraOption.Recursive = extraOptionRecursive;
+                command.Options.Add(extraOption);
             }
             command.Arguments.Add(
                 new Argument<string[]>("values")

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -722,6 +722,76 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void LaterCommonArgumentFailuresSurviveCandidateSpecificErrors()
+    {
+        CandidateFixture first =
+            new("first", parentName: "scope", extraOptionName: "--only-in-first");
+        CandidateFixture second = new("second");
+        (string[] Suffix, CliRowSelectionOccurrenceKind Kind,
+            CliRowSelectionArgumentFailureReason Reason)[] cases =
+        [
+            (["--rows"], CliRowSelectionOccurrenceKind.Rows,
+                CliRowSelectionArgumentFailureReason.MissingValue),
+            (["--head=true"], CliRowSelectionOccurrenceKind.Head,
+                CliRowSelectionArgumentFailureReason.AttachedValueOnModifier),
+            (["--rows", "--head=true"], CliRowSelectionOccurrenceKind.Rows,
+                CliRowSelectionArgumentFailureReason.MissingValue),
+            (["--head=true", "--rows"], CliRowSelectionOccurrenceKind.Head,
+                CliRowSelectionArgumentFailureReason.AttachedValueOnModifier)
+        ];
+        foreach (var scenario in cases)
+        {
+            string[] arguments = ["Target", "-n", "--only-in-first", .. scenario.Suffix];
+            CliRowSelectionRouteEnvelopeResult result = Evaluate(arguments, first, second);
+            CliRowSelectionRouteEnvelopeResult reversed = Evaluate(arguments, second, first);
+
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure, result.Outcome);
+            Assert.Equal(result.Outcome, reversed.Outcome);
+            Assert.Equal(scenario.Reason, result.ArgumentFailure!.Reason);
+            Assert.Equal(result.ArgumentFailure.Reason, reversed.ArgumentFailure!.Reason);
+            Assert.Equal(scenario.Kind, result.RequestKind);
+            Assert.Equal(result.RequestKind, reversed.RequestKind);
+            Assert.Equal(3, result.Position);
+            Assert.Equal(result.Position, reversed.Position);
+        }
+    }
+
+    [Fact]
+    public void LaterCommonLoweringFailuresSurviveCandidateSpecificErrors()
+    {
+        CandidateFixture first =
+            new("first", extraOptionName: "--only-in-first");
+        CandidateFixture second = new("second");
+        (string[] Suffix, CliRowSelectionOccurrenceKind Kind, int Position,
+            CliRowSelectionFailureReason Reason)[] cases =
+        [
+            (["--rows", "bad"], CliRowSelectionOccurrenceKind.Rows, 3,
+                CliRowSelectionFailureReason.InvalidWindowForm),
+            (["--head", "--tail"], CliRowSelectionOccurrenceKind.Tail, 4,
+                CliRowSelectionFailureReason.ConflictingDirection),
+            (["--rows", "1..2", "--rows", "2..3"], CliRowSelectionOccurrenceKind.Rows, 5,
+                CliRowSelectionFailureReason.RepeatedGesture),
+            (["--rows", "bad", "--head", "--tail"], CliRowSelectionOccurrenceKind.Rows, 3,
+                CliRowSelectionFailureReason.InvalidWindowForm)
+        ];
+        foreach (var scenario in cases)
+        {
+            string[] arguments = ["Target", "-n", "--only-in-first", .. scenario.Suffix];
+            CliRowSelectionRouteEnvelopeResult result = Evaluate(arguments, first, second);
+            CliRowSelectionRouteEnvelopeResult reversed = Evaluate(arguments, second, first);
+
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, result.Outcome);
+            Assert.Equal(result.Outcome, reversed.Outcome);
+            Assert.Equal(scenario.Reason, result.Failure!.Reason);
+            Assert.Equal(result.Failure.Reason, reversed.Failure!.Reason);
+            Assert.Equal(scenario.Kind, result.RequestKind);
+            Assert.Equal(result.RequestKind, reversed.RequestKind);
+            Assert.Equal(scenario.Position, result.Position);
+            Assert.Equal(result.Position, reversed.Position);
+        }
+    }
+
+    [Fact]
     public void CandidateSpecificArityDoesNotTruncateLineUnitEvidence()
     {
         CandidateFixture ownsFollowingOption =
@@ -999,6 +1069,90 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void MissingCanonicalAliasesRemainExplicitRequests()
+    {
+        static CandidateFixture Renamed(string name) =>
+            new(
+                name,
+                limitName: "--limit",
+                rowsName: "--window",
+                topName: "--rank",
+                orderByName: "--sort",
+                headName: "--first",
+                tailName: "--last",
+                linesName: "--text",
+                tailLinesName: "--last-text");
+
+        CandidateFixture first = Renamed("first");
+        CandidateFixture second = Renamed("second");
+        CandidateFixture canonical = new("canonical");
+        (string Token, string? Value, CliRowSelectionOccurrenceKind Kind)[] options =
+        [
+            ("-n", "2", CliRowSelectionOccurrenceKind.Limit),
+            ("--rows", "1..2", CliRowSelectionOccurrenceKind.Rows),
+            ("--top", "2", CliRowSelectionOccurrenceKind.Top),
+            ("--order-by", "name", CliRowSelectionOccurrenceKind.OrderBy),
+            ("--head", null, CliRowSelectionOccurrenceKind.Head),
+            ("--tail", null, CliRowSelectionOccurrenceKind.Tail),
+            ("--lines", null, CliRowSelectionOccurrenceKind.Lines),
+            ("--tail-lines", null, CliRowSelectionOccurrenceKind.TailLines)
+        ];
+        foreach (var option in options)
+        {
+            string[][] forms = option.Value is { } value
+                ?
+                [
+                    ["Target", option.Token, value],
+                    ["Target", $"{option.Token}={value}"],
+                    ["Target", $"{option.Token}:{value}"]
+                ]
+                :
+                [
+                    ["Target", option.Token],
+                    ["Target", $"{option.Token}=true"],
+                    ["Target", $"{option.Token}:true"]
+                ];
+            foreach (string[] arguments in forms)
+            {
+                CliRowSelectionRouteEnvelopeResult unsupported =
+                    Evaluate(arguments, first, second);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability,
+                    unsupported.Outcome);
+                Assert.Equal(option.Kind, unsupported.RequestKind);
+                Assert.Equal(1, unsupported.Position);
+
+                CliRowSelectionRouteEnvelopeResult mixed =
+                    Evaluate(arguments, canonical, first);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(arguments, first, canonical);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.ExplicitCommandRequired,
+                    mixed.Outcome);
+                Assert.Equal(mixed.Outcome, reversed.Outcome);
+                Assert.Equal(option.Kind, mixed.RequestKind);
+                Assert.Equal(mixed.RequestKind, reversed.RequestKind);
+                Assert.Equal(1, mixed.Position);
+                Assert.Equal(mixed.Position, reversed.Position);
+            }
+        }
+
+        CliRowSelectionRouteEnvelopeResult compact =
+            Evaluate(["Target", "-n2"], first, second);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability, compact.Outcome);
+        Assert.Equal(CliRowSelectionOccurrenceKind.Limit, compact.RequestKind);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            Evaluate(["Target", "-2"], first, second).Outcome);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            Evaluate(["Target", "--", "-n", "2"], first, second).Outcome);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Success,
+            Evaluate(["Target", "--limit", "2", "--window", "1..2"], first, second).Outcome);
+    }
+
+    [Fact]
     public void CanonicalValueSpellingsRequireMatchingBindings()
     {
         (string Canonical, string Renamed, string Value,
@@ -1147,10 +1301,15 @@ public sealed class CliRowSelectionRouterPreflightTests
             bool omitTopOrderBindings = false,
             string rowsName = "--rows",
             string topName = "--top",
-            string orderByName = "--order-by")
+            string orderByName = "--order-by",
+            string limitName = "-n",
+            string headName = "--head",
+            string tailName = "--tail",
+            string linesName = "--lines",
+            string tailLinesName = "--tail-lines")
         {
             Option<string[]> limit =
-                RowValueOption("-n");
+                RowValueOption(limitName);
             Option<string[]> rows =
                 RowValueOption(rowsName);
             Option<string[]>? top =
@@ -1162,13 +1321,13 @@ public sealed class CliRowSelectionRouterPreflightTests
                     ? null
                     : RowValueOption(orderByName);
             Option<bool> head =
-                ModifierOption("--head");
+                ModifierOption(headName);
             Option<bool> tail =
-                ModifierOption("--tail");
+                ModifierOption(tailName);
             Option<bool> lines =
-                ModifierOption("--lines");
+                ModifierOption(linesName);
             Option<bool> tailLines =
-                ModifierOption("--tail-lines");
+                ModifierOption(tailLinesName);
             var required =
                 new Option<string?>("--required")
                 {

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -1017,6 +1017,124 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void InheritedCountScopePreservesMissingCountFailures()
+    {
+        CandidateFixture first =
+            new("first", parentName: "scope", childName: "Target",
+                childDeclarations: RowDeclarations.All);
+        CandidateFixture second =
+            new("second", childName: "Target", childDeclarations: RowDeclarations.All);
+        (string Token, RowDeclarations Declaration,
+            CliRowSelectionOccurrenceKind Kind)[] modifiers =
+        [
+            ("--lines", RowDeclarations.Lines, CliRowSelectionOccurrenceKind.Lines),
+            ("--tail-lines", RowDeclarations.TailLines, CliRowSelectionOccurrenceKind.TailLines),
+            ("--head", RowDeclarations.Head, CliRowSelectionOccurrenceKind.Head),
+            ("--tail", RowDeclarations.Tail, CliRowSelectionOccurrenceKind.Tail)
+        ];
+        foreach (var modifier in modifiers)
+        {
+            CandidateFixture relevantScope =
+                new("relevant-scope", childName: "Target",
+                    childDeclarations: RowDeclarations.Limit | modifier.Declaration);
+            foreach (CandidateFixture other in new[] { second, relevantScope })
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(["Target", modifier.Token], first, other);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(["Target", modifier.Token], other, first);
+
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal(CliRowSelectionFailureReason.ModifierRequiresCount, result.Failure!.Reason);
+                Assert.Equal(result.Failure.Reason, reversed.Failure!.Reason);
+                Assert.Equal(modifier.Kind, result.RequestKind);
+                Assert.Equal(result.RequestKind, reversed.RequestKind);
+                Assert.Equal(1, result.Position);
+                Assert.Equal(result.Position, reversed.Position);
+
+                CliRowSelectionRouteEnvelopeResult suppliedCount =
+                    Evaluate(["Target", modifier.Token, "-n", "2"], first, other);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, suppliedCount.Outcome);
+                Assert.Equal([0], suppliedCount.DeferredPositions);
+            }
+        }
+    }
+
+    [Fact]
+    public void HiddenLineScopeDefersUnitDependentCapabilityChecks()
+    {
+        RowDeclarations inherited =
+            RowDeclarations.All & ~RowDeclarations.Lines & ~RowDeclarations.TailLines;
+        CandidateFixture first =
+            new("first", capabilities: CliRowSelectionCapabilities.Lines,
+                parentName: "scope", childName: "Target", childDeclarations: inherited);
+        CandidateFixture second =
+            new("second", capabilities: CliRowSelectionCapabilities.Lines,
+                childName: "Target", childDeclarations: inherited);
+
+        foreach (string modifier in new[] { "--lines", "--tail-lines" })
+        {
+            (string[] Arguments, int ChildPosition)[] cases =
+            [
+                (["Target", modifier, "-n", "2"], 0),
+                (["Target", "-n", "2", modifier], 0),
+                (["Target", modifier, "-n", "2", "--head"], 0),
+                (["Target", modifier, "-n", "2", "--tail"], 0),
+                (["Target", "-2", modifier], 0),
+                (["-n", "2", "Target", modifier], 2)
+            ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([scenario.ChildPosition], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+
+            CliRowSelectionRouteEnvelopeResult commonValueFailure =
+                Evaluate(["Target", modifier, "--rows", "bad", "-n", "2"], first, second);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, commonValueFailure.Outcome);
+            Assert.Equal(CliRowSelectionFailureReason.InvalidWindowForm, commonValueFailure.Failure!.Reason);
+            Assert.Equal(2, commonValueFailure.Position);
+
+            CandidateFixture unsupportedFirst =
+                new("unsupported-first", capabilities: CliRowSelectionCapabilities.HeadTail,
+                    childName: "Target", childDeclarations: inherited);
+            CandidateFixture unsupportedSecond =
+                new("unsupported-second", capabilities: CliRowSelectionCapabilities.HeadTail,
+                    childName: "Target", childDeclarations: inherited);
+            CliRowSelectionRouteEnvelopeResult commonUnsupported =
+                Evaluate(["Target", modifier, "-n", "2"], unsupportedFirst, unsupportedSecond);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability,
+                commonUnsupported.Outcome);
+            Assert.Equal(CliRowSelectionCapabilities.Lines, commonUnsupported.Failure!.MissingCapabilities);
+            Assert.Equal(1, commonUnsupported.Position);
+
+            CandidateFixture ordinaryFirst =
+                new("ordinary-first", capabilities: CliRowSelectionCapabilities.Lines);
+            CandidateFixture ordinarySecond =
+                new("ordinary-second", capabilities: CliRowSelectionCapabilities.Lines);
+            CliRowSelectionRouteEnvelopeResult ordinary =
+                Evaluate(["Target", modifier, "-n", "2"], ordinaryFirst, ordinarySecond);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Success, ordinary.Outcome);
+        }
+
+        CliRowSelectionRouteEnvelopeResult semanticUnsupported =
+            Evaluate(["Target", "-n", "2"], first, second);
+        Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability, semanticUnsupported.Outcome);
+        Assert.Equal(CliRowSelectionCapabilities.HeadTail, semanticUnsupported.Failure!.MissingCapabilities);
+        Assert.Equal(CliRowSelectionOccurrenceKind.Limit, semanticUnsupported.RequestKind);
+        Assert.Equal(1, semanticUnsupported.Position);
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -795,6 +795,53 @@ public sealed class CliRowSelectionRouterPreflightTests
         Assert.Null(reversed.RequestKind);
         Assert.Equal(1, result.Position);
         Assert.Equal(result.Position, reversed.Position);
+
+        CandidateFixture undeclaredTopMeaning =
+            new(
+                "undeclared-top-meaning",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Top);
+        CandidateFixture undeclaredRowsMeaning =
+            new(
+                "undeclared-rows-meaning",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Rows,
+                rowsName: "--top",
+                omitTopOrderBindings: true);
+        CliRowSelectionRouteEnvelopeResult undeclared =
+            Evaluate(
+                [
+                    "Target",
+                    "--top",
+                    "2"
+                ],
+                undeclaredTopMeaning,
+                undeclaredRowsMeaning);
+        CliRowSelectionRouteEnvelopeResult undeclaredReversed =
+            Evaluate(
+                [
+                    "Target",
+                    "--top",
+                    "2"
+                ],
+                undeclaredRowsMeaning,
+                undeclaredTopMeaning);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            undeclared.Outcome);
+        Assert.Equal(
+            undeclared.Outcome,
+            undeclaredReversed.Outcome);
+        Assert.Null(undeclared.RequestKind);
+        Assert.Null(undeclaredReversed.RequestKind);
+        Assert.Equal(1, undeclared.Position);
+        Assert.Equal(
+            undeclared.Position,
+            undeclaredReversed.Position);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -1135,6 +1135,165 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void ChildShadowedRowOptionsKeepTheirParsedOwner()
+    {
+        string[] aliases =
+            ["-n", "--rows", "--top", "--order-by", "--head", "--tail", "--lines", "--tail-lines"];
+        foreach (string alias in aliases)
+        {
+            CandidateFixture first =
+                new("first", capabilities: CliRowSelectionCapabilities.None,
+                    parentName: "scope", childName: "Target",
+                    childDeclarations: RowDeclarations.All, childOptionName: alias);
+            CandidateFixture second =
+                new("second", capabilities: CliRowSelectionCapabilities.None,
+                    childName: "Target", childDeclarations: RowDeclarations.All,
+                    childOptionName: alias);
+            (string[] Arguments, bool HasValue)[] cases =
+            [
+                (["Target", alias, "payload"], true),
+                (["Target", $"{alias}=payload"], true),
+                (["Target", $"{alias}:payload"], true),
+                (["Target", alias], false)
+            ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([0], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+
+                foreach (CandidateFixture fixture in new[] { first, second })
+                {
+                    string[] explicitArguments =
+                        [.. fixture.Candidate.CommandPrefix, .. scenario.Arguments];
+                    CliRowSelectionArgumentResult inspected =
+                        CliRowSelectionArgumentAdapter.InspectExplicit(
+                            fixture.Candidate.ParserRoot, explicitArguments, fixture.Candidate.Bindings);
+                    Assert.Empty(inspected.Occurrences);
+                    Assert.Empty(inspected.ArgumentFailures);
+
+                    CliRowSelectionArgumentResult lowered =
+                        CliRowSelectionArgumentAdapter.LowerExplicit(
+                            fixture.Candidate.ParserRoot, explicitArguments, fixture.Candidate.Bindings,
+                            CliRowSelectionCapabilities.All);
+                    Assert.Empty(lowered.Occurrences);
+                    Assert.Empty(lowered.ArgumentFailures);
+                    if (scenario.HasValue)
+                    {
+                        Assert.Empty(inspected.ParseErrors);
+                        Assert.Equal("payload", inspected.ParseResult.GetValue(fixture.ChildOption!));
+                        Assert.True(lowered.LoweringResult!.IsSuccess);
+                    }
+                    else
+                    {
+                        Assert.NotEmpty(inspected.ParseErrors);
+                        Assert.True(lowered.HasParseErrors);
+                        Assert.Null(lowered.LoweringResult);
+                    }
+                }
+            }
+
+            if (alias == "-n")
+            {
+                foreach (string shorthand in new[] { "-2", "-n2" })
+                {
+                    string[] arguments = ["Target", shorthand];
+                    CliRowSelectionRouteEnvelopeResult result = Evaluate(arguments, first, second);
+                    Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                    Assert.Equal([0], result.DeferredPositions);
+                    string[] explicitArguments = [.. first.Candidate.CommandPrefix, .. arguments];
+                    CliRowSelectionArgumentResult inspected =
+                        CliRowSelectionArgumentAdapter.InspectExplicit(
+                            first.Candidate.ParserRoot, explicitArguments, first.Candidate.Bindings);
+                    Assert.Equal(explicitArguments, inspected.Arguments);
+                    Assert.Empty(inspected.Occurrences);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void ChildShadowedLinesCannotCreateCountAbsenceOrCapabilities()
+    {
+        foreach (string modifier in new[] { "--lines", "--tail-lines" })
+        {
+            CandidateFixture first =
+                new("first", capabilities: CliRowSelectionCapabilities.Lines,
+                    parentName: "scope", childName: "Target",
+                    childDeclarations: RowDeclarations.All, childOptionName: modifier);
+            CandidateFixture second =
+                new("second", capabilities: CliRowSelectionCapabilities.Lines,
+                    childName: "Target", childDeclarations: RowDeclarations.All,
+                    childOptionName: modifier);
+            (string[] Arguments, int ChildPosition)[] cases =
+            [
+                (["Target", modifier, "-n2"], 0),
+                (["Target", modifier, "-2"], 0),
+                (["Target", modifier, "payload", "-n2"], 0),
+                (["Target", $"{modifier}=payload", "-n2"], 0),
+                ([modifier, "-n", "2", "Target", modifier, "payload"], 3)
+            ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([scenario.ChildPosition], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+
+            CandidateFixture unshadowed =
+                new("unshadowed", capabilities: CliRowSelectionCapabilities.Lines,
+                    childName: "Target", childDeclarations: RowDeclarations.All);
+            CliRowSelectionRouteEnvelopeResult neighbor =
+                Evaluate(["Target", modifier, "-n2"], unshadowed, unshadowed);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, neighbor.Outcome);
+            Assert.Equal([0], neighbor.DeferredPositions);
+        }
+    }
+
+    [Fact]
+    public void ChildShadowedCountCannotEstablishAbsence()
+    {
+        CandidateFixture first =
+            new("first", childName: "Target", childDeclarations: RowDeclarations.All,
+                childOptionName: "-n");
+        CandidateFixture second =
+            new("second", parentName: "scope", childName: "Target",
+                childDeclarations: RowDeclarations.All, childOptionName: "-n");
+        foreach (string modifier in new[] { "--lines", "--tail-lines", "--head", "--tail" })
+        {
+            (string[] Arguments, int ChildPosition)[] cases =
+            [
+                (["Target", modifier], 0),
+                (["Target", modifier, "-n", "payload"], 0),
+                (["-n", "2", "Target", modifier, "-n", "payload"], 2),
+                (["-2", "Target", modifier, "-n", "payload"], 1),
+                (["-n2", "Target", modifier, "-n", "payload"], 1)
+            ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([scenario.ChildPosition], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+        }
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =
@@ -1495,7 +1654,8 @@ public sealed class CliRowSelectionRouterPreflightTests
             string headName = "--head",
             string tailName = "--tail",
             string linesName = "--lines",
-            string tailLinesName = "--tail-lines")
+            string tailLinesName = "--tail-lines",
+            string? childOptionName = null)
         {
             Option<string[]> limit =
                 RowValueOption(limitName);
@@ -1635,6 +1795,14 @@ public sealed class CliRowSelectionRouterPreflightTests
                 {
                     tailLines.Recursive = true;
                 }
+                if (childOptionName is not null)
+                {
+                    ChildOption = new Option<string?>(childOptionName)
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    };
+                    child.Options.Add(ChildOption);
+                }
                 command.Subcommands.Add(child);
             }
 
@@ -1678,6 +1846,8 @@ public sealed class CliRowSelectionRouterPreflightTests
         }
 
         public CliRowSelectionRouteCandidate Candidate { get; }
+
+        public Option<string?>? ChildOption { get; }
 
         private static void Add(
             Command command,

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -946,6 +946,77 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void UnexpectedChildSelectionCannotEstablishCountAbsence()
+    {
+        CandidateFixture first =
+            new(
+                "first",
+                parentName: "scope",
+                childName: "Target",
+                childDeclarations: RowDeclarations.All & ~RowDeclarations.Limit);
+        CandidateFixture second =
+            new(
+                "second",
+                childName: "Target",
+                childDeclarations: RowDeclarations.All & ~RowDeclarations.Limit);
+
+        foreach (string modifier in new[] { "--lines", "--tail-lines", "--head", "--tail" })
+        {
+            (string[] Arguments, int ChildPosition)[] cases =
+            [
+                (["Target", modifier, "-n", "2"], 0),
+                (["Target", modifier, "-n"], 0),
+                (["Target", modifier, "-n=2"], 0),
+                (["Target", modifier, "-2"], 0),
+                (["-n", "2", "Target", modifier], 2)
+            ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([scenario.ChildPosition], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+
+            CliRowSelectionRouteEnvelopeResult commonValueFailure =
+                Evaluate(["Target", "--rows", "bad", modifier, "-n", "2"], first, second);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+                commonValueFailure.Outcome);
+            Assert.Equal(
+                CliRowSelectionFailureReason.InvalidWindowForm,
+                commonValueFailure.Failure!.Reason);
+            Assert.Equal(1, commonValueFailure.Position);
+
+            CliRowSelectionRouteEnvelopeResult commonArityFailure =
+                Evaluate(["Target", modifier, "--rows"], first, second);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure,
+                commonArityFailure.Outcome);
+            Assert.Equal(
+                CliRowSelectionArgumentFailureReason.MissingValue,
+                commonArityFailure.ArgumentFailure!.Reason);
+            Assert.Equal(CliRowSelectionOccurrenceKind.Rows, commonArityFailure.RequestKind);
+            Assert.Equal(2, commonArityFailure.Position);
+        }
+
+        CliRowSelectionRouteEnvelopeResult commonConflict =
+            Evaluate(["Target", "--head", "--tail", "-n", "2"], first, second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            commonConflict.Outcome);
+        Assert.Equal(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            commonConflict.Failure!.Reason);
+        Assert.Equal(2, commonConflict.Position);
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -1404,6 +1404,115 @@ public sealed class CliRowSelectionRouterPreflightTests
         Assert.Equal(1, commonValue.Position);
     }
 
+    [Theory]
+    [InlineData("--rows", "--lines")]
+    [InlineData("--rows", "--tail-lines")]
+    [InlineData("--order-by", "--lines")]
+    [InlineData("--order-by", "--tail-lines")]
+    [InlineData("-n", "--lines")]
+    [InlineData("-n", "--tail-lines")]
+    public void ScopeDependentValuesCannotFixCountUnits(string valueAlias, string modifier)
+    {
+        RowDeclarations inherited =
+            RowDeclarations.All & ~RowDeclarations.Lines & ~RowDeclarations.TailLines;
+        CliRowSelectionCapabilities withoutHeadTail =
+            CliRowSelectionCapabilities.All & ~CliRowSelectionCapabilities.HeadTail;
+        foreach (CliRowSelectionCapabilities firstCapabilities in new[]
+            { withoutHeadTail, CliRowSelectionCapabilities.All })
+        {
+            CandidateFixture first =
+                new("first", capabilities: firstCapabilities, parentName: "scope",
+                    childName: "Target", childDeclarations: inherited);
+            CandidateFixture second =
+                new("second", capabilities: withoutHeadTail,
+                    childName: "Target", childDeclarations: inherited);
+            (string[] Arguments, int ChildPosition)[] cases =
+                valueAlias == "-n"
+                    ? [
+                        (["Target", "-n", modifier], 0),
+                        (["Target", "--head", "-n", modifier], 0),
+                        (["Target", "--tail", "-n", modifier], 0)
+                    ]
+                    : [
+                        (["Target", valueAlias, modifier, "-n", "2"], 0),
+                        (["Target", valueAlias, modifier, "-2"], 0),
+                        (["-2", "Target", valueAlias, modifier], 1),
+                        (["Target", "--head", valueAlias, modifier, "-n", "2"], 0),
+                        (["Target", "--tail", valueAlias, modifier, "-n", "2"], 0)
+                    ];
+            foreach (var scenario in cases)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(scenario.Arguments, first, second);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(scenario.Arguments, second, first);
+                Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal([scenario.ChildPosition], result.DeferredPositions);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("--lines")]
+    [InlineData("--tail-lines")]
+    public void ScopeDependentUnitsPreserveIndependentFailures(string modifier)
+    {
+        RowDeclarations inherited =
+            RowDeclarations.All & ~RowDeclarations.Lines & ~RowDeclarations.TailLines;
+        CliRowSelectionCapabilities withoutHeadTail =
+            CliRowSelectionCapabilities.All & ~CliRowSelectionCapabilities.HeadTail;
+        CandidateFixture first =
+            new("first", capabilities: withoutHeadTail, parentName: "scope",
+                childName: "Target", childDeclarations: inherited, extraOptionName: "--other");
+        CandidateFixture second =
+            new("second", capabilities: withoutHeadTail,
+                childName: "Target", childDeclarations: inherited, extraOptionName: "--other");
+        CandidateFixture undeclaredFirst =
+            new("undeclared-first", declarations: inherited, capabilities: withoutHeadTail,
+                childName: "Target", childDeclarations: inherited);
+        CandidateFixture undeclaredSecond =
+            new("undeclared-second", declarations: inherited, capabilities: withoutHeadTail,
+                childName: "Target", childDeclarations: inherited);
+
+        foreach (bool reverse in new[] { false, true })
+        {
+            CandidateFixture[] candidates = reverse ? [second, first] : [first, second];
+            CliRowSelectionRouteEnvelopeResult independentValue =
+                Evaluate(["--rows", "bad", "Target", "--order-by", modifier, "-n", "2"], candidates);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.LoweringFailure, independentValue.Outcome);
+            Assert.Equal(CliRowSelectionFailureReason.InvalidWindowForm, independentValue.Failure!.Reason);
+            Assert.Equal(0, independentValue.Position);
+
+            CliRowSelectionRouteEnvelopeResult independentArity =
+                Evaluate(["Target", "--order-by", modifier, "--rows"], candidates);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure, independentArity.Outcome);
+            Assert.Equal(CliRowSelectionArgumentFailureReason.MissingValue, independentArity.ArgumentFailure!.Reason);
+            Assert.Equal(3, independentArity.Position);
+
+            CliRowSelectionRouteEnvelopeResult nonLineValue =
+                Evaluate(["Target", "--rows", "--other", "-n", "2"], candidates);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability, nonLineValue.Outcome);
+            Assert.Equal(CliRowSelectionCapabilities.HeadTail, nonLineValue.Failure!.MissingCapabilities);
+            Assert.Equal(CliRowSelectionOccurrenceKind.Limit, nonLineValue.RequestKind);
+            Assert.Equal(3, nonLineValue.Position);
+
+            CliRowSelectionRouteEnvelopeResult determinateValue =
+                Evaluate(["Target", "--order-by", modifier, "-n", "2"],
+                    reverse ? [undeclaredSecond, undeclaredFirst] : [undeclaredFirst, undeclaredSecond]);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability, determinateValue.Outcome);
+            Assert.Equal(CliRowSelectionCapabilities.HeadTail, determinateValue.Failure!.MissingCapabilities);
+            Assert.Equal(CliRowSelectionOccurrenceKind.Limit, determinateValue.RequestKind);
+            Assert.Equal(3, determinateValue.Position);
+
+            CliRowSelectionRouteEnvelopeResult attached =
+                Evaluate(["Target", "--rows=1..2", modifier, "-n", "2"], candidates);
+            Assert.Equal(CliRowSelectionRouteEnvelopeOutcome.Deferred, attached.Outcome);
+            Assert.Equal([0], attached.DeferredPositions);
+        }
+    }
+
     [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -614,6 +614,39 @@ public sealed class CliRowSelectionRouterPreflightTests
         Assert.Equal([1], reordered.DeferredPositions);
     }
 
+    [Fact]
+    public void CandidateBindingsMayOmitTopGrammar()
+    {
+        CandidateFixture windowOnly =
+            new(
+                "window-only",
+                omitTopOrderBindings: true);
+
+        CliRowSelectionRouteEnvelopeResult noRequest =
+            Evaluate(
+                ["Target"],
+                windowOnly);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            noRequest.Outcome);
+
+        CliRowSelectionRouteEnvelopeResult unsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "--top",
+                    "2"
+                ],
+                windowOnly);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            unsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Top,
+            unsupported.RequestKind);
+    }
+
     private static CliRowSelectionRouteEnvelopeResult Evaluate(
         string[] arguments,
         params CandidateFixture[] candidates) =>
@@ -659,16 +692,21 @@ public sealed class CliRowSelectionRouterPreflightTests
             string? childName = null,
             RowDeclarations childDeclarations =
                 RowDeclarations.None,
-            string? extraOptionName = null)
+            string? extraOptionName = null,
+            bool omitTopOrderBindings = false)
         {
             Option<string[]> limit =
                 RowValueOption("-n");
             Option<string[]> rows =
                 RowValueOption("--rows");
-            Option<string[]> top =
-                RowValueOption("--top");
-            Option<string[]> orderBy =
-                RowValueOption("--order-by");
+            Option<string[]>? top =
+                omitTopOrderBindings
+                    ? null
+                    : RowValueOption("--top");
+            Option<string[]>? orderBy =
+                omitTopOrderBindings
+                    ? null
+                    : RowValueOption("--order-by");
             Option<bool> head =
                 ModifierOption("--head");
             Option<bool> tail =
@@ -696,16 +734,22 @@ public sealed class CliRowSelectionRouterPreflightTests
                 declarations,
                 RowDeclarations.Rows,
                 rows);
-            Add(
-                command,
-                declarations,
-                RowDeclarations.Top,
-                top);
-            Add(
-                command,
-                declarations,
-                RowDeclarations.OrderBy,
-                orderBy);
+            if (top is not null)
+            {
+                Add(
+                    command,
+                    declarations,
+                    RowDeclarations.Top,
+                    top);
+            }
+            if (orderBy is not null)
+            {
+                Add(
+                    command,
+                    declarations,
+                    RowDeclarations.OrderBy,
+                    orderBy);
+            }
             Add(
                 command,
                 declarations,
@@ -756,12 +800,18 @@ public sealed class CliRowSelectionRouterPreflightTests
                 if ((childDeclarations
                         & RowDeclarations.Top) != 0)
                 {
-                    top.Recursive = true;
+                    if (top is not null)
+                    {
+                        top.Recursive = true;
+                    }
                 }
                 if ((childDeclarations
                         & RowDeclarations.OrderBy) != 0)
                 {
-                    orderBy.Recursive = true;
+                    if (orderBy is not null)
+                    {
+                        orderBy.Recursive = true;
+                    }
                 }
                 if ((childDeclarations
                         & RowDeclarations.Head) != 0)

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -226,6 +226,23 @@ public sealed class CliRowSelectionRouterPreflightTests
             explicitLimit.RequestKind);
         Assert.Equal(1, explicitLimit.Position);
 
+        CliRowSelectionRouteEnvelopeResult attachedExplicitLimit =
+            Evaluate(
+                [
+                    "Target",
+                    "-n=5"
+                ],
+                declared,
+                undeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            attachedExplicitLimit.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Limit,
+            attachedExplicitLimit.RequestKind);
+        Assert.Equal(1, attachedExplicitLimit.Position);
+
         CandidateFixture alsoUndeclared =
             new(
                 "also-undeclared",
@@ -248,6 +265,22 @@ public sealed class CliRowSelectionRouterPreflightTests
         Assert.Equal(
             CliRowSelectionCapabilities.HeadTail,
             unsupported.Failure!.MissingCapabilities);
+
+        CliRowSelectionRouteEnvelopeResult attachedUnsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "-n:5"
+                ],
+                undeclared,
+                alsoUndeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            attachedUnsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Limit,
+            attachedUnsupported.RequestKind);
 
         CliRowSelectionRouteEnvelopeResult unboundBare =
             Evaluate(
@@ -315,6 +348,60 @@ public sealed class CliRowSelectionRouterPreflightTests
         Assert.Equal(
             CliRowSelectionCapabilities.Window,
             unsupported.Failure!.MissingCapabilities);
+
+        CliRowSelectionRouteEnvelopeResult attachedUnsupportedWindow =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows=1..2"
+                ],
+                noWindow,
+                alsoNoWindow);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            attachedUnsupportedWindow.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            attachedUnsupportedWindow.RequestKind);
+
+        CliRowSelectionRouteEnvelopeResult attachedMixedWindow =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows:1..2"
+                ],
+                window,
+                noWindow);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            attachedMixedWindow.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            attachedMixedWindow.RequestKind);
+
+        CliRowSelectionRouteEnvelopeResult neighboringAttachedWindow =
+            Evaluate(
+                [
+                    "Target",
+                    "-5",
+                    "--rows=2..4"
+                ],
+                new CandidateFixture(
+                    "all-capabilities"),
+                new CandidateFixture(
+                    "headtail-only",
+                    capabilities:
+                        CliRowSelectionCapabilities.HeadTail));
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            neighboringAttachedWindow.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            neighboringAttachedWindow.RequestKind);
+        Assert.Equal(2, neighboringAttachedWindow.Position);
 
         CandidateFixture semanticOnly =
             new(
@@ -444,6 +531,26 @@ public sealed class CliRowSelectionRouterPreflightTests
             CliRowSelectionOccurrenceKind.OrderBy,
             firstUnsupported.RequestKind);
         Assert.Equal(1, firstUnsupported.Position);
+
+        CliRowSelectionRouteEnvelopeResult attachedTop =
+            Evaluate(
+                [
+                    "Target",
+                    "--top=3"
+                ],
+                new CandidateFixture(
+                    "top-capable"),
+                new CandidateFixture(
+                    "not-top-capable",
+                    capabilities:
+                        CliRowSelectionCapabilities.None));
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            attachedTop.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Top,
+            attachedTop.RequestKind);
     }
 
     [Fact]
@@ -615,6 +722,82 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void DeferredLineModifierCannotChangeEarlierCountMeaning()
+    {
+        CandidateFixture lineIsRequiredValue =
+            new(
+                "line-is-required-value",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Lines,
+                requiredArity:
+                    ArgumentArity.ExactlyOne);
+        CandidateFixture lineIsModifier =
+            new(
+                "line-is-modifier",
+                requiredArity:
+                    ArgumentArity.ZeroOrOne);
+
+        CliRowSelectionRouteEnvelopeResult result =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "2",
+                    "--required",
+                    "--lines"
+                ],
+                lineIsRequiredValue,
+                lineIsModifier);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            result.Outcome);
+        Assert.Equal([4], result.DeferredPositions);
+    }
+
+    [Fact]
+    public void MixedMeaningsDoNotSelectACandidateKind()
+    {
+        CandidateFixture topMeaning =
+            new("top-meaning");
+        CandidateFixture rowsMeaning =
+            new(
+                "rows-meaning",
+                rowsName: "--top",
+                omitTopOrderBindings: true);
+
+        CliRowSelectionRouteEnvelopeResult result =
+            Evaluate(
+                [
+                    "Target",
+                    "--top",
+                    "2"
+                ],
+                topMeaning,
+                rowsMeaning);
+        CliRowSelectionRouteEnvelopeResult reversed =
+            Evaluate(
+                [
+                    "Target",
+                    "--top",
+                    "2"
+                ],
+                rowsMeaning,
+                topMeaning);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            result.Outcome);
+        Assert.Equal(result.Outcome, reversed.Outcome);
+        Assert.Null(result.RequestKind);
+        Assert.Null(reversed.RequestKind);
+        Assert.Equal(1, result.Position);
+        Assert.Equal(result.Position, reversed.Position);
+    }
+
+    [Fact]
     public void CandidateBindingsMayOmitTopGrammar()
     {
         CandidateFixture windowOnly =
@@ -693,12 +876,13 @@ public sealed class CliRowSelectionRouterPreflightTests
             RowDeclarations childDeclarations =
                 RowDeclarations.None,
             string? extraOptionName = null,
-            bool omitTopOrderBindings = false)
+            bool omitTopOrderBindings = false,
+            string rowsName = "--rows")
         {
             Option<string[]> limit =
                 RowValueOption("-n");
             Option<string[]> rows =
-                RowValueOption("--rows");
+                RowValueOption(rowsName);
             Option<string[]>? top =
                 omitTopOrderBindings
                     ? null

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -1,0 +1,859 @@
+using System.CommandLine;
+using DotnetInspector.CommandLine;
+using DotnetInspector.RowSelection;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+public sealed class CliRowSelectionRouterPreflightTests
+{
+    [Fact]
+    public void CommonRequestLowersWithoutRouting()
+    {
+        CandidateFixture first = new("first");
+        CandidateFixture second = new("second");
+
+        CliRowSelectionRouteEnvelopeResult result =
+            Evaluate(
+                ["Target", "-5"],
+                first,
+                second);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Success,
+            result.Outcome);
+        Assert.NotNull(result.LoweringResult);
+        RowSelectionIntentOperation<string> operation =
+            Assert.Single(
+                result.LoweringResult!.Value!
+                    .SemanticIntent.Operations);
+        Assert.Equal(
+            RowSelectionStageKind.Head,
+            operation.Kind);
+        Assert.Equal(5, operation.Count);
+
+        CliRowSelectionRouteEnvelopeResult unrelatedUnknown =
+            Evaluate(
+                [
+                    "Target",
+                    "--unknown",
+                    "-n",
+                    "2"
+                ],
+                first,
+                second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Success,
+            unrelatedUnknown.Outcome);
+        Assert.Equal(
+            2,
+            Assert.Single(
+                unrelatedUnknown.LoweringResult!.Value!
+                    .SemanticIntent.Operations)
+                .Count);
+
+        CliRowSelectionRouteEnvelopeResult noRequest =
+            Evaluate(
+                [
+                    "Target",
+                    "--unknown"
+                ],
+                first,
+                second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            noRequest.Outcome);
+
+        CliRowSelectionRouteEnvelopeResult afterTerminator =
+            Evaluate(
+                [
+                    "Target",
+                    "--",
+                    "-5"
+                ],
+                first,
+                second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            afterTerminator.Outcome);
+    }
+
+    [Fact]
+    public void RequiredValueUnionDefersOnlyDependentDecisions()
+    {
+        CandidateFixture required =
+            new(
+                "required",
+                requiredArity:
+                    ArgumentArity.ExactlyOne);
+        CandidateFixture optional =
+            new(
+                "optional",
+                requiredArity:
+                    ArgumentArity.ZeroOrOne);
+
+        CliRowSelectionRouteEnvelopeResult deferred =
+            Evaluate(
+                [
+                    "Target",
+                    "--required",
+                    "-5"
+                ],
+                required,
+                optional);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            deferred.Outcome);
+        Assert.Equal(
+            [2],
+            deferred.DeferredPositions);
+
+        CandidateFixture alsoRequired =
+            new(
+                "also-required",
+                requiredArity:
+                    ArgumentArity.ExactlyOne);
+        CliRowSelectionRouteEnvelopeResult protectedValue =
+            Evaluate(
+                [
+                    "Target",
+                    "--required",
+                    "-5"
+                ],
+                required,
+                alsoRequired);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            protectedValue.Outcome);
+
+        CliRowSelectionRouteEnvelopeResult commonEarlierFailure =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "bad",
+                    "--required",
+                    "-5"
+                ],
+                required,
+                optional);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            commonEarlierFailure.Outcome);
+        Assert.Equal(
+            CliRowSelectionFailureReason.InvalidWindowForm,
+            commonEarlierFailure.Failure!.Reason);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            commonEarlierFailure.Failure.OccurrenceKind);
+        Assert.Equal(
+            1,
+            commonEarlierFailure.Failure.Position);
+
+        CandidateFixture noWindow =
+            new(
+                "no-window",
+                capabilities:
+                    CliRowSelectionCapabilities.None,
+                requiredArity:
+                    ArgumentArity.ExactlyOne);
+        CandidateFixture noWindowOptional =
+            new(
+                "no-window-optional",
+                capabilities:
+                    CliRowSelectionCapabilities.None,
+                requiredArity:
+                    ArgumentArity.ZeroOrOne);
+        CliRowSelectionRouteEnvelopeResult independentFailure =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "1..2",
+                    "--required",
+                    "-5"
+                ],
+                noWindow,
+                noWindowOptional);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            independentFailure.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            independentFailure.RequestKind);
+    }
+
+    [Fact]
+    public void MixedDeclarationsPreserveExplicitOptionIdentity()
+    {
+        CandidateFixture declared = new("declared");
+        CandidateFixture undeclared =
+            new(
+                "undeclared",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Limit);
+
+        CliRowSelectionRouteEnvelopeResult bare =
+            Evaluate(
+                [
+                    "Target",
+                    "-5"
+                ],
+                declared,
+                undeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            bare.Outcome);
+        Assert.Equal([1], bare.DeferredPositions);
+
+        CliRowSelectionRouteEnvelopeResult explicitLimit =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "5"
+                ],
+                declared,
+                undeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            explicitLimit.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Limit,
+            explicitLimit.RequestKind);
+        Assert.Equal(1, explicitLimit.Position);
+
+        CandidateFixture alsoUndeclared =
+            new(
+                "also-undeclared",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Limit);
+        CliRowSelectionRouteEnvelopeResult unsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "5"
+                ],
+                undeclared,
+                alsoUndeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            unsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionCapabilities.HeadTail,
+            unsupported.Failure!.MissingCapabilities);
+
+        CliRowSelectionRouteEnvelopeResult unboundBare =
+            Evaluate(
+                [
+                    "Target",
+                    "-5"
+                ],
+                undeclared,
+                alsoUndeclared);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.NoRequest,
+            unboundBare.Outcome);
+    }
+
+    [Fact]
+    public void CandidateCapabilitiesAreComparedPerRequest()
+    {
+        CandidateFixture window =
+            new(
+                "window",
+                capabilities:
+                    CliRowSelectionCapabilities.Window);
+        CandidateFixture noWindow =
+            new(
+                "no-window",
+                capabilities:
+                    CliRowSelectionCapabilities.None);
+
+        CliRowSelectionRouteEnvelopeResult mixed =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "1..2"
+                ],
+                window,
+                noWindow);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            mixed.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            mixed.RequestKind);
+        Assert.Equal(1, mixed.Position);
+
+        CandidateFixture alsoNoWindow =
+            new(
+                "also-no-window",
+                capabilities:
+                    CliRowSelectionCapabilities.None);
+        CliRowSelectionRouteEnvelopeResult unsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "1..2"
+                ],
+                noWindow,
+                alsoNoWindow);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            unsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionCapabilities.Window,
+            unsupported.Failure!.MissingCapabilities);
+
+        CandidateFixture semanticOnly =
+            new(
+                "semantic-only",
+                capabilities:
+                    CliRowSelectionCapabilities.HeadTail);
+        CandidateFixture lines =
+            new(
+                "lines",
+                capabilities:
+                    CliRowSelectionCapabilities.Lines);
+        CliRowSelectionRouteEnvelopeResult lineUnit =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "2",
+                    "--lines"
+                ],
+                semanticOnly,
+                lines);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            lineUnit.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Limit,
+            lineUnit.RequestKind);
+        Assert.Equal(1, lineUnit.Position);
+
+        CandidateFixture mixedLineDeclaration =
+            new(
+                "mixed-line",
+                capabilities:
+                    CliRowSelectionCapabilities.Lines);
+        CandidateFixture semanticWithLineCapability =
+            new(
+                "semantic-with-line-capability",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Lines,
+                capabilities:
+                    CliRowSelectionCapabilities.Lines);
+        CliRowSelectionRouteEnvelopeResult mixedLineMeaning =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "2",
+                    "--lines"
+                ],
+                mixedLineDeclaration,
+                semanticWithLineCapability);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            mixedLineMeaning.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Limit,
+            mixedLineMeaning.RequestKind);
+        Assert.Equal(1, mixedLineMeaning.Position);
+
+        CandidateFixture noLineDeclaration =
+            new(
+                "no-line-declaration",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Lines,
+                capabilities:
+                    CliRowSelectionCapabilities.HeadTail);
+        CandidateFixture alsoNoLineDeclaration =
+            new(
+                "also-no-line-declaration",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.Lines,
+                capabilities:
+                    CliRowSelectionCapabilities.HeadTail);
+        CliRowSelectionRouteEnvelopeResult undeclaredLineUnit =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "2",
+                    "--lines"
+                ],
+                noLineDeclaration,
+                alsoNoLineDeclaration);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            undeclaredLineUnit.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Lines,
+            undeclaredLineUnit.RequestKind);
+        Assert.Equal(3, undeclaredLineUnit.Position);
+
+        CandidateFixture noOrder =
+            new(
+                "no-order",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.OrderBy
+                    & ~RowDeclarations.Top);
+        CandidateFixture topOnly =
+            new(
+                "top-only",
+                declarations:
+                    RowDeclarations.All
+                    & ~RowDeclarations.OrderBy);
+        CliRowSelectionRouteEnvelopeResult firstUnsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "--order-by",
+                    "name",
+                    "--top",
+                    "3"
+                ],
+                noOrder,
+                topOnly);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            firstUnsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.OrderBy,
+            firstUnsupported.RequestKind);
+        Assert.Equal(1, firstUnsupported.Position);
+    }
+
+    [Fact]
+    public void CommonFailuresUseOriginalImplicitArgvPositions()
+    {
+        CandidateFixture first =
+            new(
+                "first",
+                parentName: "outer");
+        CandidateFixture second =
+            new(
+                "second",
+                parentName: "outer");
+
+        CliRowSelectionRouteEnvelopeResult missing =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows"
+                ],
+                first,
+                second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure,
+            missing.Outcome);
+        Assert.Equal(
+            CliRowSelectionArgumentFailureReason.MissingValue,
+            missing.ArgumentFailure!.Reason);
+        Assert.Equal(1, missing.ArgumentFailure.Position);
+
+        CliRowSelectionRouteEnvelopeResult repeated =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "1",
+                    "-2"
+                ],
+                first,
+                second);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            repeated.Outcome);
+        Assert.Equal(
+            CliRowSelectionFailureReason.RepeatedGesture,
+            repeated.Failure!.Reason);
+        Assert.Equal(3, repeated.Failure.Position);
+    }
+
+    [Fact]
+    public void UnexpectedChildSelectionDefersToRouting()
+    {
+        CandidateFixture ordinary =
+            new("ordinary");
+        CandidateFixture withTargetSubcommand =
+            new(
+                "with-child",
+                childName: "Target",
+                childDeclarations:
+                    RowDeclarations.All);
+
+        CliRowSelectionRouteEnvelopeResult result =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "2"
+                ],
+                ordinary,
+                withTargetSubcommand);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            result.Outcome);
+        Assert.Equal([0], result.DeferredPositions);
+
+        CliRowSelectionRouteEnvelopeResult commonFailure =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "bad"
+                ],
+                ordinary,
+                withTargetSubcommand);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            commonFailure.Outcome);
+        Assert.Equal(
+            CliRowSelectionFailureReason.InvalidWindowForm,
+            commonFailure.Failure!.Reason);
+        Assert.Equal(1, commonFailure.Failure.Position);
+
+        CandidateFixture unsupportedOrdinary =
+            new(
+                "unsupported-ordinary",
+                capabilities:
+                    CliRowSelectionCapabilities.None);
+        CandidateFixture unsupportedWithChild =
+            new(
+                "unsupported-with-child",
+                capabilities:
+                    CliRowSelectionCapabilities.None,
+                childName: "Target",
+                childDeclarations:
+                    RowDeclarations.All);
+        CliRowSelectionRouteEnvelopeResult commonUnsupported =
+            Evaluate(
+                [
+                    "Target",
+                    "--rows",
+                    "1..2"
+                ],
+                unsupportedOrdinary,
+                unsupportedWithChild);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            commonUnsupported.Outcome);
+        Assert.Equal(
+            CliRowSelectionOccurrenceKind.Rows,
+            commonUnsupported.RequestKind);
+        Assert.Equal(1, commonUnsupported.Position);
+    }
+
+    [Fact]
+    public void CandidateSpecificParserErrorsCannotManufactureACommonRequest()
+    {
+        CandidateFixture ownsFollowingOption =
+            new(
+                "owns-option",
+                extraOptionName:
+                    "--only-in-first");
+        CandidateFixture doesNotOwnFollowingOption =
+            new("does-not-own-option");
+        CandidateFixture third =
+            new("third");
+
+        CliRowSelectionRouteEnvelopeResult result =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "--only-in-first"
+                ],
+                ownsFollowingOption,
+                doesNotOwnFollowingOption,
+                third);
+
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            result.Outcome);
+        Assert.Equal([1], result.DeferredPositions);
+
+        CliRowSelectionRouteEnvelopeResult reordered =
+            Evaluate(
+                [
+                    "Target",
+                    "-n",
+                    "--only-in-first"
+                ],
+                third,
+                ownsFollowingOption,
+                doesNotOwnFollowingOption);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            reordered.Outcome);
+        Assert.Equal([1], reordered.DeferredPositions);
+    }
+
+    private static CliRowSelectionRouteEnvelopeResult Evaluate(
+        string[] arguments,
+        params CandidateFixture[] candidates) =>
+        CliRowSelectionRouteEnvelope.Evaluate(
+            arguments,
+            candidates
+                .Select(candidate => candidate.Candidate)
+                .ToArray());
+
+    [Flags]
+    private enum RowDeclarations
+    {
+        None = 0,
+        Limit = 1,
+        Rows = 2,
+        Top = 4,
+        OrderBy = 8,
+        Head = 16,
+        Tail = 32,
+        Lines = 64,
+        TailLines = 128,
+        All =
+            Limit
+            | Rows
+            | Top
+            | OrderBy
+            | Head
+            | Tail
+            | Lines
+            | TailLines
+    }
+
+    private sealed class CandidateFixture
+    {
+        public CandidateFixture(
+            string name,
+            RowDeclarations declarations =
+                RowDeclarations.All,
+            CliRowSelectionCapabilities capabilities =
+                CliRowSelectionCapabilities.All,
+            ArgumentArity? requiredArity = null,
+            string? parentName = null,
+            string? childName = null,
+            RowDeclarations childDeclarations =
+                RowDeclarations.None,
+            string? extraOptionName = null)
+        {
+            Option<string[]> limit =
+                RowValueOption("-n");
+            Option<string[]> rows =
+                RowValueOption("--rows");
+            Option<string[]> top =
+                RowValueOption("--top");
+            Option<string[]> orderBy =
+                RowValueOption("--order-by");
+            Option<bool> head =
+                ModifierOption("--head");
+            Option<bool> tail =
+                ModifierOption("--tail");
+            Option<bool> lines =
+                ModifierOption("--lines");
+            Option<bool> tailLines =
+                ModifierOption("--tail-lines");
+            var required =
+                new Option<string?>("--required")
+                {
+                    Arity =
+                        requiredArity
+                        ?? ArgumentArity.ZeroOrOne
+                };
+            var command =
+                new Command(name);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Limit,
+                limit);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Rows,
+                rows);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Top,
+                top);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.OrderBy,
+                orderBy);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Head,
+                head);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Tail,
+                tail);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.Lines,
+                lines);
+            Add(
+                command,
+                declarations,
+                RowDeclarations.TailLines,
+                tailLines);
+            command.Options.Add(required);
+            if (extraOptionName is not null)
+            {
+                command.Options.Add(
+                    ModifierOption(
+                        extraOptionName));
+            }
+            command.Arguments.Add(
+                new Argument<string[]>("values")
+                {
+                    Arity =
+                        ArgumentArity.ZeroOrMore
+                });
+            if (childName is not null)
+            {
+                var child =
+                    new Command(childName);
+                if ((childDeclarations
+                        & RowDeclarations.Limit) != 0)
+                {
+                    limit.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.Rows) != 0)
+                {
+                    rows.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.Top) != 0)
+                {
+                    top.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.OrderBy) != 0)
+                {
+                    orderBy.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.Head) != 0)
+                {
+                    head.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.Tail) != 0)
+                {
+                    tail.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.Lines) != 0)
+                {
+                    lines.Recursive = true;
+                }
+                if ((childDeclarations
+                        & RowDeclarations.TailLines) != 0)
+                {
+                    tailLines.Recursive = true;
+                }
+                command.Subcommands.Add(child);
+            }
+
+            var root = new RootCommand();
+            string[] prefix;
+            if (parentName is null)
+            {
+                root.Subcommands.Add(command);
+                prefix = [name];
+            }
+            else
+            {
+                var parent =
+                    new Command(parentName)
+                    {
+                        command
+                    };
+                root.Subcommands.Add(parent);
+                prefix =
+                    [
+                        parentName,
+                        name
+                    ];
+            }
+
+            Candidate =
+                new(
+                    root,
+                    command,
+                    prefix,
+                    new(
+                        limit,
+                        rows,
+                        top,
+                        orderBy,
+                        head,
+                        tail,
+                        lines,
+                        tailLines),
+                    capabilities);
+        }
+
+        public CliRowSelectionRouteCandidate Candidate { get; }
+
+        private static void Add(
+            Command command,
+            RowDeclarations declarations,
+            RowDeclarations declaration,
+            Option option)
+        {
+            if ((declarations & declaration) != 0)
+            {
+                command.Options.Add(option);
+            }
+        }
+
+        private static Option<string[]> RowValueOption(
+            string name) =>
+            new(name)
+            {
+                Arity =
+                    ArgumentArity.OneOrMore,
+                AllowMultipleArgumentsPerToken = false
+            };
+
+        private static Option<bool> ModifierOption(
+            string name) =>
+            new(name)
+            {
+                Arity =
+                    ArgumentArity.Zero
+            };
+    }
+}

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -722,6 +722,47 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void CandidateSpecificArityDoesNotTruncateLineUnitEvidence()
+    {
+        CandidateFixture ownsFollowingOption =
+            new("owns-option", extraOptionName: "--only-in-first");
+        CandidateFixture doesNotOwnFollowingOption =
+            new("does-not-own-option");
+
+        foreach (string modifier in new[] { "--lines", "--tail-lines" })
+        {
+            string[][] inputs =
+            [
+                ["Target", "-n", "--only-in-first", modifier],
+                ["Target", modifier, "-n", "--only-in-first"],
+                ["Target", "-n", "2", "--rows", "--only-in-first", modifier]
+            ];
+            foreach (string[] arguments in inputs)
+            {
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(arguments, ownsFollowingOption, doesNotOwnFollowingOption);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(arguments, doesNotOwnFollowingOption, ownsFollowingOption);
+
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.Deferred,
+                    result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+            }
+
+            CliRowSelectionRouteEnvelopeResult determinate =
+                Evaluate(
+                    ["Target", "-n=2", "--only-in-first", modifier],
+                    ownsFollowingOption,
+                    doesNotOwnFollowingOption);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.Success,
+                determinate.Outcome);
+        }
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =
@@ -845,6 +886,73 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void CanonicalValueSpellingsRequireMatchingBindings()
+    {
+        (string Canonical, string Renamed, string Value,
+            CliRowSelectionOccurrenceKind Kind)[] options =
+        [
+            ("--top", "--rank", "2", CliRowSelectionOccurrenceKind.Top),
+            ("--order-by", "--sort", "name", CliRowSelectionOccurrenceKind.OrderBy)
+        ];
+        foreach (var option in options)
+        {
+            string[][] inputs =
+            [
+                ["Target", option.Canonical, option.Value],
+                ["Target", $"{option.Canonical}={option.Value}"],
+                ["Target", $"{option.Canonical}:{option.Value}"]
+            ];
+            foreach (string[] arguments in inputs)
+            {
+                CandidateFixture canonical = new("canonical");
+                CandidateFixture renamed =
+                    new("renamed", topName: "--rank", orderByName: "--sort");
+                CandidateFixture alsoRenamed =
+                    new("also-renamed", topName: "--rank", orderByName: "--sort");
+
+                CliRowSelectionRouteEnvelopeResult result =
+                    Evaluate(arguments, canonical, renamed);
+                CliRowSelectionRouteEnvelopeResult reversed =
+                    Evaluate(arguments, renamed, canonical);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.ExplicitCommandRequired,
+                    result.Outcome);
+                Assert.Equal(result.Outcome, reversed.Outcome);
+                Assert.Equal(option.Kind, result.RequestKind);
+                Assert.Equal(result.RequestKind, reversed.RequestKind);
+                Assert.Equal(1, result.Position);
+                Assert.Equal(result.Position, reversed.Position);
+
+                CliRowSelectionRouteEnvelopeResult unsupported =
+                    Evaluate(arguments, renamed, alsoRenamed);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.UnsupportedCapability,
+                    unsupported.Outcome);
+                Assert.Equal(option.Kind, unsupported.RequestKind);
+
+                CliRowSelectionRouteEnvelopeResult custom =
+                    Evaluate(
+                        ["Target", option.Renamed, option.Value],
+                        renamed,
+                        alsoRenamed);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.Success,
+                    custom.Outcome);
+
+                Option binding = option.Kind == CliRowSelectionOccurrenceKind.Top
+                    ? renamed.Candidate.Bindings.Top!
+                    : renamed.Candidate.Bindings.OrderBy!;
+                binding.Aliases.Add(option.Canonical);
+                CliRowSelectionRouteEnvelopeResult aliased =
+                    Evaluate(arguments, canonical, renamed);
+                Assert.Equal(
+                    CliRowSelectionRouteEnvelopeOutcome.Success,
+                    aliased.Outcome);
+            }
+        }
+    }
+
+    [Fact]
     public void CandidateBindingsMayOmitTopGrammar()
     {
         CandidateFixture windowOnly =
@@ -924,7 +1032,9 @@ public sealed class CliRowSelectionRouterPreflightTests
                 RowDeclarations.None,
             string? extraOptionName = null,
             bool omitTopOrderBindings = false,
-            string rowsName = "--rows")
+            string rowsName = "--rows",
+            string topName = "--top",
+            string orderByName = "--order-by")
         {
             Option<string[]> limit =
                 RowValueOption("-n");
@@ -933,11 +1043,11 @@ public sealed class CliRowSelectionRouterPreflightTests
             Option<string[]>? top =
                 omitTopOrderBindings
                     ? null
-                    : RowValueOption("--top");
+                    : RowValueOption(topName);
             Option<string[]>? orderBy =
                 omitTopOrderBindings
                     ? null
-                    : RowValueOption("--order-by");
+                    : RowValueOption(orderByName);
             Option<bool> head =
                 ModifierOption("--head");
             Option<bool> tail =

--- a/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
+++ b/src/dotnet-inspect.Tests/CliRowSelectionRouterPreflightTests.cs
@@ -763,6 +763,119 @@ public sealed class CliRowSelectionRouterPreflightTests
     }
 
     [Fact]
+    public void TruncatedOccurrencesCannotEstablishMissingCount()
+    {
+        (string Token, RowDeclarations Declaration,
+            CliRowSelectionOccurrenceKind Kind)[] modifiers =
+        [
+            ("--lines", RowDeclarations.Lines, CliRowSelectionOccurrenceKind.Lines),
+            ("--tail-lines", RowDeclarations.TailLines, CliRowSelectionOccurrenceKind.TailLines),
+            ("--head", RowDeclarations.Head, CliRowSelectionOccurrenceKind.Head),
+            ("--tail", RowDeclarations.Tail, CliRowSelectionOccurrenceKind.Tail)
+        ];
+        CandidateFixture ordinary = new("ordinary");
+        CandidateFixture withoutCount =
+            new("without-count", declarations: RowDeclarations.All & ~RowDeclarations.Limit);
+
+        foreach (var modifier in modifiers)
+        {
+            CandidateFixture partialChild =
+                new(
+                    "partial-child",
+                    childName: "Target",
+                    childDeclarations: modifier.Declaration);
+            (CandidateFixture Other, CliRowSelectionRouteEnvelopeOutcome Outcome)[] cases =
+            [
+                (withoutCount, CliRowSelectionRouteEnvelopeOutcome.ExplicitCommandRequired),
+                (partialChild, CliRowSelectionRouteEnvelopeOutcome.Deferred)
+            ];
+            foreach (var candidate in cases)
+            {
+                foreach (string[] arguments in new string[][]
+                {
+                    ["Target", modifier.Token, "-n"],
+                    ["Target", modifier.Token, "-n", "2"]
+                })
+                {
+                    CliRowSelectionRouteEnvelopeResult result =
+                        Evaluate(arguments, ordinary, candidate.Other);
+                    CliRowSelectionRouteEnvelopeResult reversed =
+                        Evaluate(arguments, candidate.Other, ordinary);
+
+                    Assert.Equal(candidate.Outcome, result.Outcome);
+                    Assert.Equal(result.Outcome, reversed.Outcome);
+                    Assert.Equal(result.RequestKind, reversed.RequestKind);
+                    Assert.Equal(result.Position, reversed.Position);
+                    Assert.Equal(result.DeferredPositions, reversed.DeferredPositions);
+                    if (candidate.Outcome
+                        == CliRowSelectionRouteEnvelopeOutcome.ExplicitCommandRequired)
+                    {
+                        Assert.Equal(CliRowSelectionOccurrenceKind.Limit, result.RequestKind);
+                        Assert.Equal(2, result.Position);
+                    }
+                    else
+                    {
+                        Assert.Equal([0], result.DeferredPositions);
+                    }
+                }
+            }
+
+            CandidateFixture completeChild =
+                new(
+                    "complete-child",
+                    childName: "Target",
+                    childDeclarations: modifier.Declaration | RowDeclarations.Limit);
+            CliRowSelectionRouteEnvelopeResult commonArity =
+                Evaluate(["Target", modifier.Token, "-n"], ordinary, completeChild);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure,
+                commonArity.Outcome);
+            Assert.Equal(
+                CliRowSelectionArgumentFailureReason.MissingValue,
+                commonArity.ArgumentFailure!.Reason);
+            Assert.Equal(CliRowSelectionOccurrenceKind.Limit, commonArity.RequestKind);
+            Assert.Equal(2, commonArity.Position);
+
+            CliRowSelectionRouteEnvelopeResult realAbsence =
+                Evaluate(["Target", modifier.Token], ordinary, withoutCount);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+                realAbsence.Outcome);
+            Assert.Equal(
+                CliRowSelectionFailureReason.ModifierRequiresCount,
+                realAbsence.Failure!.Reason);
+            Assert.Equal(modifier.Kind, realAbsence.RequestKind);
+            Assert.Equal(1, realAbsence.Position);
+
+            CliRowSelectionRouteEnvelopeResult prefixValueFailure =
+                Evaluate(
+                    ["Target", "--rows", "bad", modifier.Token, "-n"],
+                    ordinary,
+                    withoutCount);
+            Assert.Equal(
+                CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+                prefixValueFailure.Outcome);
+            Assert.Equal(
+                CliRowSelectionFailureReason.InvalidWindowForm,
+                prefixValueFailure.Failure!.Reason);
+            Assert.Equal(1, prefixValueFailure.Position);
+        }
+
+        CliRowSelectionRouteEnvelopeResult prefixConflict =
+            Evaluate(
+                ["Target", "--head", "--tail", "-n"],
+                ordinary,
+                withoutCount);
+        Assert.Equal(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            prefixConflict.Outcome);
+        Assert.Equal(
+            CliRowSelectionFailureReason.ConflictingDirection,
+            prefixConflict.Failure!.Reason);
+        Assert.Equal(2, prefixConflict.Position);
+    }
+
+    [Fact]
     public void DeferredLineModifierCannotChangeEarlierCountMeaning()
     {
         CandidateFixture lineIsRequiredValue =

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -282,16 +282,12 @@ internal static class CliRowSelectionArgumentAdapter
         CliRowSelectionOptionBindings bindings,
         out CliRowSelectionOccurrenceKind kind)
     {
-        foreach (BoundOption bound in BoundOptions(bindings))
+        if (TryClassifyBoundRowToken(
+                token,
+                bindings,
+                out kind))
         {
-            if (IsOptionToken(
-                    token,
-                    bound.Option,
-                    bindings.Limit))
-            {
-                kind = bound.Kind;
-                return true;
-            }
+            return true;
         }
 
         if (MatchesCanonicalValueOption(
@@ -308,6 +304,27 @@ internal static class CliRowSelectionArgumentAdapter
         {
             kind = CliRowSelectionOccurrenceKind.OrderBy;
             return true;
+        }
+
+        kind = default;
+        return false;
+    }
+
+    internal static bool TryClassifyBoundRowToken(
+        string token,
+        CliRowSelectionOptionBindings bindings,
+        out CliRowSelectionOccurrenceKind kind)
+    {
+        foreach (BoundOption bound in BoundOptions(bindings))
+        {
+            if (IsOptionToken(
+                    token,
+                    bound.Option,
+                    bindings.Limit))
+            {
+                kind = bound.Kind;
+                return true;
+            }
         }
 
         kind = default;

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -79,6 +79,7 @@ internal sealed class CliRowSelectionArgumentResult
 {
     private readonly ReadOnlyCollection<string> _arguments;
     private readonly ReadOnlyCollection<ParseError> _parseErrors;
+    private readonly ReadOnlyCollection<int> _requiredValuePositions;
     private readonly ReadOnlyCollection<
         CliRowSelectionOccurrence<string>> _occurrences;
 
@@ -86,24 +87,30 @@ internal sealed class CliRowSelectionArgumentResult
         string[] arguments,
         ParseResult parseResult,
         IReadOnlyList<ParseError> parseErrors,
+        IReadOnlyList<int> requiredValuePositions,
         IReadOnlyList<CliRowSelectionOccurrence<string>> occurrences,
         CliRowSelectionArgumentFailure? argumentFailure,
-        CliRowSelectionLoweringResult<string>? loweringResult)
+        CliRowSelectionLoweringResult<string>? loweringResult,
+        int? selectedCommandPosition)
     {
         ArgumentNullException.ThrowIfNull(arguments);
         ArgumentNullException.ThrowIfNull(parseResult);
         ArgumentNullException.ThrowIfNull(parseErrors);
+        ArgumentNullException.ThrowIfNull(requiredValuePositions);
         ArgumentNullException.ThrowIfNull(occurrences);
 
         _arguments =
             Array.AsReadOnly((string[])arguments.Clone());
         _parseErrors =
             Array.AsReadOnly(parseErrors.ToArray());
+        _requiredValuePositions =
+            Array.AsReadOnly(requiredValuePositions.ToArray());
         _occurrences =
             Array.AsReadOnly(occurrences.ToArray());
         ParseResult = parseResult;
         ArgumentFailure = argumentFailure;
         LoweringResult = loweringResult;
+        SelectedCommandPosition = selectedCommandPosition;
     }
 
     public IReadOnlyList<string> Arguments => _arguments;
@@ -119,9 +126,14 @@ internal sealed class CliRowSelectionArgumentResult
 
     public bool HasParseErrors => _parseErrors.Count > 0;
 
+    public IReadOnlyList<int> RequiredValuePositions =>
+        _requiredValuePositions;
+
     public CliRowSelectionArgumentFailure? ArgumentFailure { get; }
 
     public CliRowSelectionLoweringResult<string>? LoweringResult { get; }
+
+    public int? SelectedCommandPosition { get; }
 }
 
 internal static class CliRowSelectionArgumentAdapter
@@ -139,6 +151,30 @@ internal static class CliRowSelectionArgumentAdapter
         string[] arguments,
         CliRowSelectionOptionBindings bindings,
         CliRowSelectionCapabilities capabilities)
+        => AnalyzeExplicit(
+            command,
+            arguments,
+            bindings,
+            capabilities,
+            preserveRowEvidenceAcrossParseErrors: false);
+
+    internal static CliRowSelectionArgumentResult InspectExplicit(
+        Command command,
+        string[] arguments,
+        CliRowSelectionOptionBindings bindings)
+        => AnalyzeExplicit(
+            command,
+            arguments,
+            bindings,
+            CliRowSelectionCapabilities.All,
+            preserveRowEvidenceAcrossParseErrors: true);
+
+    private static CliRowSelectionArgumentResult AnalyzeExplicit(
+        Command command,
+        string[] arguments,
+        CliRowSelectionOptionBindings bindings,
+        CliRowSelectionCapabilities capabilities,
+        bool preserveRowEvidenceAcrossParseErrors)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -153,6 +189,12 @@ internal static class CliRowSelectionArgumentAdapter
             MapArguments(
                 ownershipParse,
                 arguments);
+        int[] requiredValuePositions =
+            preserveRowEvidenceAcrossParseErrors
+                ? FindRequiredValuePositions(
+                    ownershipParse,
+                    ownershipArguments)
+                : [];
         NormalizedArguments normalized =
             NormalizeShortLimitForms(
                 ownershipParse,
@@ -172,6 +214,12 @@ internal static class CliRowSelectionArgumentAdapter
                 : MapArguments(
                     authoritativeParse,
                     normalized.Arguments);
+        int? selectedCommandPosition =
+            FindTokenPosition(
+                authoritativeArguments,
+                normalized,
+                authoritativeParse.CommandResult
+                    .IdentifierToken);
         ParseError[] parseErrors =
             authoritativeParse.Errors.ToArray();
         CliRowSelectionArgumentFailure? argumentFailure =
@@ -181,33 +229,99 @@ internal static class CliRowSelectionArgumentAdapter
                 normalized,
                 bindings);
 
-        if (parseErrors.Length > 0
-            || argumentFailure is not null)
+        if (!preserveRowEvidenceAcrossParseErrors
+            && (parseErrors.Length > 0
+                || argumentFailure is not null))
         {
             return new(
                 normalized.Arguments,
                 authoritativeParse,
                 parseErrors,
+                requiredValuePositions,
                 Array.Empty<
                     CliRowSelectionOccurrence<string>>(),
                 argumentFailure,
-                null);
+                null,
+                selectedCommandPosition);
         }
 
         CliRowSelectionOccurrence<string>[] occurrences =
             ExtractOccurrences(
                 authoritativeArguments,
                 normalized,
-                bindings);
+                bindings,
+                preserveRowEvidenceAcrossParseErrors
+                    ? argumentFailure?.Position
+                    : null);
         return new(
             normalized.Arguments,
             authoritativeParse,
             parseErrors,
+            requiredValuePositions,
             occurrences,
-            null,
+            argumentFailure,
             CliRowSelectionLowerer.Lower(
                 occurrences,
-                capabilities));
+                capabilities),
+            selectedCommandPosition);
+    }
+
+    internal static bool IsBareLimitShorthand(string token) =>
+        IsBareShorthand(token);
+
+    internal static bool HasShortLimitAlias(
+        CliRowSelectionOptionBindings bindings) =>
+        Aliases(bindings.Limit).Any(
+            alias =>
+                alias.Equals(
+                    "-n",
+                    StringComparison.Ordinal));
+
+    internal static bool TryClassifyExplicitRowToken(
+        string token,
+        CliRowSelectionOptionBindings bindings,
+        out CliRowSelectionOccurrenceKind kind)
+    {
+        foreach (BoundOption bound in BoundOptions(bindings))
+        {
+            if (IsOptionToken(
+                    token,
+                    bound.Option,
+                    bindings.Limit))
+            {
+                kind = bound.Kind;
+                return true;
+            }
+        }
+
+        kind = default;
+        return false;
+    }
+
+    internal static bool IsDeclared(
+        ParseResult parseResult,
+        CliRowSelectionOptionBindings bindings,
+        CliRowSelectionOccurrenceKind kind)
+    {
+        Option option =
+            BoundOptions(bindings)
+                .Single(bound => bound.Kind == kind)
+                .Option;
+        for (CommandResult? command = parseResult.CommandResult;
+            command is not null;
+            command = command.Parent as CommandResult)
+        {
+            if (command.Command.Options.Any(
+                    candidate =>
+                        ReferenceEquals(
+                            candidate,
+                            option)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static ParseResult ParseExplicit(
@@ -483,6 +597,65 @@ internal static class CliRowSelectionArgumentAdapter
                                     ReferenceEquals(
                                         token,
                                         candidate))));
+    }
+
+    private static int[] FindRequiredValuePositions(
+        ParseResult parseResult,
+        IReadOnlyList<ParsedArgument> parsedArguments)
+    {
+        IReadOnlyList<OptionResult> optionResults =
+            GetOptionResults(parseResult);
+        var positions = new List<int>();
+        for (int index = 0;
+            index < parsedArguments.Count;
+            index++)
+        {
+            ParsedArgument argument =
+                parsedArguments[index];
+            if (optionResults.Any(
+                    option =>
+                        option.Option.Arity.MinimumNumberOfValues > 0
+                        && argument.Tokens.Any(
+                            candidate =>
+                                candidate.Type == TokenType.Argument
+                                && option.Tokens.Any(
+                                    token =>
+                                        ReferenceEquals(
+                                            token,
+                                            candidate)))))
+            {
+                positions.Add(index);
+            }
+        }
+
+        return [.. positions];
+    }
+
+    private static int? FindTokenPosition(
+        IReadOnlyList<ParsedArgument> parsedArguments,
+        NormalizedArguments normalized,
+        Token? target)
+    {
+        if (target is null)
+        {
+            return null;
+        }
+
+        for (int index = 0;
+            index < parsedArguments.Count;
+            index++)
+        {
+            if (parsedArguments[index].Tokens.Any(
+                    token =>
+                        ReferenceEquals(
+                            token,
+                            target)))
+            {
+                return normalized.Positions[index];
+            }
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<OptionResult> GetOptionResults(
@@ -890,7 +1063,8 @@ internal static class CliRowSelectionArgumentAdapter
         ExtractOccurrences(
             IReadOnlyList<ParsedArgument> parsedArguments,
             NormalizedArguments normalized,
-            CliRowSelectionOptionBindings bindings)
+            CliRowSelectionOptionBindings bindings,
+            int? stopBeforePosition = null)
     {
         var occurrences =
             new List<CliRowSelectionOccurrence<string>>();
@@ -909,6 +1083,12 @@ internal static class CliRowSelectionArgumentAdapter
 
             int position =
                 normalized.Positions[index];
+            if (stopBeforePosition is not null
+                && position >= stopBeforePosition.Value)
+            {
+                break;
+            }
+
             foreach (BoundOption bound in boundOptions)
             {
                 int valueIndex = index;
@@ -919,6 +1099,7 @@ internal static class CliRowSelectionArgumentAdapter
                         ref valueIndex,
                         token,
                         bound.Option,
+                        bindings.Limit,
                         out string? value))
                 {
                     occurrences.Add(
@@ -1006,11 +1187,13 @@ internal static class CliRowSelectionArgumentAdapter
         ref int index,
         string token,
         Option option,
+        Option limit,
         out string value)
     {
         if (!TryClassifyValueToken(
                 token,
                 option,
+                limit,
                 out bool consumesNext,
                 out string? attachedValue,
                 out string? alias)
@@ -1035,18 +1218,7 @@ internal static class CliRowSelectionArgumentAdapter
     private static bool TryClassifyValueToken(
         string token,
         Option option,
-        out bool consumesNext,
-        out string? matchedAlias) =>
-        TryClassifyValueToken(
-            token,
-            option,
-            out consumesNext,
-            out _,
-            out matchedAlias);
-
-    private static bool TryClassifyValueToken(
-        string token,
-        Option option,
+        Option limit,
         out bool consumesNext,
         out string? attachedValue,
         out string? matchedAlias)
@@ -1079,7 +1251,15 @@ internal static class CliRowSelectionArgumentAdapter
                     return true;
                 }
 
-                if (IsShortAlias(alias))
+                if (ReferenceEquals(
+                        option,
+                        limit)
+                    && alias.Equals(
+                        "-n",
+                        StringComparison.Ordinal)
+                    && IsCompactShortLimitToken(
+                        token,
+                        alias))
                 {
                     consumesNext = false;
                     attachedValue =
@@ -1130,9 +1310,6 @@ internal static class CliRowSelectionArgumentAdapter
             }
         }
     }
-
-    private static bool IsShortAlias(string alias) =>
-        alias is ['-', not '-'];
 
     private readonly record struct NormalizedArguments(
         string[] Arguments,

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -79,6 +79,7 @@ internal sealed class CliRowSelectionArgumentResult
 {
     private readonly ReadOnlyCollection<string> _arguments;
     private readonly ReadOnlyCollection<ParseError> _parseErrors;
+    private readonly ReadOnlyCollection<CliRowSelectionArgumentFailure> _argumentFailures;
     private readonly ReadOnlyCollection<int> _requiredValuePositions;
     private readonly ReadOnlyCollection<
         CliRowSelectionOccurrence<string>> _occurrences;
@@ -89,13 +90,14 @@ internal sealed class CliRowSelectionArgumentResult
         IReadOnlyList<ParseError> parseErrors,
         IReadOnlyList<int> requiredValuePositions,
         IReadOnlyList<CliRowSelectionOccurrence<string>> occurrences,
-        CliRowSelectionArgumentFailure? argumentFailure,
+        IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
         CliRowSelectionLoweringResult<string>? loweringResult,
         int? selectedCommandPosition)
     {
         ArgumentNullException.ThrowIfNull(arguments);
         ArgumentNullException.ThrowIfNull(parseResult);
         ArgumentNullException.ThrowIfNull(parseErrors);
+        ArgumentNullException.ThrowIfNull(argumentFailures);
         ArgumentNullException.ThrowIfNull(requiredValuePositions);
         ArgumentNullException.ThrowIfNull(occurrences);
 
@@ -103,12 +105,13 @@ internal sealed class CliRowSelectionArgumentResult
             Array.AsReadOnly((string[])arguments.Clone());
         _parseErrors =
             Array.AsReadOnly(parseErrors.ToArray());
+        _argumentFailures =
+            Array.AsReadOnly(argumentFailures.ToArray());
         _requiredValuePositions =
             Array.AsReadOnly(requiredValuePositions.ToArray());
         _occurrences =
             Array.AsReadOnly(occurrences.ToArray());
         ParseResult = parseResult;
-        ArgumentFailure = argumentFailure;
         LoweringResult = loweringResult;
         SelectedCommandPosition = selectedCommandPosition;
     }
@@ -129,7 +132,11 @@ internal sealed class CliRowSelectionArgumentResult
     public IReadOnlyList<int> RequiredValuePositions =>
         _requiredValuePositions;
 
-    public CliRowSelectionArgumentFailure? ArgumentFailure { get; }
+    public IReadOnlyList<CliRowSelectionArgumentFailure> ArgumentFailures =>
+        _argumentFailures;
+
+    public CliRowSelectionArgumentFailure? ArgumentFailure =>
+        _argumentFailures.FirstOrDefault();
 
     public CliRowSelectionLoweringResult<string>? LoweringResult { get; }
 
@@ -138,6 +145,19 @@ internal sealed class CliRowSelectionArgumentResult
 
 internal static class CliRowSelectionArgumentAdapter
 {
+    private static readonly (string Alias, CliRowSelectionOccurrenceKind Kind)[]
+        CanonicalOptions =
+        [
+            ("-n", CliRowSelectionOccurrenceKind.Limit),
+            ("--rows", CliRowSelectionOccurrenceKind.Rows),
+            ("--top", CliRowSelectionOccurrenceKind.Top),
+            ("--order-by", CliRowSelectionOccurrenceKind.OrderBy),
+            ("--head", CliRowSelectionOccurrenceKind.Head),
+            ("--tail", CliRowSelectionOccurrenceKind.Tail),
+            ("--lines", CliRowSelectionOccurrenceKind.Lines),
+            ("--tail-lines", CliRowSelectionOccurrenceKind.TailLines)
+        ];
+
     private static readonly ParserConfiguration
         ExplicitParserConfiguration =
             new()
@@ -222,8 +242,8 @@ internal static class CliRowSelectionArgumentAdapter
                     .IdentifierToken);
         ParseError[] parseErrors =
             authoritativeParse.Errors.ToArray();
-        CliRowSelectionArgumentFailure? argumentFailure =
-            FindArgumentFailure(
+        CliRowSelectionArgumentFailure[] argumentFailures =
+            FindArgumentFailures(
                 authoritativeParse,
                 authoritativeArguments,
                 normalized,
@@ -231,7 +251,7 @@ internal static class CliRowSelectionArgumentAdapter
 
         if (!preserveRowEvidenceAcrossParseErrors
             && (parseErrors.Length > 0
-                || argumentFailure is not null))
+                || argumentFailures.Length > 0))
         {
             return new(
                 normalized.Arguments,
@@ -240,7 +260,7 @@ internal static class CliRowSelectionArgumentAdapter
                 requiredValuePositions,
                 Array.Empty<
                     CliRowSelectionOccurrence<string>>(),
-                argumentFailure,
+                argumentFailures,
                 null,
                 selectedCommandPosition);
         }
@@ -250,16 +270,16 @@ internal static class CliRowSelectionArgumentAdapter
                 authoritativeArguments,
                 normalized,
                 bindings,
-                preserveRowEvidenceAcrossParseErrors
-                    ? argumentFailure?.Position
-                    : null);
+                argumentFailures
+                    .Select(failure => failure.Position)
+                    .ToHashSet());
         return new(
             normalized.Arguments,
             authoritativeParse,
             parseErrors,
             requiredValuePositions,
             occurrences,
-            argumentFailure,
+            argumentFailures,
             CliRowSelectionLowerer.Lower(
                 occurrences,
                 capabilities),
@@ -290,20 +310,15 @@ internal static class CliRowSelectionArgumentAdapter
             return true;
         }
 
-        if (MatchesCanonicalValueOption(
-                token,
-                "--top"))
+        foreach (var canonical in CanonicalOptions)
         {
-            kind = CliRowSelectionOccurrenceKind.Top;
-            return true;
-        }
-
-        if (MatchesCanonicalValueOption(
-                token,
-                "--order-by"))
-        {
-            kind = CliRowSelectionOccurrenceKind.OrderBy;
-            return true;
+            if (MatchesCanonicalOption(token, canonical.Alias)
+                || canonical.Kind == CliRowSelectionOccurrenceKind.Limit
+                && IsCompactShortLimitToken(token, canonical.Alias))
+            {
+                kind = canonical.Kind;
+                return true;
+            }
         }
 
         kind = default;
@@ -331,7 +346,7 @@ internal static class CliRowSelectionArgumentAdapter
         return false;
     }
 
-    private static bool MatchesCanonicalValueOption(
+    private static bool MatchesCanonicalOption(
         string token,
         string alias) =>
         token.Equals(
@@ -870,13 +885,14 @@ internal static class CliRowSelectionArgumentAdapter
         }
     }
 
-    private static CliRowSelectionArgumentFailure?
-        FindArgumentFailure(
+    private static CliRowSelectionArgumentFailure[]
+        FindArgumentFailures(
             ParseResult parseResult,
             IReadOnlyList<ParsedArgument> parsedArguments,
             NormalizedArguments normalized,
             CliRowSelectionOptionBindings bindings)
     {
+        var failures = new List<CliRowSelectionArgumentFailure>();
         BoundOption[] boundOptions =
             BoundOptions(bindings);
         for (int index = 0;
@@ -902,9 +918,11 @@ internal static class CliRowSelectionArgumentAdapter
                         bound.Option,
                         bindings.Limit))
                 {
-                    return MissingValueFailure(
-                        bound.Kind,
-                        normalized.Positions[index]);
+                    failures.Add(
+                        MissingValueFailure(
+                            bound.Kind,
+                            normalized.Positions[index]));
+                    break;
                 }
 
                 if (!bound.HasValue
@@ -916,14 +934,16 @@ internal static class CliRowSelectionArgumentAdapter
                         parsedArguments[index],
                         alias!))
                 {
-                    return AttachedModifierFailure(
-                        bound.Kind,
-                        normalized.Positions[index]);
+                    failures.Add(
+                        AttachedModifierFailure(
+                            bound.Kind,
+                            normalized.Positions[index]));
+                    break;
                 }
             }
         }
 
-        return null;
+        return [.. failures];
     }
 
     private static bool IsMissingValue(
@@ -1121,7 +1141,7 @@ internal static class CliRowSelectionArgumentAdapter
             IReadOnlyList<ParsedArgument> parsedArguments,
             NormalizedArguments normalized,
             CliRowSelectionOptionBindings bindings,
-            int? stopBeforePosition = null)
+            IReadOnlySet<int> invalidPositions)
     {
         var occurrences =
             new List<CliRowSelectionOccurrence<string>>();
@@ -1140,10 +1160,9 @@ internal static class CliRowSelectionArgumentAdapter
 
             int position =
                 normalized.Positions[index];
-            if (stopBeforePosition is not null
-                && position >= stopBeforePosition.Value)
+            if (invalidPositions.Contains(position))
             {
-                break;
+                continue;
             }
 
             foreach (BoundOption bound in boundOptions)

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -651,7 +651,8 @@ internal static class CliRowSelectionArgumentAdapter
         {
             ParsedArgument argument =
                 parsedArguments[index];
-            if (optionResults.Any(
+            if (!HasOptionToken(argument)
+                && optionResults.Any(
                     option =>
                         option.Option.Arity.MinimumNumberOfValues > 0
                         && argument.Tokens.Any(

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -361,7 +361,8 @@ internal static class CliRowSelectionArgumentAdapter
     internal static bool IsDeclared(
         ParseResult parseResult,
         CliRowSelectionOptionBindings bindings,
-        CliRowSelectionOccurrenceKind kind)
+        CliRowSelectionOccurrenceKind kind,
+        bool recursiveAncestorsOnly = false)
     {
         Option? option = null;
         foreach (BoundOption bound in BoundOptions(bindings))
@@ -382,7 +383,10 @@ internal static class CliRowSelectionArgumentAdapter
             command is not null;
             command = command.Parent as CommandResult)
         {
-            if (command.Command.Options.Any(
+            if ((!recursiveAncestorsOnly
+                    || ReferenceEquals(command, parseResult.CommandResult)
+                    || option.Recursive)
+                && command.Command.Options.Any(
                     candidate =>
                         ReferenceEquals(
                             candidate,

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -75,6 +75,10 @@ internal sealed class CliRowSelectionArgumentFailure
     public int Position { get; }
 }
 
+internal readonly record struct CliRowSelectionScopeDependentArgument(
+    int OptionPosition,
+    int FollowingPosition);
+
 internal sealed class CliRowSelectionArgumentResult
 {
     private readonly ReadOnlyCollection<string> _arguments;
@@ -82,7 +86,7 @@ internal sealed class CliRowSelectionArgumentResult
     private readonly ReadOnlyCollection<CliRowSelectionArgumentFailure> _argumentFailures;
     private readonly ReadOnlyCollection<int> _requiredValuePositions;
     private readonly ReadOnlyCollection<int> _shadowedRowOptionPositions;
-    private readonly ReadOnlyCollection<int> _scopeDependentArgumentPositions;
+    private readonly ReadOnlyCollection<CliRowSelectionScopeDependentArgument> _scopeDependentArguments;
     private readonly ReadOnlyCollection<
         CliRowSelectionOccurrence<string>> _occurrences;
 
@@ -92,7 +96,7 @@ internal sealed class CliRowSelectionArgumentResult
         IReadOnlyList<ParseError> parseErrors,
         IReadOnlyList<int> requiredValuePositions,
         IReadOnlyList<int> shadowedRowOptionPositions,
-        IReadOnlyList<int> scopeDependentArgumentPositions,
+        IReadOnlyList<CliRowSelectionScopeDependentArgument> scopeDependentArguments,
         IReadOnlyList<CliRowSelectionOccurrence<string>> occurrences,
         IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
         CliRowSelectionLoweringResult<string>? loweringResult,
@@ -104,7 +108,7 @@ internal sealed class CliRowSelectionArgumentResult
         ArgumentNullException.ThrowIfNull(argumentFailures);
         ArgumentNullException.ThrowIfNull(requiredValuePositions);
         ArgumentNullException.ThrowIfNull(shadowedRowOptionPositions);
-        ArgumentNullException.ThrowIfNull(scopeDependentArgumentPositions);
+        ArgumentNullException.ThrowIfNull(scopeDependentArguments);
         ArgumentNullException.ThrowIfNull(occurrences);
 
         _arguments =
@@ -117,8 +121,8 @@ internal sealed class CliRowSelectionArgumentResult
             Array.AsReadOnly(requiredValuePositions.ToArray());
         _shadowedRowOptionPositions =
             Array.AsReadOnly(shadowedRowOptionPositions.ToArray());
-        _scopeDependentArgumentPositions =
-            Array.AsReadOnly(scopeDependentArgumentPositions.ToArray());
+        _scopeDependentArguments =
+            Array.AsReadOnly(scopeDependentArguments.ToArray());
         _occurrences =
             Array.AsReadOnly(occurrences.ToArray());
         ParseResult = parseResult;
@@ -145,8 +149,8 @@ internal sealed class CliRowSelectionArgumentResult
     public IReadOnlyList<int> ShadowedRowOptionPositions =>
         _shadowedRowOptionPositions;
 
-    public IReadOnlyList<int> ScopeDependentArgumentPositions =>
-        _scopeDependentArgumentPositions;
+    public IReadOnlyList<CliRowSelectionScopeDependentArgument> ScopeDependentArguments =>
+        _scopeDependentArguments;
 
     public IReadOnlyList<CliRowSelectionArgumentFailure> ArgumentFailures =>
         _argumentFailures;
@@ -268,10 +272,10 @@ internal static class CliRowSelectionArgumentAdapter
                     normalized,
                     bindings)
                 : [];
-        int[] scopeDependentArgumentPositions =
+        CliRowSelectionScopeDependentArgument[] scopeDependentArguments =
             expectedScope is null
                 ? []
-                : FindScopeDependentArgumentPositions(
+                : FindScopeDependentArguments(
                     authoritativeArguments,
                     normalized,
                     bindings,
@@ -292,7 +296,7 @@ internal static class CliRowSelectionArgumentAdapter
                 parseErrors,
                 requiredValuePositions,
                 shadowedRowOptionPositions,
-                scopeDependentArgumentPositions,
+                scopeDependentArguments,
                 Array.Empty<
                     CliRowSelectionOccurrence<string>>(),
                 argumentFailures,
@@ -314,7 +318,7 @@ internal static class CliRowSelectionArgumentAdapter
             parseErrors,
             requiredValuePositions,
             shadowedRowOptionPositions,
-            scopeDependentArgumentPositions,
+            scopeDependentArguments,
             occurrences,
             argumentFailures,
             CliRowSelectionLowerer.Lower(
@@ -800,13 +804,13 @@ internal static class CliRowSelectionArgumentAdapter
         return null;
     }
 
-    private static int[] FindScopeDependentArgumentPositions(
+    private static CliRowSelectionScopeDependentArgument[] FindScopeDependentArguments(
         IReadOnlyList<ParsedArgument> parsedArguments,
         NormalizedArguments normalized,
         CliRowSelectionOptionBindings bindings,
         CommandResult expectedScope)
     {
-        var positions = new List<int>();
+        var arguments = new List<CliRowSelectionScopeDependentArgument>();
         BoundOption[] boundOptions = BoundOptions(bindings);
         for (int index = 0; index + 1 < normalized.Arguments.Length; index++)
         {
@@ -835,14 +839,16 @@ internal static class CliRowSelectionArgumentAdapter
                 if (IsKnownOptionToken(following, parsedArguments[index + 1].Scope, bindings.Limit)
                     != IsKnownOptionToken(following, expectedScope, bindings.Limit))
                 {
-                    positions.Add(normalized.Positions[index]);
+                    arguments.Add(new(
+                        normalized.Positions[index],
+                        normalized.Positions[index + 1]));
                 }
 
                 break;
             }
         }
 
-        return [.. positions];
+        return [.. arguments];
     }
 
     private static int[] FindShadowedRowOptionPositions(

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -82,6 +82,7 @@ internal sealed class CliRowSelectionArgumentResult
     private readonly ReadOnlyCollection<CliRowSelectionArgumentFailure> _argumentFailures;
     private readonly ReadOnlyCollection<int> _requiredValuePositions;
     private readonly ReadOnlyCollection<int> _shadowedRowOptionPositions;
+    private readonly ReadOnlyCollection<int> _scopeDependentArgumentPositions;
     private readonly ReadOnlyCollection<
         CliRowSelectionOccurrence<string>> _occurrences;
 
@@ -91,6 +92,7 @@ internal sealed class CliRowSelectionArgumentResult
         IReadOnlyList<ParseError> parseErrors,
         IReadOnlyList<int> requiredValuePositions,
         IReadOnlyList<int> shadowedRowOptionPositions,
+        IReadOnlyList<int> scopeDependentArgumentPositions,
         IReadOnlyList<CliRowSelectionOccurrence<string>> occurrences,
         IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
         CliRowSelectionLoweringResult<string>? loweringResult,
@@ -102,6 +104,7 @@ internal sealed class CliRowSelectionArgumentResult
         ArgumentNullException.ThrowIfNull(argumentFailures);
         ArgumentNullException.ThrowIfNull(requiredValuePositions);
         ArgumentNullException.ThrowIfNull(shadowedRowOptionPositions);
+        ArgumentNullException.ThrowIfNull(scopeDependentArgumentPositions);
         ArgumentNullException.ThrowIfNull(occurrences);
 
         _arguments =
@@ -114,6 +117,8 @@ internal sealed class CliRowSelectionArgumentResult
             Array.AsReadOnly(requiredValuePositions.ToArray());
         _shadowedRowOptionPositions =
             Array.AsReadOnly(shadowedRowOptionPositions.ToArray());
+        _scopeDependentArgumentPositions =
+            Array.AsReadOnly(scopeDependentArgumentPositions.ToArray());
         _occurrences =
             Array.AsReadOnly(occurrences.ToArray());
         ParseResult = parseResult;
@@ -139,6 +144,9 @@ internal sealed class CliRowSelectionArgumentResult
 
     public IReadOnlyList<int> ShadowedRowOptionPositions =>
         _shadowedRowOptionPositions;
+
+    public IReadOnlyList<int> ScopeDependentArgumentPositions =>
+        _scopeDependentArgumentPositions;
 
     public IReadOnlyList<CliRowSelectionArgumentFailure> ArgumentFailures =>
         _argumentFailures;
@@ -189,20 +197,23 @@ internal static class CliRowSelectionArgumentAdapter
     internal static CliRowSelectionArgumentResult InspectExplicit(
         Command command,
         string[] arguments,
-        CliRowSelectionOptionBindings bindings)
+        CliRowSelectionOptionBindings bindings,
+        CommandResult? expectedScope = null)
         => AnalyzeExplicit(
             command,
             arguments,
             bindings,
             CliRowSelectionCapabilities.All,
-            preserveRowEvidenceAcrossParseErrors: true);
+            preserveRowEvidenceAcrossParseErrors: true,
+            expectedScope);
 
     private static CliRowSelectionArgumentResult AnalyzeExplicit(
         Command command,
         string[] arguments,
         CliRowSelectionOptionBindings bindings,
         CliRowSelectionCapabilities capabilities,
-        bool preserveRowEvidenceAcrossParseErrors)
+        bool preserveRowEvidenceAcrossParseErrors,
+        CommandResult? expectedScope = null)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -257,9 +268,16 @@ internal static class CliRowSelectionArgumentAdapter
                     normalized,
                     bindings)
                 : [];
+        int[] scopeDependentArgumentPositions =
+            expectedScope is null
+                ? []
+                : FindScopeDependentArgumentPositions(
+                    authoritativeArguments,
+                    normalized,
+                    bindings,
+                    expectedScope);
         CliRowSelectionArgumentFailure[] argumentFailures =
             FindArgumentFailures(
-                authoritativeParse,
                 authoritativeArguments,
                 normalized,
                 bindings);
@@ -274,6 +292,7 @@ internal static class CliRowSelectionArgumentAdapter
                 parseErrors,
                 requiredValuePositions,
                 shadowedRowOptionPositions,
+                scopeDependentArgumentPositions,
                 Array.Empty<
                     CliRowSelectionOccurrence<string>>(),
                 argumentFailures,
@@ -295,6 +314,7 @@ internal static class CliRowSelectionArgumentAdapter
             parseErrors,
             requiredValuePositions,
             shadowedRowOptionPositions,
+            scopeDependentArgumentPositions,
             occurrences,
             argumentFailures,
             CliRowSelectionLowerer.Lower(
@@ -780,6 +800,51 @@ internal static class CliRowSelectionArgumentAdapter
         return null;
     }
 
+    private static int[] FindScopeDependentArgumentPositions(
+        IReadOnlyList<ParsedArgument> parsedArguments,
+        NormalizedArguments normalized,
+        CliRowSelectionOptionBindings bindings,
+        CommandResult expectedScope)
+    {
+        var positions = new List<int>();
+        BoundOption[] boundOptions = BoundOptions(bindings);
+        for (int index = 0; index + 1 < normalized.Arguments.Length; index++)
+        {
+            string token = normalized.Arguments[index];
+            if (token == "--")
+            {
+                break;
+            }
+
+            if (normalized.Positions[index] == normalized.Positions[index + 1]
+                || normalized.Arguments[index + 1] == "--")
+            {
+                continue;
+            }
+
+            foreach (BoundOption bound in boundOptions)
+            {
+                if (!bound.HasValue
+                    || !TryGetExactOptionAlias(token, bound.Option, out string? alias)
+                    || !IsOwnedOptionToken(parsedArguments[index], alias!, bound.Option))
+                {
+                    continue;
+                }
+
+                string following = normalized.Arguments[index + 1];
+                if (IsKnownOptionToken(following, parsedArguments[index + 1].Scope, bindings.Limit)
+                    != IsKnownOptionToken(following, expectedScope, bindings.Limit))
+                {
+                    positions.Add(normalized.Positions[index]);
+                }
+
+                break;
+            }
+        }
+
+        return [.. positions];
+    }
+
     private static int[] FindShadowedRowOptionPositions(
         IReadOnlyList<ParsedArgument> parsedArguments,
         NormalizedArguments normalized,
@@ -991,7 +1056,6 @@ internal static class CliRowSelectionArgumentAdapter
 
     private static CliRowSelectionArgumentFailure[]
         FindArgumentFailures(
-            ParseResult parseResult,
             IReadOnlyList<ParsedArgument> parsedArguments,
             NormalizedArguments normalized,
             CliRowSelectionOptionBindings bindings)
@@ -1016,7 +1080,6 @@ internal static class CliRowSelectionArgumentAdapter
                     && IsMissingValue(
                         token,
                         index,
-                        parseResult,
                         parsedArguments,
                         normalized.Arguments,
                         bound.Option,
@@ -1054,7 +1117,6 @@ internal static class CliRowSelectionArgumentAdapter
     private static bool IsMissingValue(
         string token,
         int index,
-        ParseResult parseResult,
         IReadOnlyList<ParsedArgument> parsedArguments,
         IReadOnlyList<string> arguments,
         Option option,
@@ -1076,16 +1138,16 @@ internal static class CliRowSelectionArgumentAdapter
             || arguments[index + 1] == "--"
             || IsKnownOptionToken(
                 arguments[index + 1],
-                parseResult,
+                parsedArguments[index + 1].Scope,
                 limit);
     }
 
     private static bool IsKnownOptionToken(
         string token,
-        ParseResult parseResult,
+        CommandResult selectedScope,
         Option limit)
     {
-        for (CommandResult? command = parseResult.CommandResult;
+        for (CommandResult? command = selectedScope;
             command is not null;
             command = command.Parent as CommandResult)
         {
@@ -1094,7 +1156,8 @@ internal static class CliRowSelectionArgumentAdapter
                         IsOptionToken(
                             token,
                             option,
-                            limit)))
+                            limit,
+                            selectedScope)))
             {
                 return true;
             }
@@ -1164,35 +1227,21 @@ internal static class CliRowSelectionArgumentAdapter
     private static bool IsOptionToken(
         string token,
         Option option,
-        Option limit)
+        Option limit,
+        CommandResult? scope = null)
     {
         foreach (string alias in Aliases(option))
         {
-            if (token.Equals(
-                    alias,
-                    StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            if (token.Length <= alias.Length
-                || !token.StartsWith(
-                    alias,
-                    StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            if (token[alias.Length] is '=' or ':'
-                || (ReferenceEquals(
-                        option,
-                        limit)
-                    && alias.Equals(
-                        "-n",
-                        StringComparison.Ordinal)
-                    && IsCompactShortLimitToken(
-                        token,
-                        alias)))
+            bool matches =
+                token.Equals(alias, StringComparison.Ordinal)
+                || token.Length > alias.Length
+                    && token.StartsWith(alias, StringComparison.Ordinal)
+                    && (token[alias.Length] is '=' or ':'
+                        || ReferenceEquals(option, limit)
+                            && alias.Equals("-n", StringComparison.Ordinal)
+                            && IsCompactShortLimitToken(token, alias));
+            if (matches
+                && (scope is null || ReferenceEquals(FindOptionInScope(scope, alias), option)))
             {
                 return true;
             }

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -1550,6 +1550,9 @@ internal static class CliRowSelectionArgumentAdapter
         }
     }
 
+    private static bool IsShortAlias(string alias) =>
+        alias is ['-', not '-'];
+
     private readonly record struct NormalizedArguments(
         string[] Arguments,
         int[] Positions);

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -81,6 +81,7 @@ internal sealed class CliRowSelectionArgumentResult
     private readonly ReadOnlyCollection<ParseError> _parseErrors;
     private readonly ReadOnlyCollection<CliRowSelectionArgumentFailure> _argumentFailures;
     private readonly ReadOnlyCollection<int> _requiredValuePositions;
+    private readonly ReadOnlyCollection<int> _shadowedRowOptionPositions;
     private readonly ReadOnlyCollection<
         CliRowSelectionOccurrence<string>> _occurrences;
 
@@ -89,6 +90,7 @@ internal sealed class CliRowSelectionArgumentResult
         ParseResult parseResult,
         IReadOnlyList<ParseError> parseErrors,
         IReadOnlyList<int> requiredValuePositions,
+        IReadOnlyList<int> shadowedRowOptionPositions,
         IReadOnlyList<CliRowSelectionOccurrence<string>> occurrences,
         IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
         CliRowSelectionLoweringResult<string>? loweringResult,
@@ -99,6 +101,7 @@ internal sealed class CliRowSelectionArgumentResult
         ArgumentNullException.ThrowIfNull(parseErrors);
         ArgumentNullException.ThrowIfNull(argumentFailures);
         ArgumentNullException.ThrowIfNull(requiredValuePositions);
+        ArgumentNullException.ThrowIfNull(shadowedRowOptionPositions);
         ArgumentNullException.ThrowIfNull(occurrences);
 
         _arguments =
@@ -109,6 +112,8 @@ internal sealed class CliRowSelectionArgumentResult
             Array.AsReadOnly(argumentFailures.ToArray());
         _requiredValuePositions =
             Array.AsReadOnly(requiredValuePositions.ToArray());
+        _shadowedRowOptionPositions =
+            Array.AsReadOnly(shadowedRowOptionPositions.ToArray());
         _occurrences =
             Array.AsReadOnly(occurrences.ToArray());
         ParseResult = parseResult;
@@ -131,6 +136,9 @@ internal sealed class CliRowSelectionArgumentResult
 
     public IReadOnlyList<int> RequiredValuePositions =>
         _requiredValuePositions;
+
+    public IReadOnlyList<int> ShadowedRowOptionPositions =>
+        _shadowedRowOptionPositions;
 
     public IReadOnlyList<CliRowSelectionArgumentFailure> ArgumentFailures =>
         _argumentFailures;
@@ -242,6 +250,13 @@ internal static class CliRowSelectionArgumentAdapter
                     .IdentifierToken);
         ParseError[] parseErrors =
             authoritativeParse.Errors.ToArray();
+        int[] shadowedRowOptionPositions =
+            preserveRowEvidenceAcrossParseErrors
+                ? FindShadowedRowOptionPositions(
+                    authoritativeArguments,
+                    normalized,
+                    bindings)
+                : [];
         CliRowSelectionArgumentFailure[] argumentFailures =
             FindArgumentFailures(
                 authoritativeParse,
@@ -258,6 +273,7 @@ internal static class CliRowSelectionArgumentAdapter
                 authoritativeParse,
                 parseErrors,
                 requiredValuePositions,
+                shadowedRowOptionPositions,
                 Array.Empty<
                     CliRowSelectionOccurrence<string>>(),
                 argumentFailures,
@@ -278,6 +294,7 @@ internal static class CliRowSelectionArgumentAdapter
             authoritativeParse,
             parseErrors,
             requiredValuePositions,
+            shadowedRowOptionPositions,
             occurrences,
             argumentFailures,
             CliRowSelectionLowerer.Lower(
@@ -379,14 +396,17 @@ internal static class CliRowSelectionArgumentAdapter
             return false;
         }
 
+        if (recursiveAncestorsOnly)
+        {
+            return Aliases(option).All(alias =>
+                ReferenceEquals(FindOptionInScope(parseResult.CommandResult, alias), option));
+        }
+
         for (CommandResult? command = parseResult.CommandResult;
             command is not null;
             command = command.Parent as CommandResult)
         {
-            if ((!recursiveAncestorsOnly
-                    || ReferenceEquals(command, parseResult.CommandResult)
-                    || option.Recursive)
-                && command.Command.Options.Any(
+            if (command.Command.Options.Any(
                     candidate =>
                         ReferenceEquals(
                             candidate,
@@ -425,6 +445,27 @@ internal static class CliRowSelectionArgumentAdapter
             foreach (var modifier in modifiers)
                 modifier.Option.Arity = modifier.Arity;
         }
+    }
+
+    private static Option? FindOptionInScope(
+        CommandResult selectedScope,
+        string alias)
+    {
+        for (CommandResult? scope = selectedScope;
+            scope is not null;
+            scope = scope.Parent as CommandResult)
+        {
+            foreach (Option candidate in scope.Command.Options)
+            {
+                if ((ReferenceEquals(scope, selectedScope) || candidate.Recursive)
+                    && Aliases(candidate).Contains(alias, StringComparer.Ordinal))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
     }
 
     private static BoundOption[] BoundOptions(
@@ -535,6 +576,11 @@ internal static class CliRowSelectionArgumentAdapter
                     out string? value)
                 || HasOptionToken(
                     ownershipArguments[index])
+                || ownershipArguments[index].Tokens.Any(
+                    candidate => candidate.Type == TokenType.Command)
+                || !ReferenceEquals(
+                    FindOptionInScope(ownershipArguments[index].Scope, shorthandAlias),
+                    limit)
                 || IsClaimedByRequiredOption(
                     ownershipArguments[index],
                     ownershipParse))
@@ -734,6 +780,33 @@ internal static class CliRowSelectionArgumentAdapter
         return null;
     }
 
+    private static int[] FindShadowedRowOptionPositions(
+        IReadOnlyList<ParsedArgument> parsedArguments,
+        NormalizedArguments normalized,
+        CliRowSelectionOptionBindings bindings)
+    {
+        HashSet<Token> rowTokens =
+            BoundOptions(bindings)
+                .SelectMany(bound => Aliases(bound.Option)
+                    .Select(alias => new Token(alias, TokenType.Option, bound.Option)))
+                .ToHashSet();
+        HashSet<string> aliases =
+            rowTokens.Select(token => token.Value).ToHashSet(StringComparer.Ordinal);
+        bool hasShortLimitAlias = HasShortLimitAlias(bindings);
+        return Enumerable.Range(0, parsedArguments.Count)
+            .Where(index => parsedArguments[index].Tokens.Any(
+                token => token.Type == TokenType.Option
+                    && aliases.Contains(token.Value)
+                    && !rowTokens.Contains(token))
+                || hasShortLimitAlias
+                    && IsCompactShortLimitToken(normalized.Arguments[index], "-n")
+                    && FindOptionInScope(parsedArguments[index].Scope, "-n") is { } owner
+                    && !ReferenceEquals(owner, bindings.Limit))
+            .Select(index => normalized.Positions[index])
+            .Distinct()
+            .ToArray();
+    }
+
     private static IReadOnlyList<OptionResult> GetOptionResults(
         ParseResult parseResult)
     {
@@ -765,6 +838,16 @@ internal static class CliRowSelectionArgumentAdapter
                     alias,
                     StringComparison.Ordinal));
 
+    private static bool IsOwnedOptionToken(
+        ParsedArgument argument,
+        string alias,
+        Option option)
+    {
+        // Token equality includes the bound symbol identity, including repeats.
+        var expected = new Token(alias, TokenType.Option, option);
+        return argument.Tokens.Contains(expected);
+    }
+
     private static ParsedArgument[] MapArguments(
         ParseResult parseResult,
         IReadOnlyList<string> arguments)
@@ -773,6 +856,19 @@ internal static class CliRowSelectionArgumentAdapter
             parseResult.Tokens;
         var result =
             new ParsedArgument[arguments.Count];
+        var commandScopes =
+            new Dictionary<Token, CommandResult>(ReferenceEqualityComparer.Instance);
+        CommandResult activeScope = parseResult.CommandResult;
+        for (CommandResult? scope = parseResult.CommandResult;
+            scope is not null;
+            scope = scope.Parent as CommandResult)
+        {
+            activeScope = scope;
+            if (scope.IdentifierToken is { } identifier)
+            {
+                commandScopes.Add(identifier, scope);
+            }
+        }
         int tokenIndex = 0;
 
         for (int argumentIndex = 0;
@@ -801,12 +897,16 @@ internal static class CliRowSelectionArgumentAdapter
                 }
             }
 
-            result[argumentIndex] =
-                new(
-                    tokens
-                        .Skip(start)
-                        .Take(tokenIndex - start)
-                        .ToArray());
+            Token[] mappedTokens = tokens.Skip(start).Take(tokenIndex - start).ToArray();
+            foreach (Token mappedToken in mappedTokens)
+            {
+                if (commandScopes.TryGetValue(mappedToken, out CommandResult? scope))
+                {
+                    activeScope = scope;
+                }
+            }
+
+            result[argumentIndex] = new(mappedTokens, activeScope);
         }
 
         return result;
@@ -936,7 +1036,8 @@ internal static class CliRowSelectionArgumentAdapter
                         out string? alias)
                     && IsOwnedOptionToken(
                         parsedArguments[index],
-                        alias!))
+                        alias!,
+                        bound.Option))
                 {
                     failures.Add(
                         AttachedModifierFailure(
@@ -965,7 +1066,8 @@ internal static class CliRowSelectionArgumentAdapter
                 out string? alias)
             || !IsOwnedOptionToken(
                 parsedArguments[index],
-                alias!))
+                alias!,
+                option))
         {
             return false;
         }
@@ -1198,7 +1300,8 @@ internal static class CliRowSelectionArgumentAdapter
                         out string? alias)
                     && IsOwnedOptionToken(
                         parsedArguments[index],
-                        alias!))
+                        alias!,
+                        bound.Option))
                 {
                     occurrences.Add(
                         ModifierOccurrence(
@@ -1279,7 +1382,8 @@ internal static class CliRowSelectionArgumentAdapter
                 out string? alias)
             || !IsOwnedOptionToken(
                 parsedArgument,
-                alias!))
+                alias!,
+                option))
         {
             value = null!;
             return false;
@@ -1396,7 +1500,8 @@ internal static class CliRowSelectionArgumentAdapter
         int[] Positions);
 
     private readonly record struct ParsedArgument(
-        Token[] Tokens);
+        Token[] Tokens,
+        CommandResult Scope);
 
     private readonly record struct BoundOption(
         Option Option,

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionArgumentAdapter.cs
@@ -294,19 +294,58 @@ internal static class CliRowSelectionArgumentAdapter
             }
         }
 
+        if (MatchesCanonicalValueOption(
+                token,
+                "--top"))
+        {
+            kind = CliRowSelectionOccurrenceKind.Top;
+            return true;
+        }
+
+        if (MatchesCanonicalValueOption(
+                token,
+                "--order-by"))
+        {
+            kind = CliRowSelectionOccurrenceKind.OrderBy;
+            return true;
+        }
+
         kind = default;
         return false;
     }
+
+    private static bool MatchesCanonicalValueOption(
+        string token,
+        string alias) =>
+        token.Equals(
+            alias,
+            StringComparison.Ordinal)
+        || token.Length > alias.Length
+        && token.StartsWith(
+            alias,
+            StringComparison.Ordinal)
+        && token[alias.Length] is '=' or ':';
 
     internal static bool IsDeclared(
         ParseResult parseResult,
         CliRowSelectionOptionBindings bindings,
         CliRowSelectionOccurrenceKind kind)
     {
-        Option option =
-            BoundOptions(bindings)
-                .Single(bound => bound.Kind == kind)
-                .Option;
+        Option? option = null;
+        foreach (BoundOption bound in BoundOptions(bindings))
+        {
+            if (bound.Kind == kind)
+            {
+                option = bound.Option;
+                break;
+            }
+        }
+
+        if (option is null)
+        {
+            return false;
+        }
+
         for (CommandResult? command = parseResult.CommandResult;
             command is not null;
             command = command.Parent as CommandResult)

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionLowerer.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionLowerer.cs
@@ -560,7 +560,7 @@ internal static class CliRowSelectionLowerer
         return null;
     }
 
-    private static CliRowSelectionCapabilities RequiredCapabilities(
+    internal static CliRowSelectionCapabilities RequiredCapabilities(
         CliRowSelectionOccurrenceKind kind,
         bool lineSelection) =>
         kind switch

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -646,12 +646,26 @@ internal static class CliRowSelectionRouteEnvelope
                         CliRowSelectionOccurrenceKind
                             candidateKind
                     && CliRowSelectionArgumentAdapter
-                        .TryClassifyExplicitRowToken(
+                        .TryClassifyBoundRowToken(
                             token,
                             observations[index].Candidate.Bindings,
                             out _)
                     && observations[index].IsDeclared(
                         candidateKind);
+
+                if (declared[index]
+                    && meanings[index] is
+                        CliRowSelectionOccurrenceKind.Lines
+                        or CliRowSelectionOccurrenceKind.TailLines
+                    && !observations[index].LineSelection
+                    && observations[index].ArgumentFailure is { } failure
+                    && failure.Position <= position)
+                {
+                    // Extraction stops at an arity failure; missing later
+                    // line evidence does not establish a semantic count unit.
+                    lineSelectionDeferred = true;
+                    deferredPositions.Add(failure.Position);
+                }
             }
 
             requests.Add(

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -443,6 +443,11 @@ internal static class CliRowSelectionRouteEnvelope
                 .Distinct()
                 .Order()
                 .ToArray();
+        int[] shadowedRowOptionPositions =
+            result.ShadowedRowOptionPositions
+                .Where(position => position >= prefixLength)
+                .Select(position => position - prefixLength)
+                .ToArray();
         int? unexpectedCommandPosition =
             !ReferenceEquals(
                 result.ParseResult.CommandResult.Command,
@@ -471,6 +476,7 @@ internal static class CliRowSelectionRouteEnvelope
             occurrences,
             argumentFailures,
             requiredValuePositions,
+            shadowedRowOptionPositions,
             unexpectedCommandPosition,
             declaredKinds);
     }
@@ -611,11 +617,40 @@ internal static class CliRowSelectionRouteEnvelope
                 continue;
             }
 
+            CandidateObservation[] shadowed =
+                observations.Where(observation =>
+                    observation.ShadowedRowOptionPositions.Contains(position)).ToArray();
+            if (shadowed.Length > 0)
+            {
+                lineSelectionDeferred |= meanings.Any(meaning =>
+                    meaning is CliRowSelectionOccurrenceKind.Lines
+                        or CliRowSelectionOccurrenceKind.TailLines);
+                if (shadowed.All(observation => observation.ExpectedCommandSelected))
+                {
+                    deferredPositions.Add(position);
+                }
+
+                continue;
+            }
+
             if (bare)
             {
                 if (bareDeclared.Any(value => !value))
                 {
                     deferredPositions.Add(position);
+                    continue;
+                }
+
+                if (observations.Any(observation =>
+                    !observation.Occurrences.Any(occurrence =>
+                        occurrence.Kind == CliRowSelectionOccurrenceKind.Limit
+                        && occurrence.Position == position)))
+                {
+                    if (observations.All(observation => observation.ExpectedCommandSelected))
+                    {
+                        deferredPositions.Add(position);
+                    }
+
                     continue;
                 }
 
@@ -835,6 +870,7 @@ internal static class CliRowSelectionRouteEnvelope
                 occurrences,
             IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
             IReadOnlyList<int> requiredValuePositions,
+            IReadOnlyList<int> shadowedRowOptionPositions,
             int? unexpectedCommandPosition,
             bool[] declaredKinds)
         {
@@ -844,6 +880,7 @@ internal static class CliRowSelectionRouteEnvelope
             Occurrences = occurrences;
             ArgumentFailures = argumentFailures;
             RequiredValuePositions = requiredValuePositions;
+            ShadowedRowOptionPositions = shadowedRowOptionPositions;
             UnexpectedCommandPosition =
                 unexpectedCommandPosition;
             DeclaredKinds = declaredKinds;
@@ -871,6 +908,8 @@ internal static class CliRowSelectionRouteEnvelope
             ExpectedCommandSelected && ArgumentFailures.Count == 0;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
+
+        public IReadOnlyList<int> ShadowedRowOptionPositions { get; }
 
         public int? UnexpectedCommandPosition { get; }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -125,7 +125,7 @@ internal sealed class CliRowSelectionRouteEnvelopeResult
 
     public static CliRowSelectionRouteEnvelopeResult
         ExplicitCommandRequired(
-            CliRowSelectionOccurrenceKind kind,
+            CliRowSelectionOccurrenceKind? kind,
             int position) =>
         new(
             CliRowSelectionRouteEnvelopeOutcome
@@ -257,10 +257,21 @@ internal static class CliRowSelectionRouteEnvelope
                 {
                     return CliRowSelectionRouteEnvelopeResult
                         .ExplicitCommandRequired(
-                            request.Kind,
+                            request.MeaningsDiffer
+                                ? null
+                                : request.Kind,
                             request.Position);
                 }
 
+                continue;
+            }
+
+            if (scan.LineSelectionDeferred
+                && request.Kind is
+                    CliRowSelectionOccurrenceKind.Limit
+                    or CliRowSelectionOccurrenceKind.Head
+                    or CliRowSelectionOccurrenceKind.Tail)
+            {
                 continue;
             }
 
@@ -511,6 +522,7 @@ internal static class CliRowSelectionRouteEnvelope
             new List<RequestToken>();
         var deferredPositions =
             new SortedSet<int>();
+        bool lineSelectionDeferred = false;
 
         for (int position = 0;
             position < arguments.Count;
@@ -572,6 +584,13 @@ internal static class CliRowSelectionRouteEnvelope
 
             if (requiredClaims.Any(claimed => claimed))
             {
+                lineSelectionDeferred |=
+                    meanings.Any(
+                        meaning =>
+                            meaning is
+                                CliRowSelectionOccurrenceKind.Lines
+                                or CliRowSelectionOccurrenceKind
+                                    .TailLines);
                 deferredPositions.Add(position);
                 continue;
             }
@@ -645,7 +664,8 @@ internal static class CliRowSelectionRouteEnvelope
         return new(
             requests,
             deferredPositions.ToArray(),
-            lineSelection);
+            lineSelection,
+            lineSelectionDeferred);
     }
 
     private static IReadOnlyList<
@@ -850,5 +870,6 @@ internal static class CliRowSelectionRouteEnvelope
     private sealed record RequestScan(
         IReadOnlyList<RequestToken> Requests,
         IReadOnlyList<int> DeferredPositions,
-        bool LineSelection);
+        bool LineSelection,
+        bool LineSelectionDeferred);
 }

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -422,7 +422,8 @@ internal static class CliRowSelectionRouteEnvelope
                 .Where(
                     occurrence =>
                         occurrence.Position >= prefixLength
-                        && !result.ScopeDependentArgumentPositions.Contains(occurrence.Position))
+                        && !result.ScopeDependentArguments.Any(
+                            argument => argument.OptionPosition == occurrence.Position))
                 .Select(
                     occurrence =>
                         Translate(
@@ -432,7 +433,8 @@ internal static class CliRowSelectionRouteEnvelope
         CliRowSelectionArgumentFailure[] argumentFailures =
             result.ArgumentFailures
                 .Where(failure => failure.Position >= prefixLength
-                    && !result.ScopeDependentArgumentPositions.Contains(failure.Position))
+                    && !result.ScopeDependentArguments.Any(
+                        argument => argument.OptionPosition == failure.Position))
                 .Select(failure =>
                     new CliRowSelectionArgumentFailure(
                         failure.Reason,
@@ -451,10 +453,12 @@ internal static class CliRowSelectionRouteEnvelope
                 .Where(position => position >= prefixLength)
                 .Select(position => position - prefixLength)
                 .ToArray();
-        int[] scopeDependentArgumentPositions =
-            result.ScopeDependentArgumentPositions
-                .Where(position => position >= prefixLength)
-                .Select(position => position - prefixLength)
+        CliRowSelectionScopeDependentArgument[] scopeDependentArguments =
+            result.ScopeDependentArguments
+                .Where(argument => argument.OptionPosition >= prefixLength)
+                .Select(argument => new CliRowSelectionScopeDependentArgument(
+                    argument.OptionPosition - prefixLength,
+                    argument.FollowingPosition - prefixLength))
                 .ToArray();
         int? unexpectedCommandPosition =
             !ReferenceEquals(
@@ -485,7 +489,7 @@ internal static class CliRowSelectionRouteEnvelope
             argumentFailures,
             requiredValuePositions,
             shadowedRowOptionPositions,
-            scopeDependentArgumentPositions,
+            scopeDependentArguments,
             unexpectedCommandPosition,
             declaredKinds);
     }
@@ -534,7 +538,7 @@ internal static class CliRowSelectionRouteEnvelope
             && observations.Any(
                 observation =>
                     observation.ArgumentFailures.Count != 0
-                    || observation.ScopeDependentArgumentPositions.Count != 0
+                    || observation.ScopeDependentArguments.Count != 0
                     || !observation.PreservesOptionScope(
                         CliRowSelectionOccurrenceKind.Limit)
                     || observation.Occurrences.Any(occurrence =>
@@ -608,6 +612,14 @@ internal static class CliRowSelectionRouteEnvelope
                 || meanings.Any(
                     meaning =>
                         meaning is not null);
+            // Scope-dependent protection cannot establish the count unit.
+            lineSelectionDeferred |=
+                meanings.Any(meaning =>
+                    meaning is CliRowSelectionOccurrenceKind.Lines
+                        or CliRowSelectionOccurrenceKind.TailLines)
+                && observations.Any(observation =>
+                    observation.ScopeDependentArguments.Any(
+                        argument => argument.FollowingPosition == position));
             if (!potentialRequest
                 || requiredClaims.All(claimed => claimed))
             {
@@ -881,7 +893,7 @@ internal static class CliRowSelectionRouteEnvelope
             IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
             IReadOnlyList<int> requiredValuePositions,
             IReadOnlyList<int> shadowedRowOptionPositions,
-            IReadOnlyList<int> scopeDependentArgumentPositions,
+            IReadOnlyList<CliRowSelectionScopeDependentArgument> scopeDependentArguments,
             int? unexpectedCommandPosition,
             bool[] declaredKinds)
         {
@@ -892,7 +904,7 @@ internal static class CliRowSelectionRouteEnvelope
             ArgumentFailures = argumentFailures;
             RequiredValuePositions = requiredValuePositions;
             ShadowedRowOptionPositions = shadowedRowOptionPositions;
-            ScopeDependentArgumentPositions = scopeDependentArgumentPositions;
+            ScopeDependentArguments = scopeDependentArguments;
             UnexpectedCommandPosition =
                 unexpectedCommandPosition;
             DeclaredKinds = declaredKinds;
@@ -919,13 +931,13 @@ internal static class CliRowSelectionRouteEnvelope
         public bool HasCompleteOccurrences =>
             ExpectedCommandSelected
             && ArgumentFailures.Count == 0
-            && ScopeDependentArgumentPositions.Count == 0;
+            && ScopeDependentArguments.Count == 0;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
 
         public IReadOnlyList<int> ShadowedRowOptionPositions { get; }
 
-        public IReadOnlyList<int> ScopeDependentArgumentPositions { get; }
+        public IReadOnlyList<CliRowSelectionScopeDependentArgument> ScopeDependentArguments { get; }
 
         public int? UnexpectedCommandPosition { get; }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -427,15 +427,15 @@ internal static class CliRowSelectionRouteEnvelope
                             occurrence,
                             prefixLength))
                 .ToArray();
-        CliRowSelectionArgumentFailure? argumentFailure =
-            result.ArgumentFailure is not null
-                && result.ArgumentFailure.Position >= prefixLength
-                ? new(
-                    result.ArgumentFailure.Reason,
-                    result.ArgumentFailure.OccurrenceKind,
-                    result.ArgumentFailure.Position
-                        - prefixLength)
-                : null;
+        CliRowSelectionArgumentFailure[] argumentFailures =
+            result.ArgumentFailures
+                .Where(failure => failure.Position >= prefixLength)
+                .Select(failure =>
+                    new CliRowSelectionArgumentFailure(
+                        failure.Reason,
+                        failure.OccurrenceKind,
+                        failure.Position - prefixLength))
+                .ToArray();
         int[] requiredValuePositions =
             result.RequiredValuePositions
                 .Where(position => position >= prefixLength)
@@ -452,10 +452,6 @@ internal static class CliRowSelectionRouteEnvelope
             && selectedCommandPosition >= prefixLength
                 ? selectedCommandPosition - prefixLength
                 : null;
-        CliRowSelectionLoweringResult<string> loweringResult =
-            CliRowSelectionLowerer.Lower(
-                occurrences,
-                CliRowSelectionCapabilities.All);
         bool[] declaredKinds =
             Enum.GetValues<CliRowSelectionOccurrenceKind>()
                 .Select(
@@ -473,10 +469,9 @@ internal static class CliRowSelectionRouteEnvelope
                 result.ParseResult.CommandResult.Command,
                 candidate.ExpectedCommand),
             occurrences,
-            argumentFailure,
+            argumentFailures,
             requiredValuePositions,
             unexpectedCommandPosition,
-            loweringResult,
             declaredKinds);
     }
 
@@ -484,54 +479,53 @@ internal static class CliRowSelectionRouteEnvelope
         CommonArgumentFailure(
             IReadOnlyList<CandidateObservation> observations)
     {
-        CliRowSelectionArgumentFailure? first =
-            observations[0].ArgumentFailure;
-        if (first is null)
+        foreach (CliRowSelectionArgumentFailure failure in observations[0].ArgumentFailures)
         {
-            return null;
+            if (observations.Skip(1).All(
+                    observation => observation.ArgumentFailures.Any(
+                        candidateFailure => Same(failure, candidateFailure))))
+            {
+                return failure;
+            }
         }
 
-        return observations.All(
-            observation =>
-                Same(
-                    first,
-                    observation.ArgumentFailure))
-            ? first
-            : null;
+        return null;
     }
 
     private static CliRowSelectionLoweringResult<string>?
         CommonLoweringFailure(
             IReadOnlyList<CandidateObservation> observations)
     {
-        CliRowSelectionLoweringResult<string> first =
-            observations[0].LoweringResult;
-        if (first.IsSuccess)
+        CliRowSelectionOccurrence<string>[] common =
+            observations[0].Occurrences
+                .Where(occurrence =>
+                    observations.Skip(1).All(observation =>
+                        observation.Occurrences.Any(candidateOccurrence =>
+                            Same(occurrence, candidateOccurrence))))
+                .ToArray();
+        CliRowSelectionLoweringResult<string> lowering =
+            CliRowSelectionLowerer.Lower(
+                common,
+                CliRowSelectionCapabilities.All);
+        if (lowering.IsSuccess)
         {
             return null;
         }
 
-        // A shared prefix can prove a bad value or a completed conflict,
-        // but missing-count absence requires evidence through end of argv.
-        if (first.Failure!.Reason
+        // Shared occurrences prove present-token failures. Count absence
+        // additionally requires complete, count-free evidence in every route.
+        if (lowering.Failure!.Reason
                 == CliRowSelectionFailureReason.ModifierRequiresCount
             && observations.Any(
-                observation => !observation.HasCompleteOccurrences))
+                observation =>
+                    !observation.HasCompleteOccurrences
+                    || observation.Occurrences.Any(occurrence =>
+                        occurrence.Kind == CliRowSelectionOccurrenceKind.Limit)))
         {
             return null;
         }
 
-        return observations
-            .Skip(1)
-            .Select(observation => observation.LoweringResult)
-            .All(
-                result =>
-                    !result.IsSuccess
-                    && Same(
-                        first.Failure!,
-                        result.Failure!))
-            ? first
-            : null;
+        return lowering;
     }
 
     private static RequestScan ScanRequests(
@@ -668,11 +662,10 @@ internal static class CliRowSelectionRouteEnvelope
                         CliRowSelectionOccurrenceKind.Lines
                         or CliRowSelectionOccurrenceKind.TailLines
                     && !observations[index].LineSelection
-                    && observations[index].ArgumentFailure is { } failure
-                    && failure.Position <= position)
+                    && observations[index].ArgumentFailures.FirstOrDefault(
+                        candidateFailure => candidateFailure.Position == position) is { } failure)
                 {
-                    // Extraction stops at an arity failure; missing later
-                    // line evidence does not establish a semantic count unit.
+                    // A failed line modifier cannot establish the count unit.
                     lineSelectionDeferred = true;
                     deferredPositions.Add(failure.Position);
                 }
@@ -732,15 +725,6 @@ internal static class CliRowSelectionRouteEnvelope
         && expected.Reason == actual.Reason
         && expected.OccurrenceKind == actual.OccurrenceKind
         && expected.Position == actual.Position;
-
-    private static bool Same(
-        CliRowSelectionFailure expected,
-        CliRowSelectionFailure actual) =>
-        expected.Reason == actual.Reason
-        && expected.OccurrenceKind == actual.OccurrenceKind
-        && expected.Position == actual.Position
-        && expected.MissingCapabilities
-            == actual.MissingCapabilities;
 
     private static bool Same(
         IReadOnlyList<CliRowSelectionOccurrence<string>> expected,
@@ -843,21 +827,19 @@ internal static class CliRowSelectionRouteEnvelope
             bool expectedCommandSelected,
             IReadOnlyList<CliRowSelectionOccurrence<string>>
                 occurrences,
-            CliRowSelectionArgumentFailure? argumentFailure,
+            IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
             IReadOnlyList<int> requiredValuePositions,
             int? unexpectedCommandPosition,
-            CliRowSelectionLoweringResult<string> loweringResult,
             bool[] declaredKinds)
         {
             Candidate = candidate;
             ParseResult = parseResult;
             ExpectedCommandSelected = expectedCommandSelected;
             Occurrences = occurrences;
-            ArgumentFailure = argumentFailure;
+            ArgumentFailures = argumentFailures;
             RequiredValuePositions = requiredValuePositions;
             UnexpectedCommandPosition =
                 unexpectedCommandPosition;
-            LoweringResult = loweringResult;
             DeclaredKinds = declaredKinds;
         }
 
@@ -873,21 +855,16 @@ internal static class CliRowSelectionRouteEnvelope
         public IReadOnlyList<CliRowSelectionOccurrence<string>>
             Occurrences { get; }
 
-        public CliRowSelectionArgumentFailure? ArgumentFailure
+        public IReadOnlyList<CliRowSelectionArgumentFailure> ArgumentFailures
         {
             get;
         }
 
-        public bool HasCompleteOccurrences => ArgumentFailure is null;
+        public bool HasCompleteOccurrences => ArgumentFailures.Count == 0;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
 
         public int? UnexpectedCommandPosition { get; }
-
-        public CliRowSelectionLoweringResult<string> LoweringResult
-        {
-            get;
-        }
 
         private bool[] DeclaredKinds { get; }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -238,6 +238,19 @@ internal static class CliRowSelectionRouteEnvelope
         // earlier request.
         foreach (RequestToken request in scan.Requests)
         {
+            if (request.MeaningsDiffer)
+            {
+                if (!hasUnexpectedCommand)
+                {
+                    return CliRowSelectionRouteEnvelopeResult
+                        .ExplicitCommandRequired(
+                            null,
+                            request.Position);
+                }
+
+                continue;
+            }
+
             if (request.Declared.All(
                     declared => !declared))
             {
@@ -249,17 +262,14 @@ internal static class CliRowSelectionRouteEnvelope
                         scan.LineSelection));
             }
 
-            if (request.MeaningsDiffer
-                || request.Declared.Any(
+            if (request.Declared.Any(
                     declared => !declared))
             {
                 if (!hasUnexpectedCommand)
                 {
                     return CliRowSelectionRouteEnvelopeResult
                         .ExplicitCommandRequired(
-                            request.MeaningsDiffer
-                                ? null
-                                : request.Kind,
+                            request.Kind,
                             request.Position);
                 }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -518,7 +518,9 @@ internal static class CliRowSelectionRouteEnvelope
                 == CliRowSelectionFailureReason.ModifierRequiresCount
             && observations.Any(
                 observation =>
-                    !observation.HasCompleteOccurrences
+                    observation.ArgumentFailures.Count != 0
+                    || !observation.PreservesOptionScope(
+                        CliRowSelectionOccurrenceKind.Limit)
                     || observation.Occurrences.Any(occurrence =>
                         occurrence.Kind == CliRowSelectionOccurrenceKind.Limit)))
         {
@@ -658,16 +660,20 @@ internal static class CliRowSelectionRouteEnvelope
                         candidateKind);
 
                 if (declared[index]
-                    && meanings[index] is
+                    && meanings[index] is CliRowSelectionOccurrenceKind lineKind
+                    && lineKind is
                         CliRowSelectionOccurrenceKind.Lines
                         or CliRowSelectionOccurrenceKind.TailLines
-                    && !observations[index].LineSelection
-                    && observations[index].ArgumentFailures.FirstOrDefault(
-                        candidateFailure => candidateFailure.Position == position) is { } failure)
+                    && !observations[index].LineSelection)
                 {
-                    // A failed line modifier cannot establish the count unit.
-                    lineSelectionDeferred = true;
-                    deferredPositions.Add(failure.Position);
+                    // Hidden or invalid line evidence cannot imply semantic items.
+                    lineSelectionDeferred |= !observations[index].PreservesOptionScope(lineKind);
+                    if (observations[index].ArgumentFailures.FirstOrDefault(
+                        candidateFailure => candidateFailure.Position == position) is { } failure)
+                    {
+                        lineSelectionDeferred = true;
+                        deferredPositions.Add(failure.Position);
+                    }
                 }
             }
 
@@ -860,7 +866,7 @@ internal static class CliRowSelectionRouteEnvelope
             get;
         }
 
-        // A different command scope can hide options without a row-arity failure.
+        // Whole-request success still belongs to the expected command.
         public bool HasCompleteOccurrences =>
             ExpectedCommandSelected && ArgumentFailures.Count == 0;
 
@@ -880,6 +886,16 @@ internal static class CliRowSelectionRouteEnvelope
         public bool IsDeclared(
             CliRowSelectionOccurrenceKind kind) =>
             DeclaredKinds[(int)kind];
+
+        public bool PreservesOptionScope(
+            CliRowSelectionOccurrenceKind kind) =>
+            ExpectedCommandSelected
+            || !IsDeclared(kind)
+            || CliRowSelectionArgumentAdapter.IsDeclared(
+                ParseResult,
+                Candidate.Bindings,
+                kind,
+                recursiveAncestorsOnly: true);
     }
 
     private sealed record RequestToken(

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -860,7 +860,9 @@ internal static class CliRowSelectionRouteEnvelope
             get;
         }
 
-        public bool HasCompleteOccurrences => ArgumentFailures.Count == 0;
+        // A different command scope can hide options without a row-arity failure.
+        public bool HasCompleteOccurrences =>
+            ExpectedCommandSelected && ArgumentFailures.Count == 0;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -511,6 +511,16 @@ internal static class CliRowSelectionRouteEnvelope
             return null;
         }
 
+        // A shared prefix can prove a bad value or a completed conflict,
+        // but missing-count absence requires evidence through end of argv.
+        if (first.Failure!.Reason
+                == CliRowSelectionFailureReason.ModifierRequiresCount
+            && observations.Any(
+                observation => !observation.HasCompleteOccurrences))
+        {
+            return null;
+        }
+
         return observations
             .Skip(1)
             .Select(observation => observation.LoweringResult)
@@ -696,6 +706,12 @@ internal static class CliRowSelectionRouteEnvelope
         CliRowSelectionOccurrence<string>>? CommonOccurrences(
             IReadOnlyList<CandidateObservation> observations)
     {
+        if (observations.Any(
+                observation => !observation.HasCompleteOccurrences))
+        {
+            return null;
+        }
+
         IReadOnlyList<CliRowSelectionOccurrence<string>> first =
             observations[0].Occurrences;
         return observations
@@ -861,6 +877,8 @@ internal static class CliRowSelectionRouteEnvelope
         {
             get;
         }
+
+        public bool HasCompleteOccurrences => ArgumentFailure is null;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
 

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -1,0 +1,854 @@
+using System.Collections.ObjectModel;
+using System.CommandLine;
+
+namespace DotnetInspector.CommandLine;
+
+internal sealed class CliRowSelectionRouteCandidate
+{
+    private readonly ReadOnlyCollection<string> _commandPrefix;
+
+    public CliRowSelectionRouteCandidate(
+        Command parserRoot,
+        Command expectedCommand,
+        IReadOnlyList<string> commandPrefix,
+        CliRowSelectionOptionBindings bindings,
+        CliRowSelectionCapabilities capabilities)
+    {
+        ArgumentNullException.ThrowIfNull(parserRoot);
+        ArgumentNullException.ThrowIfNull(expectedCommand);
+        ArgumentNullException.ThrowIfNull(commandPrefix);
+        ArgumentNullException.ThrowIfNull(bindings);
+
+        ParserRoot = parserRoot;
+        ExpectedCommand = expectedCommand;
+        _commandPrefix =
+            Array.AsReadOnly(commandPrefix.ToArray());
+        Bindings = bindings;
+        Capabilities = capabilities;
+    }
+
+    public Command ParserRoot { get; }
+
+    public Command ExpectedCommand { get; }
+
+    public IReadOnlyList<string> CommandPrefix =>
+        _commandPrefix;
+
+    public CliRowSelectionOptionBindings Bindings { get; }
+
+    public CliRowSelectionCapabilities Capabilities { get; }
+}
+
+internal enum CliRowSelectionRouteEnvelopeOutcome
+{
+    NoRequest,
+    Deferred,
+    ArgumentFailure,
+    LoweringFailure,
+    ExplicitCommandRequired,
+    UnsupportedCapability,
+    Success
+}
+
+internal sealed class CliRowSelectionRouteEnvelopeResult
+{
+    private readonly ReadOnlyCollection<int> _deferredPositions;
+
+    private CliRowSelectionRouteEnvelopeResult(
+        CliRowSelectionRouteEnvelopeOutcome outcome,
+        IReadOnlyList<int>? deferredPositions = null,
+        CliRowSelectionArgumentFailure? argumentFailure = null,
+        CliRowSelectionFailure? failure = null,
+        CliRowSelectionLoweringResult<string>? loweringResult = null,
+        CliRowSelectionOccurrenceKind? requestKind = null,
+        int? position = null)
+    {
+        Outcome = outcome;
+        _deferredPositions =
+            Array.AsReadOnly(
+                deferredPositions?.ToArray()
+                ?? []);
+        ArgumentFailure = argumentFailure;
+        Failure = failure;
+        LoweringResult = loweringResult;
+        RequestKind = requestKind;
+        Position = position;
+    }
+
+    public CliRowSelectionRouteEnvelopeOutcome Outcome { get; }
+
+    public IReadOnlyList<int> DeferredPositions =>
+        _deferredPositions;
+
+    public CliRowSelectionArgumentFailure? ArgumentFailure { get; }
+
+    public CliRowSelectionFailure? Failure { get; }
+
+    public CliRowSelectionLoweringResult<string>? LoweringResult { get; }
+
+    public CliRowSelectionOccurrenceKind? RequestKind { get; }
+
+    public int? Position { get; }
+
+    public static CliRowSelectionRouteEnvelopeResult NoRequest() =>
+        new(CliRowSelectionRouteEnvelopeOutcome.NoRequest);
+
+    public static CliRowSelectionRouteEnvelopeResult Deferred(
+        IReadOnlyList<int> positions) =>
+        new(
+            CliRowSelectionRouteEnvelopeOutcome.Deferred,
+            deferredPositions: positions);
+
+    public static CliRowSelectionRouteEnvelopeResult Failed(
+        CliRowSelectionArgumentFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new(
+            CliRowSelectionRouteEnvelopeOutcome.ArgumentFailure,
+            argumentFailure: failure,
+            requestKind: failure.OccurrenceKind,
+            position: failure.Position);
+    }
+
+    public static CliRowSelectionRouteEnvelopeResult Failed(
+        CliRowSelectionLoweringResult<string> loweringResult)
+    {
+        ArgumentNullException.ThrowIfNull(loweringResult);
+        ArgumentNullException.ThrowIfNull(loweringResult.Failure);
+        return new(
+            CliRowSelectionRouteEnvelopeOutcome.LoweringFailure,
+            failure: loweringResult.Failure,
+            loweringResult: loweringResult,
+            requestKind: loweringResult.Failure.OccurrenceKind,
+            position: loweringResult.Failure.Position);
+    }
+
+    public static CliRowSelectionRouteEnvelopeResult
+        ExplicitCommandRequired(
+            CliRowSelectionOccurrenceKind kind,
+            int position) =>
+        new(
+            CliRowSelectionRouteEnvelopeOutcome
+                .ExplicitCommandRequired,
+            requestKind: kind,
+            position: position);
+
+    public static CliRowSelectionRouteEnvelopeResult
+        Unsupported(
+            CliRowSelectionOccurrenceKind kind,
+            int position,
+            CliRowSelectionCapabilities missingCapabilities)
+    {
+        var failure =
+            new CliRowSelectionFailure(
+                CliRowSelectionFailureReason.UnsupportedCapability,
+                kind,
+                position,
+                missingCapabilities);
+        return new(
+            CliRowSelectionRouteEnvelopeOutcome
+                .UnsupportedCapability,
+            failure: failure,
+            requestKind: kind,
+            position: position);
+    }
+
+    public static CliRowSelectionRouteEnvelopeResult Success(
+        CliRowSelectionLoweringResult<string> loweringResult)
+    {
+        ArgumentNullException.ThrowIfNull(loweringResult);
+        if (!loweringResult.IsSuccess)
+        {
+            throw new ArgumentException(
+                "A successful route envelope requires successful lowering.",
+                nameof(loweringResult));
+        }
+
+        return new(
+            CliRowSelectionRouteEnvelopeOutcome.Success,
+            loweringResult: loweringResult);
+    }
+}
+
+internal static class CliRowSelectionRouteEnvelope
+{
+    public static CliRowSelectionRouteEnvelopeResult Evaluate(
+        string[] arguments,
+        IReadOnlyList<CliRowSelectionRouteCandidate> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        ArgumentNullException.ThrowIfNull(candidates);
+        if (candidates.Count == 0)
+        {
+            throw new ArgumentException(
+                "At least one route candidate is required.",
+                nameof(candidates));
+        }
+
+        CandidateObservation[] observations =
+            candidates
+                .Select(candidate =>
+                    Observe(
+                        arguments,
+                        candidate))
+                .ToArray();
+        bool hasUnexpectedCommand =
+            observations.Any(
+                observation =>
+                    !observation.ExpectedCommandSelected);
+
+        int[] unexpectedCommandPositions =
+            observations
+                .Where(
+                    observation =>
+                        !observation.ExpectedCommandSelected)
+                .Select(
+                    observation =>
+                        observation.UnexpectedCommandPosition)
+                .Where(position => position is not null)
+                .Select(position => position!.Value)
+                .Distinct()
+                .Order()
+                .ToArray();
+        // Common grammar failures remain reportable even when an unrelated
+        // token must later be deferred to routing.
+        CliRowSelectionArgumentFailure? commonArgumentFailure =
+            CommonArgumentFailure(observations);
+        if (commonArgumentFailure is not null)
+        {
+            return CliRowSelectionRouteEnvelopeResult.Failed(
+                commonArgumentFailure);
+        }
+
+        CliRowSelectionLoweringResult<string>? commonLoweringFailure =
+            CommonLoweringFailure(observations);
+        if (commonLoweringFailure is not null)
+        {
+            return CliRowSelectionRouteEnvelopeResult.Failed(
+                commonLoweringFailure);
+        }
+
+        RequestScan scan =
+            ScanRequests(
+                arguments,
+                observations);
+
+        // Declaration and capability failures are compared in argv order so
+        // naming a command cannot be suggested for a uniformly unsupported
+        // earlier request.
+        foreach (RequestToken request in scan.Requests)
+        {
+            if (request.Declared.All(
+                    declared => !declared))
+            {
+                return CliRowSelectionRouteEnvelopeResult.Unsupported(
+                    request.Kind,
+                    request.Position,
+                    CliRowSelectionLowerer.RequiredCapabilities(
+                        request.Kind,
+                        scan.LineSelection));
+            }
+
+            if (request.MeaningsDiffer
+                || request.Declared.Any(
+                    declared => !declared))
+            {
+                if (!hasUnexpectedCommand)
+                {
+                    return CliRowSelectionRouteEnvelopeResult
+                        .ExplicitCommandRequired(
+                            request.Kind,
+                            request.Position);
+                }
+
+                continue;
+            }
+
+            CliRowSelectionCapabilities[] required =
+                observations
+                    .Select(
+                        observation =>
+                            CliRowSelectionLowerer
+                                .RequiredCapabilities(
+                                    request.Kind,
+                                    observation.LineSelection))
+                    .ToArray();
+            bool[] supported =
+                observations
+                    .Select(
+                        (observation, index) =>
+                            (observation.Candidate.Capabilities
+                                & required[index])
+                            == required[index])
+                    .ToArray();
+            CliRowSelectionCapabilities commonRequired =
+                required[0];
+            bool commonMeaning =
+                required.All(
+                    candidateRequired =>
+                        candidateRequired == commonRequired);
+            if (!commonMeaning)
+            {
+                if (!hasUnexpectedCommand)
+                {
+                    return CliRowSelectionRouteEnvelopeResult
+                        .ExplicitCommandRequired(
+                            request.Kind,
+                            request.Position);
+                }
+
+                continue;
+            }
+
+            if (supported.All(value => value))
+            {
+                continue;
+            }
+
+            if (supported.Any(value => value))
+            {
+                if (!hasUnexpectedCommand)
+                {
+                    return CliRowSelectionRouteEnvelopeResult
+                        .ExplicitCommandRequired(
+                            request.Kind,
+                            request.Position);
+                }
+
+                continue;
+            }
+
+            return CliRowSelectionRouteEnvelopeResult.Unsupported(
+                request.Kind,
+                request.Position,
+                commonRequired);
+        }
+
+        if (hasUnexpectedCommand
+            || scan.DeferredPositions.Count > 0)
+        {
+            return CliRowSelectionRouteEnvelopeResult.Deferred(
+                unexpectedCommandPositions
+                    .Concat(scan.DeferredPositions)
+                    .Distinct()
+                    .Order()
+                    .ToArray());
+        }
+
+        if (scan.Requests.Count == 0)
+        {
+            return CliRowSelectionRouteEnvelopeResult.NoRequest();
+        }
+
+        IReadOnlyList<CliRowSelectionOccurrence<string>>?
+            commonOccurrences =
+                CommonOccurrences(observations);
+        if (commonOccurrences is null)
+        {
+            return CliRowSelectionRouteEnvelopeResult.Deferred(
+                scan.Requests
+                    .Select(request => request.Position)
+                    .Distinct()
+                    .Order()
+                    .ToArray());
+        }
+
+        if (commonOccurrences.Count == 0)
+        {
+            return CliRowSelectionRouteEnvelopeResult.Deferred(
+                scan.Requests
+                    .Select(request => request.Position)
+                    .Distinct()
+                    .Order()
+                    .ToArray());
+        }
+
+        CliRowSelectionLoweringResult<string> lowering =
+            CliRowSelectionLowerer.Lower(
+                commonOccurrences,
+                CliRowSelectionCapabilities.All);
+        return lowering.IsSuccess
+            ? CliRowSelectionRouteEnvelopeResult.Success(
+                lowering)
+            : CliRowSelectionRouteEnvelopeResult.Failed(
+                lowering);
+    }
+
+    private static CandidateObservation Observe(
+        string[] arguments,
+        CliRowSelectionRouteCandidate candidate)
+    {
+        string[] prefixedArguments =
+            [
+                .. candidate.CommandPrefix,
+                .. arguments
+            ];
+        CliRowSelectionArgumentResult result =
+            CliRowSelectionArgumentAdapter.InspectExplicit(
+                candidate.ParserRoot,
+                prefixedArguments,
+                candidate.Bindings);
+        CliRowSelectionArgumentResult declarationResult =
+            CliRowSelectionArgumentAdapter.InspectExplicit(
+                candidate.ParserRoot,
+                candidate.CommandPrefix.ToArray(),
+                candidate.Bindings);
+        int prefixLength =
+            candidate.CommandPrefix.Count;
+        CliRowSelectionOccurrence<string>[] occurrences =
+            result.Occurrences
+                .Where(
+                    occurrence =>
+                        occurrence.Position >= prefixLength)
+                .Select(
+                    occurrence =>
+                        Translate(
+                            occurrence,
+                            prefixLength))
+                .ToArray();
+        CliRowSelectionArgumentFailure? argumentFailure =
+            result.ArgumentFailure is not null
+                && result.ArgumentFailure.Position >= prefixLength
+                ? new(
+                    result.ArgumentFailure.Reason,
+                    result.ArgumentFailure.OccurrenceKind,
+                    result.ArgumentFailure.Position
+                        - prefixLength)
+                : null;
+        int[] requiredValuePositions =
+            result.RequiredValuePositions
+                .Where(position => position >= prefixLength)
+                .Select(position => position - prefixLength)
+                .Distinct()
+                .Order()
+                .ToArray();
+        int? unexpectedCommandPosition =
+            !ReferenceEquals(
+                result.ParseResult.CommandResult.Command,
+                candidate.ExpectedCommand)
+            && result.SelectedCommandPosition is int
+                selectedCommandPosition
+            && selectedCommandPosition >= prefixLength
+                ? selectedCommandPosition - prefixLength
+                : null;
+        CliRowSelectionLoweringResult<string> loweringResult =
+            CliRowSelectionLowerer.Lower(
+                occurrences,
+                CliRowSelectionCapabilities.All);
+        bool[] declaredKinds =
+            Enum.GetValues<CliRowSelectionOccurrenceKind>()
+                .Select(
+                    kind =>
+                        CliRowSelectionArgumentAdapter.IsDeclared(
+                            declarationResult.ParseResult,
+                            candidate.Bindings,
+                            kind))
+                .ToArray();
+
+        return new(
+            candidate,
+            result.ParseResult,
+            ReferenceEquals(
+                result.ParseResult.CommandResult.Command,
+                candidate.ExpectedCommand),
+            occurrences,
+            argumentFailure,
+            requiredValuePositions,
+            unexpectedCommandPosition,
+            loweringResult,
+            declaredKinds);
+    }
+
+    private static CliRowSelectionArgumentFailure?
+        CommonArgumentFailure(
+            IReadOnlyList<CandidateObservation> observations)
+    {
+        CliRowSelectionArgumentFailure? first =
+            observations[0].ArgumentFailure;
+        if (first is null)
+        {
+            return null;
+        }
+
+        return observations.All(
+            observation =>
+                Same(
+                    first,
+                    observation.ArgumentFailure))
+            ? first
+            : null;
+    }
+
+    private static CliRowSelectionLoweringResult<string>?
+        CommonLoweringFailure(
+            IReadOnlyList<CandidateObservation> observations)
+    {
+        CliRowSelectionLoweringResult<string> first =
+            observations[0].LoweringResult;
+        if (first.IsSuccess)
+        {
+            return null;
+        }
+
+        return observations
+            .Skip(1)
+            .Select(observation => observation.LoweringResult)
+            .All(
+                result =>
+                    !result.IsSuccess
+                    && Same(
+                        first.Failure!,
+                        result.Failure!))
+            ? first
+            : null;
+    }
+
+    private static RequestScan ScanRequests(
+        IReadOnlyList<string> arguments,
+        IReadOnlyList<CandidateObservation> observations)
+    {
+        var requests =
+            new List<RequestToken>();
+        var deferredPositions =
+            new SortedSet<int>();
+
+        for (int position = 0;
+            position < arguments.Count;
+            position++)
+        {
+            string token =
+                arguments[position];
+            if (token == "--")
+            {
+                break;
+            }
+
+            bool[] requiredClaims =
+                observations
+                    .Select(
+                        observation =>
+                            observation.RequiredValuePositions
+                                .Contains(position))
+                    .ToArray();
+            bool bare =
+                CliRowSelectionArgumentAdapter
+                    .IsBareLimitShorthand(token);
+            bool[] bareDeclared =
+                observations
+                    .Select(
+                        observation =>
+                            CliRowSelectionArgumentAdapter
+                                .HasShortLimitAlias(
+                                    observation.Candidate.Bindings)
+                            && observation.IsDeclared(
+                                    CliRowSelectionOccurrenceKind
+                                        .Limit))
+                    .ToArray();
+            CliRowSelectionOccurrenceKind?[] meanings =
+                observations
+                    .Select(
+                        observation =>
+                            CliRowSelectionArgumentAdapter
+                                .TryClassifyExplicitRowToken(
+                                    token,
+                                    observation.Candidate.Bindings,
+                                    out CliRowSelectionOccurrenceKind
+                                        kind)
+                                ? (CliRowSelectionOccurrenceKind?)kind
+                                : null)
+                    .ToArray();
+            bool potentialRequest =
+                bare
+                && bareDeclared.Any(
+                    declared => declared)
+                || meanings.Any(
+                    meaning =>
+                        meaning is not null);
+            if (!potentialRequest
+                || requiredClaims.All(claimed => claimed))
+            {
+                continue;
+            }
+
+            if (requiredClaims.Any(claimed => claimed))
+            {
+                deferredPositions.Add(position);
+                continue;
+            }
+
+            if (bare)
+            {
+                if (bareDeclared.Any(value => !value))
+                {
+                    deferredPositions.Add(position);
+                    continue;
+                }
+
+                requests.Add(
+                    new(
+                        position,
+                        CliRowSelectionOccurrenceKind.Limit,
+                        bareDeclared,
+                        MeaningsDiffer: false));
+                continue;
+            }
+
+            CliRowSelectionOccurrenceKind kind =
+                meanings
+                    .Where(meaning => meaning is not null)
+                    .Select(meaning => meaning!.Value)
+                    .First();
+            bool meaningsDiffer =
+                meanings.Any(meaning => meaning is null)
+                || meanings
+                    .Where(meaning => meaning is not null)
+                    .Select(meaning => meaning!.Value)
+                    .Distinct()
+                    .Skip(1)
+                    .Any();
+            var declared =
+                new bool[observations.Count];
+            for (int index = 0;
+                index < observations.Count;
+                index++)
+            {
+                declared[index] =
+                    meanings[index] is
+                        CliRowSelectionOccurrenceKind
+                            candidateKind
+                    && CliRowSelectionArgumentAdapter
+                        .TryClassifyExplicitRowToken(
+                            token,
+                            observations[index].Candidate.Bindings,
+                            out _)
+                    && observations[index].IsDeclared(
+                        candidateKind);
+            }
+
+            requests.Add(
+                new(
+                    position,
+                    kind,
+                    declared,
+                    meaningsDiffer));
+        }
+
+        bool lineSelection =
+            requests.Any(
+                request =>
+                    request.Kind is
+                        CliRowSelectionOccurrenceKind.Lines
+                        or CliRowSelectionOccurrenceKind.TailLines
+                    && !request.MeaningsDiffer
+                    && request.Declared.All(
+                        declared => declared));
+        return new(
+            requests,
+            deferredPositions.ToArray(),
+            lineSelection);
+    }
+
+    private static IReadOnlyList<
+        CliRowSelectionOccurrence<string>>? CommonOccurrences(
+            IReadOnlyList<CandidateObservation> observations)
+    {
+        IReadOnlyList<CliRowSelectionOccurrence<string>> first =
+            observations[0].Occurrences;
+        return observations
+            .Skip(1)
+            .All(
+                observation =>
+                    Same(
+                        first,
+                        observation.Occurrences))
+            ? first
+            : null;
+    }
+
+    private static bool Same(
+        CliRowSelectionArgumentFailure expected,
+        CliRowSelectionArgumentFailure? actual) =>
+        actual is not null
+        && expected.Reason == actual.Reason
+        && expected.OccurrenceKind == actual.OccurrenceKind
+        && expected.Position == actual.Position;
+
+    private static bool Same(
+        CliRowSelectionFailure expected,
+        CliRowSelectionFailure actual) =>
+        expected.Reason == actual.Reason
+        && expected.OccurrenceKind == actual.OccurrenceKind
+        && expected.Position == actual.Position
+        && expected.MissingCapabilities
+            == actual.MissingCapabilities;
+
+    private static bool Same(
+        IReadOnlyList<CliRowSelectionOccurrence<string>> expected,
+        IReadOnlyList<CliRowSelectionOccurrence<string>> actual)
+    {
+        if (expected.Count != actual.Count)
+        {
+            return false;
+        }
+
+        for (int index = 0;
+            index < expected.Count;
+            index++)
+        {
+            if (!Same(
+                    expected[index],
+                    actual[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool Same(
+        CliRowSelectionOccurrence<string> expected,
+        CliRowSelectionOccurrence<string> actual)
+    {
+        if (expected.Kind != actual.Kind
+            || expected.Position != actual.Position)
+        {
+            return false;
+        }
+
+        return expected.Kind switch
+        {
+            CliRowSelectionOccurrenceKind.Limit
+                or CliRowSelectionOccurrenceKind.Rows
+                or CliRowSelectionOccurrenceKind.Top =>
+                expected.Value.Equals(
+                    actual.Value,
+                    StringComparison.Ordinal),
+            CliRowSelectionOccurrenceKind.OrderBy =>
+                expected.OrderOperand.Equals(
+                    actual.OrderOperand,
+                    StringComparison.Ordinal),
+            _ => true
+        };
+    }
+
+    private static CliRowSelectionOccurrence<string> Translate(
+        CliRowSelectionOccurrence<string> occurrence,
+        int prefixLength)
+    {
+        int position =
+            occurrence.Position - prefixLength;
+        return occurrence.Kind switch
+        {
+            CliRowSelectionOccurrenceKind.Limit =>
+                CliRowSelectionOccurrence<string>.Limit(
+                    position,
+                    occurrence.Value),
+            CliRowSelectionOccurrenceKind.Rows =>
+                CliRowSelectionOccurrence<string>.Rows(
+                    position,
+                    occurrence.Value),
+            CliRowSelectionOccurrenceKind.Top =>
+                CliRowSelectionOccurrence<string>.Top(
+                    position,
+                    occurrence.Value),
+            CliRowSelectionOccurrenceKind.OrderBy =>
+                CliRowSelectionOccurrence<string>.OrderBy(
+                    position,
+                    occurrence.OrderOperand),
+            CliRowSelectionOccurrenceKind.Head =>
+                CliRowSelectionOccurrence<string>.Head(
+                    position),
+            CliRowSelectionOccurrenceKind.Tail =>
+                CliRowSelectionOccurrence<string>.Tail(
+                    position),
+            CliRowSelectionOccurrenceKind.Lines =>
+                CliRowSelectionOccurrence<string>.Lines(
+                    position),
+            CliRowSelectionOccurrenceKind.TailLines =>
+                CliRowSelectionOccurrence<string>.TailLines(
+                    position),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(occurrence),
+                occurrence.Kind,
+                null)
+        };
+    }
+
+    private sealed class CandidateObservation
+    {
+        public CandidateObservation(
+            CliRowSelectionRouteCandidate candidate,
+            ParseResult parseResult,
+            bool expectedCommandSelected,
+            IReadOnlyList<CliRowSelectionOccurrence<string>>
+                occurrences,
+            CliRowSelectionArgumentFailure? argumentFailure,
+            IReadOnlyList<int> requiredValuePositions,
+            int? unexpectedCommandPosition,
+            CliRowSelectionLoweringResult<string> loweringResult,
+            bool[] declaredKinds)
+        {
+            Candidate = candidate;
+            ParseResult = parseResult;
+            ExpectedCommandSelected = expectedCommandSelected;
+            Occurrences = occurrences;
+            ArgumentFailure = argumentFailure;
+            RequiredValuePositions = requiredValuePositions;
+            UnexpectedCommandPosition =
+                unexpectedCommandPosition;
+            LoweringResult = loweringResult;
+            DeclaredKinds = declaredKinds;
+        }
+
+        public CliRowSelectionRouteCandidate Candidate { get; }
+
+        public ParseResult ParseResult
+        {
+            get;
+        }
+
+        public bool ExpectedCommandSelected { get; }
+
+        public IReadOnlyList<CliRowSelectionOccurrence<string>>
+            Occurrences { get; }
+
+        public CliRowSelectionArgumentFailure? ArgumentFailure
+        {
+            get;
+        }
+
+        public IReadOnlyList<int> RequiredValuePositions { get; }
+
+        public int? UnexpectedCommandPosition { get; }
+
+        public CliRowSelectionLoweringResult<string> LoweringResult
+        {
+            get;
+        }
+
+        private bool[] DeclaredKinds { get; }
+
+        public bool LineSelection =>
+            Occurrences.Any(
+                occurrence =>
+                    occurrence.Kind is
+                        CliRowSelectionOccurrenceKind.Lines
+                        or CliRowSelectionOccurrenceKind.TailLines);
+
+        public bool IsDeclared(
+            CliRowSelectionOccurrenceKind kind) =>
+            DeclaredKinds[(int)kind];
+    }
+
+    private sealed record RequestToken(
+        int Position,
+        CliRowSelectionOccurrenceKind Kind,
+        bool[] Declared,
+        bool MeaningsDiffer);
+
+    private sealed record RequestScan(
+        IReadOnlyList<RequestToken> Requests,
+        IReadOnlyList<int> DeferredPositions,
+        bool LineSelection);
+}

--- a/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
+++ b/src/dotnet-inspect/CommandLine/RowSelection/CliRowSelectionRouteEnvelope.cs
@@ -404,23 +404,25 @@ internal static class CliRowSelectionRouteEnvelope
                 .. candidate.CommandPrefix,
                 .. arguments
             ];
-        CliRowSelectionArgumentResult result =
-            CliRowSelectionArgumentAdapter.InspectExplicit(
-                candidate.ParserRoot,
-                prefixedArguments,
-                candidate.Bindings);
         CliRowSelectionArgumentResult declarationResult =
             CliRowSelectionArgumentAdapter.InspectExplicit(
                 candidate.ParserRoot,
                 candidate.CommandPrefix.ToArray(),
                 candidate.Bindings);
+        CliRowSelectionArgumentResult result =
+            CliRowSelectionArgumentAdapter.InspectExplicit(
+                candidate.ParserRoot,
+                prefixedArguments,
+                candidate.Bindings,
+                declarationResult.ParseResult.CommandResult);
         int prefixLength =
             candidate.CommandPrefix.Count;
         CliRowSelectionOccurrence<string>[] occurrences =
             result.Occurrences
                 .Where(
                     occurrence =>
-                        occurrence.Position >= prefixLength)
+                        occurrence.Position >= prefixLength
+                        && !result.ScopeDependentArgumentPositions.Contains(occurrence.Position))
                 .Select(
                     occurrence =>
                         Translate(
@@ -429,7 +431,8 @@ internal static class CliRowSelectionRouteEnvelope
                 .ToArray();
         CliRowSelectionArgumentFailure[] argumentFailures =
             result.ArgumentFailures
-                .Where(failure => failure.Position >= prefixLength)
+                .Where(failure => failure.Position >= prefixLength
+                    && !result.ScopeDependentArgumentPositions.Contains(failure.Position))
                 .Select(failure =>
                     new CliRowSelectionArgumentFailure(
                         failure.Reason,
@@ -445,6 +448,11 @@ internal static class CliRowSelectionRouteEnvelope
                 .ToArray();
         int[] shadowedRowOptionPositions =
             result.ShadowedRowOptionPositions
+                .Where(position => position >= prefixLength)
+                .Select(position => position - prefixLength)
+                .ToArray();
+        int[] scopeDependentArgumentPositions =
+            result.ScopeDependentArgumentPositions
                 .Where(position => position >= prefixLength)
                 .Select(position => position - prefixLength)
                 .ToArray();
@@ -477,6 +485,7 @@ internal static class CliRowSelectionRouteEnvelope
             argumentFailures,
             requiredValuePositions,
             shadowedRowOptionPositions,
+            scopeDependentArgumentPositions,
             unexpectedCommandPosition,
             declaredKinds);
     }
@@ -525,6 +534,7 @@ internal static class CliRowSelectionRouteEnvelope
             && observations.Any(
                 observation =>
                     observation.ArgumentFailures.Count != 0
+                    || observation.ScopeDependentArgumentPositions.Count != 0
                     || !observation.PreservesOptionScope(
                         CliRowSelectionOccurrenceKind.Limit)
                     || observation.Occurrences.Any(occurrence =>
@@ -871,6 +881,7 @@ internal static class CliRowSelectionRouteEnvelope
             IReadOnlyList<CliRowSelectionArgumentFailure> argumentFailures,
             IReadOnlyList<int> requiredValuePositions,
             IReadOnlyList<int> shadowedRowOptionPositions,
+            IReadOnlyList<int> scopeDependentArgumentPositions,
             int? unexpectedCommandPosition,
             bool[] declaredKinds)
         {
@@ -881,6 +892,7 @@ internal static class CliRowSelectionRouteEnvelope
             ArgumentFailures = argumentFailures;
             RequiredValuePositions = requiredValuePositions;
             ShadowedRowOptionPositions = shadowedRowOptionPositions;
+            ScopeDependentArgumentPositions = scopeDependentArgumentPositions;
             UnexpectedCommandPosition =
                 unexpectedCommandPosition;
             DeclaredKinds = declaredKinds;
@@ -905,11 +917,15 @@ internal static class CliRowSelectionRouteEnvelope
 
         // Whole-request success still belongs to the expected command.
         public bool HasCompleteOccurrences =>
-            ExpectedCommandSelected && ArgumentFailures.Count == 0;
+            ExpectedCommandSelected
+            && ArgumentFailures.Count == 0
+            && ScopeDependentArgumentPositions.Count == 0;
 
         public IReadOnlyList<int> RequiredValuePositions { get; }
 
         public IReadOnlyList<int> ShadowedRowOptionPositions { get; }
+
+        public IReadOnlyList<int> ScopeDependentArgumentPositions { get; }
 
         public int? UnexpectedCommandPosition { get; }
 


### PR DESCRIPTION
## Summary

Implement the pure implicit-route row-selection envelope before target
acquisition.

- `-n` has one default meaning across adopting commands: select semantic
  items; rendered lines require explicit `--lines`.
- Candidate parses preserve required-value ownership, original argv positions,
  and child-specific parse errors without letting those errors suppress common
  row grammar failures.
- The envelope distinguishes common success, common grammar failure, uniform
  non-support, non-uniform declarations/capabilities, and decisions that must
  defer to the routed child.

Closes #5784.

## Demo

This slice deliberately has no production router wiring. Its focused contract
fixture demonstrates the pre-acquisition outcomes:

| Raw implicit argv | Candidate declarations | Envelope result |
| --- | --- | --- |
| `Target -5` | every candidate binds `-n` | semantic `HeadIntent(5)` |
| `Target -n 2 --lines` | every candidate binds the line unit | first two rendered lines |
| `Target --required -5` | candidate arities disagree | defer position 2 to routing |
| `Target --rows 1..2` | no candidate supports Window | common unsupported capability |
| `Target -5` | only some candidates bind `-n` | defer shorthand to routing |
| `Target -n 5` | only some candidates bind `-n` | require an explicit command |
| `Target -n --only-in-first --lines` | private flag creates candidate-specific arity failure | defer rather than infer a different count unit |
| `Target --top 2` | Top bound as `--top` versus only `--rank` | require an explicit command |
| `Target --lines -n` | only one candidate declares `-n` | require an explicit command at the count token, not a false absence failure |
| `Target -n --only-in-first --rows` | earlier count failure differs across candidates | common missing Rows value at position 3 |
| `Target --lines -n 2` | every candidate selects a child inheriting modifiers but not `-n` | defer to routing, not a false missing-count failure |
| `Target --lines` | every candidate's child inherits the count and line declarations | common missing-count failure |
| `Target --lines -n 2` | child inherits count but hides Lines; candidates support only Lines | defer, not a false semantic HeadTail rejection |
| `Target --lines -n2` | child owns a distinct required-value `--lines` option | defer; child value is not a parent row modifier or count |
| `Target --lines=payload` | same child override | defer; no false attached-modifier failure |
| `Target -n --other` | child inherits count but not the parent's `--other` option | defer the scope-dependent argument interpretation |
| `Target --rows --lines -n 2` | child inherits value options but hides line modifiers; HeadTail unsupported | defer, not a false semantic capability rejection |

The same gates include an accidental deeper-child parse and show that an
independent common row failure still wins, while the child selection itself
cannot manufacture non-uniformity, count absence, or success.

## Design

`docs/design/cli-row-selection.md` remains the sole normative owner. The
implementation parses each supplied candidate through its real
System.CommandLine declaration, compares only row-selection evidence, and
lowers one common occurrence sequence through the existing typed lowerer.

The adapter now has an inspection mode that retains row evidence across
unrelated parser errors. Ordinary explicit-command behavior is preserved;
shadowed child options no longer manufacture parent row evidence. Candidate
declaration is taken from the expected route, while required-value ownership
and row occurrences come from the actual candidate parse.
Count absence and unit decisions use visibility of the relevant option, rather
than command identity alone; whole-request success still defers unexpected
command selection.
Token equality preserves the parsed bound option identity, and shorthand uses
the command scope at its raw position rather than the final selected scope.
Row-argument classification is also compared with the expected route; an
interpretation that changes across scopes cannot become a common failure.
The option and following-token positions remain paired, so a protected but
scope-dependent value cannot silently establish the count's semantic unit.
Independent common failures and determinate item-count capability rejections
remain reportable.

This is an upper stacked slice targeting #5809 because that PR broadens the
adapter bindings for the first semantic package-version adoption. The overlap
is compatible and the diff against the parent contains only the route
envelope.

## Non-claims

- no candidate-set construction;
- no target resolution or acquisition;
- no production router wiring;
- no final diagnostic rendering;
- no additional command adoption.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release`
- Current-head focused gate: 105 row-selection and affected package-version
  adoption cases passed, including presence arity, scoped shorthand, valued
  direction guidance, numeric/Boolean package input, compact option ownership,
  coordinate-query evidence, and options-first routing with ordinary Boolean
  option and legacy binding controls.
- `npx markdownlint-cli docs/design/cli-row-selection.md`
- `git diff --check`

## Stack

- Parent: #5809
- This slice: implicit-route envelope
- Remaining: candidate-set construction and router integration, then further
  command adoptions under #4677

The envelope's counted production-host path has two steps: this pure envelope,
then real candidate construction and pre-acquisition router wiring through the
existing diagnostic boundary. That path and the broader migration/retirement
boundary are recorded in
[#4677](https://github.com/richlander/dotnet-inspect/issues/4677#issuecomment-5547337715).
