### PR TITLE
Remove Query and Workspace buttons from the package query page

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -113,8 +113,8 @@ terminal-deficit states inside the remaining page boundary.
 The application-scope strip uses a distinct quiet treatment and may be removed
 at constrained widths only after focus has left it. Query remains reachable
 through Spotlight's global keyboard entry and Workspace through hierarchical
-drill-out or a return action. On `/query`, the visible heading and
-route-specific Back action continue to orient the surface if the strip yields.
+drill-out or a return action. The standalone `/query` surface does not render
+this strip; its visible heading and route-specific Back action orient it.
 
 The subject and inspector region has `min-width: 0`. Its preferred allocation
 is large enough to expose complete common inventories, but exact pixel
@@ -418,6 +418,11 @@ initial prefix, and requests this route. [Inspect Web Navigation
 Consumer](inspect-web-navigation-consumer.md#package-query-entry-and-return)
 owns this route's browser-history entry and return-focus behavior, including
 its visible `Back` action.
+
+The page header contains the product home link and `Back`, not the
+`Query`/`Workspace` application-scope buttons. This placement is independent of
+viewport width and whether a workspace is retained in the session; the
+workspace shell keeps its application-scope strip.
 
 The route renders one visible level-one `Package query` heading followed by an
 editable `Package ID prefix` input and `Run query` action.

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -2027,7 +2027,7 @@ test("application scope rerenders preserve focus until responsive yielding", asy
   await expect(page.locator(".brand")).toBeFocused();
 });
 
-test("query rerenders preserve product focus and reject yielded scopes", async ({
+test("query header omits scope buttons and preserves navigation focus across widths", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 700, height: 900 });
@@ -2041,11 +2041,13 @@ test("query rerenders preserve product focus and reject yielded scopes", async (
     app.innerHTML = renderPackageQueryView({
       state: initialQueryState(),
       availableFacets: [],
-      workspaceAvailable: true,
       escapeHtml: value => String(value),
     });
   });
 
+  await expect(page.getByRole("button", { name: "Query", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Workspace", exact: true })).toHaveCount(0);
+  await expect(page.locator("#package-query-back")).toBeVisible();
   await page.locator("#package-query-product").focus();
   const productResult = await page.evaluate(async () => {
     const { initialQueryState } = await import("../src/package-query.ts");
@@ -2060,7 +2062,6 @@ test("query rerenders preserve product focus and reject yielded scopes", async (
     app.innerHTML = renderPackageQueryView({
       state: initialQueryState(),
       availableFacets: [],
-      workspaceAvailable: true,
       escapeHtml: value => String(value),
     });
     return {
@@ -2073,11 +2074,11 @@ test("query rerenders preserve product focus and reject yielded scopes", async (
     activeId: "package-query-product",
   });
 
-  const workspace = page.locator("[data-application-scope='workspace']");
-  await workspace.focus();
+  const back = page.locator("#package-query-back");
+  await back.focus();
   await page.setViewportSize({ width: 500, height: 900 });
-  await expect(workspace).toBeVisible();
-  const yieldedResult = await page.evaluate(async () => {
+  await expect(back).toBeVisible();
+  const backResult = await page.evaluate(async () => {
     const { initialQueryState } = await import("../src/package-query.ts");
     const {
       capturePackageQueryFocus,
@@ -2090,7 +2091,6 @@ test("query rerenders preserve product focus and reject yielded scopes", async (
     app.innerHTML = renderPackageQueryView({
       state: initialQueryState(),
       availableFacets: [],
-      workspaceAvailable: true,
       escapeHtml: value => String(value),
     });
     return {
@@ -2098,12 +2098,13 @@ test("query rerenders preserve product focus and reject yielded scopes", async (
       activeId: document.activeElement?.id,
     };
   });
-  expect(yieldedResult).toEqual({
-    restoration: "fallback",
-    activeId: "package-query-prefix",
+  expect(backResult).toEqual({
+    restoration: "restored",
+    activeId: "package-query-back",
   });
-  await expect(page.locator(".query-page-bar .application-scope-region"))
-    .toBeHidden();
+  await expect(page.getByRole("button", { name: "Query", exact: true })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Workspace", exact: true })).toHaveCount(0);
+  await expect(page.locator("#package-query-product")).toBeVisible();
 });
 
 test("Workspace retains its full split height at constrained widths", async ({

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -249,7 +249,6 @@ import {
   renderScopeBar as renderScopeBarPure,
   restoreScopeBarFocus,
   scopeBarShortLabel,
-  type ApplicationScopeBarBinding,
   type ScopeBarBinding,
 } from "./scope-bar.ts";
 import {
@@ -962,7 +961,6 @@ type AppState = Omit<typeof initialState, keyof StateOverrides> & StateOverrides
 const state: AppState = initialState;
 const scopeBarState = createScopeBarState();
 let scopeBarBinding: ScopeBarBinding | null = null;
-let packageQueryScopeBinding: ApplicationScopeBarBinding | null = null;
 let workbenchShellBinding: WorkbenchShellBinding | null = null;
 type FailedWorkspaceUrlState = WorkspaceUrlPreservation & (
   | { kind: "canonical" }
@@ -3098,8 +3096,6 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   const levelOneHeadingHadFocus =
     focusedElement?.matches("main h1") === true;
   scopeBarBinding?.disconnect();
-  packageQueryScopeBinding?.disconnect();
-  packageQueryScopeBinding = null;
   workbenchShellBinding?.disconnect();
   workbenchShellBinding = null;
 
@@ -8744,17 +8740,10 @@ function openPackageQueryRoute(
   focusPackageQueryInput();
 }
 
-function selectWorkspaceApplicationScope(fromPackageQuery = false) {
+function selectWorkspaceApplicationScope() {
   const pkg = state.package;
   if (!pkg) return;
-  const navigationSeq = navigationSequence.begin();
-  if (fromPackageQuery) {
-    packageQueryController.cancel();
-    packageQueryHandoffNavigationSeq = null;
-    state.packageQueryOpen = false;
-    state.credits = false;
-    state.home = false;
-  }
+  navigationSequence.begin();
   state.workspaceSubjectOpen = true;
   state.atPackageRoot = true;
   state.selectedMemberKey = "";
@@ -8776,9 +8765,6 @@ function selectWorkspaceApplicationScope(fromPackageQuery = false) {
     appendQueryNotice(
       `Workspace opened, but its complete state could not be saved in the address bar: ${errorMessage(successor.projectionError)
         || "workspace URL encoding failed."}`);
-  }
-  if (fromPackageQuery) {
-    packageQueryWorkspaceFocusNavigationSeq = navigationSeq;
   }
   workspaceLocation.push(successor.url.toString());
   render();
@@ -8896,11 +8882,6 @@ async function openPackageQueryRow(
 }
 
 const packageQueryActions: PackageQueryBindingActions = {
-  onApplicationScopeSelect: applicationScope => {
-    if (applicationScope === "workspace") {
-      selectWorkspaceApplicationScope(true);
-    }
-  },
   onBack: closePackageQueryRoute,
   onCancel: () => packageQueryController.cancel(),
   onFacetToggle: togglePackageQueryFacet,
@@ -8933,11 +8914,9 @@ function renderPackageQueryPage() {
       state.packageQueryCatalogError,
       state.packageQueryNavigationError,
     ].filter(Boolean).join(" "),
-    workspaceAvailable: state.package !== null,
     escapeHtml,
   });
-  packageQueryScopeBinding =
-    bindPackageQueryView(document, packageQueryActions);
+  bindPackageQueryView(document, packageQueryActions);
   const focusRestoration = restorePackageQueryFocus(document, focus);
   if (focusRestoration !== "fallback") {
     restorePackageQueryScroll(document, scrollTop);

--- a/prototypes/inspect-web/src/package-query-view.ts
+++ b/prototypes/inspect-web/src/package-query-view.ts
@@ -4,15 +4,9 @@ import type {
   QueryResultRow,
 } from "./package-query.ts";
 import { renderBrand } from "./brand.ts";
-import {
-  bindApplicationScopeBar,
-  focusRenderedElement,
-  renderApplicationScopeBar,
-  type ApplicationScope,
-} from "./scope-bar.ts";
+import { focusRenderedElement } from "./scope-bar.ts";
 
 export interface PackageQueryBindingActions {
-  onApplicationScopeSelect: (scope: ApplicationScope) => void;
   onBack: () => void;
   onCancel: () => void;
   onFacetToggle: (facetKey: string, prefix: string) => void;
@@ -27,7 +21,6 @@ export type PackageQueryFocusSnapshot =
       selectionStart: number | null;
       selectionEnd: number | null;
     }
-  | { kind: "application-scope"; value: ApplicationScope }
   | { kind: "product" }
   | { kind: "back" }
   | { kind: "run" }
@@ -75,10 +68,6 @@ export function capturePackageQueryFocus(
         : null,
     };
   }
-  const applicationScope = active.dataset.applicationScope;
-  if (applicationScope === "query" || applicationScope === "workspace") {
-    return { kind: "application-scope", value: applicationScope };
-  }
   if (active.id === "package-query-product") return { kind: "product" };
   if (active.id === "package-query-back") return { kind: "back" };
   if (active.id === "package-query-run") return { kind: "run" };
@@ -110,12 +99,6 @@ export function restorePackageQueryFocus(
   switch (snapshot.kind) {
     case "prefix":
       target = root.querySelector("#package-query-prefix");
-      break;
-    case "application-scope":
-      target = [...root.querySelectorAll<HTMLElement>(
-        "[data-application-scope]")]
-        .find(element =>
-          element.dataset.applicationScope === snapshot.value) ?? null;
       break;
     case "product":
       target = root.querySelector("#package-query-product");
@@ -182,13 +165,6 @@ export function bindPackageQueryView(
 ) {
   const prefixInput = () =>
     root.querySelector<HTMLInputElement>("#package-query-prefix");
-  const applicationBinding = bindApplicationScopeBar(root, {
-    onApplicationScopeSelect: actions.onApplicationScopeSelect,
-    onFocusedControlUnavailable: () => {
-      focusRenderedElement(prefixInput(), { preventScroll: true });
-    },
-  });
-
   root.querySelector("#package-query-back")
     ?.addEventListener("click", actions.onBack);
   root.querySelector<HTMLFormElement>("#package-query-form")
@@ -210,7 +186,6 @@ export function bindPackageQueryView(
       prefixInput()?.value ?? "")));
   root.querySelectorAll<HTMLElement>("[data-query-cancel]").forEach(button =>
     button.addEventListener("click", actions.onCancel));
-  return applicationBinding;
 }
 
 function renderRow(
@@ -400,7 +375,6 @@ export interface RenderPackageQueryOptions {
   prefix?: string;
   availableFacets: readonly QueryFacetTerm[];
   navigationError?: string;
-  workspaceAvailable?: boolean;
   escapeHtml: (value: unknown) => string;
 }
 
@@ -412,7 +386,6 @@ export function renderPackageQueryView(
     prefix = state.request?.scopeQuery ?? "",
     availableFacets,
     navigationError = "",
-    workspaceAvailable = false,
     escapeHtml,
   } = options;
   const activeKeys = new Set(state.request?.facets.map(facet => facet.key) ?? []);
@@ -440,12 +413,6 @@ export function renderPackageQueryView(
       <header class="query-page-bar">
         ${renderBrand({ id: "package-query-product" })}
         <div class="query-page-navigation">
-          <div class="application-scope-region">
-            ${renderApplicationScopeBar(
-              "query",
-              workspaceAvailable,
-              escapeHtml)}
-          </div>
           <button id="package-query-back" type="button">Back</button>
         </div>
       </header>

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -2662,9 +2662,6 @@ kbd {
   gap: 8px;
   padding-right: 12px;
 }
-.query-page-navigation .application-scope-region {
-  flex-basis: auto;
-}
 .query-page-bar button,
 .query-bar button,
 .query-row-meta button,
@@ -2956,13 +2953,6 @@ kbd {
     --application-scope-yield: 1;
   }
   .titlebar > .application-scope-region:not(:focus-within) { display: none; }
-}
-
-@media (max-width: 560px) {
-  .query-page-bar .application-scope-region {
-    --application-scope-yield: 1;
-  }
-  .query-page-bar .application-scope-region:not(:focus-within) { display: none; }
 }
 
 /* Light mode: code surfaces are light, so re-tint the syntax tokens and copy

--- a/prototypes/inspect-web/test/package-query-view.test.ts
+++ b/prototypes/inspect-web/test/package-query-view.test.ts
@@ -91,17 +91,15 @@ test("an unstarted query renders the composing empty state", () => {
   assert.match(html, /Query nuget\.org/);
 });
 
-test("the persistent application scopes distinguish Query from Workspace", () => {
+test("the query header keeps home and Back without Query or Workspace buttons", () => {
   const html = renderPackageQueryView({
     state: initialQueryState(),
     availableFacets: FACETS,
-    workspaceAvailable: true,
     escapeHtml,
   });
 
-  assert.match(
-    html,
-    /data-application-scope="query"[^>]*aria-current="page"[\s\S]*data-application-scope="workspace"(?![^>]*aria-current)/);
+  assert.doesNotMatch(html, /application-scope/);
+  assert.match(html, /id="package-query-back" type="button">Back<\/button>/);
   assert.match(
     html,
     /id="package-query-product" class="brand" href="\/" aria-label="dotnet inspect home"/);
@@ -135,6 +133,8 @@ test("a streaming result renders rows, product facets, and the streaming footer"
   assert.match(html, /1M\+ downloads/);
   assert.match(html, /streaming…/);
   assert.match(html, /data-query-cancel="1"/);
+  assert.match(html, />Open in workspace<\/button>/);
+  assert.doesNotMatch(html, /application-scope/);
   assert.doesNotMatch(html, /Deepen|data-query-row-select/);
   assert.doesNotMatch(html, /class="query-footer" role="status"/);
 });
@@ -532,11 +532,6 @@ test("query focus snapshots restore semantic controls after a full render", () =
       replacement: new FakeElement({}, "package-query-run"),
     },
     {
-      active: new FakeElement({ applicationScope: "workspace" }),
-      selector: "[data-application-scope]",
-      replacement: new FakeElement({ applicationScope: "workspace" }),
-    },
-    {
       active: new FakeElement({}, "package-query-product"),
       selector: "#package-query-product",
       replacement: new FakeElement({}, "package-query-product"),
@@ -635,13 +630,13 @@ test("a vanished query control reports prefix fallback", () => {
   }
 });
 
-test("a CSS-hidden application scope reports prefix fallback", () => {
-  const active = new FakeElement({ applicationScope: "workspace" });
-  const replacement = new FakeElement({ applicationScope: "workspace" });
+test("a CSS-hidden query control reports prefix fallback", () => {
+  const active = new FakeElement({}, "package-query-back");
+  const replacement = new FakeElement({}, "package-query-back");
   replacement.rendered = false;
   const prefix = new FakeElement({}, "package-query-prefix");
   const root = new FakeRoot(active);
-  root.add("[data-application-scope]", replacement);
+  root.add("#package-query-back", replacement);
   root.add("#package-query-prefix", prefix);
   // Test fake implements the Document and ParentNode subset consumed by the helpers.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
@@ -693,17 +688,12 @@ test("query prefix focus preserves its selection across a full render", () => {
 test("bindPackageQueryView wires back, row-open, facet, and cancel", () => {
   const root = new FakeRoot();
   const [back] = root.add("#package-query-back", new FakeElement());
-  const [workspace] = root.add(
-    "[data-application-scope]",
-    new FakeElement({ applicationScope: "workspace" }));
   const [open] = root.add("[data-query-row-open]", new FakeElement({ queryRowOpen: "A", queryRowVersion: "1.0.0" }));
   const [facet] = root.add("[data-query-facet]", new FakeElement({ queryFacet: "tfm-out-of-support" }));
   const [cancel] = root.add("[data-query-cancel]", new FakeElement());
 
   const calls: string[] = [];
   const actions: PackageQueryBindingActions = {
-    onApplicationScopeSelect: scope =>
-      calls.push(`application:${scope}`),
     onBack: () => calls.push("back"),
     onCancel: () => calls.push("cancel"),
     onFacetToggle: key => calls.push(`facet:${key}`),
@@ -714,14 +704,12 @@ test("bindPackageQueryView wires back, row-open, facet, and cancel", () => {
 
   bindPackageQueryView(fakeDom.parentNode(root), actions);
 
-  workspace?.dispatch("click");
   back?.dispatch("click");
   open?.dispatch("click");
   facet?.dispatch("click");
   cancel?.dispatch("click");
 
   assert.deepEqual(calls, [
-    "application:workspace",
     "back",
     "open:A:1.0.0",
     "facet:tfm-out-of-support",

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3317,16 +3317,13 @@ test("Package query is a routed Spotlight action with typed workspace handoff", 
     /id="package-query-announcement"[\s\S]*class="query-announcement"[\s\S]*role="alert"[\s\S]*aria-live="assertive"[\s\S]*aria-atomic="true"/);
   assert.match(
     appSource,
-    /workspaceAvailable: state\.package !== null/);
-  assert.match(
-    appSource,
     /renderApplicationScopeBar\(\s*activeScope === "workspace" \? "workspace" : null,\s*true,\s*escapeHtml\)/);
   assert.match(
     appSource,
     /openPackageQueryRoute\("", \{\s*preserveState: true,\s*returnFocus: "application-query"/);
   assert.match(
     appSource,
-    /function selectWorkspaceApplicationScope\(fromPackageQuery = false\) \{\s*const pkg = state\.package;\s*if \(!pkg\) return;\s*const navigationSeq = navigationSequence\.begin\(\);[\s\S]*resolvePackageQueryWorkspaceSuccessor\(\s*\(\) => buildStateUrl\(\),[\s\S]*fallback\.hash = "workspace";[\s\S]*appendQueryNotice\([\s\S]*complete state could not be saved in the address bar[\s\S]*if \(fromPackageQuery\) \{\s*packageQueryWorkspaceFocusNavigationSeq = navigationSeq;\s*\}\s*workspaceLocation\.push\(successor\.url\.toString\(\)\);\s*render\(\)/);
+    /function selectWorkspaceApplicationScope\(\) \{\s*const pkg = state\.package;\s*if \(!pkg\) return;\s*navigationSequence\.begin\(\);[\s\S]*resolvePackageQueryWorkspaceSuccessor\(\s*\(\) => buildStateUrl\(\),[\s\S]*fallback\.hash = "workspace";[\s\S]*appendQueryNotice\([\s\S]*complete state could not be saved in the address bar[\s\S]*workspaceLocation\.push\(successor\.url\.toString\(\)\);\s*render\(\)/);
   assert.match(
     appSource,
     /onApplicationScopeSelect: applicationScope => \{[\s\S]*applicationScope === "query"[\s\S]*else if \(scope\(\) !== "workspace"\) \{\s*selectWorkspaceApplicationScope\(\)/);


### PR DESCRIPTION
Keep Package query focused on package discovery, with less persistent navigation chrome.

Removes the Query/Workspace buttons from the standalone `/query` page at every viewport width. Home, Back, Run query, facets, cancellation, and per-result Open in workspace remain. The workspace shell retains its scope strip. Also removes the now-unused page-specific binding, focus, and responsive-style plumbing.

Normative owner: `docs/design/inspect-web-surface-composition.md`, Package query placement. The header consists of the product home link and Back, independent of retained workspace state.

## Demo

Open `/query`:

```text
Before: [dotnet inspect]                      [Query] [Workspace] [Back]
After:  [dotnet inspect]                                          [Back]
```

The Firefox renderer scenario confirms the buttons are absent at 700px and 500px, with home and Back visible and their focus preserved across rerenders. A streaming result still offers Open in workspace; ordinary workspace scope rendering is unchanged.

## Validation

- `npm run typecheck`
- `node --test test/package-query-view.test.ts test/package-query-route.test.ts test/spotlight-identity.test.ts test/scope-bar.test.ts` — 239 passed.
- `CI=1 npm run test:browser -- browser/workspace-titlebar.spec.ts --grep "query header omits scope buttons"` — passed in Firefox.
- `npx --no-install markdownlint-cli docs/design/inspect-web-surface-composition.md`

## Review tier

Trivial: a page-local removal of two unwanted controls and their exclusively associated wiring, with no new algorithm, data contract, or change to remaining navigation behavior. No adversarial review required under the repository trivial-change tier.

Candidate: head `c62e64bc9`; effective base `0a436273d274ac5b8ca73522a82be3bd25fa9a76`. Not merged or deployed.