### PR TITLE
Adopt typed assembly selection for type API surfaces

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -106,6 +106,37 @@ and
 `LibraryCommand_TfmAll_PreservesHealthyResultsWhenDescriptorSelectionIsRejected`
 gate this composition.
 
+### Type API-surface selection
+
+Type listing, single-type inspection, and compact platform listing consume
+Metadata's typed assembly selection before API extraction. `Ready` supplies
+the selected descriptor to extraction and retains it with each root `ApiType`;
+forwarded types retain their supplier descriptors. `Rejected` is a visible
+failure naming the selected path, not a retry through a path-only reader.
+Only `Descriptorless` retains the module/non-assembly compatibility route.
+Platform-prefix listing applies the same rule to each selected library.
+
+The descriptor carries the resolved source's package/version/TFM, platform
+framework/version, project context, or local provenance. Deferred type/member
+routing uses the same selection path and passes the loaded surface to `type`
+unchanged, rather than selecting or extracting it again.
+
+`TypeApiSelection_RejectsUnusableAssemblyIdentity`,
+`TypeApiSelection_RejectsUnusablePackageAssembly`,
+`TypeApiSelection_PreservesAssemblyAndModuleInspection`,
+`TypeApiSelection_RetainsResolvedProvenance`,
+`TypeApiSelection_RetainsForwardedSupplier`,
+`TypeApiSelection_CompactSummaryUsesTypedSelection`, and
+`Router_DeferredExactTypeReusesResolvedApiSurface` gate this composition.
+
+This is the API-surface slice in
+[#5853](https://github.com/richlander/dotnet-inspect/issues/5853), not complete
+descriptor adoption for every `type` operation. Existing source/PDB policy
+consumers keep receiving the selected type's descriptor. Runtime and
+source-context acquisition, deep Analysis/decompiler acquisition, and
+acquired-PDB propagation remain focused successors under
+[#4867](https://github.com/richlander/dotnet-inspect/issues/4867).
+
 ## Command families
 
 The command surface is organized by operation shape rather than by

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -1435,6 +1435,238 @@ public class SourceForwarderResolutionTests
         }
     }
 
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("N.Type", false)]
+    [InlineData("N.Type", true)]
+    public async Task TypeApiSelection_RejectsUnusableAssemblyIdentity(
+        string? typeName,
+        bool deferred)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "BlankIdentity.dll");
+            File.WriteAllBytes(path, BuildAssembly(" "));
+
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => deferred
+                    ? MemberCommand.ExecuteAsync(new MemberOptions
+                    {
+                        AssemblyPath = path,
+                        TypeName = typeName,
+                        RouterDeferredTypeOrMember = true,
+                        JsonOutput = true,
+                    })
+                    : TypeCommand.ExecuteAsync(new TypeOptions
+                    {
+                        AssemblyPath = path,
+                        TypeName = typeName,
+                        JsonOutput = true,
+                    }));
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains(path, error);
+            Assert.Contains("Could not select API assembly", error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("N.Type")]
+    public async Task TypeApiSelection_RejectsUnusablePackageAssembly(string? typeName)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string content = Path.Combine(directory, "content");
+            string library = Path.Combine(content, "lib", "net11.0");
+            Directory.CreateDirectory(library);
+            File.WriteAllBytes(
+                Path.Combine(library, "BlankIdentity.dll"),
+                BuildAssembly(" "));
+            string package = Path.Combine(directory, "Selected.Package.2.3.4.nupkg");
+            ZipFile.CreateFromDirectory(content, package);
+
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteAsync(new TypeOptions
+                {
+                    PackagePath = package,
+                    TypeName = typeName,
+                    JsonOutput = true,
+                }));
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("BlankIdentity.dll", error);
+            Assert.Contains("Could not select API assembly", error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false, null)]
+    [InlineData(false, "N.Type")]
+    [InlineData(true, null)]
+    [InlineData(true, "N.Type")]
+    public async Task TypeApiSelection_PreservesAssemblyAndModuleInspection(
+        bool isModule,
+        string? typeName)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "Healthy.dll");
+            File.WriteAllBytes(path, BuildAssembly("Healthy", isModule: isModule));
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteAsync(new TypeOptions
+                {
+                    AssemblyPath = path,
+                    TypeName = typeName,
+                    JsonOutput = true,
+                }));
+
+            Assert.Equal(0, exit);
+            Assert.Contains("N.Type", output);
+            Assert.DoesNotContain("Could not select API assembly", error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(SourceKind.Library)]
+    [InlineData(SourceKind.NuGet)]
+    [InlineData(SourceKind.Project)]
+    [InlineData(SourceKind.Platform)]
+    public void TypeApiSelection_RetainsResolvedProvenance(string sourceKind)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "Root.dll");
+            File.WriteAllBytes(path, BuildAssembly("Root"));
+            var source = CreateApiSource(path, sourceKind);
+            var options = new TypeOptions { ProjectPath = "selected-project" };
+            var loaded = Assert.IsType<ApiServices.LoadedApiSurface>(
+                ApiServices.LoadTypeApi(source, options));
+            var assembly = loaded.GetSourceAssembly(Assert.Single(loaded.Api.Types));
+
+            Assert.Equal(Path.GetFullPath(path), assembly.Path);
+            Assert.Equal("Root", assembly.Identity.Name);
+            var expected = sourceKind switch
+            {
+                SourceKind.NuGet => AssemblyResolutionProvenance.Package(
+                    "Selected.Package", "2.3.4", "net11.0", rid: null),
+                SourceKind.Project => AssemblyResolutionProvenance.Project(
+                    "selected-project", "net11.0", rid: null),
+                SourceKind.Platform => AssemblyResolutionProvenance.Platform(
+                    "aspnetcore", "2.3.4", "ApiServices"),
+                _ => AssemblyResolutionProvenance.Local("ApiServices"),
+            };
+            Assert.Equal(expected, assembly.Provenance);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TypeApiSelection_RetainsForwardedSupplier(bool summaryOnly)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string facadePath = Path.Combine(directory, "Facade.dll");
+            string targetPath = Path.Combine(directory, "Target.dll");
+            File.WriteAllBytes(facadePath, BuildAssembly(
+                "Facade", new AssemblyReferenceIdentity(
+                    "Target", new Version(1, 0, 0, 0), null, null)));
+            File.WriteAllBytes(targetPath, BuildAssembly("Target"));
+            var loaded = Assert.IsType<ApiServices.LoadedApiSurface>(
+                ApiServices.LoadTypeApi(
+                    CreateApiSource(facadePath, SourceKind.Platform),
+                    new TypeOptions(),
+                    summaryOnly));
+            var type = Assert.Single(loaded.Api.Types);
+            var supplier = loaded.GetSourceAssembly(type);
+
+            Assert.Equal(summaryOnly, loaded.IsSummary);
+            Assert.True(type.IsForwarded);
+            Assert.Equal(Path.GetFullPath(targetPath), supplier.Path);
+            Assert.Equal("Target", supplier.Identity.Name);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("Healthy")]
+    public void TypeApiSelection_CompactSummaryUsesTypedSelection(string name)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "Input.dll");
+            File.WriteAllBytes(path, BuildAssembly(name));
+            var source = CreateApiSource(path, SourceKind.Platform);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                var error = Assert.Throws<BadImageFormatException>(
+                    () => ApiServices.LoadTypeApi(source, new TypeOptions(), summaryOnly: true));
+                Assert.Contains(path, error.Message);
+                return;
+            }
+
+            var loaded = Assert.IsType<ApiServices.LoadedApiSurface>(
+                ApiServices.LoadTypeApi(source, new TypeOptions(), summaryOnly: true));
+            Assert.True(loaded.IsSummary);
+            var root = loaded.GetSourceAssembly(Assert.Single(loaded.Api.Types));
+            Assert.Equal(
+                AssemblyResolutionProvenance.Platform("aspnetcore", "2.3.4", "ApiServices"),
+                root.Provenance);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static ApiSourceResult CreateApiSource(string path, string sourceKind) =>
+        new(
+            SearchPath: path,
+            RuntimeAssemblyPath: sourceKind == SourceKind.Platform ? path : null,
+            PackageName: "Selected.Package",
+            PackageVersion: "2.3.4",
+            ResolvedPackagePath: null,
+            PackageExtractPath: null,
+            ApiSource: sourceKind,
+            ApiVersion: "2.3.4",
+            PlatformFramework: "aspnetcore",
+            SelectedTfm: "net11.0",
+            ProjectAssetsPath: null,
+            TempDir: null,
+            TypeName: null,
+            PackageReplaySourceUrls: null,
+            PackageReplayUsesOriginalSources: false,
+            Context: new CommandContext(verbose: false));
+
     static MetadataTypeDefinitionName TypeName() =>
         Assert.IsType<MetadataTypeDefinitionNameResult.Valid>(
             MetadataTypeDefinitionName.Create("N", ["Type"])).Name;
@@ -1494,7 +1726,8 @@ public class SourceForwarderResolutionTests
         AssemblyReferenceIdentity? forwardTarget = null,
         bool definesType = false,
         string typeNamespace = "N",
-        string typeName = "Type")
+        string typeName = "Type",
+        bool isModule = false)
     {
         var metadata = new MetadataBuilder();
         metadata.AddModule(
@@ -1503,13 +1736,16 @@ public class SourceForwarderResolutionTests
             mvid: metadata.GetOrAddGuid(Guid.NewGuid()),
             encId: default,
             encBaseId: default);
-        metadata.AddAssembly(
-            metadata.GetOrAddString(assemblyName),
-            new Version(1, 0, 0, 0),
-            culture: default,
-            publicKey: default,
-            flags: default,
-            hashAlgorithm: default);
+        if (!isModule)
+        {
+            metadata.AddAssembly(
+                metadata.GetOrAddString(assemblyName),
+                new Version(1, 0, 0, 0),
+                culture: default,
+                publicKey: default,
+                flags: default,
+                hashAlgorithm: default);
+        }
         metadata.AddTypeDefinition(
             default,
             default,

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -81,7 +81,9 @@ public static class MemberCommand
 
         try
         {
-            var loaded = ApiServices.LoadFullApi(
+            var loaded = options.RouterDeferredTypeOrMember
+                ? ApiServices.LoadTypeApi(source, options)
+                : ApiServices.LoadFullApi(
                 searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
                 apiSource, source.ApiVersion, selectedTfm, logger, options,
                 source.PackageExtractPath);

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -170,22 +170,14 @@ public static class TypeCommand
             {
                 // No type specified - list all types
                 var loaded = loadedSurface
-                    ?? (CanUsePlatformSummary(
+                    ?? ApiServices.LoadTypeApi(
+                        source,
+                        options,
+                        summaryOnly: CanUsePlatformSummary(
                             options,
                             searchPath,
                             runtimeAssemblyPath,
-                            platformFramework)
-                        ? ApiServices.LoadPlatformApiSummary(
-                            searchPath,
-                            runtimeAssemblyPath!,
-                            apiSource,
-                            apiVersion,
-                            selectedTfm,
-                            logger)
-                        : ApiServices.LoadFullApi(
-                            searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
-                            apiSource, apiVersion, selectedTfm, logger, options,
-                            source.PackageExtractPath));
+                            platformFramework));
                 if (loaded == null)
                 {
                     CommandError.Write("Could not extract API from library.");
@@ -255,10 +247,7 @@ public static class TypeCommand
             else
             {
                 var loaded = loadedSurface
-                    ?? ApiServices.LoadFullApi(
-                        searchPath, runtimeAssemblyPath, options.PackagePath, packageName,
-                        apiSource, apiVersion, selectedTfm, logger, options,
-                        source.PackageExtractPath);
+                    ?? ApiServices.LoadTypeApi(source, options);
                 if (loaded == null)
                 {
                     CommandError.Write("Could not extract API from library.");
@@ -852,7 +841,7 @@ public static class TypeCommand
 
         foreach (var ((framework, assembly, _), fullNames) in resultNamesByAssembly)
         {
-            var (assemblyPath, _, _, error) = await PlatformResolver.ResolveAssemblyAsync(
+            var (assemblyPath, resolvedFramework, version, error) = await PlatformResolver.ResolveAssemblyAsync(
                 assembly,
                 context.HttpClient,
                 logger.Log,
@@ -864,19 +853,25 @@ public static class TypeCommand
                 continue;
             }
 
-            var api = AssemblySetSurfaceBuilder.Build(
-                [assemblyPath],
-                options.IncludeAll);
-            if (api == null)
-                continue;
-
-            ApiServices.ResolveForwardedTypes(
-                api,
+            var loaded = ApiServices.LoadFullApi(
                 assemblyPath,
+                runtimeAssemblyPath: null,
+                packagePath: null,
+                packageName: null,
+                SourceKind.Platform,
+                version,
+                selectedTfm: null,
                 logger,
-                options.IncludeAll,
-                isPlatformAssembly: true,
-                options);
+                options,
+                useTypedSelection: true,
+                platformFramework: resolvedFramework);
+            if (loaded is null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not extract API from platform library '{assemblyPath}'.");
+            }
+
+            var api = loaded.Api;
 
             List<ApiType> selectedTypes =
             [

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -48,6 +48,33 @@ internal static class ApiServices
         }
     }
 
+    internal static LoadedApiSurface? LoadTypeApi(
+        ApiSourceResult source,
+        ApiOptions options,
+        bool summaryOnly = false) =>
+        summaryOnly
+            ? LoadPlatformApiSummary(
+                source.SearchPath,
+                source.RuntimeAssemblyPath!,
+                source.ApiSource,
+                source.ApiVersion,
+                source.SelectedTfm,
+                source.Context.Logger,
+                source.PlatformFramework)
+            : LoadFullApi(
+                source.SearchPath,
+                source.RuntimeAssemblyPath,
+                source.ResolvedPackagePath,
+                source.PackageName,
+                source.ApiSource,
+                source.ApiVersion,
+                source.SelectedTfm,
+                source.Context.Logger,
+                options,
+                source.PackageExtractPath,
+                useTypedSelection: true,
+                platformFramework: source.PlatformFramework);
+
     internal static LoadedApiSurface? LoadFullApi(
         string searchPath,
         string? runtimeAssemblyPath,
@@ -59,24 +86,41 @@ internal static class ApiServices
         VerboseLogger logger,
         ApiOptions options,
         string? packageExtractPath = null,
-        bool usePackageSourcePolicy = false)
+        bool usePackageSourcePolicy = false,
+        bool useTypedSelection = false,
+        string? platformFramework = null)
     {
         string? apiDllPath = FindApiDll(searchPath, logger);
         if (apiDllPath is null)
             return null;
 
+        var provenance = CreateRootProvenance(
+            apiSource,
+            apiVersion,
+            packageName,
+            selectedTfm,
+            options,
+            platformFramework);
+        bool isPlatformAssembly = runtimeAssemblyPath is not null
+            || useTypedSelection && apiSource == SourceKind.Platform;
         ResolvedAssemblyReference? rootAssembly =
-            TryCreateRootAssembly(
-                apiDllPath,
-                CreateRootProvenance(
-                    apiSource,
-                    apiVersion,
-                    packageName,
-                    selectedTfm,
-                    options));
+            useTypedSelection
+                ? SelectRootAssembly(apiDllPath, provenance)
+                : TryCreateRootAssembly(apiDllPath, provenance);
         using TypeDefinitionResolutionSession? resolution =
             rootAssembly is null
                 ? null
+                : useTypedSelection
+                ? new TypeDefinitionResolutionSession(
+                    rootAssembly,
+                    isPlatformAssembly,
+                    options.ProjectAssetsPath,
+                    options.Tfm ?? selectedTfm,
+                    platformFramework ?? options.PlatformFramework,
+                    packageExtractPath,
+                    options.SourceOptions,
+                    usePackageSourcePolicy:
+                        usePackageSourcePolicy || packageExtractPath is not null)
                 : TryCreateResolutionSession(
                     rootAssembly,
                     isPlatformAssembly:
@@ -114,8 +158,7 @@ internal static class ApiServices
                 apiDllPath,
                 logger,
                 options.IncludeAll,
-                isPlatformAssembly:
-                    runtimeAssemblyPath is not null,
+                isPlatformAssembly,
                 resolution: resolution,
                 sourceAssemblies);
         }
@@ -141,6 +184,22 @@ internal static class ApiServices
             runtimeAssemblyPath ?? apiDllPath,
             sourceAssemblies);
     }
+
+    static ResolvedAssemblyReference? SelectRootAssembly(
+        string assemblyPath,
+        AssemblyResolutionProvenance provenance) =>
+        ResolvedAssemblyReference.SelectFromPath(assemblyPath, provenance)
+            switch
+            {
+                AssemblyDescriptorSelectionResult.Ready ready =>
+                    ready.Reference,
+                AssemblyDescriptorSelectionResult.Descriptorless => null,
+                AssemblyDescriptorSelectionResult.Rejected rejected =>
+                    throw new BadImageFormatException(
+                        $"Could not select API assembly '{assemblyPath}': "
+                        + $"{rejected.Failure.Kind}: {rejected.Failure.Detail}"),
+                _ => throw new System.Diagnostics.UnreachableException(),
+            };
 
     static TypeDefinitionResolutionSession? TryCreateResolutionSession(
         ResolvedAssemblyReference rootAssembly,
@@ -199,7 +258,8 @@ internal static class ApiServices
         string? apiVersion,
         string? packageName,
         string? selectedTfm,
-        ApiOptions options)
+        ApiOptions options,
+        string? platformFramework = null)
     {
         if (string.Equals(
                 apiSource,
@@ -207,7 +267,7 @@ internal static class ApiServices
                 StringComparison.Ordinal))
         {
             return AssemblyResolutionProvenance.Platform(
-                options.PlatformFramework ?? "InstalledPlatform",
+                platformFramework ?? options.PlatformFramework ?? "InstalledPlatform",
                 apiVersion,
                 "ApiServices");
         }
@@ -248,36 +308,47 @@ internal static class ApiServices
         string? apiSource,
         string? apiVersion,
         string? selectedTfm,
-        VerboseLogger logger)
+        VerboseLogger logger,
+        string? platformFramework = null)
     {
         logger.Log($"Extracting compact API summary from: {Path.GetFileName(searchPath)}");
-        var api = AssemblyReader.ExtractApiSummarySurface(searchPath);
+        ResolvedAssemblyReference? rootAssembly =
+            SelectRootAssembly(
+                searchPath,
+                AssemblyResolutionProvenance.Platform(
+                    platformFramework ?? "InstalledPlatform",
+                    apiVersion,
+                    "ApiServices"));
+        using Stream stream = rootAssembly is null
+            ? File.OpenRead(searchPath)
+            : rootAssembly.OpenRead();
+        var api = AssemblyReader.ExtractApiSummarySurface(stream);
         if (api == null)
             return null;
 
-        ResolvedAssemblyReference rootAssembly =
-            ResolvedAssemblyReference.CreateFromPath(
-                searchPath,
-                AssemblyResolutionProvenance.Platform(
-                    "InstalledPlatform",
-                    apiVersion,
-                    "ApiServices"));
+        api.SetInspectionSourceAssemblyPath(searchPath);
         var sourceAssemblies =
             new Dictionary<ApiType, ResolvedAssemblyReference>(
                 ReferenceEqualityComparer.Instance);
-        foreach (ApiType type in api.Types)
-            sourceAssemblies.Add(type, rootAssembly);
+        if (rootAssembly is not null)
+        {
+            foreach (ApiType type in api.Types)
+                sourceAssemblies.Add(type, rootAssembly);
+        }
 
-        ResolveForwardedTypes(
-            api,
-            searchPath,
-            logger,
-            includeAll: false,
-            isPlatformAssembly: true,
-            targetFramework: selectedTfm,
-            summaryOnly: true,
-            summaryRootAssembly: rootAssembly,
-            sourceAssemblies: sourceAssemblies);
+        if (rootAssembly is not null)
+        {
+            ResolveForwardedTypes(
+                api,
+                searchPath,
+                logger,
+                includeAll: false,
+                isPlatformAssembly: true,
+                targetFramework: selectedTfm,
+                summaryOnly: true,
+                summaryRootAssembly: rootAssembly,
+                sourceAssemblies: sourceAssemblies);
+        }
 
         api.Name = Path.GetFileNameWithoutExtension(searchPath);
         api.Tfm = selectedTfm;

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -4,6 +4,11 @@
 
 ### Inspection and matching
 
+- Type API inspection now rejects unusable managed assembly identities with a
+  path-attributed error instead of falling back to path-only extraction.
+  Listing, compact platform summaries, and deferred type routing preserve the
+  selected API assembly's provenance; managed netmodules retain their existing
+  inspection behavior (#5853).
 - Adds the `match` command for identity-agnostic structural comparison of two
   selected methods in one retained assembly. It preserves exact, near,
   different, unsupported, failed, limit-reached, and


### PR DESCRIPTION
## Purpose

Build reliable type inspection by carrying the selected API acquisition through
the existing CLI consumer. This is conventionally sound composition of the
Metadata-owned selection result, not a new acquisition framework.

Fixes #5853. Advances #4867 without claiming complete `type` descriptor adoption.

## Demo

Two small ECMA-335 inputs contain the same public `N.Type`: one has a blank
Assembly name and the neighboring input has a valid identity. The regression
fixtures are constructed in `SourceForwarderResolutionTests`.

Before, with production `dotnet-inspect` 0.24.0:

```console
$ dotnet-inspect type --library /tmp/type-surface-adoption-demo/BlankIdentity.dll --tips q
Error: Could not extract API from library.
# exit 1
```

After:

```console
$ dotnet-inspect type --library /tmp/type-surface-adoption-demo/BlankIdentity.dll --tips q
Error: Could not select API assembly '/tmp/type-surface-adoption-demo/BlankIdentity.dll': InvalidImage: The selected managed assembly has no usable identity.
# exit 1
```

The diagnostic identifies both the selected file and the Metadata-owned reason;
Rejected selection no longer enters the compatibility extraction path.

Neighboring valid input:

```console
$ dotnet-inspect type --library /tmp/type-surface-adoption-demo/Healthy.dll --tips q
# Healthy

## Classes

| Type | Members |
| ---- | ------- |
| `N.Type` | 0 |
# exit 0
```

## Design and scope

**One normative owner:** `docs/cli-architecture.md#type-api-surface-selection`.
The host consumes Ready/Descriptorless/Rejected rather than decoding metadata
or inferring classification from exception text.

- Explicit type listing and single-type inspection use typed selection.
  Ready descriptors enter the existing resolution session and remain
  associated with root types; forwarded types retain supplier descriptors.
- Compact platform listing opens the selected descriptor instead of first
  extracting through its path. Platform-prefix listing uses the same typed
  loading path.
- Deferred type/member routing selects once and reuses its loaded surface.
  Resolved platform family/version and package/project/local provenance are
  retained. Descriptorless managed netmodules retain their existing behavior.

The implementation follows the `library` precedent from #5756. Metadata
classification (#5661), forwarding (#5448), and PDB-policy precedence (#5335)
are consumed contracts, not additional normative owners.

**Residual work:** runtime/source-context acquisition, deep Analysis/decompiler
acquisition, and acquired-PDB propagation still need focused type successors.
Standalone member, diff, match, and browser adoption remain under #4867.
There is no new shared substrate, output shape, CLI option, or platform
exception; existing Markout rendering and source/expensive-work gates remain.

The production-host path for this slice is three steps: resolved CLI source,
typed API loading with retained suppliers, existing type/deferred rendering.
This PR completes all three and retires the nullable-root/path fallback for
these selected API routes, while retaining it for explicitly out-of-scope
commands until their own adoption.

## Validation

Release with SDK `11.0.100-preview.7.26381.103`:

- Focused type selection, deferred routing, compact summary, and source-policy
  suite: 38 passed.
- Source-forwarder regression class before the final two package cases:
  40 passed; the final two cases are covered by the 38-test focused run above.
- Prefix-browse regression suite: 39 passed.
- Changed Markdown passes `markdownlint`; `git diff --check` is clean.
- Normal Release solution build passed at the pushed head.
- Full CLI suite: 5,565 total, 5,543 passed, 22 skipped, zero failures.
- Current-head `ci-required`: success.

No prior PR's review evidence is transferred to this head.

Round 1 is review-clean after public reconciliation: GPT-5.6 Sol returned
CLEAN; Claude Opus 5's evidence-only finding was dismissed. The reviewed head
remains `ab5295d6ce1302245ddb1ca0308af8ba8f02a042`. This does not claim live merge
readiness or grant merge authorization.
