### PR TITLE
Adopt configured authorities for CLI version queries

### DIFF
--- a/docs/design/package-source-model.md
+++ b/docs/design/package-source-model.md
@@ -481,10 +481,18 @@ scopes become attributed pre-client failures before transport construction.
 Other valid selected authorities still run, and usable peer evidence is
 reported as partial.
 
-Offline version enumeration and the `--versions-with-feed`,
-`--include-unlisted`, latest-version, range, payload, metadata, search, and
-extraction paths remain on the legacy composition until their package-owned
-adoption slices land. The process-global authentication decorator therefore
+Online metadata-only version queries also use this composition: pinned
+verification, latest-version, range enumeration, `--versions-with-feed`, and
+`--include-unlisted`. Latest and range selection require authoritative
+discovery; a healthy subset cannot choose the answer. A pinned verification
+can report an observed exact coordinate with peer failures disclosed, but
+cannot infer absence from unreadable peers. Failed operations, including the
+terminal operation deadline, publish no query rows.
+
+Offline version queries, payload-selecting latest/wildcard/range resolution,
+payload, metadata, search, and extraction paths remain on the legacy
+composition until their package-owned adoption slices land.
+The process-global authentication decorator therefore
 also remains solely for those legacy paths; it cannot be removed until they no
 longer depend on it. This first live slice does not read or publish the legacy
 producer-keyed version-list cache; authority-safe cache adoption remains a
@@ -520,13 +528,46 @@ recognition and finite observation limits remain owned by NuGetFetch.
 Release gates for this adoption. The existing terminal-operation-timeout and
 HTTP source-association gates remain unchanged.
 
-The remaining production adoption path is tracked by
-[#5400](https://github.com/richlander/dotnet-inspect/issues/5400): after this
-version-listing slice, migrate remaining candidate selection modes, then
-payload/cache authority, then CLI and reusable workspace consumers (including
-Browser/Wasm's supported source clients). Those slices retire the corresponding
-legacy composition paths. This slice does not add browser filesystem
-registration, local payload acquisition, or offline version discovery.
+The production adoption path is tracked by
+[#5400](https://github.com/richlander/dotnet-inspect/issues/5400) in five steps:
+configured authorities, ordinary version listing, metadata-only version
+queries, payload/cache authority (including payload-selecting resolution),
+and remaining CLI consumers/legacy retirement. The user explicitly approved
+CLI-only continuation ("CLI is good enough. proceed"); browser adoption is
+not a prerequisite for this workstream. These slices do not add browser
+filesystem registration or claim that offline local discovery is supported.
+
+### Metadata-only version queries
+
+The consumer is the CLI version-query family, not package inspection. The
+aggregate projects adopted observations into existing `PackageVersionInfo`
+and `PackageVersionSourceInfo` presentation models. These projections are not
+payload authorization receipts. Existing Markout-backed output paths retain
+their Markdown, TSV, JSONL, row-window, and count shapes.
+
+Listing state is per authority. An unlisted Gallery row is hidden by default
+even if another authority lists that version; the merged listing is visible
+if any authority lists it. Local/V3 sources without listing semantics retain
+the existing visible/`listed` presentation convention. Feed labels are
+credential-safe presentation only; colliding labels get operation-local
+ordinals, never hashes of HTTP authority keys.
+
+Limits apply to distinct versions after the union, not source rows. Range
+limits apply after inclusive endpoint resolution in caller direction.
+Explicit latest queries exclude unlisted versions even when their output
+requests the listing column. Pinned queries enumerate including prereleases
+and unlisted coordinates, compare normalized versions, and do not consult
+legacy payload caches online. Raw partial listings (including `--versions 1`)
+retain warnings; bare `--version`, explicit latest, and range queries fail
+before rendering when evidence is partial.
+
+`CliVersionQueries_LocalSelectorsUseCompleteEvidence`,
+`CliVersionQueries_PartialEvidenceCannotSelectLatestOrRange`,
+`CliVersionQueries_PinnedEvidenceDoesNotRequireReadablePeers`,
+`CliVersionQueries_ListingLensesPreservePerAuthorityRows`, and
+`CliVersionQueries_SourceOrderCannotChangeLatest` are the Release gates for
+this slice. Payload-selecting wildcard/latest/range paths remain outside this
+claim and migrate with their authority-preserving payload handoff.
 
 ### Reusable authority authorization
 

--- a/docs/design/version-resolution.md
+++ b/docs/design/version-resolution.md
@@ -229,6 +229,14 @@ each endpoint.
 
 ## Listed vs. unlisted versions
 
+The online CLI metadata-only version queries now adopt typed configured
+authority results under
+[Package Source Model](package-source-model.md#metadata-only-version-queries).
+They bypass the legacy caches described below, disclose partial raw listings,
+and require complete evidence for latest and range selection. Payload-selecting
+resolution and offline queries retain the legacy behavior in this section
+until their separately tracked adoption.
+
 NuGet lets a publisher **unlist** a version: it stays restorable by exact
 coordinate but is hidden from discovery on nuget.org. The flat-container
 `index.json` that drives version enumeration lists **every** published version

--- a/skills/private-feeds/SKILL.md
+++ b/skills/private-feeds/SKILL.md
@@ -41,24 +41,37 @@ Version discovery combines all eligible sources and chooses the highest
 semantic version; source order is not precedence. Pin `Package@Version` when
 the exact coordinate matters.
 
-### List versions from a folder feed
+### Query versions from a folder feed
 
-Ordinary version listing also supports NuGet V2/V3 folder feeds, specified as a
+Online version queries support NuGet V2/V3 folder feeds, specified as a
 path, a `file://` URI, or a mapped source in `NuGet.Config`:
 
 ```bash
 dnx dotnet-inspect -y -- package MyCompany.Widget --versions --source ./feed
 dnx dotnet-inspect -y -- package MyCompany.Widget --versions 5 --preview \
   --source ./feed --jsonl
+dnx dotnet-inspect -y -- package MyCompany.Widget --latest-version --source ./feed
+dnx dotnet-inspect -y -- package MyCompany.Widget@1.2.3 --version --source ./feed
+dnx dotnet-inspect -y -- package MyCompany.Widget@1.0.0..2.0.0 --versions \
+  --source ./feed --include-unlisted
+dnx dotnet-inspect -y -- package MyCompany.Widget --versions-with-feed \
+  --source ./feed --add-source https://api.nuget.org/v3/index.json
 ```
 
 Local and HTTP versions are combined and sorted before the result limit.
 Missing folders or invalid archives are source failures, not package absence;
 usable peer results carry an explicit partial warning on stderr. Local reads
 use bounded enumeration rather than treating filenames as version evidence.
-This applies to ordinary `--versions` without `--offline`, not yet
-`--versions-with-feed`, `--include-unlisted`, latest/range selection, or payload
-acquisition.
+Latest, single-version discovery, and range selection require complete
+evidence: an unreadable peer makes them fail instead of choosing from a
+healthy subset. A pinned verification may report a coordinate observed on a
+readable feed, with peer failures disclosed. `--include-unlisted` and
+`--versions-with-feed` retain their listing and feed columns; local versions
+use the non-Gallery `listed` convention.
+
+These are metadata-only queries without `--offline`. Local-feed payload
+inspection, including latest/wildcard/range selection that downloads packages,
+has not migrated yet.
 
 ### Restrict package ids to feeds
 
@@ -140,8 +153,9 @@ coordinate only when `.nupkg.metadata.source` names an authorized producer.
 Missing or mismatched provenance is a cache miss, and installed payloads do not
 introduce version candidates. Use `--no-nuget-cache` to exclude that layer.
 `--offline` forbids network access and does not start credential plugins, so it
-succeeds only from producer-authorized caches. Outside ordinary online
-`--versions`, configured folder feeds remain on legacy paths that skip them;
+succeeds only from producer-authorized caches. Online version queries bypass
+these legacy caches. Outside metadata-only online version queries,
+configured folder feeds remain on legacy paths that skip them;
 `--verbose` reports the skip. Pass a local `.nupkg` path directly for package
 inspection when the package is available as a file.
 

--- a/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
+++ b/src/DotnetInspector.Packages/DesktopPackageSourceComposition.cs
@@ -44,12 +44,17 @@ public sealed class PackageVersionDiscoveryResult
 {
     internal PackageVersionDiscoveryResult(
         PackageVersionDiscoveryState state,
-        IReadOnlyList<string> versions,
+        IReadOnlyList<PackageVersionSourceInfo> sourceListings,
         IReadOnlyList<PackageAuthorityFailure> failures,
         bool hasAnyCandidate)
     {
         State = state;
-        Versions = new ReadOnlyCollection<string>([.. versions]);
+        SourceListings = new ReadOnlyCollection<PackageVersionSourceInfo>([.. sourceListings]);
+        Listings = new ReadOnlyCollection<PackageVersionInfo>(
+            [.. sourceListings
+                .GroupBy(row => row.Version, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new PackageVersionInfo(group.Key, group.Any(row => row.Listed)))]);
+        Versions = new ReadOnlyCollection<string>([.. Listings.Select(row => row.Version)]);
         Failures =
             new ReadOnlyCollection<PackageAuthorityFailure>([.. failures]);
         HasAnyCandidate = hasAnyCandidate;
@@ -57,6 +62,10 @@ public sealed class PackageVersionDiscoveryResult
 
     public PackageVersionDiscoveryState State { get; }
     public IReadOnlyList<string> Versions { get; }
+    public IReadOnlyList<PackageVersionInfo> Listings { get; }
+
+    /// <summary>Per-authority display rows, not payload authorization receipts.</summary>
+    public IReadOnlyList<PackageVersionSourceInfo> SourceListings { get; }
     public IReadOnlyList<PackageAuthorityFailure> Failures { get; }
     public bool HasAnyCandidate { get; }
 }
@@ -117,7 +126,8 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
         int? limit,
         NuGetSourceOptions? sourceOptions = null,
         Action<string>? log = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool includeUnlisted = false)
     {
         ObjectDisposedException.ThrowIf(
             Volatile.Read(ref _disposed) != 0,
@@ -208,7 +218,8 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
             _options.RequestTimeout,
             _options.OperationTimeout,
             cancellationToken);
-        var versions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        IReadOnlyList<InertString> feedLabels = PackageSourceDisplay.ForVersionListings(sources);
+        var versions = new Dictionary<string, List<PackageVersionSourceInfo>>(StringComparer.OrdinalIgnoreCase);
         bool hasAnyCandidate = false;
         bool operationTimedOut = false;
 
@@ -322,10 +333,17 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
                     bool listed = !value.HasAuthoritativeListingState
                         || candidate.ListingState
                             != PackageListingState.Unlisted;
-                    if (listed
+                    if ((listed || includeUnlisted)
                         && (includePrerelease || !parsed.IsPrerelease))
                     {
-                        versions.Add(candidate.Coordinate.Version);
+                        string version = candidate.Coordinate.Version;
+                        if (!versions.TryGetValue(version, out var rows))
+                        {
+                            rows = [];
+                            versions.Add(version, rows);
+                        }
+                        rows.Add(new PackageVersionSourceInfo(
+                            version, feedLabels[sourceIndex].ToString(), listed));
                     }
                 }
             }
@@ -353,15 +371,15 @@ public sealed class DesktopPackageSourceComposition : IAsyncDisposable
             }
         }
 
-        List<string> ordered =
+        List<PackageVersionSourceInfo> ordered =
         [
-            .. versions
+            .. versions.Keys
                 .Select(version => (
                     Parsed: NuGetVersion.Parse(version),
                     Original: version))
                 .OrderByDescending(candidate => candidate.Parsed)
                 .Take(limit ?? int.MaxValue)
-                .Select(candidate => candidate.Original),
+                .SelectMany(candidate => versions[candidate.Original]),
         ];
         try
         {

--- a/src/DotnetInspector.Packages/PackageSourceDisplay.cs
+++ b/src/DotnetInspector.Packages/PackageSourceDisplay.cs
@@ -60,6 +60,43 @@ public static class PackageSourceDisplay
         return new InertString(TextPolicy.Field, name);
     }
 
+    internal static IReadOnlyList<InertString> ForVersionListings(
+        IReadOnlyList<NuGetSource> sources)
+    {
+        var labels = sources.Select(source =>
+        {
+            if (!string.IsNullOrEmpty(source.Name)
+                && !string.Equals(source.Name, source.Url, StringComparison.Ordinal))
+                return ForDiagnostics(source).ToString();
+            if (source.IsNuGetOrg)
+                return "nuget.org";
+            return Uri.TryCreate(source.Url, UriKind.Absolute, out var uri)
+                && !string.IsNullOrEmpty(uri.Host)
+                    ? new InertString(TextPolicy.Field, uri.Host).ToString()
+                    : ForDiagnostics(source).ToString();
+        }).ToArray();
+        var counts = labels.GroupBy(label => label, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+        var reserved = labels.ToHashSet(StringComparer.Ordinal);
+        var result = new List<InertString>(labels.Length);
+        for (int index = 0; index < labels.Length; index++)
+        {
+            string label = labels[index];
+            if (counts[label] > 1)
+            {
+                // Disambiguate presentation without hashing or exposing authority keys.
+                int ordinal = index + 1;
+                do
+                {
+                    label = $"{labels[index]} [source {ordinal++}]";
+                }
+                while (!reserved.Add(label));
+            }
+            result.Add(new InertString(TextPolicy.Field, label));
+        }
+        return result;
+    }
+
     static bool IsUrlShaped(string name) =>
         name.Contains("://", StringComparison.Ordinal)
         || (Uri.TryCreate(name, UriKind.Absolute, out Uri? parsed)

--- a/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
+++ b/src/dotnet-inspect.Tests/SourceScopedRoutingTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.IO.Compression;
 using System.Net;
+using System.Text.Json;
 using System.Xml.Linq;
 
 using DotnetInspector.CommandLine;
@@ -547,13 +548,9 @@ public sealed class SourceScopedRoutingTests : IDisposable
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("requires credentials", error);
-        if (query != "all")
-            Assert.Contains("HTTP 401", error);
         Assert.Contains(RefusedSource, error);
         Assert.Contains(
-            query == "all"
-                ? "Supply credentials for the source and retry."
-                : "The package may exist; the source was not readable.",
+            "Supply credentials for the source and retry.",
             error,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -593,7 +590,7 @@ public sealed class SourceScopedRoutingTests : IDisposable
     }
 
     [Fact]
-    public async Task PackageVersionQuery_UsesAReadableSourceAfterA401()
+    public async Task PackageVersionQuery_DoesNotChooseLatestAfterA401()
     {
         string packageName = $"PartialVersion{Guid.NewGuid():N}";
 
@@ -612,9 +609,9 @@ public sealed class SourceScopedRoutingTests : IDisposable
                 ],
                 refusedStatus: HttpStatusCode.Unauthorized);
 
-        Assert.Equal(0, exit);
-        Assert.Equal("2.0.0", output.Trim());
-        Assert.Empty(error);
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("requires credentials", error);
         Assert.Contains(
             requests,
             url => url.Equals(
@@ -1584,7 +1581,6 @@ public sealed class SourceScopedRoutingTests : IDisposable
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("requires credentials", error);
-        Assert.Contains("HTTP 401", error);
         Assert.DoesNotContain(
             "Version '3.0.0'",
             error,
@@ -1595,24 +1591,28 @@ public sealed class SourceScopedRoutingTests : IDisposable
     public async Task MissingPinnedVersion_RemainsAbsentWhenOnlyListingStatusFails()
     {
         string packageName = $"RegistrationFailure{Guid.NewGuid():N}";
-        DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
-            innerHandler => new NuGetOrgRegistrationFailureHandler(
-                packageName,
-                ["2.0.0"],
-                innerHandler));
         DotnetInspector.Core.HttpClientFactory.Initialize(
             new HttpClientFactoryOptions());
         DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        using var client = new HttpClient();
+        var context = new CommandContext(false, client, () =>
+            new DesktopPackageSourceComposition(
+                TimeSpan.FromSeconds(5), new UnavailableCredentialSource(),
+                (_, _) => new NuGetOrgRegistrationFailureHandler(
+                    packageName, ["2.0.0"], new HttpClientHandler())));
         try
         {
-            var (exit, output, error) = await RunCommandAsync(
-                [
-                    "package",
-                    $"{packageName}@3.0.0",
-                    "--version",
-                    "--source",
-                    "https://api.nuget.org/v3/index.json",
-                ]);
+            var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+                PackageCommand.ExecuteAsync(new InspectionOptions
+                {
+                    PackageArgs = [$"{packageName}@3.0.0"],
+                    ListVersions = true,
+                    Limit = 1,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = ["https://api.nuget.org/v3/index.json"],
+                    },
+                }, context));
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
@@ -1624,8 +1624,6 @@ public sealed class SourceScopedRoutingTests : IDisposable
         }
         finally
         {
-            DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
-                null);
             DotnetInspector.Core.HttpClientFactory.Initialize(
                 new HttpClientFactoryOptions { Offline = true });
             DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
@@ -1636,30 +1634,33 @@ public sealed class SourceScopedRoutingTests : IDisposable
     public async Task PackageRange_DoesNotDeclareAbsenceWhenListingStatusIsUnavailable()
     {
         string packageName = $"RangeRegistrationFailure{Guid.NewGuid():N}";
-        DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
-            innerHandler => new NuGetOrgRegistrationFailureHandler(
-                packageName,
-                ["1.0.0", "2.0.0"],
-                innerHandler,
-                HttpStatusCode.NotFound));
         DotnetInspector.Core.HttpClientFactory.Initialize(
             new HttpClientFactoryOptions());
         DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
+        using var client = new HttpClient();
+        var context = new CommandContext(false, client, () =>
+            new DesktopPackageSourceComposition(
+                TimeSpan.FromSeconds(5), new UnavailableCredentialSource(),
+                (_, _) => new NuGetOrgRegistrationFailureHandler(
+                    packageName, ["1.0.0", "2.0.0"], new HttpClientHandler(),
+                    HttpStatusCode.NotFound)));
         try
         {
-            var (exit, output, error) = await RunCommandAsync(
-                [
-                    "package",
-                    $"{packageName}@1.0.0..2.0.0",
-                    "--versions",
-                    "--source",
-                    "https://api.nuget.org/v3/index.json",
-                ]);
+            var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+                PackageCommand.ExecuteAsync(new InspectionOptions
+                {
+                    PackageArgs = [$"{packageName}@1.0.0..2.0.0"],
+                    ListVersions = true,
+                    SourceOptions = new NuGetSourceOptions
+                    {
+                        Sources = ["https://api.nuget.org/v3/index.json"],
+                    },
+                }, context));
 
             Assert.Equal(1, exit);
             Assert.Empty(output);
             Assert.Contains(
-                $"Could not retrieve versions for package '{packageName}'.",
+                $"Package '{packageName}' version discovery failed.",
                 error);
             Assert.DoesNotContain(
                 "not found",
@@ -1668,8 +1669,6 @@ public sealed class SourceScopedRoutingTests : IDisposable
         }
         finally
         {
-            DotnetInspector.Core.HttpClientFactory.SetAuthenticationDecorator(
-                null);
             DotnetInspector.Core.HttpClientFactory.Initialize(
                 new HttpClientFactoryOptions { Offline = true });
             DotnetInspector.Core.HttpClientFactory.ResetSharedForTesting();
@@ -1793,6 +1792,243 @@ public sealed class SourceScopedRoutingTests : IDisposable
                 includePrerelease),
             version,
             extension: "txt");
+    }
+
+    [Theory]
+    [InlineData("", "--latest-version", false, "2.0.0")]
+    [InlineData("@latest", "--versions", true, "3.0.0-preview.1")]
+    [InlineData("@1.0", "--version", false, "1.0.0")]
+    [InlineData("@3.0.0-preview.1", "--version", false, "3.0.0-preview.1")]
+    [InlineData("@1.0.0..2.0.0", "--versions", false, "1.0.0\n2.0.0")]
+    [InlineData("@3.0.0-preview.1..1.0.0", "--versions", false, "3.0.0-preview.1\n2.0.0\n1.0.0")]
+    public async Task CliVersionQueries_LocalSelectorsUseCompleteEvidence(
+        string suffix, string mode, bool preview, string expected)
+    {
+        const string PackageName = "local-selectors";
+        string local = Path.Combine(_testRoot, "selectors");
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(local, PackageName, "2.0.0", hierarchical: true);
+        WriteLocalPackage(local, PackageName, "3.0.0-preview.1");
+        var (exit, output, error, requests) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "9.0.0",
+            ["package", PackageName + suffix, mode, "--source", local,
+                .. preview ? new[] { "--preview" } : []]);
+        Assert.Equal(0, exit);
+        Assert.Equal(expected, output.ReplaceLineEndings("\n").Trim());
+        Assert.Empty(error);
+        Assert.Empty(requests);
+    }
+
+    [Theory]
+    [InlineData("--latest-version", false)]
+    [InlineData("--version", false)]
+    [InlineData("--versions", true)]
+    public async Task CliVersionQueries_PartialEvidenceCannotSelectLatestOrRange(
+        string mode, bool range)
+    {
+        const string PackageName = "partial-selectors";
+        string local = Path.Combine(_testRoot, "partial-selectors");
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(local, PackageName, "2.0.0");
+        var (exit, output, error, _) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "9.0.0",
+            ["package", PackageName + (range ? "@1.0.0..2.0.0" : ""), mode,
+                "--source", local, "--source", RefusedSource],
+            refusedStatus: HttpStatusCode.Unauthorized);
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("requires credentials", error);
+        Assert.DoesNotContain("not found", error);
+    }
+
+    [Fact]
+    public async Task CliVersionQueries_PinnedEvidenceDoesNotRequireReadablePeers()
+    {
+        const string PackageName = "pinned-local";
+        string local = Path.Combine(_testRoot, PackageName);
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        var (exit, output, error, _) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "9.0.0",
+            ["package", PackageName + "@1.0", "--version", "--jsonl",
+                "--source", RefusedSource, "--source", local],
+            refusedStatus: HttpStatusCode.Unauthorized);
+        Assert.Equal(0, exit);
+        Assert.Equal("""{"version":"1.0.0"}""", output.Trim());
+        Assert.Contains("partial", error);
+        Assert.Contains("requires credentials", error);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CliVersionQueries_SourceOrderCannotChangeLatest(bool reverse)
+    {
+        const string PackageName = "order-independent";
+        string local = Path.Combine(_testRoot, PackageName);
+        WriteLocalPackage(local, PackageName, "3.0.0");
+        string[] sources = reverse ? [SecondSource, local] : [local, SecondSource];
+        var (exit, output, error, _) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "2.0.0",
+            ["package", PackageName, "--latest-version",
+                "--source", sources[0], "--source", sources[1]]);
+        Assert.Equal(0, exit);
+        Assert.Equal("3.0.0", output.Trim());
+        Assert.Empty(error);
+    }
+
+    [Theory]
+    [InlineData("--jsonl")]
+    [InlineData("--tsv")]
+    public async Task CliVersionQueries_ListingLensesPreservePerAuthorityRows(string format)
+    {
+        const string PackageName = "listing-lenses";
+        string local = Path.Combine(_testRoot, PackageName);
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(local, PackageName, "2.0.0");
+        var (exit, output, error, _) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "2.0.0",
+            ["package", PackageName, "--versions-with-feed", "--versions", "1",
+                "--include-unlisted", format, "--source", local, "--source", SecondSource]);
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("1.0.0", output);
+        Assert.Equal(2, output.Split("2.0.0", StringSplitOptions.None).Length - 1);
+        Assert.Contains("second.invalid", output);
+        Assert.Contains(PackageName, output);
+    }
+
+    [Fact]
+    public async Task CliVersionQueries_RangeWindowAndCountUseSelectedRows()
+    {
+        const string PackageName = "range-window";
+        string local = Path.Combine(_testRoot, PackageName);
+        WriteLocalPackage(local, PackageName, "1.0.0");
+        WriteLocalPackage(local, PackageName, "2.0.0");
+        WriteLocalPackage(local, PackageName, "3.0.0");
+        string[] args = ["package", PackageName + "@3.0.0..1.0.0", "--versions", "2",
+            "--include-unlisted", "--rows", "2..2", "--source", local];
+        var (exit, output, error, _) = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "9.0.0", [.. args, "--jsonl"]);
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("""{"version":"2.0.0","listing":"listed"}""", output.Trim());
+        var counted = await RunOnlineVersionFeedCommandAsync(
+            PackageName, "9.0.0", [.. args, "--count"]);
+        Assert.Equal(0, counted.Exit);
+        Assert.Equal("1", counted.Output.Trim());
+        Assert.Empty(counted.Error);
+    }
+
+    [Fact]
+    public async Task CliVersionQueries_DoesNotUseLegacyPayloadAsOnlinePinnedEvidence()
+    {
+        string packageName = $"LegacyPinned{Guid.NewGuid():N}";
+        SeedPackage(packageName, SecondSource);
+        var (exit, output, error, requests) = await RunOnlineVersionFeedCommandAsync(
+            packageName, "2.0.0",
+            ["package", packageName + "@1.0.0", "--version", "--source", SecondSource]);
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("not found", error);
+        Assert.NotEmpty(requests);
+    }
+
+    [Theory]
+    [InlineData("all", true, "3.0.0,2.0.0,1.0.0")]
+    [InlineData("feeds", false, "2.0.0,1.0.0")]
+    [InlineData("feeds", true, "3.0.0,2.0.0,2.0.0,1.0.0")]
+    [InlineData("latest", true, "2.0.0")]
+    [InlineData("pinned", true, "3.0.0")]
+    [InlineData("range", true, "3.0.0,2.0.0,1.0.0")]
+    public async Task CliVersionQueries_GalleryListingStateSurvivesSelection(
+        string mode, bool includeUnlisted, string expected)
+    {
+        const string PackageName = "gallery-query";
+        const string Gallery = "https://api.nuget.org/v3/index.json";
+        string local = Path.Combine(_testRoot, PackageName);
+        WriteLocalPackage(local, PackageName, "2.0.0");
+        var responses = new Dictionary<string, string>
+        {
+            [$"https://globalcdn.nuget.org/v3-flatcontainer/{PackageName}/index.json"] =
+                """{"versions":["1.0.0","2.0.0","3.0.0"]}""",
+            [$"https://globalcdn.nuget.org/v3/registration5-gz-semver2/{PackageName}/index.json"] =
+                """
+                {"items":[{"items":[
+                    {"catalogEntry":{"version":"1.0.0","listed":true}},
+                    {"catalogEntry":{"version":"2.0.0","listed":false}},
+                    {"catalogEntry":{"version":"3.0.0","listed":false}}
+                ]}]}
+                """,
+        };
+        using var client = new HttpClient();
+        var context = new CommandContext(false, client, () =>
+            new DesktopPackageSourceComposition(
+                TimeSpan.FromSeconds(5), new UnavailableCredentialSource(),
+                (_, _) => new CannedResponseHandler(responses)));
+        string suffix = mode switch
+        {
+            "pinned" => "@3.0.0",
+            "range" => "@3.0.0..1.0.0",
+            _ => "",
+        };
+        DotnetInspector.Core.HttpClientFactory.Initialize(new HttpClientFactoryOptions());
+        var (exit, output, error) = await ConsoleCapture.RunAsync(() =>
+            PackageCommand.ExecuteAsync(new InspectionOptions
+            {
+                PackageArgs = [PackageName + suffix],
+                ListVersions = true,
+                ListVersionsWithFeed = mode == "feeds",
+                Limit = mode is "pinned" or "latest" ? 1 : null,
+                ForceLatest = mode == "latest",
+                IncludeUnlisted = includeUnlisted,
+                Jsonl = true,
+                SourceOptions = new NuGetSourceOptions { Sources = [Gallery, local] },
+            }, context));
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var rows = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(line =>
+        {
+            using var document = JsonDocument.Parse(line);
+            return document.RootElement.Clone();
+        }).ToArray();
+        Assert.Equal(expected, string.Join(",", rows.Select(row => row.GetProperty("version").GetString())));
+        foreach (var row in rows)
+        {
+            if (!includeUnlisted)
+                continue;
+            string version = row.GetProperty("version").GetString()!;
+            bool unlisted = version == "3.0.0"
+                || (mode == "feeds" && version == "2.0.0"
+                    && row.GetProperty("feed").GetString() == "nuget.org");
+            Assert.Equal(unlisted ? "unlisted" : "listed", row.GetProperty("listing").GetString());
+        }
+    }
+
+    [Fact]
+    public async Task CliVersionQueries_QueryDistinctFeedsHaveDistinctSafeLabels()
+    {
+        const string PackageName = "feed-labels";
+        string[] sources = [
+            "https://feed.example/v3/index.json?tenant=one",
+            "https://feed.example/v3/index.json?tenant=two"];
+        const string Flat = "https://feed.example/flat/";
+        await using var composition = new DesktopPackageSourceComposition(
+            TimeSpan.FromSeconds(5), new UnavailableCredentialSource(),
+            (source, _) => new CannedResponseHandler(new Dictionary<string, string>
+            {
+                [source.Url] = $$"""
+                    {"version":"3.0.0","resources":[{"@id":"{{Flat}}","@type":"PackageBaseAddress/3.0.0"}]}
+                    """,
+                [$"{Flat}{PackageName}/index.json"] = """{"versions":["1.0.0"]}""",
+            }));
+        var result = await composition.GetVersionsAsync(
+            PackageName, false, 1, new NuGetSourceOptions { Sources = sources },
+            cancellationToken: TestContext.Current.CancellationToken);
+        Assert.Equal(PackageVersionDiscoveryState.Authoritative, result.State);
+        Assert.Equal(2, result.SourceListings.Count);
+        Assert.Equal(["feed.example [source 1]", "feed.example [source 2]"],
+            result.SourceListings.Select(row => row.Feed));
+        Assert.Single(result.Listings);
     }
 
     private static void WriteLocalPackage(
@@ -2142,9 +2378,9 @@ public sealed class SourceScopedRoutingTests : IDisposable
         {
             string url = request.RequestUri!.GetLeftPart(UriPartial.Path);
             string flatContainer =
-                $"https://api.nuget.org/v3-flatcontainer/{packageName.ToLowerInvariant()}/index.json";
+                $"https://globalcdn.nuget.org/v3-flatcontainer/{packageName.ToLowerInvariant()}/index.json";
             string registration =
-                $"https://api.nuget.org/v3/registration5-gz-semver2/{packageName.ToLowerInvariant()}/index.json";
+                $"https://globalcdn.nuget.org/v3/registration5-gz-semver2/{packageName.ToLowerInvariant()}/index.json";
 
             HttpResponseMessage response;
             if (url.Equals(flatContainer, StringComparison.OrdinalIgnoreCase))

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -139,6 +139,7 @@ public static class PackageOptionsParser
             ScopeLib = parseResult.GetValue(args.LibOption),
             ScopeTools = parseResult.GetValue(args.ToolsOption),
             ListVersions = showVersions,
+            SingleVersionQuery = bareVersion,
             ListVersionsWithFeed = showVersionsWithFeed,
             IncludePrerelease = parseResult.GetValue(args.PrereleaseOption),
             IncludeUnlisted = parseResult.GetValue(args.IncludeUnlistedOption),

--- a/src/dotnet-inspect/Commands/CommandContext.cs
+++ b/src/dotnet-inspect/Commands/CommandContext.cs
@@ -8,6 +8,8 @@ namespace DotnetInspector.Commands;
 /// </summary>
 public class CommandContext
 {
+    private readonly Func<DesktopPackageSourceComposition>? _createPackageSourceComposition;
+
     /// <summary>
     /// Logger for verbose output.
     /// </summary>
@@ -28,14 +30,16 @@ public class CommandContext
 
     internal CommandContext(
         bool verbose,
-        HttpClient httpClient)
+        HttpClient httpClient,
+        Func<DesktopPackageSourceComposition>? createPackageSourceComposition = null)
     {
         Logger = new VerboseLogger(verbose);
         HttpClient = httpClient
             ?? throw new ArgumentNullException(nameof(httpClient));
+        _createPackageSourceComposition = createPackageSourceComposition;
     }
 
     internal DesktopPackageSourceComposition
         CreatePackageSourceComposition() =>
-        new(HttpClient.Timeout);
+        _createPackageSourceComposition?.Invoke() ?? new(HttpClient.Timeout);
 }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -351,6 +351,9 @@ public class PackageCommand
         // Handle --versions mode: list versions and exit early
         if (options.ListVersions)
         {
+            if (!Core.HttpClientFactory.IsOffline)
+                return await ExecuteOnlineVersionQueryAsync(packageArgs[0], options, context);
+
             using var failureScope = FeedFailureTelemetry.Scope();
             PackageVersionRange? range = null;
             string? rangeError = null;
@@ -672,55 +675,13 @@ public class PackageCommand
                 return 0;
             }
 
-            List<string>? versions;
-            if (Core.HttpClientFactory.IsOffline)
-            {
-                versions = await PackageExtractor.GetVersionsAsync(
-                    context.HttpClient,
-                    normalizedName,
-                    options.IncludePrerelease,
-                    options.Limit,
-                    logger.Log,
-                    options.SourceOptions);
-            }
-            else
-            {
-                await using DesktopPackageSourceComposition composition =
-                    context.CreatePackageSourceComposition();
-                PackageVersionDiscoveryResult discovery =
-                    await composition.GetVersionsAsync(
-                        normalizedName,
-                        options.IncludePrerelease,
-                        options.Limit,
-                        options.SourceOptions,
-                        logger.Log);
-                if (discovery.State
-                    == PackageVersionDiscoveryState.Failed)
-                {
-                    WriteVersionDiscoveryFailure(
-                        normalizedName,
-                        discovery.Failures);
-                    return 1;
-                }
-
-                if (discovery.State == PackageVersionDiscoveryState.Partial)
-                {
-                    CommandError.WriteWarning(
-                        $"Version results for package '{normalizedName}' are partial.",
-                        [.. discovery.Failures.Select(
-                            failure => failure.Message)]);
-                }
-
-                if (!discovery.HasAnyCandidate)
-                {
-                    WriteVersionLookupFailure(
-                        normalizedName,
-                        $"Package '{packageArgs[0]}' not found on eligible configured sources.");
-                    return 1;
-                }
-
-                versions = [.. discovery.Versions];
-            }
+            List<string>? versions = await PackageExtractor.GetVersionsAsync(
+                context.HttpClient,
+                normalizedName,
+                options.IncludePrerelease,
+                options.Limit,
+                logger.Log,
+                options.SourceOptions);
 
             if (versions == null)
             {
@@ -1220,6 +1181,127 @@ public class PackageCommand
                 }
             }
         }
+    }
+
+    private static async Task<int> ExecuteOnlineVersionQueryAsync(
+        string packageReference,
+        InspectionOptions options,
+        CommandContext context)
+    {
+        PackageVersionRange? range = null;
+        string? rangeError = null;
+        bool isRange = !File.Exists(packageReference)
+            && PackageVersionRange.TryParse(packageReference, out range, out rangeError);
+        if (rangeError is not null)
+        {
+            CommandError.Write(rangeError);
+            return 1;
+        }
+
+        var (name, requestedVersion) = PackageExtractor.ParsePackageReference(packageReference);
+        string packageId = isRange ? range!.PackageId : name.ToLowerInvariant();
+        bool latest = !isRange && (options.ForceLatest
+            || string.Equals(requestedVersion, "latest", StringComparison.OrdinalIgnoreCase));
+        bool pinned = !isRange && !latest
+            && !string.IsNullOrEmpty(requestedVersion) && options.Limit == 1;
+        NuGet.Versioning.NuGetVersion? pinnedVersion = null;
+        if (pinned && !NuGet.Versioning.NuGetVersion.TryParse(requestedVersion, out pinnedVersion))
+        {
+            CommandError.Write($"Version '{requestedVersion}' is not an exact NuGet version.");
+            return 1;
+        }
+
+        using var requestScope = RequestTelemetry.Scope($"package {packageId}", "package versions");
+        await using DesktopPackageSourceComposition composition = context.CreatePackageSourceComposition();
+        PackageVersionDiscoveryResult discovery = await composition.GetVersionsAsync(
+            packageId,
+            pinned || options.IncludePrerelease || (range?.IncludesPrerelease ?? false),
+            isRange || pinned ? null : latest ? 1 : options.Limit,
+            options.SourceOptions,
+            context.Logger.Log,
+            includeUnlisted: !latest && (pinned || options.IncludeUnlisted));
+
+        bool requiresCompleteEvidence = latest || isRange
+            || (!pinned && options.SingleVersionQuery);
+        if (discovery.State == PackageVersionDiscoveryState.Failed
+            || (requiresCompleteEvidence && discovery.State != PackageVersionDiscoveryState.Authoritative))
+        {
+            WriteVersionDiscoveryFailure(packageId, discovery.Failures);
+            return 1;
+        }
+
+        IReadOnlyList<PackageVersionInfo> listings = discovery.Listings;
+        if (pinned)
+        {
+            listings = [.. listings.Where(row =>
+                NuGet.Versioning.VersionComparer.VersionRelease.Equals(
+                    NuGet.Versioning.NuGetVersion.Parse(row.Version), pinnedVersion))];
+            if (listings.Count == 0
+                && discovery.Failures.Any(failure => failure.Kind != PackageAuthorityFailureKind.IncompleteMetadata))
+            {
+                WriteVersionDiscoveryFailure(packageId, discovery.Failures);
+                return 1;
+            }
+        }
+
+        if (!discovery.HasAnyCandidate || ((pinned || latest) && listings.Count == 0))
+        {
+            CommandError.Write(pinned
+                ? $"Version '{requestedVersion}' of package '{packageId}' not found. Use --versions to see available versions."
+                : $"Package '{packageReference}' not found on eligible configured sources.");
+            return 1;
+        }
+
+        if (isRange)
+        {
+            try
+            {
+                listings = [.. PackageVersionVector.CreateListingAware(
+                    range!, listings, options.IncludePrerelease)
+                    .Take(options.Limit ?? int.MaxValue)];
+            }
+            catch (ArgumentException exception)
+            {
+                CommandError.Write(exception.Message);
+                return 1;
+            }
+        }
+
+        if (discovery.State == PackageVersionDiscoveryState.Partial)
+        {
+            CommandError.WriteWarning(
+                $"Version results for package '{packageId}' are partial.",
+                [.. discovery.Failures.Select(failure => failure.Message)]);
+        }
+
+        if (options.ListVersionsWithFeed)
+        {
+            var rowsByVersion = discovery.SourceListings.ToLookup(
+                row => row.Version, StringComparer.OrdinalIgnoreCase);
+            var rows = RowWindow.Apply(options.Rows,
+                listings.SelectMany(row => rowsByVersion[row.Version]).ToList());
+            if (LensProjection.TryProject(options, "--versions-with-feed",
+                    rows.Count, out var exit, VersionFeedColumns(rows, options)))
+                return exit;
+            OutputFormatter.WriteVersionFeedTable(rows, options, Console.Out);
+        }
+        else if (options.IncludeUnlisted)
+        {
+            var rows = RowWindow.Apply(options.Rows, listings);
+            if (LensProjection.TryProject(options, "--versions",
+                    rows.Count, out var exit, ["Version", "Listing"]))
+                return exit;
+            OutputFormatter.WriteVersionListings(rows, options, Console.Out);
+        }
+        else
+        {
+            var rows = RowWindow.Apply(options.Rows, listings.Select(row => row.Version).ToList());
+            if (LensProjection.TryProject(options, latest ? "--latest-version" : "--versions",
+                    rows.Count, out var exit, ["Version"]))
+                return exit;
+            WriteVersions(rows, options);
+        }
+        return 0;
     }
 
     private static void WriteVersions(

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -95,6 +95,11 @@ public record InspectionOptions : IProjectionOptions
     public bool ListVersions { get; init; }
 
     /// <summary>
+    /// Select one version with bare --version, rather than limit a raw listing.
+    /// </summary>
+    public bool SingleVersionQuery { get; init; }
+
+    /// <summary>
     /// Annotate each listed version with the feed it came from, one row per version and feed.
     /// </summary>
     public bool ListVersionsWithFeed { get; init; }

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -73,6 +73,16 @@
 
 ### Package acquisition and audit
 
+- Online metadata-only package version queries now support configured folder
+  feeds for pinned verification, latest and range selection, listing status,
+  and per-feed rows. Payload inspection and offline local discovery remain
+  separate work (#5400).
+- **Breaking:** Online bare `--version`, `--latest-version`, and version ranges
+  now fail when an eligible source is unreadable instead of selecting from
+  incomplete evidence. Fix or exclude the failing source, or use raw
+  `--versions` to inspect explicitly partial results. Online version queries
+  bypass legacy producer-keyed caches; offline behavior is unchanged (#5400).
+
 - Adds the opt-in `Audit: Findings` package section for bounded scans of
   text-bearing package files and decoded SourceLink maps. Findings identify
   control or bidi text, package-source declarations, cleared restore sources,


### PR DESCRIPTION
# Outcome

Make configured local feeds useful through the real CLI version-query family,
while refusing to present a healthy subset as the latest or complete range.
This is a focused, conventionally grounded continuation of #5400 under #3759.

Online metadata-only latest, pinned verification, ranges, `--include-unlisted`,
and `--versions-with-feed` now use package-owned source composition. Local and
HTTP candidates share the existing bounded operations, exact result adoption,
semantic union, and source-policy rules. No package bytes are acquired.

## Demo

A real folder feed contains `Contoso.Widget` at `1.0.0`, `2.0.0`, and
`3.0.0-preview.1`, each in a ZIP package with matching nuspec coordinates.

```bash
dotnet-inspect package Contoso.Widget --latest-version \
  --source /tmp/5400-version-demo-feed
```

Before:

```text
Error: Package 'Contoso.Widget' not found on eligible configured sources.
```

Exit 1. After:

```text
2.0.0
```

Exit 0. The local feed now participates in latest selection rather than being
silently skipped.

Neighbor: a descending range with a prerelease endpoint, limited only after
inclusive range resolution:

```bash
dotnet-inspect package Contoso.Widget@3.0.0-preview.1..1.0.0 --versions 2 \
  --source /tmp/5400-version-demo-feed --include-unlisted --jsonl
```

```jsonl
{"version":"3.0.0-preview.1","listing":"listed"}
{"version":"2.0.0","listing":"listed"}
```

Failure neighbor: add `--add-source /tmp/5400-version-demo-missing` to the
latest query. Stdout is empty, exit is 1, and stderr reports:

```text
Error: Package 'contoso.widget' version discovery failed.
  Package source /tmp/5400-version-demo-missing could not be reached while enumerating versions.
  Check the package source location, access permissions, and connectivity before retrying.
```

These are source-built Release CLI runs, not mockups.

## Design basis and scope

One normative owner: `docs/design/package-source-model.md`, **Candidate
aggregation** and **Metadata-only version queries**. Exact claim: online
metadata-only CLI queries adopt eligible local/HTTP observations through the
existing composition; automatic latest/range selection requires complete
authority evidence, while raw listings may disclose partial evidence.

Supporting roles: version-resolution owns semantic ordering/range rules;
local-package-source-identity owns lexical folder identity; NuGetFetch's
local-folder design owns filesystem/ZIP admission and finite bounds. Their
contracts are consumed, not redefined. The existing composition TLA+ model
motivates completeness and deadline handling; this slice changes no model.

Baseline/analogy: reuse this repository's already-live raw online composition
and existing listing-aware vector and Markout renderers. NuGet's explicitly
named unlisted coordinates remain valid; automatic discovery hides unlisted
Gallery rows. No external code or architecture is imported.

Complexity is limited to retained listing/feed projections and one online CLI
dispatch path. `SingleVersionQuery` distinguishes bare `--version` selection
from the raw `--versions 1` limit; only selection fails closed. Feed labels
disambiguate with operation-local ordinals, not authority-key hashes.
`CommandContext` can supply the existing composition for deterministic Gallery
transport fixtures; fixtures do not manufacture adopted candidate results.

Existing typed `PackageVersionInfo` / `PackageVersionSourceInfo` reach the
existing Markout-backed Markdown, TSV, JSONL, row-window, and Count renderers.
Display rows explicitly are not payload-authorization receipts.

## Production adoption and retirement

The user approved this workstream's CLI-only scope: **"CLI is good enough.
proceed"**. Browser adoption is not a prerequisite; no browser filesystem
registration or new platform exception is introduced.

The counted #5400 plan is five steps:

1. Configured authorities: merged in #5752.
2. Ordinary online local version listing: merged in #5855.
3. Metadata-only CLI version queries: this PR.
4. Authority-correct payload/cache adoption, including payload-selecting
   latest/wildcard/range resolution.
5. Remaining CLI consumers and corresponding legacy retirement.

This PR retires online version-query calls to the legacy composition. Offline
queries, inspection/extraction, search/enrichment, and payload-selecting
resolution still use legacy paths and are not claimed migrated. This avoids
selecting a local version only to acquire bytes from an unrelated legacy
source. The process-global authentication decorator remains for those users.
No legacy candidate/payload cache is reinterpreted as authority evidence.

## Compatibility

**Corrective but breaking:** online bare version, latest, and range queries
fail rather than select after an eligible-source failure. Raw enumeration
still exposes usable peers with an explicit warning. Pinned verification can
succeed with an observed coordinate and disclose peer failures, but cannot
declare absence from unreadable peers. Online metadata queries bypass legacy
producer-keyed caches. Release notes and the shipped private-feeds skill
disclose these boundaries; offline behavior remains unchanged.

The explicit `Package@latest --versions N` spelling likewise resolves one
latest version, even when N is greater than one. Use `Package --versions N`
for a raw N-version listing. Round 1 noted this additional spelling of the
correction; it does not require a different implementation.

## Validation

SDK `11.0.100-preview.7.26381.103`, Release:

- `SourceScopedRoutingTests`, `NuGetSearchSourcesTests`,
  `PackageVersionVectorTests`, and `SkillCommandTests`: 278 passed.
- Existing `CommandExecutionTests.Versions_*` output/projection cases: 6 passed.
- `PackageVersionTests` and `RouterVersionTests`: 20 passed.
- Changed Markdown passes `markdownlint`; `git diff --check` is clean.

Contract cases include real V2/V3 archives; mixed-source order independence;
partial/latest/range failure; normalized pinned coordinates; no legacy pinned
payload shortcut online; Gallery unlisted/local-visible joins; per-authority
rows under distinct-version limits; query-distinct feed labels; descending
range windows and Count; and inherited operation-ceiling gates.

Current-head `ci-required` succeeded. Round 1 is 2/2 clean (GPT-6 Astra and
Claude Opus 5) at `9e3f63ecd5c3a958b55f510cd71831a120533a74`; see
[public reconciliation](https://github.com/richlander/dotnet-inspect/pull/5900#issuecomment-5548173442).
Main movement through `191e8dacc2fc1fec7faa887253cf5c7005d1a633` is classified
no interaction. The reviewed head remains unchanged.
