### PR TITLE
Define bounded Browser artifact scope lifetime

### DIFF
--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -320,6 +320,110 @@ group for both roles. When both roles exist and differ, they split the scope's
 has one group and uses the full budget; performance analysis falls back to that
 surface group when no implementation participant exists.
 
+### Artifact-backed package scope adoption
+
+**Status: planned, not implemented.** This section owns the Browser registry
+contract for [#5576](https://github.com/richlander/dotnet-inspect/issues/5576).
+The synchronous behavior described above remains current until that adoption
+lands. The end-to-end tracker is
+[#5577](https://github.com/richlander/dotnet-inspect/issues/5577); the CLI
+consumer has landed in
+[#5799](https://github.com/richlander/dotnet-inspect/pull/5799).
+[Package Root realization](../../docs/design/artifact-acquisition-and-workspaces.md#package-root-realization)
+owns artifact construction, role selection, rejection, and the budget split.
+[Inspection space](../../docs/inspection-space.md#retained-package-realization-caller)
+explains why this remains whole-scope reuse in the existing Browser registry,
+not workspace-local retained-demand caching or a second Integrations cache.
+
+The focused claim is one shared realization for an exact Browser package
+operation, with bounded retention through asynchronous cleanup. The production
+consumers are ordinary single-package scope opening and Workspace occurrence
+activation; surface, Integrations, and the other existing query hand-offs keep
+their typed inputs. Interactive DOM lowering remains Browser-owned rather than
+parsing CLI or Markout output. This adoption does not change multi-package role
+planning, Platform realization, package selection, source acquisition, or
+persistence. Those existing scopes still participate in the same registry
+bounds and reclamation policy.
+
+**Exact operation and use.** Repeated unbound requests for the same acquired
+coordinate, content generation, and selection request join the retained binding
+before another selection token is issued. The association includes the
+authoritative producer and framework request, including default selection as
+distinct from an explicit request. It lives with the counted scope entry, not
+in an additional unbounded binding cache. A caller with an already-issued
+binding preserves that binding's coordinate, `ContentGenerationIdentity`, and
+`SelectionIdentity`; independently issued selection tokens are not
+interchangeable merely because package/version/TFM labels match. Such a request
+can join only its exact binding operation, otherwise it is a distinct demand.
+Every singleton entry point uses the same opener; synchronous occurrence
+activation must become awaitable rather than constructing a competing legacy
+singleton scope.
+
+Concurrent callers join pending work as well as ready work. Each caller has its
+own cancellation and receives protected use of the exact entry before the
+opening operation completes; protection lasts through that caller's query, not
+just until the factory returns. Cancelling one caller does not cancel another
+caller's shared work. When the last pending caller leaves, the abandoned work
+retires. A shared factory also has its own bounded operation deadline, so
+joining requests cannot extend construction indefinitely.
+
+**Capacity and eviction.** The existing four-scope bound counts pending, ready,
+and retiring entries together, including legacy multi-package and Platform
+entries. Each reserves its full 64 MiB image allowance before construction,
+giving at most 256 MiB of reserved scope image capacity. The artifact-backed
+path passes 64 MiB as the shared realization's total budget, not an extra
+artifact allowance: artifacts receive 32 MiB and group images share the
+remaining 32 MiB, or 16 MiB per group when roles differ. This deliberately
+tightens the old one-copy admission capacity while preserving the total bound;
+budget rejection must remain visible. The 256-assembly per-role bound remains.
+These are retained-image limits, not a total Wasm heap estimate.
+
+Archive bytes and download reservations separately keep the existing
+12-package/128 MiB aggregate. Packages referenced by pending construction,
+protected queries, or unfinished retirement remain charged there. Neither a
+scope eviction nor a package-cache removal returns capacity while its owned
+resources are still settling. Ready entries without protected callers are
+evicted in least-recently-used order. When capacity is held by active work,
+admission visibly fails rather than evicting a caller's scope. When selected
+eviction requires asynchronous reclamation, an async admission awaits it before
+reusing capacity; a synchronous reservation that cannot reclaim immediately
+visibly rejects capacity instead of blocking Wasm or bypassing accounting.
+
+**Retirement and failure.** Removal or replacement immediately ends the exact
+entry's eligibility for new callers. Already-protected queries retain their
+use until release. Retirement is irreversible: an equal later request cannot
+revive that entry, and an old factory completion cannot publish into its
+replacement. Stale or cancelled construction is still owned until all of its
+construction and cleanup work settles, including artifact sessions not yet
+transferred to a workspace. Replacement does not require a new query-selection
+algorithm or a host-issued artifact identity.
+
+Registry retirement has an awaitable terminal outcome. Synchronous scope
+disposal is adapted as an already-completed retirement; an asynchronous
+workspace uses `CloseAsync`, never a synchronous wait or request-only
+`Dispose` pretending that reclamation finished. The outcome includes the
+workspace's group results and `ArtifactSessionCleanupFailures`, not merely
+whether its close task completed. The primary operation failure and any cleanup
+failures remain observable together. If cleanup fails, the entry remains
+charged and unavailable, with its bounded failure record surfaced to awaiting
+callers and subsequent admissions; no retry silently clears it or allocates
+replacement resources against unproven capacity. An abandoned caller does not
+abandon this outcome. A runtime restart is the recovery boundary for such a
+terminal cleanup failure, not an in-place cache reset.
+
+**Adoption evidence: unverified.** The implementation must add Release Browser
+engine gates for joined requests and independent cancellation, non-joining
+content/selection identities, use protected across async return, four-entry
+pressure and awaited eviction, stale completion after cancellation/replacement,
+and observable cleanup failure. It must preserve visible selected rejection
+carriers beside healthy participants and the existing multi-package/Platform
+registry cases. The Browser/Wasm gate must exercise the awaitable production
+opening/activation path. The two-host demo uses
+`Microsoft.Extensions.Http@10.0.0`: record the concrete TFM resolved by the CLI
+pilot's default selection and select that same TFM in Browser, with a
+neighboring replacement/eviction and valid-reference/malformed-implementation
+fixture. These are required future gates, not evidence supplied by this design.
+
 ## Supported
 
 | Operation | Workspace | Query that owns the session |


### PR DESCRIPTION
Define the Browser lifetime contract needed for robust, shared package inspection: exact requests share one realization, memory stays charged through asynchronous cleanup, and stale work cannot replace current results.

## Design basis

Normative owner: `prototypes/inspect-web/README.md#artifact-backed-package-scope-adoption`.

The contract stays at the existing bounded whole-scope registry. The shared Package Root artifact design supplies realization and its budget partition; `InspectionWorkspace.CloseAsync` supplies terminal group/artifact cleanup outcomes. `docs/inspection-space.md#retained-package-realization-caller` explains why a lower-level retained-demand cache or an Integrations-only workspace is not the right topology.

**This is a design-only prerequisite to #5576, not its implementation.** The new section is explicitly planned and its implementation properties are unverified. It does not change current Browser behavior.

## Demo

Contract mockup, not observed product output:

```text
Open Microsoft.Extensions.Http@10.0.0 at the CLI pilot's resolved TFM
  request A starts one pending realization
  request B joins its retained binding and realization
  A cancels; B still receives protected use
  Surface and Integrations use the same scope's typed roles

Under four-entry pressure
  retire the least-recently-used idle scope
  keep its slot, image reservation, and archive accounting through cleanup
  await cleanup before admitting replacement resources
  a late old completion cannot publish into the replacement
```

Neighbor: if selected implementation metadata is malformed, the existing typed rejection remains visible beside healthy participants. If cleanup fails instead, capacity is not returned as if cleanup succeeded, and the failure is retained and surfaced. The eventual two-host demo must record the CLI pilot's concrete default-selected TFM and use it in Browser; an explicit CLI `--tfm` would take the legacy route and is not evidence for this pilot.

## Consumer and adoption plan

The production Browser consumers are ordinary singleton scope opening and Workspace occurrence activation; their surface, Integrations, and other existing query hand-offs remain typed. The CLI shared-path consumer already landed in #5799. #5577 is the two-host composition tracker with **ten counted steps**: four complete steps through the CLI, four Browser adoption steps, joint demo evidence, and final legacy retirement. #5840 owns that mandatory retirement of the remaining parallel CLI Integrations realization.

There are four Browser adoption steps under #5576:

1. Settle this Browser-owned lifecycle contract before implementation.
2. Adapt the existing shared registry to count pending/ready/retiring resources and await terminal cleanup, retaining multi-package and Platform realization behavior.
3. Route ordinary singleton opening and awaitable occurrence activation through one artifact-backed opener, retiring the competing singleton legacy construction path.
4. Add the named Release engine/Browser-Wasm gates. The next tracker step publishes the same-coordinate two-host demo with replacement/eviction and rejection neighbors.

No platform overlays, package-selection redesign, PDB/source acquisition, persistence, multi-package role redesign, or new retained-demand cache. No new substrate is introduced: Browser consumes the already two-host artifact substrate. Interactive DOM lowering continues from typed product results and does not parse Markout.

## Validation

`npx markdownlint-cli prototypes/inspect-web/README.md`

No implementation gate is claimed. This head changes only the owning README; future gates are marked unverified.
