### PR TITLE
Fix stale browser decompiler style choices

### DIFF
--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -332,6 +332,7 @@ import {
 } from "./metadata-viewer.ts";
 import {
   bindSettingsPanel,
+  reconcileStyleTaste,
   renderSettingsView,
   type StyleOption,
   type StyleTier,
@@ -11924,6 +11925,13 @@ async function bootstrap() {
       state.styleOptions = (
         sections.find(section => section.id === "csharp.style-choices")?.values
         || []).filter(isStyleOption);
+      const reconciledTaste = reconcileStyleTaste(
+        state.taste,
+        state.styleOptions);
+      if (reconciledTaste.length !== state.taste.length) {
+        state.taste = reconciledTaste;
+        localStorage.setItem("inspect-taste", JSON.stringify(state.taste));
+      }
     } catch (error) {
       state.styleTiers = [];
       state.styleOptions = [];

--- a/prototypes/inspect-web/src/settings-panel.ts
+++ b/prototypes/inspect-web/src/settings-panel.ts
@@ -29,6 +29,14 @@ export interface StyleCatalogState {
 
 type EscapeHtml = (value: unknown) => string;
 
+export function reconcileStyleTaste(
+  taste: readonly string[],
+  options: readonly StyleOption[],
+): string[] {
+  const currentIds = new Set(options.map(option => option.id));
+  return taste.filter(id => currentIds.has(id));
+}
+
 export interface SettingsPanelBindingActions {
   onClose: () => void;
   onOpen: (from: "home" | "workbench") => void;

--- a/prototypes/inspect-web/test/settings-panel.test.ts
+++ b/prototypes/inspect-web/test/settings-panel.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   bindSettingsPanel,
+  reconcileStyleTaste,
   renderSettingsView,
   type SettingsPanelBindingActions,
   styleCatalogGroupsHtml,
@@ -96,6 +97,14 @@ const styleOptions = [
   { id: "readable-locals", tier: "naming", title: "Readable local names", summary: "Synthesize readable local names.", oracle_endorsed: true },
   { id: "expanded-braces", tier: "layout", title: "Expanded braces", summary: "Always use braces." },
 ];
+
+test("style taste reconciliation drops retired catalog choices", () => {
+  assert.deepEqual(
+    reconcileStyleTaste(
+      ["readable-local-names", "expanded-braces"],
+      styleOptions),
+    ["expanded-braces"]);
+});
 
 test("settings bindings dispatch the home entry control", () => {
   const root = new FakeRoot();

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2428,6 +2428,16 @@ test("ready status shows versioned linked build provenance", () => {
     /-getProperty:VersionPrefix[\s\S]*-p:VersionPrefix="\$version"[\s\S]*-p:SourceRevisionId="\$GITHUB_SHA"[\s\S]*-p:BuildTimestampUtc="\$built_at"/);
 });
 
+test("bootstrap reconciles persisted style choices with the product catalog", () => {
+  const bootstrap =
+    appSource.match(
+      /async function bootstrap\(\) \{[\s\S]*?\n}\n\nfunction computeDiagnostics/,
+    )?.[0] ?? "";
+  assert.match(
+    bootstrap,
+    /state\.styleOptions = \([\s\S]*reconcileStyleTaste\(\s*state\.taste,\s*state\.styleOptions\);[\s\S]*state\.taste = reconciledTaste;[\s\S]*localStorage\.setItem\("inspect-taste", JSON\.stringify\(state\.taste\)\)/);
+});
+
 test("bare home paints before wasm engine download", () => {
   const renderDispatch =
     appSource.match(


### PR DESCRIPTION
Build robust browser inspection experiences by keeping persisted UI state aligned with the product-owned decompiler catalog.

## Demo

Before, a browser profile that had stored the retired `readable-local-names` choice showed:

```text
Type source failed
'readable-local-names' is not a style choice in the product catalog.
Arg_ParamName_Name, choiceIds
```

After bootstrap loads `csharp.style-choices`, it removes retired IDs from the locally persisted selection before any Source request. The Source tab therefore uses the current readable-local-names product default instead of failing.

Neighboring case: current choices remain selected and persisted; the regression test keeps a valid choice while dropping `readable-local-names`.

## Change

- Reconcile locally persisted taste IDs against the current product catalog.
- Persist the repaired selection so later sessions do not repeat the failure.
- Keep strict product-side rejection for IDs that bypass the browser catalog boundary.

## Validation

- `npm test`
- `npm run lint`
