### PR TITLE
Require local conflict probes during status waits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -553,8 +553,10 @@ owns the full contract and the inspect-web hosting pointer.
   `ci-required` unless parallel review is approved or conflict recovery applies.
   Query GitHub status only when the round cadence requires it; follow
   [GitHub status queries](docs/github-status-queries.md)'s bounded waiting
-  instead of polling. If an hour passes without an authored change while an
-  independent gate hasn't started, fix the sequencing or record the blocker.
+  instead of polling. During a bounded wait, fetch the live base and locally
+  test each new tip for conflicts; never report budget exhaustion without
+  checking the final tip. If an hour passes without an authored change while
+  an independent gate hasn't started, fix the sequencing or record the blocker.
 - `ci-required` is this repository's aggregate merge gate
   (`.github/workflows/ci.yml`): it passes only when the aggregate itself
   concludes `success`, and a missing aggregate is not green. Never require a

--- a/docs/github-status-queries.md
+++ b/docs/github-status-queries.md
@@ -18,12 +18,13 @@ limit endpoint can itself count against secondary limits. See
 The [round cadence](round-orchestration.md#bounded-status-waiting) is a decision
 that justifies a read; it is not a time-triggered poll. Repository policy uses
 REST for routine PR lifecycle, mergeability, and CI status. Use GraphQL for
-graph-shaped data such as review threads or one consistent snapshot of related
-objects. A merge or readiness goal also justifies a GraphQL snapshot because
+graph-shaped data such as review threads or a consistent group of related
+objects. A merge or readiness goal also justifies GraphQL because
 `mergeStateStatus` is the documented field that reports a blocked merge.
-During a bounded third- or sixth-round wait, GraphQL may also provide the
-status snapshot when the REST **primary** limit is exhausted because the
-primary limits are separate. Do not switch APIs to evade a secondary limit.
+During a bounded third- or sixth-round wait, GraphQL may also provide CI status
+when the REST **primary** limit is exhausted because the primary limits are
+separate, but the lifecycle and status reads remain separated by the local
+conflict probe below. Do not switch APIs to evade a secondary limit.
 
 ## Routine REST snapshot
 
@@ -128,14 +129,19 @@ authorization.
 
 ## Graph-shaped snapshots
 
-When GraphQL is justified, request the lifecycle and fixed-head fields needed
-by the same interpretation rules: `state`, `merged`, `headRefOid`,
-`baseRefName`, `baseRefOid`, `baseRef { target { oid } }`, `isDraft`,
-`mergeable`, `mergeStateStatus`, and `statusCheckRollup` state and contexts with
-`pageInfo`. Request enough contexts for the normal check matrix; if another
-page exists and `ci-required` is absent, page before concluding that the check
-is missing. These fields and the `MergeableState` and `MergeStateStatus` enums
-are defined in the [GraphQL object][graphql-pr] and
+When GraphQL is justified during a bounded status wait, first request only the
+lifecycle and fixed-head fields needed by the same interpretation rules:
+`state`, `merged`, `headRefOid`, `baseRefName`, `baseRefOid`,
+`baseRef { target { oid } }`, `isDraft`, `mergeable`, and `mergeStateStatus`.
+Do not request `statusCheckRollup` in that first query.
+
+After validating the response and completing a clean local conflict probe,
+request `headRefOid` and `statusCheckRollup` state and contexts with `pageInfo`
+in a second query. Confirm `headRefOid` still equals the expected head before
+using the status result. Request enough contexts for the normal check matrix;
+if another page exists and `ci-required` is absent, page before concluding that
+the check is missing. These fields and the `MergeableState` and
+`MergeStateStatus` enums are defined in the [GraphQL object][graphql-pr] and
 [enum][graphql-enums] references.
 
 Use `git fetch`, not GraphQL, to discover the live base tip for local conflict

--- a/docs/github-status-queries.md
+++ b/docs/github-status-queries.md
@@ -92,6 +92,40 @@ and response headers; `--jq` selects values from the response body. See
 [required-check troubleshooting][required-checks],
 [REST pagination][pagination], and the [`gh api` manual][gh-api].
 
+## Probe the live base locally
+
+GitHub's test-merge result does not replace a local conflict probe during a
+bounded status wait. After the PR response validates lifecycle, head, and base
+ref, a reported GitHub conflict may short-circuit the snapshot. Otherwise,
+fetch the live base non-mutating before querying checks:
+
+```bash
+git fetch origin "$base_ref"
+base_tip=$(git rev-parse FETCH_HEAD)
+```
+
+Compare `base_tip` with the `conflict-checked-base` recorded for the expected
+head and base ref. When no tip is recorded or the tip changed, run the
+non-mutating test merge:
+
+```bash
+git merge-tree --write-tree "$head_sha" "$base_tip"
+```
+
+Exit status zero records `conflict-checked-base=$base_tip` and allows the
+snapshot to continue. Exit status one means the candidate conflicts with the
+live base and enters conflict recovery before any CI query. Any other exit
+status is a probe failure, not evidence of either outcome; classify a concrete
+transport failure as transient and an invalid ref, missing object, or command
+failure as terminal.
+
+Fetch on every scheduled snapshot so base movement is discovered, but rerun
+the test merge only for an unrecorded tip. Base movement alone does not
+invalidate the candidate, trigger integration, or spend review evidence. The
+probe establishes only whether Git can form a tree merge for that head and
+base tip; it does not establish CI state, semantic non-interaction, or merge
+authorization.
+
 ## Graph-shaped snapshots
 
 When GraphQL is justified, request the lifecycle and fixed-head fields needed
@@ -104,8 +138,8 @@ is missing. These fields and the `MergeableState` and `MergeStateStatus` enums
 are defined in the [GraphQL object][graphql-pr] and
 [enum][graphql-enums] references.
 
-Use `git fetch`, not GraphQL, to discover the live base tip for carry-forward
-analysis.
+Use `git fetch`, not GraphQL, to discover the live base tip for local conflict
+probes and carry-forward analysis.
 
 ## Classify failures
 
@@ -152,6 +186,8 @@ Keep these distinctions:
   `mergeable: MERGEABLE` positive mergeability. GitHub explicitly documents
   the GraphQL value in terms of merge conflicts and documents the REST value as
   the result of its test-merge computation.
+- A local conflict against the fetched live base takes precedence over positive
+  or pending GitHub mergeability and enters conflict recovery.
 - A missing `ci-required` is inconclusive, not green.
 - GitHub branch protection accepts required-check conclusions `success`,
   `skipped`, and `neutral`. This repository deliberately uses the stricter

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -174,9 +174,9 @@ snapshot runs and how its result changes round state.
 ### Obtain one snapshot
 
 Follow [GitHub status queries](github-status-queries.md) for API selection,
-request ordering, fixed-head checks, and response classification. This document
-does not restate those mechanics. It consumes one classified snapshot and
-applies the round transition below.
+request ordering, live-base conflict probing, fixed-head checks, and response
+classification. This document does not restate those mechanics. It consumes
+one classified snapshot and applies the round transition below.
 
 ### Apply the result
 
@@ -196,7 +196,7 @@ unrelated members such as `review`. In the table, **status members** means
 | PR is closed or draft | Leave the status wait, publish the human action or stopped state, and end. |
 | Base ref changed | Leave the status wait; expire merge authorization and route the unchanged head through candidate formation without inheriting fixed-head evidence. |
 | Head changed | Leave the status wait; disable auto-merge first, handle an already-merged result as terminal, then route the returned head through candidate formation without inheriting fixed-head evidence. |
-| REST `mergeable: false` or GraphQL `mergeable: CONFLICTING` | Leave the status wait; apply conflict recovery before considering CI. |
+| GitHub reports a conflict, or the local live-base test merge conflicts | Leave the status wait; apply conflict recovery before considering CI. |
 | `ci-required` completed without `success` while required for the current round or goal | Leave the status wait; classify the result and apply the applicable recovery transition. |
 | `ci-required` completed without `success` while not required for the current round or goal | Record the final-readiness failure and continue the current review path. |
 | GraphQL `mergeStateStatus: BLOCKED`, `goal=merge` | Leave the status wait, publish `blocked=<pr-number> rec=wait`, and end. |
@@ -233,7 +233,9 @@ Arm at most one schedule at a time. Key it to its own ID plus the expected
 `head`, complete `waiting` set, `goal`, and deadline. A stale run stops itself
 and exits before querying GitHub. A current run stops itself, clears the
 retained ID, obtains one snapshot, and may arm one successor only when the
-deadline still permits it.
+deadline still permits it. Retain `conflict-checked-base` with the wait state;
+each snapshot fetches the live base and locally tests it only when that exact
+tip has not already been checked for the expected head.
 
 For rate limits, never schedule before the query classification's
 retry-not-before time. GitHub documents `Retry-After` as authoritative,
@@ -244,10 +246,12 @@ choose a conservative delay and never schedule beyond the deadline. Do not use
 `gh run watch`, `gh pr checks --watch`, fixed-rate schedules, synchronous
 sleeps, or concurrent status requests.
 
-When the budget expires with status unresolved, clear `schedule`, keep the
-unresolved predicates, publish the report below, set `rec=stop`, and end. This
-is an informational stop: it ends observation only and neither closes nor
-abandons the PR.
+When the budget expires with status unresolved, obtain a final snapshot. Do not
+publish the report below unless its fetched live base equals
+`conflict-checked-base`; classify and surface a fetch or probe failure instead.
+Then clear `schedule`, keep the unresolved predicates, publish the report, set
+`rec=stop`, and end. This is an informational stop: it ends observation only
+and neither closes nor abandons the PR.
 
 ### Status budget report
 
@@ -260,6 +264,7 @@ Status not observed for PR <number> at round <n> after <mm> minutes.
 - Unresolved: <waiting predicates>
 - Last observation: ci-required=<state|not-observed>,
   mergeable=<true|false|null|not-observed> at <datetime>.
+- Local conflict probe: base=<40-character SHA>, checked at <datetime>.
 - Cause: <rate-limit evidence, transient failure, or still running/queued>.
 - Snapshots: <count>, last at <datetime>.
 - This is not a CI result. No failing check was observed. GitHub documents


### PR DESCRIPTION
Closes #5818.

## Summary

- require bounded status snapshots to fetch the live base and locally test each
  newly observed tip for merge conflicts
- split bounded-wait GraphQL lifecycle and status reads around the local probe
- retain `conflict-checked-base` so unchanged tips are not tested repeatedly
- prevent status-budget exhaustion reports unless the final live base tip was
  checked
- preserve the rule that base movement alone does not invalidate a candidate

## Demo

PR #5792 demonstrated the gap. GitHub reported positive mergeability while its
exact-head `ci-required` check remained unobserved. The local probe distinguishes
the recorded publication base from the current live base:

```text
$ git merge-tree --write-tree 51407338c 733abf863
ed2abde184758e3ff19839a055093ee683583633
exit 0

$ git merge-tree --write-tree 51407338c origin/main
CONFLICT (modify/delete): eng/CiChangeDetection/DetectionTestSuite.cs ...
exit 1
```

What to notice: the unchanged candidate is conflict-free against its recorded
base but conflicts with the advanced live base. Under the new guidance, the
first snapshot observing that base tip enters conflict recovery before querying
CI or exhausting the status budget. A neighboring snapshot that observes the
same checked tip performs no second test merge.

## Compatibility

The local probe supplements GitHub mergeability; it does not replace lifecycle,
CI, review, carry-forward, or merge-authorization checks. A clean probe records
the base tip and continues without integrating it or spending fixed-head
evidence.

## Validation

- `wc -l AGENTS.md` (`596`, below the 600-line cap)
- `npx markdownlint-cli AGENTS.md docs/github-status-queries.md docs/round-orchestration.md`
- `git diff origin/main..HEAD --check`
