### PR TITLE
Report actual context for each authored rebuild lane

### DIFF
--- a/docs/design/fact-planned-compile-back-harness.md
+++ b/docs/design/fact-planned-compile-back-harness.md
@@ -45,8 +45,7 @@ and cannot produce an `Exact` receipt under the current contract; until then the
 causal control is unavailable.
 
 The focused [authored-source rebuild fidelity reporting
-contract](#authored-source-rebuild-fidelity) distinguishes current aggregate
-context reporting from the lane-specific evidence planned in
+contract](#authored-source-rebuild-fidelity) defines the lane-specific evidence in
 [#5851](https://github.com/richlander/dotnet-inspect/issues/5851).
 
 The existing `CB_CLUSTER=1` path already has a strong generic answer for closure
@@ -906,19 +905,22 @@ Examples:
 **Owner:** ReturnToSender / DecompilerHarness, within this reporting contract.
 **Tracker:** [#5851](https://github.com/richlander/dotnet-inspect/issues/5851),
 Slice 3 of [#2673](https://github.com/richlander/dotnet-inspect/issues/2673).
-The strengthened contract below is **planned and unverified**; its adoption
-gates are specified below, not claimed to exist.
+The lane-specific reporting contract is implemented in the existing harness,
+with the focused Release gates named below. Original-build reconstruction and
+owner-issued replacement-artifact digests remain unavailable; this reporting
+does not certify them.
 
 #### Existing lane and design basis
 
 `--authored-rebuild-fidelity` already compiles an acquired authored body in the
 final RTS artifact/reference context and retains an independent decompiler
 result. This slice extends that lane rather than introducing a new oracle.
-The present context assessment compares recorded options to RTS defaults even
-though the authored compilation applies some PDB-recorded options. Its reference
-comparison uses filenames; `Recorded` can coexist with missing compiler,
-generator, and project evidence. That is not a reconstruction of the original
-build context.
+Before #5851, context assessment compared recorded options to RTS defaults even
+though the authored compilation applied some PDB-recorded options. Its reference
+comparison used filenames; `Recorded` could coexist with missing compiler,
+generator, and project evidence. The lane-specific result replaces that
+projection, retaining each actual attempt's product source artifact, parse and
+compilation settings, and frozen-reference provenance.
 
 The exact claim is: **for one shipped target, report independent authored and
 decompiled IL comparisons with the recorded-versus-effective context of each
@@ -1015,6 +1017,11 @@ shows both outcomes, acquisition/checksum and determinism, both context
 summaries, and the material differing/unknown/failed facts. A favorable authored
 outcome cannot by itself filter out a failing decompiler example. Keep the
 example limit explicit; it limits presentation, not retained evidence.
+Agreeing references may be summarized by count with their comparison coverage;
+their individual facts remain in the typed result. If no compilation ran, show
+the recorded inventory count and unavailable effective inventory rather than
+repeating the same unavailable comparison for every reference. The retained
+PDB inspection still contains the individual original records.
 
 Illustrative mockup, not current command output, for the existing invocation:
 
@@ -1051,10 +1058,10 @@ MVIDs are a context difference, not agreement.
 The production host is the existing DecompilerHarness mode. The complete
 focused adoption path has **two steps**, tracked in #5851 under #2673:
 
-1. Land this documentation-only contract and its examples.
+1. Land the documentation-only contract and its examples (#5852).
 2. Adopt lane-specific evidence in the existing typed result, assessor, and
-   bounded report together; replace the old unqualified context projection in
-   that same slice, with focused Release gates and a pinned real-source demo.
+   bounded report together, replacing the old unqualified context projection
+   with focused Release gates and a pinned real-source demo.
 
 There is no alternative harness architecture to retain or retire. This extends
 test infrastructure, not shared product substrate; existing product CLI and
@@ -1063,28 +1070,41 @@ exercise product-owned artifact construction, not introduce tools-side shell
 repair. If an adjacent prerequisite prevents that, record the blocker rather
 than broadening this issue.
 
-Existing tests in `AuthoredRebuildFidelityTests` cover narrower behavior:
+Tests in `AuthoredRebuildFidelityTests` retain the original outcome coverage:
 `BuildContextAssessment_KeepsDeterminismSeparateFromRecordedContext`,
 `BuildContextAssessment_ReportsContextDriftIndependently`, and
-`AuthoredBody_ReusesFinalRtsRequestAndProductIlDiff`. They are not evidence for
-the new per-lane contract. The following are proposed outcome gates, all
-**unverified** until implemented and run by
+`AuthoredBody_ReusesFinalRtsRequestAndProductIlDiff`. The per-lane contract is
+gated by the following methods in `AuthoredBuildContextTests`, run by
 `src/ILInspector.Decompiler.Tests` in Release:
 
-| Proposed gate | Required observation |
+| Gate | Required observation |
 | --- | --- |
-| Applied-options witness | A applies recorded debug options while B uses release; the report assesses each actual attempt correctly. |
-| Incomplete-context witness | Exact normalized A plus deterministic/checksum agreement still discloses unknown compiler/generator/project facts. |
-| Reference-identity neighbors | Same filename/different MVID reports drift; unavailable identity reports unknown; comparable matching fields report only their scoped agreement. |
-| Independent-outcome matrix | A exact/different/failed/unavailable with differing B outcomes preserves both results; replacing an attempt cannot retain stale context. |
-| Failed-inspection witness | A recorded-context inspection error stays failed evidence, distinguishable from absence and from the independently obtained B result. |
-| Bounded-report witness | An exact A does not hide a failed B; each emitted example contains both lane contexts and counts remain independent of the example cap. |
+| `AppliedOptions_UseEachActualAttempt` | Compiler-recorded checked arithmetic is applied by A while B remains unchecked. The PDB's omitted default debug optimization is unknown, not inferred. |
+| `ExactAuthoredIl_DoesNotCertifyUnknownContext` | Exact normalized A plus deterministic/checksum agreement still discloses unknown compiler/generator/project facts. |
+| `ReferenceIdentity_DoesNotUseFilenameAsProof` | Same filename/different MVID reports drift; unavailable identity reports unknown; comparable matching fields report only their scoped agreement. |
+| `ReplacingAuthoredAttempt_DoesNotReuseItsContextOrVerdict` | Explicitly recorded debug/release settings and differing/failed A observations preserve B; the replacement has its own context. |
+| `FloorReplacement_DropsPreviousCompilationContext` | An independent compile-back floor does not retain the superseded RTS attempt's context. |
+| `FailedInspection_RemainsSeparateFromBothComparisons`, `FailedReferences_DoNotDiscardRecordedOptions` | Decode failure stays failed evidence without erasing an independently obtained comparison or usable option records. |
+| `MissingAuthoredAttempt_DoesNotBorrowDecompilerContext` | Source absence does not borrow B's effective settings for an A compilation that never ran. |
+| `UnsupportedAndMissingOptions_DiscloseActualDefaults` | Unsupported values and unhandled options remain unknown; actual fallback settings are disclosed. |
+| `Report_PreservesBothLanesAndIndependentCountsUnderCap` | Exact A does not hide failed B; both contexts survive the example cap, and expanded field text uses `InertString` at the text-rendering boundary. |
+| `LocalAuthoredSource_RetainsBothActualContextsAfterEvaluation` | Local PDB and checksum-verified local source exercise acquisition through reporting evidence without a network dependency; contexts survive release of the final request. |
 
-Use compiled fixtures for option/reference boundaries and run the actual
-harness report over retained results. A pinned package/source/PDB demo in
-step 2 supplies real-input evidence without turning live network availability
-into a contract gate. This design adds no state machine or concurrency
-protocol requiring a new formal model.
+The cataloged `decompiler.authored-rebuild` fixture is compiled with optimization
+disabled, checked arithmetic, and local source. It supplies
+compiler-produced option/IL boundaries; the reference neighbors consume the
+actual retained compilation provenance. PDB readers omit some default options:
+their absence is not a license to reconstruct defaults from compiler lore.
+Independently available options are now retained even if the reference-metadata
+inspection is absent or failed; A still uses its frozen RTS reference closure.
+The command's existing outcome-based exit policy is unchanged.
+
+Pinned Markout 0.36.0 and NuGet.Versioning 7.3.0 probes supply real-input
+absence/failure evidence without turning live network availability into a gate.
+The former acquires checksum-matching source but its first three accessor
+bodies remain unsupported by extraction; those A attempts are unavailable,
+not compilations in B's context. This design adds no state machine or
+concurrency protocol requiring a new formal model.
 
 ## Migration plan
 

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -29,6 +29,7 @@
     <Project Path="fixtures/analysis/ILInspector.Analysis.UnoptimizedAsyncFixtures/ILInspector.Analysis.UnoptimizedAsyncFixtures.csproj" />
     <Project Path="fixtures/cli/DotnetInspector.HostileNameFixtures/DotnetInspector.HostileNameFixtures.csproj" />
     <Project Path="fixtures/cli/DotnetInspector.InstallScriptFixture/DotnetInspector.InstallScriptFixture.csproj" />
+    <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/ILInspector.Decompiler.Fixtures.AuthoredRebuild.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />
     <Project Path="fixtures/decompiler/ILInspector.Decompiler.Fixtures.ClassicAsyncArtifacts/ILInspector.Decompiler.Fixtures.ClassicAsyncArtifacts.csproj" />

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/ILInspector.Decompiler.Fixtures.AuthoredRebuild.csproj
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/ILInspector.Decompiler.Fixtures.AuthoredRebuild.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <Optimize>false</Optimize>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DebugType>portable</DebugType>
+    <Deterministic>true</Deterministic>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="RebuildSamples.cs" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/RebuildSamples.cs
+++ b/fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild/RebuildSamples.cs
@@ -1,0 +1,13 @@
+namespace AuthoredRebuildFixtures;
+
+public sealed class ContextSample
+{
+    public int Value
+    {
+        get
+        {
+            int value = 42;
+            return value;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredBuildContextTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredBuildContextTests.cs
@@ -1,0 +1,273 @@
+using DotnetInspector.Fixtures;
+using DotnetInspector.Services;
+using ILInspector.Decompiler.Tests;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+
+namespace ILInspector.DecompilerHarness;
+
+[Trait("Area", "Fidelity")]
+[Collection(FidelityGateCollection.Name)]
+public sealed class AuthoredBuildContextTests
+{
+    static readonly FindingSubject Subject = new("rebuild-context", "rebuild-context");
+
+    [Fact]
+    public async Task LocalAuthoredSource_RetainsBothActualContextsAfterEvaluation()
+    {
+        using var http = new HttpClient(new NoNetworkHandler());
+        var results = await AuthoredRebuildFidelity.EvaluateAssembliesAsync(
+            [FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath()],
+            1, http, new SourceFetcher(http));
+        var result = Assert.Single(results);
+
+        Assert.True(result.ChecksumVerification == SourceChecksumVerification.Exact, result.Detail);
+        Assert.NotNull(result.ImplementationDiff);
+        Assert.NotNull(result.AuthoredAttempt);
+        Assert.NotNull(result.DecompilerLane.CompilationAttempt);
+        Assert.Null(result.DecompilerLane.FinalRequest);
+        Assert.Equal(BuildContextFactStatus.Agree, Fact(result.AuthoredContext, "checked").Status);
+        Assert.Equal(BuildContextFactStatus.Different, Fact(result.DecompiledContext, "checked").Status);
+    }
+
+    [Fact]
+    public void AppliedOptions_UseEachActualAttempt()
+    {
+        string assemblyPath = FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath();
+        using var source = SourceLinkService.Open(assemblyPath);
+        var context = new RecordedBuildContext(
+            SourceLinkInspector.InspectDll(assemblyPath).IsDeterministic,
+            MetadataFindings.InspectCompilationOptions(source.Context, Subject),
+            MetadataFindings.InspectCompilationReferences(source.Context, Subject));
+        Assert.Equal("True", context.Option("checked"));
+        Assert.Null(context.Option("optimization"));
+        var result = Rebuild(context);
+
+        Assert.True(Assert.IsType<RebuildCompilationAttempt>(result.AuthoredAttempt).Options.CheckOverflow);
+        Assert.False(Assert.IsType<RebuildCompilationAttempt>(result.DecompilerLane.CompilationAttempt).Options.CheckOverflow);
+        Assert.Equal(BuildContextFactStatus.Agree, Fact(result.AuthoredContext, "checked").Status);
+        Assert.Equal(BuildContextFactStatus.Different, Fact(result.DecompiledContext, "checked").Status);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(result.AuthoredContext, "optimization").Status);
+        Assert.Equal(result.DecompilerLane.CompilationAttempt.Target, result.AuthoredAttempt.Target);
+        Assert.NotSame(result.DecompilerLane.CompilationAttempt.Artifact, result.AuthoredAttempt.Artifact);
+        Assert.NotNull(result.ImplementationDiff);
+    }
+
+    [Fact]
+    public void ExactAuthoredIl_DoesNotCertifyUnknownContext()
+    {
+        var result = Rebuild(Context(new CompilationOptionInfo("optimization", "debug")));
+
+        Assert.Equal(AuthoredRebuildOutcome.Exact, result.Outcome);
+        Assert.Equal(SourceChecksumVerification.Exact, result.ChecksumVerification);
+        Assert.True(result.BuildContext.IsDeterministic);
+        Assert.Equal(AuthoredBuildContextStatus.Incomplete, result.AuthoredContext.Status);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(result.AuthoredContext, "compiler-version").Status);
+        Assert.Contains(result.AuthoredContext.Facts, fact =>
+            fact.Dimension == "generators" && fact.Status == BuildContextFactStatus.Unknown);
+        Assert.Contains(result.AuthoredContext.Facts, fact =>
+            fact.Dimension == "project" && fact.Status == BuildContextFactStatus.Unknown);
+    }
+
+    [Theory]
+    [InlineData("match", "Agree")]
+    [InlineData("different", "Different")]
+    [InlineData("missing", "Unknown")]
+    public void ReferenceIdentity_DoesNotUseFilenameAsProof(string mode, string expected)
+    {
+        var decompiler = Decompile();
+        var attempt = Assert.IsType<RebuildCompilationAttempt>(decompiler.CompilationAttempt);
+        var reference = attempt.Provenance.References.First(reference => reference.ModuleVersionId is not null);
+        Guid mvid = mode switch
+        {
+            "match" => reference.ModuleVersionId!.Value,
+            "different" => Guid.NewGuid(),
+            _ => Guid.Empty,
+        };
+        string name = Path.GetFileName(reference.Display);
+        var recorded = new CompilationReferenceInfo(
+            $"C:\\recorded\\{name}",
+            string.Join(",", reference.Aliases),
+            attempt.ReferenceKinds[reference.Ordinal] == MetadataImageKind.Assembly
+                ? CompilationReferenceImageKind.Assembly : CompilationReferenceImageKind.Module,
+            reference.EmbedInteropTypes, 0, 0, mvid);
+        var context = new RecordedBuildContext(
+            true, Options(), MetadataFindings.InspectCompilationReferences([recorded], Subject));
+        var fact = Assert.Single(context.Assess(attempt).Facts, fact =>
+            fact.Dimension == "references" && fact.Name == name && fact.Recorded is not null);
+        Assert.Equal(expected, fact.Status.ToString());
+        Assert.Contains("MVID=", fact.Effective, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReplacingAuthoredAttempt_DoesNotReuseItsContextOrVerdict()
+    {
+        var decompiler = Decompile();
+        var debug = AuthoredRebuildFidelity.CompileAuthoredBody(
+            decompiler, AuthoredBody(), SourceChecksumVerification.Exact, Context(new CompilationOptionInfo("optimization", "debug")));
+        var release = AuthoredRebuildFidelity.CompileAuthoredBody(
+            decompiler, AuthoredBody(), SourceChecksumVerification.Exact, Context(new CompilationOptionInfo("optimization", "release")));
+        var failed = AuthoredRebuildFidelity.CompileAuthoredBody(
+            decompiler, "return MissingValue;", null, Context());
+        var different = AuthoredRebuildFidelity.CompileAuthoredBody(
+            decompiler, "return 43;", null, Context(new CompilationOptionInfo("optimization", "debug")));
+
+        Assert.Same(decompiler, debug.DecompilerLane);
+        Assert.Same(decompiler, release.DecompilerLane);
+        Assert.Same(decompiler, failed.DecompilerLane);
+        Assert.Same(decompiler, different.DecompilerLane);
+        Assert.Equal(AuthoredRebuildOutcome.IlDifferent, different.Outcome);
+        Assert.Equal(BuildContextFactStatus.Agree, Fact(debug.AuthoredContext, "optimization").Status);
+        Assert.Equal(BuildContextFactStatus.Different, Fact(debug.DecompiledContext, "optimization").Status);
+        Assert.Equal("debug", Fact(debug.AuthoredContext, "optimization").Effective);
+        Assert.Equal("release", Fact(release.AuthoredContext, "optimization").Effective);
+        Assert.Equal(AuthoredRebuildOutcome.RecompileFailed, failed.Outcome);
+        Assert.NotNull(failed.AuthoredAttempt);
+        Assert.Null(failed.ImplementationDiff);
+        Assert.Equal("debug", Fact(debug.AuthoredContext, "optimization").Effective);
+    }
+
+    [Fact]
+    public void FloorReplacement_DropsPreviousCompilationContext()
+    {
+        var decompiler = Decompile();
+        Assert.NotNull(decompiler.CompilationAttempt);
+        var target = decompiler.Plan.TargetMethod;
+        var floor = new FidelityCheck.CompileBackResult(
+            target.Type, target.Method, target.Overload, target.Signature,
+            FidelityCheck.CompileBackStatus.Exact, "ret", "ret", null);
+
+        var replaced = ReturnToSender.WithCompileBackFloor(decompiler, floor);
+
+        Assert.True(replaced.UsedCompileBackFloor);
+        Assert.Null(replaced.CompilationAttempt);
+        Assert.NotNull(decompiler.CompilationAttempt);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(Context().Assess(replaced.CompilationAttempt), "optimization").Status);
+    }
+
+    [Fact]
+    public void FailedInspection_RemainsSeparateFromBothComparisons()
+    {
+        var context = RecordedBuildContext.Failed(Subject, "PDB options unavailable after decode failure");
+        var result = Rebuild(context);
+
+        Assert.NotNull(result.ImplementationDiff);
+        Assert.Equal(AuthoredBuildContextStatus.Failed, result.AuthoredContext.Status);
+        Assert.Equal(AuthoredBuildContextStatus.Failed, result.DecompiledContext.Status);
+        Assert.Null(context.IsDeterministic);
+        Assert.Contains(result.AuthoredContext.Facts, fact =>
+            fact.Status == BuildContextFactStatus.Failed && fact.Detail.Contains("decode failure", StringComparison.Ordinal));
+        Assert.NotNull(result.DecompilerLane.CompilationAttempt);
+    }
+
+    [Fact]
+    public void FailedReferences_DoNotDiscardRecordedOptions()
+    {
+        var context = new RecordedBuildContext(
+            true,
+            Options(new CompilationOptionInfo("optimization", "debug")),
+            new FindingInspection<CompilationReferenceInfo>.Failed(
+                new(Subject, MetadataFindings.CompilationReferenceDescriptor, "Reference metadata could not be decoded.")));
+        var result = Rebuild(context);
+
+        Assert.Equal(AuthoredRebuildOutcome.Exact, result.Outcome);
+        Assert.Equal(AuthoredBuildContextStatus.Failed, result.AuthoredContext.Status);
+        Assert.Equal(BuildContextFactStatus.Agree, Fact(result.AuthoredContext, "optimization").Status);
+        Assert.Equal("debug", Fact(result.AuthoredContext, "optimization").Effective);
+        Assert.Contains(result.AuthoredContext.Facts, fact =>
+            fact.Dimension == "references" && fact.Status == BuildContextFactStatus.Failed);
+    }
+
+    [Fact]
+    public void UnsupportedAndMissingOptions_DiscloseActualDefaults()
+    {
+        var result = Rebuild(Context(
+            new("optimization", "unsupported-mode"),
+            new("unsafe", "not-a-boolean"),
+            new("custom-option", "custom-value")));
+
+        Assert.NotNull(result.AuthoredAttempt);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(result.AuthoredContext, "optimization").Status);
+        Assert.Equal("debug", Fact(result.AuthoredContext, "optimization").Effective);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(result.AuthoredContext, "unsafe").Status);
+        Assert.Equal("False", Fact(result.AuthoredContext, "unsafe").Effective);
+        Assert.Equal(BuildContextFactStatus.Unknown, Fact(result.AuthoredContext, "custom-option").Status);
+    }
+
+    [Fact]
+    public void MissingAuthoredAttempt_DoesNotBorrowDecompilerContext()
+    {
+        var complete = Rebuild(Context());
+        var unavailable = new AuthoredRebuildFidelityResult(
+            complete.DecompilerLane, AuthoredRebuildOutcome.SourceAbsent,
+            null, complete.BuildContext, "No source", null);
+
+        Assert.Null(unavailable.AuthoredAttempt);
+        Assert.Null(Fact(unavailable.AuthoredContext, "optimization").Effective);
+        Assert.Equal("release", Fact(unavailable.DecompiledContext, "optimization").Effective);
+        Assert.Same(complete.DecompilerLane, unavailable.DecompilerLane);
+    }
+
+    [Fact]
+    public void Report_PreservesBothLanesAndIndependentCountsUnderCap()
+    {
+        var result = Rebuild(Context(new("optimization", "debug"), new("custom-option", "\u001bvalue")));
+        var failedDecompiler = result with
+        {
+            DecompilerLane = result.DecompilerLane with
+            {
+                Status = FidelityCheck.CompileBackStatus.RecompileFail,
+                CompilationAttempt = null,
+            },
+        };
+        using var output = new StringWriter();
+        AuthoredRebuildFidelity.WriteReport([failedDecompiler, result], 1, output);
+        string text = output.ToString();
+
+        Assert.Contains("over 2 target(s)", text, StringComparison.Ordinal);
+        Assert.Contains("Examples: 1 shown (limit 1; all results retained)", text, StringComparison.Ordinal);
+        Assert.Contains("decompiled : RecompileFail", text, StringComparison.Ordinal);
+        Assert.Contains("authored   : Exact", text, StringComparison.Ordinal);
+        Assert.Contains("A context  :", text, StringComparison.Ordinal);
+        Assert.Contains("B context  :", text, StringComparison.Ordinal);
+        Assert.Contains("custom-option: Unknown", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("\u001b", text, StringComparison.Ordinal);
+
+        using var noExamples = new StringWriter();
+        AuthoredRebuildFidelity.WriteReport([failedDecompiler, result], 0, noExamples);
+        Assert.Contains("over 2 target(s)", noExamples.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Examples: 0 shown", noExamples.ToString(), StringComparison.Ordinal);
+    }
+
+    static BuildContextFact Fact(LaneBuildContext context, string name)
+        => Assert.Single(context.Facts, fact => fact.Name == name);
+
+    static ReturnToSender.Result Decompile()
+        => ReturnToSender.CompileBackFirstPropertyGetter(FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath());
+
+    static string AuthoredBody()
+    {
+        string source = File.ReadAllText(FixtureCatalog.DecompilerAuthoredRebuild.AssetPath("source"));
+        Assert.True(AuthoredRebuildFidelity.TryExtractTargetBody(source, "get_Value", 0, out string body));
+        return body;
+    }
+
+    static AuthoredRebuildFidelityResult Rebuild(RecordedBuildContext context)
+        => AuthoredRebuildFidelity.CompileAuthoredBody(
+            Decompile(), AuthoredBody(), SourceChecksumVerification.Exact, context);
+
+    static RecordedBuildContext Context(params CompilationOptionInfo[] options)
+        => new(true, Options(options), MetadataFindings.InspectCompilationReferences([], Subject));
+
+    static FindingInspection<CompilationOptionInfo> Options(params CompilationOptionInfo[] options)
+        => MetadataFindings.InspectCompilationOptions(options, Subject);
+
+    sealed class NoNetworkHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new InvalidOperationException("The fixture must use its local PDB and checksum-verified local source.");
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AuthoredRebuildFidelityTests.cs
@@ -25,31 +25,29 @@ public sealed class AuthoredRebuildFidelityTests
     [Fact]
     public void BuildContextAssessment_KeepsDeterminismSeparateFromRecordedContext()
     {
-        string runtimePath = typeof(object).Assembly.Location;
-        var assessment = AuthoredRebuildFidelity.AssessBuildContext(
-            isDeterministic: false,
+        var decompiler = ReturnToSender.CompileBackFirstPropertyGetter(
+            FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath());
+        var recorded = new RecordedBuildContext(
+            IsDeterministic: false,
             CompleteOptions(
                 new CompilationOptionInfo("optimization", "release"),
                 new CompilationOptionInfo("unsafe", "true")),
-            CompleteReferences(new CompilationReferenceInfo(
-                Path.GetFileName(runtimePath),
-                Aliases: "",
-                CompilationReferenceImageKind.Assembly,
-                EmbedInteropTypes: false,
-                Timestamp: 0,
-                ImageSize: 0,
-                ModuleVersionId: Guid.Empty)),
-            [MetadataReference.CreateFromFile(runtimePath)]);
+            CompleteReferences());
+        var assessment = recorded.Assess(Assert.IsType<RebuildCompilationAttempt>(decompiler.CompilationAttempt));
 
-        Assert.Equal(AuthoredBuildContextStatus.Recorded, assessment.Status);
-        Assert.False(assessment.IsDeterministic);
+        Assert.Equal(AuthoredBuildContextStatus.Incomplete, assessment.Status);
+        Assert.False(recorded.IsDeterministic);
+        Assert.Contains(assessment.Facts, fact =>
+            fact.Name == "optimization" && fact.Status == BuildContextFactStatus.Agree);
     }
 
     [Fact]
     public void BuildContextAssessment_ReportsContextDriftIndependently()
     {
-        var assessment = AuthoredRebuildFidelity.AssessBuildContext(
-            isDeterministic: true,
+        var decompiler = ReturnToSender.CompileBackFirstPropertyGetter(
+            FixtureCatalog.DecompilerAuthoredRebuild.AssemblyPath());
+        var recorded = new RecordedBuildContext(
+            IsDeterministic: true,
             CompleteOptions(new CompilationOptionInfo("optimization", "debug")),
             CompleteReferences(new CompilationReferenceInfo(
                 "Missing.Reference.dll",
@@ -58,13 +56,15 @@ public sealed class AuthoredRebuildFidelityTests
                 EmbedInteropTypes: false,
                 Timestamp: 0,
                 ImageSize: 0,
-                ModuleVersionId: Guid.Empty)),
-            []);
+                ModuleVersionId: Guid.Empty)));
+        var assessment = recorded.Assess(Assert.IsType<RebuildCompilationAttempt>(decompiler.CompilationAttempt));
 
         Assert.Equal(AuthoredBuildContextStatus.Drift, assessment.Status);
-        Assert.True(assessment.IsDeterministic);
-        Assert.Contains("optimization=debug", assessment.Detail, StringComparison.Ordinal);
-        Assert.Contains("Missing.Reference.dll", assessment.Detail, StringComparison.Ordinal);
+        Assert.True(recorded.IsDeterministic);
+        Assert.Contains(assessment.Facts, fact =>
+            fact.Name == "optimization" && fact.Status == BuildContextFactStatus.Different);
+        Assert.Contains(assessment.Facts, fact =>
+            fact.Name == "Missing.Reference.dll" && fact.Status == BuildContextFactStatus.Different);
     }
 
     [Fact]
@@ -73,10 +73,10 @@ public sealed class AuthoredRebuildFidelityTests
     {
         var decompiler = ReturnToSender.CompileBackFirstPropertyGetter(
             FixtureCatalog.DiffPair.OldAssemblyPath());
-        var context = new AuthoredBuildContextAssessment(
-            AuthoredBuildContextStatus.Incomplete,
+        var context = new RecordedBuildContext(
             IsDeterministic: true,
-            "test context");
+            CompleteOptions(),
+            CompleteReferences());
 
         var result = AuthoredRebuildFidelity.CompileAuthoredBody(
             decompiler,
@@ -118,10 +118,10 @@ public sealed class AuthoredRebuildFidelityTests
                 "namespace D; public sealed class After { }",
                 directory,
                 "RtsAuthoredDependency");
-            var context = new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Incomplete,
+            var context = new RecordedBuildContext(
                 IsDeterministic: true,
-                "test context");
+                CompleteOptions(),
+                CompleteReferences());
 
             AuthoredRebuildFidelityResult result =
                 AuthoredRebuildFidelity.CompileAuthoredBody(

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -65,6 +65,7 @@
     <ProjectReference Include="..\..\fixtures\decompiler\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
     <ProjectReference Include="..\..\fixtures\decompiler\ILInspector.Decompiler.Fixtures.VbFinalizer\ILInspector.Decompiler.Fixtures.VbFinalizer.vbproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\decompiler\ILInspector.Decompiler.Fixtures.Ladder\ILInspector.Decompiler.Fixtures.Ladder.csproj" />
+    <ProjectReference Include="..\..\fixtures\decompiler\ILInspector.Decompiler.Fixtures.AuthoredRebuild\ILInspector.Decompiler.Fixtures.AuthoredRebuild.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\decompiler\ILInspector.Decompiler.Fixtures.TypeIdentity\ILInspector.Decompiler.Fixtures.TypeIdentity.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\diff\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\..\fixtures\diff\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
@@ -134,6 +135,8 @@
              Link="ReturnToSenderSourceProbe.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AuthoredRebuildFidelity.cs"
              Link="AuthoredRebuildFidelity.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AuthoredBuildContext.cs"
+             Link="AuthoredBuildContext.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CSharpSourceIdentity.cs"
              Link="CSharpSourceIdentity.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderCatalogReport.cs"

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -85,6 +85,7 @@ public static class FixtureIds
     public const string AnalysisSpoofSystemRuntime = "analysis.spoof.system-runtime";
 
     public const string DecompilerCheckedArithmetic = "decompiler.checked-arithmetic";
+    public const string DecompilerAuthoredRebuild = "decompiler.authored-rebuild";
     public const string DecompilerClassicAsync = "decompiler.classic-async";
     public const string DecompilerClassicAsyncArtifacts =
         "decompiler.classic-async-artifacts";
@@ -124,6 +125,14 @@ public static class FixtureIds
 
 public static class FixtureCatalog
 {
+    public static readonly FixtureDefinition DecompilerAuthoredRebuild = Fixture(
+        FixtureIds.DecompilerAuthoredRebuild,
+        "ILInspector.Decompiler.Fixtures.AuthoredRebuild",
+        "ILInspector.Decompiler.Fixtures.AuthoredRebuild.dll",
+        ["decompiler", "authored-rebuild", "unoptimized"],
+        Boundaries(FixtureBoundary.CompilerLowering, FixtureBoundary.SidecarAsset),
+        Asset("source", "ILInspector.Decompiler.Fixtures.AuthoredRebuild", "RebuildSamples.cs"));
+
     /// <summary>
     /// Attacker-controlled text inside C# string literals — a parameter default
     /// value, an [Obsolete] message, and a custom attribute argument, each
@@ -557,6 +566,7 @@ public static class FixtureCatalog
 
     public static readonly IReadOnlyList<FixtureDefinition> All =
     [
+        DecompilerAuthoredRebuild,
         HostileLiterals,
         SourceLinkMalformed,
         SourceLinkPartiallyMalformed,
@@ -933,6 +943,7 @@ public static class FixtureCatalog
             "ILInspector.Decompiler.Fixtures.ClassicStateMachines" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.ClassicStateMachines",
             "ILInspector.Decompiler.Fixtures.ExpressionTreeSpoof" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.ExpressionTreeSpoof",
             "ILInspector.Decompiler.Fixtures.Ladder" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.Ladder",
+            "ILInspector.Decompiler.Fixtures.AuthoredRebuild" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.AuthoredRebuild",
             "ILInspector.Decompiler.Fixtures.LegacyUnsafe" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.LegacyUnsafe",
             "ILInspector.Decompiler.Fixtures.NewUnsafe" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.NewUnsafe",
             "ILInspector.Decompiler.Fixtures.RuntimeAsync" => "fixtures/decompiler/ILInspector.Decompiler.Fixtures.RuntimeAsync",

--- a/tools/DecompilerHarness/AuthoredBuildContext.cs
+++ b/tools/DecompilerHarness/AuthoredBuildContext.cs
@@ -1,0 +1,263 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+using DotnetInspector.RoundTripCompilation;
+using ILInspector.CSharp;
+using ILInspector.Findings;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.DecompilerHarness;
+
+enum BuildContextFactStatus
+{
+    Agree,
+    Different,
+    Unknown,
+    Failed,
+}
+
+sealed record BuildContextFact(
+    string Dimension,
+    string Name,
+    string? Recorded,
+    string? Effective,
+    BuildContextFactStatus Status,
+    string Detail);
+
+sealed record LaneBuildContext(ImmutableArray<BuildContextFact> Facts)
+{
+    public AuthoredBuildContextStatus Status
+        => Facts.Any(fact => fact.Status == BuildContextFactStatus.Failed)
+            ? AuthoredBuildContextStatus.Failed
+            : Facts.Any(fact => fact.Status == BuildContextFactStatus.Different)
+                ? AuthoredBuildContextStatus.Drift
+                : Facts.Any(fact => fact.Status == BuildContextFactStatus.Unknown)
+                    ? AuthoredBuildContextStatus.Incomplete
+                    : AuthoredBuildContextStatus.Recorded;
+}
+
+sealed record RebuildCompilationAttempt(
+    MetadataMethodAddress Target,
+    CSharpSourceArtifact Artifact,
+    CSharpParseOptions ParseOptions,
+    CSharpCompilationOptions Options,
+    RoundTripCompilationProvenance Provenance,
+    ImmutableArray<MetadataImageKind> ReferenceKinds,
+    string CompilerIdentity)
+{
+    internal static RebuildCompilationAttempt Capture(
+        ProductArtifact artifact,
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions options,
+        RoundTripCompilationProvenance provenance,
+        IReadOnlyList<MetadataReference> references)
+        => new(
+            MetadataMethodAddress.Create(artifact.Request.Reader, artifact.Request.TargetMethod),
+            artifact.SourceArtifact,
+            parseOptions,
+            options,
+            provenance,
+            references.Select(reference => reference.Properties.Kind).ToImmutableArray(),
+            typeof(CSharpCompilation).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion
+                ?? typeof(CSharpCompilation).Assembly.GetName().Version?.ToString()
+                ?? "unknown");
+}
+
+sealed record RecordedBuildContext(
+    bool? IsDeterministic,
+    FindingInspection<CompilationOptionInfo> Options,
+    FindingInspection<CompilationReferenceInfo> References)
+{
+    internal static RecordedBuildContext Failed(FindingSubject subject, string reason)
+        => new(
+            null,
+            new FindingInspection<CompilationOptionInfo>.Failed(
+                new(subject, MetadataFindings.CompilationOptionDescriptor, reason)),
+            new FindingInspection<CompilationReferenceInfo>.Failed(
+                new(subject, MetadataFindings.CompilationReferenceDescriptor, reason)));
+
+    internal string? Option(string name)
+    {
+        var values = OptionValues(name);
+        return values.Length == 1 ? values[0] : null;
+    }
+
+    ImmutableArray<string> OptionValues(string name)
+        => Options.Value is FindingInspection<CompilationOptionInfo>.Complete complete
+            ? complete.Findings
+                .Where(finding => string.Equals(finding.Payload.Name, name, StringComparison.OrdinalIgnoreCase))
+                .Select(finding => finding.Payload.Value)
+                .ToImmutableArray()
+            : [];
+
+    internal LaneBuildContext Assess(RebuildCompilationAttempt? attempt)
+    {
+        var facts = ImmutableArray.CreateBuilder<BuildContextFact>();
+        AddOption("compiler", "compiler-version", attempt?.CompilerIdentity, value => value);
+        AddOption("options", "language-version",
+            attempt?.ParseOptions.LanguageVersion.ToDisplayString(), NormalizeLanguage);
+        AddOption("options", "define",
+            attempt is null ? null : NormalizeNames(attempt.ParseOptions.PreprocessorSymbolNames),
+            value => NormalizeNames(value.Split(',')));
+        AddOption("options", "optimization",
+            attempt?.Options.OptimizationLevel.ToString().ToLowerInvariant(),
+            value => value.ToLowerInvariant() is "debug" or "release" ? value.ToLowerInvariant() : null);
+        AddOption("options", "unsafe", attempt?.Options.AllowUnsafe.ToString(), NormalizeBoolean);
+        AddOption("options", "checked", attempt?.Options.CheckOverflow.ToString(), NormalizeBoolean);
+        AddOption("options", "nullable", attempt?.Options.NullableContextOptions.ToString(),
+            value => Enum.TryParse<NullableContextOptions>(value, true, out var parsed)
+                && Enum.IsDefined(parsed) ? parsed.ToString() : null);
+
+        if (Options.Value is FindingInspection<CompilationOptionInfo>.Complete completeOptions)
+        {
+            var handled = facts.Select(fact => fact.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+            foreach (var option in completeOptions.Findings.Select(finding => finding.Payload))
+            {
+                if (!handled.Contains(option.Name))
+                {
+                    facts.Add(new("options", option.Name, option.Value, null,
+                        BuildContextFactStatus.Unknown, "Recorded option is not compared by this harness."));
+                }
+            }
+        }
+
+        AddReferences(facts, attempt);
+        facts.Add(new("generators", "invocation", null,
+            attempt is null ? null : "No generator invocation; supplied artifact only",
+            BuildContextFactStatus.Unknown, "Original generator inputs and invocation are unavailable."));
+        facts.Add(new("project", "build", null,
+            attempt is null ? null : "Body in RTS artifact; retained compilation closure",
+            BuildContextFactStatus.Unknown, "Original project, SDK/MSBuild settings, and build inputs are unavailable."));
+        if (attempt is null)
+        {
+            facts.Add(new("attempt", "compilation", null, null,
+                BuildContextFactStatus.Unknown, "No compilation attempt is retained for this artifact."));
+        }
+        return new(facts.ToImmutable());
+
+        void AddOption(string dimension, string name, string? effective, Func<string, string?> normalize)
+        {
+            if (Options.Value is FindingInspection<CompilationOptionInfo>.Failed failed)
+            {
+                facts.Add(new(dimension, name, null, effective,
+                    BuildContextFactStatus.Failed, failed.Error.Reason));
+                return;
+            }
+
+            var values = OptionValues(name);
+            string? recorded = values.Length == 0 ? null : string.Join(" | ", values);
+            string? normalized = values.Length == 1 ? normalize(values[0]) : null;
+            bool comparable = normalized is not null && effective is not null;
+            facts.Add(new(dimension, name, recorded, effective,
+                !comparable ? BuildContextFactStatus.Unknown
+                    : string.Equals(normalized, effective, StringComparison.Ordinal)
+                        ? BuildContextFactStatus.Agree : BuildContextFactStatus.Different,
+                comparable ? "Comparison covers this recorded setting only."
+                    : values.Length > 1 ? "Multiple recorded values; no value was selected."
+                    : effective is null ? "No effective compilation setting is retained."
+                    : recorded is null ? "Original setting is not recorded."
+                    : "Recorded value is unsupported; the effective setting is shown, not assumed applied."));
+        }
+    }
+
+    void AddReferences(
+        ImmutableArray<BuildContextFact>.Builder facts,
+        RebuildCompilationAttempt? attempt)
+    {
+        if (References.Value is FindingInspection<CompilationReferenceInfo>.Failed failed)
+        {
+            facts.Add(new("references", "inventory", null, null,
+                BuildContextFactStatus.Failed, failed.Error.Reason));
+            return;
+        }
+        if (References.Value is not FindingInspection<CompilationReferenceInfo>.Complete complete
+            || complete.Findings.IsEmpty)
+        {
+            facts.Add(new("references", "inventory", null,
+                attempt is null ? null : $"{attempt.Provenance.References.Length} retained references",
+                BuildContextFactStatus.Unknown, "Original reference inventory is unavailable."));
+            return;
+        }
+        if (attempt is null)
+        {
+            facts.Add(new("references", "inventory", $"{complete.Findings.Length} recorded references", null,
+                BuildContextFactStatus.Unknown, "No effective reference inventory is retained."));
+            return;
+        }
+
+        var consumed = new HashSet<int>();
+        foreach (var recorded in complete.Findings.Select(finding => finding.Payload))
+        {
+            string name = FileName(recorded.Name);
+            var candidates = attempt.Provenance.References
+                .Where(reference => string.Equals(FileName(reference.Display), name, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            var exact = candidates.Where(reference =>
+                recorded.ModuleVersionId != Guid.Empty
+                && reference.ModuleVersionId == recorded.ModuleVersionId
+                && NormalizeNames(reference.Aliases) == NormalizeNames(recorded.Aliases.Split(','))
+                && reference.EmbedInteropTypes == recorded.EmbedInteropTypes
+                && attempt.ReferenceKinds[reference.Ordinal].ToString() == recorded.ImageKind.ToString()).ToArray();
+            var effective = exact.Length == 1 ? exact[0] : candidates.Length == 1 ? candidates[0] : null;
+            if (effective is null)
+            {
+                facts.Add(new("references", name, Describe(recorded), null,
+                    candidates.Length == 0
+                        ? BuildContextFactStatus.Different : BuildContextFactStatus.Unknown,
+                    candidates.Length == 0 ? "Reference is absent from the effective closure."
+                        : "Reference selection is ambiguous; filename equality is not identity."));
+                continue;
+            }
+
+            consumed.Add(effective.Ordinal);
+            bool known = recorded.ModuleVersionId != Guid.Empty
+                && effective.ModuleVersionId is { } mvid && mvid != Guid.Empty;
+            bool equal = exact.Length == 1;
+            facts.Add(new("references", name, Describe(recorded),
+                $"MVID={effective.ModuleVersionId}; aliases={NormalizeNames(effective.Aliases)}; "
+                    + $"kind={attempt.ReferenceKinds[effective.Ordinal]}; embed={effective.EmbedInteropTypes}",
+                !known ? BuildContextFactStatus.Unknown
+                    : equal ? BuildContextFactStatus.Agree : BuildContextFactStatus.Different,
+                known ? "Compared MVID, aliases, image kind, and embed-interop; not original reference-byte equality."
+                    : "MVID unavailable; filename and reference properties cannot establish identity."));
+            if (recorded.AdditionalFlags != 0)
+            {
+                facts.Add(new("references", $"{name} flags", recorded.AdditionalFlags.ToString(), null,
+                    BuildContextFactStatus.Unknown, "Additional PDB reference flags are not interpreted."));
+            }
+        }
+
+        foreach (var reference in attempt.Provenance.References.Where(reference => !consumed.Contains(reference.Ordinal)))
+        {
+            facts.Add(new("references", FileName(reference.Display), null,
+                $"MVID={reference.ModuleVersionId}; aliases={NormalizeNames(reference.Aliases)}",
+                BuildContextFactStatus.Unknown,
+                "Effective reference has no unambiguous recorded counterpart."));
+        }
+    }
+
+    static string Describe(CompilationReferenceInfo reference)
+        => $"MVID={reference.ModuleVersionId}; aliases={NormalizeNames(reference.Aliases.Split(','))}; "
+            + $"kind={reference.ImageKind}; embed={reference.EmbedInteropTypes}";
+
+    static string FileName(string value) => Path.GetFileName(value.Replace('\\', '/'));
+
+    static string NormalizeNames(IEnumerable<string> values)
+        => string.Join(",", values.Select(value => value.Trim())
+            .Where(value => value.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal));
+
+    static string? NormalizeBoolean(string value)
+        => bool.TryParse(value, out bool parsed) ? parsed.ToString() : null;
+
+    static string? NormalizeLanguage(string value)
+        => LanguageVersionFacts.TryParse(value, out var parsed)
+            ? new CSharpParseOptions(parsed).LanguageVersion.ToDisplayString() : null;
+}

--- a/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
+++ b/tools/DecompilerHarness/AuthoredRebuildFidelity.cs
@@ -2,15 +2,16 @@ using System.Net;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
-using System.Reflection;
 using System.Text;
 
 using DotnetInspector.Core;
 using DotnetInspector.Packages;
+using DotnetInspector.RoundTripCompilation;
 using DotnetInspector.Services;
 using ILInspector.Findings;
 using ILInspector.Metadata;
 using ILInspector.Research;
+using InertText;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -36,19 +37,18 @@ enum AuthoredBuildContextStatus
     Failed,
 }
 
-sealed record AuthoredBuildContextAssessment(
-    AuthoredBuildContextStatus Status,
-    bool IsDeterministic,
-    string Detail,
-    IReadOnlyDictionary<string, string>? RecordedOptions = null);
-
 sealed record AuthoredRebuildFidelityResult(
     ReturnToSender.Result DecompilerLane,
     AuthoredRebuildOutcome Outcome,
     SourceChecksumVerification? ChecksumVerification,
-    AuthoredBuildContextAssessment BuildContext,
+    RecordedBuildContext BuildContext,
     string? Detail,
-    ImplementationMemberDiffResult? ImplementationDiff);
+    ImplementationMemberDiffResult? ImplementationDiff,
+    RebuildCompilationAttempt? AuthoredAttempt = null)
+{
+    public LaneBuildContext AuthoredContext => BuildContext.Assess(AuthoredAttempt);
+    public LaneBuildContext DecompiledContext => BuildContext.Assess(DecompilerLane.CompilationAttempt);
+}
 
 static class AuthoredRebuildFidelity
 {
@@ -131,26 +131,20 @@ static class AuthoredRebuildFidelity
             {
                 pdbAcquisitionFailure = ex;
             }
-            IReadOnlyList<MetadataReference> compilationReferences =
-                decompilerResults.FirstOrDefault()?.FinalRequest?
-                    .CompilationClosure?.References
-                ?? ReturnToSender.CompilationReferences(
-                    assemblyPath).ToArray();
-            AuthoredBuildContextAssessment buildContext =
+            var subject = new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath));
+            RecordedBuildContext buildContext =
                 source is null
-                    ? new AuthoredBuildContextAssessment(
-                        AuthoredBuildContextStatus.Failed,
-                        IsDeterministic: false,
+                    ? RecordedBuildContext.Failed(
+                        subject,
                         "Portable PDB acquisition failed before build-context inspection.")
-                    : AssessBuildContext(
+                    : new RecordedBuildContext(
                         SourceLinkInspector.InspectDll(assemblyPath).IsDeterministic,
                         MetadataFindings.InspectCompilationOptions(
                             source.Context,
-                            new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath))),
+                            subject),
                         MetadataFindings.InspectCompilationReferences(
                             source.Context,
-                            new FindingSubject(assemblyPath, Path.GetFileName(assemblyPath))),
-                        compilationReferences);
+                            subject));
 
             using (source)
             {
@@ -218,7 +212,7 @@ static class AuthoredRebuildFidelity
         SourceLinkService source,
         SourceFetcher fetcher,
         ReturnToSender.Result decompilerResult,
-        AuthoredBuildContextAssessment buildContext)
+        RecordedBuildContext buildContext)
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(fetcher);
@@ -832,7 +826,7 @@ static class AuthoredRebuildFidelity
         ReturnToSender.Result decompilerResult,
         string authoredBody,
         SourceChecksumVerification? checksumVerification,
-        AuthoredBuildContextAssessment buildContext)
+        RecordedBuildContext buildContext)
     {
         ArgumentNullException.ThrowIfNull(decompilerResult);
         ArgumentNullException.ThrowIfNull(authoredBody);
@@ -848,6 +842,7 @@ static class AuthoredRebuildFidelity
                 ImplementationDiff: null);
         }
 
+        RebuildCompilationAttempt? authoredAttempt = null;
         try
         {
             using var originalPe = new PEReader(File.OpenRead(request.AssemblyPath));
@@ -857,8 +852,8 @@ static class AuthoredRebuildFidelity
                 request,
                 new ProductTargetBody(authoredBody, []));
             var artifact = CompileBackSourceComposer.Compose(authoredRequest);
-            var parseOptions = ParseOptions(buildContext.RecordedOptions);
-            var compileOptions = CompilationOptions(buildContext.RecordedOptions);
+            var parseOptions = ParseOptions(buildContext);
+            var compileOptions = CompilationOptions(buildContext);
             if (request.CompilationClosure is not { } compilationClosure)
             {
                 return new AuthoredRebuildFidelityResult(
@@ -871,16 +866,19 @@ static class AuthoredRebuildFidelity
             }
             MetadataReference[] references =
                 compilationClosure.References;
-            var compilation = CSharpCompilation.Create(
-                "return-to-sender",
-                [CSharpSyntaxTree.ParseText(artifact.Source, parseOptions)],
+            var compilation = RoundTripCompilationEngine.Compile(
+                () => artifact,
+                produced => produced.Source,
                 references,
-                compileOptions);
-            using var stream = new MemoryStream();
-            var emit = compilation.Emit(stream);
-            if (!emit.Success)
+                parseOptions,
+                compileOptions,
+                static (_, _, _) => RoundTripGrowthResult.Stop("authored-recompile-failed"),
+                new RoundTripCompilationOptions { AssemblyName = "return-to-sender", MaxIterations = 1 });
+            authoredAttempt = RebuildCompilationAttempt.Capture(
+                artifact, parseOptions, compileOptions, compilation.Provenance, references);
+            if (!compilation.Succeeded || compilation.PeImage is null)
             {
-                var error = emit.Diagnostics.FirstOrDefault(diagnostic =>
+                var error = compilation.Diagnostics.FirstOrDefault(diagnostic =>
                     diagnostic.Severity == DiagnosticSeverity.Error);
                 return new AuthoredRebuildFidelityResult(
                     decompilerResult,
@@ -890,7 +888,8 @@ static class AuthoredRebuildFidelity
                     error is null
                         ? "The authored body did not compile in the RTS shell."
                         : $"{error.Id}: {error.GetMessage()}",
-                    ImplementationDiff: null);
+                    ImplementationDiff: null,
+                    AuthoredAttempt: authoredAttempt);
             }
 
             var originalMethod = MetadataTokens.MethodDefinitionHandle(
@@ -899,7 +898,7 @@ static class AuthoredRebuildFidelity
                 request.AssemblyPath,
                 originalReader,
                 originalMethod,
-                stream.ToArray(),
+                compilation.PeImage,
                 request.FullType,
                 request.MethodName,
                 overload: 0,
@@ -912,7 +911,8 @@ static class AuthoredRebuildFidelity
                     checksumVerification,
                     buildContext,
                     "The authored rebuild target could not be compared to shipped IL.",
-                    ImplementationDiff: null);
+                    ImplementationDiff: null,
+                    AuthoredAttempt: authoredAttempt);
             }
 
             return new AuthoredRebuildFidelityResult(
@@ -923,7 +923,8 @@ static class AuthoredRebuildFidelity
                 checksumVerification,
                 buildContext,
                 Detail: null,
-                implementationDiff);
+                implementationDiff,
+                authoredAttempt);
         }
         catch (Exception ex) when (ex is BadImageFormatException
             or InvalidOperationException
@@ -936,101 +937,21 @@ static class AuthoredRebuildFidelity
                 checksumVerification,
                 buildContext,
                 $"{ex.GetType().Name}: {ex.Message}",
-                ImplementationDiff: null);
+                ImplementationDiff: null,
+                AuthoredAttempt: authoredAttempt);
         }
     }
 
-    internal static AuthoredBuildContextAssessment AssessBuildContext(
-        bool isDeterministic,
-        FindingInspection<CompilationOptionInfo> options,
-        FindingInspection<CompilationReferenceInfo> references,
-        IEnumerable<MetadataReference> actualReferences)
-    {
-        ArgumentNullException.ThrowIfNull(options);
-        ArgumentNullException.ThrowIfNull(references);
-        ArgumentNullException.ThrowIfNull(actualReferences);
-
-        if (options.Value is FindingInspection<CompilationOptionInfo>.Failed optionFailure)
-        {
-            return new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Failed,
-                isDeterministic,
-                $"Compilation options: {optionFailure.Error.Reason}");
-        }
-        if (references.Value is FindingInspection<CompilationReferenceInfo>.Failed referenceFailure)
-        {
-            return new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Failed,
-                isDeterministic,
-                $"Compilation references: {referenceFailure.Error.Reason}");
-        }
-        if (options.Value is not FindingInspection<CompilationOptionInfo>.Complete optionComplete
-            || references.Value is not FindingInspection<CompilationReferenceInfo>.Complete referenceComplete
-            || optionComplete.Findings.IsEmpty
-            || referenceComplete.Findings.IsEmpty)
-        {
-            return new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Incomplete,
-                isDeterministic,
-                "Portable-PDB compilation options or references are incomplete.");
-        }
-
-        var drift = new List<string>();
-        var optionValues = optionComplete.Findings
-            .Select(finding => finding.Payload)
-            .ToDictionary(option => option.Name, option => option.Value, StringComparer.OrdinalIgnoreCase);
-        CheckOption(optionValues, "optimization", "release", drift);
-        CheckOption(optionValues, "unsafe", "true", drift, missingIsDrift: false);
-        CheckOption(optionValues, "language-version", "preview", drift, missingIsDrift: false);
-        CheckOption(
-            optionValues,
-            "compiler-version",
-            typeof(CSharpCompilation).Assembly
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                ?.InformationalVersion
-                ?? typeof(CSharpCompilation).Assembly.GetName().Version?.ToString()
-                ?? "unknown",
-            drift,
-            missingIsDrift: false);
-
-        var actualNames = actualReferences
-            .Select(reference => Path.GetFileName(reference.Display))
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var missingReferences = referenceComplete.Findings
-            .Select(finding => finding.Payload.Name)
-            .Select(Path.GetFileName)
-            .Where(name => !string.IsNullOrWhiteSpace(name))
-            .Where(name => !actualNames.Contains(name!))
-            .Take(3)
-            .ToArray();
-        if (missingReferences.Length > 0)
-            drift.Add($"references missing from RTS context: {string.Join(", ", missingReferences)}");
-
-        return drift.Count == 0
-            ? new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Recorded,
-                isDeterministic,
-                "Portable-PDB options and reference names agree with the RTS context.",
-                optionValues)
-            : new AuthoredBuildContextAssessment(
-                AuthoredBuildContextStatus.Drift,
-                isDeterministic,
-                string.Join("; ", drift),
-                optionValues);
-    }
-
-    static CSharpParseOptions ParseOptions(
-        IReadOnlyDictionary<string, string>? options)
+    static CSharpParseOptions ParseOptions(RecordedBuildContext context)
     {
         var languageVersion = LanguageVersion.Preview;
-        if (options?.TryGetValue("language-version", out string? language) == true
+        if (context.Option("language-version") is { } language
             && LanguageVersionFacts.TryParse(language, out var parsedLanguage))
         {
             languageVersion = parsedLanguage;
         }
 
-        var symbols = options?.TryGetValue("define", out string? define) == true
+        var symbols = context.Option("define") is { } define
             ? define.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             : [];
         return new CSharpParseOptions(
@@ -1038,14 +959,13 @@ static class AuthoredRebuildFidelity
             preprocessorSymbols: symbols);
     }
 
-    static CSharpCompilationOptions CompilationOptions(
-        IReadOnlyDictionary<string, string>? options)
+    static CSharpCompilationOptions CompilationOptions(RecordedBuildContext context)
     {
-        bool release = options?.TryGetValue("optimization", out string? optimization) != true
+        bool release = context.Option("optimization") is not { } optimization
             || string.Equals(optimization, "release", StringComparison.OrdinalIgnoreCase);
-        bool allowUnsafe = options?.TryGetValue("unsafe", out string? unsafeValue) != true
+        bool allowUnsafe = context.Option("unsafe") is not { } unsafeValue
             || bool.TryParse(unsafeValue, out bool parsedUnsafe) && parsedUnsafe;
-        bool checkOverflow = options?.TryGetValue("checked", out string? checkedValue) == true
+        bool checkOverflow = context.Option("checked") is { } checkedValue
             && bool.TryParse(checkedValue, out bool parsedChecked) && parsedChecked;
         return new CSharpCompilationOptions(
             OutputKind.DynamicallyLinkedLibrary,
@@ -1053,24 +973,6 @@ static class AuthoredRebuildFidelity
             nullableContextOptions: NullableContextOptions.Disable,
             allowUnsafe: allowUnsafe,
             checkOverflow: checkOverflow);
-    }
-
-    static void CheckOption(
-        IReadOnlyDictionary<string, string> options,
-        string name,
-        string expected,
-        ICollection<string> drift,
-        bool missingIsDrift = true)
-    {
-        if (!options.TryGetValue(name, out string? actual))
-        {
-            if (missingIsDrift)
-                drift.Add($"{name} is not recorded");
-            return;
-        }
-
-        if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
-            drift.Add($"{name}={actual} (RTS uses {expected})");
     }
 
     internal static async Task AcquirePdbAsync(
@@ -1153,42 +1055,83 @@ static class AuthoredRebuildFidelity
             or HttpRequestException
             or TaskCanceledException;
 
-    static void WriteReport(
+    internal static void WriteReport(
         IReadOnlyList<AuthoredRebuildFidelityResult> results,
-        int maxExamples)
+        int maxExamples,
+        TextWriter? output = null)
     {
-        Console.WriteLine($"AUTHORED-SOURCE REBUILD FIDELITY over {results.Count} target(s)");
-        Console.WriteLine();
+        ArgumentNullException.ThrowIfNull(results);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxExamples);
+        output ??= Console.Out;
+        var rows = results.Select(result => (
+            Result: result, Authored: result.AuthoredContext, Decompiled: result.DecompiledContext)).ToArray();
+        output.WriteLine($"AUTHORED-SOURCE REBUILD FIDELITY over {results.Count} target(s)");
+        output.WriteLine();
         foreach (AuthoredRebuildOutcome outcome in Enum.GetValues<AuthoredRebuildOutcome>())
-            Console.WriteLine($"  {outcome,-16}: {results.Count(result => result.Outcome == outcome)}");
-        Console.WriteLine();
-        Console.WriteLine("Build context:");
-        foreach (AuthoredBuildContextStatus status in Enum.GetValues<AuthoredBuildContextStatus>())
-            Console.WriteLine($"  {status,-16}: {results.Count(result => result.BuildContext.Status == status)}");
-        Console.WriteLine($"  {"Deterministic",-16}: {results.Count(result => result.BuildContext.IsDeterministic)}");
+            output.WriteLine($"  {outcome,-16}: {results.Count(result => result.Outcome == outcome)}");
+        output.WriteLine();
+        output.WriteLine("Decompiler outcomes:");
+        foreach (var group in results.GroupBy(result => result.DecompilerLane.Status).OrderBy(group => group.Key))
+            output.WriteLine($"  {group.Key,-16}: {group.Count()}");
+        WriteContextSummary("A (authored)", rows.Select(row => row.Authored));
+        WriteContextSummary("B (decompiled)", rows.Select(row => row.Decompiled));
+        output.WriteLine($"  {"Deterministic",-16}: {results.Count(result => result.BuildContext.IsDeterministic == true)}");
+        output.WriteLine($"  {"Determinism unknown",-16}: {results.Count(result => result.BuildContext.IsDeterministic is null)}");
 
-        var examples = results
-            .Where(result => result.Outcome != AuthoredRebuildOutcome.Exact
-                || result.BuildContext.Status != AuthoredBuildContextStatus.Recorded
-                || !result.BuildContext.IsDeterministic)
+        var examples = rows
+            .Where(row => row.Result.Outcome != AuthoredRebuildOutcome.Exact
+                || row.Result.DecompilerLane.Status != FidelityCheck.CompileBackStatus.Exact
+                || row.Authored.Status != AuthoredBuildContextStatus.Recorded
+                || row.Decompiled.Status != AuthoredBuildContextStatus.Recorded
+                || row.Result.BuildContext.IsDeterministic != true)
             .Take(maxExamples)
             .ToArray();
-        if (examples.Length == 0)
-            return;
 
-        Console.WriteLine();
-        Console.WriteLine("Examples:");
-        foreach (var result in examples)
+        output.WriteLine();
+        output.WriteLine($"Examples: {examples.Length} shown (limit {maxExamples}; all results retained)");
+        foreach (var row in examples)
         {
+            var result = row.Result;
             var target = result.DecompilerLane.Plan.TargetMethod;
-            Console.WriteLine($"  {target.Type}::{target.Method}");
-            Console.WriteLine($"    decompiled : {result.DecompilerLane.Status}");
-            Console.WriteLine($"    authored   : {result.Outcome}");
-            Console.WriteLine($"    checksum   : {result.ChecksumVerification?.ToString() ?? "unavailable"}");
-            Console.WriteLine($"    deterministic: {result.BuildContext.IsDeterministic}");
-            Console.WriteLine($"    context    : {result.BuildContext.Status} — {result.BuildContext.Detail}");
+            output.WriteLine($"  {Field(target.Type)}::{Field(target.Method)}");
+            output.WriteLine($"    decompiled : {result.DecompilerLane.Status}");
+            output.WriteLine($"    authored   : {result.Outcome} (comparison-only; normalized IL-body when available)");
+            output.WriteLine($"    checksum   : {result.ChecksumVerification?.ToString() ?? "unavailable"}");
+            output.WriteLine($"    deterministic: {result.BuildContext.IsDeterministic?.ToString() ?? "unavailable"}");
+            WriteContext("A", row.Authored, result.AuthoredAttempt);
+            WriteContext("B", row.Decompiled, result.DecompilerLane.CompilationAttempt);
             if (!string.IsNullOrWhiteSpace(result.Detail))
-                Console.WriteLine($"    detail     : {result.Detail}");
+                output.WriteLine($"    detail     : {Field(result.Detail)}");
+            if (!string.IsNullOrWhiteSpace(result.DecompilerLane.Detail))
+                output.WriteLine($"    decompiler detail: {Field(result.DecompilerLane.Detail)}");
         }
+
+        void WriteContextSummary(string label, IEnumerable<LaneBuildContext> contexts)
+        {
+            output.WriteLine();
+            output.WriteLine($"{label} build context (disclosed evidence only):");
+            foreach (AuthoredBuildContextStatus status in Enum.GetValues<AuthoredBuildContextStatus>())
+                output.WriteLine($"  {status,-16}: {contexts.Count(context => context.Status == status)}");
+        }
+
+        void WriteContext(string lane, LaneBuildContext context, RebuildCompilationAttempt? attempt)
+        {
+            output.WriteLine($"    {lane} context  : {context.Status}");
+            if (attempt is not null)
+                output.WriteLine($"      target: {Field(attempt.Target.ToString())}; owner artifact retained; artifact digest unavailable");
+            int agreeingReferences = context.Facts.Count(fact =>
+                fact.Dimension == "references" && fact.Status == BuildContextFactStatus.Agree);
+            if (agreeingReferences > 0)
+                output.WriteLine($"      references: {agreeingReferences} agree on MVID, aliases, kind, and embed-interop (not original bytes)");
+            foreach (var fact in context.Facts)
+            {
+                if (fact.Dimension == "references" && fact.Status == BuildContextFactStatus.Agree)
+                    continue;
+                output.WriteLine($"      {Field(fact.Dimension)}/{Field(fact.Name)}: {fact.Status}; "
+                    + $"recorded={Field(fact.Recorded)}; effective={Field(fact.Effective)}; {Field(fact.Detail)}");
+            }
+        }
+
+        static InertString Field(string? value) => new(TextPolicy.Field, value ?? "unavailable");
     }
 }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -320,12 +320,20 @@ reports deterministic-build and portable-PDB option/reference context
 separately. `SourceAbsent` is missing evidence; `SourceFailed` is an acquisition
 or integrity failure.
 
-The current context assessment is an aggregate comparison of recorded options
-and reference names against RTS context, not proof of a reproduced build.
-The planned [lane-specific rebuild-context
+The [lane-specific rebuild-context
 contract](../../docs/design/fact-planned-compile-back-harness.md#authored-source-rebuild-fidelity)
-tracks separate recorded-versus-effective evidence for each compilation;
-that expanded reporting is not implemented yet.
+reports separate recorded-versus-effective evidence from each actual
+compilation. Compiler/options, reference identity, generator context, and
+project context distinguish agreement, difference, unknown evidence, and
+inspection failure. A source failure cannot borrow B's context for an A
+compilation that never ran. Omitted PDB options stay unknown, and independently
+available option records are retained even when reference metadata is missing.
+This is not proof of a reproduced build: normalized authored IL exactness,
+checksum agreement, and determinism remain independent observations.
+
+The text report counts both lanes independently and limits examples, not
+retained evidence. `AuthoredBuildContextTests` gates these outcomes in Release,
+including actual local-source acquisition and the bounded text projection.
 
 ### Authored-source correspondence corpus (offline benchmark)
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -111,6 +111,7 @@ static class ReturnToSender
         [JsonIgnore]
         public byte[]? DonorPe { get; init; }
         internal ArtifactRequest? FinalRequest { get; init; }
+        internal RebuildCompilationAttempt? CompilationAttempt { get; init; }
     }
 
     public sealed record RequestedTarget(string Type, string Method, int Overload, string? Signature = null);
@@ -984,6 +985,7 @@ static class ReturnToSender
             RecompiledOpcodes = floor.RecompiledOpcodes,
             Detail = floorDetail,
             CompileBackFloor = floor,
+            CompilationAttempt = null,
             FidelityDiff = floor.FidelityDiff,
             FaultIsolation = null,
             SupersededFaultIsolation = result.FaultIsolation,
@@ -1749,6 +1751,10 @@ static class ReturnToSender
         var sourceResult = compilationResult.Artifact;
         var plan = sourceResult.Plan;
         string unit = sourceResult.Source;
+        var compilationAttempt = compilationResult.Status == RoundTripCompilationStatus.IterationBudget
+            ? null
+            : RebuildCompilationAttempt.Capture(
+                sourceResult, parseOptions, compileOptions, compilationResult.Provenance, references);
         if (!compilationResult.Succeeded || compilationResult.PeImage is null)
         {
             if (identityFailure is { } identityDiagnostic)
@@ -1766,6 +1772,7 @@ static class ReturnToSender
                 {
                     FinalRequest = sourceResult.Request,
                     Compilation = compilationResult.Provenance,
+                    CompilationAttempt = compilationAttempt,
                     BodyPolicy = bodyPolicy,
                     FullBodies = sourceResult.FullBodies,
                 };
@@ -1804,6 +1811,7 @@ static class ReturnToSender
             {
                 FinalRequest = sourceResult.Request,
                 Compilation = compilationResult.Provenance,
+                CompilationAttempt = compilationAttempt,
                 BodyPolicy = bodyPolicy,
                 FullBodies = sourceResult.FullBodies,
             };
@@ -1843,6 +1851,7 @@ static class ReturnToSender
             {
                 FinalRequest = sourceResult.Request,
                 Compilation = compilationResult.Provenance,
+                CompilationAttempt = compilationAttempt,
                 DonorPe = recompiledBytes,
                 BodyPolicy = bodyPolicy,
                 FullBodies = sourceResult.FullBodies,
@@ -1891,6 +1900,7 @@ static class ReturnToSender
         {
             FinalRequest = sourceResult.Request,
             Compilation = compilationResult.Provenance,
+            CompilationAttempt = compilationAttempt,
             DonorPe = recompiledBytes,
             BodyPolicy = bodyPolicy,
             FullBodies = sourceResult.FullBodies,


### PR DESCRIPTION
## Summary

Make authored-source and decompiler evidence independently useful: the existing
rebuild-fidelity report now explains each actual compilation context instead of
assessing both lanes against assumed RTS defaults.

**Step 2 of 2** under #5851 and end-to-end tracker #2673, following design #5852.
Fixes #5851.

The old unqualified projection is replaced, not retained beside another oracle.
Compiler/options, reference identity, and unavailable generator/project evidence
remain separate from both IL verdicts and checksum/determinism observations.

## Demo

Pinned input: Markout **0.36.0**, SHA-256
`81c28ec7db5c6ab6e36c24320255712c7ff6017d1255eb58f57e4cacafb1d64f`.
The package's first three accessor sources are checksum-matching but remain
unsupported by body extraction. That limitation is unchanged.

```bash
dotnet run --project tools/DecompilerHarness -c Release -- \
  --authored-rebuild-fidelity --cap 3 \
  tools/DecompilerHarness/bin/Release/net11.0/Markout.dll
```

Before, for `Markout.MarkoutBoolFormatAttribute::get_TrueValue` (excerpt):

```text
    decompiled : Exact
    authored   : SourceFailed
    checksum   : Exact
    deterministic: True
    context    : Drift — language-version=14.0 (RTS uses preview); compiler-version=5.9.0-1.26379.115+14fbf8d5271c98133561eb55185fdb05b286f578 (RTS uses 5.6.0-2.26263.10+c0573ed0a7dc3e3b4d2e70da47f97cc51a35524f)
```

After (excerpt; both verdicts and the exit code remain unchanged):

```text
    decompiled : Exact
    authored   : SourceFailed (comparison-only; normalized IL-body when available)
    A context  : Incomplete
      options/language-version: Unknown; recorded=14.0; effective=unavailable; No effective compilation setting is retained.
    B context  : Drift
      options/language-version: Different; recorded=14.0; effective=preview; Comparison covers this recorded setting only.
```

**Notice:** an A compilation that never ran no longer borrows B's context.
Source failure remains visible, rather than being converted into success. Both
commands exit 1 because of the existing authored source failures.

The neighboring compiled fixture exercises the positive acquisition path:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- \
  --authored-rebuild-fidelity --cap 1 \
  artifacts/bin/ILInspector.Decompiler.Fixtures.AuthoredRebuild/release/ILInspector.Decompiler.Fixtures.AuthoredRebuild.dll
```

Actual output excerpt:

```text
  AuthoredRebuildFixtures.ContextSample::get_Value
    decompiled : OpcodeDiff
    authored   : IlDifferent (comparison-only; normalized IL-body when available)
    checksum   : Exact
    A context  : Drift
      options/optimization: Unknown; recorded=unavailable; effective=release; Original setting is not recorded.
      options/checked: Agree; recorded=True; effective=True; Comparison covers this recorded setting only.
    B context  : Drift
      options/optimization: Unknown; recorded=unavailable; effective=release; Original setting is not recorded.
      options/checked: Different; recorded=True; effective=False; Comparison covers this recorded setting only.
```

The compiler omits its default debug optimization from the PDB. That stays
unknown; the recorded checked-arithmetic setting is actually applied by A but
not B. Neither difference becomes causal attribution. The fixture invocation
exits 0 under the unchanged outcome-based exit policy.

A NuGet.Versioning **7.3.0** cap-5 neighboring probe encountered unavailable PDB
acquisition: A stayed `SourceFailed`, while B retained four `Exact` results and
one `OpcodeDiff`. It is acquisition-failure evidence, not a successful rebuild
claim or a live-network gate.

## Ownership and implementation

One normative owner:
`docs/design/fact-planned-compile-back-harness.md#authored-source-rebuild-fidelity`.

The harness captures actual parse/compilation settings, the product-produced
source artifact, typed shipped MethodDef address, and existing
`RoundTripCompilationEngine` frozen-reference provenance. The authored lane
uses that existing engine for its single compilation attempt; no new shell
builder, equivalence algorithm, reference-file reopening, or receipt is added.
Iteration-budget artifacts that never compiled have unavailable context, and
compile-back-floor replacement clears the preceding RTS attempt.

PDB Finding inspections remain owner-issued input. The independent option
inventory is now usable even when the reference-metadata inspection fails;
the failure remains visible and A still uses the retained RTS closure.
Reference comparison covers MVID, aliases, image kind, and embed-interop flags;
filename matching only selects candidates and does not establish agreement.
Missing or unsupported values remain unknown.

Typed facts feed the existing bounded text renderer. Agreeing reference facts
can be summarized; all facts remain retained. Expanded field text is rendered
through `InertString`. The harness is the production host for this test
infrastructure; CLI/browser product paths are unchanged.

## Boundaries and compatibility

There is no original project/compiler/generator replay, semantic-equivalence or
whole-binary claim, source-provenance certification, or causal fault attribution.
#4931's owner-issued replacement-artifact digest remains unavailable and is
reported as such. Embedded-source retrieval is an existing adjacent limitation,
not implemented to accommodate this fixture; the end-to-end gate uses the
supported checksum-verified local-source path.

The counted adoption path is complete in this PR: design (#5852), then this
existing-harness adoption. There is no alternative architecture to retire.
The command's outcome-based exit policy and both comparison verdicts remain
independent; context reporting intentionally changes.

## Validation

SDK: worktree-local `11.0.100-preview.7.26381.103`; central installation and PATH
unchanged.

- **89 passed:** authored context, existing authored acquisition/rebuild, and
  compile-back-floor outcome coverage.
- **3 passed:** fixture ID, explicit project-directory, and group registration.
- Release harness build and the real invocations above.
- Changed Markdown passes `markdownlint`; `git diff --check` is clean.

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class '*AuthoredBuildContextTests' \
  -class '*AuthoredRebuildFidelityTests' \
  -class '*CompileBackFloorFaultIsolationTests'
```

The new fixture is in the solution and catalog, with its unoptimized/checked
compiler boundary and source sidecar. Outcome gates include explicit debug
options, exact A with unknown context, same-filename MVID neighbors, independent
failure/difference outcomes, replacement freshness, actual local acquisition,
and both lanes under the example cap.
