### PR TITLE
Refresh platform and documentation CLI guidance

### DIFF
--- a/docs/design/style-guide.md
+++ b/docs/design/style-guide.md
@@ -84,7 +84,7 @@ Then the subject's own facts:
 - `**Kind:** class` / `interface` / `struct` / `enum`
 - `**Modifiers:** static, sealed` (only if modifiers exist)
 - `**Source:** https://...`
-- `**Samples:** N available` (only with `--docs`, indicates samples exist)
+- `**Samples:** N available` (when the view has sample-reference metadata)
 
 ```markdown
 **Package:** System.Text.Json 10.0.0
@@ -98,13 +98,14 @@ Then the subject's own facts:
 
 Fields always appear in a consistent order. Empty/null fields are omitted.
 
-The `**Samples:**` field is a count indicator. Sample URL tables belong in a
-dedicated `Samples` section when package/docs metadata can provide trustworthy
-links.
+The `**Samples:**` field is a count indicator, not a guarantee that a target
+exposes a `Samples` section. Discover the current section catalog before
+requesting sample output; do not invent URLs from the count.
 
 ### 4. H2 sections
 
-Tables and structured content appear under H2 headings. Section visibility is controlled by verbosity level.
+Tables and structured content appear under H2 headings. Section visibility is
+controlled by the command's verbosity preset and explicit section selection.
 
 ```markdown
 ## Members
@@ -118,22 +119,37 @@ When there is only a single table, the H2 heading may be omitted for brevity.
 
 ## Verbosity levels
 
-Verbosity controls which H2 sections appear, not which fields appear:
+The [progressive disclosure model](progressive-disclosure.md#verbosity) owns
+verbosity presets and explicit section selection. Verbosity can also change
+signature detail and documentation columns within a command's view:
 
 | Level | Description | Sections |
 | ----- | ----------- | -------- |
-| Quiet | Title and fields only | None |
-| Minimal | Compact section view (default) | Summary sections only |
-| Normal | Full output | All standard sections |
-| Detailed | Extended output | All sections including audit details |
+| Quiet | Compact identity/context, where supported | No automatic content sections |
+| Minimal | Compact view (default) | One high-value base section |
+| Normal | More detail about the same subject | Multiple base sections |
+| Detailed | Extended base output | All applicable base sections, not every domain |
 
 Note: The dotnet CLI uses minimal as the default verbosity level, not normal. This tool follows that convention.
 
-The H1, description, and fields are always present regardless of verbosity.
+Descriptions and optional fields depend on the view and available evidence.
+Focused section output may omit the identity header. For single-type section
+output, use `--markdown`; the default type tree supports `-v:m`, `-v:n`, and
+`-v:d`, not `-v:q`.
 
-### Verbosity-independent views
+### Documentation columns
 
-Some views use the same layout at all verbosity levels because differentiation would not be meaningful. The **types listing** (full-library view) is verbosity-independent: it always shows per-kind sections (`## Classes`, `## Structs`, etc.) with `Type | Members` columns. The only variation is `--docs` adding a Description column. Verbosity differentiation is reserved for the **member view** (per-type), where quiet groups by name, minimal abbreviates signatures, and normal/detailed show full signatures.
+Type listings, single-type views, member groups, and selected signatures have
+different schemas; they are not one verbosity-independent table. A selected
+member's `Signature` can include a `Description` from available XML
+documentation. Single-type Markdown views enable available XML summaries at
+normal verbosity and above. Columns follow the selected view and its available
+documentation, not a separate documentation switch.
+
+Use `-D` to discover section names and `-D <section>` to inspect a section's
+schema rather than assuming a standalone `Documentation` section.
+[Platform components](../platform-components.md#documentation-access) shows the
+package and platform invocations.
 
 ## Table formatting
 
@@ -154,7 +170,8 @@ Tables use pipe-delimited markdown:
 
 **Common table formats:**
 
-- Member tables: `| Member | Kind | Signature |` (+ `| Description |` with `--docs`)
+- Member tables: names/selectors and signatures, with `Description` where the
+  selected view includes available documentation
 - Metadata tables: `| Property | Value |`
 - Audit tables: `| File | Deterministic | SourceLink |`
 

--- a/docs/platform-components.md
+++ b/docs/platform-components.md
@@ -1,199 +1,212 @@
 # Accessing Platform Components
 
-This document explains how to access .NET platform (SDK) libraries and compare them with NuGet package versions using dotnet-inspect.
+Use `find` to discover where a type lives, then retain its package or platform
+scope when inspecting the type and its members.
+
+The former `api` and standalone `platform` commands, and the `--docs`,
+`--use-local-docs`, and `--samples` switches, are not current invocation syntax.
+The examples below use `type`, `member`, verbosity, and section selection.
 
 ## Overview
 
-Some types exist in **two places**:
+Some APIs are available from both:
 
-1. **NuGet packages** - Published to nuget.org, downloaded on demand
-2. **Platform libraries** - Installed with the .NET SDK in `packs/` directory
+1. **NuGet packages**, selected with a package coordinate.
+2. **Platform libraries**, selected from a framework such as `runtime`,
+   `aspnetcore`, or `netstandard`.
 
-For example, `JsonSerializer` ships in both:
+For example, `JsonSerializer` is available in the `System.Text.Json` package
+and the .NET runtime. These are distinct inputs and need not have the same
+version or API surface.
 
-- The `System.Text.Json` NuGet package
-- The .NET runtime (as part of the SDK)
+Platform resolution can use installed SDK/runtime assets or acquired platform
+packs. Selecting `--platform` is not an offline guarantee: a requested framework
+version that is not available locally may require acquisition. See
+[version resolution](design/version-resolution.md) for the selection and cache
+rules.
 
 ## Using `find` to Discover Types
 
-The `find` command searches across both packages and platform libraries simultaneously:
+Explicit search scopes compose. To search the platform and one package:
 
 ```bash
-# Search for JsonSerializer in platform and a specific package
-dnx dotnet-inspect -y -- find JsonSerializer --platform --package System.Text.Json
+dnx dotnet-inspect -y -- find JsonSerializer \
+  --platform --package System.Text.Json@10.0.0
 ```
 
-Output:
+The results distinguish the sources even when the type, namespace, and library
+names agree. For example, the `Source` column identifies a package coordinate
+such as `System.Text.Json@10.0.0` separately from a `runtime@...` version.
+The platform version depends on the selected installation/framework.
 
-```text
-# Find: JsonSerializer
-
-**Matches:** 2
-
-| Type | Namespace | Kind | Library | Source |
-|------|-----------|------|----------|--------|
-| JsonSerializer | System.Text.Json | class | System.Text.Json | System.Text.Json@10.0.2 |
-| JsonSerializer | System.Text.Json | class | System.Text.Json | runtime@10.0.1 |
-```
-
-This shows the type exists in both locations with potentially different versions.
+Without an explicit source, `find` uses its implicit platform scope. An
+explicit package suppresses that default; add bare `--platform` when both
+sources should participate.
 
 ## Package vs Platform Access
 
 ### From NuGet Package (`--package`)
 
 ```bash
-dnx dotnet-inspect -y -- api JsonSerializer --package System.Text.Json
+dnx dotnet-inspect -y -- type JsonSerializer \
+  --package System.Text.Json@10.0.0 --markdown -v:q
 ```
 
-**Advantages:**
+The compact output identifies the selected package, version, and TFM. A pinned
+coordinate selects that package version; omitting `@version` resolves a current
+stable version. Package acquisition may download a missing payload.
 
-- Has SourceLink and embedded PDBs
-- Supports `--docs` to show XML documentation from source
-- Supports `--samples` to find code sample references
-- Can specify exact versions with `@version` syntax
+Documentation and symbols depend on the package's actual contents. A package
+is not guaranteed to include XML documentation, an embedded PDB, or SourceLink.
 
 ### From Platform (`--platform`)
 
 ```bash
-dnx dotnet-inspect -y -- api JsonSerializer --platform System.Text.Json
+dnx dotnet-inspect -y -- type JsonSerializer \
+  --platform System.Text.Json --markdown -v:q
 ```
 
-**Advantages:**
+Here `--platform` takes a **library name**, unlike the bare search-scope flag on
+`find`. Use `--framework` to select a framework, optionally with `@version`.
 
-- No download required (uses local SDK)
-- Faster for quick lookups
-- Shows what's actually installed
+Platform inputs include reference assemblies for API surfaces and runtime
+assemblies for implementations. Source availability depends on the selected
+assembly and matching symbols, not simply on whether its scope is a package or
+platform.
 
-**Current limitations:**
-
-- Reference assemblies lack PDBs, so no SourceLink
-- `--docs` and `--samples` require source access via SourceLink
+Single-type output uses a tree by default. Add `--markdown` for section-based
+output; the tree renderer accepts minimal, normal, and detailed verbosity,
+while compact `-v:q` requires the Markdown view.
 
 ## Documentation Access
 
-### Package Source (Full Support)
-
-When using `--package`, the tool can fetch documentation from source files via SourceLink:
-
-```bash
-dnx dotnet-inspect -y -- api JsonSerializer --package System.Text.Json --docs
-```
-
-This retrieves the `///` XML doc comments directly from the source repository.
-
-### Platform Source (Automatic Fallback)
-
-Platform libraries in the `packs/` directory include XML documentation files alongside the DLLs:
-
-```text
-/usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/10.0.1/ref/net10.0/
-├── System.Text.Json.dll
-├── System.Text.Json.xml    ← XML docs available here
-└── ...
-```
-
-The tool automatically falls back to these XML files when SourceLink/MSDL isn't available:
+Member inspection reads available XML documentation and includes descriptions
+in its member/signature output. Select an overload rather than requesting a
+separate documentation flag:
 
 ```bash
-# Automatic fallback to XML docs when MSDL symbols aren't available
-dnx dotnet-inspect -y -- api JsonSerializer --platform System.Text.Json --docs
+dnx dotnet-inspect -y -- member JsonSerializer Serialize:1 \
+  --package System.Text.Json@10.0.0
+
+dnx dotnet-inspect -y -- member JsonSerializer Serialize:1 \
+  --platform System.Text.Json
 ```
 
-You can also force local XML docs with `--use-local-docs` for faster offline access:
+Both invocations render the selected `Signature`. When the XML documentation
+is available, its `Description` explains the operation. The numeric overload
+selector is local to that selected type surface; use `-S "Member Index"` to
+inspect the overloads before choosing another member or version.
+
+For a single type, normal verbosity enables available XML summaries in the
+Markdown view:
 
 ```bash
-# Use local XML docs directly (skip MSDL lookup)
-dnx dotnet-inspect -y -- api JsonSerializer --platform System.Text.Json --use-local-docs
+dnx dotnet-inspect -y -- type JsonSerializer \
+  --platform System.Text.Json --markdown -v:n
 ```
 
-| Option | Behavior |
-| ------ | -------- |
-| `--docs` | Try MSDL/SourceLink first, fall back to XML |
-| `--use-local-docs` | Use XML docs directly (faster, works offline, implies --docs) |
+Package/local-library documentation is read from XML beside the assembly.
+Platform member/type documentation can come from the framework reference
+pack's XML files. Reading those available descriptions does not require
+fetching authored source through SourceLink. Missing XML documentation does not
+mean the metadata API or PDB source is missing.
 
-## Sample References
-
-Sample references are extracted from `<code source="...">` and `<seealso href="...">` tags in XML doc comments:
+If the platform inputs are already installed or cached, use the actual network
+policy flag for an offline inspection:
 
 ```bash
-dnx dotnet-inspect -y -- api JsonSerializer --package System.Text.Json --samples
+dnx dotnet-inspect -y -- member JsonSerializer Serialize:1 \
+  --platform System.Text.Json --offline
 ```
 
-This requires SourceLink access, so it only works with `--package`, not `--platform`.
+Offline mode does not manufacture a missing target, XML file, or PDB. The flag
+governs dotnet-inspect's acquisition, not an initial tool download by `dnx`;
+disconnected use also requires the tool itself to be installed or cached.
+
+## Documentation vs Source and Samples
+
+API descriptions, PDB-mapped source, and sample references are different
+evidence. Do not infer a `Documentation` or `Samples` section from the presence
+of XML documentation, or assume a package supplies usable sample URLs.
+
+Discover the current type or member section catalog with `-D`:
+
+```bash
+dnx dotnet-inspect -y -- type JsonSerializer \
+  --platform System.Text.Json --markdown -D
+```
+
+Source-specific selections include type `Source Files` and member
+`Source Locations` / `PDB Source`. Those paths may need matching PDBs and
+authorized source acquisition. A supported section name is not a promise of
+source evidence for every artifact. See [SourceLink exposure](sourcelink-exposure.md)
+and [PDB acquisition](pdb-acquisition.md) for those boundaries.
+
+[Sample references](sample-references.md) describes reference formats in
+documentation; it is not a package-only sample-discovery command.
 
 ## Comparing Package and Platform Versions
 
-You can compare what's in your installed SDK vs what's on nuget.org:
+Use discovery to see the selected platform version, and package version
+listing to inspect published package versions:
 
 ```bash
-# Check platform version
 dnx dotnet-inspect -y -- find JsonSerializer --platform
-
-# Check latest package version
 dnx dotnet-inspect -y -- package System.Text.Json --versions -n 1
 ```
 
-The versions may differ - the SDK ships with a specific version, while nuget.org may have newer releases.
+The results answer different questions: the platform version currently
+selected and the latest stable package version. They need not match. Retain
+the appropriate scope when continuing to `type` or `member`.
 
 ## Scope Flags
 
-Search commands support scope flags to control where to search:
+Search commands support these source groups:
 
 | Flag | What it searches |
 | ---- | ---------------- |
-| *(no flags)* | Implicit platform scope (runtime, aspnetcore, netstandard) |
-| `--platform` | All platform frameworks (runtime, aspnetcore, netstandard) |
-| `--extensions` | Current Microsoft.Extensions.* packages that add APIs beyond the shared frameworks |
-| `--aspnetcore` | Current Microsoft.AspNetCore.* packages that add APIs beyond the shared frameworks |
+| *(no source flags)* | Implicit platform scope: runtime, aspnetcore, netstandard |
+| bare `--platform` | Explicit platform scope, including when packages are also selected |
+| `--extensions` | Current Microsoft.Extensions package set |
+| `--aspnetcore` | Current ASP.NET Core package set |
+| `--package Name@version` | The specified package coordinate |
 
-[Search scope resolution](design/search-scope-resolution.md) defines when the
-implicit scope activates and how explicit source selectors compose.
-
-```bash
-# Search all platform frameworks
-dnx dotnet-inspect -y -- find "*Logger*" --platform
-
-# Search ASP.NET Core packages
-dnx dotnet-inspect -y -- find "*Controller*" --aspnetcore
-```
+[Search scope resolution](design/search-scope-resolution.md) owns default
+activation and explicit composition. Named package sets can require package
+downloads; they are not aliases for the installed shared frameworks.
 
 ## When to Use Each
 
-| Scenario | Use |
-| -------- | --- |
-| Quick API lookup | `--platform` |
-| Need documentation | `--platform --docs` or `--package --docs` |
-| Need source URLs | `--package` |
-| Need code samples | `--package --samples` |
-| Specific version | `--package Name@version` |
-| Offline/no network | `--platform --use-local-docs` |
-| Discover type location | `find <pattern>` or `find <pattern> --package Name` |
+| Scenario | Starting point |
+| -------- | -------------- |
+| Discover a type's location | `find <pattern>`; add explicit package/platform scopes as needed |
+| Inspect a package version | `type <type> --package Name@version` |
+| Inspect a platform API | `type <type> --platform Library` |
+| Read a member's available XML description | `member <type> Name:N` with the retained source scope |
+| Request PDB-mapped source evidence | Discover with `-D`, then select the relevant source section |
+| Prohibit network acquisition | Add `--offline`; required inputs must already be available |
 
 ## Platform Directory Structure
 
-The tool locates platform libraries via the SDK installation:
+Use the .NET CLI to list installed SDKs and runtimes:
 
 ```bash
-# Find dotnet installation
-which dotnet
-# /usr/lib/dotnet/dotnet
-
-# Packs directory contains reference assemblies
-ls /usr/lib/dotnet/packs/
-# Microsoft.NETCore.App.Ref/
-# Microsoft.AspNetCore.App.Ref/
-# ...
-
-# Each pack has versioned ref assemblies
-ls /usr/lib/dotnet/packs/Microsoft.NETCore.App.Ref/10.0.1/ref/net10.0/
-# System.Text.Json.dll
-# System.Text.Json.xml
-# ...
+dotnet --list-sdks
+dotnet --list-runtimes
 ```
 
-The `platform` command lists all available frameworks and their installed versions:
+Under a .NET installation, reference packs and runtime implementations occupy
+different directories. For example:
 
-```bash
-dnx dotnet-inspect -y -- platform
+```text
+packs/Microsoft.NETCore.App.Ref/<version>/ref/<tfm>/
+  System.Text.Json.dll
+  System.Text.Json.xml
+
+shared/Microsoft.NETCore.App/<version>/
+  System.Text.Json.dll
 ```
+
+Paths and installed versions vary by host. Use `find --platform` and
+`type`/`member --platform Library` to inspect through the tool's resolver rather
+than assuming one installation path.


### PR DESCRIPTION
Make the platform/package guide useful with today's CLI: replace commands that
fail with real discovery, type, and member examples, and explain the evidence
without overstating documentation, symbols, or offline availability.

Closes #5895.

## Scope and basis

The existing normative owner is
`docs/design/progressive-disclosure.md#verbosity`: presentation uses verbosity
presets and explicit section selection. Search scope resolution and PDB/source
acquisition remain supporting contracts. This PR changes only two Markdown
documents; it defines no new architecture, host path, renderer, or behavior.

The consumer is the existing CLI user following `docs/platform-components.md`.
The issue tracks one documentation delivery step, with zero product-adoption
or architecture-retirement steps.

## Demo

Real production output from dotnet-inspect `0.24.0+b2fde2a`, using SDK
`11.0.100-preview.7.26381.103` on Linux.

### Before

The old guide used this command shape:

```bash
dnx dotnet-inspect -y -- api JsonSerializer \
  --package System.Text.Json@10.0.0 --docs
```

It exits unsuccessfully:

```text
The 'api' command is deprecated. Please use:

  type   - Discover types in a package/library (compact table, no docs by default)
  member - Inspect type members (docs by default)
```

### After

```bash
dnx dotnet-inspect -y -- member JsonSerializer Serialize:1 \
  --package System.Text.Json@10.0.0 -T q
```

Actual output excerpt:

```text
## Signature

| Signature | Digest | Canonical Signature | Description |
| --------- | ------ | ------------------- | ----------- |
| `public static string Serialize<TValue>(TValue value, System.Text.Json.JsonSerializerOptions? options = null)` | `1dc14dd1fb` | `M:System.Text.Json.JsonSerializer.Serialize<TValue>(TValue,System.Text.Json.JsonSerializerOptions?)` | Converts the value of a type specified by a generic type parameter into a JSON string. |
```

Notice that the XML description is part of the selected signature; no
documentation switch or invented `Documentation` section is needed.

The neighboring installed-platform case:

```bash
dnx dotnet-inspect -y -- member JsonSerializer Serialize:1 \
  --platform System.Text.Json --offline -T q
```

Its context is `Source: Platform | TFM: net11.0`, and it emits the same
signature and description. Its complete output matches the platform invocation
without `--offline`. The guide explicitly distinguishes this product flag from
any initial tool acquisition by `dnx`.

Package/platform discovery also retains the distinction:

```bash
dnx dotnet-inspect -y -- find JsonSerializer \
  --platform --package System.Text.Json@10.0.0 -T q
```

Actual result:

```text
| Type | Namespace | Kind | Library | Source |
| ---- | --------- | ---- | ------- | ------ |
| JsonSerializer | System.Text.Json | class | System.Text.Json | System.Text.Json@10.0.0 |
| JsonSerializer | System.Text.Json | class | System.Text.Json | runtime@11.0.0-preview.7.26381.103 |
```

## Meaningful changes

- Replace retired `api`/standalone `platform` examples and documentation/sample
  switches with current `find`, `type`, `member`, and .NET inventory commands.
- Use `type --markdown -v:q` for compact type context; explain the default
  tree's supported verbosity levels.
- Distinguish XML descriptions from PDB source and sample references.
- Correct package-only symbol/sample assumptions and the claim that platform
  selection always means no download.
- Align the style guide's documentation-column and verbosity passages with
  existing progressive disclosure and actual selected-signature output.

The SourceLink and sample-reference documents are supporting context, not a
promise that a selected member exposes `Documentation` or `Samples` sections.
Unrelated style-guide conventions and product behavior remain unchanged.

## Validation

Both edited documents pass:

```bash
npx markdownlint-cli docs/platform-components.md docs/design/style-guide.md
git diff --check
```

Production examples exercised: combined discovery; package/platform compact
type views; package/platform selected-member descriptions; normal type
Markdown; installed-platform offline output; type discovery; member-index and
Signature-schema discovery; platform version discovery; and the one-version
package listing. The obsolete invocation failed as expected. The online and
offline platform member outputs matched exactly.

No source code or tests changed, and no repository build was required.
