### PR TITLE
Preserve selected type descriptors during source and PDB opening

### DIFF
--- a/docs/cli-architecture.md
+++ b/docs/cli-architecture.md
@@ -132,10 +132,43 @@ unchanged, rather than selecting or extracting it again.
 This is the API-surface slice in
 [#5853](https://github.com/richlander/dotnet-inspect/issues/5853), not complete
 descriptor adoption for every `type` operation. Existing source/PDB policy
-consumers keep receiving the selected type's descriptor. Runtime and
-source-context acquisition, deep Analysis/decompiler acquisition, and
+consumers keep receiving the selected type's descriptor; the next subsection
+owns source-context opening. Runtime acquisition, deep Analysis/decompiler acquisition, and
 acquired-PDB propagation remain focused successors under
 [#4867](https://github.com/richlander/dotnet-inspect/issues/4867).
+
+### Type source-context opening
+
+When type source enrichment or portable-PDB-path acquisition receives a
+selected supplier descriptor, that exact descriptor opens the PE/PDB context
+and supplies symbol acquisition policy. Its path projection is not an
+alternative opener. Thrown opening or acquisition failures reach the command's
+visible error boundary instead of becoming absent symbols or empty source
+output. A missing mapping does not replace the selected supplier with a new
+path-based forwarding lookup.
+
+Missing symbols, Windows PDBs, and absent SourceLink retain their existing
+non-throwing absence behavior. Descriptorless callers keep the path-based
+compatibility route. Section authorization and the XML-documentation shortcut
+are unchanged. The API supplier remains distinct from any runtime candidate:
+this adoption does not select another runtime image or establish cross-image
+correspondence.
+
+`TypeSourceAcquisition_SourceFilesUsesSelectedOpener`,
+`TypeSourceAcquisition_PdbPathUsesSelectedOpener`,
+`TypeSourceAcquisition_ReportsSelectedOpenFailure`,
+`TypeSourceAcquisition_PreservesMissingSymbols`, and
+`TypeSourceAcquisition_ReportsMalformedDebugData` gate this composition.
+Existing source-printing and selected-supplier policy cases remain its
+neighboring outcome gates.
+
+This is [#5888](https://github.com/richlander/dotnet-inspect/issues/5888)'s
+three-step CLI adoption path: the loaded surface supplies its descriptor,
+source/PDB acquisition consumes it, and existing rendering or command error
+reporting publishes the result. It uses Metadata/SourceLink's existing
+host-neutral descriptor APIs; their contracts remain owned by
+[PDB acquisition](pdb-acquisition.md). Standalone member, browser, runtime
+selection, and deep-body adoption remain separate #4867 successors.
 
 ## Command families
 

--- a/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
+++ b/src/dotnet-inspect.Tests/SourceForwarderResolutionTests.cs
@@ -11,6 +11,7 @@ using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
+using DotnetInspector.Queries.EmbeddedFixtures;
 using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
@@ -1648,6 +1649,240 @@ public class SourceForwarderResolutionTests
         }
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TypeSourceAcquisition_SourceFilesUsesSelectedOpener(bool isForwarded)
+    {
+        int opens = 0;
+        string original = typeof(EmbeddedSourceFixture).Assembly.Location;
+        byte[] image = File.ReadAllBytes(original);
+        var fixture = CreateTypeSourceFixture(
+            AssemblyResolutionProvenance.Local("source-opening"),
+            isForwarded,
+            () =>
+            {
+                opens++;
+                return new MemoryStream(image, writable: false);
+            },
+            typeof(EmbeddedSourceFixture));
+        try
+        {
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+            var source = CreateApiSource(fixture.AssemblyPath, SourceKind.Library) with
+            {
+                TypeName = fixture.Type.FullName,
+                RuntimeAssemblyPath = typeof(object).Assembly.Location,
+                Context = new CommandContext(verbose: false, client),
+            };
+
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteResolvedAsync(
+                    new TypeOptions
+                    {
+                        TypeName = fixture.Type.FullName,
+                        Select = [SectionNames.SourceFiles],
+                        DocsExplicitlySet = true,
+                        ShowDocs = false,
+                    },
+                    source,
+                    fixture.Loaded));
+
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("Error:", error);
+            Assert.Contains("EmbeddedSourceFixture.cs", output);
+            Assert.Equal(1, opens);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TypeSourceAcquisition_PdbPathUsesSelectedOpener()
+    {
+        int opens = 0;
+        string original = typeof(SourceForwarderResolutionTests).Assembly.Location;
+        byte[] image = File.ReadAllBytes(original);
+        var fixture = CreateTypeSourceFixture(
+            AssemblyResolutionProvenance.Local("pdb-opening"),
+            isForwarded: false,
+            () =>
+            {
+                opens++;
+                return new MemoryStream(image, writable: false);
+            });
+        try
+        {
+            string expected = Path.ChangeExtension(fixture.AssemblyPath, ".pdb");
+            File.Copy(Path.ChangeExtension(original, ".pdb"), expected);
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+
+            string? path = await ApiCommand.TryAcquirePdbPathAsync(
+                Path.Combine(fixture.Directory, "unused-path-projection.dll"),
+                fixture.Loaded.GetSourceAssembly(fixture.Type),
+                new TypeOptions(),
+                new VerboseLogger(enabled: false),
+                client,
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal(expected, path);
+            Assert.Equal(1, opens);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(SectionNames.SourceFiles)]
+    [InlineData(SectionNames.DecompiledSource)]
+    public async Task TypeSourceAcquisition_ReportsSelectedOpenFailure(string section)
+    {
+        int opens = 0;
+        var fixture = CreateTypeSourceFixture(
+            AssemblyResolutionProvenance.Local("failed-opening"),
+            isForwarded: false,
+            () =>
+            {
+                opens++;
+                throw new IOException("Selected source image could not be opened.");
+            });
+        try
+        {
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+            var source = CreateApiSource(fixture.AssemblyPath, SourceKind.Library) with
+            {
+                TypeName = fixture.Type.FullName,
+                Context = new CommandContext(verbose: false, client),
+            };
+
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteResolvedAsync(
+                    new TypeOptions
+                    {
+                        TypeName = fixture.Type.FullName,
+                        Select = [section],
+                        DocsExplicitlySet = true,
+                    },
+                    source,
+                    fixture.Loaded));
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("Selected source image could not be opened.", error);
+            Assert.Equal(1, opens);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TypeSourceAcquisition_PreservesMissingSymbols(bool isModule)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            string path = Path.Combine(directory, "NoSymbols.dll");
+            File.WriteAllBytes(path, BuildAssembly("NoSymbols", isModule: isModule));
+            var handler = new RecordingNotFoundHandler();
+            using var client = new HttpClient(handler);
+            var source = CreateApiSource(path, SourceKind.Library) with
+            {
+                TypeName = "N.Type",
+                Context = new CommandContext(verbose: false, client),
+            };
+            var options = new TypeOptions
+            {
+                TypeName = "N.Type",
+                Select = [SectionNames.SourceFiles],
+                DocsExplicitlySet = true,
+            };
+            var loaded = Assert.IsType<ApiServices.LoadedApiSurface>(
+                ApiServices.LoadTypeApi(source, options));
+
+            var (exit, _, error) = await ConsoleCapture.RunAsync(
+                () => TypeCommand.ExecuteResolvedAsync(options, source, loaded));
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("Error:", error);
+
+            var descriptor = loaded.TryGetSourceAssembly(Assert.Single(loaded.Api.Types));
+            string? pdb = descriptor is null
+                ? await ApiCommand.TryAcquirePdbPathAsync(
+                    path, options, new VerboseLogger(enabled: false), client,
+                    TestContext.Current.CancellationToken)
+                : await ApiCommand.TryAcquirePdbPathAsync(
+                    path, descriptor, options, new VerboseLogger(enabled: false), client,
+                    TestContext.Current.CancellationToken);
+            Assert.Null(pdb);
+            Assert.Empty(handler.RequestUris);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task TypeSourceAcquisition_ReportsMalformedDebugData(bool deferred)
+    {
+        string directory = CreateDirectory();
+        try
+        {
+            byte[] image = File.ReadAllBytes(typeof(EmbeddedSourceFixture).Assembly.Location);
+            using (var reader = new PEReader(new MemoryStream(image, writable: false)))
+            {
+                DebugDirectoryEntry embedded = Assert.Single(
+                    reader.ReadDebugDirectory(),
+                    entry => entry.Type == DebugDirectoryEntryType.EmbeddedPortablePdb);
+                image[embedded.DataPointer] = 0;
+            }
+            string path = Path.Combine(directory, "MalformedDebug.dll");
+            File.WriteAllBytes(path, image);
+            var options = new TypeOptions
+            {
+                AssemblyPath = path,
+                TypeName = typeof(EmbeddedSourceFixture).FullName,
+                Select = [SectionNames.SourceFiles],
+                DocsExplicitlySet = true,
+            };
+
+            var (exit, output, error) = await ConsoleCapture.RunAsync(
+                () => deferred
+                    ? MemberCommand.ExecuteAsync(new MemberOptions
+                    {
+                        AssemblyPath = options.AssemblyPath,
+                        TypeName = options.TypeName,
+                        Select = options.Select,
+                        DocsExplicitlySet = true,
+                        RouterDeferredTypeOrMember = true,
+                    })
+                    : TypeCommand.ExecuteAsync(options));
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("embedded portable PDB signature is invalid", error);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     static ApiSourceResult CreateApiSource(string path, string sourceKind) =>
         new(
             SearchPath: path,
@@ -2049,11 +2284,14 @@ public class SourceForwarderResolutionTests
         ApiServices.LoadedApiSurface Loaded)
         CreateTypeSourceFixture(
             AssemblyResolutionProvenance provenance,
-            bool isForwarded)
+            bool isForwarded,
+            Func<Stream>? openRead = null,
+            Type? fixtureType = null)
     {
+        fixtureType ??= typeof(SourceForwarderResolutionTests);
         string directory = CreateDirectory();
         string sourceAssemblyPath =
-            typeof(SourceForwarderResolutionTests).Assembly.Location;
+            fixtureType.Assembly.Location;
         string assemblyPath = Path.Combine(
             directory,
             Path.GetFileName(sourceAssemblyPath));
@@ -2062,9 +2300,9 @@ public class SourceForwarderResolutionTests
             AssemblyReader.ExtractApiSurface(assemblyPath)!;
         ApiType type = Assert.Single(
             api.Types,
-            static candidate =>
+            candidate =>
                 candidate.FullName
-                == "DotnetInspector.Tests.SourceForwarderResolutionTests");
+                == fixtureType.FullName);
         api.Types = [type];
         type.IsForwarded = isForwarded;
         type.SourceAssemblyPath = assemblyPath;
@@ -2072,6 +2310,14 @@ public class SourceForwarderResolutionTests
             ResolvedAssemblyReference.CreateFromPath(
                 assemblyPath,
                 provenance);
+        if (openRead is not null)
+        {
+            assembly = ResolvedAssemblyReference.Create(
+                assembly.Identity,
+                assembly.Path,
+                openRead,
+                provenance);
+        }
         var sourceAssemblies =
             new Dictionary<
                 ApiType,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -1287,7 +1287,9 @@ public class ApiCommand
         cancellationToken.ThrowIfCancellationRequested();
         try
         {
-            using var service = SourceLinkService.Open(dllPath, logger.Log);
+            using var service = sourceAssembly is null
+                ? SourceLinkService.Open(dllPath, logger.Log)
+                : SourceLinkService.Open(sourceAssembly, logger.Log);
             var context = service.Context;
             if (context.NeedsPdb)
             {
@@ -1329,7 +1331,7 @@ public class ApiCommand
         {
             throw;
         }
-        catch
+        catch when (sourceAssembly is null)
         {
             return null;
         }

--- a/src/dotnet-inspect/Inspectors/SourceEnricher.cs
+++ b/src/dotnet-inspect/Inspectors/SourceEnricher.cs
@@ -128,7 +128,9 @@ internal static class SourceEnricher
 
         try
         {
-            using var service = SourceLinkService.Open(dllPath, logger.Log);
+            using var service = sourceAssembly is null
+                ? SourceLinkService.Open(dllPath, logger.Log)
+                : SourceLinkService.Open(sourceAssembly, logger.Log);
             var context = service.Context;
 
             if (!context.HasMetadata)
@@ -200,7 +202,8 @@ internal static class SourceEnricher
             var sourceInfo = service.ResolveTypeSource(typeName);
             if (sourceInfo == null)
             {
-                if (apiType.DefinitionName is not null
+                if (sourceAssembly is null
+                    && apiType.DefinitionName is not null
                     && await TryEnrichFromForwardedAssemblyAsync(
                         apiType,
                         typeName,
@@ -222,7 +225,7 @@ internal static class SourceEnricher
                 options,
                 logger);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (sourceAssembly is null)
         {
             logger.Log($"Error enriching source info: {ex.Message}");
         }

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -56,6 +56,10 @@
 
 ### Source and implementation evidence
 
+- Type source-file and portable-PDB acquisition now open the selected supplier
+  descriptor, preserving its opener as well as its symbol policy. Thrown
+  source-context failures are reported as command errors instead of appearing
+  as missing source or symbols; genuine absence remains best-effort (#5888).
 - Renames `Original Source` to `PDB Source` and the Implementation Diff
   `--authored-source` flag to `--pdb-source`, reflecting that checksum and
   SourceLink-origin evidence do not independently prove build provenance.


### PR DESCRIPTION
## Purpose

Make existing type inspection reliably carry its selected acquisition through
source/PDB opening: robust provenance continuity with a visible error when the
selected image cannot be inspected.

Closes #5888. Continues #4867 after #5853 / #5859.

## Demo

Inspect a valid managed assembly whose embedded-PDB signature is malformed:

```sh
dotnet-inspect type DotnetInspector.Queries.EmbeddedFixtures.EmbeddedSourceFixture \
  --library /tmp/type-source-malformed.dll -S "Source Files" -v:m --tips q
```

Before (production `dotnet-inspect@0.24.0`):

```text
# DotnetInspector.Queries.EmbeddedFixtures.EmbeddedSourceFixture
exit: 0
```

After (this branch):

```text
Error: The embedded portable PDB signature is invalid.
exit: 1
```

Notice that failed source-context construction no longer looks like successful
inspection with no source. `TypeSourceAcquisition_ReportsMalformedDebugData`
constructs this fixture reproducibly and exercises both direct and deferred
type routes.

Neighbor: the same invocation against the healthy embedded fixture still
returns:

```text
# DotnetInspector.Queries.EmbeddedFixtures.EmbeddedSourceFixture

## Source Files

| Url |
| --- |
| https://example.test/dotnet-inspect/EmbeddedSourceFixture.cs |
```

Both demo invocations ran offline. The changed rendering still uses the existing
typed source rows and Markout path.

## Design basis and scope

One normative owner:
`docs/cli-architecture.md#type-source-context-opening`. The exact selected
supplier descriptor opens its source/PDB context and supplies symbol policy;
its path is not a fallback opener. Thrown failures remain visible, and an
absent mapping does not replace the supplier through a new path lookup.

Supporting contracts: Metadata's descriptor-backed `PdbContext.Open`,
SourceLink's existing descriptor overload, and the acquisition-policy and
absence semantics in `docs/pdb-acquisition.md`. The existing library and
forwarded-source helper are analogous descriptor-opening consumers.

This is a CLI adoption correction, not a new shared architecture. Three steps
land together: the loaded surface supplies its descriptor, source/PDB helpers
consume it, and existing rendering/error reporting publishes the result.
Consumers are `type -S "Source Files"` (including printing and deferred type
routing) and explicit type sections that acquire a portable PDB for local names.
The small conditional changes serve opener continuity and visible failure;
they add no acquisition framework or output mode.

The API supplier remains separate from the runtime candidate. Existing
extraction already stamps the supplier path on each type, and the new outcome
case supplies a distinct runtime path without changing the source supplier.
Missing symbols, Windows PDBs, absent SourceLink, descriptorless compatibility,
the XML-doc shortcut, and authorization gates retain existing behavior.
Standalone member, browser adoption, runtime selection/correspondence, deep
Analysis/decompiler opening, and acquired-PDB propagation remain separate
#4867 successors. Existing host-neutral descriptor APIs remain unchanged.

## Validation

- Release focused CLI run: 14 passed, covering selected openers, portable-PDB
  paths, visible opening failures in source and decompiler-PDB preparation,
  missing symbols, descriptorless modules, malformed debug data, source
  printing, supplier policy, and caller cancellation.
- Changed Markdown passes `markdownlint`.
- Adjacent Release CLI classes: 117 passed across
  `SourceForwarderResolutionTests`, `LocalRepoSourceProjectionTests`, and
  `BodyShapesSectionTests`.
- Normal Release solution build passed with zero warnings or errors.
