### PR TITLE
Clarify Metadata substrate evidence and outcome terminology

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Find Type-Search Service](design/find-search-service.md) | CLI-scoped candidate collection and exact, glob, namespace-prefix, partial, and miss classification into typed results. |
 | [Skill Guidance Taste](../taste/skill-guidance.md) | Good and bad examples for maintaining the embedded skill. |
 | [Inspection Layers](design/inspection-layers.md) | Layering and consumer-boundary rules between Metadata, Analysis, CSharpText, CSharp, Research, and the CLI. |
+| [Metadata Semantic Substrates](design/metadata-semantic-substrates.md) | Admission, typed outcomes, identity, evidence, bounds, and consumer boundaries for shared metadata-derived meaning. |
 | [Workspace Research Target Composition](design/research-workspace-target-composition.md) | Queries-owned association from a workspace facade through Metadata forwarding evidence and the Queries-to-Research population receipt to one exact Research target attempt. |
 | [Analysis Universe Realization](design/analysis-universe-realization.md) | Operation-scoped binding from one exact finite analysis universe and validated plan to owner-issued executable capabilities, deterministic access, retained lifetimes, and visible failure. |
 | [Artifact Acquisition and Workspaces](design/artifact-acquisition-and-workspaces.md) | How artifacts are acquired and composed into an inspection workspace. |

--- a/docs/design/metadata-semantic-substrates.md
+++ b/docs/design/metadata-semantic-substrates.md
@@ -1,9 +1,9 @@
 # Metadata semantic substrates
 
-A **Metadata semantic substrate** authenticates higher-level structural meaning
+A **Metadata semantic substrate** authenticates higher-level meaning
 from physical metadata and publishes immutable typed outcomes that independent
 higher layers can consume. It sits above raw row and blob decoding and below
-consumer semantics: it establishes what the metadata structurally asserts and
+consumer semantics: it establishes the meaning the metadata supports and
 takes no position on IL-body attribution, source reconstruction, project policy,
 recommendation, or presentation.
 
@@ -103,8 +103,9 @@ publication, identity, construction, and boundary contracts below.
 ### Worked admissions
 
 **Property backing storage - admit; accessor association rides along.** These
-are two meanings. Accessor association is structural: `MethodSemantics` states
-it directly, so it is a helper rather than an independently admissible meaning.
+are two meanings. Accessor association fails requirement 1: a single
+`MethodSemantics` row states it outright, so it is a helper rather than an
+independently admissible meaning. Its evidence grade is structural.
 Backing-storage association is conventional: it rests on the
 `<Prop>k__BackingField` grammar
 (`src/ILInspector.MetadataPrimitives/GeneratedNameGrammar.cs:57`-`58`), not on a
@@ -138,8 +139,8 @@ A substrate declares each distinction reachable through its chosen contract:
 - **Resolved** - the meaning was established, with supporting evidence.
 - **Absent** - the metadata is well formed and the meaning does not apply.
 - **Malformed** - relevant metadata is present but cannot be decoded.
-- **Ambiguous** - multiple candidates satisfy the structural test and no rule
-  selects one.
+- **Ambiguous** - multiple candidates satisfy the substrate's matching test
+  and no rule selects one.
 - **Unsupported** - the shape decodes but falls outside the declared scope.
 - **Budget-limited** - a declared work or resource bound stopped derivation.
 - **Unexamined** - the substrate deliberately did not look.
@@ -265,8 +266,8 @@ behavior gate of its own.
 
 Each admitting issue and PR carries the evidence for requirement 3. Each
 implemented substrate names gates for its construction totality, bounds,
-identity, evidence lifetime, and routing obligations, or records the applicable
-property as `unverified`.
+identity, evidence lifetime, correct outcome classification, and evidence
+labelling, or records the applicable property as `unverified`.
 
 An adoption replacing a consumer's private derivation changes behavior wherever
 the two disagree. The adopting owner must demonstrate equivalence or document


### PR DESCRIPTION
Clarifies the landed Metadata pattern so independent consumers can share
evidence without confusing admission with evidence grade. This is the
separate wording follow-up requested after #5706, not a reopening of its
accepted pattern contract.

**Review status:** Round 1 is **2/2 CLEAN** at
`81e69da7a8b55239d150b6a1e3f2641b000f54be` (GPT-5.6 Sol and Claude Opus 5).
No review-driven changes were needed. This is exact-head review state, not a
claim about live merge readiness.

## Demo

Documentation mockup: apply the existing contract to neighboring meanings.

| Scenario | Before | After |
| --- | --- | --- |
| A convention-supported backing-field association | The introduction calls all meaning structural, although admission permits conventional evidence. | The introduction describes meaning supported by metadata; the evidence grade remains conventional. |
| Multiple convention-matching candidates, with no rule selecting one | `Ambiguous` refers only to a structural test. | `Ambiguous` refers to the substrate's matching test, including conventional matches. |
| Direct accessor association | Helper status and structural grade appear in the same causal sentence. | Helper status explicitly follows from requirement 1: one `MethodSemantics` row already states it. Its grade is separately structural. |
| A derivation exhausts its budget | The Gates section asks for evidence of vaguely named routing obligations. | Correct outcome classification and evidence labelling are explicit; the result remains `Budget-limited`, not `Malformed`. |

The neighboring IL-dependent lambda/local-function example remains rejected.
The documentation index again links the pattern without displacing the
Workspace Research Target Composition entry.

## Design basis and scope

The sole normative owner is `ILInspector.Metadata`, through
`docs/design/metadata-semantic-substrates.md`:

- **Admission test**, including **Worked admissions**, distinguishes derived
  meaning from direct row reads and structural from conventional evidence.
- **Outcome vocabulary** applies the existing ambiguity distinction to each
  substrate's matching test.
- **Gates** retains the existing outcome/evidence obligation with explicit
  terminology rather than deleting it.

`docs/design-scope.md#one-owner-per-focused-design` is the scope constraint,
not a second contract owner. Existing consumers and their adoption decisions
are unchanged.

This is a wording and discoverability correction to a landed pattern, not a
new architecture, capability, substrate implementation, host path, or rendering
domain. **Status and decision** limits this document to the pattern;
**Non-goals** excludes an adoption sweep and exact-codomain work. No new
complexity, consumer, host-adoption path, retirement plan, platform exception,
or rendering strategy is introduced by this diff. The existing pattern's
adoption work remains separate; exact-codomain design remains #5838.

The conventional baseline is consistent terminology across a specification:
admissibility, evidence grade, and outcome classification are separate axes.
There is no intentional divergence or imported implementation. The landed
worked admission is the comparative evidence; no new source census is added.
Product properties remain subject to the existing implementation-gate or
`unverified` rule rather than being certified by this documentation change.

## Validation

- `npx markdownlint-cli docs/design/metadata-semantic-substrates.md docs/README.md`
- `git diff --check`
- Markdown-only changes in the owner document and documentation index.
