### PR TITLE
Add phase-scoped retained artifact byte access

### DIFF
--- a/docs/design/artifact-acquisition-and-workspaces.md
+++ b/docs/design/artifact-acquisition-and-workspaces.md
@@ -717,8 +717,8 @@ separate workspace admission roles. This is a target change from the current
 parameterless
 `ResolvedAssemblyReference.OpenRead` and public readable `Path`.
 
-`ArtifactContentReference` is the query-time input to a downstream content
-consumer. The artifact owner issues it for one identity in a sealed generation
+`ArtifactContentReference` is the compatibility query-time input to a downstream
+content consumer. The artifact owner issues it for one identity in a sealed generation
 and binds that artifact's descriptor and acquisition registration. Role
 and registration observations and retained-content opens revalidate the query
 lease supplied when the reference was issued. The type makes no claim that the
@@ -730,6 +730,103 @@ reference's guarded content callback to
 registration, decodes assembly identity, and binds a non-empty MVID. It does
 not receive the workspace role set or interpret a lease-scoped path as content
 authority, designation, or trust.
+
+#### Phase-scoped retained byte access
+
+Issue [#5884](https://github.com/richlander/dotnet-inspect/issues/5884) supplies
+the Artifact Acquisition boundary consumed by Metadata admission and query
+validation in
+[#4857](https://github.com/richlander/dotnet-inspect/issues/4857). That consumer's
+[assembly projection contract](assembly-inspection-query.md#admission-scoped-artifact-projection)
+owns classification and assembly facts; this section owns only the retained
+image, authorization, and callback lifetime.
+
+One immutable owner-retained image backs admission, subsequent query callbacks,
+and compatibility streams for an artifact. Scoped access does not reopen the
+source or allocate another full-image copy. The owner transfers its private
+materialized array into immutable storage; a low-level owner supplying an
+`ImmutableArray<byte>` must already have relinquished mutable aliases. This
+follows the existing `AssemblyImageSnapshot` ownership-transfer pattern rather
+than treating trusted in-process owners as hostile. A stream-only retained
+content registration remains a compatibility facility and explicitly rejects
+scoped byte access; arbitrary openers cannot attest an immutable image.
+
+The synchronous callback convention follows .NET span callbacks: two distinct
+`readonly ref struct` views carry the exact opaque `ArtifactIdentity`, its
+generation, and `ReadOnlySpan<byte>`. Only the artifact owner constructs these
+views. `ArtifactAdmissionContentCallback<TResult>` and
+`ArtifactQueryContentCallback<TResult>` take a scoped view and caller
+cancellation token. Their result type cannot be byref-like. The consumer
+finishes image-local work before returning; retaining a view or borrowed span
+across an asynchronous continuation is not an available operation.
+
+`RetainedArtifactContent.WithAdmissionContent` accepts only admission leases;
+`WithQueryContent` accepts only query leases. Each registers access atomically
+with authorization validation, before invoking consumer code. Missing,
+foreign, disposed, revoked, or ended authority produces
+`ArtifactContentAccessOutcome<TResult>.Unauthorized` without invocation.
+`Accessed.Value` is the consumer's result, including any consumer-owned typed
+rejection. Consumer exceptions retain their instance and type, including
+`UnauthorizedAccessException` and `ObjectDisposedException`; they cannot be
+mistaken for owner rejection. Caller cancellation is observed before access
+and after a normally returning callback, and remains cancellation.
+
+Authorization expiry rejects subsequent callbacks, not work already admitted.
+An active callback keeps acquisition leases alive through generation end until
+it unwinds, just as an already-returned compatibility stream does until
+disposal. Callbacks must return; they must not synchronously wait for the
+session's own disposal, which waits for them. No worker thread or background
+execution is required by this contract.
+
+`ArtifactSetSession.SealWithProjectionAsync` is the pre-publication integration
+point. After bounded materialization succeeds, it supplies each artifact in
+catalog order through an admission callback while the catalog remains
+unpublished. The callback returns either no failure or an
+`ArtifactSetAdmissionFailure`. A failure rejects the whole generation and stops
+further projection. An exception aborts and cleans the generation, then
+propagates unchanged with the session's existing ancillary cleanup evidence.
+Projected values collected by the caller remain provisional until `Published`;
+they cannot authorize content and must be discarded on any other completion.
+Publication occurs only after every callback succeeds and caller cancellation
+and session termination are checked. Ordinary `SealAsync` remains the
+compatibility path without projection.
+
+The session's query callback validates current authorization before selecting
+an artifact. A valid lease with an identity outside that session is an explicit
+lookup error, not a request to reacquire or substitute content. After selection,
+the retained-content owner atomically admits the callback, so revocation or
+termination during that handoff can still reject it.
+
+The existing
+[generation-access model](models/artifact-generation-access/README.md) supplies
+the access-registration/quiescent-release design basis. Scoped callbacks reuse
+that protocol; they do not add a second release mechanism or alter the session's
+construction, sealing, publication, and disposal states. The model's recorded
+stream results are not evidence of these new APIs. Release conformance is
+established by the focused product gates:
+
+- `ScopedContent_AdmissionAndQueryKeepExactIdentityAndBytes`
+- `ScopedContent_RejectsAuthorityBeforeInvocation`
+- `ScopedContent_ConsumerExceptionsAreNotAuthorizationFailures`
+- `ScopedContent_CancellationRemainsCancellation`
+- `ScopedContent_RequiresImmutableSnapshot`
+- `ScopedContent_RepeatedQueriesDoNotAllocateFullImage`
+- `ScopedContent_ActiveCallbackPinsRelease`
+- `ArtifactProjection_PrecedesPublicationAndReusesSnapshot`
+- `ArtifactProjection_RejectsAtomicallyAndRetainsDiagnostic`
+- `ArtifactProjection_MaterializationFailureDoesNotInvokeConsumer`
+- `ArtifactProjection_ExceptionAbortsWithoutReclassification`
+- `ArtifactProjection_CancellationOrTerminationPreventsPublication`
+- `ArtifactProjection_QueryRejectsBeforeSelectionAndPinsRelease`
+
+Production-host adoption is tracked by
+[#5766](https://github.com/richlander/dotnet-inspect/issues/5766). Its revised
+path has **13 steps**, inserting this prerequisite before Metadata
+implementation; CLI and Browser/Wasm both adopt the shared query/result
+contract in step 13. Sparse composition (#5843) and explicit-context composition
+(#5053) replace the relevant compatibility reference consumers after #4857.
+General retirement of unrelated stream/descriptor consumers remains outside
+this slice; neither host claims assembly-pattern search from this API alone.
 
 It does not:
 

--- a/docs/design/package-query-assembly-evaluation.md
+++ b/docs/design/package-query-assembly-evaluation.md
@@ -129,7 +129,7 @@ That composition will own candidate scheduling, progress, item-failure
 publication, completion accounting, and bounded concurrency. This document
 does not pre-empt those decisions.
 
-The end-to-end tracker #5766 carries the production-host adoption path. Its 12
+The end-to-end tracker #5766 carries the production-host adoption path. Its 13
 steps are enumerated under [Delivery sequence](#delivery-sequence), ending in
 the separate CLI and Browser gestures and exact result-opening adoptions.
 
@@ -1033,31 +1033,33 @@ implementation.
 
 ## Delivery sequence
 
-The production-host adoption path has 12 steps:
+The production-host adoption path has 13 steps:
 
 1. Lock this focused design and transfer the promoted-tier responsibility from
    the Package Query CLI proposal.
-2. Implement the #5143/#4857 Metadata-owned artifact admission and query
+2. Implement #5884's Artifact Acquisition-owned phase-scoped retained byte
+   access before and after artifact publication.
+3. Implement the #5143/#4857 Metadata-owned artifact admission and query
    validation path, including both unsupported-Windows-Metadata gates.
-3. Define #5843's sparse composition with the Metadata admission result and
+4. Define #5843's sparse composition with the Metadata admission result and
    query-validation registration.
-4. Define and implement #5837's Artifact Acquisition-owned exact package Root
+5. Define and implement #5837's Artifact Acquisition-owned exact package Root
    reacquisition request and destination Workspace transition.
-5. Define #5842's Artifact Acquisition-owned resource-free pre-transfer cleanup
+6. Define #5842's Artifact Acquisition-owned resource-free pre-transfer cleanup
    receipt.
-6. Implement the merged #5798 sparse-projection contract and its named gates,
+7. Implement the merged #5798 sparse-projection contract and its named gates,
    preserving the exact Root binding, issuing #5842 receipts when applicable,
    composing #5843's Metadata result, and avoiding full role realization.
-7. Define the first concrete producer under #5795, including its exact
+8. Define the first concrete producer under #5795, including its exact
    semantic occurrence, bounded operand, and optional UTF-16LE prefilter proof.
-8. Implement the one-candidate evaluator and its structural gates in
+9. Implement the one-candidate evaluator and its structural gates in
    `DotnetInspector.PackageQueries`.
-9. Adopt the first producer, adding its semantic gate and a prefilter gate only
+10. Adopt the first producer, adding its semantic gate and a prefilter gate only
    when that producer declares a complete representation set.
-10. Measure a pinned package corpus and choose explicit selected-entry,
+11. Measure a pinned package corpus and choose explicit selected-entry,
    retained-image, producer-working-set, and semantic-work bounds.
-11. Compose the evaluator into the bounded Package Query event stream, with
+12. Compose the evaluator into the bounded Package Query event stream, with
    candidate scheduling and disposal owned by a separate focused pipeline
    slice.
-12. Add CLI and Browser gestures and exact result opening in their respective
+13. Add CLI and Browser gestures and exact result opening in their respective
     owners.

--- a/src/DotnetInspector.Artifacts.Tests/ArtifactScopedContentTests.cs
+++ b/src/DotnetInspector.Artifacts.Tests/ArtifactScopedContentTests.cs
@@ -1,0 +1,538 @@
+using System.Collections.Immutable;
+using DotnetInspector.Artifacts.Workspaces;
+
+namespace DotnetInspector.Artifacts.Tests;
+
+public sealed class ArtifactScopedContentTests
+{
+    [Fact]
+    public void ScopedContent_AdmissionAndQueryKeepExactIdentityAndBytes()
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease admissionLease = owner.IssueLease(admission);
+        (ArtifactContribution contribution, RetainedArtifactContent content) =
+            Retain(owner, admission);
+        var marker = new object();
+
+        var projected = Assert.IsType<ArtifactContentAccessOutcome<object>.Accessed>(
+            content.WithAdmissionContent(admissionLease, (view, _) =>
+            {
+                Assert.Same(contribution.Registration.Artifact, view.Artifact);
+                Assert.Same(owner.Generation, view.Generation);
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                return marker;
+            }, TestContext.Current.CancellationToken));
+        Assert.Same(marker, projected.Value);
+        owner.CompleteAdmission(admission);
+        using ArtifactQueryLease query = owner.IssueLease(owner.CreateQueryAuthorization());
+        Assert.IsType<ArtifactContentAccessOutcome<int>.Accessed>(
+            content.WithQueryContent(query, (view, _) =>
+            {
+                Assert.Same(contribution.Registration.Artifact, view.Artifact);
+                Assert.Same(owner.Generation, view.Generation);
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                return view.Content.Length;
+            }, TestContext.Current.CancellationToken));
+        using Stream stream = content.OpenRead(query);
+        Assert.False(stream.CanWrite);
+        Assert.Equal(1, stream.ReadByte());
+        owner.EndGeneration();
+    }
+
+    [Theory]
+    [InlineData(false, "missing")]
+    [InlineData(false, "foreign")]
+    [InlineData(false, "disposed")]
+    [InlineData(false, "revoked")]
+    [InlineData(false, "ended")]
+    [InlineData(true, "missing")]
+    [InlineData(true, "foreign")]
+    [InlineData(true, "disposed")]
+    [InlineData(true, "revoked")]
+    [InlineData(true, "replaced")]
+    [InlineData(true, "ended")]
+    public void ScopedContent_RejectsAuthorityBeforeInvocation(bool query, string state)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease admissionLease = owner.IssueLease(admission);
+        (_, RetainedArtifactContent content) = Retain(owner, admission);
+        var foreign = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization foreignAdmission = foreign.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease foreignAdmissionLease = foreign.IssueLease(foreignAdmission);
+        ArtifactQueryLease? foreignQueryLease = null;
+        if (query)
+        {
+            foreign.CompleteAdmission(foreignAdmission);
+            foreignQueryLease = foreign.IssueLease(foreign.CreateQueryAuthorization());
+        }
+        int calls = 0;
+        ArtifactContentAccessOutcome<int> outcome;
+        if (query)
+        {
+            owner.CompleteAdmission(admission);
+            ArtifactQueryAuthorization authorization = owner.CreateQueryAuthorization();
+            using ArtifactQueryLease lease = owner.IssueLease(authorization);
+            if (state == "disposed")
+                lease.Dispose();
+            if (state == "revoked")
+                owner.Revoke(authorization);
+            if (state == "replaced")
+                owner.ReplaceQueryAuthorization(authorization);
+            if (state == "ended")
+                owner.EndGeneration();
+            outcome = content.WithQueryContent(
+                state == "missing" ? null : state == "foreign" ? foreignQueryLease : lease,
+                (_, _) => ++calls, TestContext.Current.CancellationToken);
+        }
+        else
+        {
+            if (state == "disposed")
+                admissionLease.Dispose();
+            if (state == "revoked")
+                owner.CompleteAdmission(admission);
+            if (state == "ended")
+                owner.EndGeneration();
+            outcome = content.WithAdmissionContent(
+                state == "missing" ? null : state == "foreign" ? foreignAdmissionLease : admissionLease,
+                (_, _) => ++calls, TestContext.Current.CancellationToken);
+        }
+
+        Assert.IsType<ArtifactContentAccessOutcome<int>.Unauthorized>(outcome);
+        Assert.Equal(0, calls);
+        foreignQueryLease?.Dispose();
+        owner.EndGeneration();
+        foreign.EndGeneration();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ScopedContent_ConsumerExceptionsAreNotAuthorizationFailures(bool query)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease admissionLease = owner.IssueLease(admission);
+        (_, RetainedArtifactContent content) = Retain(owner, admission);
+        Exception[] failures =
+        [
+            new UnauthorizedAccessException("consumer"),
+            new ObjectDisposedException("consumer"),
+            new IOException("consumer"),
+            new InvalidOperationException("consumer"),
+        ];
+        if (query)
+        {
+            owner.CompleteAdmission(admission);
+            using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
+            foreach (Exception failure in failures)
+            {
+                Assert.Same(failure, Record.Exception(() =>
+                    content.WithQueryContent<int>(
+                        lease, (_, _) => throw failure, TestContext.Current.CancellationToken)));
+            }
+        }
+        else
+        {
+            foreach (Exception failure in failures)
+            {
+                Assert.Same(failure, Record.Exception(() =>
+                    content.WithAdmissionContent<int>(
+                        admissionLease, (_, _) => throw failure, TestContext.Current.CancellationToken)));
+            }
+        }
+        Assert.True(owner.EndGenerationAsync().IsCompletedSuccessfully);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ScopedContent_CancellationRemainsCancellation(bool query)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease admissionLease = owner.IssueLease(admission);
+        (_, RetainedArtifactContent content) = Retain(owner, admission);
+        using var cancellation = new CancellationTokenSource();
+        int calls = 0;
+        int Cancel(CancellationToken token)
+        {
+            Assert.Equal(cancellation.Token, token);
+            calls++;
+            cancellation.Cancel();
+            return 1;
+        }
+
+        OperationCanceledException failure;
+        if (query)
+        {
+            owner.CompleteAdmission(admission);
+            using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
+            failure = Assert.Throws<OperationCanceledException>(() =>
+                content.WithQueryContent(lease, (_, token) => Cancel(token), cancellation.Token));
+            Assert.Throws<OperationCanceledException>(() =>
+                content.WithQueryContent(lease, (_, _) => ++calls, cancellation.Token));
+        }
+        else
+        {
+            failure = Assert.Throws<OperationCanceledException>(() =>
+                content.WithAdmissionContent(admissionLease, (_, token) => Cancel(token), cancellation.Token));
+            Assert.Throws<OperationCanceledException>(() =>
+                content.WithAdmissionContent(admissionLease, (_, _) => ++calls, cancellation.Token));
+        }
+        Assert.Equal(cancellation.Token, failure.CancellationToken);
+        Assert.Equal(1, calls);
+        Assert.True(owner.EndGenerationAsync().IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void ScopedContent_RequiresImmutableSnapshot()
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease lease = owner.IssueLease(admission);
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope = owner.BeginContribution(admission))
+            contribution = scope.Register(new Provenance(), _ => new MemoryStream([1]));
+        int opens = 0;
+        RetainedArtifactContent content = owner.CreateRetainedContent(
+            contribution.Registration, _ =>
+            {
+                opens++;
+                return new MemoryStream([1]);
+            });
+        Assert.Throws<InvalidOperationException>(() =>
+            content.WithAdmissionContent(lease, (_, _) => 0, TestContext.Current.CancellationToken));
+        Assert.Equal(0, opens);
+        using (Stream stream = content.OpenRead(lease))
+            Assert.Equal(1, stream.ReadByte());
+        Assert.Equal(1, opens);
+        owner.EndGeneration();
+    }
+
+    [Fact]
+    public void ScopedContent_RepeatedQueriesDoNotAllocateFullImage()
+    {
+        const int imageSize = 1024 * 1024;
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope = owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance(), _ => throw new InvalidOperationException("Source must not reopen."));
+        }
+        RetainedArtifactContent content = owner.CreateRetainedContent(
+            contribution.Registration, ImmutableArray.Create(new byte[imageSize]));
+        owner.CompleteAdmission(admission);
+        using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
+        ArtifactQueryContentCallback<int> callback = static (view, _) => view.Content.Length;
+        CancellationToken token = TestContext.Current.CancellationToken;
+        content.WithQueryContent(lease, callback, token);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int index = 0; index < 16; index++)
+            content.WithQueryContent(lease, callback, token);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated < imageSize, $"Scoped query allocations: {allocated} bytes.");
+        owner.EndGeneration();
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ScopedContent_ActiveCallbackPinsRelease(bool query)
+    {
+        var owner = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization admission = owner.CreateAdmissionAuthorization();
+        using ArtifactAdmissionLease admissionLease = owner.IssueLease(admission);
+        (_, RetainedArtifactContent content) = Retain(owner, admission);
+        Task? ending = null;
+        int End()
+        {
+            ending = owner.EndGenerationAsync().AsTask();
+            Assert.False(ending.IsCompleted);
+            return 3;
+        }
+        if (query)
+        {
+            owner.CompleteAdmission(admission);
+            using ArtifactQueryLease lease = owner.IssueLease(owner.CreateQueryAuthorization());
+            content.WithQueryContent(lease, (view, _) =>
+            {
+                int result = End();
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                return result;
+            }, TestContext.Current.CancellationToken);
+        }
+        else
+        {
+            content.WithAdmissionContent(admissionLease, (view, _) =>
+            {
+                int result = End();
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                return result;
+            }, TestContext.Current.CancellationToken);
+        }
+        Assert.NotNull(ending);
+        await ending.WaitAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ArtifactProjection_PrecedesPublicationAndReusesSnapshot(bool checkpointed)
+    {
+        await using var session = new ArtifactSetSession();
+        byte[] source = [1, 2, 3];
+        int opens = 0;
+        var sourceLease = new TrackingLease();
+        ArtifactIdentity? acquiredIdentity = null;
+        await session.AddRequiredAcquisitionAsync((scope, _) =>
+        {
+            ArtifactContribution contribution = scope.Register(new Provenance(), _ =>
+            {
+                opens++;
+                return new MemoryStream(source, writable: false);
+            });
+            acquiredIdentity = contribution.Descriptor.Identity;
+            return Acquired(contribution, sourceLease);
+        }, cancellationToken: TestContext.Current.CancellationToken);
+        if (checkpointed)
+        {
+            await session.AddSupplementalAcquisitionAsync(
+                (_, _, _) => ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+                    new ArtifactAcquisitionOutcome.Acquired([], new TrackingLease())),
+                cancellationToken: TestContext.Current.CancellationToken);
+        }
+        int projections = 0;
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealWithProjectionAsync((view, _) =>
+            {
+                projections++;
+                Assert.Same(acquiredIdentity, view.Artifact);
+                Assert.Same(session.Generation, view.Generation);
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                Assert.Throws<InvalidOperationException>(() => session.CreateQueryAuthorization());
+                source[0] = 99;
+                return null;
+            }, TestContext.Current.CancellationToken));
+        using ArtifactQueryLease query = session.IssueLease(session.CreateQueryAuthorization());
+        var result = Assert.IsType<ArtifactContentAccessOutcome<int>.Accessed>(
+            session.WithQueryContent(acquiredIdentity!, query, (view, _) =>
+            {
+                Assert.Same(acquiredIdentity, view.Artifact);
+                Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                return view.Content.Length;
+            }, TestContext.Current.CancellationToken));
+        Assert.Equal(3, result.Value);
+        Assert.Equal(1, projections);
+        Assert.Equal(1, opens);
+        await session.DisposeAsync();
+        Assert.Equal(1, sourceLease.Disposals);
+    }
+
+    [Fact]
+    public async Task ArtifactProjection_RejectsAtomicallyAndRetainsDiagnostic()
+    {
+        await using var session = new ArtifactSetSession();
+        var lease = new TrackingLease();
+        await Add(session, lease);
+        await Add(session, new TrackingLease());
+        var failure = new ArtifactSetAdmissionFailure(
+            ArtifactSetAdmissionFailureKind.Rejected, new Diagnostic());
+        int calls = 0;
+        var result = Assert.IsType<ArtifactSetPublicationOutcome.NotPublished>(
+            await session.SealWithProjectionAsync((_, _) =>
+            {
+                calls++;
+                return failure;
+            }, TestContext.Current.CancellationToken));
+        Assert.Same(failure, Assert.Single(result.Failures));
+        Assert.Equal(1, calls);
+        Assert.Equal(1, lease.Disposals);
+        Assert.Throws<ObjectDisposedException>(() => session.CreateQueryAuthorization());
+    }
+
+    [Fact]
+    public async Task ArtifactProjection_MaterializationFailureDoesNotInvokeConsumer()
+    {
+        await using var session = new ArtifactSetSession(
+            new ArtifactSetSessionLimits { MaxArtifactBytes = 2 });
+        var lease = new TrackingLease();
+        await Add(session, lease);
+        int calls = 0;
+        var result = Assert.IsType<ArtifactSetPublicationOutcome.NotPublished>(
+            await session.SealWithProjectionAsync((_, _) =>
+            {
+                calls++;
+                return null;
+            }, TestContext.Current.CancellationToken));
+        Assert.Equal("artifact.session.artifact-byte-limit",
+            Assert.Single(result.Failures).Diagnostic.Code);
+        Assert.Equal(0, calls);
+        Assert.Equal(1, lease.Disposals);
+    }
+
+    [Theory]
+    [InlineData("unauthorized")]
+    [InlineData("disposed")]
+    [InlineData("io")]
+    [InlineData("invalid")]
+    [InlineData("cancelled")]
+    public async Task ArtifactProjection_ExceptionAbortsWithoutReclassification(string kind)
+    {
+        await using var session = new ArtifactSetSession();
+        var cleanup = new IOException("cleanup");
+        var lease = new TrackingLease(cleanup);
+        await Add(session, lease);
+        using var cancellation = new CancellationTokenSource();
+        Exception primary = kind switch
+        {
+            "unauthorized" => new UnauthorizedAccessException("consumer"),
+            "disposed" => new ObjectDisposedException("consumer"),
+            "io" => new IOException("consumer"),
+            "invalid" => new InvalidOperationException("consumer"),
+            _ => new OperationCanceledException(cancellation.Token),
+        };
+        Exception? actual = await Record.ExceptionAsync(async () =>
+            await session.SealWithProjectionAsync(
+                (_, _) => throw primary, TestContext.Current.CancellationToken));
+        Assert.Same(primary, actual);
+        Assert.Equal(1, lease.Disposals);
+        Assert.Same(cleanup, Assert.Single(session.CleanupFailures));
+        var evidence = Assert.IsAssignableFrom<IReadOnlyList<Exception>>(
+            primary.Data["DotnetInspector.Artifacts.Workspaces.CleanupFailures"]);
+        Assert.Same(cleanup, Assert.Single(evidence));
+        Assert.Throws<ObjectDisposedException>(() => session.CreateQueryAuthorization());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ArtifactProjection_CancellationOrTerminationPreventsPublication(bool dispose)
+    {
+        await using var session = new ArtifactSetSession();
+        var cleanup = new IOException("cleanup");
+        var lease = new TrackingLease(cleanup);
+        await Add(session, lease);
+        using var cancellation = new CancellationTokenSource();
+        Task? disposal = null;
+        Exception? actual = await Record.ExceptionAsync(async () =>
+            await session.SealWithProjectionAsync((view, _) =>
+            {
+                if (dispose)
+                {
+                    disposal = session.DisposeAsync().AsTask();
+                    Assert.False(disposal.IsCompleted);
+                    Assert.Equal(0, lease.Disposals);
+                    Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+                }
+                else
+                {
+                    cancellation.Cancel();
+                }
+                return null;
+            }, cancellation.Token));
+        if (dispose)
+        {
+            Assert.IsType<ObjectDisposedException>(actual);
+            await disposal!.WaitAsync(TestContext.Current.CancellationToken);
+        }
+        else
+        {
+            Assert.Equal(cancellation.Token,
+                Assert.IsType<OperationCanceledException>(actual).CancellationToken);
+        }
+        Assert.Equal(1, lease.Disposals);
+        var evidence = Assert.IsAssignableFrom<IReadOnlyList<Exception>>(
+            actual!.Data["DotnetInspector.Artifacts.Workspaces.CleanupFailures"]);
+        Assert.Same(cleanup, Assert.Single(evidence));
+    }
+
+    [Fact]
+    public async Task ArtifactProjection_QueryRejectsBeforeSelectionAndPinsRelease()
+    {
+        await using var session = new ArtifactSetSession();
+        var lease = new TrackingLease();
+        await Add(session, lease);
+        Assert.IsType<ArtifactSetPublicationOutcome.Published>(
+            await session.SealAsync(TestContext.Current.CancellationToken));
+        ArtifactQueryAuthorization authorization = session.CreateQueryAuthorization();
+        using ArtifactQueryLease query = session.IssueLease(authorization);
+        ArtifactIdentity identity = Assert.Single(session.GetCatalog(query)).Identity;
+        var foreign = new ArtifactGenerationAuthority();
+        ArtifactAdmissionAuthorization foreignAdmission = foreign.CreateAdmissionAuthorization();
+        (ArtifactContribution foreignContribution, _) = Retain(foreign, foreignAdmission);
+        session.Revoke(authorization);
+        int calls = 0;
+        Assert.IsType<ArtifactContentAccessOutcome<int>.Unauthorized>(
+            session.WithQueryContent(foreignContribution.Descriptor.Identity, query,
+                (_, _) => ++calls, TestContext.Current.CancellationToken));
+        Assert.Equal(0, calls);
+        using ArtifactQueryLease current = session.IssueLease(session.CreateQueryAuthorization());
+        Assert.Throws<KeyNotFoundException>(() =>
+            session.WithQueryContent(foreignContribution.Descriptor.Identity, current,
+                (_, _) => ++calls, TestContext.Current.CancellationToken));
+        Task? disposal = null;
+        session.WithQueryContent(identity, current, (view, _) =>
+        {
+            disposal = session.DisposeAsync().AsTask();
+            Assert.False(disposal.IsCompleted);
+            Assert.Equal(0, lease.Disposals);
+            Assert.True(view.Content.SequenceEqual<byte>([1, 2, 3]));
+            return 1;
+        }, TestContext.Current.CancellationToken);
+        await disposal!.WaitAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(1, lease.Disposals);
+        Assert.IsType<ArtifactContentAccessOutcome<int>.Unauthorized>(
+            session.WithQueryContent(identity, current,
+                (_, _) => ++calls, TestContext.Current.CancellationToken));
+        Assert.Equal(0, calls);
+        foreign.EndGeneration();
+    }
+
+    private static (ArtifactContribution, RetainedArtifactContent) Retain(
+        ArtifactGenerationAuthority owner, ArtifactAdmissionAuthorization admission)
+    {
+        ArtifactContribution contribution;
+        using (ArtifactContributionScope scope = owner.BeginContribution(admission))
+        {
+            contribution = scope.Register(
+                new Provenance(), _ => throw new InvalidOperationException("Source must not reopen."));
+        }
+        return (contribution, owner.CreateRetainedContent(
+            contribution.Registration, ImmutableArray.Create<byte>(1, 2, 3)));
+    }
+
+    private static ValueTask Add(ArtifactSetSession session, TrackingLease lease) =>
+        session.AddRequiredAcquisitionAsync((scope, _) =>
+            Acquired(scope.Register(new Provenance(), _ => new MemoryStream([1, 2, 3])), lease),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+    private static ValueTask<ArtifactAcquisitionOutcome> Acquired(
+        ArtifactContribution contribution, TrackingLease lease) =>
+        ValueTask.FromResult<ArtifactAcquisitionOutcome>(
+            new ArtifactAcquisitionOutcome.Acquired([contribution], lease));
+
+    private sealed record Provenance : IArtifactProvenance;
+
+    private sealed record Diagnostic : IArtifactAcquisitionDiagnostic
+    {
+        public string Code => "test.projection.rejected";
+        public string Summary => "The consumer rejected the artifact.";
+    }
+
+    private sealed class TrackingLease(Exception? failure = null) : IArtifactAcquisitionLease
+    {
+        public int Disposals { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposals++;
+            return failure is null ? ValueTask.CompletedTask : ValueTask.FromException(failure);
+        }
+    }
+}

--- a/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
+++ b/src/DotnetInspector.Artifacts.Workspaces/ArtifactSetSession.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Runtime.InteropServices;
 
 namespace DotnetInspector.Artifacts.Workspaces;
 
@@ -679,8 +680,26 @@ public sealed class ArtifactSetSession : IAsyncDisposable
             .ConfigureAwait(false);
     }
 
-    public async ValueTask<ArtifactSetPublicationOutcome> SealAsync(
+    public ValueTask<ArtifactSetPublicationOutcome> SealAsync(
+        CancellationToken cancellationToken = default) =>
+        SealCoreAsync(null, cancellationToken);
+
+    /// <summary>
+    /// Projects each retained artifact before publishing the catalog. A
+    /// returned failure rejects the generation; exceptions propagate after
+    /// cleanup. Projected facts are provisional until publication succeeds.
+    /// </summary>
+    public ValueTask<ArtifactSetPublicationOutcome> SealWithProjectionAsync(
+        ArtifactAdmissionContentCallback<ArtifactSetAdmissionFailure?> project,
         CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        return SealCoreAsync(project, cancellationToken);
+    }
+
+    private async ValueTask<ArtifactSetPublicationOutcome> SealCoreAsync(
+        ArtifactAdmissionContentCallback<ArtifactSetAdmissionFailure?>? project,
+        CancellationToken cancellationToken)
     {
         List<AcquiredBatch> acquired;
         List<PublishedArtifact> prepared;
@@ -728,12 +747,14 @@ public sealed class ArtifactSetSession : IAsyncDisposable
             return await RejectAsync(failures).ConfigureAwait(false);
         }
 
+        Dictionary<ArtifactIdentity, PublishedArtifact> published;
+        List<ArtifactDescriptor> descriptors;
         try
         {
-            var published =
+            published =
                 new Dictionary<ArtifactIdentity, PublishedArtifact>(
                     ReferenceEqualityComparer.Instance);
-            var descriptors =
+            descriptors =
                 new List<ArtifactDescriptor>(artifactCount);
             var identities = new HashSet<ArtifactIdentity>(
                 ReferenceEqualityComparer.Instance);
@@ -824,35 +845,6 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                     }
                 }
             }
-
-            IReadOnlyList<ArtifactDescriptor> catalog =
-                new ReadOnlyCollection<ArtifactDescriptor>(
-                    descriptors);
-
-            lock (_gate)
-            {
-                ObjectDisposedException.ThrowIf(
-                    _state == SessionState.Disposed,
-                    this);
-                if (_state != SessionState.Sealing)
-                {
-                    throw new InvalidOperationException(
-                        "Artifact publication requires an active sealing operation.");
-                }
-
-                _authority.CompleteAdmission(_admission);
-                _artifacts = published;
-                _catalog = catalog;
-                _acquired.Clear();
-                _prepared.Clear();
-                _preparedIdentities.Clear();
-                _preparedArtifactCount = 0;
-                _preparedRetainedBytes = 0;
-                _failures.Clear();
-                _state = SessionState.Published;
-            }
-
-            return new ArtifactSetPublicationOutcome.Published();
         }
         catch (OperationCanceledException) when (IsDisposed())
         {
@@ -890,12 +882,102 @@ public sealed class ArtifactSetSession : IAsyncDisposable
                     "An artifact exceeds the per-artifact byte limit."));
             return await RejectAsync(failures).ConfigureAwait(false);
         }
-        catch (Exception ex) when (
-            ex is IOException
-                or UnauthorizedAccessException
-                or NotSupportedException
-                or InvalidOperationException
-                or OverflowException)
+        catch (Exception ex) when (IsMaterializationFailure(ex))
+        {
+            if (IsDisposed())
+            {
+                throw new ObjectDisposedException(
+                    nameof(ArtifactSetSession),
+                    "The artifact session was disposed during publication.");
+            }
+
+            failures.Add(
+                Failure(
+                    ArtifactSetAdmissionFailureKind.Failed,
+                    "artifact.session.materialization-failed",
+                    "Artifact content could not be materialized for publication."));
+            return await RejectAsync(failures).ConfigureAwait(false);
+        }
+
+        // Consumer failures must not enter the materialization classifiers.
+        try
+        {
+            if (project is not null)
+            {
+                foreach (ArtifactDescriptor descriptor in descriptors)
+                {
+                    ArtifactContentAccessOutcome<ArtifactSetAdmissionFailure?> outcome =
+                        published[descriptor.Identity].Content.WithAdmissionContent(
+                            _admissionLease,
+                            project,
+                            cancellationToken);
+                    if (outcome is not
+                        ArtifactContentAccessOutcome<ArtifactSetAdmissionFailure?>.Accessed accessed)
+                    {
+                        throw new ObjectDisposedException(
+                            nameof(ArtifactSetSession),
+                            "Admission ended before artifact projection.");
+                    }
+                    if (accessed.Value is ArtifactSetAdmissionFailure failure)
+                    {
+                        failures.Add(failure);
+                        return await RejectAsync(failures).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            IReadOnlyList<Exception> cleanupFailures =
+                await AbortAsync().ConfigureAwait(false);
+            AttachCleanupFailures(ex, cleanupFailures);
+            throw;
+        }
+
+        try
+        {
+            IReadOnlyList<ArtifactDescriptor> catalog =
+                new ReadOnlyCollection<ArtifactDescriptor>(descriptors);
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(
+                    _state == SessionState.Disposed,
+                    this);
+                if (_state != SessionState.Sealing)
+                {
+                    throw new InvalidOperationException(
+                        "Artifact publication requires an active sealing operation.");
+                }
+                cancellationToken.ThrowIfCancellationRequested();
+                _authority.CompleteAdmission(_admission);
+                _artifacts = published;
+                _catalog = catalog;
+                _acquired.Clear();
+                _prepared.Clear();
+                _preparedIdentities.Clear();
+                _preparedArtifactCount = 0;
+                _preparedRetainedBytes = 0;
+                _failures.Clear();
+                _state = SessionState.Published;
+            }
+
+            return new ArtifactSetPublicationOutcome.Published();
+        }
+        catch (OperationCanceledException ex)
+        {
+            IReadOnlyList<Exception> cleanupFailures =
+                await AbortAsync().ConfigureAwait(false);
+            AttachCleanupFailures(ex, cleanupFailures);
+            throw;
+        }
+        catch (ObjectDisposedException ex) when (IsDisposed())
+        {
+            IReadOnlyList<Exception> cleanupFailures =
+                await AbortAsync().ConfigureAwait(false);
+            AttachCleanupFailures(ex, cleanupFailures);
+            throw;
+        }
+        catch (Exception ex) when (IsMaterializationFailure(ex))
         {
             if (IsDisposed())
             {
@@ -1033,6 +1115,35 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         }
 
         return retained.OpenRead(lease);
+    }
+
+    public ArtifactContentAccessOutcome<TResult> WithQueryContent<TResult>(
+        ArtifactIdentity identity,
+        ArtifactQueryLease? lease,
+        ArtifactQueryContentCallback<TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        ArgumentNullException.ThrowIfNull(callback);
+        cancellationToken.ThrowIfCancellationRequested();
+        RetainedArtifactContent retained;
+        lock (_gate)
+        {
+            if (_state != SessionState.Published || lease is null)
+                return new ArtifactContentAccessOutcome<TResult>.Unauthorized();
+            try
+            {
+                _authority.ValidateQueryLease(lease);
+            }
+            catch (Exception ex) when (
+                ex is UnauthorizedAccessException or ObjectDisposedException)
+            {
+                return new ArtifactContentAccessOutcome<TResult>.Unauthorized();
+            }
+            retained = FindArtifact(identity).Content;
+        }
+
+        return retained.WithQueryContent(lease, callback, cancellationToken);
     }
 
     /// <summary>
@@ -1267,7 +1378,7 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         RetainedArtifactContent retained =
             _authority.CreateRetainedContent(
                 contribution.Registration,
-                _ => OpenSnapshot(snapshot));
+                ImmutableCollectionsMarshal.AsImmutableArray(snapshot));
         return new PublishedArtifact(
             contribution.Descriptor,
             contribution.Registration,
@@ -1664,14 +1775,6 @@ public sealed class ArtifactSetSession : IAsyncDisposable
         string code,
         string summary) =>
         new(kind, new SessionDiagnostic(code, summary));
-
-    private static MemoryStream OpenSnapshot(byte[] snapshot) =>
-        new(
-            snapshot,
-            index: 0,
-            count: snapshot.Length,
-            writable: false,
-            publiclyVisible: false);
 
     private enum SessionState
     {

--- a/src/DotnetInspector.Artifacts/ArtifactAccess.cs
+++ b/src/DotnetInspector.Artifacts/ArtifactAccess.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
 namespace DotnetInspector.Artifacts;
 
 /// <summary>
@@ -173,15 +176,18 @@ public sealed class RetainedArtifactContent
 {
     private readonly ArtifactGenerationAuthority _authority;
     private readonly Func<CancellationToken, Stream> _openRead;
+    private readonly ImmutableArray<byte> _snapshot;
 
     internal RetainedArtifactContent(
         ArtifactGenerationAuthority authority,
         ArtifactAcquisitionRegistration registration,
-        Func<CancellationToken, Stream> openRead)
+        Func<CancellationToken, Stream> openRead,
+        ImmutableArray<byte> snapshot)
     {
         _authority = authority;
         Registration = registration;
         _openRead = openRead;
+        _snapshot = snapshot;
     }
 
     public ArtifactAcquisitionRegistration Registration { get; }
@@ -198,6 +204,59 @@ public sealed class RetainedArtifactContent
         return _authority.OpenRetained(
             access,
             _openRead);
+    }
+
+    public ArtifactContentAccessOutcome<TResult> WithAdmissionContent<TResult>(
+        ArtifactAdmissionLease? lease,
+        ArtifactAdmissionContentCallback<TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        cancellationToken.ThrowIfCancellationRequested();
+        using ArtifactGenerationAuthority.ArtifactContentAccess? access =
+            _authority.TryBeginScopedAccess(lease);
+        if (access is null)
+            return new ArtifactContentAccessOutcome<TResult>.Unauthorized();
+
+        EnsureSnapshot();
+        TResult result = callback(
+            new ArtifactAdmissionContentView(
+                Registration.Artifact,
+                _snapshot.AsSpan()),
+            cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ArtifactContentAccessOutcome<TResult>.Accessed(result);
+    }
+
+    public ArtifactContentAccessOutcome<TResult> WithQueryContent<TResult>(
+        ArtifactQueryLease? lease,
+        ArtifactQueryContentCallback<TResult> callback,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        cancellationToken.ThrowIfCancellationRequested();
+        using ArtifactGenerationAuthority.ArtifactContentAccess? access =
+            _authority.TryBeginScopedAccess(lease);
+        if (access is null)
+            return new ArtifactContentAccessOutcome<TResult>.Unauthorized();
+
+        EnsureSnapshot();
+        TResult result = callback(
+            new ArtifactQueryContentView(
+                Registration.Artifact,
+                _snapshot.AsSpan()),
+            cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ArtifactContentAccessOutcome<TResult>.Accessed(result);
+    }
+
+    private void EnsureSnapshot()
+    {
+        if (_snapshot.IsDefault)
+        {
+            throw new InvalidOperationException(
+                "Scoped byte access requires owner-retained immutable content, not a compatibility stream opener.");
+        }
     }
 }
 
@@ -289,7 +348,38 @@ public sealed class ArtifactGenerationAuthority
     /// </remarks>
     public RetainedArtifactContent CreateRetainedContent(
         ArtifactAcquisitionRegistration registration,
-        Func<CancellationToken, Stream> openRead)
+        Func<CancellationToken, Stream> openRead) =>
+        CreateRetainedContentCore(registration, openRead, default);
+
+    /// <summary>
+    /// Retains one immutable snapshot for both scoped byte and stream access.
+    /// </summary>
+    /// <remarks>
+    /// The owner must relinquish any mutable alias before supplying the image.
+    /// The immutable array is retained without making another full-image copy.
+    /// </remarks>
+    public RetainedArtifactContent CreateRetainedContent(
+        ArtifactAcquisitionRegistration registration,
+        ImmutableArray<byte> snapshot)
+    {
+        if (snapshot.IsDefault)
+            throw new ArgumentException("A snapshot is required.", nameof(snapshot));
+
+        return CreateRetainedContentCore(
+            registration,
+            _ => new MemoryStream(
+                ImmutableCollectionsMarshal.AsArray(snapshot)!,
+                index: 0,
+                count: snapshot.Length,
+                writable: false,
+                publiclyVisible: false),
+            snapshot);
+    }
+
+    private RetainedArtifactContent CreateRetainedContentCore(
+        ArtifactAcquisitionRegistration registration,
+        Func<CancellationToken, Stream> openRead,
+        ImmutableArray<byte> snapshot)
     {
         ArgumentNullException.ThrowIfNull(registration);
         ArgumentNullException.ThrowIfNull(openRead);
@@ -320,7 +410,8 @@ public sealed class ArtifactGenerationAuthority
             var content = new RetainedArtifactContent(
                 this,
                 registration,
-                openRead);
+                openRead,
+                snapshot);
             _registrations[registration] = true;
             return content;
         }
@@ -565,6 +656,28 @@ public sealed class ArtifactGenerationAuthority
                 expectedAuthorization: null,
                 cancelReads: false);
         return OpenReadable(openRead, access);
+    }
+
+    internal ArtifactContentAccess? TryBeginScopedAccess(
+        ArtifactAccessLease? lease)
+    {
+        if (lease is null)
+            return null;
+
+        // Only admission failure is translated. Consumer code runs after this
+        // catch and keeps its own exception type and identity.
+        try
+        {
+            return BeginAccess(
+                lease,
+                expectedAuthorization: null,
+                cancelReads: false);
+        }
+        catch (Exception ex) when (
+            ex is UnauthorizedAccessException or ObjectDisposedException)
+        {
+            return null;
+        }
     }
 
     private ArtifactContentAccess BeginAccess(

--- a/src/DotnetInspector.Artifacts/ArtifactContentView.cs
+++ b/src/DotnetInspector.Artifacts/ArtifactContentView.cs
@@ -1,0 +1,65 @@
+namespace DotnetInspector.Artifacts;
+
+/// <summary>Owner-attested retained bytes borrowed during admission.</summary>
+public readonly ref struct ArtifactAdmissionContentView
+{
+    internal ArtifactAdmissionContentView(
+        ArtifactIdentity artifact,
+        ReadOnlySpan<byte> content)
+    {
+        Artifact = artifact;
+        Content = content;
+    }
+
+    public ArtifactGenerationIdentity Generation => Artifact.Generation;
+    public ArtifactIdentity Artifact { get; }
+    public ReadOnlySpan<byte> Content { get; }
+}
+
+/// <summary>Owner-attested retained bytes borrowed during a query.</summary>
+public readonly ref struct ArtifactQueryContentView
+{
+    internal ArtifactQueryContentView(
+        ArtifactIdentity artifact,
+        ReadOnlySpan<byte> content)
+    {
+        Artifact = artifact;
+        Content = content;
+    }
+
+    public ArtifactGenerationIdentity Generation => Artifact.Generation;
+    public ArtifactIdentity Artifact { get; }
+    public ReadOnlySpan<byte> Content { get; }
+}
+
+public delegate TResult ArtifactAdmissionContentCallback<TResult>(
+    scoped ArtifactAdmissionContentView view,
+    CancellationToken cancellationToken);
+
+public delegate TResult ArtifactQueryContentCallback<TResult>(
+    scoped ArtifactQueryContentView view,
+    CancellationToken cancellationToken);
+
+/// <summary>
+/// Separates owner authorization rejection from a consumer result or exception.
+/// </summary>
+public abstract class ArtifactContentAccessOutcome<TResult>
+{
+    private protected ArtifactContentAccessOutcome()
+    {
+    }
+
+    public sealed class Accessed : ArtifactContentAccessOutcome<TResult>
+    {
+        internal Accessed(TResult value) => Value = value;
+
+        public TResult Value { get; }
+    }
+
+    public sealed class Unauthorized : ArtifactContentAccessOutcome<TResult>
+    {
+        public Unauthorized()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Outcome

Provide the retained-byte foundation for a fast, bounded Package Query
experience in both CLI and Browser/Wasm: Artifact Acquisition can now lend
the same immutable image to admission and query consumers without a source
reopen or an additional full-image copy per callback.

Closes #5884. Unblocks the Artifact Acquisition prerequisite of #4857.
End-to-end tracker: #5766.

## Demo

Before this change, `ArtifactSetSession` materialized and published without an
admission projection hook; its content references were query-only compatibility
openers. A Metadata consumer could not obtain the #5143 view before publication.

A Release file-based demo now acquires a three-byte artifact, projects it
before publication, and queries the same image afterward:

```text
Admission: artifact 0, 3 bytes
Publication: Published
Query: 60
Revoked query: Unauthorized; callback calls: 0
Source opens: 1
```

The neighboring revoked-query case returns an owner rejection without running
the consumer. Existing `SealAsync` and guarded stream callers continue to work.

The core calls are:

```csharp
await session.SealWithProjectionAsync((view, token) =>
{
    // Retain content-free facts keyed by view.Artifact, provisional until Published.
    return null;
}, cancellationToken);

var result = session.WithQueryContent(
    selectedArtifact, currentLease,
    (view, token) => view.Content.Length,
    cancellationToken);
```

## Design basis

**Normative owner:** Artifact Acquisition,
`docs/design/artifact-acquisition-and-workspaces.md#phase-scoped-retained-byte-access`.
The owned claim is exact immutable-image access under phase-specific authority
with callback-bounded lifetime and distinguishable owner rejection.

Supporting evidence and boundaries:

- The existing generation-access model supplies the access-registration and
  quiescent-release protocol; its historic results are not new-API evidence.
- `AssemblyImageSnapshot` supplies the in-repository immutable ownership-transfer
  precedent. Span callbacks supply the conventional synchronous borrowing shape.
- Metadata's #5143 design supplies the consumer requirements, not authorization
  implementation or view construction.

The low-level immutable snapshot overload reuses the existing retained-content
owner. The session's projection hook runs after bounded materialization and
before publication. Consumer exceptions are outside materialization and
authorization classifiers; cancellation and ancillary cleanup evidence survive.
Active callbacks pin release through termination.

## Adoption and boundaries

The approved #5766 production-host path now has **13 steps**:

1. Lock the evaluator design (#5785 / #5823, merged).
2. Implement phase-scoped retained bytes (#5884, this PR).
3. Implement Metadata admission/query validation (#4857).
4. Define sparse/Metadata composition (#5843).
5. Implement exact Root reacquisition (#5837).
6. Define pre-transfer cleanup receipts (#5842).
7. Implement sparse selected-assembly projection (#5798).
8. Define the first semantic producer (#5795).
9. Implement the candidate evaluator (#5785).
10. Adopt semantic and applicable prefilter gates (#5795).
11. Measure a pinned corpus and set explicit resource/work bounds.
12. Compose the bounded event stream.
13. Adopt CLI and Browser gestures and exact result opening.

#5843 and the explicit-context work under #5053 migrate their relevant
compatibility references after #4857. Unrelated compatibility consumers remain
unchanged; this PR does not claim assembly-pattern search already works.
No new rendering surface or host-specific execution mechanism is introduced.
The existing platform contract is inherited.

## Validation

Release artifact gates: **80 passed** across `ArtifactScopedContentTests`,
`ArtifactSetSessionTests`, and `ArtifactContractTests`:

```sh
dotnet run --project src/DotnetInspector.Artifacts.Tests -c Release -- \
  -class DotnetInspector.Artifacts.Tests.ArtifactScopedContentTests \
  -class DotnetInspector.Artifacts.Tests.ArtifactSetSessionTests \
  -class DotnetInspector.Artifacts.Tests.ArtifactContractTests
```

The new cases include missing/foreign/disposed/revoked/ended authority,
authorization replacement, exact identity and snapshot reuse, consumer
exception identity, cancellation, pre-publication rejection, materialization
bounds, cleanup evidence, active callback release, and repeated-query
allocation below one full-image copy.

Both changed Markdown files pass `markdownlint`. The Release demo above ran
against the integrated candidate.
