### PR TITLE
Specify source-oracle candidate ledger evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -139,7 +139,8 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Classic Async Request Adapter](design/classic-async-request-adapter.md) | Carries exact Metadata relationship evidence and owner failures into the Decompiler classic-inverse boundary. |
 | [Classic Async Inverse Core](design/classic-async-reconstruction.md) | Proof-carrying reconstruction of authenticated classic async requests. |
 | [Committed Authored-Corpus History](design/authored-corpus-history.md) | Admission, ordered observation addressing, sequence validity, provenance, compatibility, and consumer trust for the committed EVIL benchmark history. |
-| [Decompiler Raise Discipline](decompiler-raise-discipline.md) | Rules for raising IL into decompiler structures. |
+| [Source-Oracle Candidate Ledger](design/source-oracle-candidate-ledger.md) | Denominator-complete candidate-file verdicts, accepted baseline evidence, deterministic next-enrollment ranking, provenance disclosure, and archive limits. |
+| [Decompiler Raise Discipline](decompiler-raise-discipline.md) | Rules for raising IL into decompiler structures.  |
 
 ### Contributor workflow and process docs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,13 @@ and validating the ordered committed sequence. Its
 separates persistence evidence from benchmark production, methodology,
 ratchet comparison, and history-card rendering.
 
+`SourceOracleCandidateLedger` is the focused harness owner for complete
+candidate-file accounting and deterministic next-enrollment ranking over one
+accepted source-oracle baseline. Its
+[candidate-ledger contract](design/source-oracle-candidate-ledger.md) consumes
+PDB mapping, acquisition, evaluation, syntax-inventory, and provenance evidence
+without taking ownership of those producers or of manifest enrollment.
+
 Within the CLI host, `PackageIndexCache` is a focused derived-result owner. Its
 [package index cache](design/package-index-cache.md) contract defines when a
 persistent filesystem-derived package projection may replace cold inspection;

--- a/docs/design/source-oracle-candidate-ledger.md
+++ b/docs/design/source-oracle-candidate-ledger.md
@@ -1,0 +1,354 @@
+# Source-oracle candidate ledger
+
+## Status
+
+Current design for the source-oracle candidate ledger tracked by
+[#5841](https://github.com/richlander/dotnet-inspect/issues/5841).
+`SourceOracleCandidateLedger` implements the contract. The production consumer
+is the operator running `--source-oracle-candidates` and reading its card or
+JSON report.
+
+## Decision
+
+`SourceOracleCandidateLedger` owns one decision: whether one
+candidate-discovery run has enough evidence to publish denominator-complete
+file verdicts and a deterministic next-enrollment ranking for every file it
+conclusively qualifies against one accepted baseline.
+
+Denominator-complete does not mean fully measured. A successful run may retain
+unmapped targets and files whose source could not be acquired. It is complete
+because every eligible target in the exact scanned assembly set remains
+accounted for as attributed, unattributed, measured, or unmeasured; only
+currently qualified files enter the ranking.
+
+## Change classification and complexity
+
+This design specifies an existing correctness-harness component. It adds no
+product command, shared substrate, browser/Wasm path, or rendering mechanism.
+The existing consumer is a deliberate operator mode in
+`tools/DecompilerHarness`; no automated consumer of its JSON report exists.
+The harness remains a tools host, so this design requires no browser enablement
+plan or single-host substrate exception.
+
+The ledger is a finite, deterministic transformation over one run's evidence.
+It has no concurrent writer, retry protocol, distributed state, or scheduling
+lifecycle, so a TLA+ model would add no useful contract evidence.
+
+## Owner and boundaries
+
+The owner is `SourceOracleCandidateLedger` in
+`tools/DecompilerHarness/SourceOracleCandidateLedger.cs`.
+
+It consumes:
+
+- one accepted `AuthoredCorpusBenchmark` source-oracle report as the enrolled
+  feature baseline;
+- the exact identities of all assemblies supplied to the run;
+- a complete pre-acquisition primary-document census for those assemblies;
+- per-target acquisition and source-oracle evaluation outcomes; and
+- current run provenance.
+
+It returns either:
+
+- one typed report with complete target accounting, file verdicts, and a
+  deterministic ranking;
+- the card or JSON projection of that same report; or
+- a visible refusal without a partial ranking.
+
+It does not own:
+
+- Portable PDB mapping or primary-document selection;
+- PDB, SourceLink, repository, or source-body acquisition;
+- the meaning of real-method eligibility or authored-body extraction;
+- Valid, Correct, or Printer-exact evaluation;
+- syntax-feature vocabulary or inventory parsing;
+- source-oracle manifest enrollment or perfection-gate policy;
+- command-line argument policy; or
+- card and JSON presentation conventions.
+
+`ILInspector.Metadata` and `PdbSourceAcquisition` own mapping and acquisition.
+`AuthoredSourceHarvest` owns authored-source harvesting.
+`AuthoredCorpusSourceEvaluator` owns source-oracle evaluation.
+`PrinterSyntaxInventory` owns feature extraction.
+`AuthoredSourceOracleManifest` owns enrollment and its perfection gate.
+`AuthoredCorpusHistoryStore` supplies provenance facts but does not impose its
+committed-history admission contract on this measurement.
+
+## Evidence currencies
+
+The owner relates four currencies:
+
+```text
+AcceptedBaseline
+  measured enrolled feature set
+  enrolled source URL projection
+  producer-reported provenance
+  baseline text digest
+
+CandidateDenominator
+  exact scanned assembly identities
+  complete primary-document census
+  eligible real-method subset
+  checksum-pinned per-run file identities
+
+CandidateVerdicts
+  every attributed file status
+  every unattributed eligible target
+  complete measured and unmeasured counts
+
+RankedCandidates
+  qualified, not-recognizably-enrolled files
+  deterministic marginal feature gains
+  complete deterministic order
+```
+
+The accepted baseline establishes measured enrolled features, not clean
+repository history. The denominator establishes what this run attempted, not
+every declaration physically present in a source file. A ranked report is an
+operator observation, not enrollment authorization.
+
+## Run admission and assembly-set integrity
+
+The run is admitted only after current provenance is captured, the baseline is
+accepted, and every supplied assembly contributes one usable identity and a
+complete census. The assembly identity is name, version, MVID, and SHA-256;
+local paths are execution inputs, not durable report identity.
+
+The supplied assembly set is all-or-nothing. An unreadable or invalid assembly,
+duplicate MVID, assembly with no real-method target, or failed PDB census
+refuses the run rather than publishing a ranking for the remaining inputs.
+Acquisition may then fail for individual target sources without shortening the
+assembly set or denominator.
+
+After acquisition and evaluation, at least one eligible target with a
+checksum-pinned file identity must have reached evaluation. This distinguishes
+a partial but informative measurement from a run that decided nothing.
+`MeasurementIntegrity_FailsOnlyWhenNothingWasDecided` gates that lower bound.
+The execution-level all-or-nothing composition is unverified; the implementation
+returns before report construction when any per-assembly scan refuses.
+
+## Denominator and file membership
+
+The ledger consumes the complete Portable PDB MethodDef-to-primary-document
+mapping before source acquisition. Primary-document selection is owner-issued:
+`IsPrimaryDocument` descending, then `DocumentRowId` ascending. The ledger
+intersects that census with the real-method targets without deriving membership
+from successful harvest records.
+
+Each mapped document with a resolved URL, recognized checksum algorithm, and
+checksum contributes the per-run file identity:
+
+```text
+(sourceUrl, uppercase checksumAlgorithm, uppercase checksum)
+```
+
+That triple pins the source bytes used in this run and is the same identity
+shape the enrollment manifest uses. Members sharing the triple are one
+candidate file even when they come from multiple assemblies.
+
+An eligible member with no primary-document mapping remains an unattributed
+`no-pdb-source-mapping` row. A mapping without a complete checksum-pinned
+identity remains an unattributed `no-immutable-source-identity` row. Neither
+case invents file membership.
+
+For an attributed file:
+
+- `mappedMembers` counts every primary-document-mapped MethodDef;
+- `eligibleTargets` counts the real-method subset;
+- `evaluatedTargets` counts eligible targets that reached evaluation; and
+- `unevaluatedMappedMembers` is `mappedMembers - evaluatedTargets`.
+
+The final value deliberately includes mapped members outside the eligible
+subset; it is scope disclosure, not a count of acquisition outages.
+`QualifiedFile_PublishesItsUnevaluatedMappedMembers` gates this distinction.
+
+Missing acquisition or evaluation remains inside the denominator.
+`AcquisitionFailure_CannotLeaveAFileQualified` and
+`MissingEvaluation_IsUnevaluableRatherThanAShorterDenominator` gate that
+property. `UnmappedEligibleTarget_StaysExplicitAndInventsNoFileMembership`
+gates unattributed accounting.
+
+## Accepted baseline
+
+The baseline is a current `AuthoredCorpusBenchmark` report, not a source-oracle
+manifest. A manifest declares intended enrollment; only a completed benchmark
+report can establish the syntax features the enrolled set actually observed.
+
+The ledger accepts the report only when:
+
+1. strict current-schema deserialization succeeds;
+2. the benchmark's complete-input predicate recomputes successfully;
+3. a source-oracle report is present, passed, non-vacuous, and retains no
+   failures;
+4. every registered file is Valid, Correct, inventory-tracked, and Printer
+   exact at the supported versions;
+5. every enrolled URL has supporting Correct and Printer-exact row evidence;
+6. aggregate and per-file feature sets are nonempty where required, unique,
+   ordinal-sorted, and have an exact union; and
+7. producer counts do not contradict the row evidence.
+
+These checks establish a measured enrolled feature set. They do not establish
+that the baseline was built from a clean checkout, that its build revision
+matched the then-current `HEAD`, or that its commit is on a particular branch.
+Those producer-reported facts remain disclosure. The candidate report preserves
+the baseline's date, commit, build source state, revision-match verdict, dirty
+state, input digests, and enrolled URLs without promoting them into admission
+requirements.
+
+The baseline digest is SHA-256 over the decoded baseline text encoded as UTF-8.
+It identifies the consumed text, not the original file encoding or a
+repository-verified artifact. The local baseline path is not report data.
+
+The `Baseline_*` tests gate the accepted measurement invariants.
+`Provenance_IsDisclosedRatherThanAnAdmissionGate` gates the provenance
+boundary.
+
+## Enrollment correspondence
+
+Candidate grouping uses the complete URL, checksum-algorithm, and checksum
+triple. The accepted baseline's current per-file projection retains only source
+URLs, so the ledger must not claim general full-triple correspondence across
+runs.
+
+A currently qualified file becomes `Enrolled` only when:
+
+1. its source URL is present in the accepted baseline; and
+2. `SourceLinkUrls` recognizes that exact URL as an immutable, commit-pinned
+   GitHub or Azure DevOps content URL.
+
+The recognized provenance grammar supplies the missing cross-run immutability
+claim. A moving selector or unknown-host URL is insufficient even when its
+current bytes match its PDB checksum; that file remains `Qualified` and is
+ranked. This conservative duplicate may have zero incremental gain, but it
+cannot hide changed content behind an unproved URL identity.
+
+Baseline membership never hides current evidence. A baseline URL whose current
+file is rejected or unevaluable retains that current verdict; `Enrolled` means
+recognizably enrolled and qualified now.
+`AlreadyEnrolledFile_IsReportedButNotRankedAsANextCandidate`,
+`MutableBaselineUrl_DoesNotSuppressAQualifiedCandidate`, and
+`BaselineMembership_DoesNotHideACurrentRejection` gate these properties.
+
+## File verdicts
+
+Each attributed file has exactly one status:
+
+- `Enrolled`: currently qualified with recognized immutable baseline
+  correspondence;
+- `Qualified`: every eligible target was evaluated, Correct, Printer exact at
+  the supported version, and inventory-parseable;
+- `Rejected`: measurement completed and at least one structural, quality, or
+  inventory requirement failed; or
+- `Unevaluable`: at least one eligible target was not measured.
+
+A file with no eligible target is structurally rejected rather than vacuously
+qualified. An acquisition-family reason dominates the status because any
+unmeasured eligible member prevents a conclusive file verdict. Rejected and
+unevaluable files publish no rankable feature set.
+
+Stable serialized reason codes retain all observed reason classes. The one
+reported rejection family is a deterministic summary; it does not replace the
+reason set. `EveryCandidateReason_HasAFamilyAndAStableCode` and the
+classification tests gate those distinctions.
+
+## Ranking
+
+Only `Qualified` files enter the next-enrollment ranking. `Enrolled`,
+`Rejected`, and `Unevaluable` files remain visible but unranked.
+
+Ranking uses the conventional greedy maximum-coverage step:
+
+1. seed covered features with the accepted baseline;
+2. select the remaining file with the most currently uncovered features;
+3. record that marginal feature set and add all selected features to coverage;
+4. recompute every remaining marginal gain; and
+5. continue through all qualified files, placing zero-gain files after every
+   positive-gain file.
+
+Equal marginal gain breaks by total feature count descending, eligible-target
+count descending, source URL ordinal, checksum algorithm ordinal, then checksum
+ordinal. Unranked report rows also use the complete file identity as their final
+ordering keys. Input, dictionary, acquisition, and evaluation order therefore
+cannot select a different report order.
+
+Greedy maximum coverage supplies the useful marginal-gain convention. Its
+fixed-budget approximation guarantee does not transfer: this ledger accepts no
+selection budget, emits the full order, and makes no claim that a prefix is the
+globally optimal enrollment set.
+
+`GreedyRanking_IsDeterministicAndUpdatesIncrementalGain`,
+`GreedyRanking_BreaksTiesDeterministically`,
+`GreedyRanking_UsesTheCompleteFileIdentityAsTheFinalTieBreak`, and
+`UnrankedFiles_AreOrderedByTheCompleteFileIdentity` gate the ranking and report
+order.
+
+## Provenance and archive semantics
+
+The report discloses current and baseline provenance separately. For each run
+it carries the UTC date, build commit, build source state, whether the build
+commit matched the observed checkout, and whether that checkout was dirty.
+Dirty or mismatched state does not refuse this measurement mode.
+
+The version-2 JSON report is archiveable operator output. Its identities,
+counts, statuses, reason codes, feature names, ranking, and disclosed provenance
+remain readable without local paths. It deliberately omits authored source,
+Printer source, diffs, PDB content, baseline text, and assembly bytes.
+
+No report parser, complete-report verifier, or automated downstream consumer
+exists. An archived report cannot replay its classifications, authenticate its
+historical checkout, become a new source-oracle baseline, or authorize manifest
+enrollment. Calling it durable evidence would overstate what survives archival;
+the accepted benchmark report and source-oracle manifest remain separate owner
+currencies.
+
+`Json_ExcludesAuthoredAndPrinterSourceTextAndLocalPaths` gates the omission
+boundary. The ledger schema version changes when the typed serialized shape
+changes; version 2 adds the baseline revision-match disclosure.
+
+## Failure and partial measurement
+
+Ordinary findings are successful measurement data:
+
+- no file qualifies;
+- measured files are rejected;
+- source acquisition leaves some attributed files unevaluable;
+- eligible targets remain unattributed; or
+- only a subset of checksum-identified files reaches evaluation.
+
+The command refuses when it cannot preserve measurement integrity:
+
+- current provenance cannot be captured;
+- the baseline cannot be read or accepted;
+- any supplied assembly cannot contribute its complete census;
+- assembly, census, acquired identity, or evaluator correlation contradicts
+  itself;
+- the exact assembly set has no usable real-method denominator; or
+- no checksum-identified target reaches evaluation.
+
+Refusal publishes no partial ranking. A successful partial measurement
+publishes every missing outcome explicitly rather than presenting absence as a
+qualified or rejected result.
+
+## Untrusted input and non-claims
+
+Assemblies, PDBs, SourceLink maps, network source, and baseline JSON may be
+untrusted. Their owning readers retain bounding, parsing, SSRF, attribution,
+and checksum controls. The ledger consumes only checksum-verified source
+outcomes and serializes no source body, preventing internet-origin text from
+entering its report body.
+
+The pure `Build` seam consumes cooperating typed census and evaluation values
+constructed by the supported execution path. This contract does not add
+defenses against deliberately contradictory in-process callers; command input
+and producer correlation are the real boundaries.
+
+The ledger does not claim:
+
+- that every C# declaration in a candidate file was evaluated;
+- that every target was measured in a successful run;
+- that an attributed checksum proves repository provenance;
+- that URL overlap proves enrollment outside the recognized immutable grammar;
+- that the baseline or current checkout was clean;
+- that a ranked file is authorized for enrollment;
+- that a ranking prefix is globally optimal; or
+- that archived JSON is replay-verifiable evidence.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -141,6 +141,11 @@ substrates, and inspection producers that will extend that space.
   and validity of the ordered committed observation sequence. Benchmark
   production, methodology, ratchet comparison, and history-card rendering
   remain separate concerns.
+- [Source-oracle candidate ledger](design/source-oracle-candidate-ledger.md)
+  owns whether one candidate-discovery run can publish denominator-complete
+  file verdicts and a deterministic next-enrollment ranking against one
+  accepted baseline. PDB mapping, source acquisition, oracle evaluation,
+  enrollment policy, and presentation remain separate concerns.
 - [Repository xUnit test host](design/xunit-test-host.md) owns the repository's
   use of Microsoft Testing Platform for aggregate non-vacuity of xUnit test
   execution. MTP and xUnit retain runner semantics; suite owners retain

--- a/src/ILInspector.Decompiler.Tests/SourceOracleCandidateLedgerTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SourceOracleCandidateLedgerTests.cs
@@ -8,7 +8,7 @@ namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
 /// Gates on the source-oracle candidate ledger's classification, ranking, baseline
-/// intake, and durable shape.
+/// intake, and archiveable shape.
 ///
 /// <para>Everything here except the PDB canary is pure: <see
 /// cref="SourceOracleCandidateLedger.Build"/> takes the census and the per-target
@@ -19,9 +19,10 @@ namespace ILInspector.Decompiler.Tests;
 [Trait("Area", "Corpus")]
 public class SourceOracleCandidateLedgerTests
 {
-    const string FileA = "https://raw.githubusercontent.com/owner/repo/aaaa/src/A.cs";
-    const string FileB = "https://raw.githubusercontent.com/owner/repo/aaaa/src/B.cs";
-    const string FileC = "https://raw.githubusercontent.com/owner/repo/aaaa/src/C.cs";
+    const string Commit = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const string FileA = "https://raw.githubusercontent.com/owner/repo/" + Commit + "/src/A.cs";
+    const string FileB = "https://raw.githubusercontent.com/owner/repo/" + Commit + "/src/B.cs";
+    const string FileC = "https://raw.githubusercontent.com/owner/repo/" + Commit + "/src/C.cs";
 
     /// <summary>
     /// The defect the ledger exists for: a file whose eligible member was never measured
@@ -296,6 +297,38 @@ public class SourceOracleCandidateLedgerTests
         Assert.Equal(1, report.FilesQualified);
     }
 
+    [Fact]
+    public void MutableBaselineUrl_DoesNotSuppressAQualifiedCandidate()
+    {
+        const string movingUrl =
+            "https://raw.githubusercontent.com/owner/repo/main/src/A.cs";
+        var member = Member(0x06000001);
+        var report = Build(
+            [Mapped(member, movingUrl, eligible: true)],
+            [Qualified(member, movingUrl, "statement.if")],
+            enrolledSourceUrls: [movingUrl]);
+
+        var file = Assert.Single(report.Files);
+        Assert.Equal("Qualified", file.Status);
+        Assert.Equal(1, file.Rank);
+        Assert.Equal(0, report.FilesEnrolled);
+    }
+
+    [Fact]
+    public void BaselineMembership_DoesNotHideACurrentRejection()
+    {
+        var member = Member(0x06000001);
+        var report = Build(
+            [Mapped(member, FileA, eligible: true)],
+            [Rejected(member, FileA, SourceOracleCandidateLedger.CandidateReason.NotCorrect)],
+            enrolledSourceUrls: [FileA]);
+
+        var file = Assert.Single(report.Files);
+        Assert.Equal("Rejected", file.Status);
+        Assert.Equal("Quality", file.RejectionFamily);
+        Assert.Equal(0, report.FilesEnrolled);
+    }
+
     /// <summary>
     /// Equal gain breaks on total feature count, then eligible-target count, then source
     /// URL ordinal — never on dictionary or input order.
@@ -383,6 +416,49 @@ public class SourceOracleCandidateLedgerTests
                     .OrderBy(file => file.Rank)
                     .Select(file => file.Checksum)
                     .ToArray());
+        }
+    }
+
+    [Fact]
+    public void UnrankedFiles_AreOrderedByTheCompleteFileIdentity()
+    {
+        var first = Member(0x06000001);
+        var second = Member(0x06000002);
+        var identityA = new SourceOracleCandidateLedger.FileIdentity(FileA, "A", "SAME");
+        var identityB = new SourceOracleCandidateLedger.FileIdentity(FileA, "B", "SAME");
+
+        SourceOracleCandidateLedger.Report Run(bool reversed)
+        {
+            SourceOracleCandidateLedger.CensusMember[] members =
+            [
+                new(first, identityA, null, Eligible: true),
+                new(second, identityB, null, Eligible: true),
+            ];
+            SourceOracleCandidateLedger.TargetOutcome[] outcomes =
+            [
+                new(
+                    first,
+                    identityA,
+                    SourceOracleCandidateLedger.CandidateReason.NotCorrect,
+                    Evaluated: true,
+                    Features: []),
+                new(
+                    second,
+                    identityB,
+                    SourceOracleCandidateLedger.CandidateReason.NotCorrect,
+                    Evaluated: true,
+                    Features: []),
+            ];
+            return Build(
+                reversed ? [.. members.Reverse()] : members,
+                reversed ? [.. outcomes.Reverse()] : outcomes);
+        }
+
+        foreach (bool reversed in new[] { false, true })
+        {
+            Assert.Equal(
+                ["A", "B"],
+                Run(reversed).Files.Select(file => file.ChecksumAlgorithm).ToArray());
         }
     }
 
@@ -645,6 +721,52 @@ public class SourceOracleCandidateLedgerTests
         Assert.Equal(1, baseline.FilesRegistered);
         Assert.Equal(PrinterSyntaxInventory.Version, baseline.SyntaxInventoryVersion);
         Assert.Equal("digest", baseline.Digest);
+        Assert.True(baseline.SourceRevisionMatchesHead);
+    }
+
+    [Fact]
+    public void Provenance_IsDisclosedRatherThanAnAdmissionGate()
+    {
+        var baselineReport = Baseline() with
+        {
+            SourceStateAtBuild = "dirty",
+            SourceRevisionMatchesHead = false,
+            SourceDirty = true,
+        };
+        Assert.True(
+            SourceOracleCandidateLedger.TryParseBaseline(
+                SerializeBaseline(baselineReport),
+                "digest",
+                out var baseline,
+                out string? error),
+            error);
+
+        var member = Member(0x06000001);
+        var report = SourceOracleCandidateLedger.Build(
+            new SourceOracleCandidateLedger.LedgerInput(
+                [
+                    new SourceOracleCandidateLedger.ScannedAssembly(
+                        "Oracle",
+                        "1.0.0.0",
+                        Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                        new string('a', 64)),
+                ],
+                [Mapped(member, FileA, eligible: true)],
+                [Qualified(member, FileA, "statement.return")]),
+            baseline!,
+            new AuthoredCorpusHistoryStore.BenchmarkProvenance(
+                "2026-01-02",
+                new string('c', 40),
+                "dirty",
+                SourceRevisionMatchesHead: false,
+                SourceDirty: true));
+
+        Assert.False(report.Baseline.SourceRevisionMatchesHead);
+        Assert.True(report.Baseline.SourceDirty);
+        Assert.Equal("dirty", report.Baseline.SourceStateAtBuild);
+        Assert.False(report.SourceRevisionMatchesHead);
+        Assert.True(report.SourceDirty);
+        Assert.Equal(2, report.LedgerVersion);
     }
 
     [Theory]
@@ -1174,7 +1296,7 @@ public class SourceOracleCandidateLedgerTests
 
         Assert.NotEmpty(members);
 
-        // Every mapped member is either attributed to an immutable file identity or
+        // Every mapped member is either attributed to a checksum-pinned file identity or
         // carries the reason it is not. Neither state is silent.
         Assert.All(
             members,
@@ -1273,6 +1395,7 @@ public class SourceOracleCandidateLedgerTests
             "2026-01-01",
             new string('b', 40),
             "clean",
+            true,
             false,
             new string('d', 64),
             new string('e', 64),

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -529,13 +529,17 @@ eligible-method completeness for the exact scanned assembly set; it is **not** a
 claim that every C# declaration in the file was checked. A file with no eligible
 target is rejected structurally rather than qualifying vacuously.
 
-Each immutable file identity — the `(sourceUrl, checksumAlgorithm, checksum)`
+Each checksum-pinned file identity — the `(sourceUrl, checksumAlgorithm, checksum)`
 triple the manifest registers, grouped across assemblies and marked
 `sharedAcrossAssemblies` when more than one module maps it — is:
 
-- **Enrolled** — its exact commit-pinned source URL is already present in the
-  verified baseline, so it remains visible but is not ranked as a next
-  candidate.
+- **Enrolled** — it qualifies in the current run, and its exact source URL is
+  already present in the accepted baseline and is commit-pinned under the
+  product's recognized SourceLink provenance grammar. It remains visible but
+  is not ranked as a next candidate. A mutable or unknown-host URL is not
+  enough to establish cross-run enrollment correspondence, and a currently
+  rejected or unevaluable file retains that verdict rather than being
+  relabeled.
 - **Qualified** — every eligible target has a captured record, evaluates
   `ValidMatch`, is `PrinterExact` `Exact` at the supported printer comparison
   version, and its Printer body parses for the syntax inventory.
@@ -596,11 +600,17 @@ rejected.
 inventory entries. The
 candidate report records the baseline's provenance, digest, and feature set —
 never its local path.
+Baseline cleanliness is disclosed rather than admitted: a dirty baseline or one
+whose build revision did not match the then-current checkout may still supply a
+passing measured feature set. The ledger preserves those facts, including
+`sourceRevisionMatchesHead`, so the operator can distinguish measurement
+consistency from repository reproducibility.
 
 Qualified files are then ranked greedily and deterministically: starting from
 the baseline's observed features, repeatedly take the remaining qualified file
 covering the most currently uncovered features, breaking ties on total feature
-count descending, eligible-target count descending, then source URL ordinal.
+count descending, eligible-target count descending, source URL ordinal,
+checksum algorithm ordinal, and checksum ordinal.
 Each pick records its `rank` and `incrementalFeatures` and updates the covered
 set, so a file's gain reflects the picks before it and zero-gain files rank
 after every positive-gain file.
@@ -608,13 +618,16 @@ after every positive-gain file.
 `GreedyRanking_BreaksTiesDeterministically` are the named gates.
 
 **Exit code.** Candidate rejection and transient source unavailability are typed
-data and exit 0. The run fails only on measurement integrity: no usable assembly
-or real-method target, a failed PDB mapping census, an evaluation count or
-correlation mismatch, an invalid or unverified baseline report, or a run in
-which no checksum-identified file was evaluated at all.
+data and exit 0. The supplied assembly set is all-or-nothing for measurement
+integrity: an unreadable assembly, duplicate module identity, absent real-method
+target, or failed complete PDB census in any input refuses the run rather than
+publishing a ranking for the remainder. An evaluation count or correlation
+mismatch, an unaccepted baseline report, or a run in which no
+checksum-identified file was evaluated also refuses the run.
 
-**Durable output.** The `--json` report carries identities, checksums, counts,
-typed reason codes, outcomes, feature names, and member identities only.
+**Archiveable output.** The version-2 `--json` report carries identities,
+checksums, counts, typed reason codes, outcomes, feature names, member
+identities, and disclosed current and baseline provenance only.
 Assembly provenance is content-derived; path-derived labels such as a parent
 directory interpreted as a target framework are excluded. The report never
 carries an authored body, a Printer body, a diff, or a local path;
@@ -625,14 +638,17 @@ it classifies and serializes. The text card is the same data: input and
 denominator totals, status counts, the rejection-family and reason histograms,
 the baseline feature count, the ranked candidates with gain, total, and member
 counts, and the explicit unevaluable and unmapped counts. Data goes to stdout
-and diagnostics to stderr.
+and diagnostics to stderr. No parser or complete-report verifier promotes an
+archived candidate report into a new baseline or enrollment authorization; the
+omitted source, PDB, and baseline bodies prevent replaying its verdicts from the
+report alone.
 
 ```bash
 bash eng/restore-authored-source-corpus.sh
 bash eng/prepare-authored-source-oracles.sh /tmp/source-oracle-assemblies.txt
 mapfile -t oracle_assemblies < /tmp/source-oracle-assemblies.txt
 
-# 1. Produce the verified enrolled baseline the ranking is incremental to.
+# 1. Produce the accepted measured baseline the ranking is incremental to.
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --benchmark-authored-corpus external/authored-source-corpus/oracle/corpus.jsonl \
   --source-oracle-manifest external/authored-source-corpus/oracle/manifest.json \
@@ -1997,7 +2013,7 @@ dotnet run --project tools/DecompilerHarness -c Release -- \
   /path/to/System.Private.CoreLib.dll --bind-check --max-examples 20
 
 # Which whole source files could be enrolled in the source oracle next, ranked by
-# the new C# syntax each one adds over a VERIFIED enrolled benchmark report.
+# the new C# syntax each one adds over an accepted measured benchmark report.
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --source-oracle-candidates \
   --baseline-source-oracle-report /tmp/source-oracle-baseline.json \

--- a/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
+++ b/tools/DecompilerHarness/SourceOracleCandidateLedger.cs
@@ -17,10 +17,10 @@ namespace ILInspector.DecompilerHarness;
 /// complete portable-PDB MethodDef to primary-document mapping <em>before</em> acquiring
 /// any source, intersects that mapping with the real-method targets, attempts each
 /// eligible target, and evaluates the captured rows through the same source-oracle
-/// evaluator the enrolled gate uses. Each immutable file identity — the
+/// evaluator the enrolled gate uses. Each checksum-pinned file identity — the
 /// <c>(sourceUrl, checksumAlgorithm, checksum)</c> triple — is then Enrolled,
 /// Qualified, Rejected, or Unevaluable, and the qualifying files are ranked greedily by
-/// how many syntax features they add on top of an already VERIFIED enrolled-oracle
+/// how many syntax features they add on top of an accepted enrolled-oracle
 /// benchmark report.</para>
 ///
 /// <para><strong>Why the denominator comes from the PDB.</strong> Deriving file
@@ -32,8 +32,8 @@ namespace ILInspector.DecompilerHarness;
 /// rejected candidate and a source fetch that did not answer are typed data and leave the
 /// exit code at zero. Only measurement integrity fails the run: no usable assembly or
 /// target, a failed PDB mapping census, an evaluation count or correlation mismatch, a
-/// baseline report that is not a verified enrolled-oracle report, or a run in which no
-/// checksum-identified file was evaluated at all.</para>
+/// baseline report that does not carry accepted enrolled-oracle evidence, or a run in
+/// which no checksum-identified file was evaluated at all.</para>
 ///
 /// <para><strong>Scope honesty.</strong> Qualification is eligible-method completeness
 /// for the scanned assembly set, not a claim that every C# declaration in the file was
@@ -44,13 +44,14 @@ namespace ILInspector.DecompilerHarness;
 static class SourceOracleCandidateLedger
 {
     /// <summary>The candidate ledger's own report schema version.</summary>
-    public const int LedgerVersion = 1;
+    public const int LedgerVersion = 2;
 
     // ---------------------------------------------------------------- identities
 
     /// <summary>
-    /// One immutable source-file identity. The same triple the enrolled source-oracle
-    /// manifest registers, so a candidate promoted out of this ledger keys identically.
+    /// One checksum-pinned source-file identity. The same triple the enrolled
+    /// source-oracle manifest registers, so a candidate promoted out of this ledger keys
+    /// identically.
     /// </summary>
     internal readonly record struct FileIdentity(
         string SourceUrl,
@@ -209,7 +210,10 @@ static class SourceOracleCandidateLedger
     /// <summary>A file's verdict for the scanned assembly set.</summary>
     internal enum CandidateStatus
     {
-        /// <summary>The exact commit-pinned source URL is already in the verified baseline.</summary>
+        /// <summary>
+        /// The file qualifies now, and its recognized immutable source URL is already in
+        /// the accepted baseline.
+        /// </summary>
         Enrolled,
 
         /// <summary>Every eligible target is Printer exact at the supported version.</summary>
@@ -272,14 +276,16 @@ static class SourceOracleCandidateLedger
     // -------------------------------------------------------------------- baseline
 
     /// <summary>
-    /// The verified enrolled-oracle benchmark report the ranking is incremental to.
-    /// Provenance and digest only: no local path is carried into the candidate report.
+    /// The accepted enrolled-oracle benchmark evidence the ranking is incremental to.
+    /// Provenance and text digest are retained, but no local path is carried into the
+    /// candidate report.
     /// </summary>
     internal sealed record Baseline(
         string Digest,
         string Date,
         string Commit,
         string SourceStateAtBuild,
+        bool SourceRevisionMatchesHead,
         bool SourceDirty,
         string? CorpusSha256,
         string? PoolSha256,
@@ -301,6 +307,7 @@ static class SourceOracleCandidateLedger
         [property: JsonRequired] string Date,
         [property: JsonRequired] string Commit,
         [property: JsonRequired] string SourceStateAtBuild,
+        [property: JsonRequired] bool SourceRevisionMatchesHead,
         [property: JsonRequired] bool SourceDirty,
         [property: JsonRequired] string? CorpusSha256,
         [property: JsonRequired] string? PoolSha256,
@@ -366,7 +373,7 @@ static class SourceOracleCandidateLedger
     // ------------------------------------------------------------------ pure build
 
     /// <summary>
-    /// Judges every immutable file identity in <paramref name="input"/> and ranks the
+    /// Judges every checksum-pinned file identity in <paramref name="input"/> and ranks the
     /// qualifying ones by incremental syntax coverage over
     /// <paramref name="baseline"/>.
     ///
@@ -425,6 +432,7 @@ static class SourceOracleCandidateLedger
             .Select(file =>
                 file.Status == CandidateStatus.Qualified
                     && enrolledSourceUrls.Contains(file.File.SourceUrl)
+                    && SourceLinkUrls.IsImmutable(file.File.SourceUrl)
                         ? file with { Status = CandidateStatus.Enrolled }
                         : file)
             .ToList();
@@ -454,6 +462,7 @@ static class SourceOracleCandidateLedger
             .ThenBy(report => report.Rank ?? 0)
             .ThenBy(report => report.Status, StringComparer.Ordinal)
             .ThenBy(report => report.SourceUrl, StringComparer.Ordinal)
+            .ThenBy(report => report.ChecksumAlgorithm, StringComparer.Ordinal)
             .ThenBy(report => report.Checksum, StringComparer.Ordinal)
             .ToArray();
 
@@ -471,6 +480,7 @@ static class SourceOracleCandidateLedger
                 baseline.Date,
                 baseline.Commit,
                 baseline.SourceStateAtBuild,
+                baseline.SourceRevisionMatchesHead,
                 baseline.SourceDirty,
                 baseline.CorpusSha256,
                 baseline.PoolSha256,
@@ -706,8 +716,8 @@ static class SourceOracleCandidateLedger
     // ------------------------------------------------------------- baseline intake
 
     /// <summary>
-    /// Reads the baseline authored-corpus benchmark report and accepts it only when it is
-    /// a <em>verified</em> enrolled-oracle result.
+    /// Reads the baseline authored-corpus benchmark report and accepts it only when it
+    /// carries the required enrolled-oracle measurement evidence.
     ///
     /// <para>The baseline is the benchmark report, not the manifest, and the distinction
     /// is the whole point: a manifest declares what someone expects to be enrolled, while
@@ -745,9 +755,9 @@ static class SourceOracleCandidateLedger
     }
 
     /// <summary>
-    /// The verification contract, separated from the file read so it is directly
-    /// testable: every rejection below is a way an unverified report could otherwise be
-    /// mistaken for enrolled evidence.
+    /// The acceptance contract, separated from the file read so it is directly testable:
+    /// every rejection below is a way an incomplete or contradictory report could
+    /// otherwise be mistaken for enrolled evidence.
     /// </summary>
     internal static bool TryParseBaseline(
         string text,
@@ -967,6 +977,7 @@ static class SourceOracleCandidateLedger
             report.Date,
             report.Commit,
             report.SourceStateAtBuild,
+            report.SourceRevisionMatchesHead,
             report.SourceDirty,
             report.CorpusSha256,
             report.PoolSha256,


### PR DESCRIPTION
dotnet-inspect's hardening serves robust, capable features that provide
foundational or compelling user experiences while remaining conventionally
sound or delightfully new. This PR gives the source-oracle enrollment operator
an explicit evidence contract instead of relying on mixed operational prose.

## Summary

- Establishes `SourceOracleCandidateLedger` as the focused owner for
  denominator-complete candidate-file verdicts and deterministic
  next-enrollment ranking against one accepted measured baseline.
- Separates accepted feature evidence from disclosed provenance: dirty or
  revision-mismatched runs remain measurements, and the version-2 report now
  preserves the baseline's omitted `sourceRevisionMatchesHead` fact.
- Prevents URL overlap from suppressing a candidate unless the existing
  SourceLink provenance grammar proves the URL is immutable and commit-pinned.
  Current rejection or unavailability still wins over baseline membership.
- Completes deterministic report ordering with checksum algorithm and checksum
  tie-breaks, and defines JSON as archiveable operator output rather than
  replay-verifiable durable evidence.
- Registers the owner in the architecture, overview, and documentation index
  while keeping PDB mapping, acquisition, evaluation, inventory, enrollment,
  and presentation under their existing owners.

## Demo

Canonical operator workflow:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- \
  --benchmark-authored-corpus \
  external/authored-source-corpus/oracle/corpus.jsonl \
  --source-oracle-manifest \
  external/authored-source-corpus/oracle/manifest.json \
  --json "${oracle_assemblies[@]}" > /tmp/source-oracle-baseline.json

dotnet run --project tools/DecompilerHarness -c Release -- \
  --source-oracle-candidates \
  --baseline-source-oracle-report /tmp/source-oracle-baseline.json \
  --repo "$(git rev-parse --show-toplevel)" \
  artifacts/bin/ILInspector.MetadataPrimitives/release/ILInspector.MetadataPrimitives.dll
```

Real output:

```text
SOURCE-ORACLE CANDIDATE LEDGER

  assemblies scanned    : 1
    ILInspector.MetadataPrimitives 1.0.0.0 79f50571-98c1-45af-a87e-733c1c5b8838
  mapped members        : 673
  eligible targets      : 587
  evaluated targets     : 404
  unmapped eligible     : 183
  unidentified source   : 0

  files observed        : 24
    already enrolled    : 0
    qualified           : 0
    rejected            : 24
    unevaluable         : 0

  Rejection families (files):
    Quality        : 6
    Structural     : 18

  baseline features     : 13 (commit 540925c0, 4 enrolled file(s))

  Ranked qualified candidates:
    (none — no file qualified for this assembly set)
```

What to notice: acquisition did not shorten the denominator. The report retains
all 587 eligible targets, including 183 explicit unmapped targets, and reports
the measured files as rejected rather than inventing candidates.

The cross-run correspondence fix is exercised with the exact moving-URL
fixture:

```text
baseline URL: https://raw.githubusercontent.com/owner/repo/main/src/A.cs

before: Enrolled, rank = null
after:  Qualified, rank = 1
```

The neighboring cases remain distinct: a recognized full-commit GitHub URL
that qualifies is still `Enrolled` and unranked, while an enrolled URL whose
current measurement fails remains `Rejected`.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class '*SourceOracleCandidateLedgerTests*'`
  (74 passed)
- `npx markdownlint-cli docs/design/source-oracle-candidate-ledger.md docs/README.md docs/architecture.md docs/overview.md tools/DecompilerHarness/README.md`
- `git diff --check`
- Canonical baseline and candidate-ledger run shown above

Closes #5841.
