### PR TITLE
Implement Research local producer session and completion

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -913,9 +913,13 @@ This boundary does not define:
 
 ## Research local producer session and completion
 
-**Status:** target design for
-[#5441](https://github.com/richlander/dotnet-inspect/issues/5441). No runtime
-type implements this contract, and every named gate below is **unverified**.
+**Status:** implemented by `ResearchProducerSession`,
+`ResearchProducerSessionValidator`, and the Research-owned models in
+`ResearchProducerSessionModels.cs`, tracked by
+[#5820](https://github.com/richlander/dotnet-inspect/issues/5820).
+`ResearchProducerSessionTests` contains the named implementation gates below.
+The design was established by
+[#5441](https://github.com/richlander/dotnet-inspect/issues/5441).
 The ILDiff owner now supplies its focused typed-inspection adapter through
 `IlAssemblyDiff.CompareMemberEndpoints`, gated by the owner-specific tests named
 in [IL diff canonicalization boundary](il-diff-canonicalization.md). The C#
@@ -1033,6 +1037,19 @@ A null reader, handle, body, collection, or native result authorizes no state.
 Input access or validation that prevents the adapter from receiving its exact
 endpoint is retained as Research unavailability, not translated into subject
 absence or no applicable input.
+
+The body-producer subject for paired or one-sided correspondence is the exact
+`ResearchTargetCorrespondenceKey.CanonicalIdentity` retained by that
+correspondence. A both-absent domain uses its exact scope's declaring-type
+intent and normalized Metadata selector. Both sides receive the same logical
+subject. The subject is producer payload identity, not work-item identity.
+
+A resolved API-only target whose relationship role is `None` has no
+`MetadataMethodAddress` that either body-producer endpoint can admit. Research
+retains that item as `EndpointAddressUnavailable` and invokes no producer. It
+does not reinterpret the missing physical endpoint as producer-owned
+`NoApplicableInput`; a bodyful/bodyless MethodDef pair still reaches both
+native adapters, which classify the bodyless side themselves.
 
 Research invokes only the producer's total endpoint adapter and never calls its
 pair algorithm directly. The imported producer contract ensures that every
@@ -1196,7 +1213,8 @@ Implementation proceeds in focused owner order:
    [#5444](https://github.com/richlander/dotnet-inspect/issues/5444) and
    [#5443](https://github.com/richlander/dotnet-inspect/issues/5443).
 2. Research implements its catalog, exact work derivation, sequential session,
-   input access, cleanup, and completion validator.
+   input access, cleanup, and completion validator through
+   `ResearchProducerSession`.
 3. The Research completion becomes available to the separately owned rank-5
    direct-member and rank-6 publication efforts; this design specifies neither
    adoption.

--- a/src/ILInspector.Research.Tests/ResearchComparisonAdmissionTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchComparisonAdmissionTests.cs
@@ -419,15 +419,34 @@ public class ResearchComparisonAdmissionTests
                 field => IsGenericDefinition(field.FieldType, typeof(Dictionary<,>)));
         }
 
-        FieldInfo map = Assert.Single(
-            typeof(ResearchAdmittedPopulation).GetFields(
-                BindingFlags.NonPublic | BindingFlags.Instance),
-            field => IsGenericDefinition(field.FieldType, typeof(FrozenDictionary<,>)));
-        var frozen =
+        FieldInfo[] maps =
+        [
+            .. typeof(ResearchAdmittedPopulation).GetFields(
+                    BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(
+                    field => IsGenericDefinition(
+                        field.FieldType,
+                        typeof(FrozenDictionary<,>))),
+        ];
+        Assert.Equal(2, maps.Length);
+        FieldInfo occurrenceMap = Assert.Single(
+            maps,
+            field => field.FieldType.GenericTypeArguments[0]
+                == typeof(ResearchComparisonInputOccurrence));
+        var byOccurrence =
             (FrozenDictionary<ResearchComparisonInputOccurrence, ResearchAdmittedInput>)
-                map.GetValue(population)!;
-        Assert.Same(ReferenceEqualityComparer.Instance, frozen.Comparer);
-        Assert.Equal(2, frozen.Count);
+                occurrenceMap.GetValue(population)!;
+        FieldInfo idMap = Assert.Single(
+            maps,
+            field => field.FieldType.GenericTypeArguments[0]
+                == typeof(ResearchComparisonInputId));
+        var byId =
+            (FrozenDictionary<ResearchComparisonInputId, ResearchAdmittedInput>)
+                idMap.GetValue(population)!;
+        Assert.Same(ReferenceEqualityComparer.Instance, byOccurrence.Comparer);
+        Assert.Same(ReferenceEqualityComparer.Instance, byId.Comparer);
+        Assert.Equal(2, byOccurrence.Count);
+        Assert.Equal(2, byId.Count);
         Assert.NotSame(population.GetInput(first), population.GetInput(second));
     }
 

--- a/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
@@ -1,0 +1,1113 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+using DotnetInspector.Artifacts;
+using DotnetInspector.Fixtures;
+
+using ILInspector.Analysis;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Research.Tests;
+
+public class ResearchProducerSessionTests
+{
+    const string SampleType =
+        "ILInspector.Research.TargetFixtures.TargetSample";
+
+    [Fact]
+    public void ResearchProducerCatalog_AdmitsEveryDeclaredLocalKind()
+    {
+        Assert.Equal(
+            Enum.GetValues<ResearchProducerKind>(),
+            ResearchProducerCatalog.Kinds);
+    }
+
+    [Fact]
+    public void ResearchProducerSession_RejectsForeignPopulationResolutionAndCatalogShapes()
+    {
+        SessionFixture first = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        SessionFixture second = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = first.Resolve(
+            SampleType,
+            "Method");
+
+        Assert.Equal(
+            ResearchProducerRejectionKind.ForeignResolution,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    second.Population,
+                    resolution,
+                    ResearchProducerCatalog.Kinds)).Kind);
+        Assert.Equal(
+            ResearchProducerRejectionKind.EmptyProducerSelection,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    first.Population,
+                    resolution,
+                    [])).Kind);
+        Assert.Equal(
+            ResearchProducerRejectionKind.DuplicateProducerKind,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    first.Population,
+                    resolution,
+                    [
+                        ResearchProducerKind.CSharp,
+                        ResearchProducerKind.CSharp,
+                    ])).Kind);
+        Assert.Equal(
+            ResearchProducerRejectionKind.UnknownProducerKind,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    first.Population,
+                    resolution,
+                    [(ResearchProducerKind)int.MaxValue])).Kind);
+
+        var broken = new ResearchTargetResolution(
+            first.Population.Operation,
+            resolution.Scopes,
+            [],
+            []);
+        Assert.Equal(
+            ResearchProducerRejectionKind.InvalidIdentityClosure,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    first.Population,
+                    broken,
+                    [ResearchProducerKind.CSharp])).Kind);
+
+        LibraryBodyIndex bodyIndex = LibraryBodyIndex.Open(
+            FixtureCatalog.ResearchTargetSample.AssemblyPath());
+        ResearchAdmittedPopulation bodySignal =
+            Assert.IsType<ResearchAdmissionOutcome.Admitted>(
+                ResearchComparisonAdmission.Admit(
+                    new ResearchComparisonAdmissionRequest(
+                        ResearchComparisonProfile.BodySignal,
+                        [
+                            new ResearchComparisonAdmissionQuestion(
+                                [new BodySignalComparisonInputOccurrence(bodyIndex)],
+                                []),
+                        ]))).Population;
+        Assert.Equal(
+            ResearchProducerRejectionKind.UnsupportedProfile,
+            Reject(
+                new ResearchProducerSessionRequest(
+                    bodySignal,
+                    resolution,
+                    [ResearchProducerKind.CSharp])).Kind);
+    }
+
+    [Fact]
+    public void ResearchProducerWorkItems_DeriveExactOrderedCorrespondenceCatalogProduct()
+    {
+        int beforeOpens = 0;
+        int afterOpens = 0;
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(
+                FixtureCatalog.ResearchTargetSample.AssemblyPath(),
+                () => beforeOpens++),
+            Occurrence(
+                FixtureCatalog.ResearchTargetSample.AssemblyPath(),
+                () => afterOpens++));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        int beforeResolutionOpens = beforeOpens;
+        int afterResolutionOpens = afterOpens;
+
+        var invoker = new TrackingInvoker();
+        ResearchProducerCompletion completion = Complete(
+            new ResearchProducerSessionRequest(
+                fixture.Population,
+                resolution,
+                [
+                    ResearchProducerKind.IlBody,
+                    ResearchProducerKind.CSharp,
+                ]),
+            invoker);
+
+        Assert.Equal(2, completion.WorkItems.Length);
+        Assert.Collection(
+            completion.WorkItems,
+            item =>
+            {
+                Assert.Same(resolution.Correspondences[0], item.Correspondence);
+                Assert.Equal(ResearchProducerKind.CSharp, item.Producer);
+            },
+            item =>
+            {
+                Assert.Same(resolution.Correspondences[0], item.Correspondence);
+                Assert.Equal(ResearchProducerKind.IlBody, item.Producer);
+            });
+        Assert.Collection(
+            completion.Results,
+            result => Assert.IsType<
+                ResearchProducerWorkOutcome.ProducedCSharp>(result.Outcome),
+            result => Assert.IsType<
+                ResearchProducerWorkOutcome.ProducedIlBody>(result.Outcome));
+        Assert.True(beforeOpens > beforeResolutionOpens);
+        Assert.True(afterOpens > afterResolutionOpens);
+        Assert.Equal(2, invoker.CSharpSources.Count);
+        Assert.Collection(
+            completion.Cleanup,
+            outcome => Assert.Same(
+                fixture.Population.Inputs[1].Id,
+                outcome.Input),
+            outcome => Assert.Same(
+                fixture.Population.Inputs[0].Id,
+                outcome.Input));
+    }
+
+    [Fact]
+    public void ResearchProducerAdapters_MapExactCorrespondenceEvidence()
+    {
+        SessionFixture pairedFixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution paired = pairedFixture.Resolve(
+            SampleType,
+            "Method");
+        ResearchProducerCompletion pairedCompletion = Complete(
+            Request(pairedFixture, paired));
+
+        var csharp = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedCSharp>(
+                pairedCompletion.Results[0].Outcome);
+        var il = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedIlBody>(
+                pairedCompletion.Results[1].Outcome);
+        Assert.NotNull(csharp.Result.BodyDiff);
+        Assert.NotNull(il.Result.MemberDiff);
+        Assert.Equal(
+            FindingInspectionState.Complete,
+            Assert.IsType<
+                FindingComparison<CSharpCanonicalLine>.Complete>(
+                    csharp.Result.Findings.Value).Transition.Old);
+        Assert.Equal(
+            FindingInspectionState.Complete,
+            Assert.IsType<
+                FindingComparison<CanonicalIlOperation>.Complete>(
+                    il.Result.Findings.Value).Transition.New);
+
+        SessionFixture absentFixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution absent = absentFixture.Resolve(
+            "ILInspector.Research.TargetFixtures.NotHere",
+            "Method");
+        ResearchProducerCompletion absentCompletion = Complete(
+            Request(absentFixture, absent));
+        Assert.All(
+            absentCompletion.Results,
+            result =>
+            {
+                object native = result.Outcome switch
+                {
+                    ResearchProducerWorkOutcome.ProducedCSharp produced =>
+                        produced.Result.Findings.Value,
+                    ResearchProducerWorkOutcome.ProducedIlBody produced =>
+                        produced.Result.Findings.Value,
+                    _ => throw new Xunit.Sdk.XunitException(
+                        "Both-absent correspondence must invoke each adapter."),
+                };
+                FindingInspectionTransition transition = native switch
+                {
+                    FindingComparison<CSharpCanonicalLine>.Complete complete =>
+                        complete.Transition,
+                    FindingComparison<CanonicalIlOperation>.Complete complete =>
+                        complete.Transition,
+                    _ => throw new Xunit.Sdk.XunitException(
+                        "Both-absent comparison must complete."),
+                };
+                Assert.Equal(
+                    FindingInspectionState.SubjectAbsent,
+                    transition.Old);
+                Assert.Equal(
+                    FindingInspectionState.SubjectAbsent,
+                    transition.New);
+            });
+        Assert.Empty(absentCompletion.Cleanup);
+    }
+
+    [Fact]
+    public void ResearchProducerAdapters_RetainOneSidedNativeResults()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.DiffV1.AssemblyPath()),
+            Occurrence(FixtureCatalog.DiffV2.AssemblyPath()));
+        ResearchTargetResolution ordinal = fixture.Resolve(
+            "DiffFixtureSample.ConstructorRemovalSample",
+            ".ctor:1");
+        MemberAnchor beforeAnchor = Assert.Single(
+            ordinal.Correspondences
+                .OfType<
+                    ResearchTargetCorrespondenceOutcome
+                        .CounterpartUnavailable>(),
+            outcome => outcome.Attempt.Request.Side
+                == ResearchComparisonSide.Before)
+            .Target.Anchor;
+        ResearchTargetResolution oneSided = fixture.Resolve(
+            "DiffFixtureSample.ConstructorRemovalSample",
+            new MemberTargetSelector(
+                beforeAnchor.StableSelector,
+                ".ctor",
+                DigestPrefix: beforeAnchor.Fingerprint));
+        Assert.IsType<ResearchTargetCorrespondenceOutcome.BeforeOnly>(
+            Assert.Single(oneSided.Correspondences));
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, oneSided));
+        var csharp = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedCSharp>(
+                completion.Results[0].Outcome);
+        var il = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedIlBody>(
+                completion.Results[1].Outcome);
+        Assert.Null(csharp.Result.BodyDiff);
+        Assert.Null(il.Result.MemberDiff);
+        Assert.Equal(
+            FindingInspectionState.SubjectAbsent,
+            Assert.IsType<
+                FindingComparison<CSharpCanonicalLine>.Complete>(
+                    csharp.Result.Findings.Value).Transition.New);
+        Assert.Equal(
+            FindingInspectionState.SubjectAbsent,
+            Assert.IsType<
+                FindingComparison<CanonicalIlOperation>.Complete>(
+                    il.Result.Findings.Value).Transition.New);
+    }
+
+    [Fact]
+    public void ResearchProducerAdapters_ClassifyNoEndpointInsideResearch()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.DiffV1.AssemblyPath()),
+            Occurrence(FixtureCatalog.DiffV2.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            "DiffFixtureSample.BodyStateSample",
+            "BodyState");
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution));
+        var csharp = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedCSharp>(
+                completion.Results[0].Outcome);
+        var il = Assert.IsType<
+            ResearchProducerWorkOutcome.ProducedIlBody>(
+                completion.Results[1].Outcome);
+        FindingInspectionTransition csharpTransition = Assert.IsType<
+            FindingComparison<CSharpCanonicalLine>.Complete>(
+                csharp.Result.Findings.Value).Transition;
+        FindingInspectionTransition ilTransition = Assert.IsType<
+            FindingComparison<CanonicalIlOperation>.Complete>(
+                il.Result.Findings.Value).Transition;
+
+        Assert.Equal(
+            FindingInspectionState.NoApplicableInput,
+            csharpTransition.Old);
+        Assert.Equal(FindingInspectionState.Complete, csharpTransition.New);
+        Assert.Equal(
+            FindingInspectionState.NoApplicableInput,
+            ilTransition.Old);
+        Assert.Equal(FindingInspectionState.Complete, ilTransition.New);
+        Assert.Null(csharp.Result.BodyDiff);
+        Assert.Null(il.Result.MemberDiff);
+    }
+
+    [Fact]
+    public void ResearchProducerSession_UsesOnlyValidatedAdmittedInputAccess()
+    {
+        string v1 = FixtureCatalog.DiffV1.AssemblyPath();
+        string v2 = FixtureCatalog.DiffV2.AssemblyPath();
+        int beforeOpens = 0;
+        LibraryBodyIndex beforeIndex = LibraryBodyIndex.Open(v1);
+        var changed = new ImplementationComparisonInputOccurrence(
+            ResolvedAssemblyReference.Create(
+                beforeIndex.ModuleIdentity.AssemblyIdentity!,
+                v1,
+                () =>
+                {
+                    beforeOpens++;
+                    return File.OpenRead(beforeOpens == 1 ? v1 : v2);
+                },
+                AssemblyResolutionProvenance.Project(
+                    "DiffFixtures.V1",
+                    tfm: null,
+                    rid: null)),
+            new NullResolver(),
+            beforeIndex);
+        SessionFixture fixture = SessionFixture.Create(
+            changed,
+            Occurrence(v1));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            "DiffFixtureSample.BodyStateSample",
+            "BodyState");
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+
+        Assert.Equal(0, invoker.InvocationCount);
+        Assert.All(
+            completion.Results,
+            result => Assert.Equal(
+                ResearchProducerUnavailableKind.ModuleIdentityMismatch,
+                Assert.IsType<
+                    ResearchProducerWorkOutcome.Unavailable>(result.Outcome)
+                    .Reason.Kind));
+        Assert.Single(completion.Cleanup);
+    }
+
+    [Fact]
+    public void ResearchProducerSession_InvokesOnlyTotalNativeAdapters()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+
+        Assert.Collection(
+            invoker.EndpointShapes,
+            shape => Assert.Equal(
+                (ResearchProducerKind.CSharp, "Present", "Present"),
+                shape),
+            shape => Assert.Equal(
+                (ResearchProducerKind.IlBody, "Present", "Present"),
+                shape));
+        Assert.Equal(2, completion.Results.Length);
+    }
+
+    [Fact]
+    public void ResearchProducerResults_RetainExactNativeTopologyAndPayload()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+
+        Assert.Same(
+            Assert.Single(invoker.CSharpResults),
+            Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+                completion.Results[0].Outcome).Result);
+        Assert.Same(
+            Assert.Single(invoker.IlResults),
+            Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+                completion.Results[1].Outcome).Result);
+    }
+
+    [Fact]
+    public void ResearchProducerSession_AccountsForTheExactWorkBudget()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+
+        Assert.Equal(
+            resolution.Correspondences.Length
+                * ResearchProducerCatalog.Kinds.Length,
+            completion.WorkItems.Length);
+        Assert.Equal(completion.WorkItems.Length, completion.Results.Length);
+        Assert.Equal(completion.WorkItems.Length, invoker.InvocationCount);
+        Assert.Equal(
+            completion.WorkItems.Length,
+            completion.WorkItems.Select(item => item.Id).Distinct(
+                ReferenceEqualityComparer.Instance).Count());
+    }
+
+    [Fact]
+    public void ResearchProducerSession_OwnsOnlyExactInputStages()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            (SampleType, "Method"),
+            (SampleType, "Many:1"));
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            new ResearchProducerSessionRequest(
+                fixture.Population,
+                resolution,
+                [ResearchProducerKind.CSharp]),
+            invoker);
+
+        Assert.Equal(4, invoker.CSharpSources.Count);
+        Assert.Same(
+            invoker.CSharpSources[0],
+            invoker.CSharpSources[2]);
+        Assert.Same(
+            invoker.CSharpSources[1],
+            invoker.CSharpSources[3]);
+        Assert.Equal(2, completion.Cleanup.Length);
+    }
+
+    [Fact]
+    public void ResearchProducerWorkItems_KeepUnavailableCorrespondenceWithoutInvocation()
+    {
+        int beforeOpens = 0;
+        int afterOpens = 0;
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(
+                FixtureCatalog.DiffV1.AssemblyPath(),
+                () => beforeOpens++),
+            Occurrence(
+                FixtureCatalog.DiffV2.AssemblyPath(),
+                () => afterOpens++));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            "DiffFixtureSample.ConstructorRemovalSample",
+            ".ctor:1");
+        int beforeSession = beforeOpens;
+        int afterSession = afterOpens;
+        var invoker = new TrackingInvoker();
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+
+        Assert.Equal(
+            resolution.Correspondences.Length
+                * ResearchProducerCatalog.Kinds.Length,
+            completion.WorkItems.Length);
+        Assert.All(
+            completion.Results,
+            result => Assert.Equal(
+                ResearchProducerUnavailableKind.CorrespondenceUnavailable,
+                Assert.IsType<
+                    ResearchProducerWorkOutcome.Unavailable>(result.Outcome)
+                    .Reason.Kind));
+        Assert.Equal(0, invoker.InvocationCount);
+        Assert.Equal(beforeSession, beforeOpens);
+        Assert.Equal(afterSession, afterOpens);
+        Assert.Empty(completion.Cleanup);
+    }
+
+    [Fact]
+    public void ResearchProducerException_IsLocalAndDoesNotSuppressIndependentWork()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var invoker = new TrackingInvoker
+        {
+            ThrowCSharp = true,
+        };
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution),
+            invoker);
+        var failed = Assert.IsType<
+            ResearchProducerWorkOutcome.Failed>(
+                completion.Results[0].Outcome);
+        Assert.Equal(
+            ResearchProducerDiagnosticKind.ProducerException,
+            failed.Diagnostic.Kind);
+        Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+            completion.Results[1].Outcome);
+        Assert.Equal(2, invoker.InvocationCount);
+        Assert.Equal(2, completion.Cleanup.Length);
+        Assert.All(
+            completion.Cleanup,
+            outcome => Assert.IsType<
+                ResearchProducerCleanupOutcome.Succeeded>(outcome));
+    }
+
+    [Fact]
+    public void ResearchProducerCancellation_ExposesNoPartialWorkOrCompletion()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        using var cancellation = new CancellationTokenSource();
+        var invoker = new TrackingInvoker
+        {
+            AfterCSharp = cancellation.Cancel,
+        };
+
+        var cancelled =
+            Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+                ResearchProducerSession.Run(
+                    Request(fixture, resolution),
+                    invoker,
+                    cancellation.Token));
+
+        Assert.Equal(1, invoker.InvocationCount);
+        Assert.Equal(2, cancelled.Cleanup.Length);
+        Assert.All(
+            cancelled.Cleanup,
+            outcome => Assert.IsType<
+                ResearchProducerCleanupOutcome.Succeeded>(outcome));
+
+        using var alreadyCancelled = new CancellationTokenSource();
+        alreadyCancelled.Cancel();
+        var notInvoked = new TrackingInvoker();
+        var beforeAcquisition =
+            Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+                ResearchProducerSession.Run(
+                    Request(fixture, resolution),
+                    notInvoked,
+                    alreadyCancelled.Token));
+        Assert.Equal(0, notInvoked.InvocationCount);
+        Assert.Empty(beforeAcquisition.Cleanup);
+    }
+
+    [Fact]
+    public void ResearchProducerCleanup_FailurePreventsCompletionWithoutSuppressingCleanup()
+    {
+        int beforeOpens = 0;
+        int afterOpens = 0;
+        string path = FixtureCatalog.ResearchTargetSample.AssemblyPath();
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(
+                path,
+                () => beforeOpens++,
+                () => beforeOpens > 1),
+            Occurrence(
+                path,
+                () => afterOpens++));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+
+        var failed = Assert.IsType<ResearchProducerSessionOutcome.Failed>(
+            ResearchProducerSession.Run(
+                Request(fixture, resolution),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            ResearchProducerDiagnosticKind.CleanupFailed,
+            failed.Diagnostic.Kind);
+        Assert.Equal(2, failed.Cleanup.Length);
+        Assert.Single(
+            failed.Cleanup,
+            outcome => outcome
+                is ResearchProducerCleanupOutcome.Failed);
+        Assert.Single(
+            failed.Cleanup,
+            outcome => outcome
+                is ResearchProducerCleanupOutcome.Succeeded);
+    }
+
+    [Fact]
+    public void ResearchProducerWorkItemIdentities_AreFreshOwnerIssuedReferences()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var request = Request(fixture, resolution);
+
+        ResearchProducerCompletion first = Complete(request);
+        ResearchProducerCompletion second = Complete(request);
+
+        Assert.NotSame(first.Session, second.Session);
+        Assert.Same(first.Operation, second.Operation);
+        Assert.Equal(first.WorkItems.Length, second.WorkItems.Length);
+        for (int index = 0; index < first.WorkItems.Length; index++)
+        {
+            Assert.NotSame(
+                first.WorkItems[index].Id,
+                second.WorkItems[index].Id);
+            Assert.Same(
+                first.WorkItems[index].Correspondence,
+                second.WorkItems[index].Correspondence);
+        }
+    }
+
+    [Fact]
+    public void ResearchProducerCleanup_AccountsForEveryOwnedResourceExactlyOnce()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution));
+
+        Assert.Collection(
+            completion.Cleanup,
+            outcome => Assert.Same(
+                fixture.Population.Inputs[1].Id,
+                outcome.Input),
+            outcome => Assert.Same(
+                fixture.Population.Inputs[0].Id,
+                outcome.Input));
+        Assert.Equal(
+            completion.Cleanup.Length,
+            completion.Cleanup.Select(outcome => outcome.Input).Distinct(
+                ReferenceEqualityComparer.Instance).Count());
+    }
+
+    [Fact]
+    public void ResearchProducerCompletion_AccountsForEveryWorkItemExactlyOnce()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution));
+
+        Assert.Equal(completion.WorkItems.Length, completion.Results.Length);
+        for (int index = 0; index < completion.WorkItems.Length; index++)
+            Assert.Same(completion.WorkItems[index], completion.Results[index].Item);
+        Assert.Equal(
+            completion.WorkItems.Length,
+            completion.Results.Select(result => result.Item).Distinct(
+                ReferenceEqualityComparer.Instance).Count());
+    }
+
+    [Fact]
+    public void ResearchProducerCompletion_RejectsBrokenCrossLinksAndNativeKinds()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var request = Request(fixture, resolution);
+        ResearchProducerCompletion valid = Complete(request);
+        ImmutableArray<ResearchProducerWorkResult> wrongNativeKind =
+            valid.Results.SetItem(
+                0,
+                new ResearchProducerWorkResult(
+                    valid.WorkItems[0],
+                    valid.Results[1].Outcome));
+
+        Assert.False(
+            ResearchProducerSessionValidator.TryCreateCompletion(
+                request,
+                valid.Session,
+                valid.WorkItems,
+                wrongNativeKind,
+                [
+                    .. valid.Cleanup.Reverse()
+                        .Select(outcome => outcome.Input),
+                ],
+                valid.Cleanup,
+                out _));
+
+        var wrongSubject = new TrackingInvoker
+        {
+            ReturnWrongCSharpSubject = true,
+        };
+        var failed = Assert.IsType<ResearchProducerSessionOutcome.Failed>(
+            ResearchProducerSession.Run(
+                request,
+                wrongSubject,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(
+            ResearchProducerDiagnosticKind.ProducerContractViolation,
+            failed.Diagnostic.Kind);
+        Assert.Equal(2, wrongSubject.InvocationCount);
+        Assert.False(
+            ResearchProducerSessionValidator.TryCreateCompletion(
+                request,
+                valid.Session,
+                valid.WorkItems,
+                valid.Results.RemoveAt(0),
+                [
+                    .. valid.Cleanup.Reverse()
+                        .Select(outcome => outcome.Input),
+                ],
+                valid.Cleanup,
+                out _));
+    }
+
+    [Fact]
+    public void ResearchProducerCompletion_RetainsNoBorrowedResourcesOrPresentation()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        ResearchProducerCompletion completion = Complete(
+            Request(fixture, resolution));
+        Type[] forbidden =
+        [
+            typeof(ResolvedAssemblyReference),
+            typeof(IAssemblyReferenceResolver),
+            typeof(LibraryBodyIndex),
+            typeof(MetadataSource),
+            typeof(Stream),
+            typeof(Delegate),
+        ];
+
+        Type[] producerTypes =
+        [
+            typeof(ResearchProducerCompletion),
+            typeof(ResearchProducerSessionId),
+            typeof(ResearchProducerWorkItem),
+            typeof(ResearchProducerWorkItemId),
+            typeof(ResearchProducerWorkResult),
+            typeof(ResearchProducerWorkOutcome.ProducedCSharp),
+            typeof(ResearchProducerWorkOutcome.ProducedIlBody),
+            typeof(ResearchProducerWorkOutcome.Unavailable),
+            typeof(ResearchProducerWorkOutcome.Failed),
+            typeof(ResearchProducerCleanupOutcome.Succeeded),
+            typeof(ResearchProducerCleanupOutcome.Failed),
+        ];
+        foreach (Type type in producerTypes)
+        {
+            Assert.DoesNotContain(
+                type.GetFields(
+                    BindingFlags.Instance
+                        | BindingFlags.Public
+                        | BindingFlags.NonPublic),
+                field => forbidden.Any(
+                    denied => denied.IsAssignableFrom(field.FieldType)));
+        }
+        Assert.Same(
+            fixture.Population.Operation,
+            completion.Operation);
+    }
+
+    [Fact]
+    public void ResearchProducerCancellation_RetainsEveryCleanupOutcome()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        var invoker = new TrackingInvoker
+        {
+            AfterCSharp = cancellation.Cancel,
+        };
+
+        var cancelled =
+            Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+                ResearchProducerSession.Run(
+                    Request(fixture, resolution),
+                    invoker,
+                    cancellation.Token));
+
+        Assert.Collection(
+            cancelled.Cleanup,
+            outcome => Assert.Same(
+                fixture.Population.Inputs[1].Id,
+                outcome.Input),
+            outcome => Assert.Same(
+                fixture.Population.Inputs[0].Id,
+                outcome.Input));
+    }
+
+    [Fact]
+    public void ResearchProducerCancellation_RetryMintsFreshSessionAndWorkItems()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(
+            SampleType,
+            "Method");
+        var request = Request(fixture, resolution);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+            ResearchProducerSession.Run(
+                request,
+                new TrackingInvoker(),
+                cancellation.Token));
+
+        ResearchProducerCompletion first = Complete(request);
+        ResearchProducerCompletion second = Complete(request);
+        Assert.NotSame(first.Session, second.Session);
+        for (int index = 0; index < first.WorkItems.Length; index++)
+            Assert.NotSame(first.WorkItems[index].Id, second.WorkItems[index].Id);
+    }
+
+    static ResearchProducerSessionRequest Request(
+        SessionFixture fixture,
+        ResearchTargetResolution resolution)
+        => new(
+            fixture.Population,
+            resolution,
+            ResearchProducerCatalog.Kinds);
+
+    static ResearchProducerRejection Reject(
+        ResearchProducerSessionRequest request)
+        => Assert.IsType<ResearchProducerSessionOutcome.Rejected>(
+            ResearchProducerSession.Run(request)).Rejection;
+
+    static ResearchProducerCompletion Complete(
+        ResearchProducerSessionRequest request,
+        IResearchProducerInvoker? invoker = null)
+        => Assert.IsType<ResearchProducerSessionOutcome.Completed>(
+            invoker is null
+                ? ResearchProducerSession.Run(request)
+                : ResearchProducerSession.Run(request, invoker))
+            .Completion;
+
+    static ImplementationComparisonInputOccurrence Occurrence(
+        string path,
+        Action? onOpen = null,
+        Func<bool>? throwOnDispose = null)
+    {
+        LibraryBodyIndex index = LibraryBodyIndex.Open(path);
+        return new ImplementationComparisonInputOccurrence(
+            ResolvedAssemblyReference.Create(
+                index.ModuleIdentity.AssemblyIdentity!,
+                path,
+                () =>
+                {
+                    onOpen?.Invoke();
+                    Stream stream = File.OpenRead(path);
+                    return throwOnDispose?.Invoke() == true
+                        ? new ThrowOnDisposeStream(stream)
+                        : stream;
+                },
+                AssemblyResolutionProvenance.Project(
+                    Path.GetFileNameWithoutExtension(path),
+                    tfm: null,
+                    rid: null)),
+            new NullResolver(),
+            index);
+    }
+
+    sealed class SessionFixture
+    {
+        SessionFixture(ResearchAdmittedPopulation population)
+            => Population = population;
+
+        public ResearchAdmittedPopulation Population { get; }
+
+        public static SessionFixture Create(
+            ImplementationComparisonInputOccurrence before,
+            ImplementationComparisonInputOccurrence after)
+        {
+            ResearchAdmittedPopulation population =
+                Assert.IsType<ResearchAdmissionOutcome.Admitted>(
+                    ResearchComparisonAdmission.Admit(
+                        new ResearchComparisonAdmissionRequest(
+                            ResearchComparisonProfile.ImplementationComparison,
+                            [
+                                new ResearchComparisonAdmissionQuestion(
+                                    [before],
+                                    [after]),
+                            ]))).Population;
+            return new SessionFixture(population);
+        }
+
+        public ResearchTargetResolution Resolve(
+            string declaringType,
+            string selector)
+            => Resolve(
+                declaringType,
+                MemberTargetSelector.Parse(selector));
+
+        public ResearchTargetResolution Resolve(
+            string declaringType,
+            MemberTargetSelector selector)
+            => Resolve((declaringType, selector));
+
+        public ResearchTargetResolution Resolve(
+            params (string DeclaringType, string Selector)[] selections)
+            => Resolve(
+                [
+                    .. selections.Select(
+                        selection => (
+                            selection.DeclaringType,
+                            MemberTargetSelector.Parse(selection.Selector))),
+                ]);
+
+        ResearchTargetResolution Resolve(
+            params (string DeclaringType, MemberTargetSelector Selector)[]
+                selections)
+        {
+            ImmutableArray<ResearchTargetInputRoleAssignment?> roles =
+            [
+                .. Population.Inputs.Select(
+                    input => new ResearchTargetInputRoleAssignment(
+                        input,
+                        ResearchTargetInputRole.Implementation)),
+            ];
+            return Assert.IsType<ResearchTargetPlanningOutcome.Planned>(
+                ResearchTargetResolver.Resolve(
+                    new ResearchTargetPlanningRequest(
+                        Population,
+                        roles,
+                        [
+                            .. selections.Select(
+                                selection =>
+                                    new ResearchCarriedMemberSelection(
+                                        Population.Questions[0].Id,
+                                        selection.DeclaringType,
+                                        selection.Selector)),
+                        ]))).Resolution;
+        }
+    }
+
+    sealed class TrackingInvoker : IResearchProducerInvoker
+    {
+        public bool ThrowCSharp { get; init; }
+
+        public bool ReturnWrongCSharpSubject { get; init; }
+
+        public Action? AfterCSharp { get; init; }
+
+        public int InvocationCount { get; private set; }
+
+        public List<MetadataSource> CSharpSources { get; } = [];
+
+        public List<CSharpMemberEndpointComparison> CSharpResults { get; } = [];
+
+        public List<IlMemberEndpointComparison> IlResults { get; } = [];
+
+        public List<(ResearchProducerKind Kind, string Old, string New)>
+            EndpointShapes { get; } = [];
+
+        public CSharpMemberEndpointComparison CompareCSharp(
+            CSharpMemberDiffEndpoint oldEndpoint,
+            CSharpMemberDiffEndpoint newEndpoint)
+        {
+            InvocationCount++;
+            if (ThrowCSharp)
+                throw new InvalidOperationException("Injected producer escape.");
+            if (ReturnWrongCSharpSubject)
+            {
+                var wrong = new FindingSubject("wrong", "wrong");
+                return CSharpBodyDiff.CompareMemberEndpoints(
+                    new CSharpMemberDiffEndpoint.SubjectAbsent(wrong),
+                    new CSharpMemberDiffEndpoint.SubjectAbsent(wrong));
+            }
+            EndpointShapes.Add(
+                (
+                    ResearchProducerKind.CSharp,
+                    oldEndpoint.GetType().Name,
+                    newEndpoint.GetType().Name));
+            CSharpSources.Add(
+                Assert.IsType<CSharpMemberDiffEndpoint.Present>(oldEndpoint)
+                    .Source);
+            CSharpSources.Add(
+                Assert.IsType<CSharpMemberDiffEndpoint.Present>(newEndpoint)
+                    .Source);
+            CSharpMemberEndpointComparison result =
+                CSharpBodyDiff.CompareMemberEndpoints(
+                    oldEndpoint,
+                    newEndpoint);
+            CSharpResults.Add(result);
+            AfterCSharp?.Invoke();
+            return result;
+        }
+
+        public IlMemberEndpointComparison CompareIl(
+            IlMemberDiffEndpoint oldEndpoint,
+            IlMemberDiffEndpoint newEndpoint)
+        {
+            InvocationCount++;
+            EndpointShapes.Add(
+                (
+                    ResearchProducerKind.IlBody,
+                    oldEndpoint.GetType().Name,
+                    newEndpoint.GetType().Name));
+            IlMemberEndpointComparison result =
+                IlAssemblyDiff.CompareMemberEndpoints(
+                oldEndpoint,
+                newEndpoint);
+            IlResults.Add(result);
+            return result;
+        }
+    }
+
+    sealed class NullResolver : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(
+            AssemblyReferenceIdentity identity,
+            AssemblyResolutionScope scope)
+            => null;
+    }
+
+    sealed class ThrowOnDisposeStream(Stream inner) : Stream
+    {
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(
+            byte[] buffer,
+            int offset,
+            int count)
+            => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => inner.Seek(offset, origin);
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(
+            byte[] buffer,
+            int offset,
+            int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+            throw new IOException("Injected cleanup failure.");
+        }
+    }
+}

--- a/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
@@ -321,6 +321,26 @@ public class ResearchProducerSessionTests
         Assert.Equal(FindingInspectionState.Complete, ilTransition.New);
         Assert.Null(csharp.Result.BodyDiff);
         Assert.Null(il.Result.MemberDiff);
+
+        SessionFixture apiOnlyFixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution apiOnly = apiOnlyFixture.Resolve(
+            SampleType,
+            "Field");
+        var invoker = new TrackingInvoker();
+        ResearchProducerCompletion apiOnlyCompletion = Complete(
+            Request(apiOnlyFixture, apiOnly),
+            invoker);
+        Assert.All(
+            apiOnlyCompletion.Results,
+            result => Assert.Equal(
+                ResearchProducerUnavailableKind.EndpointAddressUnavailable,
+                Assert.IsType<
+                    ResearchProducerWorkOutcome.Unavailable>(result.Outcome)
+                    .Reason.Kind));
+        Assert.Equal(0, invoker.InvocationCount);
+        Assert.Empty(apiOnlyCompletion.Cleanup);
     }
 
     [Fact]
@@ -587,6 +607,25 @@ public class ResearchProducerSessionTests
                     alreadyCancelled.Token));
         Assert.Equal(0, notInvoked.InvocationCount);
         Assert.Empty(beforeAcquisition.Cleanup);
+
+        using var finalCancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+        var finalInvoker = new TrackingInvoker
+        {
+            AfterCSharp = finalCancellation.Cancel,
+        };
+        var finalItem =
+            Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+                ResearchProducerSession.Run(
+                    new ResearchProducerSessionRequest(
+                        fixture.Population,
+                        resolution,
+                        [ResearchProducerKind.CSharp]),
+                    finalInvoker,
+                    finalCancellation.Token));
+        Assert.Equal(1, finalInvoker.InvocationCount);
+        Assert.Equal(2, finalItem.Cleanup.Length);
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchComparisonAdmission.cs
+++ b/src/ILInspector.Research/ResearchComparisonAdmission.cs
@@ -209,6 +209,8 @@ public sealed class ResearchAdmittedPopulation
 {
     readonly FrozenDictionary<ResearchComparisonInputOccurrence, ResearchAdmittedInput>
         _byOccurrence;
+    readonly FrozenDictionary<ResearchComparisonInputId, ResearchAdmittedInput>
+        _byId;
 
     internal ResearchAdmittedPopulation(
         ResearchComparisonProfile profile,
@@ -225,6 +227,11 @@ public sealed class ResearchAdmittedPopulation
         // caller-reachable state can alter an admitted association.
         _byOccurrence = byOccurrence.ToFrozenDictionary(
             ReferenceEqualityComparer.Instance);
+        _byId = Inputs.ToFrozenDictionary(
+            static input => input.Id,
+            static input => input,
+            (IEqualityComparer<ResearchComparisonInputId>)
+                ReferenceEqualityComparer.Instance);
     }
 
     /// <summary>The profile this population was admitted for.</summary>
@@ -265,6 +272,31 @@ public sealed class ResearchAdmittedPopulation
             : throw new ArgumentException(
                 "The occurrence was not admitted by this population.",
                 nameof(occurrence));
+
+    /// <summary>
+    /// The admitted input carrying one exact owner-issued input identity.
+    /// Association is by reference identity.
+    /// </summary>
+    public bool TryGetInput(
+        ResearchComparisonInputId id,
+        [MaybeNullWhen(false)] out ResearchAdmittedInput input)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        return _byId.TryGetValue(id, out input);
+    }
+
+    /// <summary>
+    /// The admitted input carrying one exact owner-issued input identity.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// The identity does not belong to this population.
+    /// </exception>
+    public ResearchAdmittedInput GetInput(ResearchComparisonInputId id)
+        => TryGetInput(id, out ResearchAdmittedInput? input)
+            ? input
+            : throw new ArgumentException(
+                "The input identity does not belong to this population.",
+                nameof(id));
 }
 
 /// <summary>

--- a/src/ILInspector.Research/ResearchInputImageValidation.cs
+++ b/src/ILInspector.Research/ResearchInputImageValidation.cs
@@ -1,0 +1,57 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Analysis;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research;
+
+internal static class ResearchInputImageValidation
+{
+    internal static ResearchTargetInputValidationEvidence Capture(
+        MetadataReader reader,
+        ImplementationComparisonInputOccurrence occurrence)
+    {
+        bool isAssembly = reader.IsAssembly;
+        AssemblyReferenceIdentity? identity = isAssembly
+            ? AssemblyReferenceIdentity.FromAssemblyDefinition(reader)
+            : null;
+        Guid moduleVersionId =
+            reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        return new ResearchTargetInputValidationEvidence(
+            ReadFailed: false,
+            isAssembly,
+            identity,
+            moduleVersionId,
+            occurrence.Assembly.Registration.ModuleVersionId,
+            reader.MethodDefinitions.Count,
+            Surface: null);
+    }
+
+    internal static ResearchTargetDiagnosticKind? Validate(
+        ResearchTargetInputValidationEvidence evidence,
+        ImplementationComparisonInputOccurrence occurrence)
+    {
+        LibraryBodyModuleIdentity analysis = occurrence.BodyIndex.ModuleIdentity;
+        if (!evidence.IsAssembly)
+            return ResearchTargetDiagnosticKind.StandaloneModule;
+        if (analysis.AssemblyIdentity is null)
+            return ResearchTargetDiagnosticKind.AssemblyIdentityMismatch;
+
+        AssemblyReferenceIdentity live = evidence.LiveAssemblyIdentity!;
+        if (!AssemblyReferenceIdentity.EquivalentComparer.Equals(
+                live,
+                occurrence.Assembly.Identity)
+            || !AssemblyReferenceIdentity.EquivalentComparer.Equals(
+                live,
+                analysis.AssemblyIdentity))
+        {
+            return ResearchTargetDiagnosticKind.AssemblyIdentityMismatch;
+        }
+
+        return evidence.LiveModuleVersionId == analysis.ModuleVersionId
+                && (evidence.ArtifactModuleVersionId is not Guid artifact
+                    || artifact == evidence.LiveModuleVersionId)
+            ? null
+            : ResearchTargetDiagnosticKind.ModuleIdentityMismatch;
+    }
+}

--- a/src/ILInspector.Research/ResearchProducerSession.cs
+++ b/src/ILInspector.Research/ResearchProducerSession.cs
@@ -87,8 +87,7 @@ public static class ResearchProducerSession
                     firstFailure ??= failed.Diagnostic;
                 }
 
-                if (index + 1 < workItems.Length
-                    && cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested)
                 {
                     cancelled = true;
                     break;

--- a/src/ILInspector.Research/ResearchProducerSession.cs
+++ b/src/ILInspector.Research/ResearchProducerSession.cs
@@ -1,0 +1,709 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Research;
+
+/// <summary>
+/// Runs the closed Research-local producer catalog over one complete target
+/// resolution and publishes only a fully accounted inert completion.
+/// </summary>
+public static class ResearchProducerSession
+{
+    /// <summary>Runs one producer session sequentially.</summary>
+    public static ResearchProducerSessionOutcome Run(
+        ResearchProducerSessionRequest request,
+        CancellationToken cancellationToken = default)
+        => Run(request, NativeProducerInvoker.Instance, cancellationToken);
+
+    internal static ResearchProducerSessionOutcome Run(
+        ResearchProducerSessionRequest request,
+        IResearchProducerInvoker invoker,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(invoker);
+
+        if (ResearchProducerSessionValidator.ValidateRequest(
+                request,
+                out ImmutableArray<ResearchProducerKind> producers) is
+            ResearchProducerRejection rejection)
+        {
+            return new ResearchProducerSessionOutcome.Rejected(rejection);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return new ResearchProducerSessionOutcome.Cancelled([]);
+        }
+
+        var session = new ResearchProducerSessionId(
+            request.Population.Operation,
+            request.Identity);
+        ImmutableArray<ResearchProducerWorkItem> workItems =
+            DeriveWorkItems(session, request.Resolution, producers);
+        var results = ImmutableArray.CreateBuilder<ResearchProducerWorkResult>(
+            workItems.Length);
+        var stages = new Dictionary<ResearchComparisonInputId, StageAccess>(
+            ReferenceEqualityComparer.Instance);
+        var acquired = new List<InputStage>();
+        ResearchProducerDiagnostic? firstFailure = null;
+        bool cancelled = false;
+        ImmutableArray<ResearchProducerCleanupOutcome> cleanup = [];
+        try
+        {
+            for (int index = 0; index < workItems.Length; index++)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    cancelled = true;
+                    break;
+                }
+
+                ResearchProducerWorkItem item = workItems[index];
+                ResearchProducerWorkOutcome outcome = Execute(
+                    request.Population,
+                    request.Resolution,
+                    item,
+                    stages,
+                    acquired,
+                    invoker);
+                results.Add(new ResearchProducerWorkResult(item, outcome));
+                if (outcome is ResearchProducerWorkOutcome.Failed
+                    {
+                        Diagnostic.Kind:
+                            ResearchProducerDiagnosticKind
+                                .ProducerContractViolation,
+                    } failed)
+                {
+                    firstFailure ??= failed.Diagnostic;
+                }
+
+                if (index + 1 < workItems.Length
+                    && cancellationToken.IsCancellationRequested)
+                {
+                    cancelled = true;
+                    break;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+            when (cancellationToken.IsCancellationRequested)
+        {
+            cancelled = true;
+        }
+        catch (Exception exception) when (IsRecoverableExecutionFailure(exception))
+        {
+            firstFailure ??= new ResearchProducerDiagnostic(
+                ResearchProducerDiagnosticKind.ResearchExecutionFailed);
+        }
+        finally
+        {
+            cleanup = Cleanup(acquired);
+        }
+
+        if (cancelled)
+            return new ResearchProducerSessionOutcome.Cancelled(cleanup);
+
+        if (cleanup.Any(
+                static outcome =>
+                    outcome is ResearchProducerCleanupOutcome.Failed))
+        {
+            return new ResearchProducerSessionOutcome.Failed(
+                new ResearchProducerDiagnostic(
+                    ResearchProducerDiagnosticKind.CleanupFailed),
+                cleanup);
+        }
+
+        if (firstFailure is not null)
+        {
+            return new ResearchProducerSessionOutcome.Failed(
+                firstFailure,
+                cleanup);
+        }
+
+        if (!ResearchProducerSessionValidator.TryCreateCompletion(
+                request,
+                session,
+                workItems,
+                results.ToImmutable(),
+                [.. acquired.Select(static stage => stage.Input)],
+                cleanup,
+                out ResearchProducerCompletion? completion))
+        {
+            return new ResearchProducerSessionOutcome.Failed(
+                new ResearchProducerDiagnostic(
+                    ResearchProducerDiagnosticKind.CompletionValidationFailed),
+                cleanup);
+        }
+
+        return new ResearchProducerSessionOutcome.Completed(completion!);
+    }
+
+    static ImmutableArray<ResearchProducerWorkItem> DeriveWorkItems(
+        ResearchProducerSessionId session,
+        ResearchTargetResolution resolution,
+        ImmutableArray<ResearchProducerKind> producers)
+    {
+        var items = ImmutableArray.CreateBuilder<ResearchProducerWorkItem>(
+            resolution.Correspondences.Length * producers.Length);
+        foreach (ResearchTargetCorrespondenceOutcome correspondence in
+            resolution.Correspondences)
+        {
+            foreach (ResearchProducerKind producer in producers)
+            {
+                items.Add(
+                    new ResearchProducerWorkItem(
+                        new ResearchProducerWorkItemId(session),
+                        correspondence,
+                        producer));
+            }
+        }
+
+        return items.ToImmutable();
+    }
+
+    static ResearchProducerWorkOutcome Execute(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution,
+        ResearchProducerWorkItem item,
+        Dictionary<ResearchComparisonInputId, StageAccess> stages,
+        List<InputStage> acquired,
+        IResearchProducerInvoker invoker)
+    {
+        if (item.Correspondence
+            is ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
+                or ResearchTargetCorrespondenceOutcome.DomainUnavailable)
+        {
+            return new ResearchProducerWorkOutcome.Unavailable(
+                Unavailable(
+                    ResearchProducerUnavailableKind.CorrespondenceUnavailable));
+        }
+
+        EndpointPair endpoints = CreateEndpoints(
+            population,
+            resolution,
+            item.Correspondence,
+            stages,
+            acquired);
+        if (endpoints.Unavailable is { } unavailable)
+            return new ResearchProducerWorkOutcome.Unavailable(unavailable);
+
+        if (item.Producer is not ResearchProducerKind.CSharp
+            and not ResearchProducerKind.IlBody)
+        {
+            throw new InvalidOperationException(
+                "A validated work item must name a cataloged producer.");
+        }
+
+        try
+        {
+            return item.Producer switch
+            {
+                ResearchProducerKind.CSharp => ProduceCSharp(
+                    endpoints,
+                    invoker),
+                ResearchProducerKind.IlBody => ProduceIl(endpoints, invoker),
+                _ => throw new UnreachableException(),
+            };
+        }
+        catch (Exception exception) when (IsRecoverableProducerFailure(exception))
+        {
+            return new ResearchProducerWorkOutcome.Failed(
+                new ResearchProducerDiagnostic(
+                    ResearchProducerDiagnosticKind.ProducerException,
+                    item.Producer));
+        }
+    }
+
+    static ResearchProducerWorkOutcome ProduceCSharp(
+        EndpointPair endpoints,
+        IResearchProducerInvoker invoker)
+    {
+        CSharpMemberDiffEndpoint oldEndpoint = CSharpEndpoint(endpoints.Before!);
+        CSharpMemberDiffEndpoint newEndpoint = CSharpEndpoint(endpoints.After!);
+        CSharpMemberEndpointComparison result = invoker.CompareCSharp(
+            oldEndpoint,
+            newEndpoint);
+        return result is not null
+            && NativeResultMatches(endpoints, result)
+                ? new ResearchProducerWorkOutcome.ProducedCSharp(result)
+                : ContractViolation(ResearchProducerKind.CSharp);
+    }
+
+    static ResearchProducerWorkOutcome ProduceIl(
+        EndpointPair endpoints,
+        IResearchProducerInvoker invoker)
+    {
+        IlMemberDiffEndpoint oldEndpoint = IlEndpoint(endpoints.Before!);
+        IlMemberDiffEndpoint newEndpoint = IlEndpoint(endpoints.After!);
+        IlMemberEndpointComparison result = invoker.CompareIl(
+            oldEndpoint,
+            newEndpoint);
+        return result is not null
+            && NativeResultMatches(endpoints, result)
+                ? new ResearchProducerWorkOutcome.ProducedIlBody(result)
+                : ContractViolation(ResearchProducerKind.IlBody);
+    }
+
+    static ResearchProducerWorkOutcome ContractViolation(
+        ResearchProducerKind producer)
+        => new ResearchProducerWorkOutcome.Failed(
+            new ResearchProducerDiagnostic(
+                ResearchProducerDiagnosticKind.ProducerContractViolation,
+                producer));
+
+    static EndpointPair CreateEndpoints(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome correspondence,
+        Dictionary<ResearchComparisonInputId, StageAccess> stages,
+        List<InputStage> acquired)
+    {
+        string subject = SubjectIdentity(resolution, correspondence);
+        return correspondence switch
+        {
+            ResearchTargetCorrespondenceOutcome.Paired paired =>
+                PairPresent(
+                    population,
+                    paired.Before,
+                    paired.After,
+                    subject,
+                    stages,
+                    acquired),
+            ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                Pair(
+                    Present(
+                        population,
+                        beforeOnly.Before,
+                        subject,
+                        stages,
+                        acquired),
+                    EndpointAccess.Absent(
+                        subject,
+                        "The correspondence key is absent from this side.")),
+            ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                Pair(
+                    EndpointAccess.Absent(
+                        subject,
+                        "The correspondence key is absent from this side."),
+                    Present(
+                        population,
+                        afterOnly.After,
+                        subject,
+                        stages,
+                        acquired)),
+            ResearchTargetCorrespondenceOutcome.Absent =>
+                Pair(
+                    EndpointAccess.Absent(
+                        subject,
+                        "The target domain is absent from this side."),
+                    EndpointAccess.Absent(
+                        subject,
+                        "The target domain is absent from this side.")),
+            _ => throw new InvalidOperationException(
+                "Unavailable correspondence must not be adapted."),
+        };
+    }
+
+    static EndpointPair PairPresent(
+        ResearchAdmittedPopulation population,
+        ResearchCorrespondingTarget beforeTarget,
+        ResearchCorrespondingTarget afterTarget,
+        string subject,
+        Dictionary<ResearchComparisonInputId, StageAccess> stages,
+        List<InputStage> acquired)
+    {
+        EndpointAccess before = Present(
+            population,
+            beforeTarget,
+            subject,
+            stages,
+            acquired);
+        if (before.Unavailable is { } unavailable)
+            return new EndpointPair(null, null, unavailable);
+
+        return Pair(
+            before,
+            Present(
+                population,
+                afterTarget,
+                subject,
+                stages,
+                acquired));
+    }
+
+    static EndpointPair Pair(EndpointAccess before, EndpointAccess after)
+        => before.Unavailable is { } beforeUnavailable
+            ? new EndpointPair(null, null, beforeUnavailable)
+            : after.Unavailable is { } afterUnavailable
+                ? new EndpointPair(null, null, afterUnavailable)
+                : new EndpointPair(before, after, null);
+
+    static EndpointAccess Present(
+        ResearchAdmittedPopulation population,
+        ResearchCorrespondingTarget target,
+        string subject,
+        Dictionary<ResearchComparisonInputId, StageAccess> stages,
+        List<InputStage> acquired)
+    {
+        ResearchComparisonInputId input = target.Attempt.Request.Input;
+        MetadataMethodAddress? address = target.Target.Address;
+        if (target.Target.Role == ResearchTargetRelationshipRole.None
+            || address is null)
+        {
+            return EndpointAccess.UnavailableEndpoint(
+                Unavailable(
+                    ResearchProducerUnavailableKind.EndpointAddressUnavailable,
+                    input));
+        }
+
+        StageAccess stage = GetStage(population, input, stages, acquired);
+        if (stage.Unavailable is { } unavailable)
+            return EndpointAccess.UnavailableEndpoint(unavailable);
+
+        InputStage acquiredStage = stage.Stage!;
+        MetadataReader reader = acquiredStage.Source.Reader;
+        if (target.Target.Module
+                != acquiredStage.Occurrence.BodyIndex.ModuleIdentity
+            || !address.Value.BelongsTo(reader)
+            || address.Value.Handle.IsNil
+            || MetadataTokens.GetRowNumber(address.Value.Handle)
+                > reader.MethodDefinitions.Count)
+        {
+            return EndpointAccess.UnavailableEndpoint(
+                Unavailable(
+                    ResearchProducerUnavailableKind.ModuleIdentityMismatch,
+                    input));
+        }
+
+        return EndpointAccess.PresentEndpoint(
+            subject,
+            acquiredStage,
+            address.Value.Handle);
+    }
+
+    static StageAccess GetStage(
+        ResearchAdmittedPopulation population,
+        ResearchComparisonInputId input,
+        Dictionary<ResearchComparisonInputId, StageAccess> stages,
+        List<InputStage> acquired)
+    {
+        if (stages.TryGetValue(input, out StageAccess? existing))
+            return existing;
+
+        ResearchAdmittedInput admitted = population.GetInput(input);
+        var occurrence =
+            (ImplementationComparisonInputOccurrence)admitted.Occurrence;
+        MetadataSource source;
+        try
+        {
+            source = MetadataSource.OpenWithoutSymbols(
+                occurrence.Assembly,
+                occurrence.Resolver);
+        }
+        catch (Exception exception) when (IsExpectedInputFailure(exception))
+        {
+            var failed = new StageAccess(
+                null,
+                Unavailable(
+                    ResearchProducerUnavailableKind.InputUnreadable,
+                    input));
+            stages.Add(input, failed);
+            return failed;
+        }
+
+        var stage = new InputStage(input, occurrence, source);
+        acquired.Add(stage);
+        StageAccess access;
+        try
+        {
+            ResearchTargetInputValidationEvidence evidence =
+                ResearchInputImageValidation.Capture(
+                    source.Reader,
+                    occurrence);
+            access = ResearchInputImageValidation.Validate(evidence, occurrence)
+                switch
+                {
+                    ResearchTargetDiagnosticKind.AssemblyIdentityMismatch
+                        or ResearchTargetDiagnosticKind.StandaloneModule =>
+                        new StageAccess(
+                            stage,
+                            Unavailable(
+                                ResearchProducerUnavailableKind
+                                    .AssemblyIdentityMismatch,
+                                input)),
+                    ResearchTargetDiagnosticKind.ModuleIdentityMismatch =>
+                        new StageAccess(
+                            stage,
+                            Unavailable(
+                                ResearchProducerUnavailableKind
+                                    .ModuleIdentityMismatch,
+                                input)),
+                    null => new StageAccess(stage, null),
+                    _ => new StageAccess(
+                        stage,
+                        Unavailable(
+                            ResearchProducerUnavailableKind.InputUnreadable,
+                            input)),
+                };
+        }
+        catch (Exception exception) when (IsExpectedMetadataFailure(exception))
+        {
+            access = new StageAccess(
+                stage,
+                Unavailable(
+                    ResearchProducerUnavailableKind.InputUnreadable,
+                    input));
+        }
+
+        stages.Add(input, access);
+        return access;
+    }
+
+    static ImmutableArray<ResearchProducerCleanupOutcome> Cleanup(
+        List<InputStage> acquired)
+    {
+        var cleanup =
+            ImmutableArray.CreateBuilder<ResearchProducerCleanupOutcome>(
+                acquired.Count);
+        for (int index = acquired.Count - 1; index >= 0; index--)
+        {
+            InputStage stage = acquired[index];
+            try
+            {
+                stage.Source.Dispose();
+                cleanup.Add(
+                    new ResearchProducerCleanupOutcome.Succeeded(stage.Input));
+            }
+            catch (Exception exception) when (IsRecoverableCleanupFailure(exception))
+            {
+                cleanup.Add(
+                    new ResearchProducerCleanupOutcome.Failed(
+                        stage.Input,
+                        new ResearchProducerDiagnostic(
+                            ResearchProducerDiagnosticKind.CleanupFailed)));
+            }
+        }
+
+        return cleanup.ToImmutable();
+    }
+
+    static CSharpMemberDiffEndpoint CSharpEndpoint(EndpointAccess endpoint)
+    {
+        var subject = new FindingSubject(endpoint.Subject!, endpoint.Subject!);
+        return endpoint.Stage is { } stage
+            ? new CSharpMemberDiffEndpoint.Present(
+                subject,
+                stage.Source,
+                endpoint.Handle)
+            : new CSharpMemberDiffEndpoint.SubjectAbsent(
+                subject,
+                endpoint.AbsenceDetail);
+    }
+
+    static IlMemberDiffEndpoint IlEndpoint(EndpointAccess endpoint)
+    {
+        var subject = new IlMemberDiffSubject(
+            endpoint.Subject!,
+            endpoint.Subject!);
+        return endpoint.Stage is { } stage
+            ? new IlMemberDiffEndpoint.Present(
+                subject,
+                stage.Source.Pe,
+                stage.Source.Reader,
+                endpoint.Handle)
+            : new IlMemberDiffEndpoint.SubjectAbsent(
+                subject,
+                endpoint.AbsenceDetail);
+    }
+
+    static string SubjectIdentity(
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome correspondence)
+        => correspondence switch
+        {
+            ResearchTargetCorrespondenceOutcome.Paired paired =>
+                paired.Before.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                beforeOnly.Before.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                afterOnly.After.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.Absent =>
+                AbsentSubject(resolution, correspondence.Scope),
+            _ => throw new InvalidOperationException(
+                "Unavailable correspondence has no producer subject."),
+        };
+
+    static string AbsentSubject(
+        ResearchTargetResolution resolution,
+        ResearchTargetScopeId scopeId)
+    {
+        ResearchTargetScope scope = resolution.Scopes.Single(
+            scope => ReferenceEquals(scope.Id, scopeId));
+        return $"{scope.DeclaringTypeFullName}::{scope.Selector.NormalizedSelector}";
+    }
+
+    static bool NativeResultMatches(
+        EndpointPair endpoints,
+        CSharpMemberEndpointComparison result)
+        => string.Equals(
+                result.Old.Key,
+                endpoints.Before!.Subject,
+                StringComparison.Ordinal)
+            && string.Equals(
+                result.New.Key,
+                endpoints.After!.Subject,
+                StringComparison.Ordinal)
+            && InspectionMatches(
+                endpoints.Before,
+                result.Findings.OldInspection)
+            && InspectionMatches(
+                endpoints.After,
+                result.Findings.NewInspection);
+
+    static bool NativeResultMatches(
+        EndpointPair endpoints,
+        IlMemberEndpointComparison result)
+        => string.Equals(
+                result.Old.Identity,
+                endpoints.Before!.Subject,
+                StringComparison.Ordinal)
+            && string.Equals(
+                result.New.Identity,
+                endpoints.After!.Subject,
+                StringComparison.Ordinal)
+            && InspectionMatches(
+                endpoints.Before,
+                result.Findings.OldInspection)
+            && InspectionMatches(
+                endpoints.After,
+                result.Findings.NewInspection);
+
+    static bool InspectionMatches<T>(
+        EndpointAccess endpoint,
+        FindingInspection<T> inspection)
+        where T : notnull
+        => endpoint.Stage is null
+            ? inspection is FindingInspection<T>.Absent
+                {
+                    Kind: FindingInspectionAbsenceKind.SubjectAbsent,
+                }
+            : inspection is not FindingInspection<T>.Absent
+                {
+                    Kind: FindingInspectionAbsenceKind.SubjectAbsent,
+                };
+
+    static ResearchProducerUnavailable Unavailable(
+        ResearchProducerUnavailableKind kind,
+        ResearchComparisonInputId? input = null)
+        => new(
+            kind,
+            input,
+            kind switch
+            {
+                ResearchProducerUnavailableKind.CorrespondenceUnavailable =>
+                    "Target correspondence is unavailable.",
+                ResearchProducerUnavailableKind.InputUnreadable =>
+                    "The admitted input could not be opened or read.",
+                ResearchProducerUnavailableKind.AssemblyIdentityMismatch =>
+                    "The live input does not match the admitted assembly.",
+                ResearchProducerUnavailableKind.ModuleIdentityMismatch =>
+                    "The live input does not match the resolved module.",
+                ResearchProducerUnavailableKind.EndpointAddressUnavailable =>
+                    "The resolved target has no physical method endpoint.",
+                _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+            });
+
+    static bool IsExpectedInputFailure(Exception exception)
+        => IsRecoverableExecutionFailure(exception);
+
+    static bool IsExpectedMetadataFailure(Exception exception)
+        => IsRecoverableExecutionFailure(exception);
+
+    static bool IsRecoverableProducerFailure(Exception exception)
+        => exception is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException;
+
+    static bool IsRecoverableExecutionFailure(Exception exception)
+        => exception is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException;
+
+    static bool IsRecoverableCleanupFailure(Exception exception)
+        => exception is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException;
+
+    sealed record InputStage(
+        ResearchComparisonInputId Input,
+        ImplementationComparisonInputOccurrence Occurrence,
+        MetadataSource Source);
+
+    sealed record StageAccess(
+        InputStage? Stage,
+        ResearchProducerUnavailable? Unavailable);
+
+    sealed record EndpointAccess(
+        string? Subject,
+        InputStage? Stage,
+        MethodDefinitionHandle Handle,
+        string? AbsenceDetail,
+        ResearchProducerUnavailable? Unavailable)
+    {
+        internal static EndpointAccess PresentEndpoint(
+            string subject,
+            InputStage stage,
+            MethodDefinitionHandle handle)
+            => new(subject, stage, handle, null, null);
+
+        internal static EndpointAccess Absent(
+            string subject,
+            string detail)
+            => new(subject, null, default, detail, null);
+
+        internal static EndpointAccess UnavailableEndpoint(
+            ResearchProducerUnavailable unavailable)
+            => new(null, null, default, null, unavailable);
+    }
+
+    sealed record EndpointPair(
+        EndpointAccess? Before,
+        EndpointAccess? After,
+        ResearchProducerUnavailable? Unavailable);
+
+    sealed class NativeProducerInvoker : IResearchProducerInvoker
+    {
+        internal static NativeProducerInvoker Instance { get; } = new();
+
+        public CSharpMemberEndpointComparison CompareCSharp(
+            CSharpMemberDiffEndpoint oldEndpoint,
+            CSharpMemberDiffEndpoint newEndpoint)
+            => CSharpBodyDiff.CompareMemberEndpoints(oldEndpoint, newEndpoint);
+
+        public IlMemberEndpointComparison CompareIl(
+            IlMemberDiffEndpoint oldEndpoint,
+            IlMemberDiffEndpoint newEndpoint)
+            => IlAssemblyDiff.CompareMemberEndpoints(oldEndpoint, newEndpoint);
+    }
+}
+
+internal interface IResearchProducerInvoker
+{
+    CSharpMemberEndpointComparison CompareCSharp(
+        CSharpMemberDiffEndpoint oldEndpoint,
+        CSharpMemberDiffEndpoint newEndpoint);
+
+    IlMemberEndpointComparison CompareIl(
+        IlMemberDiffEndpoint oldEndpoint,
+        IlMemberDiffEndpoint newEndpoint);
+}

--- a/src/ILInspector.Research/ResearchProducerSessionModels.cs
+++ b/src/ILInspector.Research/ResearchProducerSessionModels.cs
@@ -1,0 +1,362 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Instructions;
+
+namespace ILInspector.Research;
+
+/// <summary>The closed set of Research-local implementation producers.</summary>
+public enum ResearchProducerKind
+{
+    CSharp,
+    IlBody,
+}
+
+/// <summary>The Research-owned declaration of local producer membership.</summary>
+public static class ResearchProducerCatalog
+{
+    /// <summary>Every local producer kind, in normative execution order.</summary>
+    public static ImmutableArray<ResearchProducerKind> Kinds { get; } =
+    [
+        ResearchProducerKind.CSharp,
+        ResearchProducerKind.IlBody,
+    ];
+}
+
+/// <summary>One request to run selected local producers over a target resolution.</summary>
+public sealed class ResearchProducerSessionRequest
+{
+    readonly object _identity = new();
+
+    public ResearchProducerSessionRequest(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution,
+        IEnumerable<ResearchProducerKind> producers)
+    {
+        ArgumentNullException.ThrowIfNull(population);
+        ArgumentNullException.ThrowIfNull(resolution);
+        ArgumentNullException.ThrowIfNull(producers);
+        Population = population;
+        Resolution = resolution;
+        Producers = [.. producers];
+    }
+
+    public ResearchAdmittedPopulation Population { get; }
+
+    public ResearchTargetResolution Resolution { get; }
+
+    public ImmutableArray<ResearchProducerKind> Producers { get; }
+
+    internal object Identity => _identity;
+}
+
+/// <summary>Why a producer session request was rejected before execution.</summary>
+public enum ResearchProducerRejectionKind
+{
+    UnsupportedProfile,
+    ForeignResolution,
+    InvalidIdentityClosure,
+    EmptyProducerSelection,
+    DuplicateProducerKind,
+    UnknownProducerKind,
+}
+
+/// <summary>One bounded pre-execution rejection.</summary>
+public sealed class ResearchProducerRejection
+{
+    internal ResearchProducerRejection(
+        ResearchProducerRejectionKind kind,
+        string summary)
+    {
+        Kind = kind;
+        Summary = summary;
+    }
+
+    public ResearchProducerRejectionKind Kind { get; }
+
+    public string Summary { get; }
+}
+
+/// <summary>An opaque Research identity for one local producer session.</summary>
+public sealed class ResearchProducerSessionId
+{
+    readonly object _request;
+
+    internal ResearchProducerSessionId(
+        ResearchComparisonOperationId operation,
+        object request)
+    {
+        Operation = operation;
+        _request = request;
+    }
+
+    public ResearchComparisonOperationId Operation { get; }
+
+    internal bool BelongsTo(object request) => ReferenceEquals(_request, request);
+}
+
+/// <summary>An opaque Research identity for one producer work item.</summary>
+public sealed class ResearchProducerWorkItemId
+{
+    internal ResearchProducerWorkItemId(ResearchProducerSessionId session)
+        => Session = session;
+
+    public ResearchProducerSessionId Session { get; }
+
+    public ResearchComparisonOperationId Operation => Session.Operation;
+}
+
+/// <summary>One exact correspondence-and-producer unit of sequential work.</summary>
+public sealed class ResearchProducerWorkItem
+{
+    internal ResearchProducerWorkItem(
+        ResearchProducerWorkItemId id,
+        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerKind producer)
+    {
+        Id = id;
+        Correspondence = correspondence;
+        Producer = producer;
+    }
+
+    public ResearchProducerWorkItemId Id { get; }
+
+    public ResearchTargetCorrespondenceOutcome Correspondence { get; }
+
+    public ResearchProducerKind Producer { get; }
+}
+
+/// <summary>Why Research could not invoke a producer for one exact item.</summary>
+public enum ResearchProducerUnavailableKind
+{
+    CorrespondenceUnavailable,
+    InputUnreadable,
+    AssemblyIdentityMismatch,
+    ModuleIdentityMismatch,
+    EndpointAddressUnavailable,
+}
+
+/// <summary>Bounded Research-local unavailability for one work item.</summary>
+public sealed class ResearchProducerUnavailable
+{
+    internal ResearchProducerUnavailable(
+        ResearchProducerUnavailableKind kind,
+        ResearchComparisonInputId? input,
+        string summary)
+    {
+        Kind = kind;
+        Input = input;
+        Summary = summary;
+    }
+
+    public ResearchProducerUnavailableKind Kind { get; }
+
+    public ResearchComparisonInputId? Input { get; }
+
+    public string Summary { get; }
+}
+
+/// <summary>Why an executing producer session failed after admission.</summary>
+public enum ResearchProducerDiagnosticKind
+{
+    ProducerException,
+    ProducerContractViolation,
+    ResearchExecutionFailed,
+    CleanupFailed,
+    CompletionValidationFailed,
+}
+
+/// <summary>One bounded Research-owned producer-session failure.</summary>
+public sealed class ResearchProducerDiagnostic
+{
+    internal ResearchProducerDiagnostic(
+        ResearchProducerDiagnosticKind kind,
+        ResearchProducerKind? producer = null)
+    {
+        Kind = kind;
+        Producer = producer;
+        Summary = kind switch
+        {
+            ResearchProducerDiagnosticKind.ProducerException =>
+                "A local producer escaped with an exception.",
+            ResearchProducerDiagnosticKind.ProducerContractViolation =>
+                "A local producer result violated its endpoint contract.",
+            ResearchProducerDiagnosticKind.ResearchExecutionFailed =>
+                "Research could not finish the local producer session.",
+            ResearchProducerDiagnosticKind.CleanupFailed =>
+                "One or more Research-owned input stages could not be closed.",
+            ResearchProducerDiagnosticKind.CompletionValidationFailed =>
+                "The Research producer completion failed final validation.",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+    }
+
+    public ResearchProducerDiagnosticKind Kind { get; }
+
+    public ResearchProducerKind? Producer { get; }
+
+    public string Summary { get; }
+}
+
+/// <summary>The closed outcome of one cataloged work item.</summary>
+public abstract class ResearchProducerWorkOutcome
+{
+    private protected ResearchProducerWorkOutcome()
+    {
+    }
+
+    public sealed class ProducedCSharp : ResearchProducerWorkOutcome
+    {
+        internal ProducedCSharp(CSharpMemberEndpointComparison result)
+            => Result = result;
+
+        public CSharpMemberEndpointComparison Result { get; }
+    }
+
+    public sealed class ProducedIlBody : ResearchProducerWorkOutcome
+    {
+        internal ProducedIlBody(IlMemberEndpointComparison result)
+            => Result = result;
+
+        public IlMemberEndpointComparison Result { get; }
+    }
+
+    public sealed class Unavailable : ResearchProducerWorkOutcome
+    {
+        internal Unavailable(ResearchProducerUnavailable reason)
+            => Reason = reason;
+
+        public ResearchProducerUnavailable Reason { get; }
+    }
+
+    public sealed class Failed : ResearchProducerWorkOutcome
+    {
+        internal Failed(ResearchProducerDiagnostic diagnostic)
+            => Diagnostic = diagnostic;
+
+        public ResearchProducerDiagnostic Diagnostic { get; }
+    }
+}
+
+/// <summary>One work item associated with its exact terminal outcome.</summary>
+public sealed class ResearchProducerWorkResult
+{
+    internal ResearchProducerWorkResult(
+        ResearchProducerWorkItem item,
+        ResearchProducerWorkOutcome outcome)
+    {
+        Item = item;
+        Outcome = outcome;
+    }
+
+    public ResearchProducerWorkItem Item { get; }
+
+    public ResearchProducerWorkOutcome Outcome { get; }
+}
+
+/// <summary>The cleanup outcome for one completely acquired input stage.</summary>
+public abstract class ResearchProducerCleanupOutcome
+{
+    private protected ResearchProducerCleanupOutcome(
+        ResearchComparisonInputId input)
+        => Input = input;
+
+    public ResearchComparisonInputId Input { get; }
+
+    public sealed class Succeeded : ResearchProducerCleanupOutcome
+    {
+        internal Succeeded(ResearchComparisonInputId input)
+            : base(input)
+        {
+        }
+    }
+
+    public sealed class Failed : ResearchProducerCleanupOutcome
+    {
+        internal Failed(
+            ResearchComparisonInputId input,
+            ResearchProducerDiagnostic diagnostic)
+            : base(input)
+            => Diagnostic = diagnostic;
+
+        public ResearchProducerDiagnostic Diagnostic { get; }
+    }
+}
+
+/// <summary>
+/// One atomically published Research-local producer completion.
+/// </summary>
+public sealed class ResearchProducerCompletion
+{
+    internal ResearchProducerCompletion(
+        ResearchComparisonOperationId operation,
+        ResearchProducerSessionId session,
+        ImmutableArray<ResearchProducerWorkItem> workItems,
+        ImmutableArray<ResearchProducerWorkResult> results,
+        ImmutableArray<ResearchProducerCleanupOutcome> cleanup)
+    {
+        Operation = operation;
+        Session = session;
+        WorkItems = workItems;
+        Results = results;
+        Cleanup = cleanup;
+    }
+
+    public ResearchComparisonOperationId Operation { get; }
+
+    public ResearchProducerSessionId Session { get; }
+
+    public ImmutableArray<ResearchProducerWorkItem> WorkItems { get; }
+
+    public ImmutableArray<ResearchProducerWorkResult> Results { get; }
+
+    public ImmutableArray<ResearchProducerCleanupOutcome> Cleanup { get; }
+}
+
+/// <summary>The closed terminal result of one producer-session request.</summary>
+public abstract class ResearchProducerSessionOutcome
+{
+    private protected ResearchProducerSessionOutcome()
+    {
+    }
+
+    public sealed class Rejected : ResearchProducerSessionOutcome
+    {
+        internal Rejected(ResearchProducerRejection rejection)
+            => Rejection = rejection;
+
+        public ResearchProducerRejection Rejection { get; }
+    }
+
+    public sealed class Completed : ResearchProducerSessionOutcome
+    {
+        internal Completed(ResearchProducerCompletion completion)
+            => Completion = completion;
+
+        public ResearchProducerCompletion Completion { get; }
+    }
+
+    public sealed class Failed : ResearchProducerSessionOutcome
+    {
+        internal Failed(
+            ResearchProducerDiagnostic diagnostic,
+            ImmutableArray<ResearchProducerCleanupOutcome> cleanup)
+        {
+            Diagnostic = diagnostic;
+            Cleanup = cleanup;
+        }
+
+        public ResearchProducerDiagnostic Diagnostic { get; }
+
+        public ImmutableArray<ResearchProducerCleanupOutcome> Cleanup { get; }
+    }
+
+    public sealed class Cancelled : ResearchProducerSessionOutcome
+    {
+        internal Cancelled(
+            ImmutableArray<ResearchProducerCleanupOutcome> cleanup)
+            => Cleanup = cleanup;
+
+        public ImmutableArray<ResearchProducerCleanupOutcome> Cleanup { get; }
+    }
+}

--- a/src/ILInspector.Research/ResearchProducerSessionValidator.cs
+++ b/src/ILInspector.Research/ResearchProducerSessionValidator.cs
@@ -1,0 +1,736 @@
+using System.Collections.Immutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+
+namespace ILInspector.Research;
+
+internal static class ResearchProducerSessionValidator
+{
+    internal static ResearchProducerRejection? ValidateRequest(
+        ResearchProducerSessionRequest request,
+        out ImmutableArray<ResearchProducerKind> selected)
+    {
+        selected = [];
+        if (request.Population.Profile
+            != ResearchComparisonProfile.ImplementationComparison)
+        {
+            return Reject(
+                ResearchProducerRejectionKind.UnsupportedProfile,
+                "The local producer session requires an implementation-comparison population.");
+        }
+
+        if (!ReferenceEquals(
+                request.Population.Operation,
+                request.Resolution.Operation))
+        {
+            return Reject(
+                ResearchProducerRejectionKind.ForeignResolution,
+                "The population and target resolution name different operations.");
+        }
+
+        if (!ValidatePopulation(request.Population)
+            || !ValidateResolution(
+                request.Population,
+                request.Resolution))
+        {
+            return Reject(
+                ResearchProducerRejectionKind.InvalidIdentityClosure,
+                "The population or target resolution has an invalid identity closure.");
+        }
+
+        if (request.Producers.IsEmpty)
+        {
+            return Reject(
+                ResearchProducerRejectionKind.EmptyProducerSelection,
+                "At least one local producer must be selected.");
+        }
+
+        var requested = new HashSet<ResearchProducerKind>();
+        foreach (ResearchProducerKind producer in request.Producers)
+        {
+            if (!ResearchProducerCatalog.Kinds.Contains(producer))
+            {
+                return Reject(
+                    ResearchProducerRejectionKind.UnknownProducerKind,
+                    "The request names a producer outside the local catalog.");
+            }
+            if (!requested.Add(producer))
+            {
+                return Reject(
+                    ResearchProducerRejectionKind.DuplicateProducerKind,
+                    "A local producer kind was selected more than once.");
+            }
+        }
+
+        selected =
+        [
+            .. ResearchProducerCatalog.Kinds.Where(requested.Contains),
+        ];
+        return null;
+    }
+
+    internal static bool TryCreateCompletion(
+        ResearchProducerSessionRequest request,
+        ResearchProducerSessionId session,
+        ImmutableArray<ResearchProducerWorkItem> workItems,
+        ImmutableArray<ResearchProducerWorkResult> results,
+        ImmutableArray<ResearchComparisonInputId> acquisitionOrder,
+        ImmutableArray<ResearchProducerCleanupOutcome> cleanup,
+        out ResearchProducerCompletion? completion)
+    {
+        completion = null;
+        if (ValidateRequest(request, out ImmutableArray<ResearchProducerKind>
+                producers) is not null
+            || !ReferenceEquals(session.Operation, request.Population.Operation)
+            || !session.BelongsTo(request.Identity)
+            || workItems.Length
+                != request.Resolution.Correspondences.Length * producers.Length
+            || results.Length != workItems.Length
+            || cleanup.Length != acquisitionOrder.Length)
+        {
+            return false;
+        }
+
+        var identities = new HashSet<ResearchProducerWorkItemId>(
+            ReferenceEqualityComparer.Instance);
+        int index = 0;
+        foreach (ResearchTargetCorrespondenceOutcome correspondence in
+            request.Resolution.Correspondences)
+        {
+            foreach (ResearchProducerKind producer in producers)
+            {
+                ResearchProducerWorkItem item = workItems[index];
+                ResearchProducerWorkResult result = results[index];
+                if (!ReferenceEquals(item.Id.Session, session)
+                    || !identities.Add(item.Id)
+                    || !ReferenceEquals(
+                        item.Correspondence,
+                        correspondence)
+                    || item.Producer != producer
+                    || !ReferenceEquals(result.Item, item)
+                    || !ValidateOutcome(
+                        request.Resolution,
+                        item,
+                        result.Outcome))
+                {
+                    return false;
+                }
+                index++;
+            }
+        }
+
+        for (int cleanupIndex = 0;
+            cleanupIndex < cleanup.Length;
+            cleanupIndex++)
+        {
+            if (cleanup[cleanupIndex]
+                    is not ResearchProducerCleanupOutcome.Succeeded succeeded
+                || !ReferenceEquals(
+                    succeeded.Input,
+                    acquisitionOrder[^(cleanupIndex + 1)]))
+            {
+                return false;
+            }
+        }
+
+        completion = new ResearchProducerCompletion(
+            request.Population.Operation,
+            session,
+            workItems,
+            results,
+            cleanup);
+        return true;
+    }
+
+    static bool ValidatePopulation(ResearchAdmittedPopulation population)
+    {
+        var questionIds = new HashSet<ResearchComparisonQuestionId>(
+            ReferenceEqualityComparer.Instance);
+        var inputIds = new HashSet<ResearchComparisonInputId>(
+            ReferenceEqualityComparer.Instance);
+        var expectedInputs = new List<ResearchAdmittedInput>();
+
+        foreach (ResearchAdmittedQuestion question in population.Questions)
+        {
+            if (!questionIds.Add(question.Id)
+                || !ReferenceEquals(question.Operation, population.Operation)
+                || !SameReferences(
+                    question.Inputs,
+                    question.Before.Concat(question.After)))
+            {
+                return false;
+            }
+
+            foreach (ResearchAdmittedInput input in question.Before)
+            {
+                if (!ValidateInput(
+                        population,
+                        question,
+                        input,
+                        ResearchComparisonSide.Before,
+                        inputIds))
+                {
+                    return false;
+                }
+                expectedInputs.Add(input);
+            }
+            foreach (ResearchAdmittedInput input in question.After)
+            {
+                if (!ValidateInput(
+                        population,
+                        question,
+                        input,
+                        ResearchComparisonSide.After,
+                        inputIds))
+                {
+                    return false;
+                }
+                expectedInputs.Add(input);
+            }
+        }
+
+        return SameReferences(population.Inputs, expectedInputs);
+    }
+
+    static bool ValidateInput(
+        ResearchAdmittedPopulation population,
+        ResearchAdmittedQuestion question,
+        ResearchAdmittedInput input,
+        ResearchComparisonSide side,
+        HashSet<ResearchComparisonInputId> inputIds)
+        => inputIds.Add(input.Id)
+            && ReferenceEquals(input.Operation, population.Operation)
+            && ReferenceEquals(input.Question, question.Id)
+            && input.Side == side
+            && population.TryGetInput(
+                input.Id,
+                out ResearchAdmittedInput? byId)
+            && ReferenceEquals(byId, input)
+            && population.TryGetInput(
+                input.Occurrence,
+                out ResearchAdmittedInput? byOccurrence)
+            && ReferenceEquals(byOccurrence, input);
+
+    static bool ValidateResolution(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution)
+    {
+        var questions = new HashSet<ResearchComparisonQuestionId>(
+            population.Questions.Select(static question => question.Id),
+            ReferenceEqualityComparer.Instance);
+        var inputs = new HashSet<ResearchComparisonInputId>(
+            population.Inputs.Select(static input => input.Id),
+            ReferenceEqualityComparer.Instance);
+        var scopeIds = new HashSet<ResearchTargetScopeId>(
+            ReferenceEqualityComparer.Instance);
+        var domainIds = new HashSet<ResearchTargetDomainId>(
+            ReferenceEqualityComparer.Instance);
+        var requestIds = new HashSet<ResearchTargetRequestId>(
+            ReferenceEqualityComparer.Instance);
+        var attemptIds = new HashSet<ResearchTargetAttemptId>(
+            ReferenceEqualityComparer.Instance);
+        var domains = new List<ResearchTargetDomain>();
+        var requests = new List<ResearchTargetRequest>();
+        var attempts = new List<ResearchTargetAttempt>();
+
+        foreach (ResearchTargetScope scope in resolution.Scopes)
+        {
+            if (!scopeIds.Add(scope.Id)
+                || !ReferenceEquals(
+                    scope.Id.Operation,
+                    population.Operation)
+                || !questions.Contains(scope.Question))
+            {
+                return false;
+            }
+
+            foreach (ResearchTargetDomain domain in scope.Domains)
+            {
+                if (!domainIds.Add(domain.Id)
+                    || !ReferenceEquals(domain.Scope, scope.Id))
+                {
+                    return false;
+                }
+                domains.Add(domain);
+
+                foreach (ResearchTargetInputDisposition disposition in
+                    domain.Inputs)
+                {
+                    if (!inputs.Contains(disposition.Input)
+                        || !ReferenceEquals(
+                            disposition.Input.Question,
+                            scope.Question))
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (ResearchTargetRequest request in domain.Requests)
+                {
+                    if (!requestIds.Add(request.Id)
+                        || !ReferenceEquals(request.Operation, population.Operation)
+                        || !ReferenceEquals(request.Question, scope.Question)
+                        || !ReferenceEquals(request.Scope, scope.Id)
+                        || !ReferenceEquals(request.Domain, domain.Id)
+                        || !inputs.Contains(request.Input)
+                        || !ReferenceEquals(
+                            request.Input.Question,
+                            scope.Question))
+                    {
+                        return false;
+                    }
+                    requests.Add(request);
+                }
+
+                foreach (ResearchTargetAttempt attempt in domain.Attempts)
+                {
+                    if (!attemptIds.Add(attempt.Id)
+                        || !ReferenceEquals(
+                            attempt.Id.Request,
+                            attempt.Request.Id)
+                        || !domain.Requests.Any(
+                            request => ReferenceEquals(
+                                request,
+                                attempt.Request)))
+                    {
+                        return false;
+                    }
+                    attempts.Add(attempt);
+                }
+            }
+        }
+
+        if (!SameReferences(resolution.Domains, domains)
+            || !SameReferences(resolution.Requests, requests)
+            || !SameReferences(resolution.Attempts, attempts)
+            || requests.Count != attempts.Count)
+        {
+            return false;
+        }
+
+        foreach (ResearchTargetRequest request in requests)
+        {
+            if (!resolution.TryGetAttempt(
+                    request.Id,
+                    out ResearchTargetAttempt? attempt)
+                || !ReferenceEquals(attempt.Request, request))
+            {
+                return false;
+            }
+        }
+
+        ResearchTargetCorrespondenceProjection expected =
+            ResearchTargetCorrespondenceBuilder.Build(resolution.Scopes);
+        return SameCensuses(expected.Censuses, resolution.Censuses)
+            && SameCorrespondences(
+                expected.Outcomes,
+                resolution.Correspondences)
+            && resolution.Correspondences.All(
+                outcome => ReferencesResolution(resolution, outcome));
+    }
+
+    static bool SameCensuses(
+        ImmutableArray<ResearchTargetDomainSideCensus> expected,
+        ImmutableArray<ResearchTargetDomainSideCensus> actual)
+    {
+        if (expected.Length != actual.Length)
+            return false;
+
+        for (int index = 0; index < expected.Length; index++)
+        {
+            ResearchTargetDomainSideCensus left = expected[index];
+            ResearchTargetDomainSideCensus right = actual[index];
+            if (!ReferenceEquals(left.Domain, right.Domain)
+                || left.Side != right.Side
+                || left.Health != right.Health
+                || !SameReferences(left.Inputs, right.Inputs)
+                || !SameReferences(left.Attempts, right.Attempts))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool SameCorrespondences(
+        ImmutableArray<ResearchTargetCorrespondenceOutcome> expected,
+        ImmutableArray<ResearchTargetCorrespondenceOutcome> actual)
+    {
+        if (expected.Length != actual.Length)
+            return false;
+
+        for (int index = 0; index < expected.Length; index++)
+        {
+            ResearchTargetCorrespondenceOutcome left = expected[index];
+            ResearchTargetCorrespondenceOutcome right = actual[index];
+            if (left.Kind != right.Kind
+                || !ReferenceEquals(left.Domain, right.Domain)
+                || !SameCorrespondence(left, right))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool SameCorrespondence(
+        ResearchTargetCorrespondenceOutcome expected,
+        ResearchTargetCorrespondenceOutcome actual)
+        => (expected, actual) switch
+        {
+            (ResearchTargetCorrespondenceOutcome.Paired left,
+                ResearchTargetCorrespondenceOutcome.Paired right) =>
+                SameTarget(left.Before, right.Before)
+                && SameTarget(left.After, right.After),
+            (ResearchTargetCorrespondenceOutcome.BeforeOnly left,
+                ResearchTargetCorrespondenceOutcome.BeforeOnly right) =>
+                SameTarget(left.Before, right.Before)
+                && SameKeyAbsence(
+                    left.AfterAbsence,
+                    right.AfterAbsence),
+            (ResearchTargetCorrespondenceOutcome.AfterOnly left,
+                ResearchTargetCorrespondenceOutcome.AfterOnly right) =>
+                SameKeyAbsence(
+                    left.BeforeAbsence,
+                    right.BeforeAbsence)
+                && SameTarget(left.After, right.After),
+            (ResearchTargetCorrespondenceOutcome.Absent left,
+                ResearchTargetCorrespondenceOutcome.Absent right) =>
+                SameDomainAbsence(
+                    left.BeforeAbsence,
+                    right.BeforeAbsence)
+                && SameDomainAbsence(
+                    left.AfterAbsence,
+                    right.AfterAbsence),
+            (ResearchTargetCorrespondenceOutcome.CounterpartUnavailable left,
+                ResearchTargetCorrespondenceOutcome.CounterpartUnavailable right) =>
+                ReferenceEquals(left.Attempt, right.Attempt)
+                && Equal(left.StrictKey, right.StrictKey)
+                && Equal(
+                    left.CorrespondenceKey,
+                    right.CorrespondenceKey)
+                && SameTaint(left.Taint, right.Taint),
+            (ResearchTargetCorrespondenceOutcome.DomainUnavailable left,
+                ResearchTargetCorrespondenceOutcome.DomainUnavailable right) =>
+                SameTaint(left.Taint, right.Taint),
+            _ => false,
+        };
+
+    static bool SameTarget(
+        ResearchCorrespondingTarget expected,
+        ResearchCorrespondingTarget actual)
+        => ReferenceEquals(expected.Attempt, actual.Attempt)
+            && expected.StrictKey.Equals(actual.StrictKey)
+            && expected.CorrespondenceKey.Equals(actual.CorrespondenceKey);
+
+    static bool SameKeyAbsence(
+        ResearchTargetKeyAbsenceProof expected,
+        ResearchTargetKeyAbsenceProof actual)
+        => expected.Side == actual.Side
+            && expected.EvidenceKind == actual.EvidenceKind
+            && expected.Key.Equals(actual.Key)
+            && ReferenceEquals(
+                expected.NotFoundAttempt,
+                actual.NotFoundAttempt);
+
+    static bool SameDomainAbsence(
+        ResearchTargetDomainAbsenceProof expected,
+        ResearchTargetDomainAbsenceProof actual)
+        => expected.Side == actual.Side
+            && expected.EvidenceKind == actual.EvidenceKind
+            && ReferenceEquals(
+                expected.NotFoundAttempt,
+                actual.NotFoundAttempt);
+
+    static bool SameTaint(
+        ResearchTargetTaintEvidence expected,
+        ResearchTargetTaintEvidence actual)
+        => expected.Kind == actual.Kind
+            && ReferenceEquals(expected.Domain, actual.Domain)
+            && SameReferences(expected.Attempts, actual.Attempts)
+            && SameValues(expected.StrictKeys, actual.StrictKeys)
+            && SameReferences(
+                expected.IncompleteInputs,
+                actual.IncompleteInputs);
+
+    static bool ReferencesResolution(
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome outcome)
+        => outcome switch
+        {
+            ResearchTargetCorrespondenceOutcome.Paired paired =>
+                HasAttempt(resolution, paired.Before.Attempt)
+                && HasAttempt(resolution, paired.After.Attempt),
+            ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                HasAttempt(resolution, beforeOnly.Before.Attempt)
+                && HasCensus(
+                    resolution,
+                    beforeOnly.AfterAbsence.Census)
+                && HasOptionalAttempt(
+                    resolution,
+                    beforeOnly.AfterAbsence.NotFoundAttempt),
+            ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                HasCensus(
+                    resolution,
+                    afterOnly.BeforeAbsence.Census)
+                && HasOptionalAttempt(
+                    resolution,
+                    afterOnly.BeforeAbsence.NotFoundAttempt)
+                && HasAttempt(resolution, afterOnly.After.Attempt),
+            ResearchTargetCorrespondenceOutcome.Absent absent =>
+                HasCensus(
+                    resolution,
+                    absent.BeforeAbsence.Census)
+                && HasCensus(
+                    resolution,
+                    absent.AfterAbsence.Census)
+                && HasOptionalAttempt(
+                    resolution,
+                    absent.BeforeAbsence.NotFoundAttempt)
+                && HasOptionalAttempt(
+                    resolution,
+                    absent.AfterAbsence.NotFoundAttempt),
+            ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
+                unavailable =>
+                HasAttempt(resolution, unavailable.Attempt)
+                && TaintReferencesResolution(
+                    resolution,
+                    unavailable.Taint),
+            ResearchTargetCorrespondenceOutcome.DomainUnavailable
+                unavailable =>
+                TaintReferencesResolution(
+                    resolution,
+                    unavailable.Taint),
+            _ => false,
+        };
+
+    static bool HasAttempt(
+        ResearchTargetResolution resolution,
+        ResearchTargetAttempt attempt)
+        => resolution.Attempts.Any(
+            candidate => ReferenceEquals(candidate, attempt));
+
+    static bool HasOptionalAttempt(
+        ResearchTargetResolution resolution,
+        ResearchTargetAttempt? attempt)
+        => attempt is null || HasAttempt(resolution, attempt);
+
+    static bool HasCensus(
+        ResearchTargetResolution resolution,
+        ResearchTargetDomainSideCensus census)
+        => resolution.Censuses.Any(
+            candidate => ReferenceEquals(candidate, census));
+
+    static bool TaintReferencesResolution(
+        ResearchTargetResolution resolution,
+        ResearchTargetTaintEvidence taint)
+        => resolution.Domains.Any(
+                domain => ReferenceEquals(domain, taint.Domain))
+            && taint.Attempts.All(
+                attempt => HasAttempt(resolution, attempt));
+
+    static bool Equal<T>(T? left, T? right)
+        where T : class, IEquatable<T>
+        => left is null ? right is null : left.Equals(right);
+
+    static bool SameValues<T>(
+        IEnumerable<T> left,
+        IEnumerable<T> right)
+        where T : IEquatable<T>
+        => left.SequenceEqual(right);
+
+    static bool ValidateOutcome(
+        ResearchTargetResolution resolution,
+        ResearchProducerWorkItem item,
+        ResearchProducerWorkOutcome outcome)
+    {
+        bool correspondenceUnavailable = item.Correspondence
+            is ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
+                or ResearchTargetCorrespondenceOutcome.DomainUnavailable;
+        return outcome switch
+        {
+            ResearchProducerWorkOutcome.ProducedCSharp produced =>
+                item.Producer == ResearchProducerKind.CSharp
+                && !correspondenceUnavailable
+                && NativeMatches(
+                    resolution,
+                    item.Correspondence,
+                    produced.Result),
+            ResearchProducerWorkOutcome.ProducedIlBody produced =>
+                item.Producer == ResearchProducerKind.IlBody
+                && !correspondenceUnavailable
+                && NativeMatches(
+                    resolution,
+                    item.Correspondence,
+                    produced.Result),
+            ResearchProducerWorkOutcome.Unavailable unavailable =>
+                ValidateUnavailable(
+                    item.Correspondence,
+                    correspondenceUnavailable,
+                    unavailable.Reason),
+            ResearchProducerWorkOutcome.Failed failed =>
+                !correspondenceUnavailable
+                && failed.Diagnostic.Kind
+                    == ResearchProducerDiagnosticKind.ProducerException
+                && failed.Diagnostic.Producer == item.Producer,
+            _ => false,
+        };
+    }
+
+    static bool ValidateUnavailable(
+        ResearchTargetCorrespondenceOutcome correspondence,
+        bool correspondenceUnavailable,
+        ResearchProducerUnavailable unavailable)
+    {
+        if (correspondenceUnavailable)
+        {
+            return unavailable.Kind
+                    == ResearchProducerUnavailableKind
+                        .CorrespondenceUnavailable
+                && unavailable.Input is null;
+        }
+        if (unavailable.Kind
+            == ResearchProducerUnavailableKind.CorrespondenceUnavailable)
+        {
+            return false;
+        }
+
+        ImmutableArray<ResearchComparisonInputId> endpointInputs =
+            correspondence switch
+            {
+                ResearchTargetCorrespondenceOutcome.Paired paired =>
+                    [
+                        paired.Before.Attempt.Request.Input,
+                        paired.After.Attempt.Request.Input,
+                    ],
+                ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                    [beforeOnly.Before.Attempt.Request.Input],
+                ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                    [afterOnly.After.Attempt.Request.Input],
+                ResearchTargetCorrespondenceOutcome.Absent => [],
+                _ => [],
+            };
+        return unavailable.Input is { } input
+            && endpointInputs.Any(
+                candidate => ReferenceEquals(candidate, input));
+    }
+
+    static bool NativeMatches(
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome correspondence,
+        CSharpMemberEndpointComparison result)
+    {
+        string subject = SubjectIdentity(resolution, correspondence);
+        return string.Equals(result.Old.Key, subject, StringComparison.Ordinal)
+            && string.Equals(result.New.Key, subject, StringComparison.Ordinal)
+            && AbsenceMatches(
+                correspondence,
+                result.Findings.OldInspection,
+                result.Findings.NewInspection);
+    }
+
+    static bool NativeMatches(
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome correspondence,
+        IlMemberEndpointComparison result)
+    {
+        string subject = SubjectIdentity(resolution, correspondence);
+        return string.Equals(
+                result.Old.Identity,
+                subject,
+                StringComparison.Ordinal)
+            && string.Equals(
+                result.New.Identity,
+                subject,
+                StringComparison.Ordinal)
+            && AbsenceMatches(
+                correspondence,
+                result.Findings.OldInspection,
+                result.Findings.NewInspection);
+    }
+
+    static bool AbsenceMatches<T>(
+        ResearchTargetCorrespondenceOutcome correspondence,
+        FindingInspection<T> oldInspection,
+        FindingInspection<T> newInspection)
+        where T : notnull
+    {
+        (bool oldAbsent, bool newAbsent) = correspondence switch
+        {
+            ResearchTargetCorrespondenceOutcome.Paired => (false, false),
+            ResearchTargetCorrespondenceOutcome.BeforeOnly => (false, true),
+            ResearchTargetCorrespondenceOutcome.AfterOnly => (true, false),
+            ResearchTargetCorrespondenceOutcome.Absent => (true, true),
+            _ => throw new InvalidOperationException(
+                "Unavailable correspondence cannot carry a native result."),
+        };
+        return IsSubjectAbsent(oldInspection) == oldAbsent
+            && IsSubjectAbsent(newInspection) == newAbsent;
+    }
+
+    static bool IsSubjectAbsent<T>(FindingInspection<T> inspection)
+        where T : notnull
+        => inspection is FindingInspection<T>.Absent
+        {
+            Kind: FindingInspectionAbsenceKind.SubjectAbsent,
+        };
+
+    static string SubjectIdentity(
+        ResearchTargetResolution resolution,
+        ResearchTargetCorrespondenceOutcome correspondence)
+        => correspondence switch
+        {
+            ResearchTargetCorrespondenceOutcome.Paired paired =>
+                paired.Before.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                beforeOnly.Before.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                afterOnly.After.CorrespondenceKey.CanonicalIdentity,
+            ResearchTargetCorrespondenceOutcome.Absent =>
+                AbsentSubject(resolution, correspondence.Scope),
+            _ => throw new InvalidOperationException(
+                "Unavailable correspondence has no producer subject."),
+        };
+
+    static string AbsentSubject(
+        ResearchTargetResolution resolution,
+        ResearchTargetScopeId scopeId)
+    {
+        ResearchTargetScope? scope = resolution.Scopes.FirstOrDefault(
+            candidate => ReferenceEquals(candidate.Id, scopeId));
+        return scope is null
+            ? ""
+            : $"{scope.DeclaringTypeFullName}::{scope.Selector.NormalizedSelector}";
+    }
+
+    static bool SameReferences<T>(
+        IEnumerable<T> left,
+        IEnumerable<T> right)
+        where T : class
+    {
+        using IEnumerator<T> leftEnumerator = left.GetEnumerator();
+        using IEnumerator<T> rightEnumerator = right.GetEnumerator();
+        while (true)
+        {
+            bool leftNext = leftEnumerator.MoveNext();
+            bool rightNext = rightEnumerator.MoveNext();
+            if (leftNext != rightNext)
+                return false;
+            if (!leftNext)
+                return true;
+            if (!ReferenceEquals(
+                    leftEnumerator.Current,
+                    rightEnumerator.Current))
+            {
+                return false;
+            }
+        }
+    }
+
+    static ResearchProducerRejection Reject(
+        ResearchProducerRejectionKind kind,
+        string summary)
+        => new(kind, summary);
+}

--- a/src/ILInspector.Research/ResearchTargetResolver.cs
+++ b/src/ILInspector.Research/ResearchTargetResolver.cs
@@ -450,9 +450,11 @@ public static class ResearchTargetResolver
             {
                 reader = source.Reader;
                 ResearchTargetInputValidationEvidence evidence =
-                    CaptureInputEvidence(reader, occurrence);
+                    ResearchInputImageValidation.Capture(reader, occurrence);
                 SetInputEvidence(requests, evidence);
-                if (ValidateImage(evidence, occurrence) is
+                if (ResearchInputImageValidation.Validate(
+                        evidence,
+                        occurrence) is
                     ResearchTargetDiagnosticKind invalid)
                 {
                     Terminate(requests, invalid);
@@ -500,58 +502,6 @@ public static class ResearchTargetResolver
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Validates that the live image, the acquisition descriptor, and the
-    /// Analysis body index all name the same assembly and the same module.
-    /// </summary>
-    static ResearchTargetInputValidationEvidence CaptureInputEvidence(
-        MetadataReader reader,
-        ImplementationComparisonInputOccurrence occurrence)
-    {
-        bool isAssembly = reader.IsAssembly;
-        AssemblyReferenceIdentity? identity = isAssembly
-            ? AssemblyReferenceIdentity.FromAssemblyDefinition(reader)
-            : null;
-        Guid moduleVersionId =
-            reader.GetGuid(reader.GetModuleDefinition().Mvid);
-        return new ResearchTargetInputValidationEvidence(
-            ReadFailed: false,
-            isAssembly,
-            identity,
-            moduleVersionId,
-            occurrence.Assembly.Registration.ModuleVersionId,
-            reader.MethodDefinitions.Count,
-            Surface: null);
-    }
-
-    static ResearchTargetDiagnosticKind? ValidateImage(
-        ResearchTargetInputValidationEvidence evidence,
-        ImplementationComparisonInputOccurrence occurrence)
-    {
-        LibraryBodyModuleIdentity analysis = occurrence.BodyIndex.ModuleIdentity;
-        if (!evidence.IsAssembly)
-            return ResearchTargetDiagnosticKind.StandaloneModule;
-        if (analysis.AssemblyIdentity is null)
-            return ResearchTargetDiagnosticKind.AssemblyIdentityMismatch;
-
-        AssemblyReferenceIdentity live = evidence.LiveAssemblyIdentity!;
-        if (!AssemblyReferenceIdentity.EquivalentComparer.Equals(
-                live,
-                occurrence.Assembly.Identity)
-            || !AssemblyReferenceIdentity.EquivalentComparer.Equals(
-                live,
-                analysis.AssemblyIdentity))
-        {
-            return ResearchTargetDiagnosticKind.AssemblyIdentityMismatch;
-        }
-
-        return evidence.LiveModuleVersionId == analysis.ModuleVersionId
-                && (evidence.ArtifactModuleVersionId is not Guid artifact
-                    || artifact == evidence.LiveModuleVersionId)
-            ? null
-            : ResearchTargetDiagnosticKind.ModuleIdentityMismatch;
     }
 
     static ResearchTargetOutcome ResolveRequest(


### PR DESCRIPTION
dotnet-inspect's rigor serves robust, capable features that become foundational
or create a compelling user experience while remaining conventionally sound
and, where useful, delightfully new. This slice supplies the Research-owned
atomic producer boundary that later direct-member and Queries consumers need.

## Demo

The real compiled-fixture gate runs two retained target correspondences through
the closed C# catalog entry while sharing the same two validated input stages:

```text
Target correspondences: 2
Requested producers: CSharp
Derived work items: 2
Native C# results retained: 2
Research input stages acquired: 2
Research cleanup outcomes: 2 (reverse acquisition order)
Published completion: Completed
```

The full owner gate also exercises both catalog entries:

```text
Correspondence: Paired
Catalog order: CSharp, IlBody
Derived work items: 2
C# topology: Complete -> Complete; native body diff retained
IL topology: Complete -> Complete; native member diff retained
Published completion: Completed
```

What to notice: work order comes from correspondence order crossed with catalog
order, both producers consume the same Research-owned validated stages, and
native typed results remain intact after those stages close. Neighboring
one-sided, both-absent, bodyless, changed-input, unavailable-correspondence,
producer-exception, cleanup-failure, and cancellation fixtures exercise the
non-happy paths without exposing partial completion.

## Summary

- Adds the closed `CSharp`/`IlBody` producer catalog, opaque session/work-item
  identities, exact ordered work roster, native result union, cleanup evidence,
  and `Rejected`/`Completed`/`Failed`/`Cancelled` terminal arms.
- Reopens each required admitted implementation input at most once, shares the
  existing assembly/MVID/body-index validation with target resolution, invokes
  producers sequentially, and closes acquired stages in reverse order.
- Lowers paired, one-sided, and both-absent correspondence into the existing
  total native endpoint adapters; unavailable correspondence invokes nothing.
  API-only targets without a physical method address remain explicitly
  Research-unavailable rather than being mislabeled as producer
  `NoApplicableInput`.
- Publishes escaped producer exceptions as local work-item failures while
  continuing independent work. Producer-contract, Research execution, and
  cleanup failures prevent completion.
- Re-derives population/resolution closure and the correspondence-by-catalog
  product before publication so stale, foreign, reordered, duplicated, or
  wrong-native evidence cannot form a completion.

## Boundary

This remains Research-owned composition below Queries. The existing
`research-dependencies` rule gives full project- and compiled-assembly coverage
for that dependency claim. This PR adds no direct-member adapter, Queries
population sealing or publication, CLI/browser host behavior, rendering,
Source/PDB/network work, or new native C#/IL algorithms; those remain rank-5,
rank-6, and later owner work in #4706.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build`
  — 281 passed
- `dotnet run --project eng/DependencyPolicy.Tests -c Release --no-build`
  — 25 passed
- `dotnet run --project eng/DependencyPolicy -c Release --no-build`
  — 24 rules, 160 projects, 41 assemblies
- `npx --no-install markdownlint-cli docs/design/implementation-diff.md`
- `git diff --check`

Closes #5820
