### PR TITLE
Add package-row removal in Search and Workspace

### DIFF
--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -455,6 +455,9 @@ coordinates with:
 - loading, ready, or failed state; and
 - an explicit Close action.
 
+The transitional Browser-owned NuGet close control is implemented through
+[Package-row removal](inspect-web-package-removal.md), shared with Home Search.
+
 Opening a demo or closing a coordinate submits its owner-issued identity and
 renders the returned workspace outcome. The UI does not choose a subject, lens,
 successor, or fallback for the product.

--- a/docs/design/inspect-web-navigation-presentation.md
+++ b/docs/design/inspect-web-navigation-presentation.md
@@ -457,15 +457,19 @@ coordinates with:
 
 The transitional Browser-owned NuGet close control is implemented through
 [Package-row removal](inspect-web-package-removal.md), shared with Home Search.
+That focused owner governs the existing Browser successor and empty `/demos`
+behavior until product-owned Close is adopted.
 
-Opening a demo or closing a coordinate submits its owner-issued identity and
-renders the returned workspace outcome. The UI does not choose a subject, lens,
-successor, or fallback for the product.
+Opening a demo, and closing a coordinate after product-owned Close adoption,
+submits its owner-issued identity and renders the returned workspace outcome.
+For those product-owned actions, the UI does not choose a subject, lens,
+successor, or fallback.
 
 Closing an inactive coordinate preserves the active coordinate's inspection
-state and keeps Workspace selected. Closing the active coordinate selects the
-returned successor while remaining in Workspace. The `/demos` entry route is an
-in-session catalog view: it preserves currently loaded coordinates while open,
+state and keeps Workspace selected. Closing the active coordinate selects its
+successor while remaining in Workspace, as governed by the current Close owner.
+The `/demos` entry route is an in-session catalog view: it preserves currently
+loaded coordinates while open,
 but a direct visit or refresh starts with an empty Workspace. After an Open demo
 or coordinate action returns to a canonical Workspace URL, Share and refresh
 preserve the Workspace subject, its application-scope presentation, and its

--- a/docs/design/inspect-web-package-removal.md
+++ b/docs/design/inspect-web-package-removal.md
@@ -43,7 +43,8 @@ Saving Workspaces, Add, prefix expansion, and Clear are separate work.
   then its heading. Occurrence-query refresh preserves these controls and
   their focus; unavailable Inspect actions do not hide removable membership.
 - Package-bound browser caches and obsolete occurrence actions are invalidated
-  when membership changes. This does not promise deletion from HTTP caches,
+  when membership changes, including membership-dependent Call graph results
+  and pending expansion. This does not promise deletion from HTTP caches,
   package sources, or saved browser history.
 
 ## Convention, rendering, and evidence
@@ -59,7 +60,9 @@ accessible control; Markout is not used for these interactive DOM controls.
 This is not a new multi-format rendering domain or shared product substrate.
 
 The enforcing gates are the existing Node test runner's package-removal,
-Spotlight, and Workspace tests and the Firefox package-removal browser tests.
+Call graph, Spotlight, and Workspace tests and the Firefox package-removal
+browser tests.
 They cover persistence failure, exact identity, active/inactive/last removal,
-click-versus-activation, keyboard removal, query preservation, and membership
+click-versus-activation, keyboard removal, query and text-selection preservation,
+graph refresh without removed callers, history-state retention, and membership
 visibility while Inspect actions are loading or unavailable.

--- a/docs/design/inspect-web-package-removal.md
+++ b/docs/design/inspect-web-package-removal.md
@@ -1,0 +1,65 @@
+# Inspect Web package-row removal
+
+## Claim and scope
+
+Home Search, modal Spotlight, and the Workspace page expose the same trailing
+`x` button for removing an exact retained NuGet package. Recent-package rows
+expose the same control to forget that history entry. Removal never activates
+the row. This document owns this focused Browser interaction; Navigation
+Presentation supplies Workspace placement, Shell Interaction supplies Search,
+and Navigation Consumer retains ownership of navigation effects.
+
+The consumer is the existing Inspect Web application, tracked by #5887. This
+user-approved Browser-only slice advances the one-live-Workspace viewer/editor in #5697
+without depending on paused #5812. Production-host adoption takes two steps:
+land this complete UI slice, then include it in a separately authorized normal
+release and website deployment. It adds no alternative Workspace architecture.
+Saving Workspaces, Add, prefix expansion, and Clear are separate work.
+
+## Behavior
+
+- The button has a visible close glyph and a complete accessible name,
+  including the package coordinate for an open row. It is a sibling of the
+  activation control, never a nested button.
+- Forgetting a recent package removes its case-insensitive package-ID entry
+  from browser-local history. An explicit later open may remember it again.
+- Removing an open row removes only that exact package coordinate and also
+  forgets its recent package-ID entry. Other versions and frameworks remain
+  loaded. Platform is not removable through these controls.
+- Persistence failure is visible and leaves the entry and membership unchanged.
+- Removing an inactive package preserves the active inspection selection.
+  Removing the active package uses the existing retained-package successor
+  order and resets package-bound selection rather than applying the old
+  package's filters or member selection to its successor.
+- Home remains Home. Modal Search remains open. Workspace remains Workspace;
+  removing its last coordinate uses the existing empty `/demos` surface.
+  Removal does not select another search result or acquire anything.
+- Search preserves its input and selection, moving selection to the next row
+  or preceding row when necessary, with focus on the input. Shift+Delete
+  removes the selected removable row. The removed ID is suppressed from
+  discovery hits until the query changes or Search resets, not permanently
+  blocked from NuGet discovery.
+- Workspace focus moves to the next removal control, then the preceding one,
+  then its heading. Occurrence-query refresh preserves these controls and
+  their focus; unavailable Inspect actions do not hide removable membership.
+- Package-bound browser caches and obsolete occurrence actions are invalidated
+  when membership changes. This does not promise deletion from HTTP caches,
+  package sources, or saved browser history.
+
+## Convention, rendering, and evidence
+
+The baseline is a browser address-bar suggestion's trailing removal button:
+remove the suggestion without navigating. The deliberate difference for a
+loaded package is that removal also releases its live Browser membership.
+No browser implementation code is copied.
+
+The existing typed package and recent-entry models flow into the Browser's
+HTML renderers. A shared small button renderer supplies the visual and
+accessible control; Markout is not used for these interactive DOM controls.
+This is not a new multi-format rendering domain or shared product substrate.
+
+The enforcing gates are the existing Node test runner's package-removal,
+Spotlight, and Workspace tests and the Firefox package-removal browser tests.
+They cover persistence failure, exact identity, active/inactive/last removal,
+click-versus-activation, keyboard removal, query preservation, and membership
+visibility while Inspect actions are loading or unavailable.

--- a/docs/design/inspect-web-shell-interaction.md
+++ b/docs/design/inspect-web-shell-interaction.md
@@ -324,6 +324,9 @@ typing, paste, drag and drop of text, autofill where applicable, and input
 method composition. Pasting a package coordinate updates results immediately;
 it is not dependent on keyboard events that paste does not emit.
 
+[Package-row removal](inspect-web-package-removal.md) owns the trailing close
+control for open and recent NuGet package rows in Home and modal Spotlight.
+
 Spotlight exposes one visible `Package query` action. Activating it closes
 Spotlight and requests the routed `/query` surface. When the current
 package-search text is a valid package-ID prefix, the action preserves it as

--- a/prototypes/inspect-web/browser/package-removal-harness.ts
+++ b/prototypes/inspect-web/browser/package-removal-harness.ts
@@ -1,0 +1,118 @@
+import { packageIdentityKey } from "../src/data.ts";
+import { KeybindingRegistry } from "../src/keybinding-registry.ts";
+import { createPackageRemoval } from "../src/package-removal.ts";
+import type { PackageControlPackage } from "../src/package-controls.ts";
+import { createSpotlight, type SpotlightResult, type SpotlightState } from "../src/spotlight.ts";
+import {
+  bindWorkspaceSubject, captureWorkspaceFocus, renderWorkspaceView,
+  restoreWorkspaceFocus,
+} from "../src/workspace-subject.ts";
+
+const root = document.querySelector<HTMLElement>("#app");
+const notice = document.querySelector<HTMLElement>("#notice");
+if (!root || !notice) throw new Error("Package removal harness elements are missing.");
+const app = root;
+const status = notice;
+const params = new URL(location.href).searchParams;
+const workspace = params.has("workspace");
+const modal = params.has("modal");
+const escapeHtml = (value: unknown) => String(value)
+  .replaceAll("&", "&amp;").replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+const initialPackages = [
+  { id: "Newtonsoft.Json", version: "13.0.4", activeFramework: "net10.0", isRuntimePack: false },
+  { id: "System.Text.Json", version: "10.0.0", activeFramework: "net10.0", isRuntimePack: false },
+];
+const recentIds = [...initialPackages.map(pkg => pkg.id), "Microsoft.Extensions.Http"];
+if (!localStorage.getItem("removal-harness-initialized")) {
+  localStorage.setItem("inspect-recent-packages", JSON.stringify(recentIds));
+  localStorage.setItem("removal-harness-initialized", "true");
+}
+const stored: unknown = JSON.parse(localStorage.getItem("inspect-recent-packages") ?? "[]");
+if (!Array.isArray(stored) || !stored.every(item => typeof item === "string")) {
+  throw new Error("Invalid harness history");
+}
+const packages: PackageControlPackage[] = params.has("cold") ? [] : initialPackages;
+const state = {
+  packages, package: packages[0] ?? null,
+  recentPackages: stored.map((id: string) => ({ id, version: "10.0.0", framework: "net10.0" })),
+};
+const search: SpotlightState = {
+  spotlightOpen: modal, spotlightQuery: "", spotlightIndex: 0,
+  spotlightScope: "all", spotlightFocus: "input", spotlightChipIndex: 0,
+};
+const keys = new KeybindingRegistry();
+document.addEventListener("keydown", event => keys.dispatch(event));
+const removal = createPackageRemoval({
+  state,
+  persistRecent: entries => {
+    if (params.has("storage-failure")) throw new Error("Storage is unavailable");
+    localStorage.setItem("inspect-recent-packages", JSON.stringify(entries.map(entry => entry.id)));
+  },
+  activate: next => { state.package = next; },
+  release: () => render(),
+});
+const spotlight = createSpotlight({
+  state: search, keybindings: keys, lenses: () => [],
+  escapeHtml, highlightRanges: value => escapeHtml(value), kindIcon: () => "T",
+  searchResults: (): SpotlightResult[] => {
+    const query = search.spotlightQuery.toLowerCase();
+    const loaded = state.packages.filter(pkg => pkg.id.toLowerCase().includes(query));
+    const recent = state.recentPackages.filter(entry =>
+      entry.id.toLowerCase().includes(query)
+      && !state.packages.some(pkg => pkg.id === entry.id));
+    return [
+      ...loaded.map(pkg => ({ kind: "pkg-loaded" as const, pkg, ranges: [] })),
+      ...recent.map(entry => ({ kind: "pkg-recent" as const, entry, ranges: [] })),
+      ...(query ? [{ kind: "pkg-nuget" as const, hit: { id: "System.Text.Json" }, ranges: [] }] : []),
+    ];
+  },
+  pickResult: () => { status.textContent = "Activated"; },
+  removeResult: result => {
+    try {
+      if (result.kind === "pkg-recent") removal.forgetRecent(result.entry.id);
+      else removal.removeLoaded(packageIdentityKey({
+        ...result.pkg, activeFramework: result.pkg.activeFramework ?? "",
+      }));
+      return true;
+    } catch (error) {
+      status.textContent = String(error);
+      return false;
+    }
+  },
+  executeCommand: () => undefined, reportCommandError: error => { throw error; },
+  commandContext: () => null, schedulePackageFetch: () => {},
+  resetPackageSearch: () => {}, packageSearchLoading: () => false,
+  packageCount: () => state.packages.length, activeFramework: () => "net10.0",
+  render,
+});
+
+function render() {
+  const focused = document.activeElement instanceof HTMLElement
+    ? captureWorkspaceFocus(document.activeElement) : null;
+  if (workspace) {
+    app.innerHTML = renderWorkspaceView({
+      packages: state.packages,
+      occurrences: state.packages.map(pkg => ({
+        action: packageIdentityKey(pkg), package: pkg.id,
+        version: pkg.version, framework: pkg.activeFramework,
+      })),
+      demos: [], demoError: "", loading: params.has("loading"),
+      error: params.has("failed-query") ? "Occurrence query unavailable" : "",
+      escapeHtml,
+    });
+    bindWorkspaceSubject(app, {
+      onSelect: () => {}, onActivate: () => { status.textContent = "Activated"; },
+      onDemo: () => {}, onRetry: () => {},
+      onRemove: key => {
+        try { removal.removeLoaded(key); }
+        catch (error) { status.textContent = String(error); }
+      },
+    });
+    if (focused) restoreWorkspaceFocus(app, focused);
+  } else {
+    app.innerHTML = modal ? spotlight.modalHtml() : spotlight.inlineHtml(false);
+    spotlight.bind(app, modal ? "modal" : "inline");
+  }
+}
+render();

--- a/prototypes/inspect-web/browser/package-removal-harness.ts
+++ b/prototypes/inspect-web/browser/package-removal-harness.ts
@@ -50,7 +50,10 @@ const removal = createPackageRemoval({
     localStorage.setItem("inspect-recent-packages", JSON.stringify(entries.map(entry => entry.id)));
   },
   activate: next => { state.package = next; },
-  release: () => render(),
+  release: () => {
+    render();
+    if (params.has("refresh")) queueMicrotask(render);
+  },
 });
 const spotlight = createSpotlight({
   state: search, keybindings: keys, lenses: () => [],

--- a/prototypes/inspect-web/browser/package-removal.html
+++ b/prototypes/inspect-web/browser/package-removal.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Package removal harness</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <main id="app"></main>
+    <p id="notice" role="status"></p>
+    <script type="module" src="./package-removal-harness.ts"></script>
+  </body>
+</html>

--- a/prototypes/inspect-web/browser/package-removal.spec.ts
+++ b/prototypes/inspect-web/browser/package-removal.spec.ts
@@ -1,13 +1,21 @@
 import { expect, test } from "@playwright/test";
 
-for (const mode of ["", "?modal=1"]) {
-  test(`package removal preserves ${mode ? "modal" : "Home"} search and forgets history`, async ({ page }) => {
+for (const mode of ["", "?modal=1", "?modal=1&refresh=1"]) {
+  test(`package removal preserves search and forgets history: ${mode || "Home"}`, async ({ page }) => {
     await page.goto(`/browser/package-removal.html${mode}`);
     const input = page.locator("#spotlight-input");
     await input.fill("Json");
+    await input.evaluate(element => {
+      if (!(element instanceof HTMLInputElement)) throw new Error("Search input is missing");
+      element.setSelectionRange(1, 3);
+    });
     await page.getByRole("button", { name: "Remove System.Text.Json 10.0.0 net10.0 from Workspace", exact: true }).click();
+    await page.evaluate(() =>
+      new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
     await expect(input).toBeFocused();
     await expect(input).toHaveValue("Json");
+    expect(await input.evaluate(element => element instanceof HTMLInputElement
+      ? [element.selectionStart, element.selectionEnd] : null)).toEqual([1, 3]);
     await expect(page.locator('[data-sl-pkg-open="System.Text.Json"]')).toHaveCount(0);
     await expect(page.locator('[data-sl-pkg-recent="System.Text.Json"]')).toHaveCount(0);
     await expect(page.locator('[data-sl-pkg-load="System.Text.Json"]')).toHaveCount(0);

--- a/prototypes/inspect-web/browser/package-removal.spec.ts
+++ b/prototypes/inspect-web/browser/package-removal.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "@playwright/test";
+
+for (const mode of ["", "?modal=1"]) {
+  test(`package removal preserves ${mode ? "modal" : "Home"} search and forgets history`, async ({ page }) => {
+    await page.goto(`/browser/package-removal.html${mode}`);
+    const input = page.locator("#spotlight-input");
+    await input.fill("Json");
+    await page.getByRole("button", { name: "Remove System.Text.Json 10.0.0 net10.0 from Workspace", exact: true }).click();
+    await expect(input).toBeFocused();
+    await expect(input).toHaveValue("Json");
+    await expect(page.locator('[data-sl-pkg-open="System.Text.Json"]')).toHaveCount(0);
+    await expect(page.locator('[data-sl-pkg-recent="System.Text.Json"]')).toHaveCount(0);
+    await expect(page.locator('[data-sl-pkg-load="System.Text.Json"]')).toHaveCount(0);
+    await expect(page.locator("#notice")).toHaveText("");
+    if (mode) await expect(page.getByRole("dialog")).toBeVisible();
+    await input.fill("System");
+    await expect(page.locator('[data-sl-pkg-load="System.Text.Json"]')).toBeVisible();
+    await page.goto("/browser/package-removal.html?cold=1");
+    await expect(page.locator('[data-sl-pkg-recent="System.Text.Json"]')).toHaveCount(0);
+  });
+}
+
+test("recent x forgets the entry across refresh without opening it", async ({ page }) => {
+  await page.goto("/browser/package-removal.html");
+  await page.getByRole("button", { name: "Forget Microsoft.Extensions.Http from recent packages", exact: true }).click();
+  await expect(page.locator("#spotlight-input")).toBeFocused();
+  await expect(page.locator('[data-sl-pkg-open="Newtonsoft.Json"]')).toBeVisible();
+  await expect(page.locator("#notice")).toHaveText("");
+  await page.reload();
+  await expect(page.locator('[data-sl-pkg-recent="Microsoft.Extensions.Http"]')).toHaveCount(0);
+});
+
+test("Shift Delete removes the selected package without activating or clearing the query", async ({ page }) => {
+  await page.goto("/browser/package-removal.html");
+  const input = page.locator("#spotlight-input");
+  await input.fill("Newton");
+  await input.press("Shift+Delete");
+  await expect(input).toHaveValue("Newton");
+  await expect(input).toBeFocused();
+  await expect(page.locator('[data-sl-pkg-open="Newtonsoft.Json"]')).toHaveCount(0);
+  await expect(page.locator("#notice")).toHaveText("");
+});
+
+for (const mode of ["workspace=1", "workspace=1&loading=1", "workspace=1&failed-query=1"]) {
+  test(`Workspace x remains usable and preserves focus: ${mode}`, async ({ page }) => {
+    await page.goto(`/browser/package-removal.html?${mode}`);
+    const first = page.getByRole("button", { name: "Remove Newtonsoft.Json 13.0.4 net10.0 from Workspace", exact: true });
+    await first.focus();
+    await first.press("Enter");
+    const next = page.getByRole("button", { name: "Remove System.Text.Json 10.0.0 net10.0 from Workspace", exact: true });
+    await expect(next).toBeFocused();
+    await next.press("Enter");
+    await expect(page.getByRole("heading", { name: "Workspace", exact: true })).toBeFocused();
+    await expect(page.getByText("No packages are loaded in this Workspace.")).toBeVisible();
+    await expect(page.locator("#notice")).toHaveText("");
+  });
+}
+
+test("storage failure keeps the row and shows the failure", async ({ page }) => {
+  await page.goto("/browser/package-removal.html?storage-failure=1");
+  const button = page.getByRole("button", { name: "Remove Newtonsoft.Json 13.0.4 net10.0 from Workspace", exact: true });
+  await button.click();
+  await expect(button).toBeVisible();
+  await expect(page.locator("#notice")).toContainText("Storage is unavailable");
+});
+
+test("removal remains visible at narrow width", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 700 });
+  await page.goto("/browser/package-removal.html");
+  const button = page.getByRole("button", { name: "Forget Microsoft.Extensions.Http from recent packages", exact: true });
+  await expect(button).toBeInViewport();
+  await button.click();
+  await expect(button).toHaveCount(0);
+});

--- a/prototypes/inspect-web/src/call-graph-inspection.ts
+++ b/prototypes/inspect-web/src/call-graph-inspection.ts
@@ -139,6 +139,7 @@ export function createCallGraphInspectionCoordinator(
   dependencies: CallGraphInspectionDependencies,
 ): CallGraphInspectionCoordinator {
   const { state } = dependencies;
+  let loadGeneration = 0;
   const resetPlatformDrill = () => {
     state.platformStack = [];
     state.platformDrillLoading = false;
@@ -195,6 +196,7 @@ export function createCallGraphInspectionCoordinator(
         await dependencies.renderCallGraph();
         return;
       }
+      const generation = ++loadGeneration;
       state.memberCallGraphKey = request.signature;
       state.memberCallGraph = null;
       state.memberCallGraphError = "";
@@ -215,8 +217,11 @@ export function createCallGraphInspectionCoordinator(
         && request.isCurrent()
         && state.memberCallGraphKey === request.signature;
       let local: InspectedCallGraph | null = null;
+      // Platform descent may retain this expansion; a fresh load must not,
+      // even if its local query returns the same graph object.
       const canceledExpansionStillMatchesView = () =>
         local != null
+        && generation === loadGeneration
         && request.isCurrent()
         && state.memberCallGraphKey === request.signature
         && state.memberCallGraph === local

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -340,12 +340,14 @@ import { renderBrand } from "./brand.ts";
 import { loadPlatformIndex, type PlatformIndex } from "./platform-index.ts";
 import {
   createSpotlight,
+  type RemovableSpotlightResult,
   type SpotlightPackageHit,
   type SpotlightResult,
   type SpotlightScope,
   visibleSpotlightPackageHits,
 } from "./spotlight.ts";
 import { createSpotlightPackageSearch } from "./spotlight-package-search.ts";
+import { createPackageRemoval } from "./package-removal.ts";
 import {
   compareVersionsDesc,
   createCatalogRequests,
@@ -1721,6 +1723,13 @@ const catalogRequests = createCatalogRequests({
   updatePlatformVersionSelect,
   updatePackageVersionSelect: updateVersionSelect,
 });
+const packageRemoval = createPackageRemoval({
+  state,
+  persistRecent: entries =>
+    localStorage.setItem("inspect-recent-packages", JSON.stringify(entries)),
+  activate: activateAfterPackageRemoval,
+  release: finishPackageRemoval,
+});
 const spotlight = createSpotlight({
   keybindings,
   state,
@@ -1730,6 +1739,7 @@ const spotlight = createSpotlight({
   kindIcon,
   searchResults: spotlightResults,
   pickResult: pickSpotlightResult,
+  removeResult: removeSpotlightPackage,
   executeCommand,
   reportCommandError: error =>
     reportAsyncFailure("Running a Spotlight command", error),
@@ -2201,6 +2211,61 @@ function releasePackageModelCaches(packageModel: AppPackage) {
   }
 }
 
+function activateAfterPackageRemoval(next: AppPackage | null): void {
+  if (next) activatePackage(next, { resetAccessibility: true });
+  else state.package = null;
+  state.dependenciesGroupIndex = null;
+  state.atPackageRoot = true;
+  state.selectedTypeId = "";
+  state.selectedMemberKey = "";
+  state.memberBrowseTypeId = "";
+  state.selectedOverloadIndex = null;
+  resetLocationFilters();
+  resetMemberSectionState();
+  if (!state.home) state.workspaceSubjectOpen = true;
+}
+
+function finishPackageRemoval(removed: AppPackage): void {
+  navigationSequence.begin();
+  invalidateGraphMemberNavigation();
+  state.workspaceShareBasis = null;
+  clearWorkspaceOccurrenceView();
+  packageInspection.invalidatePackageResults();
+  spotlightCache = null;
+  spotlightMemberCache = null;
+  releasePackageModelCaches(removed);
+  if (!state.package && !state.home) {
+    state.workspaceSubjectOpen = true;
+    workspaceLocation.replace("/demos");
+  }
+  render();
+}
+
+function removeSpotlightPackage(result: RemovableSpotlightResult): boolean {
+  try {
+    if (result.kind === "pkg-recent") {
+      packageRemoval.forgetRecent(result.entry.id);
+    } else {
+      packageRemoval.removeLoaded(packageIdentityKey({
+        ...result.pkg,
+        activeFramework: result.pkg.activeFramework ?? "",
+      }));
+    }
+    return true;
+  } catch (error) {
+    showToast(`Could not remove package: ${errorMessage(error)}`);
+    return false;
+  }
+}
+
+function removeWorkspacePackageRow(key: string): void {
+  try {
+    packageRemoval.removeLoaded(key);
+  } catch (error) {
+    showToast(`Could not remove package: ${errorMessage(error)}`);
+  }
+}
+
 function clearWorkspacePackages() {
   const discarded = state.packages;
   state.packages = [];
@@ -2303,7 +2368,7 @@ async function queryWorkspaceOccurrenceView() {
       state.workspaceOccurrenceSignature = "";
       ensureWorkspaceOccurrenceView();
     }
-    render();
+    if (ownsCurrentRequest) render();
   }
 }
 
@@ -6281,6 +6346,7 @@ function bindWorkspaceSubjectEvents() {
         "Opening the Workspace package"),
     onDemo: runHomeDemo,
     onRetry: retryWorkspaceOccurrenceView,
+    onRemove: removeWorkspacePackageRow,
   });
 }
 

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -2237,6 +2237,11 @@ function activateAfterPackageRemoval(next: AppPackage | null): void {
 function finishPackageRemoval(removed: AppPackage): void {
   navigationSequence.begin();
   invalidateGraphMemberNavigation();
+  invalidateMemberCallGraphWork(state);
+  state.memberCallGraph = null;
+  state.memberCallGraphError = "";
+  state.memberCallGraphKey = "";
+  state.platformStack = [];
   state.workspaceShareBasis = null;
   clearWorkspaceOccurrenceView();
   packageInspection.invalidatePackageResults();
@@ -2245,9 +2250,12 @@ function finishPackageRemoval(removed: AppPackage): void {
   releasePackageModelCaches(removed);
   if (!state.package && !state.home) {
     state.workspaceSubjectOpen = true;
-    workspaceLocation.replace("/demos");
+    workspaceLocation.replace("/demos", history.state);
   }
   render();
+  if (!state.home && scope() === "member" && state.memberSection === "call-graph") {
+    observeAsync(loadSelectedMemberCallGraph(), "Refreshing the member call graph");
+  }
 }
 
 function removeSpotlightPackage(result: RemovableSpotlightResult): boolean {

--- a/prototypes/inspect-web/src/package-inspection.ts
+++ b/prototypes/inspect-web/src/package-inspection.ts
@@ -118,6 +118,7 @@ export interface PackageInspectionDependencies {
 }
 
 export interface PackageInspectionCoordinator {
+  invalidatePackageResults(): void;
   loadDependencies(
     packageModel: AppPackage,
     signature: string,
@@ -165,6 +166,7 @@ export function createPackageInspectionCoordinator(
   dependencies: PackageInspectionDependencies,
 ): PackageInspectionCoordinator {
   const { state } = dependencies;
+  let packageResultGeneration = 0;
   let metadataRequestSequence = 0;
 
   const platformCoordinates = (
@@ -178,6 +180,7 @@ export function createPackageInspectionCoordinator(
   });
 
   const ensureWorkspaceDependencies = async () => {
+    const generation = packageResultGeneration;
     const missing = state.packages.filter(packageModel =>
       !packageModel.isRuntimePack
       && !Object.hasOwn(
@@ -190,11 +193,13 @@ export function createPackageInspectionCoordinator(
       return;
     }
     for (const packageModel of missing) {
+      if (generation !== packageResultGeneration) return;
       const key = workspaceDependencyKey(packageModel);
       if (!packageIsResident(state.packages, packageModel)) continue;
       state.workspaceDependencyLoads.add(key);
       try {
         const result = await dependencies.queryDependencies(packageModel);
+        if (generation !== packageResultGeneration) return;
         if (!packageIsResident(state.packages, packageModel)) continue;
         state.workspaceDependencies[key] = {
           dependencyGroups: result?.dependencyGroups || [],
@@ -207,6 +212,7 @@ export function createPackageInspectionCoordinator(
           delete state.workspaceDependencyErrors[key];
         }
       } catch (error) {
+        if (generation !== packageResultGeneration) return;
         if (!packageIsResident(state.packages, packageModel)) continue;
         state.workspaceDependencies[key] = {
           dependencyGroups: [],
@@ -215,10 +221,13 @@ export function createPackageInspectionCoordinator(
         state.workspaceDependencyErrors[key] =
           dependencies.describeError(error);
       } finally {
-        state.workspaceDependencyLoads.delete(key);
+        if (generation === packageResultGeneration) {
+          state.workspaceDependencyLoads.delete(key);
+        }
       }
     }
 
+    if (generation !== packageResultGeneration) return;
     if (state.atPackageRoot && state.packageLens === "dependencies") {
       dependencies.render();
     }
@@ -226,12 +235,41 @@ export function createPackageInspectionCoordinator(
   };
 
   return {
+    invalidatePackageResults() {
+      packageResultGeneration++;
+      state.workspaceDependencyLoads.clear();
+      state.packageDependencies = null;
+      state.packageDependenciesLoading = false;
+      state.packageDependenciesError = "";
+      state.packageDependenciesKey = "";
+      state.packageIntegrations = null;
+      state.packageIntegrationsLoading = false;
+      state.packageIntegrationsError = "";
+      state.packageIntegrationsKey = "";
+      state.packageOpportunities = null;
+      state.packageOpportunitiesLoading = false;
+      state.packageOpportunitiesError = "";
+      state.packageOpportunitiesKey = "";
+      state.packagePerformance = null;
+      state.packagePerformanceLoading = false;
+      state.packagePerformanceError = "";
+      state.packagePerformanceKey = "";
+      state.packageMetadata = null;
+      state.packageMetadataLoading = false;
+      state.packageMetadataError = "";
+      state.packageMetadataKey = "";
+    },
+
     async loadDependencies(packageModel, signature) {
       if (state.packageDependenciesKey === signature
         && (state.packageDependencies || state.packageDependenciesError)) {
         dependencies.render();
         return;
       }
+      const generation = packageResultGeneration;
+      const ownsRequest = () =>
+        state.packageDependenciesKey === signature
+        && generation === packageResultGeneration;
       state.packageDependenciesKey = signature;
       state.packageDependencies = null;
       state.packageDependenciesError = "";
@@ -246,10 +284,11 @@ export function createPackageInspectionCoordinator(
       const workspaceKey = workspaceDependencyKey(packageRequest);
       try {
         const result = await dependencies.queryDependencies(packageRequest);
-        if (state.packageDependenciesKey === signature) {
+        if (ownsRequest()) {
           state.packageDependencies = result;
         }
         if (result?.dependencyGroups
+          && generation === packageResultGeneration
           && packageIsResident(state.packages, packageRequest)) {
           state.workspaceDependencies[workspaceKey] = {
             dependencyGroups: result.dependencyGroups,
@@ -263,16 +302,18 @@ export function createPackageInspectionCoordinator(
           }
         }
       } catch (error) {
-        if (state.packageDependenciesKey === signature) {
+        if (ownsRequest()) {
           state.packageDependenciesError = dependencies.describeError(error);
         }
       } finally {
-        if (state.packageDependenciesKey === signature) {
+        if (ownsRequest()) {
           state.packageDependenciesLoading = false;
         }
-        dependencies.refreshPackageStats();
-        dependencies.render();
-        await ensureWorkspaceDependencies();
+        if (generation === packageResultGeneration) {
+          dependencies.refreshPackageStats();
+          dependencies.render();
+          await ensureWorkspaceDependencies();
+        }
       }
     },
 
@@ -285,6 +326,10 @@ export function createPackageInspectionCoordinator(
         dependencies.render();
         return;
       }
+      const generation = packageResultGeneration;
+      const ownsRequest = () =>
+        state.packageIntegrationsKey === signature
+        && generation === packageResultGeneration;
       state.packageIntegrationsKey = signature;
       state.packageIntegrations = null;
       state.packageIntegrationsError = "";
@@ -301,18 +346,20 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackageIntegrations(packageModel);
-        if (state.packageIntegrationsKey === signature) {
+        if (ownsRequest()) {
           state.packageIntegrations = result;
         }
       } catch (error) {
-        if (state.packageIntegrationsKey === signature) {
+        if (ownsRequest()) {
           state.packageIntegrationsError = dependencies.describeError(error);
         }
       } finally {
-        if (state.packageIntegrationsKey === signature) {
+        if (ownsRequest()) {
           state.packageIntegrationsLoading = false;
         }
-        dependencies.render();
+        if (generation === packageResultGeneration) {
+          dependencies.render();
+        }
       }
     },
 
@@ -323,6 +370,10 @@ export function createPackageInspectionCoordinator(
         dependencies.render();
         return;
       }
+      const generation = packageResultGeneration;
+      const ownsRequest = () =>
+        state.packageOpportunitiesKey === signature
+        && generation === packageResultGeneration;
       state.packageOpportunitiesKey = signature;
       state.packageOpportunities = null;
       state.packageOpportunitiesError = "";
@@ -339,18 +390,20 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackageOpportunities(packageModel);
-        if (state.packageOpportunitiesKey === signature) {
+        if (ownsRequest()) {
           state.packageOpportunities = result;
         }
       } catch (error) {
-        if (state.packageOpportunitiesKey === signature) {
+        if (ownsRequest()) {
           state.packageOpportunitiesError = dependencies.describeError(error);
         }
       } finally {
-        if (state.packageOpportunitiesKey === signature) {
+        if (ownsRequest()) {
           state.packageOpportunitiesLoading = false;
         }
-        dependencies.render();
+        if (generation === packageResultGeneration) {
+          dependencies.render();
+        }
       }
     },
 
@@ -361,6 +414,10 @@ export function createPackageInspectionCoordinator(
         dependencies.render();
         return;
       }
+      const generation = packageResultGeneration;
+      const ownsRequest = () =>
+        state.packagePerformanceKey === signature
+        && generation === packageResultGeneration;
       state.packagePerformanceKey = signature;
       state.packagePerformance = null;
       state.packagePerformanceError = "";
@@ -377,18 +434,20 @@ export function createPackageInspectionCoordinator(
               coordinates.assemblyFileName,
               coordinates.pack)
           : await dependencies.queryPackagePerformance(packageModel);
-        if (state.packagePerformanceKey === signature) {
+        if (ownsRequest()) {
           state.packagePerformance = result;
         }
       } catch (error) {
-        if (state.packagePerformanceKey === signature) {
+        if (ownsRequest()) {
           state.packagePerformanceError = dependencies.describeError(error);
         }
       } finally {
-        if (state.packagePerformanceKey === signature) {
+        if (ownsRequest()) {
           state.packagePerformanceLoading = false;
         }
-        dependencies.render();
+        if (generation === packageResultGeneration) {
+          dependencies.render();
+        }
       }
     },
 
@@ -400,9 +459,11 @@ export function createPackageInspectionCoordinator(
         return;
       }
       const requestSequence = ++metadataRequestSequence;
+      const generation = packageResultGeneration;
       const ownsRequest = () =>
         state.packageMetadataKey === signature
-        && metadataRequestSequence === requestSequence;
+        && metadataRequestSequence === requestSequence
+        && generation === packageResultGeneration;
       state.packageMetadataKey = signature;
       state.packageMetadata = null;
       state.packageMetadataError = "";

--- a/prototypes/inspect-web/src/package-removal.ts
+++ b/prototypes/inspect-web/src/package-removal.ts
@@ -1,0 +1,61 @@
+import {
+  packageIdentityKey,
+  removeWorkspacePackage,
+  type RemoveWorkspacePackageInput,
+} from "./data.ts";
+
+export interface RecentPackageEntry {
+  id: string;
+  version: string;
+  framework: string;
+}
+
+export interface PackageRemovalState<T> {
+  packages: T[];
+  package: T | null;
+  recentPackages: RecentPackageEntry[];
+}
+
+export function packageRemoveButton(
+  attribute: string,
+  identity: string,
+  label: string,
+  escapeHtml: (value: unknown) => string,
+): string {
+  return `<button type="button" class="package-row-remove" ${attribute}="${escapeHtml(identity)}" aria-label="${escapeHtml(label)}" title="${escapeHtml(label)}"><span aria-hidden="true">&times;</span></button>`;
+}
+
+export function createPackageRemoval<T extends RemoveWorkspacePackageInput>(
+  options: {
+    state: PackageRemovalState<T>;
+    persistRecent: (entries: readonly RecentPackageEntry[]) => void;
+    activate: (next: T | null) => void;
+    release: (removed: T) => void;
+  },
+) {
+  const { state } = options;
+
+  function forgetRecent(id: string): void {
+    const entries = state.recentPackages.filter(
+      entry => entry.id.toLowerCase() !== id.toLowerCase());
+    // Persist first: a failed write must not look like a successful deletion.
+    options.persistRecent(entries);
+    state.recentPackages = entries;
+  }
+
+  return {
+    forgetRecent,
+    removeLoaded(key: string): void {
+      const removed = removeWorkspacePackage(state.packages, state.package, key);
+      if (!removed.closed) {
+        throw new Error("That package is no longer removable from this Workspace.");
+      }
+      forgetRecent(removed.closed.id);
+      const activeChanged =
+        packageIdentityKey(state.package) !== packageIdentityKey(removed.active);
+      state.packages = removed.packages;
+      if (activeChanged) options.activate(removed.active);
+      options.release(removed.closed);
+    },
+  };
+}

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -264,6 +264,7 @@ function hasElementId(value: EventTarget | null): value is EventTarget & { id: s
 }
 
 export function createSpotlight(options: SpotlightOptions) {
+  let boundInput: HTMLInputElement | null = null;
   const { state, escapeHtml } = options;
   let interactionGeneration = 0;
   let renderedResults: readonly SpotlightResult[] = [];
@@ -575,12 +576,19 @@ export function createSpotlight(options: SpotlightOptions) {
     return true;
   }
 
-  function focus(): void {
+  function focus(selection?: {
+    start: number | null;
+    end: number | null;
+    direction: "forward" | "backward" | "none" | null;
+  }): void {
     requestAnimationFrame(() => {
       const input = document.querySelector<HTMLInputElement>("#spotlight-input");
-      if (!input) return;
+      if (!input || document.activeElement === input) return;
       input.focus();
-      input.setSelectionRange(input.value.length, input.value.length);
+      input.setSelectionRange(
+        selection?.start ?? input.value.length,
+        selection?.end ?? input.value.length,
+        selection?.direction ?? "none");
     });
   }
 
@@ -623,6 +631,7 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function reset(): void {
+    boundInput = null;
     dismissedPackageIds.clear();
     options.resetPackageSearch();
     state.spotlightOpen = false;
@@ -642,6 +651,7 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function open(seed = "", scope: SpotlightScope = "all"): void {
+    boundInput = null;
     dismissedPackageIds.clear();
     interactionGeneration++;
     options.resetPackageSearch();
@@ -846,6 +856,15 @@ export function createSpotlight(options: SpotlightOptions) {
 
   function bind(root: ParentNode, mode: "modal" | "inline"): void {
     const input = root.querySelector<HTMLInputElement>("#spotlight-input");
+    const previous = boundInput;
+    const selection = previous && input && previous.value === input.value
+      ? {
+          start: previous.selectionStart,
+          end: previous.selectionEnd,
+          direction: previous.selectionDirection,
+        }
+      : undefined;
+    boundInput = input;
     if (input) {
       input.addEventListener("input", () => {
         state.spotlightQuery = input.value;
@@ -878,7 +897,7 @@ export function createSpotlight(options: SpotlightOptions) {
           if (hasElementId(target) && target.id === "spotlight-backdrop") close();
         },
       );
-      focus();
+      focus(selection);
     }
   }
 

--- a/prototypes/inspect-web/src/spotlight.ts
+++ b/prototypes/inspect-web/src/spotlight.ts
@@ -6,6 +6,7 @@ import {
 } from "./command-bar.ts";
 import type { KeybindingRegistry } from "./keybinding-registry.ts";
 import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
+import { packageRemoveButton } from "./package-removal.ts";
 
 type LensDefinition = readonly [id: string, label: string];
 type SpotlightFocus = "input" | "chips";
@@ -16,6 +17,7 @@ interface SpotlightPackage {
   id: string;
   version: string;
   activeFramework?: string;
+  isRuntimePack?: boolean;
 }
 
 interface SpotlightType {
@@ -100,6 +102,8 @@ export type SpotlightResult =
   | TypeResult
   | MemberResult;
 
+export type RemovableSpotlightResult = PackageLoadedResult | PackageRecentResult;
+
 export interface SpotlightState {
   spotlightOpen: boolean;
   spotlightQuery: string;
@@ -121,6 +125,7 @@ interface SpotlightOptions {
   kindIcon: (kind: string) => string;
   searchResults: () => SpotlightResult[];
   pickResult: (result: SpotlightResult) => void;
+  removeResult?: (result: RemovableSpotlightResult) => boolean;
   executeCommand: (
     command: string,
     result: CommandPaletteResult,
@@ -263,6 +268,8 @@ export function createSpotlight(options: SpotlightOptions) {
   let interactionGeneration = 0;
   let renderedResults: readonly SpotlightResult[] = [];
   let selectedResultIdentity: string | null = null;
+  const dismissedPackageIds = new Set<string>();
+  let dismissalQuery = state.spotlightQuery;
 
   function scopes() {
     return options.commandContext()
@@ -277,7 +284,32 @@ export function createSpotlight(options: SpotlightOptions) {
         ? commandPaletteResults(context, options.lenses())
         : [];
     }
-    return options.searchResults();
+    if (dismissalQuery !== state.spotlightQuery) {
+      dismissedPackageIds.clear();
+      dismissalQuery = state.spotlightQuery;
+    }
+    return options.searchResults().filter(result =>
+      result.kind !== "pkg-nuget"
+      || !dismissedPackageIds.has(result.hit.id.toLowerCase()));
+  }
+
+  function removable(result: SpotlightResult): result is RemovableSpotlightResult {
+    return options.removeResult !== undefined
+      && (result.kind === "pkg-recent"
+        || (result.kind === "pkg-loaded" && !result.pkg.isRuntimePack));
+  }
+
+  function withRemoveButton(
+    result: SpotlightResult,
+    index: number,
+    row: string,
+  ): string {
+    if (!removable(result)) return row;
+    const label = result.kind === "pkg-recent"
+      ? `Forget ${result.entry.id} from recent packages`
+      : `Remove ${result.pkg.id} ${result.pkg.version} ${result.pkg.activeFramework ?? ""} from Workspace`;
+    return `<div class="package-search-row" role="presentation">${row}${packageRemoveButton(
+      "data-sl-remove", String(index), label, escapeHtml)}</div>`;
   }
 
   function rowHtml(result: SpotlightResult, index: number): string {
@@ -289,11 +321,11 @@ export function createSpotlight(options: SpotlightOptions) {
     const selectedClass = selected ? "selected" : "";
     const base = `id="spotlight-result-${index}" class="spotlight-item ${selectedClass}" role="option" aria-selected="${selected}" data-sl-index="${index}"`;
     if (result.kind === "pkg-loaded") {
-      return `<button ${base} data-sl-pkg-open="${escapeHtml(result.pkg.id)}">
+      return withRemoveButton(result, index, `<button ${base} data-sl-pkg-open="${escapeHtml(result.pkg.id)}">
         <span class="kind-icon sl-pkg">▣</span>
         <span class="spotlight-item-name">${options.highlightRanges(result.pkg.id, result.ranges)}</span>
         <span class="spotlight-item-ns">${escapeHtml(result.pkg.version)} · open</span>
-      </button>`;
+      </button>`);
     }
     if (result.kind === "pkg-nuget") {
       return `<button ${base} data-sl-pkg-load="${escapeHtml(result.hit.id)}" data-sl-pkg-version="${escapeHtml(result.hit.version || "")}">
@@ -306,11 +338,11 @@ export function createSpotlight(options: SpotlightOptions) {
       const version = result.entry.version && result.entry.version !== "latest"
         ? result.entry.version
         : "";
-      return `<button ${base} data-sl-pkg-recent="${escapeHtml(result.entry.id)}">
+      return withRemoveButton(result, index, `<button ${base} data-sl-pkg-recent="${escapeHtml(result.entry.id)}">
         <span class="kind-icon sl-pkg">▣</span>
         <span class="spotlight-item-name">${options.highlightRanges(result.entry.id, result.ranges)}</span>
         <span class="spotlight-item-ns">${version ? `${escapeHtml(version)} · ` : ""}recent</span>
-      </button>`;
+      </button>`);
     }
     if (result.kind === "package-query") {
       const suffix = result.prefix
@@ -482,7 +514,7 @@ export function createSpotlight(options: SpotlightOptions) {
           </div>
           <div class="spotlight-chips" id="spotlight-chips">${chipsHtml()}</div>
           <div class="spotlight-results" id="spotlight-results" role="listbox">${resultsHtml(items)}</div>
-          <div class="spotlight-foot"><span><kbd>Ctrl P</kbd> search</span><span>↑↓ select</span><span>→ target</span><span>↵ ${commands ? "complete / run" : "open"}</span><span>esc close</span></div>
+          <div class="spotlight-foot"><span><kbd>Ctrl P</kbd> search</span><span>↑↓ select</span><span>→ target</span><span>↵ ${commands ? "complete / run" : "open"}</span>${options.removeResult && !commands ? "<span>Shift+Delete remove</span>" : ""}<span>esc close</span></div>
         </div>
       </div>`;
   }
@@ -521,6 +553,26 @@ export function createSpotlight(options: SpotlightOptions) {
         if (result) pick(result);
       });
     });
+    root.querySelectorAll<HTMLElement>("[data-sl-remove]").forEach(button => {
+      button.addEventListener("click", () =>
+        removeResultAt(Number(button.dataset.slRemove)));
+    });
+  }
+
+  function removeResultAt(index: number): boolean {
+    const result = renderedResults[index];
+    if (!result || !removable(result)) return false;
+    const input = document.querySelector<HTMLInputElement>("#spotlight-input");
+    const start = input?.selectionStart ?? state.spotlightQuery.length;
+    const end = input?.selectionEnd ?? start;
+    if (!options.removeResult?.(result)) return true;
+    dismissedPackageIds.add((result.kind === "pkg-loaded"
+      ? result.pkg.id : result.entry.id).toLowerCase());
+    updateResults();
+    const replacement = document.querySelector<HTMLInputElement>("#spotlight-input");
+    replacement?.focus({ preventScroll: true });
+    replacement?.setSelectionRange(start, end);
+    return true;
   }
 
   function focus(): void {
@@ -571,6 +623,7 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function reset(): void {
+    dismissedPackageIds.clear();
     options.resetPackageSearch();
     state.spotlightOpen = false;
     state.spotlightQuery = "";
@@ -589,6 +642,7 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function open(seed = "", scope: SpotlightScope = "all"): void {
+    dismissedPackageIds.clear();
     interactionGeneration++;
     options.resetPackageSearch();
     state.spotlightOpen = true;
@@ -687,6 +741,9 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function handleModalKeys(event: KeyboardEvent): boolean {
+    if (event.key === "Delete" && event.shiftKey) {
+      return removeResultAt(state.spotlightIndex);
+    }
     if (event.key === "Escape") {
       close();
       return true;
@@ -758,6 +815,9 @@ export function createSpotlight(options: SpotlightOptions) {
   }
 
   function handleInlineKeys(event: KeyboardEvent): boolean {
+    if (event.key === "Delete" && event.shiftKey) {
+      return removeResultAt(state.spotlightIndex);
+    }
     const items = renderedResults;
     if (event.key === "ArrowDown") {
       state.spotlightIndex = nextSpotlightSelection(
@@ -802,7 +862,7 @@ export function createSpotlight(options: SpotlightOptions) {
         id: mode === "modal"
           ? "spotlight-modal.navigate"
           : "spotlight-inline.navigate",
-        key: ["Escape", "Tab", "ArrowRight", "ArrowLeft", "ArrowUp", "ArrowDown", "Enter"],
+        key: ["Escape", "Tab", "ArrowRight", "ArrowLeft", "ArrowUp", "ArrowDown", "Enter", "Delete"],
         allowExtraModifiers: true,
         priority: WORKBENCH_KEYBINDING_PRIORITY.element,
         run: mode === "modal" ? handleModalKeys : handleInlineKeys,

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1896,6 +1896,22 @@ kbd {
 .spotlight-item-name mark { background: transparent; color: var(--accent); font-weight: 600; }
 .spotlight-item-ns { justify-self: end; color: var(--muted); font: 11px var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
 .spotlight-item-pkg { grid-column: 2 / 4; color: var(--dim); font: 10px var(--mono); }
+.package-search-row { display: flex; align-items: center; gap: 4px; }
+.package-search-row > .spotlight-item { flex: 1; min-width: 0; }
+.package-row-remove {
+  flex: none;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 18px;
+  cursor: pointer;
+}
+.package-row-remove:hover,
+.package-row-remove:focus-visible { color: var(--accent); background: var(--accent-soft); }
 .spotlight-chips {
   display: flex;
   gap: 6px;

--- a/prototypes/inspect-web/src/workspace-subject.ts
+++ b/prototypes/inspect-web/src/workspace-subject.ts
@@ -1,4 +1,6 @@
 import type { PackageControlPackage } from "./package-controls.ts";
+import { packageIdentityKey } from "./data.ts";
+import { packageRemoveButton } from "./package-removal.ts";
 import type {
   BrowserWorkspacePackageOccurrence,
 } from "./facades/inspect-web-package.d.ts";
@@ -29,6 +31,7 @@ export interface WorkspaceSubjectBindingActions {
   onActivate: (action: string) => void;
   onDemo: (demo: ProductHomeDemoId) => void;
   onRetry: () => void;
+  onRemove?: (key: string) => void;
 }
 
 export interface WorkspaceOccurrenceVisibility {
@@ -45,6 +48,7 @@ export interface WorkspaceOccurrenceVisibility {
 
 export type WorkspaceFocusTarget =
   | { kind: "workspace" }
+  | { kind: "remove"; key: string; index: number }
   | { kind: "demo"; id: string };
 
 export function workspaceOccurrenceActionsAreVisible(
@@ -93,14 +97,23 @@ export function renderWorkspaceView(
     error,
     escapeHtml,
   } = options;
-  const packageRows = occurrences.map(occurrence => {
-    const label = `${occurrence.package} ${occurrence.version} ${occurrence.framework}`;
+  const packageRows = packages.filter(item => !item.isRuntimePack).map(item => {
+    const key = packageIdentityKey(item);
+    const occurrence = !loading && !error
+      ? occurrences.find(candidate => packageIdentityKey({
+        id: candidate.package,
+        version: candidate.version,
+        activeFramework: candidate.framework,
+      }) === key)
+      : undefined;
+    const label = `${item.id} ${item.version} ${item.activeFramework}`;
     return `<li class="workspace-occurrence-row">
-      <button class="workspace-occurrence" type="button" data-workspace-activate="${escapeHtml(occurrence.action)}" aria-label="Inspect ${escapeHtml(label)}">
+      <button class="workspace-occurrence" type="button" ${occurrence ? `data-workspace-activate="${escapeHtml(occurrence.action)}"` : "disabled"} aria-label="Inspect ${escapeHtml(label)}">
         <span>NuGet package</span>
-        <strong>${escapeHtml(occurrence.package)}</strong>
-        <small>${escapeHtml(occurrence.version)} · ${escapeHtml(occurrence.framework)}</small>
+        <strong>${escapeHtml(item.id)}</strong>
+        <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
       </button>
+      ${packageRemoveButton("data-workspace-remove", key, `Remove ${label} from Workspace`, escapeHtml)}
     </li>`;
   }).join("");
   const platformRows = packages.filter(item => item.isRuntimePack).map(item =>
@@ -110,16 +123,17 @@ export function renderWorkspaceView(
       <small>${escapeHtml(item.version)} · ${escapeHtml(item.activeFramework)}</small>
     </li>`).join("");
   const rows = `${packageRows}${platformRows}`;
-  const content = loading
+  const status = loading
     ? `<p class="workspace-empty">Reading Workspace package occurrences…</p>`
     : error
       ? `<div class="workspace-empty">
           <p>${escapeHtml(error)}</p>
           <button type="button" data-workspace-retry>Retry</button>
         </div>`
-      : rows
-        ? `<ul class="workspace-detail-list loaded">${rows}</ul>`
-        : `<p class="workspace-empty">No packages are loaded in this Workspace.</p>`;
+      : "";
+  const content = status + (rows
+    ? `<ul class="workspace-detail-list loaded">${rows}</ul>`
+    : `<p class="workspace-empty">No packages are loaded in this Workspace.</p>`);
   const demoRows = demos.map(demo =>
     `<li class="workspace-demo-row">
       <div>
@@ -149,7 +163,7 @@ export function renderWorkspaceView(
     </section>
     <section class="document-section workspace-section">
       <div class="section-title"><h2>Packages</h2><span>${packages.length} coordinate${packages.length === 1 ? "" : "s"}</span></div>
-      <p>Choose a package to inspect it. The Workspace keeps every loaded coordinate available.</p>
+      <p>Choose a package to inspect it, or remove it with the adjacent close button.</p>
       ${content}
     </section>
   </div>`;
@@ -173,6 +187,11 @@ export function bindWorkspaceSubject(
     }));
   root.querySelector<HTMLElement>("[data-workspace-retry]")
     ?.addEventListener("click", actions.onRetry);
+  root.querySelectorAll<HTMLElement>("[data-workspace-remove]").forEach(button =>
+    button.addEventListener("click", () => {
+      const key = button.dataset.workspaceRemove;
+      if (key !== undefined) actions.onRemove?.(key);
+    }));
 }
 
 export function focusWorkspace(
@@ -187,10 +206,18 @@ export function captureWorkspaceFocus(
   element: HTMLElement | null,
 ): WorkspaceFocusTarget | null {
   const target = element?.closest<HTMLElement>(
-    "[data-workspace-default], [data-workspace-demo]");
+    "[data-workspace-default], [data-workspace-demo], [data-workspace-remove]");
   if (!target) return null;
   if (target.hasAttribute("data-workspace-default")) {
     return { kind: "workspace" };
+  }
+  if (target.dataset.workspaceRemove !== undefined) {
+    return {
+      kind: "remove",
+      key: target.dataset.workspaceRemove,
+      index: [...target.ownerDocument.querySelectorAll("[data-workspace-remove]")]
+        .indexOf(target),
+    };
   }
   const demo = target.dataset.workspaceDemo;
   if (demo !== undefined) {
@@ -205,6 +232,14 @@ export function restoreWorkspaceFocus(
 ): boolean {
   let element: HTMLElement | null = null;
   switch (target.kind) {
+    case "remove": {
+      const buttons = [...root.querySelectorAll<HTMLElement>("[data-workspace-remove]")];
+      element = buttons.find(button => button.dataset.workspaceRemove === target.key)
+        ?? buttons[Math.min(target.index, buttons.length - 1)]
+        ?? root.querySelector<HTMLElement>("h1");
+      if (element?.tagName === "H1") element.tabIndex = -1;
+      break;
+    }
     case "workspace":
       element = root.querySelector<HTMLElement>("[data-workspace-default]");
       break;

--- a/prototypes/inspect-web/test/package-inspection.test.ts
+++ b/prototypes/inspect-web/test/package-inspection.test.ts
@@ -426,6 +426,67 @@ async function verifyPackageLensLifecycle<T>(
       true,
       `${fixture.name} stale loading`);
   }
+
+  for (const outcome of ["success", "failure"]) {
+    for (const completionOrder of ["stale-first", "current-first"]) {
+      const label = `${fixture.name}: ${outcome}, ${completionOrder}`;
+      const stale = deferred<T>();
+      const current = deferred<T>();
+      const currentResult = structuredClone(fixture.result);
+      let queries = 0;
+      let renders = 0;
+      const state = inspectionState({ packages: [packageModel()] });
+      const coordinator = fixture.createCoordinator(
+        state,
+        async () => ++queries === 1 ? stale.promise : current.promise,
+        () => renders++);
+
+      const staleLoad = fixture.load(coordinator, "same-coordinate");
+      state.packages = [];
+      coordinator.invalidatePackageResults();
+      state.packages = [packageModel()];
+      const currentLoad = fixture.load(coordinator, "same-coordinate");
+      assert.equal(queries, 2, label);
+
+      if (completionOrder === "current-first") {
+        current.resolve(currentResult);
+        await currentLoad;
+      }
+      const rendersBeforeStaleCompletion = renders;
+      const workspaceBeforeStaleCompletion = structuredClone(
+        state.workspaceDependencies);
+      if (outcome === "success") {
+        stale.resolve(fixture.result);
+      } else {
+        stale.reject(new Error("retired failure"));
+      }
+      await staleLoad;
+
+      assert.strictEqual(
+        fixture.readResult(state),
+        completionOrder === "current-first" ? currentResult : null,
+        label);
+      assert.equal(
+        fixture.readLoading(state),
+        completionOrder === "stale-first",
+        label);
+      assert.equal(fixture.readError(state), "", label);
+      assert.equal(renders, rendersBeforeStaleCompletion, label);
+      assert.deepEqual(
+        state.workspaceDependencies,
+        workspaceBeforeStaleCompletion,
+        label);
+      assert.deepEqual(state.workspaceDependencyErrors, {}, label);
+
+      if (completionOrder === "stale-first") {
+        current.resolve(currentResult);
+        await currentLoad;
+      }
+      assert.strictEqual(fixture.readResult(state), currentResult, label);
+      assert.equal(fixture.readLoading(state), false, label);
+      assert.equal(fixture.readError(state), "", label);
+    }
+  }
 }
 
 test("workspace dependency keys normalize complete package coordinates", () => {
@@ -618,7 +679,7 @@ test("package lens loaders reuse cached failures without querying", async () => 
   assert.equal(state.packagePerformanceError, "cached failure");
 });
 
-test("every package lens preserves its complete request lifecycle", async () => {
+test("every package lens preserves its lifecycle and same-coordinate ownership across invalidation", async () => {
   const packageItem = packageModel();
 
   await verifyPackageLensLifecycle({
@@ -787,6 +848,238 @@ test("stale package lens rejection cannot overwrite newer state", async () => {
 
   assert.equal(state.packagePerformanceError, "newer failure");
   assert.equal(state.packagePerformanceLoading, true);
+});
+
+test("invalidation clears package results, failures, keys, and loads without changing selection or workspace caches", () => {
+  const remaining = packageModel();
+  const key = workspaceDependencyKey(remaining);
+  const workspaceDependencies = {
+    [key]: {
+      dependencyGroups: dependencyResult().dependencyGroups,
+      dependencyGroupError: "retained partial data",
+    },
+  };
+  const workspaceDependencyErrors = { [key]: "retained partial data" };
+  const retainedState = {
+    packages: [remaining],
+    atPackageRoot: true,
+    packageLens: "analysis" as const,
+    workspaceDependencies,
+    workspaceDependencyErrors,
+  };
+  const state = inspectionState({
+    ...retainedState,
+    packageDependencies: dependencyResult(),
+    packageDependenciesLoading: true,
+    packageDependenciesError: "dependency failure",
+    packageDependenciesKey: "dependencies",
+    packageIntegrations: integrationsResult(),
+    packageIntegrationsLoading: true,
+    packageIntegrationsError: "integration failure",
+    packageIntegrationsKey: "integrations",
+    packageOpportunities: opportunitiesResult(),
+    packageOpportunitiesLoading: true,
+    packageOpportunitiesError: "opportunity failure",
+    packageOpportunitiesKey: "opportunities",
+    packagePerformance: performanceResult(),
+    packagePerformanceLoading: true,
+    packagePerformanceError: "performance failure",
+    packagePerformanceKey: "performance",
+    packageMetadata: metadataResult(),
+    packageMetadataLoading: true,
+    packageMetadataError: "metadata failure",
+    packageMetadataKey: "metadata",
+    workspaceDependencyLoads: new Set([key]),
+  });
+  const coordinator = createPackageInspectionCoordinator(
+    inspectionDependencies(state));
+
+  coordinator.invalidatePackageResults();
+
+  assert.deepEqual(state, inspectionState(retainedState));
+  assert.strictEqual(state.packages, retainedState.packages);
+  assert.strictEqual(state.workspaceDependencies, workspaceDependencies);
+  assert.strictEqual(state.workspaceDependencyErrors, workspaceDependencyErrors);
+});
+
+test("invalidated package completions cannot publish, render, or start follow-up work", async () => {
+  for (const outcome of ["success", "failure"]) {
+    const removed = packageModel();
+    const remaining = packageModel({ id: "Example.Remaining" });
+    const dependencies = deferred<BrowserPackageDependencies>();
+    const integrations = deferred<BrowserPackageIntegrations>();
+    const opportunities = deferred<BrowserPackageOpportunities>();
+    const performance = deferred<PackagePerformance>();
+    const metadata = deferred<PackageMetadata>();
+    const events: string[] = [];
+    const state = inspectionState({ packages: [removed, remaining] });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryDependencies: async packageItem => {
+          events.push(`query:${packageItem.id}`);
+          return dependencies.promise;
+        },
+        queryPackageIntegrations: async () => integrations.promise,
+        queryPackageOpportunities: async () => opportunities.promise,
+        queryPackagePerformance: async () => performance.promise,
+        queryPackageMetadata: async () => metadata.promise,
+        render: () => events.push("render"),
+        refreshPackageStats: () => events.push("stats"),
+        renderDependencyGraph: async () => { events.push("graph"); },
+      }));
+    const loads = [
+      coordinator.loadDependencies(removed, "dependencies"),
+      coordinator.loadIntegrations(removed, "integrations", null),
+      coordinator.loadOpportunities(removed, "opportunities", null),
+      coordinator.loadPerformance(removed, "performance", null),
+      coordinator.loadMetadata(removed, "metadata", null),
+    ];
+
+    state.packages = [remaining];
+    events.length = 0;
+    coordinator.invalidatePackageResults();
+    assert.deepEqual(state, inspectionState({ packages: [remaining] }), outcome);
+
+    if (outcome === "success") {
+      dependencies.resolve(dependencyResult());
+      integrations.resolve(integrationsResult());
+      opportunities.resolve(opportunitiesResult());
+      performance.resolve(performanceResult());
+      metadata.resolve(metadataResult());
+    } else {
+      for (const request of [
+        dependencies, integrations, opportunities, performance, metadata,
+      ]) {
+        request.reject(new Error("retired failure"));
+      }
+    }
+    await Promise.all(loads);
+
+    assert.deepEqual(state, inspectionState({ packages: [remaining] }), outcome);
+    assert.deepEqual(events, [], outcome);
+  }
+});
+
+test("invalidated workspace dependency loads cannot restore removed entries or continue their queue", async () => {
+  for (const outcome of ["success", "failure"]) {
+    const removed = packageModel();
+    const queued = packageModel({ id: "Example.Queued" });
+    const cached = packageModel({ id: "Example.Cached" });
+    const key = workspaceDependencyKey(cached);
+    const request = deferred<BrowserPackageDependencies>();
+    const events: string[] = [];
+    const state = inspectionState({
+      packages: [removed, queued, cached],
+      atPackageRoot: true,
+      packageLens: "dependencies",
+      workspaceDependencies: {
+        [key]: { dependencyGroups: dependencyResult(cached.id).dependencyGroups },
+      },
+      workspaceDependencyErrors: { [key]: "retained warning" },
+    });
+    const coordinator = createPackageInspectionCoordinator(
+      inspectionDependencies(state, {
+        queryDependencies: async packageItem => {
+          events.push(`query:${packageItem.id}`);
+          return packageItem === removed
+            ? request.promise
+            : dependencyResult(packageItem.id);
+        },
+        render: () => events.push("render"),
+        refreshPackageStats: () => events.push("stats"),
+        renderDependencyGraph: async () => { events.push("graph"); },
+      }));
+
+    const load = coordinator.ensureWorkspaceDependencies();
+    assert.deepEqual(events, [`query:${removed.id}`], outcome);
+    state.packages = [queued, cached];
+    events.length = 0;
+    coordinator.invalidatePackageResults();
+    assert.equal(state.workspaceDependencyLoads.size, 0, outcome);
+    const invalidatedState = structuredClone(state);
+
+    if (outcome === "success") {
+      request.resolve(dependencyResult(removed.id, "retired warning"));
+    } else {
+      request.reject(new Error("retired failure"));
+    }
+    await load;
+
+    assert.deepEqual(state, invalidatedState, outcome);
+    assert.deepEqual(events, [], outcome);
+
+    await coordinator.ensureWorkspaceDependencies();
+    assert.deepEqual(events, [`query:${queued.id}`, "render", "stats"], outcome);
+    assert.deepEqual(
+      state.workspaceDependencies[key],
+      invalidatedState.workspaceDependencies[key],
+      outcome);
+    assert.equal(state.workspaceDependencyErrors[key], "retained warning", outcome);
+  }
+});
+
+test("invalidated workspace completions cannot overwrite reopened results or release a new load", async () => {
+  for (const outcome of ["success", "failure"]) {
+    for (const completionOrder of ["stale-first", "current-first"]) {
+      const label = `${outcome}, ${completionOrder}`;
+      const removed = packageModel();
+      const key = workspaceDependencyKey(removed);
+      const stale = deferred<BrowserPackageDependencies>();
+      const current = deferred<BrowserPackageDependencies>();
+      const currentResult = dependencyResult(removed.id, "current warning");
+      let queries = 0;
+      const events: string[] = [];
+      const state = inspectionState({
+        packages: [removed],
+        atPackageRoot: true,
+        packageLens: "dependencies",
+      });
+      const coordinator = createPackageInspectionCoordinator(
+        inspectionDependencies(state, {
+          queryDependencies: async () => ++queries === 1
+            ? stale.promise
+            : current.promise,
+          render: () => events.push("render"),
+          refreshPackageStats: () => events.push("stats"),
+          renderDependencyGraph: async () => { events.push("graph"); },
+        }));
+
+      const staleLoad = coordinator.ensureWorkspaceDependencies();
+      state.packages = [];
+      coordinator.invalidatePackageResults();
+      state.packages = [packageModel()];
+      const currentLoad = coordinator.ensureWorkspaceDependencies();
+      assert.equal(queries, 2, label);
+      assert.deepEqual([...state.workspaceDependencyLoads], [key], label);
+      if (completionOrder === "current-first") {
+        current.resolve(currentResult);
+        await currentLoad;
+      }
+      const currentState = structuredClone(state);
+      events.length = 0;
+      if (outcome === "success") {
+        stale.resolve(dependencyResult(removed.id, "retired warning"));
+      } else {
+        stale.reject(new Error("retired failure"));
+      }
+      await staleLoad;
+
+      assert.deepEqual(state, currentState, label);
+      assert.deepEqual(events, [], label);
+      if (completionOrder === "stale-first") {
+        await coordinator.ensureWorkspaceDependencies();
+        assert.equal(queries, 2, label);
+        current.resolve(currentResult);
+        await currentLoad;
+      }
+      assert.deepEqual(state.workspaceDependencies[key], {
+        dependencyGroups: currentResult.dependencyGroups,
+        dependencyGroupError: currentResult.dependencyGroupError,
+      }, label);
+      assert.equal(state.workspaceDependencyErrors[key], "current warning", label);
+      assert.equal(state.workspaceDependencyLoads.size, 0, label);
+    }
+  }
 });
 
 test("workspace dependency loading records failures and ignores runtime packs", async () => {

--- a/prototypes/inspect-web/test/package-removal.test.ts
+++ b/prototypes/inspect-web/test/package-removal.test.ts
@@ -4,11 +4,35 @@ import { stripTypeScriptTypes } from "node:module";
 import { runInNewContext } from "node:vm";
 import test from "node:test";
 import { parseSync } from "oxc-parser";
-import { packageIdentityKey } from "../src/data.ts";
+import {
+  assemblyDescriptorForType,
+  memberRequestKey,
+  packageIdentityKey,
+} from "../src/data.ts";
+import {
+  createCallGraphInspectionCoordinator,
+  type CallGraphInspectionState,
+  type CallGraphWorkspacePackage,
+  type MemberCallGraphRequest,
+  type PlatformDrillRequest,
+} from "../src/call-graph-inspection.ts";
+import type { BrowserCallGraph } from "../src/facades/inspect-web-call-graph.d.ts";
+import {
+  invalidateGraphMemberNavigationWork,
+  invalidateMemberCallGraphWork,
+  memberScopeIsActive,
+  selectedConcreteOverload,
+} from "../src/member-filtering.ts";
 import {
   createPackageRemoval,
   type PackageRemovalState,
 } from "../src/package-removal.ts";
+import {
+  browserCreatedCallGraphTabIds,
+  createNavigationSequence,
+  selectedBrowserCallGraphPackageTabIds,
+  workspaceShareTabsMatchResolved,
+} from "../src/workspace-navigation.ts";
 
 const alpha = { id: "Alpha", version: "1.0.0", activeFramework: "net10.0" };
 const beta = { ...alpha, id: "Beta" };
@@ -100,7 +124,7 @@ const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.u
 const app = parseSync("dotnet-inspect.ts", appSource);
 const hostNames = new Set([
   "activateAfterPackageRemoval", "finishPackageRemoval", "activatePackage",
-  "packageIdentityEquals", "defaultAccessibilityFilter",
+  "packageIdentityEquals", "defaultAccessibilityFilter", "scope",
 ]);
 const hostDeclarations = app.program.body
   .filter(node => node.type === "FunctionDeclaration" && hostNames.has(node.id?.name ?? ""))
@@ -109,6 +133,7 @@ const hostDeclarations = app.program.body
 for (const home of [true, false]) {
   test(`original application removal handlers preserve ${home ? "Home" : "Workspace"} through last removal`, () => {
     const state = {
+      ...graphInspectionState(),
       home, packages: [alpha, beta], package: alpha as typeof alpha | null,
       workspaceSubjectOpen: !home, atPackageRoot: false,
       dependenciesGroupIndex: 2, selectedTypeId: "Old.Type",
@@ -117,6 +142,8 @@ for (const home of [true, false]) {
       workspaceShareBasis: { previous: true },
     };
     const locations: string[] = [];
+    const historyState = { __entryId: "workspace-entry" };
+    const replacementStates: unknown[] = [];
     const released: typeof alpha[] = [];
     const effects: string[] = [];
     const context = {
@@ -127,10 +154,17 @@ for (const home of [true, false]) {
       resetMemberSectionState: () => effects.push("member"),
       navigationSequence: { begin: () => effects.push("cancel") },
       invalidateGraphMemberNavigation: () => {},
+      invalidateMemberCallGraphWork,
       clearWorkspaceOccurrenceView: () => effects.push("occurrences"),
       packageInspection: { invalidatePackageResults: () => effects.push("results") },
       releasePackageModelCaches: (pkg: typeof alpha) => released.push(pkg),
-      workspaceLocation: { replace: (url: string) => locations.push(url) },
+      history: { state: historyState },
+      workspaceLocation: {
+        replace: (url: string, entryState: unknown) => {
+          locations.push(url);
+          replacementStates.push(entryState);
+        },
+      },
       render: () => effects.push("render"),
     };
     runInNewContext(stripTypeScriptTypes(`${hostDeclarations}
@@ -150,7 +184,310 @@ for (const home of [true, false]) {
     assert.equal(state.selectedOverloadIndex, null);
     assert.equal(state.workspaceShareBasis, null);
     assert.deepEqual(locations, home ? [] : ["/demos"]);
+    assert.deepEqual(replacementStates, home ? [] : [historyState]);
     assert.deepEqual(released, [alpha, beta]);
     assert.equal(effects.filter(effect => effect === "render").length, 2);
+  });
+}
+
+function graphInspectionState(): CallGraphInspectionState {
+  return {
+    memberCallGraph: null,
+    memberCallGraphLoading: false,
+    memberCallGraphError: "",
+    graphMemberNavigationError: "",
+    memberCallGraphKey: "",
+    memberCallGraphExpanding: false,
+    memberCallGraphSeq: 0,
+    platformStack: [],
+    platformDrillLoading: false,
+    platformDrillError: "",
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((accept, deny) => {
+    resolve = accept;
+    reject = deny;
+  });
+  return { promise, resolve, reject };
+}
+
+function removalGraph(packages: readonly typeof alpha[]): BrowserCallGraph {
+  const node = {
+    label: "Alpha.Widget.Run",
+    status: "Analyzed",
+    inLoop: false,
+    source: null,
+    children: [],
+    assembly: "Alpha.dll",
+    typeFullName: "Alpha.Widget",
+    memberName: "Run",
+  };
+  return {
+    mermaid: packages.map(pkg => pkg.id).join(" --> "),
+    callers: {
+      ...node,
+      children: packages.filter(pkg => pkg.id !== alpha.id).map(pkg => ({
+        ...node, label: `${pkg.id}.Caller.Run`, assembly: `${pkg.id}.dll`,
+      })),
+    },
+    callees: node,
+    scope: {
+      packages: packages.length,
+      assemblies: packages.length,
+      callerAssemblies: packages.length,
+      calleeScope: "target assembly",
+    },
+    targets: [],
+    diagnostics: {
+      incompleteNodes: 0,
+      incompleteEdges: 0,
+      bindingIdentityConflicts: 0,
+      hasUnexploredTraversalBoundary: false,
+      hasAnalysisFailureBoundary: false,
+      isIncomplete: false,
+    },
+    noBody: false,
+  };
+}
+
+const graphHostNames = new Set([
+  "finishPackageRemoval", "invalidateGraphMemberNavigation",
+  "loadSelectedMemberCallGraph", "memberRequestSignature", "memberRequestIsCurrent",
+  "selectedCallGraphWorkspacePackages", "capturedShareTabs", "resolvedWorkspaceShareTabs",
+  "currentPackage", "selectedType", "selectedMember", "memberGroups", "scope",
+]);
+const graphHostDeclarations = app.program.body
+  .filter(node =>
+    node.type === "FunctionDeclaration" && graphHostNames.has(node.id?.name ?? "")
+    || node.type === "VariableDeclaration"
+      && node.declarations.some(declaration =>
+        declaration.id.type === "Identifier" && declaration.id.name === "packageRemoval"))
+  .map(node => appSource.slice(node.start, node.end)).join("\n");
+
+function graphRemovalHarness() {
+  const type = {
+    id: "T:Alpha.Widget", assembly: "Alpha.dll",
+    api: [0, 1].map(index => ({
+      kind: "Method", name: "Run", signature: `void Run(${index ? "int value" : ""})`,
+      graphSelectorKey: `Run|${index ? "System.Int32" : ""}`,
+      metadataToken: 0x06000001 + index,
+    })),
+  };
+  const active = { ...alpha, types: [type], assemblies: [] };
+  const state = {
+    ...graphInspectionState(),
+    packages: [active, { ...beta, types: [], assemblies: [] }], package: active,
+    recentPackages: [alpha, beta].map(pkg => ({
+      id: pkg.id, version: pkg.version, framework: pkg.activeFramework,
+    })),
+    home: false, workspaceSubjectOpen: false, atPackageRoot: false,
+    lens: "api", selectedTypeId: type.id, selectedMemberKey: "Method:Run",
+    memberBrowseTypeId: type.id, selectedOverloadIndex: 1, memberSection: "call-graph",
+    selectedBodyTarget: { metadataToken: 0x06000002, selectorKey: "Run|System.Int32" },
+    workspaceShareBasis: null,
+    graphMemberNavigationSeq: 0, graphMemberNavigationTitle: "",
+    pendingGraphMemberDeepLink: null,
+  };
+  const local = removalGraph([alpha]);
+  const full = removalGraph([alpha, beta]);
+  const expansionStarted = deferred<void>();
+  const expansion = deferred<BrowserCallGraph>();
+  const platformStarted = deferred<void>();
+  const platform = deferred<BrowserCallGraph>();
+  let deferExpansion = false;
+  let deferPlatform = false;
+  const queries: { request: MemberCallGraphRequest; workspace: CallGraphWorkspacePackage[] }[] = [];
+  const rendered: (BrowserCallGraph | null)[] = [];
+  const pending: Promise<void>[] = [];
+  const selection = () => ({
+    package: state.package,
+    type: state.selectedTypeId,
+    member: state.selectedMemberKey,
+    overload: state.selectedOverloadIndex,
+    body: state.selectedBodyTarget,
+    browseType: state.memberBrowseTypeId,
+    section: state.memberSection,
+    lens: state.lens,
+    atPackageRoot: state.atPackageRoot,
+  });
+  const render = () => {
+    rendered.push(state.platformStack.at(-1)?.graph ?? state.memberCallGraph);
+  };
+  const coordinator = createCallGraphInspectionCoordinator({
+    state,
+    queryWorkspace: async (request, workspace) => {
+      queries.push({ request, workspace: structuredClone(workspace) });
+      if (!workspace.length) return local;
+      if (deferExpansion) {
+        expansionStarted.resolve(undefined);
+        return expansion.promise;
+      }
+      return full;
+    },
+    queryPlatform: async () => {
+      if (!deferPlatform) return removalGraph([alpha]);
+      platformStarted.resolve(undefined);
+      return platform.promise;
+    },
+    describeError: String,
+    render,
+    renderPreservingMemberFocus: () => {
+      render();
+      return {
+        selector: "", dataTarget: null, selection: null,
+        navigationScope: null, navigationSelection: null, navigationScrollTop: null,
+        focusLost: false,
+      };
+    },
+    renderCallGraph: async () => render(),
+    nextPaint: async () => {},
+    refreshPackageStats: () => {},
+    patchCallGraphSection: render,
+  });
+  let host!: { load(): Promise<void>; remove(key: string): void };
+  runInNewContext(
+    stripTypeScriptTypes(`${graphHostDeclarations}
+      registerHost({ load: loadSelectedMemberCallGraph, remove: key => packageRemoval.removeLoaded(key) });
+    `),
+    {
+      registerHost: (api: typeof host) => { host = api; },
+      state, callGraphInspection: coordinator,
+      createPackageRemoval, packageIdentityKey, memberRequestKey,
+      assemblyDescriptorForType, selectedConcreteOverload, memberScopeIsActive,
+      browserCreatedCallGraphTabIds, selectedBrowserCallGraphPackageTabIds,
+      workspaceShareTabsMatchResolved, invalidateMemberCallGraphWork,
+      invalidateGraphMemberNavigationWork, navigationSequence: createNavigationSequence(),
+      platformPackForAssembly: () => null,
+      localStorage: { setItem: () => {} },
+      activateAfterPackageRemoval: () => assert.fail("Inactive removal must not activate a package"),
+      clearWorkspaceOccurrenceView: () => {},
+      packageInspection: { invalidatePackageResults: () => {} },
+      spotlightCache: null, spotlightMemberCache: null,
+      releasePackageModelCaches: () => {},
+      render, errorMessage: String,
+      observeAsync: (work: Promise<void>) => pending.push(work),
+    });
+  return {
+    state, local, full, queries, rendered, coordinator, host, selection,
+    expansion, expansionStarted, platform, platformStarted,
+    deferExpansion: () => { deferExpansion = true; },
+    deferPlatform: () => { deferPlatform = true; },
+    remove: () => host.remove(packageIdentityKey(beta)),
+    settleRefresh: () => Promise.all(pending),
+  };
+}
+
+for (const visible of [true, false]) {
+  test(`inactive removal invalidates a completed ${visible ? "visible" : "cached"} graph without changing selection`, async () => {
+    const h = graphRemovalHarness();
+    await h.host.load();
+    assert.equal(h.state.memberCallGraph, h.full);
+    assert.equal(h.state.memberCallGraph.callers.children[0]?.assembly, "Beta.dll");
+    if (!visible) h.state.memberSection = "facts";
+    const selection = h.selection();
+
+    h.remove();
+    await h.settleRefresh();
+
+    assert.deepEqual(h.selection(), selection);
+    assert.deepEqual(h.state.packages.map(pkg => pkg.id), ["Alpha"]);
+    if (!visible) {
+      assert.equal(h.queries.length, 2, "Hidden graphs must not eagerly query");
+      assert.equal(h.state.memberCallGraph, null);
+      assert.equal(h.state.memberCallGraphKey, "");
+      h.state.memberSection = "call-graph";
+      await h.host.load();
+    }
+    assert.equal(h.queries.length, 3);
+    assert.deepEqual(structuredClone(h.queries[2]?.request.workspacePackages), [
+      { package: "Alpha", version: "1.0.0", framework: "net10.0" },
+    ]);
+    assert.equal(h.queries[2]?.request.hasOtherLibraries, false);
+    assert.equal(h.state.memberCallGraph, h.local);
+    assert.equal(h.rendered.at(-1), h.local);
+    assert.equal(h.state.memberCallGraph.scope.packages, 1);
+    assert.equal(h.state.memberCallGraph.callers.children.length, 0);
+    await h.host.load();
+    assert.equal(h.queries.length, 3, "Reopening may reuse only the refreshed graph");
+  });
+}
+
+for (const failure of [false, true]) {
+  test(`inactive removal rejects a pending expansion ${failure ? "failure" : "result"} even when the refreshed local graph is the same object`, async () => {
+    const h = graphRemovalHarness();
+    h.deferExpansion();
+    const originalLoad = h.host.load();
+    await h.expansionStarted.promise;
+    const selection = h.selection();
+    const originalRequest = h.queries[0]!.request;
+    assert.equal(h.state.memberCallGraph, h.local);
+
+    h.remove();
+    await h.settleRefresh();
+
+    assert.deepEqual(h.selection(), selection);
+    assert.equal(h.queries.length, 3);
+    assert.deepEqual(structuredClone(h.queries[2]?.request.workspacePackages), [
+      { package: "Alpha", version: "1.0.0", framework: "net10.0" },
+    ]);
+    assert.equal(h.state.memberCallGraph, h.local);
+    assert.equal(h.state.memberCallGraphKey, originalRequest.signature);
+    assert.equal(originalRequest.isCurrent(), true, "The active member selection is unchanged");
+    const renders = h.rendered.length;
+    if (failure) h.expansion.reject(new Error("Beta expansion failed"));
+    else h.expansion.resolve(h.full);
+    await originalLoad;
+
+    assert.equal(h.rendered.length, renders, "Obsolete expansion must not publish");
+    assert.equal(h.state.memberCallGraph, h.local);
+    assert.equal(h.state.memberCallGraphError, "");
+    assert.equal(h.state.memberCallGraphLoading, false);
+    assert.equal(h.state.memberCallGraphExpanding, false);
+    await h.host.load();
+    assert.equal(h.queries.length, 3);
+    assert.equal(h.state.memberCallGraph.scope.packages, 1);
+  });
+}
+
+for (const failure of [false, true]) {
+  test(`inactive removal clears platform drill state and rejects its pending ${failure ? "failure" : "result"}`, async () => {
+    const h = graphRemovalHarness();
+    await h.host.load();
+    const request: PlatformDrillRequest = {
+      framework: "net10.0", platformVersion: "10.0.0",
+      assembly: "System.Text.Json.dll", pack: "netcore.app",
+      assemblyVersion: "10.0.0.0", assemblyCulture: null,
+      assemblyPublicKeyToken: "cc7b13ffcd2ddd51",
+      type: "T:System.Text.Json.JsonSerializer", member: "Serialize",
+      selectorKey: "Serialize|System.Object", metadataToken: 0x06000001,
+      title: "JsonSerializer.Serialize", errorTarget: "JsonSerializer.Serialize",
+      isCurrent: () => true,
+    };
+    await h.coordinator.drill(request);
+    assert.equal(h.state.platformStack.length, 1);
+    h.deferPlatform();
+    const drill = h.coordinator.drill(request);
+    await h.platformStarted.promise;
+    assert.equal(h.state.platformDrillLoading, true);
+    const selection = h.selection();
+
+    h.remove();
+    await h.settleRefresh();
+    const renders = h.rendered.length;
+    if (failure) h.platform.reject(new Error("Obsolete platform failure"));
+    else h.platform.resolve(removalGraph([beta]));
+    await drill;
+
+    assert.deepEqual(h.selection(), selection);
+    assert.equal(h.state.platformStack.length, 0);
+    assert.equal(h.state.platformDrillLoading, false);
+    assert.equal(h.state.platformDrillError, "");
+    assert.equal(h.state.memberCallGraph, h.local);
+    assert.equal(h.rendered.at(-1), h.local);
+    assert.equal(h.rendered.length, renders);
   });
 }

--- a/prototypes/inspect-web/test/package-removal.test.ts
+++ b/prototypes/inspect-web/test/package-removal.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { stripTypeScriptTypes } from "node:module";
+import { runInNewContext } from "node:vm";
+import test from "node:test";
+import { parseSync } from "oxc-parser";
+import { packageIdentityKey } from "../src/data.ts";
+import {
+  createPackageRemoval,
+  type PackageRemovalState,
+} from "../src/package-removal.ts";
+
+const alpha = { id: "Alpha", version: "1.0.0", activeFramework: "net10.0" };
+const beta = { ...alpha, id: "Beta" };
+const otherAlpha = { ...alpha, version: "2.0.0" };
+
+function harness(packages = [alpha, beta, otherAlpha]) {
+  const state: PackageRemovalState<typeof alpha> = {
+    packages,
+    package: packages[0] ?? null,
+    recentPackages: [alpha, beta].map(pkg => ({
+      id: pkg.id, version: pkg.version, framework: pkg.activeFramework,
+    })),
+  };
+  let stored = JSON.stringify(state.recentPackages);
+  let failStorage = false;
+  const released: typeof alpha[] = [];
+  const activated: (typeof alpha | null)[] = [];
+  const removal = createPackageRemoval({
+    state,
+    persistRecent: entries => {
+      if (failStorage) throw new Error("Storage is unavailable");
+      stored = JSON.stringify(entries);
+    },
+    activate: next => {
+      activated.push(next);
+      state.package = next;
+    },
+    release: pkg => released.push(pkg),
+  });
+  return {
+    state, removal, released, activated,
+    persisted: () => JSON.parse(stored) as unknown,
+    failStorage: () => { failStorage = true; },
+  };
+}
+
+test("forgetting a recent ID persists without changing loaded packages", () => {
+  const h = harness();
+  h.removal.forgetRecent("aLPHa");
+  assert.deepEqual(h.persisted(), [
+    { id: "Beta", version: "1.0.0", framework: "net10.0" },
+  ]);
+  assert.deepEqual(h.state.packages, [alpha, beta, otherAlpha]);
+  assert.equal(h.state.package, alpha);
+  assert.deepEqual(h.released, []);
+});
+
+test("removing an inactive coordinate preserves active selection and other versions", () => {
+  const h = harness();
+  h.removal.removeLoaded(packageIdentityKey(otherAlpha));
+  assert.deepEqual(h.state.packages, [alpha, beta]);
+  assert.equal(h.state.package, alpha);
+  assert.deepEqual(h.activated, []);
+  assert.deepEqual(h.released, [otherAlpha]);
+  assert.equal(h.state.recentPackages.some(entry => entry.id === "Alpha"), false);
+});
+
+test("active and last removal use the existing successor and release each removed model", () => {
+  const h = harness([alpha, beta]);
+  h.removal.removeLoaded(packageIdentityKey(alpha));
+  assert.equal(h.state.package, beta);
+  h.removal.removeLoaded(packageIdentityKey(beta));
+  assert.equal(h.state.package, null);
+  assert.deepEqual(h.state.packages, []);
+  assert.deepEqual(h.persisted(), []);
+  assert.deepEqual(h.released, [alpha, beta]);
+});
+
+test("storage failure preserves membership and history without running removal effects", () => {
+  const h = harness();
+  const before = structuredClone(h.state);
+  h.failStorage();
+  assert.throws(() => h.removal.forgetRecent("Alpha"), /Storage/);
+  assert.throws(() => h.removal.removeLoaded(packageIdentityKey(alpha)), /Storage/);
+  assert.deepEqual(h.state, before);
+  assert.deepEqual(h.activated, []);
+  assert.deepEqual(h.released, []);
+});
+
+test("Platform and missing coordinates fail visibly rather than removing another package", () => {
+  const platform = { ...beta, isRuntimePack: true };
+  const h = harness([alpha, platform]);
+  assert.throws(() => h.removal.removeLoaded(packageIdentityKey(platform)), /no longer removable/);
+  assert.throws(() => h.removal.removeLoaded("missing"), /no longer removable/);
+  assert.deepEqual(h.state.packages, [alpha, platform]);
+});
+
+const appSource = readFileSync(new URL("../src/dotnet-inspect.ts", import.meta.url), "utf8");
+const app = parseSync("dotnet-inspect.ts", appSource);
+const hostNames = new Set([
+  "activateAfterPackageRemoval", "finishPackageRemoval", "activatePackage",
+  "packageIdentityEquals", "defaultAccessibilityFilter",
+]);
+const hostDeclarations = app.program.body
+  .filter(node => node.type === "FunctionDeclaration" && hostNames.has(node.id?.name ?? ""))
+  .map(node => appSource.slice(node.start, node.end)).join("\n");
+
+for (const home of [true, false]) {
+  test(`original application removal handlers preserve ${home ? "Home" : "Workspace"} through last removal`, () => {
+    const state = {
+      home, packages: [alpha, beta], package: alpha as typeof alpha | null,
+      workspaceSubjectOpen: !home, atPackageRoot: false,
+      dependenciesGroupIndex: 2, selectedTypeId: "Old.Type",
+      selectedMemberKey: "Old.Member", selectedOverloadIndex: 3,
+      memberBrowseTypeId: "Old.Type", accessibilityFilter: new Set<string>(),
+      workspaceShareBasis: { previous: true },
+    };
+    const locations: string[] = [];
+    const released: typeof alpha[] = [];
+    const effects: string[] = [];
+    const context = {
+      state, packageIdentityKey, next: beta, first: alpha,
+      spotlightCache: {}, spotlightMemberCache: {},
+      resetLocationFilters: () => effects.push("filters"),
+      resetMemberFilters: () => {},
+      resetMemberSectionState: () => effects.push("member"),
+      navigationSequence: { begin: () => effects.push("cancel") },
+      invalidateGraphMemberNavigation: () => {},
+      clearWorkspaceOccurrenceView: () => effects.push("occurrences"),
+      packageInspection: { invalidatePackageResults: () => effects.push("results") },
+      releasePackageModelCaches: (pkg: typeof alpha) => released.push(pkg),
+      workspaceLocation: { replace: (url: string) => locations.push(url) },
+      render: () => effects.push("render"),
+    };
+    runInNewContext(stripTypeScriptTypes(`${hostDeclarations}
+      state.packages = [next];
+      activateAfterPackageRemoval(next);
+      finishPackageRemoval(first);
+      state.packages = [];
+      activateAfterPackageRemoval(null);
+      finishPackageRemoval(next);
+    `), context);
+    assert.equal(state.home, home);
+    assert.equal(state.package, null);
+    assert.equal(state.workspaceSubjectOpen, !home);
+    assert.equal(state.dependenciesGroupIndex, null);
+    assert.equal(state.selectedTypeId, "");
+    assert.equal(state.selectedMemberKey, "");
+    assert.equal(state.selectedOverloadIndex, null);
+    assert.equal(state.workspaceShareBasis, null);
+    assert.deepEqual(locations, home ? [] : ["/demos"]);
+    assert.deepEqual(released, [alpha, beta]);
+    assert.equal(effects.filter(effect => effect === "render").length, 2);
+  });
+}

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -2299,7 +2299,7 @@ test("global workbench shortcuts respect the topmost modal", () => {
     /function openSpotlight\(seed = "", spotlightScope: SpotlightScope = "all"\) \{\s*if \(state\.loading \|\| state\.error\) return;\s*beginSpotlightNavigation\(\)/);
   assert.match(
     spotlightSource,
-    /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(\);/);
+    /function bind\(root: ParentNode, mode: "modal" \| "inline"\)[\s\S]*if \(mode === "modal"\)[\s\S]*focus\(selection\);/);
   assert.match(
     appSource,
     /id: "metadata-explorer\.dismiss"[\s\S]*priority: WORKBENCH_KEYBINDING_PRIORITY\.metadataExplorer[\s\S]*Boolean\(state\.explorer\?\.open\)[\s\S]*metadata-explorer\.contain-browser-shortcut/);

--- a/prototypes/inspect-web/test/spotlight.test.ts
+++ b/prototypes/inspect-web/test/spotlight.test.ts
@@ -11,6 +11,7 @@ import type {
   SpotlightResult,
   SpotlightScope,
   SpotlightState,
+  RemovableSpotlightResult,
 } from "../src/spotlight.ts";
 import type { CommandContext } from "../src/command-bar.ts";
 import { KeybindingRegistry } from "../src/keybinding-registry.ts";
@@ -34,6 +35,7 @@ interface HarnessOptions {
   executeCommand?: () => Promise<unknown> | undefined;
   searchResults?: () => SpotlightResult[];
   lenses?: () => readonly (readonly [string, string])[];
+  removeResult?: (result: RemovableSpotlightResult) => boolean;
 }
 
 // The library owns the real DOM event/element contract; this harness models only the
@@ -76,6 +78,7 @@ function createHarness({
   executeCommand = () => undefined,
   searchResults = () => [],
   lenses = () => [["api", "API"], ["metadata", "Metadata"]],
+  removeResult,
 }: HarnessOptions = {}) {
   const state: SpotlightState = {
     spotlightOpen: false,
@@ -95,6 +98,7 @@ function createHarness({
     kindIcon: () => "C",
     searchResults,
     pickResult: () => {},
+    ...(removeResult ? { removeResult } : {}),
     executeCommand,
     reportCommandError: () => {},
     commandContext: () => commandContext,
@@ -158,6 +162,23 @@ test("Spotlight selection clamps without wrapping and scope cycling wraps", () =
   assert.equal(nextSpotlightSelection(0, 1, 0), null);
   assert.equal(nextSpotlightScope(4, 5, false), 0);
   assert.equal(nextSpotlightScope(0, 5, true), 4);
+});
+
+test("Spotlight gives open and recent package rows separate named removal buttons", () => {
+  const { spotlight } = createHarness({
+    removeResult: () => true,
+    searchResults: () => [
+      { kind: "pkg-loaded", pkg: { id: "Alpha", version: "1.0.0", activeFramework: "net10.0" }, ranges: [] },
+      { kind: "pkg-recent", entry: { id: "Beta" }, ranges: [] },
+      { kind: "pkg-loaded", pkg: { id: "Platform", version: "10.0.0", isRuntimePack: true }, ranges: [] },
+      { kind: "pkg-nuget", hit: { id: "Gamma" }, ranges: [] },
+    ],
+  });
+  const html = spotlight.inlineHtml(false);
+  assert.match(html, /aria-label="Remove Alpha 1\.0\.0 net10\.0 from Workspace"/);
+  assert.match(html, /aria-label="Forget Beta from recent packages"/);
+  assert.equal(html.match(/data-sl-remove=/g)?.length, 2);
+  assert.match(html, /<\/button><button[^>]*class="package-row-remove"/);
 });
 
 test("NuGet hits are visible only for their resolved query and survive a query round trip", () => {

--- a/prototypes/inspect-web/test/workspace-subject.test.ts
+++ b/prototypes/inspect-web/test/workspace-subject.test.ts
@@ -105,7 +105,7 @@ test("Workspace details render product occurrences as opaque actions", () => {
   assert.match(html, /aria-label="Open demo System\.Text\.Json"/);
   assert.match(
     html,
-    /data-workspace-activate="opaque-action"[\s\S]*system\.text\.json/);
+    /data-workspace-activate="opaque-action"[\s\S]*System\.Text\.Json/);
   assert.match(html, /Platform[\s\S]*Microsoft\.NETCore\.App/);
   assert.doesNotMatch(html, /data-workspace-close/);
 });
@@ -131,6 +131,18 @@ test("Workspace details distinguish loading, empty, and failure", () => {
   assert.match(
     render(false, "", "Product demos are unavailable"),
     /Product demos are unavailable/);
+});
+
+test("Workspace removal remains available while occurrence activation loads or fails", () => {
+  for (const status of [{ loading: true, error: "" }, { loading: false, error: "Offline" }]) {
+    const html = renderWorkspaceView({
+      packages: [{ id: "Alpha", version: "1.0.0", activeFramework: "net10.0", isRuntimePack: false }],
+      occurrences: [], demos: [], demoError: "", escapeHtml, ...status,
+    });
+    assert.match(html, /data-workspace-remove=/);
+    assert.match(html, /aria-label="Remove Alpha 1\.0\.0 net10\.0 from Workspace"/);
+    assert.match(html, /class="workspace-occurrence"[^>]*disabled/);
+  }
 });
 
 test("Workspace selection and activation dispatch separate actions", () => {
@@ -169,7 +181,7 @@ test("Workspace selection and activation dispatch separate actions", () => {
     querySelectorAll: (selector: string) =>
       selector === "[data-workspace-activate]"
         ? [activate]
-        : [demo, invalidDemo],
+        : selector === "[data-workspace-demo]" ? [demo, invalidDemo] : [],
   };
   const calls: string[] = [];
 


### PR DESCRIPTION
Make Inspect Web's package lists directly editable with the familiar trailing
close button, without adding another Workspace-management experience.

## Demo

Before: Home Search lists `Newtonsoft.Json · open` and
`Microsoft.Extensions.Http · recent`, but neither row can be removed.

After:

```text
Newtonsoft.Json              13.0.4 · open    x
Microsoft.Extensions.Http    10.0.0 · recent  x
```

1. Click the recent row's `x`. It disappears without opening the package and
   stays forgotten after refresh.
2. Click the open row's `x`. Its exact coordinate leaves the live Workspace
   and its recent-history entry is forgotten. Search remains open with the
   same query and text selection, including after an asynchronous rerender.
3. Open Workspace and use the same button beside a package. The next removal
   control receives focus; the final removal leaves the existing empty
   Workspace surface.
4. Neighbor: Shift+Delete removes the selected removable Search row. Platform
   and online NuGet discovery rows have no deletion button.

The Firefox harness at `/browser/package-removal.html` exercises the production
renderers, bindings, and removal coordinator. `?modal=1`, `?workspace=1`,
`?modal=1&refresh=1`, `?workspace=1&loading=1`, and `?storage-failure=1`
show the neighboring states.
This is focused browser evidence, not a claim of a full running-site scenario.

## Claim and design basis

`docs/design/inspect-web-package-removal.md#claim-and-scope` owns the focused
row-removal contract. Navigation Presentation supplies Workspace placement,
Shell Interaction supplies Search, and Navigation Consumer retains navigation
effect ownership.

The implementation reuses `removeWorkspacePackage`, exact package identity,
existing recent-history storage, selection helpers, and Browser cache
ownership. Writes happen before deletion so a storage failure remains visible
without changing membership. Request-generation invalidation prevents retired
package queries from republishing removed results. Membership-dependent Call
graphs are invalidated and refreshed without losing the retained member's
selection; obsolete expansions and platform drill results cannot republish.

This is the explicitly user-approved Browser-only consumer in #5887 under
#5697. Two production delivery steps: land this complete UI slice, then a
separately authorized normal release and matching website deployment.
Interactive HTML lowering stays in the existing typed Browser renderers rather
than Markout. No shared product substrate or replacement architecture is added.

## Boundaries

- PR #5812 remains unchanged and paused; this slice does not depend on it.
- Saved Workspaces, Add, prefixes, Clear, and product Workspace runtime adoption
  remain separate.
- Other package versions/frameworks remain resident. Platform is not removable.
- Removing an inactive package preserves its neighbor's inspection selection.
- Removing a recent suggestion does not block later NuGet discovery or explicit
  reopening. Discovery suppression lasts only for the current query.
- No package-source, HTTP-cache, or browser-history deletion is claimed.

## Validation

- `npm run build`
- `npm run lint`
- `node --test test/package-removal.test.ts test/package-inspection.test.ts test/spotlight.test.ts test/workspace-subject.test.ts test/workspace-navigation.test.ts test/call-graph-inspection.test.ts test/spotlight-identity.test.ts test/spotlight-package-search.test.ts` — 335 passed
- `CI=1 npm run test:browser -- browser/package-removal.spec.ts` — 10 passed
- `CI=1 npm run test:browser -- browser/package-removal.spec.ts browser/workspace-titlebar.spec.ts` — 67 passed
- Markdown lint for the three changed design documents and `git diff --check`

Node evidence includes execution of the original application activation and
completion declarations, with rendering/acquisition collaborators isolated.
It covers warm Home, active successor reset, last-package empty routing with
retained history state, and persistence failure. The original application graph
request and removal declarations run with the production coordinator to cover
completed/pending graph invalidation and retained member selection. The Browser
harness covers actual click/keyboard separation, focus, query and text-selection
preservation, and refresh persistence.

Closes #5887
Advances #5697
