### PR TITLE
Implement Research designated-pair admission and local comparison

### DIFF
--- a/docs/design/implementation-diff.md
+++ b/docs/design/implementation-diff.md
@@ -914,10 +914,13 @@ This boundary does not define:
 
 ## Research designated-pair admission
 
-**Status:** target design for the Research-owned part of
-[#5877](https://github.com/richlander/dotnet-inspect/issues/5877);
-**unimplemented and unverified**. This section does not describe a shipped
-alternative to strict correspondence.
+**Status:** implemented by `ResearchDesignatedPairAdmission` and the
+designated-pair overload of `ResearchProducerSessionRequest`, tracked by
+[#5877](https://github.com/richlander/dotnet-inspect/issues/5877).
+The design was established by
+[#5891](https://github.com/richlander/dotnet-inspect/pull/5891).
+The named Release gates below cover the Research boundary; Queries and host
+adoption remain separate deliveries.
 
 `ILInspector.Research` owns one claim:
 
@@ -1069,11 +1072,12 @@ the same token from the wrong image must remain non-success, not another
 method's comparison. An ordinary same-scope correspondence request with
 divergent resolved keys must still report its existing `SelectionDrift`.
 
-Implementation must add the following outcome gates to the Release
-`ILInspector.Research.Tests` executable. These are planned gates, not present
-evidence; the existing session gates do not prove the new work basis.
+The following outcome gates run in `ResearchProducerSessionTests` in the
+Release `ILInspector.Research.Tests` executable. The existing
+`ResearchProducerCompletion_RetainsNoBorrowedResourcesOrPresentation` gate also
+covers the pair, work-basis, and pair-admission result types.
 
-| Planned gate | Required observation |
+| Gate | Required observation |
 | --- | --- |
 | `ResearchDesignatedPair_AdmitsExactSideLocalMethods` | Real compiled methods with different names, types, domains, and scopes admit; same-method occurrences remain distinct; exact-address opposite-side blocking is irrelevant. |
 | `ResearchDesignatedPair_PreservesAssociationFailures` | A foreign-resolution attempt, cross-question or reversed pair, unresolved/API-only target, blocked selected census, and wrong-image address cannot issue a pair; both endpoint causes survive when applicable. |
@@ -1097,9 +1101,9 @@ simplest sufficient distinction. Admission is an immutable association check;
 the sequential session and its lifetime protocol are unchanged. No new
 stateful interaction calls for a TLA+ model.
 
-This design is part of #5877, delivery step 18 of the counted
+This Research implementation is #5877, delivery step 18 of the counted
 [#4706 adoption/retirement tracker](https://github.com/richlander/dotnet-inspect/issues/4706),
-not completion of that runtime step. At introduction the tracker has 18
+not completion of its Queries or host adoption. At design introduction the tracker had 18
 remaining runtime deliveries: 9 on each local CLI/browser path, 13 on each
 Source-enabled host path, and 7 on the comparison-tool path. Step 18 precedes
 the Queries adapter (step 6), then CLI/browser/tools adopt at steps 8/9/10.
@@ -1136,8 +1140,8 @@ The delivered prerequisites were tracked by
 [#5443](https://github.com/richlander/dotnet-inspect/issues/5443) and
 [#5444](https://github.com/richlander/dotnet-inspect/issues/5444).
 The separately specified
-[designated work basis](#research-designated-pair-admission) is unimplemented
-and unverified; existing gates below cover the correspondence basis.
+[designated work basis](#research-designated-pair-admission) uses the same
+coordinator and completion protocol; its additional gates are listed above.
 
 This boundary is owned by `ILInspector.Research`. It turns one complete target
 resolution into exact local C# and IL/body work, retains each producer's native
@@ -1166,8 +1170,8 @@ endpoint or its semantic and Finding projections disagree.
 
 One request carries the exact `ResearchAdmittedPopulation` and
 `ResearchTargetResolution` for the same implementation-comparison operation,
-and a non-empty set of requested local producer kinds. The shipped request
-uses all correspondence outcomes; the designated-pair extension chooses the
+and a non-empty set of requested local producer kinds. The resolution overload
+uses all correspondence outcomes; the designated-pair overload chooses the
 alternate work basis specified above. Research validates the
 complete question, input, scope, domain, and correspondence identity closure
 before it opens input content or invokes a producer. Equal-looking identities,

--- a/src/ILInspector.Research.Tests/ResearchDesignatedPairTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDesignatedPairTests.cs
@@ -1,0 +1,506 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using DotnetInspector.Artifacts;
+using DotnetInspector.Fixtures;
+
+using ILInspector.Analysis;
+using ILInspector.Decompiler;
+using ILInspector.Findings;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research.Tests;
+
+public partial class ResearchProducerSessionTests
+{
+    [Fact]
+    public void ResearchDesignatedPair_AdmitsExactSideLocalMethods()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.DiffV2.AssemblyPath()));
+        ResearchTargetResolution resolution = ResolveExactPair(
+            fixture, SampleType, "Method", "DiffFixtureSample.BodyStateSample", "BodyState");
+        ResearchTargetAttempt before = Attempt(resolution, 0, ResearchComparisonSide.Before);
+        ResearchTargetAttempt after = Attempt(resolution, 1, ResearchComparisonSide.After);
+        ResearchDesignatedPair pair = Admit(fixture, resolution, before, after);
+
+        Assert.Same(resolution, pair.Resolution);
+        Assert.Same(before, pair.Before);
+        Assert.Same(after, pair.After);
+        Assert.Same(fixture.Population.Operation, pair.Operation);
+        Assert.Same(fixture.Population.Questions[0].Id, pair.Question);
+        Assert.NotSame(before.Request.Scope, after.Request.Scope);
+        Assert.NotSame(before.Request.Domain, after.Request.Domain);
+        Assert.NotEqual(
+            Target(before).Anchor.CanonicalSignature,
+            Target(after).Anchor.CanonicalSignature);
+
+        SessionFixture same = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution sameResolution =
+            ResolveExactPair(same, SampleType, "Method", SampleType, "Method");
+        ResearchDesignatedPair samePair = Admit(
+            same,
+            sameResolution,
+            Attempt(sameResolution, 0, ResearchComparisonSide.Before),
+            Attempt(sameResolution, 1, ResearchComparisonSide.After));
+        Assert.Equal(Target(samePair.Before).Address, Target(samePair.After).Address);
+        Assert.NotSame(samePair.Before.Request.Input, samePair.After.Request.Input);
+        Assert.Contains(
+            sameResolution.Censuses,
+            census => ReferenceEquals(census.Scope, samePair.Before.Request.Scope)
+                && census.Side == ResearchComparisonSide.After
+                && census.Health == ResearchTargetCensusHealth.Blocked);
+        Assert.NotSame(
+            samePair,
+            Admit(same, sameResolution, samePair.Before, samePair.After));
+        Assert.Equal(2, Complete(new(same.Population, samePair, ResearchProducerCatalog.Kinds))
+            .Results.Length);
+    }
+
+    [Fact]
+    public void ResearchDesignatedPair_PreservesAssociationFailures()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(SampleType, "Method");
+        ResearchTargetAttempt before = Attempt(resolution, 0, ResearchComparisonSide.Before);
+        ResearchTargetAttempt after = Attempt(resolution, 0, ResearchComparisonSide.After);
+        ResearchTargetResolution other = fixture.Resolve(SampleType, "Method");
+
+        Assert.Equal(
+            ResearchDesignatedPairRejectionKind.ForeignAttempt,
+            Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
+                ResearchDesignatedPairAdmission.Admit(
+                    fixture.Population, resolution, other.Attempts[0], after)).Kind);
+        Assert.Equal(
+            ResearchDesignatedPairRejectionKind.WrongSide,
+            Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
+                ResearchDesignatedPairAdmission.Admit(
+                    fixture.Population, resolution, after, before)).Kind);
+        Assert.Equal(
+            ResearchDesignatedPairRejectionKind.MissingEndpoint,
+            Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
+                ResearchDesignatedPairAdmission.Admit(
+                    fixture.Population, resolution, null, after)).Kind);
+        var anotherPopulation = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        Assert.Equal(
+            ResearchDesignatedPairRejectionKind.ForeignResolution,
+            Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
+                ResearchDesignatedPairAdmission.Admit(
+                    anotherPopulation.Population, resolution, before, after)).Kind);
+        Assert.Equal(
+            ResearchProducerRejectionKind.ForeignResolution,
+            Reject(new(anotherPopulation.Population,
+                Admit(fixture, resolution, before, after), ResearchProducerCatalog.Kinds)).Kind);
+
+        foreach (string selector in new[] { "Field", "NotHere", "Overloaded" })
+        {
+            ResearchTargetResolution unavailable = fixture.Resolve(SampleType, selector);
+            var outcome = Assert.IsType<ResearchDesignatedPairOutcome.Unavailable>(
+                ResearchDesignatedPairAdmission.Admit(
+                    fixture.Population,
+                    unavailable,
+                    Attempt(unavailable, 0, ResearchComparisonSide.Before),
+                    Attempt(unavailable, 0, ResearchComparisonSide.After)));
+            Assert.Equal(
+                new[] { ResearchComparisonSide.Before, ResearchComparisonSide.After },
+                outcome.Endpoints.Select(endpoint => endpoint.Side));
+            Assert.All(outcome.Endpoints, endpoint =>
+            {
+                Assert.Contains(endpoint.Attempt, unavailable.Attempts);
+                Assert.Contains(endpoint.Census, unavailable.Censuses);
+                Assert.Equal(
+                    selector == "Field"
+                        ? ResearchDesignatedPairUnavailableKind.EndpointAddressUnavailable
+                        : ResearchDesignatedPairUnavailableKind.TargetUnavailable,
+                    endpoint.Kind);
+            });
+        }
+
+        var population = Assert.IsType<ResearchAdmissionOutcome.Admitted>(
+            ResearchComparisonAdmission.Admit(
+                new ResearchComparisonAdmissionRequest(
+                    ResearchComparisonProfile.ImplementationComparison,
+                    [
+                        new ResearchComparisonAdmissionQuestion(
+                            [Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath())], []),
+                        new ResearchComparisonAdmissionQuestion(
+                            [], [Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath())]),
+                    ]))).Population;
+        var twoQuestions = new SessionFixture(population);
+        ResearchTargetResolution crossQuestion = twoQuestions.ResolveSelections(
+            new ResearchCarriedMemberSelection(
+                population.Questions[0].Id, SampleType, MemberTargetSelector.Parse("Method")),
+            new ResearchCarriedMemberSelection(
+                population.Questions[1].Id, SampleType, MemberTargetSelector.Parse("Method")));
+        Assert.Equal(
+            ResearchDesignatedPairRejectionKind.CrossQuestion,
+            Assert.IsType<ResearchDesignatedPairOutcome.Rejected>(
+                ResearchDesignatedPairAdmission.Admit(
+                    population, crossQuestion,
+                    crossQuestion.Attempts[0], crossQuestion.Attempts[1])).Kind);
+
+        SessionFixture images = SessionFixture.Create(
+            Occurrence(FixtureCatalog.DiffV1.AssemblyPath()),
+            Occurrence(FixtureCatalog.DiffV2.AssemblyPath()));
+        const string bodyType = "DiffFixtureSample.BodyStateSample";
+        ResearchTargetResolution imageTargets = images.Resolve(bodyType, "BodyState");
+        var wrongImage = new ResearchExactAddressMemberSelection(
+            images.Population.Questions[0].Id,
+            images.Population.Inputs[0],
+            bodyType,
+            MemberTargetSelector.Parse("BodyState"),
+            Target(Attempt(imageTargets, 0, ResearchComparisonSide.After)).Address!.Value,
+            ResearchTargetRelationshipRole.Method);
+        ResearchTargetResolution wrong = images.ResolveSelections(
+            wrongImage,
+            new ResearchCarriedMemberSelection(
+                images.Population.Questions[0].Id,
+                bodyType, MemberTargetSelector.Parse("BodyState")));
+        var wrongOutcome = Assert.IsType<ResearchDesignatedPairOutcome.Unavailable>(
+            ResearchDesignatedPairAdmission.Admit(
+                images.Population, wrong,
+                Attempt(wrong, 0, ResearchComparisonSide.Before),
+                Attempt(wrong, 1, ResearchComparisonSide.After)));
+        ResearchDesignatedPairUnavailable failedBefore = Assert.Single(wrongOutcome.Endpoints);
+        Assert.Equal(ResearchComparisonSide.Before, failedBefore.Side);
+        Assert.Equal(ResearchTargetCensusHealth.Blocked, failedBefore.Census.Health);
+    }
+
+    [Fact]
+    public void ResearchDesignatedPair_DoesNotRequireCorrespondence()
+    {
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution roles = fixture.Resolve(
+            (SampleType, "Value:1"), (SampleType, "Value:2"), (SampleType, "NotHere"));
+        ResearchDesignatedPair pair = Admit(
+            fixture, roles,
+            Attempt(roles, 0, ResearchComparisonSide.Before),
+            Attempt(roles, 1, ResearchComparisonSide.After));
+        Assert.NotEqual(Target(pair.Before).Role, Target(pair.After).Role);
+        Assert.Contains(roles.Correspondences, value =>
+            value is ResearchTargetCorrespondenceOutcome.Absent);
+        Assert.Equal(2, Complete(new(fixture.Population, pair, ResearchProducerCatalog.Kinds))
+            .Results.Length);
+
+        ImplementationComparisonInputOccurrence original =
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath());
+        var withoutBodyIdentity = new ImplementationComparisonInputOccurrence(
+            original.Assembly,
+            original.Resolver,
+            LibraryBodyIndex.FromEvidence([], [], moduleIdentity: original.BodyIndex.ModuleIdentity));
+        SessionFixture incomplete = SessionFixture.Create(
+            withoutBodyIdentity,
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution missingKey = incomplete.Resolve(SampleType, "Method");
+        Assert.Contains(missingKey.Correspondences, value => value is
+            ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
+            {
+                Taint.Kind: ResearchTargetTaintKind.BodyIdentityUnavailable,
+            });
+        ResearchDesignatedPair noKey = Admit(
+            incomplete, missingKey,
+            Attempt(missingKey, 0, ResearchComparisonSide.Before),
+            Attempt(missingKey, 0, ResearchComparisonSide.After));
+        Assert.Null(Target(noKey.Before).BodyIdentity);
+        Assert.Equal(2, Complete(new(incomplete.Population, noKey, ResearchProducerCatalog.Kinds))
+            .Results.Length);
+
+        SessionFixture drift = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetCorrespondenceV1.AssemblyPath()),
+            Occurrence(FixtureCatalog.ResearchTargetCorrespondenceV2.AssemblyPath()));
+        ResearchTargetResolution divergent = drift.Resolve("CorrespondenceIdentity.Outer.Inner", "M");
+        Assert.All(divergent.Correspondences, outcome => Assert.Equal(
+            ResearchTargetTaintKind.SelectionDrift,
+            Assert.IsType<ResearchTargetCorrespondenceOutcome.CounterpartUnavailable>(outcome)
+                .Taint.Kind));
+        ResearchDesignatedPair divergentPair = Admit(
+            drift, divergent,
+            Attempt(divergent, 0, ResearchComparisonSide.Before),
+            Attempt(divergent, 0, ResearchComparisonSide.After));
+        Assert.Equal(2, Complete(new(drift.Population, divergentPair, ResearchProducerCatalog.Kinds))
+            .Results.Length);
+        Assert.All(divergent.Correspondences, outcome =>
+            Assert.IsType<ResearchTargetCorrespondenceOutcome.CounterpartUnavailable>(outcome));
+    }
+
+    [Fact]
+    public void ResearchDesignatedSession_RetainsExactPairAndNativeResults()
+    {
+        int beforeOpens = 0;
+        int afterOpens = 0;
+        int unrelatedOpens = 0;
+        var population = Assert.IsType<ResearchAdmissionOutcome.Admitted>(
+            ResearchComparisonAdmission.Admit(
+                new ResearchComparisonAdmissionRequest(
+                    ResearchComparisonProfile.ImplementationComparison,
+                    [
+                        new ResearchComparisonAdmissionQuestion(
+                            [Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath(),
+                                () => beforeOpens++)],
+                            [Occurrence(FixtureCatalog.DiffV2.AssemblyPath(), () => afterOpens++)]),
+                        new ResearchComparisonAdmissionQuestion(
+                            [Occurrence(FixtureCatalog.DiffV1.AssemblyPath(), () => unrelatedOpens++)],
+                            []),
+                    ]))).Population;
+        var fixture = new SessionFixture(population);
+        ResearchTargetResolution resolution = ResolveExactPair(
+            fixture, SampleType, "Method", "DiffFixtureSample.BodyStateSample", "BodyState",
+            new ResearchCarriedMemberSelection(
+                population.Questions[1].Id, "DiffFixtureSample.BodyStateSample",
+                MemberTargetSelector.Parse("Missing")));
+        ResearchDesignatedPair pair = Admit(
+            fixture, resolution,
+            Attempt(resolution, 0, ResearchComparisonSide.Before),
+            Attempt(resolution, 1, ResearchComparisonSide.After));
+        int beforeAdmission = beforeOpens;
+        int afterAdmission = afterOpens;
+        int unrelatedBeforeSession = unrelatedOpens;
+        Assert.True(resolution.Correspondences.Length > 2);
+        Admit(fixture, resolution, pair.Before, pair.After);
+        Assert.Equal(beforeAdmission, beforeOpens);
+        Assert.Equal(afterAdmission, afterOpens);
+        int beforeAfterCSharp = 0;
+        int afterAfterCSharp = 0;
+        var invoker = new TrackingInvoker
+        {
+            AfterCSharp = () =>
+            {
+                beforeAfterCSharp = beforeOpens;
+                afterAfterCSharp = afterOpens;
+            },
+        };
+        var request = new ResearchProducerSessionRequest(fixture.Population, pair,
+            [ResearchProducerKind.IlBody, ResearchProducerKind.CSharp]);
+        ResearchProducerCompletion completion = Complete(request, invoker);
+        Assert.Equal(ResearchProducerCatalog.Kinds, completion.WorkItems.Select(item => item.Producer));
+        Assert.Equal(2, invoker.InvocationCount);
+        Assert.True(beforeOpens > beforeAdmission);
+        Assert.True(afterOpens > afterAdmission);
+        Assert.Equal(2, completion.Cleanup.Length);
+        Assert.Equal(beforeAfterCSharp, beforeOpens);
+        Assert.Equal(afterAfterCSharp, afterOpens);
+        Assert.Equal(unrelatedBeforeSession, unrelatedOpens);
+        Assert.All(completion.WorkItems, item => Assert.Same(
+            pair, Assert.IsType<ResearchProducerWorkBasis.DesignatedPair>(item.Basis).Pair));
+        var csharp = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            completion.Results[0].Outcome).Result;
+        var il = Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+            completion.Results[1].Outcome).Result;
+        Assert.Same(invoker.CSharpResults[0], csharp);
+        Assert.Same(invoker.IlResults[0], il);
+        Assert.Equal(Target(pair.Before).Anchor.CanonicalSignature, csharp.Old.Key);
+        Assert.Equal(Target(pair.After).Anchor.CanonicalSignature, csharp.New.Key);
+        Assert.Equal(csharp.Old.Key, il.Old.Identity);
+        Assert.Equal(csharp.New.Key, il.New.Identity);
+        Assert.NotNull(csharp.BodyDiff);
+        Assert.NotNull(il.MemberDiff);
+
+        Assert.False(ResearchProducerSessionValidator.TryCreateCompletion(
+            request, completion.Session, completion.WorkItems,
+            completion.Results.SetItem(0,
+                new ResearchProducerWorkResult(completion.WorkItems[0], completion.Results[1].Outcome)),
+            [.. completion.Cleanup.Reverse().Select(item => item.Input)],
+            completion.Cleanup, out _));
+
+        SessionFixture bodyless = SessionFixture.Create(
+            Occurrence(FixtureCatalog.DiffV1.AssemblyPath()),
+            Occurrence(FixtureCatalog.DiffV2.AssemblyPath()));
+        ResearchTargetResolution bodies = bodyless.Resolve("DiffFixtureSample.BodyStateSample", "BodyState");
+        ResearchDesignatedPair bodyPair = Admit(
+            bodyless, bodies,
+            Attempt(bodies, 0, ResearchComparisonSide.Before),
+            Attempt(bodies, 0, ResearchComparisonSide.After));
+        ResearchProducerCompletion bodyResult = Complete(
+            new(bodyless.Population, bodyPair, ResearchProducerCatalog.Kinds));
+        var csharpBody = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            bodyResult.Results[0].Outcome).Result;
+        var ilBody = Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+            bodyResult.Results[1].Outcome).Result;
+        Assert.Equal(FindingInspectionState.NoApplicableInput,
+            Assert.IsType<FindingComparison<CSharpCanonicalLine>.Complete>(
+                csharpBody.Findings.Value).Transition.Old);
+        Assert.Equal(FindingInspectionState.NoApplicableInput,
+            Assert.IsType<FindingComparison<CanonicalIlOperation>.Complete>(
+                ilBody.Findings.Value).Transition.Old);
+        Assert.Null(csharpBody.BodyDiff);
+        Assert.Null(ilBody.MemberDiff);
+
+        byte[] brokenImage = BrokenMethodImage();
+        LibraryBodyIndex brokenIndex = LibraryBodyIndex.OpenFromPrefetchedImage(
+            "BrokenMethod.dll", [.. brokenImage], LibraryBodyAnalysisFeatures.MethodEvidence);
+        var brokenOccurrence = new ImplementationComparisonInputOccurrence(
+            ResolvedAssemblyReference.Create(
+                brokenIndex.ModuleIdentity.AssemblyIdentity!,
+                path: null,
+                () => new MemoryStream(brokenImage, writable: false),
+                AssemblyResolutionProvenance.Project("BrokenMethod", tfm: null, rid: null)),
+            new NullResolver(),
+            brokenIndex);
+        SessionFixture nativeFailure = SessionFixture.Create(
+            brokenOccurrence, Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution broken = nativeFailure.Resolve(SampleType, "Method");
+        ResearchDesignatedPair brokenPair = Admit(
+            nativeFailure, broken,
+            Attempt(broken, 0, ResearchComparisonSide.Before),
+            Attempt(broken, 0, ResearchComparisonSide.After));
+        ResearchProducerCompletion nativeFailed = Complete(
+            new(nativeFailure.Population, brokenPair, ResearchProducerCatalog.Kinds));
+        var failedCSharp = Assert.IsType<ResearchProducerWorkOutcome.ProducedCSharp>(
+            nativeFailed.Results[0].Outcome).Result;
+        var failedIl = Assert.IsType<ResearchProducerWorkOutcome.ProducedIlBody>(
+            nativeFailed.Results[1].Outcome).Result;
+        Assert.IsType<FindingComparison<CSharpCanonicalLine>.Failed>(failedCSharp.Findings.Value);
+        Assert.IsType<FindingComparison<CanonicalIlOperation>.Failed>(failedIl.Findings.Value);
+        Assert.Null(failedCSharp.BodyDiff);
+        Assert.Null(failedIl.MemberDiff);
+    }
+
+    [Fact]
+    public void ResearchDesignatedSession_PreservesAtomicTermination()
+    {
+        bool unreadable = false;
+        bool failCleanup = false;
+        SessionFixture fixture = SessionFixture.Create(
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath(),
+                () =>
+                {
+                    if (unreadable)
+                        throw new IOException("Unavailable test input.");
+                },
+                () => failCleanup),
+            Occurrence(FixtureCatalog.ResearchTargetSample.AssemblyPath()));
+        ResearchTargetResolution resolution = fixture.Resolve(SampleType, "Method");
+        ResearchDesignatedPair pair = Admit(
+            fixture, resolution,
+            Attempt(resolution, 0, ResearchComparisonSide.Before),
+            Attempt(resolution, 0, ResearchComparisonSide.After));
+        var request = new ResearchProducerSessionRequest(
+            fixture.Population, pair, ResearchProducerCatalog.Kinds);
+        ResearchProducerCompletion first = Complete(request);
+        ResearchProducerCompletion second = Complete(request);
+        Assert.NotSame(first.Session, second.Session);
+        for (int i = 0; i < first.WorkItems.Length; i++)
+        {
+            Assert.NotSame(first.WorkItems[i].Id, second.WorkItems[i].Id);
+            Assert.Same(first.WorkItems[i].Basis, second.WorkItems[i].Basis);
+        }
+        Assert.Collection(first.Cleanup,
+            value => Assert.Same(pair.After.Request.Input, value.Input),
+            value => Assert.Same(pair.Before.Request.Input, value.Input));
+
+        using var cancellation = new CancellationTokenSource();
+        var finalInvoker = new TrackingInvoker { AfterCSharp = cancellation.Cancel };
+        var cancelled = Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+            ResearchProducerSession.Run(
+                new ResearchProducerSessionRequest(
+                    fixture.Population, pair, [ResearchProducerKind.CSharp]),
+                finalInvoker, cancellation.Token));
+        Assert.Equal(1, finalInvoker.InvocationCount);
+        Assert.Equal(2, cancelled.Cleanup.Length);
+        Assert.All(cancelled.Cleanup,
+            value => Assert.IsType<ResearchProducerCleanupOutcome.Succeeded>(value));
+        Assert.Empty(Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+            ResearchProducerSession.Run(request, cancellation.Token)).Cleanup);
+
+        unreadable = true;
+        var notInvoked = new TrackingInvoker();
+        ResearchProducerCompletion unavailable = Complete(request, notInvoked);
+        Assert.Equal(0, notInvoked.InvocationCount);
+        Assert.Empty(unavailable.Cleanup);
+        Assert.All(unavailable.Results, result =>
+        {
+            ResearchProducerUnavailable reason =
+                Assert.IsType<ResearchProducerWorkOutcome.Unavailable>(result.Outcome).Reason;
+            Assert.Equal(ResearchProducerUnavailableKind.InputUnreadable, reason.Kind);
+            Assert.Same(pair.Before.Request.Input, reason.Input);
+        });
+
+        unreadable = false;
+        failCleanup = true;
+        var failed = Assert.IsType<ResearchProducerSessionOutcome.Failed>(
+            ResearchProducerSession.Run(request, TestContext.Current.CancellationToken));
+        Assert.Equal(ResearchProducerDiagnosticKind.CleanupFailed, failed.Diagnostic.Kind);
+        Assert.Collection(failed.Cleanup,
+            value => Assert.IsType<ResearchProducerCleanupOutcome.Succeeded>(value),
+            value => Assert.IsType<ResearchProducerCleanupOutcome.Failed>(value));
+
+        using var cleanupCancellation = new CancellationTokenSource();
+        var cleanupCancelled = Assert.IsType<ResearchProducerSessionOutcome.Cancelled>(
+            ResearchProducerSession.Run(request,
+                new TrackingInvoker { AfterCSharp = cleanupCancellation.Cancel },
+                cleanupCancellation.Token));
+        Assert.Collection(cleanupCancelled.Cleanup,
+            value => Assert.IsType<ResearchProducerCleanupOutcome.Succeeded>(value),
+            value => Assert.IsType<ResearchProducerCleanupOutcome.Failed>(value));
+    }
+
+    static ResearchTargetAttempt Attempt(
+        ResearchTargetResolution resolution, int scope, ResearchComparisonSide side)
+        => Assert.Single(resolution.Attempts, attempt =>
+            ReferenceEquals(attempt.Request.Scope, resolution.Scopes[scope].Id)
+            && attempt.Request.Side == side);
+
+    static byte[] BrokenMethodImage()
+    {
+        byte[] image = File.ReadAllBytes(FixtureCatalog.ResearchTargetSample.AssemblyPath());
+        using var pe = new PEReader(new MemoryStream(image, writable: false));
+        MetadataReader reader = pe.GetMetadataReader();
+        MethodDefinition method = reader.MethodDefinitions
+            .Select(reader.GetMethodDefinition)
+            .First(method => reader.GetString(method.Name) == "Method");
+        int rva = method.RelativeVirtualAddress;
+        SectionHeader section = pe.PEHeaders.SectionHeaders.Single(
+            section => rva >= section.VirtualAddress
+                && rva < section.VirtualAddress + section.SizeOfRawData);
+        // Preserve real metadata and provenance, but make native body decoding fail.
+        image[section.PointerToRawData + rva - section.VirtualAddress] = 0;
+        return image;
+    }
+
+    static ResearchTargetOutcome.Resolved Target(ResearchTargetAttempt attempt)
+        => Assert.IsType<ResearchTargetOutcome.Resolved>(attempt.Outcome);
+
+    static ResearchDesignatedPair Admit(
+        SessionFixture fixture, ResearchTargetResolution resolution,
+        ResearchTargetAttempt before, ResearchTargetAttempt after)
+        => Assert.IsType<ResearchDesignatedPairOutcome.Admitted>(
+            ResearchDesignatedPairAdmission.Admit(
+                fixture.Population, resolution, before, after)).Pair;
+
+    static ResearchTargetResolution ResolveExactPair(
+        SessionFixture fixture,
+        string beforeType, string beforeSelector,
+        string afterType, string afterSelector,
+        params ResearchMemberSelectionOccurrence[] additionalSelections)
+    {
+        ResearchTargetResolution resolved = fixture.Resolve(
+            (beforeType, beforeSelector), (afterType, afterSelector));
+        return fixture.ResolveSelections(
+        [
+            Exact(0, beforeType, beforeSelector, ResearchComparisonSide.Before),
+            Exact(1, afterType, afterSelector, ResearchComparisonSide.After),
+            .. additionalSelections,
+        ]);
+
+        ResearchExactAddressMemberSelection Exact(
+            int scope, string type, string selector, ResearchComparisonSide side)
+        {
+            ResearchTargetAttempt attempt = Attempt(resolved, scope, side);
+            ResearchTargetOutcome.Resolved target = Target(attempt);
+            return new(
+                attempt.Request.Question,
+                fixture.Population.GetInput(attempt.Request.Input),
+                type, MemberTargetSelector.Parse(selector), target.Address!.Value, target.Role);
+        }
+    }
+}

--- a/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchProducerSessionTests.cs
@@ -14,7 +14,7 @@ using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Research.Tests;
 
-public class ResearchProducerSessionTests
+public partial class ResearchProducerSessionTests
 {
     const string SampleType =
         "ILInspector.Research.TargetFixtures.TargetSample";
@@ -140,12 +140,16 @@ public class ResearchProducerSessionTests
             completion.WorkItems,
             item =>
             {
-                Assert.Same(resolution.Correspondences[0], item.Correspondence);
+                Assert.Same(
+                    resolution.Correspondences[0],
+                    Assert.IsType<ResearchProducerWorkBasis.Correspondence>(item.Basis).Outcome);
                 Assert.Equal(ResearchProducerKind.CSharp, item.Producer);
             },
             item =>
             {
-                Assert.Same(resolution.Correspondences[0], item.Correspondence);
+                Assert.Same(
+                    resolution.Correspondences[0],
+                    Assert.IsType<ResearchProducerWorkBasis.Correspondence>(item.Basis).Outcome);
                 Assert.Equal(ResearchProducerKind.IlBody, item.Producer);
             });
         Assert.Collection(
@@ -688,8 +692,8 @@ public class ResearchProducerSessionTests
                 first.WorkItems[index].Id,
                 second.WorkItems[index].Id);
             Assert.Same(
-                first.WorkItems[index].Correspondence,
-                second.WorkItems[index].Correspondence);
+                first.WorkItems[index].Basis,
+                second.WorkItems[index].Basis);
         }
     }
 
@@ -819,6 +823,7 @@ public class ResearchProducerSessionTests
             typeof(MetadataSource),
             typeof(Stream),
             typeof(Delegate),
+            typeof(ResearchAdmittedPopulation),
         ];
 
         Type[] producerTypes =
@@ -834,6 +839,13 @@ public class ResearchProducerSessionTests
             typeof(ResearchProducerWorkOutcome.Failed),
             typeof(ResearchProducerCleanupOutcome.Succeeded),
             typeof(ResearchProducerCleanupOutcome.Failed),
+            typeof(ResearchProducerWorkBasis.Correspondence),
+            typeof(ResearchProducerWorkBasis.DesignatedPair),
+            typeof(ResearchDesignatedPair),
+            typeof(ResearchDesignatedPairUnavailable),
+            typeof(ResearchDesignatedPairOutcome.Admitted),
+            typeof(ResearchDesignatedPairOutcome.Rejected),
+            typeof(ResearchDesignatedPairOutcome.Unavailable),
         ];
         foreach (Type type in producerTypes)
         {
@@ -958,7 +970,7 @@ public class ResearchProducerSessionTests
 
     sealed class SessionFixture
     {
-        SessionFixture(ResearchAdmittedPopulation population)
+        public SessionFixture(ResearchAdmittedPopulation population)
             => Population = population;
 
         public ResearchAdmittedPopulation Population { get; }
@@ -1005,6 +1017,17 @@ public class ResearchProducerSessionTests
         ResearchTargetResolution Resolve(
             params (string DeclaringType, MemberTargetSelector Selector)[]
                 selections)
+            => ResolveSelections(
+                [
+                    .. selections.Select(
+                        selection => new ResearchCarriedMemberSelection(
+                            Population.Questions[0].Id,
+                            selection.DeclaringType,
+                            selection.Selector)),
+                ]);
+
+        public ResearchTargetResolution ResolveSelections(
+            params ResearchMemberSelectionOccurrence[] selections)
         {
             ImmutableArray<ResearchTargetInputRoleAssignment?> roles =
             [
@@ -1018,14 +1041,7 @@ public class ResearchProducerSessionTests
                     new ResearchTargetPlanningRequest(
                         Population,
                         roles,
-                        [
-                            .. selections.Select(
-                                selection =>
-                                    new ResearchCarriedMemberSelection(
-                                        Population.Questions[0].Id,
-                                        selection.DeclaringType,
-                                        selection.Selector)),
-                        ]))).Resolution;
+                        selections))).Resolution;
         }
     }
 

--- a/src/ILInspector.Research/ResearchDesignatedPair.cs
+++ b/src/ILInspector.Research/ResearchDesignatedPair.cs
@@ -1,0 +1,169 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Research;
+
+/// <summary>One owner-issued association of two explicitly selected physical methods.</summary>
+public sealed class ResearchDesignatedPair
+{
+    internal ResearchDesignatedPair(
+        ResearchTargetResolution resolution,
+        ResearchTargetAttempt before,
+        ResearchTargetAttempt after)
+    {
+        Resolution = resolution;
+        Before = before;
+        After = after;
+    }
+
+    public ResearchTargetResolution Resolution { get; }
+
+    public ResearchComparisonOperationId Operation => Resolution.Operation;
+
+    public ResearchComparisonQuestionId Question => Before.Request.Question;
+
+    public ResearchTargetAttempt Before { get; }
+
+    public ResearchTargetAttempt After { get; }
+}
+
+/// <summary>Why an explicit pair does not have a valid input association.</summary>
+public enum ResearchDesignatedPairRejectionKind
+{
+    UnsupportedProfile,
+    ForeignResolution,
+    InvalidIdentityClosure,
+    MissingEndpoint,
+    ForeignAttempt,
+    CrossQuestion,
+    WrongSide,
+}
+
+/// <summary>Why an associated endpoint cannot designate a physical method.</summary>
+public enum ResearchDesignatedPairUnavailableKind
+{
+    TargetUnavailable,
+    DomainSideBlocked,
+    EndpointAddressUnavailable,
+}
+
+/// <summary>One endpoint's original evidence and its designation failure.</summary>
+public sealed class ResearchDesignatedPairUnavailable
+{
+    internal ResearchDesignatedPairUnavailable(
+        ResearchDesignatedPairUnavailableKind kind,
+        ResearchTargetAttempt attempt,
+        ResearchTargetDomainSideCensus census)
+    {
+        Kind = kind;
+        Attempt = attempt;
+        Census = census;
+    }
+
+    public ResearchDesignatedPairUnavailableKind Kind { get; }
+
+    public ResearchComparisonSide Side => Attempt.Request.Side;
+
+    public ResearchTargetAttempt Attempt { get; }
+
+    public ResearchTargetDomainSideCensus Census { get; }
+}
+
+/// <summary>The inert, closed result of explicit method-pair admission.</summary>
+public abstract class ResearchDesignatedPairOutcome
+{
+    private protected ResearchDesignatedPairOutcome()
+    {
+    }
+
+    public sealed class Admitted : ResearchDesignatedPairOutcome
+    {
+        internal Admitted(ResearchDesignatedPair pair) => Pair = pair;
+
+        public ResearchDesignatedPair Pair { get; }
+    }
+
+    public sealed class Rejected : ResearchDesignatedPairOutcome
+    {
+        internal Rejected(ResearchDesignatedPairRejectionKind kind) => Kind = kind;
+
+        public ResearchDesignatedPairRejectionKind Kind { get; }
+    }
+
+    public sealed class Unavailable : ResearchDesignatedPairOutcome
+    {
+        internal Unavailable(ImmutableArray<ResearchDesignatedPairUnavailable> endpoints)
+            => Endpoints = endpoints;
+
+        public ImmutableArray<ResearchDesignatedPairUnavailable> Endpoints { get; }
+    }
+}
+
+/// <summary>Admits explicit physical method pairs without changing correspondence.</summary>
+public static class ResearchDesignatedPairAdmission
+{
+    public static ResearchDesignatedPairOutcome Admit(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution,
+        ResearchTargetAttempt? before,
+        ResearchTargetAttempt? after)
+    {
+        ArgumentNullException.ThrowIfNull(population);
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        if (population.Profile != ResearchComparisonProfile.ImplementationComparison)
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.UnsupportedProfile);
+        if (!ReferenceEquals(population.Operation, resolution.Operation))
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.ForeignResolution);
+        if (!ResearchProducerSessionValidator.HasValidIdentityClosure(population, resolution))
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.InvalidIdentityClosure);
+        if (before is null || after is null)
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.MissingEndpoint);
+        if (!Contains(resolution, before) || !Contains(resolution, after))
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.ForeignAttempt);
+        if (!ReferenceEquals(before.Request.Question, after.Request.Question))
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.CrossQuestion);
+        if (before.Request.Side != ResearchComparisonSide.Before
+            || after.Request.Side != ResearchComparisonSide.After)
+            return new ResearchDesignatedPairOutcome.Rejected(
+                ResearchDesignatedPairRejectionKind.WrongSide);
+
+        var unavailable = ImmutableArray.CreateBuilder<ResearchDesignatedPairUnavailable>();
+        CheckEndpoint(resolution, before, unavailable);
+        CheckEndpoint(resolution, after, unavailable);
+        return unavailable.Count == 0
+            ? new ResearchDesignatedPairOutcome.Admitted(
+                new ResearchDesignatedPair(resolution, before, after))
+            : new ResearchDesignatedPairOutcome.Unavailable(unavailable.ToImmutable());
+    }
+
+    static bool Contains(ResearchTargetResolution resolution, ResearchTargetAttempt attempt)
+        => resolution.TryGetAttempt(attempt.Request.Id, out ResearchTargetAttempt? retained)
+            && ReferenceEquals(retained, attempt);
+
+    static void CheckEndpoint(
+        ResearchTargetResolution resolution,
+        ResearchTargetAttempt attempt,
+        ImmutableArray<ResearchDesignatedPairUnavailable>.Builder unavailable)
+    {
+        ResearchTargetDomainSideCensus census = resolution.Censuses.Single(
+            census => ReferenceEquals(census.DomainId, attempt.Request.Domain)
+                && census.Side == attempt.Request.Side);
+        ResearchDesignatedPairUnavailableKind? kind =
+            attempt.Outcome is not ResearchTargetOutcome.Resolved resolved
+                ? ResearchDesignatedPairUnavailableKind.TargetUnavailable
+                : census.Health != ResearchTargetCensusHealth.Healthy
+                    ? ResearchDesignatedPairUnavailableKind.DomainSideBlocked
+                    : resolved.Role == ResearchTargetRelationshipRole.None
+                        || resolved.Address is null
+                        ? ResearchDesignatedPairUnavailableKind.EndpointAddressUnavailable
+                        : null;
+        if (kind is { } reason)
+            unavailable.Add(new ResearchDesignatedPairUnavailable(reason, attempt, census));
+    }
+}

--- a/src/ILInspector.Research/ResearchProducerSession.cs
+++ b/src/ILInspector.Research/ResearchProducerSession.cs
@@ -49,7 +49,7 @@ public static class ResearchProducerSession
             request.Population.Operation,
             request.Identity);
         ImmutableArray<ResearchProducerWorkItem> workItems =
-            DeriveWorkItems(session, request.Resolution, producers);
+            DeriveWorkItems(session, request.WorkBases, producers);
         var results = ImmutableArray.CreateBuilder<ResearchProducerWorkResult>(
             workItems.Length);
         var stages = new Dictionary<ResearchComparisonInputId, StageAccess>(
@@ -149,20 +149,19 @@ public static class ResearchProducerSession
 
     static ImmutableArray<ResearchProducerWorkItem> DeriveWorkItems(
         ResearchProducerSessionId session,
-        ResearchTargetResolution resolution,
+        ImmutableArray<ResearchProducerWorkBasis> workBases,
         ImmutableArray<ResearchProducerKind> producers)
     {
         var items = ImmutableArray.CreateBuilder<ResearchProducerWorkItem>(
-            resolution.Correspondences.Length * producers.Length);
-        foreach (ResearchTargetCorrespondenceOutcome correspondence in
-            resolution.Correspondences)
+            workBases.Length * producers.Length);
+        foreach (ResearchProducerWorkBasis basis in workBases)
         {
             foreach (ResearchProducerKind producer in producers)
             {
                 items.Add(
                     new ResearchProducerWorkItem(
                         new ResearchProducerWorkItemId(session),
-                        correspondence,
+                        basis,
                         producer));
             }
         }
@@ -178,9 +177,11 @@ public static class ResearchProducerSession
         List<InputStage> acquired,
         IResearchProducerInvoker invoker)
     {
-        if (item.Correspondence
-            is ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
-                or ResearchTargetCorrespondenceOutcome.DomainUnavailable)
+        if (item.Basis is ResearchProducerWorkBasis.Correspondence
+            {
+                Outcome: ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
+                    or ResearchTargetCorrespondenceOutcome.DomainUnavailable,
+            })
         {
             return new ResearchProducerWorkOutcome.Unavailable(
                 Unavailable(
@@ -190,7 +191,7 @@ public static class ResearchProducerSession
         EndpointPair endpoints = CreateEndpoints(
             population,
             resolution,
-            item.Correspondence,
+            item.Basis,
             stages,
             acquired);
         if (endpoints.Unavailable is { } unavailable)
@@ -263,18 +264,34 @@ public static class ResearchProducerSession
     static EndpointPair CreateEndpoints(
         ResearchAdmittedPopulation population,
         ResearchTargetResolution resolution,
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         Dictionary<ResearchComparisonInputId, StageAccess> stages,
         List<InputStage> acquired)
     {
+        if (basis is ResearchProducerWorkBasis.DesignatedPair designated)
+        {
+            ResearchDesignatedPair pair = designated.Pair;
+            return PairPresent(
+                population,
+                pair.Before,
+                pair.After,
+                Resolved(pair.Before).Anchor.CanonicalSignature,
+                Resolved(pair.After).Anchor.CanonicalSignature,
+                stages,
+                acquired);
+        }
+
+        var correspondence =
+            ((ResearchProducerWorkBasis.Correspondence)basis).Outcome;
         string subject = SubjectIdentity(resolution, correspondence);
         return correspondence switch
         {
             ResearchTargetCorrespondenceOutcome.Paired paired =>
                 PairPresent(
                     population,
-                    paired.Before,
-                    paired.After,
+                    paired.Before.Attempt,
+                    paired.After.Attempt,
+                    subject,
                     subject,
                     stages,
                     acquired),
@@ -282,7 +299,7 @@ public static class ResearchProducerSession
                 Pair(
                     Present(
                         population,
-                        beforeOnly.Before,
+                        beforeOnly.Before.Attempt,
                         subject,
                         stages,
                         acquired),
@@ -296,7 +313,7 @@ public static class ResearchProducerSession
                         "The correspondence key is absent from this side."),
                     Present(
                         population,
-                        afterOnly.After,
+                        afterOnly.After.Attempt,
                         subject,
                         stages,
                         acquired)),
@@ -315,16 +332,17 @@ public static class ResearchProducerSession
 
     static EndpointPair PairPresent(
         ResearchAdmittedPopulation population,
-        ResearchCorrespondingTarget beforeTarget,
-        ResearchCorrespondingTarget afterTarget,
-        string subject,
+        ResearchTargetAttempt beforeTarget,
+        ResearchTargetAttempt afterTarget,
+        string beforeSubject,
+        string afterSubject,
         Dictionary<ResearchComparisonInputId, StageAccess> stages,
         List<InputStage> acquired)
     {
         EndpointAccess before = Present(
             population,
             beforeTarget,
-            subject,
+            beforeSubject,
             stages,
             acquired);
         if (before.Unavailable is { } unavailable)
@@ -335,7 +353,7 @@ public static class ResearchProducerSession
             Present(
                 population,
                 afterTarget,
-                subject,
+                afterSubject,
                 stages,
                 acquired));
     }
@@ -349,14 +367,15 @@ public static class ResearchProducerSession
 
     static EndpointAccess Present(
         ResearchAdmittedPopulation population,
-        ResearchCorrespondingTarget target,
+        ResearchTargetAttempt attempt,
         string subject,
         Dictionary<ResearchComparisonInputId, StageAccess> stages,
         List<InputStage> acquired)
     {
-        ResearchComparisonInputId input = target.Attempt.Request.Input;
-        MetadataMethodAddress? address = target.Target.Address;
-        if (target.Target.Role == ResearchTargetRelationshipRole.None
+        ResearchTargetOutcome.Resolved target = Resolved(attempt);
+        ResearchComparisonInputId input = attempt.Request.Input;
+        MetadataMethodAddress? address = target.Address;
+        if (target.Role == ResearchTargetRelationshipRole.None
             || address is null)
         {
             return EndpointAccess.UnavailableEndpoint(
@@ -371,7 +390,7 @@ public static class ResearchProducerSession
 
         InputStage acquiredStage = stage.Stage!;
         MetadataReader reader = acquiredStage.Source.Reader;
-        if (target.Target.Module
+        if (target.Module
                 != acquiredStage.Occurrence.BodyIndex.ModuleIdentity
             || !address.Value.BelongsTo(reader)
             || address.Value.Handle.IsNil
@@ -389,6 +408,11 @@ public static class ResearchProducerSession
             acquiredStage,
             address.Value.Handle);
     }
+
+    static ResearchTargetOutcome.Resolved Resolved(ResearchTargetAttempt attempt)
+        => attempt.Outcome as ResearchTargetOutcome.Resolved
+            ?? throw new InvalidOperationException(
+                "A present endpoint requires a resolved target attempt.");
 
     static StageAccess GetStage(
         ResearchAdmittedPopulation population,

--- a/src/ILInspector.Research/ResearchProducerSessionModels.cs
+++ b/src/ILInspector.Research/ResearchProducerSessionModels.cs
@@ -39,6 +39,25 @@ public sealed class ResearchProducerSessionRequest
         Population = population;
         Resolution = resolution;
         Producers = [.. producers];
+        WorkBases =
+        [
+            .. resolution.Correspondences.Select(
+                static outcome => new ResearchProducerWorkBasis.Correspondence(outcome)),
+        ];
+    }
+
+    public ResearchProducerSessionRequest(
+        ResearchAdmittedPopulation population,
+        ResearchDesignatedPair pair,
+        IEnumerable<ResearchProducerKind> producers)
+    {
+        ArgumentNullException.ThrowIfNull(population);
+        ArgumentNullException.ThrowIfNull(pair);
+        ArgumentNullException.ThrowIfNull(producers);
+        Population = population;
+        Resolution = pair.Resolution;
+        Producers = [.. producers];
+        WorkBases = [new ResearchProducerWorkBasis.DesignatedPair(pair)];
     }
 
     public ResearchAdmittedPopulation Population { get; }
@@ -48,6 +67,8 @@ public sealed class ResearchProducerSessionRequest
     public ImmutableArray<ResearchProducerKind> Producers { get; }
 
     internal object Identity => _identity;
+
+    internal ImmutableArray<ResearchProducerWorkBasis> WorkBases { get; }
 }
 
 /// <summary>Why a producer session request was rejected before execution.</summary>
@@ -106,22 +127,45 @@ public sealed class ResearchProducerWorkItemId
     public ResearchComparisonOperationId Operation => Session.Operation;
 }
 
-/// <summary>One exact correspondence-and-producer unit of sequential work.</summary>
+/// <summary>The exact owner-issued evidence that authorizes a local comparison.</summary>
+public abstract class ResearchProducerWorkBasis
+{
+    private protected ResearchProducerWorkBasis()
+    {
+    }
+
+    public sealed class Correspondence : ResearchProducerWorkBasis
+    {
+        internal Correspondence(ResearchTargetCorrespondenceOutcome outcome)
+            => Outcome = outcome;
+
+        public ResearchTargetCorrespondenceOutcome Outcome { get; }
+    }
+
+    public sealed class DesignatedPair : ResearchProducerWorkBasis
+    {
+        internal DesignatedPair(ResearchDesignatedPair pair) => Pair = pair;
+
+        public ResearchDesignatedPair Pair { get; }
+    }
+}
+
+/// <summary>One exact comparison-and-producer unit of sequential work.</summary>
 public sealed class ResearchProducerWorkItem
 {
     internal ResearchProducerWorkItem(
         ResearchProducerWorkItemId id,
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         ResearchProducerKind producer)
     {
         Id = id;
-        Correspondence = correspondence;
+        Basis = basis;
         Producer = producer;
     }
 
     public ResearchProducerWorkItemId Id { get; }
 
-    public ResearchTargetCorrespondenceOutcome Correspondence { get; }
+    public ResearchProducerWorkBasis Basis { get; }
 
     public ResearchProducerKind Producer { get; }
 }

--- a/src/ILInspector.Research/ResearchProducerSessionValidator.cs
+++ b/src/ILInspector.Research/ResearchProducerSessionValidator.cs
@@ -30,10 +30,7 @@ internal static class ResearchProducerSessionValidator
                 "The population and target resolution name different operations.");
         }
 
-        if (!ValidatePopulation(request.Population)
-            || !ValidateResolution(
-                request.Population,
-                request.Resolution))
+        if (!HasValidIdentityClosure(request.Population, request.Resolution))
         {
             return Reject(
                 ResearchProducerRejectionKind.InvalidIdentityClosure,
@@ -86,7 +83,7 @@ internal static class ResearchProducerSessionValidator
             || !ReferenceEquals(session.Operation, request.Population.Operation)
             || !session.BelongsTo(request.Identity)
             || workItems.Length
-                != request.Resolution.Correspondences.Length * producers.Length
+                != request.WorkBases.Length * producers.Length
             || results.Length != workItems.Length
             || cleanup.Length != acquisitionOrder.Length)
         {
@@ -96,8 +93,7 @@ internal static class ResearchProducerSessionValidator
         var identities = new HashSet<ResearchProducerWorkItemId>(
             ReferenceEqualityComparer.Instance);
         int index = 0;
-        foreach (ResearchTargetCorrespondenceOutcome correspondence in
-            request.Resolution.Correspondences)
+        foreach (ResearchProducerWorkBasis basis in request.WorkBases)
         {
             foreach (ResearchProducerKind producer in producers)
             {
@@ -106,8 +102,8 @@ internal static class ResearchProducerSessionValidator
                 if (!ReferenceEquals(item.Id.Session, session)
                     || !identities.Add(item.Id)
                     || !ReferenceEquals(
-                        item.Correspondence,
-                        correspondence)
+                        item.Basis,
+                        basis)
                     || item.Producer != producer
                     || !ReferenceEquals(result.Item, item)
                     || !ValidateOutcome(
@@ -143,6 +139,11 @@ internal static class ResearchProducerSessionValidator
             cleanup);
         return true;
     }
+
+    internal static bool HasValidIdentityClosure(
+        ResearchAdmittedPopulation population,
+        ResearchTargetResolution resolution)
+        => ValidatePopulation(population) && ValidateResolution(population, resolution);
 
     static bool ValidatePopulation(ResearchAdmittedPopulation population)
     {
@@ -546,7 +547,9 @@ internal static class ResearchProducerSessionValidator
         ResearchProducerWorkItem item,
         ResearchProducerWorkOutcome outcome)
     {
-        bool correspondenceUnavailable = item.Correspondence
+        ResearchTargetCorrespondenceOutcome? correspondence =
+            (item.Basis as ResearchProducerWorkBasis.Correspondence)?.Outcome;
+        bool correspondenceUnavailable = correspondence
             is ResearchTargetCorrespondenceOutcome.CounterpartUnavailable
                 or ResearchTargetCorrespondenceOutcome.DomainUnavailable;
         return outcome switch
@@ -556,18 +559,18 @@ internal static class ResearchProducerSessionValidator
                 && !correspondenceUnavailable
                 && NativeMatches(
                     resolution,
-                    item.Correspondence,
+                    item.Basis,
                     produced.Result),
             ResearchProducerWorkOutcome.ProducedIlBody produced =>
                 item.Producer == ResearchProducerKind.IlBody
                 && !correspondenceUnavailable
                 && NativeMatches(
                     resolution,
-                    item.Correspondence,
+                    item.Basis,
                     produced.Result),
             ResearchProducerWorkOutcome.Unavailable unavailable =>
                 ValidateUnavailable(
-                    item.Correspondence,
+                    item.Basis,
                     correspondenceUnavailable,
                     unavailable.Reason),
             ResearchProducerWorkOutcome.Failed failed =>
@@ -580,7 +583,7 @@ internal static class ResearchProducerSessionValidator
     }
 
     static bool ValidateUnavailable(
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         bool correspondenceUnavailable,
         ResearchProducerUnavailable unavailable)
     {
@@ -598,18 +601,31 @@ internal static class ResearchProducerSessionValidator
         }
 
         ImmutableArray<ResearchComparisonInputId> endpointInputs =
-            correspondence switch
+            basis switch
             {
-                ResearchTargetCorrespondenceOutcome.Paired paired =>
+                ResearchProducerWorkBasis.DesignatedPair designated =>
+                    [
+                        designated.Pair.Before.Request.Input,
+                        designated.Pair.After.Request.Input,
+                    ],
+                ResearchProducerWorkBasis.Correspondence
+                {
+                    Outcome: ResearchTargetCorrespondenceOutcome.Paired paired,
+                } =>
                     [
                         paired.Before.Attempt.Request.Input,
                         paired.After.Attempt.Request.Input,
                     ],
-                ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly =>
+                ResearchProducerWorkBasis.Correspondence
+                {
+                    Outcome: ResearchTargetCorrespondenceOutcome.BeforeOnly beforeOnly,
+                } =>
                     [beforeOnly.Before.Attempt.Request.Input],
-                ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly =>
+                ResearchProducerWorkBasis.Correspondence
+                {
+                    Outcome: ResearchTargetCorrespondenceOutcome.AfterOnly afterOnly,
+                } =>
                     [afterOnly.After.Attempt.Request.Input],
-                ResearchTargetCorrespondenceOutcome.Absent => [],
                 _ => [],
             };
         return unavailable.Input is { } input
@@ -619,44 +635,49 @@ internal static class ResearchProducerSessionValidator
 
     static bool NativeMatches(
         ResearchTargetResolution resolution,
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         CSharpMemberEndpointComparison result)
     {
-        string subject = SubjectIdentity(resolution, correspondence);
-        return string.Equals(result.Old.Key, subject, StringComparison.Ordinal)
-            && string.Equals(result.New.Key, subject, StringComparison.Ordinal)
+        (string before, string after) = SubjectIdentities(resolution, basis);
+        return string.Equals(result.Old.Key, before, StringComparison.Ordinal)
+            && string.Equals(result.New.Key, after, StringComparison.Ordinal)
             && AbsenceMatches(
-                correspondence,
+                basis,
                 result.Findings.OldInspection,
                 result.Findings.NewInspection);
     }
 
     static bool NativeMatches(
         ResearchTargetResolution resolution,
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         IlMemberEndpointComparison result)
     {
-        string subject = SubjectIdentity(resolution, correspondence);
+        (string before, string after) = SubjectIdentities(resolution, basis);
         return string.Equals(
                 result.Old.Identity,
-                subject,
+                before,
                 StringComparison.Ordinal)
             && string.Equals(
                 result.New.Identity,
-                subject,
+                after,
                 StringComparison.Ordinal)
             && AbsenceMatches(
-                correspondence,
+                basis,
                 result.Findings.OldInspection,
                 result.Findings.NewInspection);
     }
 
     static bool AbsenceMatches<T>(
-        ResearchTargetCorrespondenceOutcome correspondence,
+        ResearchProducerWorkBasis basis,
         FindingInspection<T> oldInspection,
         FindingInspection<T> newInspection)
         where T : notnull
     {
+        if (basis is ResearchProducerWorkBasis.DesignatedPair)
+            return !IsSubjectAbsent(oldInspection) && !IsSubjectAbsent(newInspection);
+
+        var correspondence =
+            ((ResearchProducerWorkBasis.Correspondence)basis).Outcome;
         (bool oldAbsent, bool newAbsent) = correspondence switch
         {
             ResearchTargetCorrespondenceOutcome.Paired => (false, false),
@@ -676,6 +697,25 @@ internal static class ResearchProducerSessionValidator
         {
             Kind: FindingInspectionAbsenceKind.SubjectAbsent,
         };
+
+    static (string Before, string After) SubjectIdentities(
+        ResearchTargetResolution resolution,
+        ResearchProducerWorkBasis basis)
+    {
+        if (basis is ResearchProducerWorkBasis.DesignatedPair designated)
+        {
+            return (
+                ((ResearchTargetOutcome.Resolved)designated.Pair.Before.Outcome)
+                    .Anchor.CanonicalSignature,
+                ((ResearchTargetOutcome.Resolved)designated.Pair.After.Outcome)
+                    .Anchor.CanonicalSignature);
+        }
+
+        string subject = SubjectIdentity(
+            resolution,
+            ((ResearchProducerWorkBasis.Correspondence)basis).Outcome);
+        return (subject, subject);
+    }
 
     static string SubjectIdentity(
         ResearchTargetResolution resolution,


### PR DESCRIPTION
# Purpose and claim

Enable robust shared local comparison for CLI and browser callers that already
know which two methods they want to compare, without weakening identity
correspondence.

Implements the settled Research design from #5891. Fixes #5877; delivery
step 18 of #4706. This is the Research runtime slice, not Queries adapter
adoption, a host feature, or legacy retirement.

Design basis: `ILInspector.Research`, owning
`docs/design/implementation-diff.md#research-designated-pair-admission`.
The claim is an exact association of resolved Before/After physical methods
from one admitted question with native local producer work, without claiming
shared API identity.

## Demo

Real file-based-app output against compiler-produced repository fixtures,
using only product APIs:

```text
Different types, names, and assemblies
  Before: M:ILInspector.Research.TargetFixtures.TargetSample.Method()
  After:  M:DiffFixtureSample.BodyStateSample.BodyState()
  Admitted; 2 work items; 2 closed stages
  CSharp: Complete/Complete
  IlBody: Complete/Complete
Same physical method, separate occurrences
  Before: M:ILInspector.Research.TargetFixtures.TargetSample.Method()
  After:  M:ILInspector.Research.TargetFixtures.TargetSample.Method()
  Admitted; 2 work items; 2 closed stages
  CSharp: Complete/Complete
  IlBody: Complete/Complete
Bodyless neighbor
  Before: M:DiffFixtureSample.BodyStateSample.BodyState()
  After:  M:DiffFixtureSample.BodyStateSample.BodyState()
  Admitted; 2 work items; 2 closed stages
  CSharp: NoApplicableInput/Complete
  IlBody: NoApplicableInput/Complete
```

The app was run with
`"$DOTNET_ROOT/dotnet" run /tmp/pair5877-demo.cs -c Release`.
Its core handoff, after ordinary admission and target resolution:

```csharp
var pair = ((ResearchDesignatedPairOutcome.Admitted)
    ResearchDesignatedPairAdmission.Admit(
        population, resolution, beforeAttempt, afterAttempt)).Pair;
var outcome = ResearchProducerSession.Run(
    new ResearchProducerSessionRequest(
        population, pair,
        [ResearchProducerKind.IlBody, ResearchProducerKind.CSharp]));
```

Before this change, the public session accepted only all strict correspondence
outcomes; callers could not supply this explicitly chosen cross-scope pair.
Afterward, only that pair runs, in catalog order (C# then IL), with each side's
own Metadata subject. The neighboring bodyless case stays inapplicable, not
absent or exact. Completion means accounted work, not runtime equivalence.

The same scenarios, plus exact-address selection, wrong-image association,
strict `SelectionDrift`, missing body identity, native decoding failure, and
cancel/cleanup outcomes, are reproducible through the committed
`ResearchDesignatedPairTests.cs` methods.

## Implementation and boundary

`ResearchDesignatedPairAdmission` returns a pair, typed invalid-association
rejection, or ordered endpoint unavailability with original evidence.
It reuses existing identity-closure validation and gates each endpoint's own
census, without requiring an unrelated opposite census to be healthy.

`ResearchProducerWorkBasis` is a closed correspondence/designation union.
Request overloads derive either the complete correspondence roster or one
pair; callers cannot supply or mix work items. The existing executor, input
stages, catalog, native adapters, result arms, and completion/cleanup protocol
are shared. Work items retain their typed basis rather than a
correspondence-only property.

Metadata owns selection/address/anchor, Analysis owns module/body evidence,
and native C#/IL/Findings own classification and comparison. Queries population,
workspace receipts, publication, and hosts remain separate boundaries.
No native algorithm, reference policy, platform dependency, or rendering
contract changes. Tests reuse existing compiled fixtures; one in-memory copy
has an invalid body header to exercise native failure without constructing a
native result in the test.

The baseline is `ImplementationDiff.CompareMembers` and the two native
endpoint adapters. The deliberate distinction is explicit designation, not
weakened matching. One association and one alternate work basis close the
actual consumer gap; no second scheduler, executor, result lifecycle, or
concurrency protocol is introduced.

## Adoption and retirement

Immediate consumer: Queries direct-member adapter (#5878, step 6), whose
design landed in #5881. At candidate formation, tracker #4706 had 18 remaining
runtime deliveries, including this step 18. The counts below describe that
baseline; the tracker owns subsequent delivery status.

Local CLI path: 1 population/projection, 2 roles/cleanup, 3 body-signal
evidence, 4 workspace composition, 5 shared publication, 18 designated pair,
6 adapter, 7 public execution migration, 8 CLI adoption: 9 deliveries.
Browser substitutes final step 9: 9 deliveries. Source-enabled hosts add
11/12/13 plus 14 or 15: 13 deliveries each. Comparison tools use
1/2/4/5/18/6/10: 7 deliveries. The tracker owns count changes when runtime
work lands; this PR does not mark an unmerged delivery complete.

Queries/Research retirement remains steps 16/17, including explicit
Source-dependent caller disposition. `ImplementationDiff.CompareMembers`
and native algorithms are not deleted here. Structured native evidence
survives to the planned shared Markout CLI lowering and typed browser surface;
there is no host-specific rendering bypass in this Research slice.

## Validation

Required SDK installed in this worktree only:
`11.0.100-preview.7.26381.103`; shared SDK/PATH unchanged.

```sh
dotnet run --project src/ILInspector.Research.Tests -c Release -- \
  -class 'ILInspector.Research.Tests.ResearchProducerSessionTests' \
  -class 'ILInspector.Research.Tests.ResearchTargetResolverTests'
npx markdownlint-cli docs/design/implementation-diff.md
```

78 tests passed against integrated base
`08f62082d4e3899d369afac93ca3e279eccd4e7e`.
The five named designated-pair/session gates are now implemented; the existing
retention gate also covers the new pair and work-basis/result types.

## Review

Round 1 completed clean with GPT-5.6 Sol and Claude Opus 5 at unchanged head
`8cba3835b3f82fd4312a27747858534e0da345eb`, after current-head
`ci-required` succeeded. Sol took the planned GPT seat; both seats reviewed
the full exact-head diff in isolated worktrees. Neither returned findings.
Opus additionally ran the complete Research suite (286/286 Release tests)
and an independent forward/reverse association probe.

Main movement through `191e8dacc2fc1fec7faa887253cf5c7005d1a633` was
classified no interaction; no integration or replacement round was needed.
The reviewed head is unchanged. No merge authorization has been granted.
