### PR TITLE
docs: prefer GPT-6 Astra and centralize model dispatch IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -493,7 +493,7 @@ as a normal round), and **merge conflict requiring semantic resolution**
 | Tier | Requirement |
 | --- | --- |
 | Trivial | No review. State why the change is trivial. |
-| Everything else | **GPT-5.6 Sol**, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |
+| Everything else | **GPT-6 Astra**, always, plus one other roster reviewer (Claude Opus or Gemini Pro). |
 
 When uncertain, use the standard round. Second-seat selection by prior clean
 count lives in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,7 +497,8 @@ as a normal round), and **merge conflict requiring semantic resolution**
 
 When uncertain, use the standard round. Second-seat selection by prior clean
 count lives in
-[Reviewer roster](docs/round-orchestration.md#reviewer-roster). A MAI-Code
+[Reviewer roster](docs/round-orchestration.md#reviewer-roster); dispatch IDs live
+in [Agent model mapping](docs/agent-models.md). A MAI-Code
 quick read on unsettled work is neither tier: it gets no isolated worktree or
 fixed head and satisfies no review tier — label its findings as early
 feedback, since the settled PR still requires its full round.

--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Evidence and Validation](evidence-and-validation.md) | Matching evidence to claims, the style-oracle consultation procedure, and the harness/product boundary. |
 | [Fixture Governance](fixture-governance.md) | Placement, project-boundary axes, catalog metadata, consumer rules, and expectation ownership for compiled fixtures and test-local samples. |
 | [Round Orchestration](round-orchestration.md) | Running an adversarial review round: status discovery, dispatch, reconciliation, carry-forward, and block boundaries. |
+| [Agent Model Mapping](agent-models.md) | Contributor-guidance model names, exact dispatch IDs, and runtime availability resolution. |
 | [GitHub Status Queries](github-status-queries.md) | Querying PR mergeability and CI status without wasting API quota. |
 | [GitHub API Operations](github-api-operations.md) | Correct `gh api` usage for PR/issue metadata changes. |
 | [Stacked PRs](stacked-prs.md) | Mechanics for stacking multiple PRs for a multi-slice issue. |

--- a/docs/agent-models.md
+++ b/docs/agent-models.md
@@ -1,0 +1,40 @@
+# Agent model mapping
+
+This file maps names in current contributor guidance to dispatch model IDs.
+[AGENTS.md](../AGENTS.md#how-many-reviewers-and-from-which-models) owns review
+requirements; [Reviewer roster](round-orchestration.md#reviewer-roster) owns
+seat selection and substitutions. This mapping does not change either policy.
+
+## Model names and IDs
+
+The concrete IDs below are advertised by Copilot CLI's `task` tool for its
+`model` parameter. They are not portable provider API names or a guarantee of
+availability in another session or agent host.
+
+| Name in guidance | Display name | Dispatch model ID |
+| --- | --- | --- |
+| GPT-6 Astra | GPT-6 Astra | `gpt-6-astra` |
+| Claude Opus | Claude Opus 5 | `claude-opus-5` |
+| MAI-Code | MAI-Code 1.1 Flash | `mai-code-1.1-flash` |
+| Gemini Pro | Resolve an available Pro model | Not pinned; use the runtime-advertised Pro ID. |
+
+GPT-6 Astra replaces GPT-5.6 Sol in current guidance. Historical review
+attributions keep their original model names.
+
+## Resolving a dispatch
+
+Use the exact ID accepted by the active dispatch tool. Confirm a mapped ID
+against that tool's available-model list before invoking it; never construct
+an ID by changing spaces, punctuation, capitalization, or version numbers in
+a display name.
+
+Claude Opus, Gemini Pro, and MAI-Code are family-level names. Where guidance
+requests the highest available quality, resolve the appropriate current family
+member from the runtime rather than treating this table as a permanent version
+pin. Gemini Flash is not Gemini Pro. If the requested model or family is
+unavailable, follow the roster's substitution policy and record the exact
+substitute ID and reason on the PR.
+
+When updating a mapping, copy the ID from the dispatch tool's advertised model
+list. Keep current mappings here rather than duplicating tables across
+guidance files.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -287,7 +287,8 @@ snapshot satisfies the prerequisite. The duration context comes from
 
 [How many reviewers, and from which models](../AGENTS.md#how-many-reviewers-and-from-which-models)
 states the binding tier table and roster names. Pick the second seat from the
-prior round's clean count:
+prior round's clean count, using [Agent model mapping](agent-models.md) to
+resolve names to dispatch IDs:
 
 - **No prior round, or 0/2 clean:** prefer GPT-6 Astra again for the second
   seat.

--- a/docs/round-orchestration.md
+++ b/docs/round-orchestration.md
@@ -289,9 +289,9 @@ snapshot satisfies the prerequisite. The duration context comes from
 states the binding tier table and roster names. Pick the second seat from the
 prior round's clean count:
 
-- **No prior round, or 0/2 clean:** prefer GPT-5.6 Sol again for the second
+- **No prior round, or 0/2 clean:** prefer GPT-6 Astra again for the second
   seat.
-- **1/2 clean:** keep GPT-5.6 Sol fixed, rule out last round's second seat,
+- **1/2 clean:** keep GPT-6 Astra fixed, rule out last round's second seat,
   then prefer a different family than the author (the author's family only as
   a fallback) at that model's highest available quality.
 


### PR DESCRIPTION
Make robust, capable engineering easier by choosing advertised model IDs instead of guessing from display names.

Prefer GPT-6 Astra in place of GPT-5.6 Sol, and centralize current contributor model mappings in `docs/agent-models.md`. Link that focused reference from `AGENTS.md`, round orchestration, and the documentation index.

## Demo

Documentation mockup:

| Scenario | Before | After |
| --- | --- | --- |
| Required reviewer | GPT-5.6 Sol | GPT-6 Astra, mapped to `gpt-6-astra` |
| Claude Opus selection | Family name alone | Concrete mapping to `claude-opus-5`, confirmed against runtime availability |
| Gemini Pro unavailable | No mapping guidance | Resolve an advertised Pro ID or report a roster substitution; never guess an ID or relabel Flash as Pro |

The mapping also covers MAI-Code early feedback. Family-level quality selection, review seat rules, and substitution policy remain owned by the existing guidance. Historical review attributions remain unchanged.

## Design basis

`AGENTS.md#how-many-reviewers-and-from-which-models` owns the reviewer requirement. The new document is a targeted dispatch-name reference, not a new review policy or a portable provider API catalog.

## Validation

- `npx --no-install markdownlint-cli AGENTS.md docs/round-orchestration.md docs/agent-models.md docs/README.md`
- `git diff --check`
- `wc -l AGENTS.md`: 599 lines, within the 600-line cap.
- Concrete mappings match the active dispatch tool model list. No unadvertised Gemini Pro identifier was invented.

## Review classification

Trivial documentation update: the requested model replacement, a small reference table, and links to existing selection and substitution rules. No product behavior or review-tier changes; no adversarial review required.

Candidate head: `ce45ebe854ada30bd37b169fc38d642dcc3feb84`.
Effective base: `5abebda82` (`main`).