### PR TITLE
Require production-host adoption trackers for new architectures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,14 @@ development model and rationale. The binding summary:
   user-observable experience.
 - **Design first and state the basis.** Name one normative owner and exact
   claim, then supporting designs, models, constraints, and evidence by role.
-- **Start capabilities from named consumers.** Every new capability or
-  substrate identifies its consumer in the specification and issue, links an
-  overall end-to-end tracker, and may land its consumer in a later slice.
-  Shared substrate must benefit and plan enablement through both the CLI and
-  browser/Wasm hosts; a single-consumer or single-host substrate requires
-  explicit user approval from the start.
+- **Start architectures from production-host adoption.** Every new architecture,
+  capability, or substrate names its consumer and links an end-to-end tracker
+  that enumerates the production-host adoption path and total step count, even
+  when the component is host-neutral. Test infrastructure may treat its harness
+  as the production host. An alternative to an existing architecture must also
+  track that architecture's retirement. Shared product substrate must plan
+  enablement through both CLI and browser/Wasm hosts; single-consumer or
+  single-host scope requires explicit user approval.
 - **Keep hosts thin.** Put reusable concepts and algorithms in host-neutral
   code. Duplicated host logic triggers a review for a shared abstraction that
   would also benefit another future host.

--- a/docs/adversarial-review-prompt.md
+++ b/docs/adversarial-review-prompt.md
@@ -83,24 +83,30 @@ does not depend on that later work for correctness. Do report success-shaped
 unfinished behavior or a slice whose current correctness depends on a future
 change.
 
-When a candidate adds or expands a capability, substrate, host path, or broad
-rendering domain, review only design properties visible in the exact head and
-facts supplied in the candidate frame. The frame must state the complexity
-basis; named consumer, focused issue, overall end-to-end tracker, host
-enablement plan, and any applicable approval record and exact scope; and
-rendering strategy, or explain why each does not apply.
+When a candidate adds or expands an architecture, capability, substrate, host
+path, or broad rendering domain, review only design properties visible in the
+exact head and facts supplied in the candidate frame. The frame must state the
+complexity basis; named consumer, focused issue, overall end-to-end tracker,
+enumerated production-host adoption path and total step count, any applicable
+existing-architecture retirement plan, and any applicable approval record and
+exact scope; and rendering strategy, or explain why each does not apply.
 
 Verify that the stated complexity basis identifies a specific reliability or
 correctness requirement or user-observable experience, and that the visible
 design's added complexity serves that basis. Do not independently judge whether
 an experience is compelling. Verify that the design matches its named consumer
-and host plan, keeps reusable concepts host-neutral and hosts reasonably thin,
-and does not depend on unplanned later work for the current slice's
-correctness. Shared substrate must plan benefit and enablement through both the
-CLI and browser/Wasm hosts; for substrate intentionally limited to one consumer
-or host, the frame must supply the recorded approval and exact approved scope.
-Treat that record as a candidate-formation fact: verify that the design
-conforms to it, but do not infer, grant, or broaden approval.
+and counted production-host adoption plan, keeps reusable concepts host-neutral
+and hosts reasonably thin, and does not depend on unplanned later work for the
+current slice's correctness. Host-neutrality does not remove the requirement
+to explain how and in how many steps the architecture reaches observable host
+behavior. Test infrastructure may name its routinely exercising harness as the
+production host. Shared substrate must plan benefit and enablement through both
+the CLI and browser/Wasm hosts. An alternative to an existing architecture
+must track that architecture's migration and retirement. For substrate
+intentionally limited to one consumer or host, the frame must supply the
+recorded approval and exact approved scope. Treat that record as a
+candidate-formation fact: verify that the design conforms to it, but do not
+infer, grant, or broaden approval.
 
 For rendering, verify that structured information survives to the rendering
 boundary. Markout is the default host-neutral, multi-format substrate. A
@@ -111,10 +117,10 @@ uses Markout or another approach.
 
 Do not accept claimed non-applicability at face value. Verify from the
 normative owner, change intent, changed surfaces, and exact-head diff that the
-candidate does not add or expand a capability, substrate, host path, or broad
-rendering domain. When a design establishes that boundary, the explanation
-must name its exact section. If the supplied facts and exact-head evidence do
-not establish non-applicability, return a framing defect.
+candidate does not add or expand an architecture, capability, substrate, host
+path, or broad rendering domain. When a design establishes that boundary, the
+explanation must name its exact section. If the supplied facts and exact-head
+evidence do not establish non-applicability, return a framing defect.
 
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.
@@ -139,12 +145,13 @@ owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
-claimed consequence. For an applicable capability, substrate, host, or
-rendering change, also stop when the required complexity basis; named consumer,
-focused issue, overall end-to-end tracker, or host enablement plan; applicable
-approval record or exact scope; or rendering strategy is incomplete or absent.
-Return the framing defect instead of inventing the missing plan, approval, or
-broader review property.
+claimed consequence. For an applicable architecture, capability, substrate,
+host, or rendering change, also stop when the required complexity basis; named
+consumer, focused issue, overall end-to-end tracker, production-host adoption
+path or total step count, or applicable existing-architecture retirement plan;
+applicable approval record or exact scope; or rendering strategy is incomplete
+or absent. Return the framing defect instead of inventing the missing plan,
+approval, or broader review property.
 
 Treat the assigned review worktree as read-only. Do not run `git reset`,
 `git add`, or `git commit`; do not rebase or checkout another revision. Put

--- a/docs/development-practices.md
+++ b/docs/development-practices.md
@@ -69,19 +69,31 @@ developed closely with the user can reveal the actual boundary before code
 makes an accidental behavior expensive to undo. Much of the architecture is
 the act of bounding a contract and making its important properties invariant.
 
-## Start capabilities from consumers
+## Start architectures from production hosts
 
-Every new capability or substrate must name a concrete consumer from the
-start. The consumer may land in a later slice, but the focused specification
-and implementation issue must identify it, and a single overall end-to-end
-tracking issue must link the substrate and consumer work.
+Every new architecture, capability, or substrate must name a concrete consumer
+from the start. The consumer may land in a later slice, but the focused
+specification and implementation issue must identify it, and a single overall
+end-to-end tracking issue must link the architecture and consumer work.
+
+The tracker must identify each production host, enumerate the concrete adoption
+slices in order, and state the current total step count from the architecture
+to observable host behavior. A host-neutral component is not exempt: its
+tracker must explain how and in how many steps each planned production host
+will consume it. For test infrastructure, the tracker may treat the harness
+that routinely exercises the infrastructure as its production host.
+
+When the new architecture is an alternative to an existing architecture, the
+tracker must also enumerate the migration and retirement slices for the
+existing architecture. Adoption is not complete while that retirement work
+remains outstanding.
 
 Shared product substrate defaults to planned benefit in both current product
-hosts: the CLI and browser/Wasm. The end-to-end tracker records the planned
-enablement slices for both hosts from the outset. A substrate intended for only
-one consumer or host requires explicit user approval before implementation;
-record the approved scope in its specification, implementation issue, and
-end-to-end tracker from the start.
+hosts: the CLI and browser/Wasm. Both host paths must appear in the counted
+adoption plan from the outset. A substrate intended for only one consumer or
+host requires explicit user approval before implementation; record the
+approved scope in its specification, implementation issue, and end-to-end
+tracker from the start.
 
 `InertString` illustrates the shared default: its containment contract must
 work for all consumers. `ts-jsexport` is an approved exception: its website-only

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -332,19 +332,23 @@ or variable input, the boundary through which it reaches the claim, trusted
 parties and excluded scenarios, the user purpose, baseline and any divergence,
 relevant analogous evidence, pathological case and gate, current slice,
 residual work, demo and neighboring case, the observable consequence, and the
-evidence that would falsify the claim. For an applicable capability, substrate,
-host, or broad rendering change, candidate formation must also supply the
-complexity basis, named consumer, focused issue, overall end-to-end tracker,
-host-enablement plan, any recorded single-consumer or single-host approval and
-its exact scope, and the rendering strategy. Reviewers judge the visible
-design's consistency with those supplied facts; they do not grant approvals or
-invent roadmap decisions. State the facts directly in the self-contained
-prompt; links may support them but do not replace them. For a correctness
-review without an untrusted actor, name the ordinary supported caller and input
-instead. Candidate formation must make every non-applicability explanation
-judgeable from the normative owner, changed surfaces, and exact-head diff. If
-required fields cannot be filled or non-applicability cannot be established,
-return to design or scope clarification before spending a review round.
+evidence that would falsify the claim. For an applicable architecture,
+capability, substrate, host, or broad rendering change, candidate formation
+must also supply the complexity basis, named consumer, focused issue, overall
+end-to-end tracker, enumerated production-host adoption path and total step
+count, any applicable existing-architecture retirement plan, any recorded
+single-consumer or single-host approval and its exact scope, and the rendering
+strategy. Host-neutral components still require the counted path to observable
+host behavior; test infrastructure may name its harness as the production
+host. Reviewers judge the visible design's consistency with those supplied
+facts; they do not grant approvals or invent roadmap decisions. State the facts
+directly in the self-contained prompt; links may support them but do not
+replace them. For a correctness review without an untrusted actor, name the
+ordinary supported caller and input instead. Candidate formation must make
+every non-applicability explanation judgeable from the normative owner,
+changed surfaces, and exact-head diff. If required fields cannot be filled or
+non-applicability cannot be established, return to design or scope
+clarification before spending a review round.
 
 Give every seat the same completed prompt except for its worktree path. State
 candidate facts rather than rewarding findings; the canonical prompt already

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -317,11 +317,11 @@ required real-run evidence. The appended material may narrow the review but
 must not weaken or broaden the prompt's trust model and finding-admission rules.
 It also records the user purpose, convention or best-practice baseline,
 intentional divergence, analogous implementation evidence, pathological or
-boundary case and gate, complexity basis, consumer and host plan, rendering
-strategy, current slice and residual work, and the demo with a neighboring
-case. Use `Not applicable — <reason>` only when the reason names the relevant
-change classification and exact-head evidence; cite the owning design's exact
-section when it defines the boundary.
+boundary case and gate, complexity basis, consumer, production-host adoption,
+and retirement plan, rendering strategy, current slice and residual work, and
+the demo with a neighboring case. Use `Not applicable — <reason>` only when
+the reason names the relevant change classification and exact-head evidence;
+cite the owning design's exact section when it defines the boundary.
 Agents that prefer a structured composition aid may instead fill the optional
 [`docs/templates/adversarial-review-prompt.md`](templates/adversarial-review-prompt.md),
 which includes the same fixed prompt followed by candidate placeholders.

--- a/docs/templates/adversarial-review-prompt.md
+++ b/docs/templates/adversarial-review-prompt.md
@@ -83,24 +83,30 @@ does not depend on that later work for correctness. Do report success-shaped
 unfinished behavior or a slice whose current correctness depends on a future
 change.
 
-When a candidate adds or expands a capability, substrate, host path, or broad
-rendering domain, review only design properties visible in the exact head and
-facts supplied in the candidate frame. The frame must state the complexity
-basis; named consumer, focused issue, overall end-to-end tracker, host
-enablement plan, and any applicable approval record and exact scope; and
-rendering strategy, or explain why each does not apply.
+When a candidate adds or expands an architecture, capability, substrate, host
+path, or broad rendering domain, review only design properties visible in the
+exact head and facts supplied in the candidate frame. The frame must state the
+complexity basis; named consumer, focused issue, overall end-to-end tracker,
+enumerated production-host adoption path and total step count, any applicable
+existing-architecture retirement plan, and any applicable approval record and
+exact scope; and rendering strategy, or explain why each does not apply.
 
 Verify that the stated complexity basis identifies a specific reliability or
 correctness requirement or user-observable experience, and that the visible
 design's added complexity serves that basis. Do not independently judge whether
 an experience is compelling. Verify that the design matches its named consumer
-and host plan, keeps reusable concepts host-neutral and hosts reasonably thin,
-and does not depend on unplanned later work for the current slice's
-correctness. Shared substrate must plan benefit and enablement through both the
-CLI and browser/Wasm hosts; for substrate intentionally limited to one consumer
-or host, the frame must supply the recorded approval and exact approved scope.
-Treat that record as a candidate-formation fact: verify that the design
-conforms to it, but do not infer, grant, or broaden approval.
+and counted production-host adoption plan, keeps reusable concepts host-neutral
+and hosts reasonably thin, and does not depend on unplanned later work for the
+current slice's correctness. Host-neutrality does not remove the requirement
+to explain how and in how many steps the architecture reaches observable host
+behavior. Test infrastructure may name its routinely exercising harness as the
+production host. Shared substrate must plan benefit and enablement through both
+the CLI and browser/Wasm hosts. An alternative to an existing architecture
+must track that architecture's migration and retirement. For substrate
+intentionally limited to one consumer or host, the frame must supply the
+recorded approval and exact approved scope. Treat that record as a
+candidate-formation fact: verify that the design conforms to it, but do not
+infer, grant, or broaden approval.
 
 For rendering, verify that structured information survives to the rendering
 boundary. Markout is the default host-neutral, multi-format substrate. A
@@ -111,10 +117,10 @@ uses Markout or another approach.
 
 Do not accept claimed non-applicability at face value. Verify from the
 normative owner, change intent, changed surfaces, and exact-head diff that the
-candidate does not add or expand a capability, substrate, host path, or broad
-rendering domain. When a design establishes that boundary, the explanation
-must name its exact section. If the supplied facts and exact-head evidence do
-not establish non-applicability, return a framing defect.
+candidate does not add or expand an architecture, capability, substrate, host
+path, or broad rendering domain. When a design establishes that boundary, the
+explanation must name its exact section. If the supplied facts and exact-head
+evidence do not establish non-applicability, return a framing defect.
 
 Push on the named pathological or boundary case. When accepting or rejecting
 that case is part of the supported contract, require exact-head gate evidence.
@@ -139,12 +145,13 @@ owning claim defines a concrete observable requirement.
 
 Do not begin review if the candidate context contains unresolved placeholders,
 names multiple normative owners, or cannot connect the supported input to the
-claimed consequence. For an applicable capability, substrate, host, or
-rendering change, also stop when the required complexity basis; named consumer,
-focused issue, overall end-to-end tracker, or host enablement plan; applicable
-approval record or exact scope; or rendering strategy is incomplete or absent.
-Return the framing defect instead of inventing the missing plan, approval, or
-broader review property.
+claimed consequence. For an applicable architecture, capability, substrate,
+host, or rendering change, also stop when the required complexity basis; named
+consumer, focused issue, overall end-to-end tracker, production-host adoption
+path or total step count, or applicable existing-architecture retirement plan;
+applicable approval record or exact scope; or rendering strategy is incomplete
+or absent. Return the framing defect instead of inventing the missing plan,
+approval, or broader review property.
 
 Treat the assigned review worktree as read-only. Do not run `git reset`,
 `git add`, or `git commit`; do not rebase or checkout another revision. Put
@@ -193,10 +200,13 @@ section when it defines the boundary.
 - **Complexity basis:** {why this is the simplest sufficient design and which
   reliability, correctness, or user-observable experience requires any added
   complexity; or why this field does not apply}
-- **Consumer and host plan:** {consumer named by the specification, focused
-  issue, overall end-to-end tracker, and planned host enablement; for
-  single-consumer or single-host substrate, include the supplied approval
-  record and exact scope; or why this field does not apply}
+- **Consumer, production-host adoption, and retirement plan:** {consumer named
+  by the specification, focused issue, overall end-to-end tracker, enumerated
+  adoption slices and total step count for each production host, including for
+  host-neutral components; a harness may be the host for test infrastructure;
+  include existing-architecture migration and retirement when this is an
+  alternative, and for single-consumer or single-host substrate include the
+  supplied approval record and exact scope; or why this field does not apply}
 - **Rendering strategy:** {typed information model and Markout lowerings, or
   the host-specific alternative with host, rationale, and lowering ownership;
   for a broad domain, include every planned format boundary; or why this field
@@ -243,9 +253,10 @@ the exact owned claim.}
 
 {List concrete properties derived from the review frame. Describe properties,
 not attacks, and do not broaden the actor, input, boundary, or exclusions.
-Include the baseline or divergence, complexity basis, consumer and host plan,
-rendering strategy, pathological case and gate, analogous evidence transfer,
-current-slice coherence, and demonstrated neighboring case when applicable.
+Include the baseline or divergence, complexity basis, production-host adoption
+and retirement plan, rendering strategy, pathological case and gate, analogous
+evidence transfer, current-slice coherence, and demonstrated neighboring case
+when applicable.
 Do not turn subjective product purpose or taste into a property or ask the
 reviewer to grant an approval supplied by candidate formation.}
 


### PR DESCRIPTION
New architectures now require a counted path to production-host adoption, including host-neutral components, test-infrastructure harnesses, and retirement work for alternative architectures.

## Demo

A compliant architecture tracker now makes the delivery path explicit:

```text
Production host: CLI
Adoption steps: 3
1. Land the host-neutral component.
2. Bind it into the CLI operation.
3. Expose the user-visible behavior.

Alternative architecture retirement steps: 2
1. Migrate remaining callers.
2. Remove the superseded architecture.
```

For test infrastructure, the corresponding tracker may name the exercising harness as the production host and count the steps needed for routine harness adoption. A neighboring architecture that directly lands in a host still records its one-step adoption path.

## Validation

- `npx markdownlint-cli AGENTS.md docs/development-practices.md docs/round-orchestration.md docs/adversarial-review-prompt.md docs/templates/adversarial-review-prompt.md`
- canonical adversarial-review prompt and template fixed text remain synchronized
- `AGENTS.md` remains within its 600-line cap at 598 lines

Closes #5844