### PR TITLE
Test call graph signature correspondence flows

### DIFF
--- a/docs/design/call-graph-projection.md
+++ b/docs/design/call-graph-projection.md
@@ -129,6 +129,10 @@ The projection owns everything a host must not re-invent in JavaScript:
   pointers, by-reference types, tuples, method generic parameters, custom
   modifiers, and return types, plus resolution with and without an exact-token
   candidate.
+  `CallGraphCorrespondenceFlowTests.CorrespondenceFlow_MatchesRecordedStageExpectations`
+  records the exact Metadata input, API selector, independently decoded
+  `MemberRef` selector, tokenless resolution, and JSON-restored exact-token
+  recovery for vector, rank-one non-SZ, rank-two, and nested non-SZ specimens.
 - **Physical evidence.** Every projected node retains the distinct
   `GraphNodeEvidence` carried by the tree occurrences that collapsed into it.
   A catalog-resolved node also carries the exact defining assembly identity

--- a/src/ILInspector.Analysis.Tests/CallGraphArrayKindIdentityTests.Fixture.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphArrayKindIdentityTests.Fixture.cs
@@ -1,0 +1,48 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Analysis.Tests;
+
+public sealed partial class CallGraphArrayKindIdentityTests
+{
+    internal static byte[] BuildProjectionFlowImage(string specimen)
+    {
+        var metadata = CreateMetadata();
+        byte[] signatureType = specimen switch
+        {
+            "Vector" => Sz(Int32),
+            "RankOneNonSz" => MdArray(Int32, rank: 1),
+            "RankTwo" => MdArray(Int32, rank: 2),
+            "NestedRankOneNonSz" => GenericInstance(
+                isValueType: false,
+                AddListReference(metadata),
+                MdArray(Int32, rank: 1)),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(specimen),
+                specimen,
+                "Unknown call-graph projection specimen."),
+        };
+
+        return BuildImage(
+            [
+                new("M", signatureType, signatureType, IsGeneric: false),
+            ],
+            metadata);
+    }
+
+    static TypeReferenceHandle AddListReference(MetadataBuilder metadata)
+    {
+        AssemblyReferenceHandle systemCollections =
+            metadata.AddAssemblyReference(
+                metadata.GetOrAddString("System.Collections"),
+                new Version(8, 0, 0, 0),
+                default,
+                default,
+                default,
+                default);
+        return metadata.AddTypeReference(
+            systemCollections,
+            metadata.GetOrAddString("System.Collections.Generic"),
+            metadata.GetOrAddString("List`1"));
+    }
+}

--- a/src/ILInspector.Analysis.Tests/CallGraphArrayKindIdentityTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphArrayKindIdentityTests.cs
@@ -7,7 +7,7 @@ using ILInspector.Metadata;
 
 namespace ILInspector.Analysis.Tests;
 
-public sealed class CallGraphArrayKindIdentityTests
+public sealed partial class CallGraphArrayKindIdentityTests
 {
     [Fact]
     public void Resolve_PreservesArrayKindAcrossExtractedApiAndMemberRefSelectors()

--- a/src/ILInspector.Analysis.Tests/CallGraphCorrespondenceFlowTests.cs
+++ b/src/ILInspector.Analysis.Tests/CallGraphCorrespondenceFlowTests.cs
@@ -1,0 +1,175 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text.Json;
+using ILInspector.Metadata;
+
+namespace ILInspector.Analysis.Tests;
+
+public sealed class CallGraphCorrespondenceFlowTests
+{
+    const int MethodToken = 0x06000001;
+
+    public static TheoryData<
+        string,
+        string,
+        string?,
+        string,
+        string,
+        string> ProjectionExpectations => new()
+        {
+            {
+                "Vector",
+                "int[]",
+                null,
+                "System.Int32[]",
+                "System.Int32[]",
+                "1:MI;0;1;14:System.Int32[]14:System.Int32[]"
+            },
+            {
+                "RankOneNonSz",
+                "int[*]",
+                "System.Int32[*]",
+                "System.Int32[]",
+                "System.Int32[*]",
+                "1:MI;0;1;15:System.Int32[*]15:System.Int32[*]"
+            },
+            {
+                "RankTwo",
+                "int[,]",
+                null,
+                "System.Int32[,]",
+                "System.Int32[,]",
+                "1:MI;0;1;15:System.Int32[,]15:System.Int32[,]"
+            },
+            {
+                "NestedRankOneNonSz",
+                "System.Collections.Generic.List<int[*]>",
+                "System.Collections.Generic.List{System.Int32[*]}",
+                "System.Collections.Generic.List{System.Int32[]}",
+                "System.Collections.Generic.List{System.Int32[*]}",
+                "1:MI;0;1;48:System.Collections.Generic.List{System.Int32[*]}48:System.Collections.Generic.List{System.Int32[*]}"
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(ProjectionExpectations))]
+    public void CorrespondenceFlow_MatchesRecordedStageExpectations(
+        string specimen,
+        string expectedApiType,
+        string? expectedStructuralPayload,
+        string expectedDisplayIdentity,
+        string expectedStructuralIdentity,
+        string expectedSelectorKey)
+    {
+        byte[] image =
+            CallGraphArrayKindIdentityTests.BuildProjectionFlowImage(specimen);
+        using var peReader = new PEReader(
+            new MemoryStream(image, writable: false));
+        MetadataReader reader = peReader.GetMetadataReader();
+        ApiSurface live = ApiSurfaceExtractor.Extract(
+            peReader,
+            includeAll: true);
+        ApiType liveType = Assert.Single(
+            live.Types,
+            type => type.Name == "ArrayCallGraphKinds");
+        ApiMember liveMember = Assert.Single(liveType.Members);
+        Assert.Equal(MethodToken, liveMember.MetadataToken);
+        ApiSignature signature = Assert.IsType<ApiSignature>(
+            liveMember.SignatureModel);
+        ApiParameter parameter = Assert.Single(signature.Parameters);
+
+        Assert.Equal(expectedApiType, parameter.Type);
+        Assert.Equal(expectedStructuralPayload, parameter.StructuralType);
+        Assert.Equal(expectedApiType, signature.ReturnType);
+        Assert.Equal(
+            expectedStructuralPayload,
+            signature.StructuralReturnType);
+
+        MemberRef reference = MemberResolver.ResolveMethod(
+            reader,
+            MetadataTokens.EntityHandle(MethodToken),
+            GenericScope.Empty);
+        CallGraphMemberSelector apiSelector =
+            CallGraphMemberResolver.CreateSelector(liveType, liveMember);
+        CallGraphMemberSelector referenceSelector =
+            CallGraphMemberResolver.CreateSelector(reference);
+
+        AssertSelector(
+            apiSelector,
+            expectedDisplayIdentity,
+            expectedStructuralIdentity,
+            expectedSelectorKey);
+        AssertSelector(
+            referenceSelector,
+            expectedDisplayIdentity,
+            expectedStructuralIdentity,
+            expectedSelectorKey);
+
+        AssertResolution(
+            liveMember,
+            Assert.IsType<CallGraphMemberResolution>(
+                CallGraphMemberResolver.Resolve(
+                    liveType,
+                    referenceSelector.Name,
+                    referenceSelector.Key)));
+        AssertResolution(
+            liveMember,
+            Assert.IsType<CallGraphMemberResolution>(
+                CallGraphMemberResolver.Resolve(
+                    liveType,
+                    referenceSelector.Name,
+                    referenceSelector.Key,
+                    metadataToken: MethodToken)));
+
+        ApiSurface restored = JsonSerializer.Deserialize<ApiSurface>(
+            JsonSerializer.Serialize(live))!;
+        ApiType restoredType = Assert.Single(
+            restored.Types,
+            type => type.Name == "ArrayCallGraphKinds");
+        ApiMember restoredMember = Assert.Single(restoredType.Members);
+        Assert.Null(restoredMember.SignatureModel);
+        Assert.Null(
+            CallGraphMemberResolver.Resolve(
+                restoredType,
+                referenceSelector.Name,
+                referenceSelector.Key));
+        AssertResolution(
+            restoredMember,
+            Assert.IsType<CallGraphMemberResolution>(
+                CallGraphMemberResolver.Resolve(
+                    restoredType,
+                    referenceSelector.Name,
+                    referenceSelector.Key,
+                    metadataToken: MethodToken)));
+    }
+
+    static void AssertSelector(
+        CallGraphMemberSelector selector,
+        string expectedDisplayIdentity,
+        string expectedStructuralIdentity,
+        string expectedKey)
+    {
+        Assert.Equal("M", selector.Name);
+        Assert.Equal(0, selector.GenericArity);
+        Assert.Equal(
+            expectedDisplayIdentity,
+            Assert.Single(selector.ParameterTypes));
+        Assert.Equal(expectedDisplayIdentity, selector.ReturnType);
+        Assert.Equal(
+            expectedStructuralIdentity,
+            Assert.Single(selector.StructuralParameterTypes));
+        Assert.Equal(
+            expectedStructuralIdentity,
+            selector.StructuralReturnType);
+        Assert.Equal(expectedKey, selector.Key);
+    }
+
+    static void AssertResolution(
+        ApiMember expectedMember,
+        CallGraphMemberResolution resolution)
+    {
+        Assert.Same(expectedMember, resolution.Member);
+        Assert.Equal(MethodToken, resolution.BodyToken);
+    }
+}


### PR DESCRIPTION
## Summary

Records exact Analysis correspondence results for four representative array
signatures as they move from Metadata API fields into independently decoded
`MemberRef` selectors and resolver outcomes.

- Adds vector, rank-one non-SZ, rank-two, and nested non-SZ flow specimens with
  the same signature in parameter and return positions.
- Gates the Metadata display and structural inputs, Analysis display and
  structural selector types, exact selector keys, tokenless resolution, and
  exact-token resolution.
- Demonstrates the documented persistence boundary: JSON removes the live
  `SignatureModel`, tokenless structural correspondence becomes unavailable,
  and an exact MethodDef token still recovers the intended body.
- Keeps the existing 11-shape overload and accessor matrix as the non-vacuous
  competition control.

This is the Analysis-owned signature-evidence slice following #5709. It changes
no product behavior or public API.

## Demo

```text
$ dotnet run --project src/ILInspector.Analysis.Tests -c Release -- \
    --filter-class '*CallGraphCorrespondenceFlowTests*'

Test run summary: Passed!
  total: 4
  failed: 0
  succeeded: 4
```

Notice that rank-one non-SZ arrays deliberately share compatibility display
identity with vectors while retaining a different structural selector and
exact key. Rank-two and nested generic cases show the same ledger works beyond
the pathological pair.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- --filter-class '*CallGraphCorrespondenceFlowTests*'`
  - 4 passed
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- --filter-class '*CallGraphArrayKindIdentityTests*'`
  - 3 passed
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
  - 1,351 passed
- `npx markdownlint-cli docs/design/call-graph-projection.md`
