### PR TITLE
Specify local repository source acquisition

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Signals](assembly-audit.md) | Understanding Signals output and network scope flags. |
 | [SourceLink Exposure](sourcelink-exposure.md) | Where SourceLink appears in package/library/type/member flows and how PDB/network costs are controlled. |
 | [PDB Acquisition](pdb-acquisition.md) | How symbols and SourceLink are resolved. |
+| [Local Repository Source Acquisition](design/local-repository-source-acquisition.md) | When caller-supplied Git clones may provide checksum-verified PDB source; local locator meaning, decline/fallback, and execution limits. |
 | [Sample References](sample-references.md) | Extracting code samples from XML docs. |
 | [Reading IR Dumps](decompiler-ir-dumps.md) | How maintainers read DecompilerHarness per-pass IR dumps to diagnose decompiled output. |
 | [Decompiler Correctness Pipeline](decompiler-correctness-pipeline.md) | The staged gauntlet of decompiler checks, from entry gates to changed-method fidelity. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,11 @@ alphabetically.
 | `DotnetInspector.Packages` | Package adapter | Package archives, package/source caches, extraction, and version acquisition. | [Version resolution](design/version-resolution.md) |
 | `DotnetInspector.Services` | Shared services | Reusable acquisition and resolution services over explicit host policy. | The focused acquisition, package, platform, PDB, and source designs |
 
+Within Services, `LocalRepoSourceAcquisition` owns [local repository source
+acquisition](design/local-repository-source-acquisition.md): checksum-backed
+substitution of Git blob bytes for one PDB source request. PDB acquisition
+retains the surrounding source-selection and fallback policy.
+
 The artifact floor is intentionally package- and Metadata-free. Its contracts,
 local adapter, and workspace session are implemented migration foundations, not
 the universal CLI acquisition path. The current package-free fixture consumes

--- a/docs/design/local-repository-source-acquisition.md
+++ b/docs/design/local-repository-source-acquisition.md
@@ -1,0 +1,211 @@
+# Local repository source acquisition
+
+This document specifies the existing `LocalRepoSourceAcquisition` adapter.
+[Issue #5880](https://github.com/richlander/dotnet-inspect/issues/5880) tracks
+the contract and its consumer documentation. It does not introduce a new
+source-acquisition path or change product behavior.
+
+## Decision
+
+`LocalRepoSourceAcquisition` owns one claim:
+
+> A caller-supplied Git clone may satisfy one PDB document request only with
+> bytes accepted by that document's checksum verifier; an unsuccessful local
+> lookup declines the request so acquisition can continue.
+
+The result establishes correspondence with the supplied PDB, not independent
+authenticity of the PDB, package publisher, GitHub repository, or local clone.
+A successful local lookup is not an immutable-URL certificate.
+
+## Owner and boundaries
+
+The adapter consumes a resolved source locator, the checksum for the same PDB
+document, and an ordered list of caller-supplied clone paths. Its result is
+either the verified blob bytes or no local result (`null`). It does not return
+an absence Finding or a source-provenance receipt.
+
+| Supporting owner | Role in this contract |
+| --- | --- |
+| [PDB acquisition](../pdb-acquisition.md) | Owns acquisition ordering, PDB-recorded local-file reads, source decoding/slicing, and remote outcome interpretation. |
+| `PdbSourceAcquisition.VerifyChecksum` | Supplies the checksum-verification classification consumed by this adapter. |
+| Metadata and SourceLink | Supply document/checksum observations and resolved source locators. |
+| SourceLink provenance and the host source fetcher | Own immutable-origin classification and remote destination admission; local lookup does not replace either. |
+| CLI | Accepts explicit clone paths and presents the acquired source through existing views. |
+
+The resolved locator and checksum must describe the same document. A caller
+must not substitute another document's checksum or infer it from display text.
+This is a consumed association, not a new PDB selection or identity contract.
+
+### Existing consumer and host scope
+
+The production consumer is already shipped. Desktop `--repo` supplies clone
+paths to member PDB Source, printable type Source Files, printable member
+Source Locations, and implementation-diff PDB source. Reusable service paths
+reach the adapter through `PdbSourceAcquisition`; the CLI implementation-diff
+source resolver also invokes it directly.
+
+This preserves the host split owned by [PDB acquisition](../pdb-acquisition.md):
+desktop hosts can supply fully qualified filesystem clone paths; Browser/Wasm
+hosts do not supply those paths and use their host-authorized source fetcher.
+Git must be available for a local clone to answer. Its absence declines this
+optional lookup rather than making a clone capability available in a browser.
+
+The tracker has one documentation delivery step and zero remaining production
+adoption steps. There is no replacement architecture to retire. The result is
+bytes, not a new presentation model; existing source views retain rendering
+ownership.
+
+## Local locator, not origin authority
+
+Local lookup recognizes the raw-GitHub path convention:
+`https://raw.githubusercontent.com/<owner>/<repo>/<revision>/<path>`.
+Its supported interpretation is narrower than Git's general revision language
+and different from remote URL authorization:
+
+- The URI is absolute and its host is `raw.githubusercontent.com`, compared
+  without regard to case.
+- The revision selector is 7-64 hexadecimal characters. Git must be able to
+  use it to resolve the requested blob in a supplied clone.
+- The repository-relative path is URI-unescaped, nonempty, NUL-free, and does
+  not begin with a hyphen. It is an object-store path, not a request to open
+  that path in the working tree.
+- The owner and repository segments locate the revision/path fields; they
+  do not authenticate the clone's remotes.
+
+The adapter does not separately restrict URI scheme, port, user information,
+query, or fragment. Those components neither select a local clone nor supply
+credentials to Git. The HTTPS spelling above is the normal producer form, not
+an HTTPS-only admission claim. A later remote attempt must still pass the
+remote owner's policy independently.
+
+Accepting abbreviated hexadecimal selectors is deliberate: Git's local
+object database resolves them, while the PDB checksum decides whether the
+returned content qualifies. Resolution can fail or differ between clones.
+The adapter does not certify that a selector is a full commit ID, that the
+selected object has commit type, or that it is globally unambiguous.
+
+This differs from immutable SourceLink enrollment/provenance: a locally usable
+selector plus verified bytes is sufficient for this immediate source request,
+but not for cross-run URL-only identity. Requiring clone remote-name equality
+would add no independent byte evidence and would reject useful mirrors.
+
+## Byte admission
+
+Each candidate clone must be a caller-supplied, fully qualified directory.
+Relative paths, unavailable directories, and unusable repositories decline
+that candidate. Candidates are tried in caller order; the first verified blob
+wins. A clone that lacks the selector or path cannot prevent a later clone
+from answering.
+
+The source is the Git blob addressed by the locator, not the current checkout
+of that file. The clone's checked-out branch and uncommitted source edits are
+not substitutes for the requested blob. Content conversion belongs to the
+source consumer, not this adapter.
+
+A blob is admitted only when the shared PDB checksum verifier reports
+`Exact` or `LineEndingNormalized`. Missing or unusable checksum evidence,
+unsupported algorithms, and mismatches do not admit bytes. The verifier owns
+algorithm support and normalization rules; this document does not define a
+second hashing or normalization algorithm.
+
+The adapter returns the original blob bytes, including when normalization was
+needed to establish correspondence. It does not rewrite the blob into the
+PDB's line-ending form. Consumers that disclose verification status use the
+shared verifier's classification rather than calling every accepted result an
+exact byte match.
+
+## Decline and fallback
+
+The result has two meanings:
+
+| Local outcome | What the consumer may conclude |
+| --- | --- |
+| Verified bytes | This blob satisfies the supplied PDB document's checksum policy and can be passed to source interpretation. |
+| `null` | This lookup did not supply verified bytes. Other configured acquisition routes may still answer. |
+
+Malformed or unsupported locators, unavailable Git, missing objects, failed
+reads, unsuccessful Git exit, rejected blob size, process-wait timeout, and
+checksum rejection all yield no local result for their attempted candidate.
+There is no detailed per-clone diagnostic in this adapter's result.
+
+That deliberate probe contract does not turn failure into successful empty
+source. Nor does it prove that a document is absent, that a remote request
+would fail, or that another clone is unusable. Even a zero-length blob must
+pass the supplied checksum policy before it can be a successful byte result.
+Local misses do not authorize negative caching.
+
+PDB acquisition owns what happens after all clones decline. Its remote
+absence/failure distinction is unchanged; a local miss cannot convert a
+remote transport or checksum failure into authoritative absence.
+
+## Execution profile and its limits
+
+The adapter uses Git's raw object-content operation,
+`git cat-file blob <revision>:<path>`, with separate process arguments. The
+source locator is not a shell command. The existing invocation requests
+noninteractive operation and disables optional Git locks.
+
+The current per-candidate controls are a **64-MiB blob acceptance cap** and a
+**15-second wait for the Git process**. Oversized output and process-wait
+expiry decline the candidate and request process-tree termination.
+Termination is best effort.
+
+These controls are not an end-to-end deadline or a complete resource budget.
+Process startup, redirected-stream draining, checksum work, and later
+candidates are not covered by one shared deadline. The blob cap is not a
+process-wide allocation limit or a bound on standard error. The synchronous
+adapter does not consume the acquisition caller's cancellation token.
+Deterministic timeout, overflow, and teardown coverage is **unverified**.
+
+Git's executable, environment, configuration, and object-store behavior remain
+part of the caller's local tool environment. This contract does not promise
+isolation from that environment, enforce Git-wide network policy, or certify
+quiescence of all subprocesses. It does not broaden the repository threat
+model to local users, mutable checkouts, symlinks, or hostile Git configuration.
+
+## Convention and comparative evidence
+
+[Git 2.51.0 `cat-file`](https://git-scm.com/docs/git-cat-file/2.51.0) distinguishes
+raw object content from explicit `--filters` and `--textconv` conversion.
+This adapter uses the raw-content convention rather than recreating a checkout
+or borrowing working-tree conversion semantics. Git's object lookup supplies
+the candidate bytes, not their correspondence with a Portable PDB.
+
+The adjacent remote path in `PdbSourceAcquisition` likewise gates fetched bytes
+through the shared verifier. Local lookup reuses that policy instead of
+inventing weaker checksum admission. Its deliberately different locator
+admission is justified by the distinction between a local content probe and a
+network destination or immutable-origin claim.
+
+These are supporting comparisons, not additional normative owners. No external
+code or architecture is transferred by this specification.
+
+## Evidence
+
+The following existing Release tests cover the named observations. They are
+not a claim that every parser or process edge case is gated.
+`LocalRepoSourceReadTests` skips its real-Git cases when Git is unavailable;
+a skipped case supplies no execution evidence.
+
+| Claim | Existing gate |
+| --- | --- |
+| Normal raw-GitHub locator and escaped path interpretation; selected non-addressable forms decline | `LocalRepoSourceReadTests.ParsesGitHubRawUrl_IntoShaAndPath`, `ParsesGitHubRawUrl_UnescapesPath`, `RejectsNonAddressableUrls` |
+| A real committed blob is returned on checksum match and refused on mismatch | `LocalRepoSourceReadTests.ReadsBlob_WhenChecksumMatches`, `ReturnsNull_WhenChecksumMismatches` |
+| Missing selector/path or a non-repository directory supplies no bytes | `LocalRepoSourceReadTests.ReturnsNull_WhenCommitNotPresent`, `ReturnsNull_WhenPathNotPresent`, `ReturnsNull_WhenDirectoryIsNotAGitRepo` |
+| A missing object in the first clone does not hide the second clone's verified blob | `LocalRepoSourceReadTests.ReadsBlob_FromSecondRepo_WhenFirstLacksCommit` |
+| Shared verifier distinguishes accepted line-ending normalization | `PdbSourceAcquisitionTests.VerifyChecksum_AcceptsLineEndingNormalization` |
+| Member, type, and printable-projection service paths use a clone when PDB-recorded local-file reads are disabled | `LocalRepoSourceAcquisitionIntegrationTests.ServiceLocalClone_SatisfiesMemberAndTypeSourceWithoutRemoteFetch` |
+| The CLI accepts and propagates `--repo` for printable type Source Files while its HTTP path is offline | `LocalRepoSourceProjectionTests.TypeSourceFilesPrint_AcceptsRepoAtCliBoundaryWhileOffline` |
+
+Full URI-edge coverage, clone-relative selector ambiguity, working-tree
+divergence, normalized-checksum acceptance through the real-Git adapter, and
+the process-limit/cleanup profile remain **unverified** by dedicated adapter
+fixtures. The shared normalization test is not a substitute for that
+end-to-end local case. The service and CLI gates establish their stated
+consumer paths, not every `--repo` surface or Git-wide network isolation.
+
+The boundary fixture already separating useful lookup from misleading
+availability evidence is the missing-first-clone/present-second-clone case.
+The neighboring checksum-mismatch fixture prevents an existing but wrong blob
+from being presented as source. Further evidence should target a stated
+adapter claim rather than introduce a generalized subprocess framework.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -114,6 +114,10 @@ substrates, and inspection producers that will extend that space.
   Its [package metadata persistence](design/package-metadata-persistence.md)
   contract defines when one authority-scoped, time-bounded metadata observation
   may replace a fresh metadata operation.
+  `LocalRepoSourceAcquisition` owns [local repository source
+  acquisition](design/local-repository-source-acquisition.md): when a
+  caller-supplied Git clone may satisfy one PDB document request with verified
+  bytes, or decline so acquisition can continue.
 - `src/DotnetInspector.Core/` is the reference-free tool runtime kernel beneath
   Packages, Services, and the CLI: cache roots and eviction (`CoreCache`,
   `AsyncCache`), the single `HttpClientFactory` seam with offline and
@@ -278,6 +282,9 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Structured type-forwarding resolution](design/type-forwarding-resolution.md): typed reference-to-definition resolution, forwarding evidence, binding policy, outcomes, and consumer migration.
 - [Signals](assembly-audit.md): package/library signal semantics and network scope.
 - [PDB acquisition](pdb-acquisition.md): symbols and SourceLink acquisition.
+- [Local repository source acquisition](design/local-repository-source-acquisition.md):
+  local Git locator interpretation, checksum-backed byte admission, optional
+  decline, and execution-limit evidence.
 - [Untrusted data threat model](design/untrusted-data-threat-model.md): trust boundaries and security rules for inspected artifacts, network input, caches, output paths, and rendering.
 - [Inspect-web TypeScript semantic facts](design/inspect-web-typescript-semantic-facts.md):
   one pinned TypeScript project snapshot exposed through repository-owned

--- a/docs/pdb-acquisition.md
+++ b/docs/pdb-acquisition.md
@@ -14,16 +14,23 @@ After a Portable PDB maps a member or type to a checksummed source document,
 `PdbSourceAcquisition` looks for the document bytes in this order:
 
 1. The PDB-recorded local path, when local source reads are enabled.
-2. Each caller-supplied local Git clone, addressed by the exact commit and
+2. Each caller-supplied local Git clone, addressed by the revision selector and
    repository-relative path in a `raw.githubusercontent.com` SourceLink URL.
 3. The remote SourceLink URL.
 
-Every successful path must match the Portable PDB checksum before its content
-becomes evidence. Local-clone acquisition reads the committed Git blob rather
-than the working tree, so an outage does not require a pristine checkout and
-uncommitted edits cannot replace the pinned source. A missing commit, path, or
-checksum match in one clone continues through the remaining clones and then to
-the remote source.
+Every successful path must satisfy the shared Portable PDB checksum verifier
+(exact or accepted line-ending-normalized correspondence) before its content
+becomes evidence. Local-clone acquisition reads the addressed Git blob rather
+than the working-tree file. A missing revision, path, or checksum match in one
+clone continues through the remaining clones and then to the remote source.
+
+[Local repository source acquisition](design/local-repository-source-acquisition.md)
+owns that adapter's locator interpretation, byte admission, optional-lookup
+decline, and execution limits. This document retains acquisition ordering and
+remote outcome policy. A local result proves correspondence with the supplied
+PDB, not repository authenticity or globally immutable SourceLink identity.
+The adapter's focused evidence section distinguishes existing gates from
+ungated working-tree-divergence and execution-limit claims.
 
 Resolution and retrieval preserve document-specific failure state. A rejected
 SourceLink entry does not shadow a valid entry that resolves the same document,


### PR DESCRIPTION
Make local-source inspection dependable by specifying what a clone lookup
proves, what it may decline, and which execution guarantees remain unverified.

Closes #5880.

## Claim and scope

`docs/design/local-repository-source-acquisition.md#decision` is the single
normative owner: a caller-supplied clone may satisfy one PDB document request
only with bytes accepted by that document's checksum verifier; otherwise the
local lookup declines so acquisition can continue.

This specifies existing production behavior. The desktop `--repo` consumer is
already wired through `PdbSourceAcquisition` and the implementation-diff source
resolver. #5880 is the one-step documentation tracker; remaining production
adoption steps are zero. The existing Browser/Wasm source-fetcher path is
unchanged. No new architecture, host exception, replacement/retirement plan, or
rendering domain is introduced.

PDB acquisition retains ordering and remote outcome policy. The shared
checksum verifier retains hashing/normalization policy. SourceLink provenance
and the host fetcher retain immutable-origin and remote-admission policy.

## Demo

**Documentation mockup, not captured CLI output.** A user has cloned the source
repository and wants PDB-mapped source from an inspected package:

```bash
dnx dotnet-inspect -y -- type System.Text.Json.JsonSerializer \
  --package System.Text.Json@10.0.0 \
  -S "Source Files" --print --row first \
  --repo /work/runtime
```

Previously, the acquisition overview explained clone-before-network ordering
and checksum matching but left important interpretation questions in code.
The focused contract now explains these outcomes:

| Scenario | Contract explanation |
| --- | --- |
| The clone resolves the recorded object/path and its bytes satisfy the PDB checksum policy | Those bytes may satisfy the source request. The result does not independently authenticate the publisher or clone remote. |
| A first clone lacks the object, but a second supplied clone has a matching blob | Continue in caller order; the first miss must not hide the later source. |
| A blob exists but its checksum does not qualify | Decline it. Other clones and then the existing remote policy may still answer; the local result does not declare the document absent. |
| The local Git process wait expires | Decline the attempt and request termination; do not promise a total acquisition deadline or guaranteed process-tree quiescence. |

For the neighboring two-clone case, add an earlier
`--repo /work/other-clone`. The existing missing-first/present-second fixture
is the named gate for that distinction; the mismatch fixture separately
prevents an existing but wrong blob from being treated as source.

## Meaningful changes

- Register the focused adapter owner in the overview, architecture, and
  documentation index.
- Distinguish local locator interpretation from remote URL authorization and
  immutable SourceLink identity. Preserve abbreviated local Git selectors and
  checksum-backed mirror use.
- State the two-outcome optional-probe contract and preserve remote
  absence/failure semantics.
- Correct the acquisition overview's full-commit/exact-byte implications.
- Map existing tests to their actual claims and explicitly mark missing
  URI-edge, working-tree-divergence, real-Git normalization, and execution-limit
  coverage unverified.

No product code or tests change. The 15-second process wait and 64-MiB blob
acceptance cap are not presented as total time/memory limits. General Git
environment hardening and local-adversary scenarios remain outside scope.

## Validation

```bash
npx markdownlint-cli \
  docs/design/local-repository-source-acquisition.md \
  docs/pdb-acquisition.md docs/README.md docs/overview.md docs/architecture.md
git diff --check
```

Both passed. Existing test names and assertions were inspected as the evidence
map; this documentation-only change makes no new runtime measurement claim.
No .NET build or test run is needed for the Markdown-only change.
