### PR TITLE
Enable local folder feeds in package version listing

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -465,9 +465,14 @@ plugin-authentication context per configurable V3 authority, uses the
 credential-free Gallery route for the exact anonymous NuGet.org authority,
 uses one operation context across those authorities, adopts each typed result
 through the exact association, and reports authoritative, partial, or failed
-version evidence. A selected local authority is classified without
-constructing HTTP state and currently produces the explicit
-capability-unavailable result owned by #5400.
+version evidence. A selected local authority invokes the existing bounded
+NuGetFetch local-folder client without constructing an HTTP transport or
+authentication context. Its complete version observations, including an empty
+result, join the same aggregate as HTTP evidence through exact association
+lookup. Unavailable local capability, missing roots, invalid archives, and
+source limits remain attributed failures rather than package absence. The
+NuGetFetch host contract is unchanged: desktop filesystems support local reads;
+Browser/Wasm without a filesystem capability returns typed unsupported.
 When the Gallery route cannot complete its registration listing-state join,
 its retained flat-container candidates are explicitly partial rather than
 authoritative.
@@ -497,6 +502,31 @@ producer identity, transport kind, source order, or a healthy subset were
 mistakenly used as authority. Existing NuGetFetch and authentication gates
 remain evidence for their owners; they do not substitute for these
 package-composition gates.
+
+### Local version-listing adoption
+
+The CLI consumer is ordinary `package <id> --versions --source <folder>` (or a
+mapped folder in `NuGet.Config`). Local and HTTP version evidence use the same
+operation context, filtering, sorting, and final result limit. Directory layout
+recognition and finite observation limits remain owned by NuGetFetch.
+
+`PackageVersionListing_LocalFolderReadsVersionsWithoutHttpTransport`,
+`PackageVersionListing_LocalMappingPrecedesCollapseAndKeepsDistinctRoots`,
+`PackageVersionListing_LocalAndHttpUnionIsSortedBeforeLimit`,
+`PackageVersionListing_EmptyLocalRootIsAbsenceButMissingRootFails`,
+`PackageVersionListing_LocalFailureRetainsHttpPeerAsPartial`,
+`PackageVersionListing_HttpFailureRetainsLocalPeerAsPartial`, and
+`OperationContext_RequestTimeoutContinuesToLaterAuthorityWithinCeiling` are the
+Release gates for this adoption. The existing terminal-operation-timeout and
+HTTP source-association gates remain unchanged.
+
+The remaining production adoption path is tracked by
+[#5400](https://github.com/richlander/dotnet-inspect/issues/5400): after this
+version-listing slice, migrate remaining candidate selection modes, then
+payload/cache authority, then CLI and reusable workspace consumers (including
+Browser/Wasm's supported source clients). Those slices retire the corresponding
+legacy composition paths. This slice does not add browser filesystem
+registration, local payload acquisition, or offline version discovery.
 
 ### Reusable authority authorization
 

--- a/skills/private-feeds/SKILL.md
+++ b/skills/private-feeds/SKILL.md
@@ -41,6 +41,25 @@ Version discovery combines all eligible sources and chooses the highest
 semantic version; source order is not precedence. Pin `Package@Version` when
 the exact coordinate matters.
 
+### List versions from a folder feed
+
+Ordinary version listing also supports NuGet V2/V3 folder feeds, specified as a
+path, a `file://` URI, or a mapped source in `NuGet.Config`:
+
+```bash
+dnx dotnet-inspect -y -- package MyCompany.Widget --versions --source ./feed
+dnx dotnet-inspect -y -- package MyCompany.Widget --versions 5 --preview \
+  --source ./feed --jsonl
+```
+
+Local and HTTP versions are combined and sorted before the result limit.
+Missing folders or invalid archives are source failures, not package absence;
+usable peer results carry an explicit partial warning on stderr. Local reads
+use bounded enumeration rather than treating filenames as version evidence.
+This applies to ordinary `--versions` without `--offline`, not yet
+`--versions-with-feed`, `--include-unlisted`, latest/range selection, or payload
+acquisition.
+
 ### Restrict package ids to feeds
 
 dotnet-inspect honors `<packageSourceMapping>` from the selected NuGet
@@ -121,10 +140,10 @@ coordinate only when `.nupkg.metadata.source` names an authorized producer.
 Missing or mismatched provenance is a cache miss, and installed payloads do not
 introduce version candidates. Use `--no-nuget-cache` to exclude that layer.
 `--offline` forbids network access and does not start credential plugins, so it
-succeeds only from producer-authorized caches. Configured non-HTTP sources,
-including folder feeds, are skipped in every mode; `--verbose` reports the
-skip. Pass a local `.nupkg` path directly when the package is available as a
-file.
+succeeds only from producer-authorized caches. Outside ordinary online
+`--versions`, configured folder feeds remain on legacy paths that skip them;
+`--verbose` reports the skip. Pass a local `.nupkg` path directly for package
+inspection when the package is available as a file.
 
 ```bash
 dnx dotnet-inspect -y -- package MyCompany.Widget@1.2.3 \

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
@@ -62,8 +62,8 @@ public sealed class PackageVersionDiscoveryResult
 }
 
 /// <summary>
-/// Owns source associations, plugin-authentication contexts, and V3 routes for
-/// one desktop package-composition lifetime.
+/// Owns source associations, HTTP and local routes, and HTTP authentication
+/// contexts for one desktop package-composition lifetime.
 /// </summary>
 public sealed class DesktopPackageSourceComposition : IAsyncDisposable
 {
@@ -239,19 +239,6 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
                 break;
             }
 
-            if (!Uri.TryCreate(
-                    source.Url,
-                    UriKind.Absolute,
-                    out Uri? endpoint)
-                || endpoint.Scheme is not ("http" or "https"))
-            {
-                failures.Add(new PackageAuthorityFailure(
-                    PackageSourceDisplay.ForDiagnostics(source),
-                    PackageAuthorityFailureKind.Unsupported,
-                    $"Package source {PackageSourceDisplay.ForDiagnostics(source)} does not support version enumeration in this host."));
-                continue;
-            }
-
             if (!ConfiguredPackageAuthorityKey.TryCreate(
                     source,
                     out ConfiguredPackageAuthorityKey? authorityKey,
@@ -268,7 +255,8 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
 
             bool isGallery =
                 authorityKey.IsNuGetOrg && source.Credential is null;
-            if (!isGallery
+            if (authorityKey.HttpEndpoint is { } endpoint
+                && !isGallery
                 && source.Credential is null
                 && !PluginAuthenticationContext.CanScopeProviderQuery(
                     endpoint))
@@ -285,7 +273,6 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
             AuthorityEntry authority = GetOrCreateAuthority(
                 source,
                 authorityKey,
-                endpoint,
                 isGallery);
             log?.Invoke(
                 $"Fetching versions from {PackageSourceDisplay.ForDiagnostics(source)}.");
@@ -405,7 +392,6 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
     private AuthorityEntry GetOrCreateAuthority(
         PackageSource source,
         ConfiguredPackageAuthorityKey key,
-        Uri endpoint,
         bool isGallery)
     {
         if (_authorities.TryGetValue(key, out AuthorityEntry? existing))
@@ -425,29 +411,36 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
         IPackageSourceClient? client = null;
         try
         {
-            transport = _createTransport(source, isGallery);
-            if (isGallery)
+            if (key.LocalIdentity is { } local)
             {
-                client = PackageSourceClientFactory.CreateGallery(
-                    association,
-                    transport,
-                    _options);
+                client = PackageSourceClientFactory.Create(local, association);
             }
             else
             {
-                if (source.Credential is null)
+                transport = _createTransport(source, isGallery);
+                if (isGallery)
                 {
-                    owner = PluginAuthenticationContextOwner.Create(
+                    client = PackageSourceClientFactory.CreateGallery(
                         association,
-                        endpoint,
-                        _credentialSource);
+                        transport,
+                        _options);
                 }
-                client = PackageSourceClientFactory.Create(
-                    source,
-                    association,
-                    transport,
-                    _options,
-                    owner?.Context);
+                else
+                {
+                    if (source.Credential is null)
+                    {
+                        owner = PluginAuthenticationContextOwner.Create(
+                            association,
+                            key.HttpEndpoint!,
+                            _credentialSource);
+                    }
+                    client = PackageSourceClientFactory.Create(
+                        source,
+                        association,
+                        transport,
+                        _options,
+                        owner?.Context);
+                }
             }
 
             var authority =

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.IO.Compression;
 using System.Net;
+using System.Xml.Linq;
 
 using DotnetInspector.CommandLine;
 using DotnetInspector.Commands;
@@ -1261,8 +1263,11 @@ public sealed class SourceScopedRoutingTests : IDisposable
             high: sources.Length - 1);
     }
 
-    [Fact]
-    public async Task OperationContext_RequestTimeoutContinuesToLaterAuthorityWithinCeiling()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OperationContext_RequestTimeoutContinuesToLaterAuthorityWithinCeiling(
+        bool localSuccess)
     {
         const string TimedOutSource =
             "https://timeout.example/v3/index.json";
@@ -1270,6 +1275,11 @@ public sealed class SourceScopedRoutingTests : IDisposable
             "https://success.example/v3/index.json";
         const string SuccessFlat =
             "https://success.example/v3/flat2/";
+        string successSource = localSuccess
+            ? Path.Combine(_testRoot, "timeout-failover")
+            : SuccessSource;
+        if (localSuccess)
+            WriteLocalPackage(successSource, "timeout-failover", "1.0.0");
         await using var composition = new DesktopPackageSourceComposition(
             TimeSpan.FromMilliseconds(50),
             new UnavailableCredentialSource(),
@@ -1297,7 +1307,7 @@ public sealed class SourceScopedRoutingTests : IDisposable
                 limit: null,
                 new NuGetSourceOptions
                 {
-                    Sources = [TimedOutSource, SuccessSource],
+                    Sources = [TimedOutSource, successSource],
                 },
                 cancellationToken:
                     TestContext.Current.CancellationToken);
@@ -1309,12 +1319,15 @@ public sealed class SourceScopedRoutingTests : IDisposable
         Assert.Contains(TimedOutSource, failure.Message, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public async Task SourceClassification_PlainDirectoryNeverConstructsHttpTransport()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PackageVersionListing_LocalFolderReadsVersionsWithoutHttpTransport(
+        bool fileUri)
     {
         string packageName = $"LocalDirectory{Guid.NewGuid():N}";
         string localSource = Path.Combine(_testRoot, "local-source");
-        Directory.CreateDirectory(localSource);
+        WriteLocalPackage(localSource, packageName, "1.0.0", hierarchical: fileUri);
         bool transportCreated = false;
         DotnetInspector.Core.HttpClientFactory.Initialize(
             new HttpClientFactoryOptions());
@@ -1333,19 +1346,12 @@ public sealed class SourceScopedRoutingTests : IDisposable
                     packageName,
                     "--versions",
                     "--source",
-                    localSource,
+                    fileUri ? new Uri(localSource).AbsoluteUri : localSource,
                 ]);
 
-            Assert.Equal(1, exit);
-            Assert.Empty(output);
-            Assert.Contains(
-                "does not support version enumeration",
-                error,
-                StringComparison.Ordinal);
-            Assert.Contains(
-                "Use a package source that supports version enumeration",
-                error,
-                StringComparison.Ordinal);
+            Assert.Equal(0, exit);
+            Assert.Equal("1.0.0", output.Trim());
+            Assert.Empty(error);
             Assert.False(transportCreated);
         }
         finally
@@ -1354,6 +1360,205 @@ public sealed class SourceScopedRoutingTests : IDisposable
                 new HttpClientFactoryOptions { Offline = true });
             DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
         }
+    }
+
+    [Theory]
+    [InlineData(false, false, null)]
+    [InlineData(true, false, null)]
+    [InlineData(false, true, null)]
+    [InlineData(true, true, null)]
+    [InlineData(false, false, 1)]
+    [InlineData(true, true, 1)]
+    public async Task PackageVersionListing_LocalAndHttpUnionIsSortedBeforeLimit(
+        bool reverseSources,
+        bool preview,
+        int? limit)
+    {
+        const string PackageName = "Mixed.LocalVersions";
+        string local = Path.Combine(_testRoot, "mixed-source");
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(local, PackageName, "2.0.0", hierarchical: true);
+        WriteLocalPackage(local, PackageName, "3.0.0-preview.1");
+        string[] sources = reverseSources
+            ? [SecondSource, local]
+            : [local, SecondSource];
+
+        var (exit, output, error, requests) =
+            await RunOnlineVersionFeedCommandAsync(
+                PackageName,
+                "2.0.0",
+                [
+                    "package", PackageName, "--versions",
+                    .. limit is { } count ? new[] { count.ToString() } : [],
+                    "--source", sources[0], "--source", sources[1],
+                    .. preview ? new[] { "--preview" } : [],
+                    "--jsonl",
+                ]);
+
+        string[] expected = preview
+            ? ["3.0.0-preview.1", "2.0.0", "1.0.0"]
+            : ["2.0.0", "1.0.0"];
+        Assert.Equal(0, exit);
+        Assert.Equal(
+            expected.Take(limit ?? int.MaxValue)
+                .Select(version => $"{{\"version\":\"{version}\"}}"),
+            output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        Assert.Empty(error);
+        Assert.Contains(
+            $"{SecondFlatContainer}{PackageName.ToLowerInvariant()}/index.json",
+            requests);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PackageVersionListing_EmptyLocalRootIsAbsenceButMissingRootFails(
+        bool missing)
+    {
+        string local = Path.Combine(_testRoot, "empty-source");
+        if (!missing)
+            Directory.CreateDirectory(local);
+        var credentials = new RecordingCredentialSource();
+        await using var composition = new DesktopPackageSourceComposition(
+            TimeSpan.FromSeconds(5),
+            credentials,
+            (_, _) => throw new InvalidOperationException("Local source constructed HTTP transport."));
+
+        PackageVersionDiscoveryResult result =
+            await composition.GetVersionsAsync(
+                "Absent.Package",
+                includePrerelease: false,
+                limit: null,
+                new NuGetSourceOptions { Sources = [local] },
+                cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.Versions);
+        Assert.False(result.HasAnyCandidate);
+        Assert.Empty(credentials.Queries);
+        if (missing)
+        {
+            Assert.Equal(PackageVersionDiscoveryState.Failed, result.State);
+            Assert.Equal(
+                PackageAuthorityFailureKind.Transport,
+                Assert.Single(result.Failures).Kind);
+        }
+        else
+        {
+            Assert.Equal(PackageVersionDiscoveryState.Authoritative, result.State);
+            Assert.Empty(result.Failures);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PackageVersionListing_LocalFailureRetainsHttpPeerAsPartial(
+        bool malformed)
+    {
+        const string PackageName = "Incomplete.LocalVersions";
+        string local = Path.Combine(_testRoot, "failed-source");
+        if (malformed)
+        {
+            Directory.CreateDirectory(local);
+            File.WriteAllText(
+                Path.Combine(local, $"{PackageName}.1.0.0.nupkg"),
+                "not a package archive");
+        }
+
+        var (exit, output, error, _) =
+            await RunOnlineVersionFeedCommandAsync(
+                PackageName,
+                "2.0.0",
+                [
+                    "package", PackageName, "--versions", "1", "--jsonl",
+                    "--source", local, "--source", SecondSource,
+                ]);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("""{"version":"2.0.0"}""", output.Trim());
+        Assert.Contains("partial", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(local, error, StringComparison.Ordinal);
+        Assert.Contains(
+            malformed ? "invalid version metadata" : "could not be reached",
+            error,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("not found", error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task PackageVersionListing_HttpFailureRetainsLocalPeerAsPartial()
+    {
+        const string PackageName = "Readable.LocalVersions";
+        string local = Path.Combine(_testRoot, "readable-source");
+        WriteLocalPackage(local, PackageName, "1.0.0");
+
+        var (exit, output, error, _) =
+            await RunOnlineVersionFeedCommandAsync(
+                PackageName,
+                "2.0.0",
+                [
+                    "package", PackageName, "--versions", "--jsonl",
+                    "--source", RefusedSource, "--source", local,
+                ],
+                refusedStatus: HttpStatusCode.Unauthorized);
+
+        Assert.Equal(0, exit);
+        Assert.Equal("""{"version":"1.0.0"}""", output.Trim());
+        Assert.Contains("partial", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("requires credentials", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PackageVersionListing_LocalMappingPrecedesCollapseAndKeepsDistinctRoots()
+    {
+        const string PackageName = "Mapped.LocalVersions";
+        string local = Path.Combine(_testRoot, "mapped-source");
+        string other = Path.Combine(_testRoot, "other-source");
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(other, PackageName, "2.0.0");
+        string configPath = Path.Combine(_testRoot, "NuGet.Config");
+        new XDocument(
+            new XElement("configuration",
+                new XElement("packageSources",
+                    new XElement("clear"),
+                    Source("unmapped", "mapped-source"),
+                    Source("path", "mapped-source"),
+                    Source("uri", new Uri(local).AbsoluteUri),
+                    Source("other", "other-source")),
+                new XElement("packageSourceCredentials",
+                    new XElement("unmapped",
+                        new XElement("add", new XAttribute("key", "Username"), new XAttribute("value", "reader")),
+                        new XElement("add", new XAttribute("key", "ClearTextPassword"), new XAttribute("value", "test")))),
+                new XElement("packageSourceMapping",
+                    Mapping("path"), Mapping("uri"), Mapping("other"))))
+            .Save(configPath);
+
+        var credentials = new RecordingCredentialSource();
+        await using var composition = new DesktopPackageSourceComposition(
+            TimeSpan.FromSeconds(5),
+            credentials,
+            (_, _) => throw new InvalidOperationException("Local source constructed HTTP transport."));
+        var log = new List<string>();
+        PackageVersionDiscoveryResult result =
+            await composition.GetVersionsAsync(
+                PackageName,
+                includePrerelease: false,
+                limit: null,
+                new NuGetSourceOptions { ConfigFile = configPath },
+                log.Add,
+                TestContext.Current.CancellationToken);
+
+        Assert.Equal(PackageVersionDiscoveryState.Authoritative, result.State);
+        Assert.Equal(["2.0.0", "1.0.0"], result.Versions);
+        Assert.Empty(result.Failures);
+        Assert.Empty(credentials.Queries);
+        Assert.Equal(2, log.Count(message => message.StartsWith("Fetching versions from ", StringComparison.Ordinal)));
+
+        static XElement Source(string name, string location) =>
+            new("add", new XAttribute("key", name), new XAttribute("value", location));
+        static XElement Mapping(string name) =>
+            new("packageSource", new XAttribute("key", name),
+                new XElement("package", new XAttribute("pattern", PackageName)));
     }
 
     [Fact]
@@ -1588,6 +1793,28 @@ public sealed class SourceScopedRoutingTests : IDisposable
                 includePrerelease),
             version,
             extension: "txt");
+    }
+
+    private static void WriteLocalPackage(
+        string root,
+        string packageName,
+        string version,
+        bool hierarchical = false)
+    {
+        string id = packageName.ToLowerInvariant();
+        string directory = hierarchical
+            ? Path.Combine(root, id, version)
+            : root;
+        Directory.CreateDirectory(directory);
+        using var archive = new ZipArchive(
+            File.Create(Path.Combine(directory, $"{id}.{version}.nupkg")),
+            ZipArchiveMode.Create);
+        using var writer = new StreamWriter(archive.CreateEntry($"{id}.nuspec").Open());
+        writer.Write($"""
+            <package><metadata>
+              <id>{packageName}</id><version>{version}</version>
+            </metadata></package>
+            """);
     }
 
     private void SeedPackage(string packageName, string? sourceUrl = null)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1289,7 +1289,7 @@ public class PackageCommand
         if (kinds.Contains(PackageAuthorityFailureKind.Transport))
         {
             remediation.Add(
-                "Check the package source URL and network connectivity before retrying.");
+                "Check the package source location, access permissions, and connectivity before retrying.");
         }
 
         CommandError.Write(


### PR DESCRIPTION
dotnet-inspect builds robust, capable foundations for compelling inspection
experiences. This slice makes ordinary package version listing work against
local NuGet folder feeds through the existing package-owned authority boundary,
rather than treating a folder as an unsupported HTTP endpoint.

## Demo

With a folder feed containing `Contoso.Widget` versions `1.0.0`, `2.0.0`, and
`3.0.0-preview.1`, the previous implementation returned:

```text
Error: Package 'contoso.widget' version discovery failed.
  Package source /tmp/dotnet-inspect-5400-local-version-demo does not support version enumeration in this host.
  Use a package source that supports version enumeration in this host.
```

The same invocation now lists stable versions:

```text
$ dotnet run --project src/dotnet-inspect -c Release --no-build -- \
    package Contoso.Widget --versions \
    --source /tmp/dotnet-inspect-5400-local-version-demo
2.0.0
1.0.0
```

Neighboring preview, limit, and structured-output scenario:

```text
$ dotnet run --project src/dotnet-inspect -c Release --no-build -- \
    package Contoso.Widget --versions 2 --preview --jsonl \
    --source /tmp/dotnet-inspect-5400-local-version-demo
{"version":"3.0.0-preview.1"}
{"version":"2.0.0"}
```

The focused fixtures also exercise real V2/V3 archives, `file://` sources,
relative configured sources, mapped equivalent aliases, distinct roots, and
mixed local/HTTP results in both source orders. Local or HTTP failure keeps
usable peer versions explicitly partial, including with a result limit.

## Change and design basis

The single normative owner is
[`package-source-model.md`, Candidate aggregation](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/package-source-model.md#candidate-aggregation):
every eligible authority contributes authoritative evidence or a visible
failure. Supporting contracts are the existing NuGetFetch local-folder client,
canonical local identity, exact source-result association, and shared operation
context.

- Create the existing bounded local client from the authority key's canonical
  local identity. Keep the existing association and reverse-map adoption path.
- Construct HTTP transport and authentication state only for HTTP routes.
- Reuse existing union, filtering, sorting, limit, and partial/failure handling.
  An existing empty root is authoritative absence; a missing root or invalid
  archive is a source failure.
- Make transport-failure remediation apply to source locations and permissions
  as well as network connectivity.
- Update the implementation boundary and shipped private-feeds skill.

The baseline is the existing HTTP source composition and NuGetFetch's tested
V2/V3 folder adapter, not a new folder parser or aggregation algorithm. No
additional dependency or rendering pipeline is introduced. Existing CLI
formatters and stderr diagnostics remain the presentation strategy.

## Adoption and boundaries

Part of #5400, following merged #5752; this PR targets `main` with no open
parent. HTTP/Gallery composition from #5654 is reused.

This is step 1 of the four remaining production-adoption steps recorded on
#5400: local version listing, remaining candidate-selection modes, payload/cache
authority, then remaining CLI and reusable workspace consumers. Later steps
include Browser/Wasm-supported source clients and retire corresponding legacy
composition paths.

Ordinary `--versions` without `--offline` is the production consumer here.
`--versions-with-feed`, `--include-unlisted`, latest/range selection, payload and
cache authorization, and offline discovery remain unchanged. The existing
NuGetFetch host boundary is preserved: desktop local reads are supported;
Browser/Wasm without filesystem capability remains typed unsupported. This PR
does not add browser filesystem registration or UI.

## Validation

- Release source-resolution and source-scoped routing suites: 211 passed.
- Release shipped-skill suite: 23 passed.
- `npx markdownlint-cli docs/design/package-source-model.md skills/private-feeds/SKILL.md`
- `git diff --check`
- Real before/after CLI demo and neighboring preview/limit/JSONL invocation above.

Candidate head: `9720832f21e5df04fc437ca413238a9c74f4ff67`.
Effective base: `48f55ac39a1a9a1ae2784c191a1605c19346b986`.
