### PR TITLE
Implement decoded Integration scanner bindings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [View-Facet Registry](design/view-facet-registry.md) | View-facet identity and discovery: how facets are registered and looked up across CLI and browser hosts. |
 | [Package Set Registry](design/package-set-registry.md) | Front-end-only static application identities, descriptors, and package membership over reusable package-coordinate validation. |
 | [Static Ecosystem Packs](design/ecosystem-packs.md) | Front-end-only application catalog of private static ecosystem registrations composing discovery metadata with optional package-set, prefix-request, and opaque Integration scanner bindings. |
-| [Integration Scanner Binding](design/integration-scanner-binding.md) | Proposed Integration-owned static scanner handoff over immutable decoded observations, preserving evidence and owner-controlled execution. |
+| [Integration Scanner Binding](design/integration-scanner-binding.md) | Integration-owned static scanner handoff over immutable decoded observations, preserving evidence and owner-controlled execution; catalog and host adoption remain staged. |
 | [Workspace Scope and Expansion](design/workspace-scope-and-expansion.md) | Committed logical Root membership and order, closed-by-default selective dependency expansion, revision-bound edits, and complete scope-operation results. |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |
 | [Query Vocabulary](design/vocabulary.md) | Shared static catalogs for legal query values across CLI and browser hosts. |

--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -572,7 +572,8 @@ it does not join the pack-contract PR.
 The executable pack registration cannot land the scanner slot before that
 focused owner issues the binding currency under
 [#5719](https://github.com/richlander/dotnet-inspect/issues/5719), whose
-[Integration-owned contract](integration-scanner-binding.md) is design-only.
+[Integration-owned contract](integration-scanner-binding.md) now has its
+substrate implementation under #5902. Catalog adoption remains a separate step.
 The pack design does not introduce a generic delegate or parallel scan result as a
 placeholder.
 

--- a/docs/design/integration-scanner-binding.md
+++ b/docs/design/integration-scanner-binding.md
@@ -2,11 +2,13 @@
 
 ## Status and exact claim
 
-Design-only contract for [#5719](https://github.com/richlander/dotnet-inspect/issues/5719),
-owned by [Integrations](integrations.md). The binding and decoded context are
-not implemented. Current library inspection and Census behavior is unchanged.
-The enforcement described below is planned, not evidence of implemented
-behavior.
+Contract locked under [#5719](https://github.com/richlander/dotnet-inspect/issues/5719),
+owned by [Integrations](integrations.md). The observation, binding, and selected
+operation substrate is implemented under
+[#5902](https://github.com/richlander/dotnet-inspect/issues/5902).
+Existing full-library inspection and Census behavior is unchanged.
+Application-catalog registration and CLI/browser selection remain later
+adoption steps; their gates remain planned and unverified.
 
 **Claim:** Integration orchestration supplies an immutable, decoded observation
 context to one selected static semantic scanner and projects its classifications
@@ -39,19 +41,21 @@ producer-policy obligation.
 
 ## Basis in the current product
 
-The present scanner already separates three concerns:
+The scanner separates four concerns:
 
-- `EcosystemIntegrationProjection` traverses public type definitions, admits
+- `EcosystemIntegrationObservationReader` traverses public type definitions, admits
   public static extension methods, performs guarded decoding, and retains
-  structured evidence behind compact rows.
+  structured evidence on immutable observations.
 - `EcosystemIntegrationClassifier` interprets metadata names and decoded
-  signatures without owning traversal or accumulation.
+  signatures without owning traversal or evidence projection.
+- `EcosystemIntegrationProjection` attaches the original evidence to compact
+  rows and owns ordering and deduplication.
 - `EcosystemIntegrationPresenceBuilder` combines projected signals with broader
   public-type evidence and the separate OpenTelemetry predicate.
 
-The missing seam is between decoded observations and interpretation. Moving the
-existing `PEReader` facade into the application catalog would move the wrong
-responsibility.
+The observation context is the seam between decoding and interpretation.
+Moving the existing `PEReader` facade into the application catalog would move
+the wrong responsibility.
 
 The current Aspire predicates are the initial behavior oracle: public
 `Aspire.Hosting.*Resource` types, and `Add*` extension methods on
@@ -69,7 +73,7 @@ invocation belongs inside Integration orchestration.
 
 ## Static binding
 
-The proposed owner-issued currency is `EcosystemIntegrationScannerBinding`.
+The owner-issued currency is `EcosystemIntegrationScannerBinding`.
 Its authoring form is a single target-free static method group:
 
 ```text
@@ -86,6 +90,10 @@ A binding is immutable application-lifetime metadata, not an operation,
 scanner instance, or cache. One scanner may compose ordinary classification
 helpers internally. No registration graph, dynamic loading, or scanner
 collection protocol is introduced.
+
+`EcosystemIntegrationScanner.AspireBinding` exposes the existing owner-side
+Aspire rules for staged catalog adoption. It shares the same predicates as
+the broad classifier rather than maintaining a second semantic policy.
 
 ## Decoded observation context
 
@@ -134,6 +142,10 @@ The callback returns a finite immutable sequence of classifications. Each
 classification pairs an observation from this context with an existing
 Integration-owned concept descriptor and a kind under that concept's policy.
 The type/API shape follows the observation, not an application-supplied label.
+
+`EcosystemIntegrationObservation.Classify` pairs the original observation with
+its concept and kind. Kind remains the existing string currency, interpreted by
+the projection's ranking policy; this does not add a kind-descriptor catalog.
 
 Integrations admits classifications under its existing producer policy and
 projects the original evidence into ordinary `EcosystemIntegrationSignalInfo`
@@ -192,6 +204,26 @@ information beside the projected rows. It preserves these distinctions:
 This reuses the Integration owner's result semantics rather than giving the
 application a second success/failure or completion algebra.
 
+### Public operation surface
+
+`AssemblyInspectionSession.EcosystemIntegrationObservations` produces the
+decoded context. `EcosystemIntegrationScanner.Scan(context, binding)` invokes
+the binding and projects its classifications; the session's
+`EcosystemIntegrations(binding)` overload combines those operations.
+
+`AssemblyContextIntegrationScanQuery` executes over an existing group or
+package-role projection, or one participant of a reusable group. It retains
+the binding in `AssemblyContextIntegrationScanResult`. Successful participants
+use `AssemblyIntegrationsEntry.Selected`, without full-presence fields;
+rejected and failed participants reuse the existing entry variants. Only
+selected successes satisfy this result's `IsComplete`. The full query's
+definition, result, and completeness test remain unchanged.
+
+The query handles decoding failure before invoking the scanner. Callback and
+projection faults occur outside that mapping, even when their exception types
+could otherwise resemble a metadata error. No selected streaming/release API
+is introduced by this slice.
+
 ## Trust and evidence posture
 
 The scanner is trusted, source-authored application code. The supported
@@ -212,25 +244,28 @@ code execution is introduced by this design.
 
 ## Gates
 
-All new gates below are **planned Release gates** for implementation. Their
-behavior is currently unverified. Existing tests identify the oracle to
-preserve; this design-only PR does not claim to have implemented the handoff.
+The implemented substrate has the following focused Release gates. Catalog
+discovery and host adoption are separate from binding construction and the
+public operation exercised here.
 
 | Gate | Observable obligation |
 | --- | --- |
-| Focused binding tests | Construction/discovery invoke no callback; one selected binding runs once per admitted participant, including empty input; repetition runs again and neighboring bindings stay untouched. |
-| Non-friend consumer test | Application-authored interpretation constructs and carries the binding through the ordinary public Integration operation and consumes the projected result. |
-| Observation/projection parity tests | Product-owned observation construction preserves classifications, parameter order, structured type/member associations, overload evidence, row equality/order, and existing full-presence behavior on the same compiled inputs. |
-| Failure parity tests | Rejected participants remain beside later results; unclassifiable signatures and unavailable anchors retain their distinct existing treatment; callback faults are not success-shaped output. |
-| Aspire and neighboring host cases | CLI and CatalogExports use the selected binding with the same realized inputs and consume equivalent Integration-owned rows/outcomes without changing existing full-scan behavior. |
+| `Binding_ConstructionIsInertAndRejectsInstanceOrCombinedCallbacks` | Construction invokes nothing and admits exactly one target-free method group. |
+| `SelectedScan_PublicConsumerRunsOncePerParticipantWithoutCaching` | A non-friend Metadata consumer constructs the binding and executes through the public query; selected-only invocation covers admitted empty input and repetition. |
+| `SelectedScan_PreservesOrderedRowsAndPresence`, `Observations_PreserveParametersAndOutliveTheReader`, `SelectedScan_CoalescesRowsWithoutLosingOverloadEvidence` | Product-owned observations preserve parameter order, structured associations, retained overload evidence, row equality/order, and existing presence. |
+| `Observations_ExcludeReceiverlessAndUndecodableMethods`, `SelectedScan_PreservesClassifiedApiWithoutStructuredAnchor` | Unclassifiable signatures and unavailable anchors retain their distinct treatment. |
+| `SelectedScan_CarriesRejectionAndDecodeFailureBesideLaterResults`, `SelectedScan_BudgetRejectionDoesNotInvokeScanner`, `SelectedScan_PropagatesCallbackFaultsWithoutMisclassifyingThem` | Participant failures remain visible beside later results; callback faults do not become metadata failure or empty success. |
+| `SelectedScan_DifferentBindingsAndFullScanKeepTheirOwnScope`, `PackageRealizationProjection_SelectedScanKeepsTheSharedRoleReusable` | Selections do not share the full-query cache or completeness scope, and role execution preserves the reusable group. |
+| `AspireBinding_PreservesExistingCurrencyWithoutIncludingNeighboringConcepts`, `AspireBinding_DoesNotClassifyNonAspireDependencyInjection` | The compatibility binding shares the current Aspire policy and excludes neighboring DI currency. |
+| Aspire and neighboring host cases (**planned, unverified**) | CLI and CatalogExports select the same binding and consume equivalent Integration-owned rows/outcomes; no host selection has been enabled yet. |
 
 The focused oracle includes
 `EcosystemIntegrationScannerTests.Scan_ProjectsExactOrderedPublicCurrencyAndPresence`,
 `Scan_SkipsExtensionMethodWithoutReceiver`, and
 `Scan_PreservesClassifiedApiWhenStructuredAnchorIsOverBudget`, plus
 `AssemblyContextIntegrationsQueryTests` for participant ordering, snapshot
-reuse, acquisition rejection, and budget exhaustion. Add an overload case that
-compares the retained evidence set, not just the compact display row.
+reuse, acquisition rejection, and budget exhaustion. The overload gate compares
+the retained evidence set, not just the compact display row.
 
 Tests exercise product-owned decoding and projection. They do not manufacture
 the observation/evidence pair they later claim the product preserved.
@@ -246,8 +281,8 @@ pack owner; successful publication is not proof of API absence.
 [#5728](https://github.com/richlander/dotnet-inspect/issues/5728) is the
 non-normative end-to-end tracker. This scanner track has **six steps**:
 
-1. **Integration contract (#5719):** lock this design. No product code changes.
-2. **Integration implementation:** extract observations behind the existing
+1. **Integration contract (#5719), complete:** lock this design.
+2. **Integration implementation (#5902):** extract observations behind the existing
    scanner facade, add the opaque binding and selected operation, and prove
    parity with the current classifier/projection/presence paths. Existing
    library inspection is the production consumer of the extraction.
@@ -275,7 +310,15 @@ feature is presented as depending on unfinished later steps.
 
 ## Demo
 
-Design mockup, not a new CLI command:
+Shared-library API, not a new CLI command:
+
+```csharp
+using var session = AssemblyInspectionSession.Open(path);
+var rows = session.EcosystemIntegrations(
+    EcosystemIntegrationScanner.AspireBinding);
+```
+
+Catalog selection remains a later adoption step. The scenario is:
 
 ```text
 Select: ecosystem.aspire / Integration

--- a/docs/design/integrations.md
+++ b/docs/design/integrations.md
@@ -25,10 +25,11 @@ section ordering clusters the whole family together.
 Tracking: [#3629](https://github.com/richlander/dotnet-inspect/issues/3629).
 
 The focused [scanner-binding contract](integration-scanner-binding.md) covers
-the proposed decoded-data handoff to source-authored ecosystem scanners under
-[#5719](https://github.com/richlander/dotnet-inspect/issues/5719). It is
-design-only; the library scanner and incremental Census described here remain
-the current behavior.
+the decoded-data handoff to source-authored ecosystem scanners, designed under
+[#5719](https://github.com/richlander/dotnet-inspect/issues/5719) and implemented
+under [#5902](https://github.com/richlander/dotnet-inspect/issues/5902).
+Catalog and host selection remain later adoption steps; existing full-library
+inspection and Census behavior is unchanged.
 
 ## Authority
 
@@ -196,8 +197,9 @@ metadata inventory.
 ### Scanner implementation boundaries
 
 `EcosystemIntegrationScanner` is the public Metadata facade.
-`EcosystemIntegrationProjection` owns the SRM traversal, guarded signature
-decode, evidence buckets, and row ordering.
+`EcosystemIntegrationObservationReader` owns SRM traversal, guarded signature
+decode, and immutable observation construction.
+`EcosystemIntegrationProjection` owns evidence buckets and row ordering.
 `EcosystemIntegrationClassifier` owns the pure type-name and starter-method
 classification policy, while `EcosystemIntegrationPresenceBuilder` projects
 signals and broader public-type evidence into the legacy presence flags. The
@@ -221,7 +223,7 @@ gates public-method filtering, signal kind and shape, row order, and parity
 between direct and precomputed presence paths.
 
 The [scanner-binding contract](integration-scanner-binding.md) defines the
-target separation between this owner's observation construction and
+separation between this owner's observation construction and
 application-authored interpretation. It does not move SRM traversal,
 projection, or presence aggregation into the application catalog, and it does
 not change the following group-query or Census contracts.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -383,7 +383,7 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
 - [Implementation Diff](design/implementation-diff.md): product C# + IL/body diff projection shared by the opt-in `diff` section, RTS, and harnesses.
 - [C# assembly round-trip testing](design/csharp-member-recompilation.md): proposed tools-only `cluster`/`all` artifact compilation and layered IL/C# comparison.
 - [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
-- [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency; its proposed [scanner binding](design/integration-scanner-binding.md) separates decoded observations from application-authored interpretation.
+- [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency; its [scanner binding](design/integration-scanner-binding.md) separates decoded observations from application-authored interpretation.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Capability section registry spike](design/capability-section-registry-spike.md): measured static lambda-table and precompiled-plan pilot layered on `SectionPipeline`.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.

--- a/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
+++ b/src/DotnetInspector.Queries.Tests/AssemblyContextIntegrationsQueryTests.cs
@@ -1,6 +1,9 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
 using ILInspector.Metadata;
@@ -9,6 +12,261 @@ namespace DotnetInspector.Queries.Tests;
 
 public sealed class AssemblyContextIntegrationsQueryTests
 {
+    static readonly List<string> s_scanOrder = [];
+    static Exception? s_callbackFailure;
+
+    [Fact]
+    public void SelectedScan_PublicConsumerRunsOncePerParticipantWithoutCaching()
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly di = TestAssembly.Create(
+            "SelectedDi",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy);
+        TestAssembly logging = TestAssembly.Create(
+            "SelectedLogging",
+            "Microsoft.Extensions.Logging.CustomLogger",
+            policy);
+        TestAssembly empty = TestAssembly.Create(
+            "SelectedEmpty",
+            "N.Hidden",
+            policy,
+            publicType: false);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup(
+            [di.Participant, logging.Participant, empty.Participant]);
+        s_scanOrder.Clear();
+        var selected = EcosystemIntegrationScannerBinding.Create(SelectDependencyInjection);
+        var neighboring = EcosystemIntegrationScannerBinding.Create(UnselectedScanner);
+        Assert.NotSame(selected, neighboring);
+        Assert.Empty(s_scanOrder);
+
+        AssemblyContextIntegrationScanResult first =
+            AssemblyContextIntegrationScanQuery.Execute(group, selected);
+        AssemblyContextIntegrationScanResult second =
+            AssemblyContextIntegrationScanQuery.Execute(group, selected);
+
+        Assert.True(first.IsComplete);
+        Assert.True(second.IsComplete);
+        Assert.Same(selected, first.Binding);
+        Assert.False(new AssemblyContextIntegrationsResult(first.Assemblies).IsComplete);
+        Assert.Equal(
+            [
+                "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+                "Microsoft.Extensions.Logging.CustomLogger",
+                "<empty>",
+                "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+                "Microsoft.Extensions.Logging.CustomLogger",
+                "<empty>",
+            ],
+            s_scanOrder);
+        var diEntry = Assert.IsType<AssemblyIntegrationsEntry.Selected>(first.Assemblies[0]);
+        AssertSubject(di, diEntry.Subject);
+        EcosystemIntegrationSignalInfo signal = Assert.Single(diEntry.EcosystemSignals);
+        Assert.Same(IntegrationConceptCatalog.DependencyInjection, signal.GetConcept());
+        Assert.Same(IntegrationConceptCatalog.EcosystemObserved, signal.GetProducerPolicy());
+        Assert.Equal(
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            signal.GetTypeDefinition()?.ToMetadataFullName());
+        Assert.Empty(Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+            first.Assemblies[1]).EcosystemSignals);
+        Assert.Empty(Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+            first.Assemblies[2]).EcosystemSignals);
+        Assert.Equal(1, di.OpenCount);
+        Assert.Equal(1, logging.OpenCount);
+        Assert.Equal(1, empty.OpenCount);
+    }
+
+    [Fact]
+    public void SelectedScan_DifferentBindingsAndFullScanKeepTheirOwnScope()
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly source = TestAssembly.Create(
+            "SelectedScopes",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy,
+            additionalIntegrationTypeName: "Microsoft.Extensions.Logging.CustomLogger");
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup([source.Participant]);
+        s_scanOrder.Clear();
+        var di = EcosystemIntegrationScannerBinding.Create(SelectDependencyInjection);
+        var logging = EcosystemIntegrationScannerBinding.Create(SelectLogging);
+
+        var diResult = AssemblyContextIntegrationScanQuery.Execute(group, di);
+        var loggingResult = AssemblyContextIntegrationScanQuery.Execute(group, logging);
+        AssemblyContextIntegrationsResult full = AssemblyContextIntegrationsQuery.Execute(group);
+
+        Assert.Same(di, diResult.Binding);
+        Assert.Same(logging, loggingResult.Binding);
+        Assert.Same(
+            IntegrationConceptCatalog.DependencyInjection,
+            Assert.Single(Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+                Assert.Single(diResult.Assemblies)).EcosystemSignals).GetConcept());
+        Assert.Same(
+            IntegrationConceptCatalog.Logging,
+            Assert.Single(Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+                Assert.Single(loggingResult.Assemblies)).EcosystemSignals).GetConcept());
+        var available = Assert.IsType<AssemblyIntegrationsEntry.Available>(
+            Assert.Single(full.Assemblies));
+        Assert.Equal(2, available.EcosystemSignals.Length);
+        Assert.Equal(2, available.Presence.IntegrationCount);
+        Assert.True(available.Presence.HasDependencyInjectionSupport);
+        Assert.True(available.Presence.HasLoggingSupport);
+        Assert.Single(s_scanOrder);
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    [Fact]
+    public void SelectedScan_CarriesRejectionAndDecodeFailureBesideLaterResults()
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly rejected = TestAssembly.Create(
+            "SelectedRejected",
+            "N.Rejected",
+            policy,
+            selectedName: "DifferentIdentity");
+        TestAssembly malformed = TestAssembly.Create(
+            "SelectedMalformed",
+            "N.Malformed",
+            policy,
+            invalidTypeName: true);
+        TestAssembly available = TestAssembly.Create(
+            "SelectedAvailable",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup(
+            [rejected.Participant, malformed.Participant, available.Participant]);
+        s_scanOrder.Clear();
+        var binding = EcosystemIntegrationScannerBinding.Create(SelectDependencyInjection);
+
+        AssemblyContextIntegrationScanResult result =
+            AssemblyContextIntegrationScanQuery.Execute(group, binding);
+
+        Assert.False(result.IsComplete);
+        var rejection = Assert.IsType<AssemblyIntegrationsEntry.Rejected>(result.Assemblies[0]);
+        AssertSubject(rejected, rejection.Subject);
+        Assert.Equal(CandidateOpenFailureKind.InvalidImage, rejection.Failure.Kind);
+        var failure = Assert.IsType<AssemblyIntegrationsEntry.Failed>(result.Assemblies[1]);
+        AssertSubject(malformed, failure.Subject);
+        var success = Assert.IsType<AssemblyIntegrationsEntry.Selected>(result.Assemblies[2]);
+        AssertSubject(available, success.Subject);
+        Assert.Single(success.EcosystemSignals);
+        Assert.Single(s_scanOrder);
+    }
+
+    [Fact]
+    public void SelectedScan_BudgetRejectionDoesNotInvokeScanner()
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly first = TestAssembly.Create(
+            "SelectedBudgetFirst",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy);
+        TestAssembly second = TestAssembly.Create(
+            "SelectedBudgetSecond",
+            "Microsoft.Extensions.Logging.CustomLogger",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup(
+            [first.Participant, second.Participant],
+            new AssemblyContextGroupOptions { MaxRetainedImageBytes = first.Bytes.Length });
+        s_scanOrder.Clear();
+        var binding = EcosystemIntegrationScannerBinding.Create(SelectDependencyInjection);
+
+        var result = AssemblyContextIntegrationScanQuery.Execute(group, binding);
+
+        Assert.False(result.IsComplete);
+        Assert.IsType<AssemblyIntegrationsEntry.Selected>(result.Assemblies[0]);
+        Assert.Equal(
+            CandidateOpenFailureKind.ResourceBudget,
+            Assert.IsType<AssemblyIntegrationsEntry.Rejected>(result.Assemblies[1]).Failure.Kind);
+        Assert.Single(s_scanOrder);
+    }
+
+    [Theory]
+    [InlineData("metadata")]
+    [InlineData("range")]
+    [InlineData("overflow")]
+    [InlineData("configuration")]
+    public void SelectedScan_PropagatesCallbackFaultsWithoutMisclassifyingThem(string kind)
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly source = TestAssembly.Create("CallbackFault", "N.Source", policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup([source.Participant]);
+        s_callbackFailure = kind switch
+        {
+            "metadata" => new BadImageFormatException("Scanner callback marker."),
+            "range" => new ArgumentOutOfRangeException("scanner"),
+            "overflow" => new OverflowException("Scanner callback marker."),
+            _ => new InvalidOperationException("Scanner callback marker."),
+        };
+        var binding = EcosystemIntegrationScannerBinding.Create(FaultingScanner);
+
+        Exception? failure = Record.Exception(() =>
+            AssemblyContextIntegrationScanQuery.Execute(group, binding));
+
+        Assert.Same(s_callbackFailure, failure);
+    }
+
+    [Fact]
+    public void SelectedScan_ParticipantExecutionKeepsTheGroupReusable()
+    {
+        var policy = new TestBindingPolicy(new AssemblyBindingPolicyVersion());
+        TestAssembly source = TestAssembly.Create(
+            "SelectedReusable",
+            "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+            policy);
+        using var workspace = new InspectionWorkspace();
+        AssemblyContextGroup group = workspace.CreateAssemblyContextGroup([source.Participant]);
+        s_scanOrder.Clear();
+        var binding = EcosystemIntegrationScannerBinding.Create(SelectDependencyInjection);
+
+        Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+            AssemblyContextIntegrationScanQuery.ExecuteParticipant(
+                group,
+                source.Participant,
+                binding));
+        Assert.True(AssemblyContextIntegrationScanQuery.Execute(group, binding).IsComplete);
+        Assert.True(AssemblyContextIntegrationsQuery.Execute(group).IsComplete);
+        Assert.Equal(2, s_scanOrder.Count);
+        Assert.Equal(1, source.OpenCount);
+    }
+
+    static ImmutableArray<EcosystemIntegrationClassification> SelectDependencyInjection(
+        EcosystemIntegrationObservationContext context)
+    {
+        s_scanOrder.Add(context.Types.IsEmpty ? "<empty>" : context.Types[0].MetadataName);
+        return
+        [
+            .. context.Types
+                .Where(type => type.MetadataName ==
+                    "Microsoft.Extensions.DependencyInjection.IServiceCollection")
+                .Select(type => type.Classify(
+                    IntegrationConceptCatalog.DependencyInjection,
+                    "Dependency Injection")),
+        ];
+    }
+
+    static ImmutableArray<EcosystemIntegrationClassification> SelectLogging(
+        EcosystemIntegrationObservationContext context) =>
+        [
+            .. context.Types
+                .Where(type => type.MetadataName.StartsWith(
+                    "Microsoft.Extensions.Logging.",
+                    StringComparison.Ordinal))
+                .Select(type => type.Classify(IntegrationConceptCatalog.Logging, "Logging")),
+        ];
+
+    static ImmutableArray<EcosystemIntegrationClassification> UnselectedScanner(
+        EcosystemIntegrationObservationContext context) =>
+        throw new InvalidOperationException("An unselected scanner was invoked.");
+
+    static ImmutableArray<EcosystemIntegrationClassification> FaultingScanner(
+        EcosystemIntegrationObservationContext context) =>
+        throw s_callbackFailure!;
+
     [Fact]
     public void RegistryRun_ScansEveryParticipantInOrderAndReusesSnapshots()
     {
@@ -525,13 +783,16 @@ public sealed class AssemblyContextIntegrationsQueryTests
             TestBindingPolicy policy,
             Action? onOpen = null,
             string? selectedName = null,
-            string? additionalIntegrationTypeName = null)
+            string? additionalIntegrationTypeName = null,
+            bool publicType = true,
+            bool invalidTypeName = false)
         {
             byte[] bytes =
                 BuildAssembly(
                     assemblyName,
                     integrationTypeName,
-                    additionalIntegrationTypeName);
+                    additionalIntegrationTypeName,
+                    publicType);
             AssemblyReferenceIdentity actualIdentity;
             using (var peReader =
                    new PEReader(new MemoryStream(bytes, writable: false)))
@@ -539,6 +800,18 @@ public sealed class AssemblyContextIntegrationsQueryTests
                 actualIdentity =
                     AssemblyReferenceIdentity.FromAssemblyDefinition(
                         peReader.GetMetadataReader());
+                if (invalidTypeName)
+                {
+                    MetadataReader reader = peReader.GetMetadataReader();
+                    int nameOffset = peReader.PEHeaders.MetadataStartOffset
+                        + reader.GetTableMetadataOffset(TableIndex.TypeDef)
+                        + reader.GetTableRowSize(TableIndex.TypeDef)
+                        + sizeof(uint);
+                    Assert.True(reader.GetHeapSize(HeapIndex.String) < ushort.MaxValue);
+                    BinaryPrimitives.WriteUInt16LittleEndian(
+                        bytes.AsSpan(nameOffset, sizeof(ushort)),
+                        ushort.MaxValue);
+                }
             }
 
             var selectedIdentity = actualIdentity with
@@ -572,7 +845,8 @@ public sealed class AssemblyContextIntegrationsQueryTests
         static byte[] BuildAssembly(
             string assemblyName,
             string integrationTypeName,
-            string? additionalIntegrationTypeName)
+            string? additionalIntegrationTypeName,
+            bool publicType)
         {
             var assemblyBuilder = new PersistedAssemblyBuilder(
                 new AssemblyName(assemblyName),
@@ -591,7 +865,8 @@ public sealed class AssemblyContextIntegrationsQueryTests
             {
                 TypeBuilder type = module.DefineType(
                     typeName,
-                    TypeAttributes.Public | TypeAttributes.Class);
+                    (publicType ? TypeAttributes.Public : TypeAttributes.NotPublic)
+                    | TypeAttributes.Class);
                 type.DefineDefaultConstructor(
                     MethodAttributes.Public);
                 type.CreateType();

--- a/src/DotnetInspector.Queries.Tests/PackageAssemblyContextCompletionTests.cs
+++ b/src/DotnetInspector.Queries.Tests/PackageAssemblyContextCompletionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.IO.Compression;
 using System.Reflection;
 
@@ -11,6 +12,34 @@ namespace DotnetInspector.Queries.Tests;
 public sealed class PackageAssemblyContextCompletionTests
 {
     const string Framework = "net11.0";
+
+    [Fact]
+    public async Task PackageRealizationProjection_SelectedScanKeepsTheSharedRoleReusable()
+    {
+        PackageRootBinding binding = SharedBinding("Selected.Integration");
+        await using InspectionWorkspace workspace = InspectionWorkspace.CreateAsynchronous();
+        PackageAssemblyContextCompletion completion = await ExecuteAsync(workspace, [binding]);
+        PackageAssemblyContextProjection projection = completion.CreateProjection([binding]);
+        var scanner = EcosystemIntegrationScannerBinding.Create(EmptyClassification);
+
+        AssemblyContextIntegrationScanResult selected =
+            AssemblyContextIntegrationScanQuery.Execute(projection.SurfaceRole, scanner);
+        AssemblyContextIntegrationsResult full =
+            AssemblyContextIntegrationsQuery.Execute(projection.SurfaceRole);
+
+        Assert.True(selected.IsComplete);
+        var entry = Assert.IsType<AssemblyIntegrationsEntry.Selected>(
+            Assert.Single(selected.Assemblies));
+        Assert.Empty(entry.EcosystemSignals);
+        Assert.Same(
+            Assert.Single(full.Assemblies).Subject.Registration,
+            entry.Subject.Registration);
+        await projection.ReturnAsync();
+        await completion.CloseAsync();
+    }
+
+    static ImmutableArray<EcosystemIntegrationClassification> EmptyClassification(
+        EcosystemIntegrationObservationContext context) => [];
 
     [Fact]
     public async Task PackageRealizationProjection_PreservesDemandPackageIdentityAndOrder()

--- a/src/DotnetInspector.Queries/AssemblyContextIntegrationScanQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextIntegrationScanQuery.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Queries;
+
+/// <summary>Ordered participant outcomes scoped to one explicit scanner selection.</summary>
+public sealed record AssemblyContextIntegrationScanResult(
+    EcosystemIntegrationScannerBinding Binding,
+    ImmutableArray<AssemblyIntegrationsEntry> Assemblies)
+{
+    public bool IsComplete =>
+        Assemblies.All(static entry => entry is AssemblyIntegrationsEntry.Selected);
+}
+
+/// <summary>
+/// Executes one selected scanner over realized participants. This operation is
+/// uncached and does not use the full-scan query definition.
+/// </summary>
+public static class AssemblyContextIntegrationScanQuery
+{
+    public static AssemblyContextIntegrationScanResult Execute(
+        AssemblyContextGroup group,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(binding);
+
+        var entries = ImmutableArray.CreateBuilder<AssemblyIntegrationsEntry>(
+            group.Participants.Length);
+        foreach (AssemblyContextParticipant participant in group.Participants)
+            entries.Add(ExecuteParticipantCore(group, participant, binding));
+        return new AssemblyContextIntegrationScanResult(
+            binding,
+            entries.MoveToImmutable());
+    }
+
+    public static AssemblyContextIntegrationScanResult Execute(
+        PackageAssemblyContextRoleProjection role,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(binding);
+        return role.Use(group => Execute(group, binding));
+    }
+
+    public static AssemblyIntegrationsEntry ExecuteParticipant(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+        ArgumentNullException.ThrowIfNull(participant);
+        ArgumentNullException.ThrowIfNull(binding);
+        if (!group.Participants.Any(candidate => ReferenceEquals(
+                candidate.Assembly.Registration,
+                participant.Assembly.Registration)))
+        {
+            throw new ArgumentException(
+                "The requested participant is not a member of the assembly context group.",
+                nameof(participant));
+        }
+
+        return ExecuteParticipantCore(group, participant, binding);
+    }
+
+    static AssemblyIntegrationsEntry ExecuteParticipantCore(
+        AssemblyContextGroup group,
+        AssemblyContextParticipant participant,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        var subject = new AssemblyContextSubject(participant.Assembly);
+        AssemblyImageAccessResult<AssemblyIntegrationsEntry> access =
+            group.UseAssemblySession(
+                participant.Assembly,
+                session => Inspect(subject, session, binding));
+        return access switch
+        {
+            AssemblyImageAccessResult<AssemblyIntegrationsEntry>.Available available =>
+                available.Value,
+            AssemblyImageAccessResult<AssemblyIntegrationsEntry>.Rejected rejected =>
+                new AssemblyIntegrationsEntry.Rejected(subject, rejected.Failure),
+            _ => throw new InvalidOperationException("Unknown assembly image access result."),
+        };
+    }
+
+    static AssemblyIntegrationsEntry Inspect(
+        AssemblyContextSubject subject,
+        AssemblyInspectionSession session,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        EcosystemIntegrationObservationContext context;
+        try
+        {
+            context = session.EcosystemIntegrationObservations();
+        }
+        catch (BadImageFormatException ex)
+        {
+            return new AssemblyIntegrationsEntry.Failed(subject, ex);
+        }
+        catch (Exception ex) when (ex is ArgumentOutOfRangeException or OverflowException)
+        {
+            return new AssemblyIntegrationsEntry.Failed(
+                subject,
+                new BadImageFormatException(
+                    "The selected image contains invalid metadata.",
+                    ex));
+        }
+
+        // Callback and projection faults are not malformed inspected metadata.
+        return new AssemblyIntegrationsEntry.Selected(
+            subject,
+            EcosystemIntegrationScanner.Scan(context, binding).ToImmutableArray());
+    }
+}

--- a/src/DotnetInspector.Queries/AssemblyContextIntegrationsQuery.cs
+++ b/src/DotnetInspector.Queries/AssemblyContextIntegrationsQuery.cs
@@ -34,6 +34,14 @@ public abstract record AssemblyIntegrationsEntry(
         EcosystemIntegrationPresence Presence)
         : AssemblyIntegrationsEntry(Subject);
 
+    /// <summary>
+    /// The selected scanner produced its rows, without claiming full presence or Census coverage.
+    /// </summary>
+    public sealed record Selected(
+        AssemblyContextSubject Subject,
+        ImmutableArray<EcosystemIntegrationSignalInfo> EcosystemSignals)
+        : AssemblyIntegrationsEntry(Subject);
+
     /// <summary>The participant's immutable image could not be acquired.</summary>
     public sealed record Rejected(
         AssemblyContextSubject Subject,

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -213,6 +213,25 @@ public sealed class AssemblyInspectionSession : IDisposable
     public List<EcosystemIntegrationSignalInfo> EcosystemIntegrations()
         => EcosystemIntegrationScanner.Scan(_image.PEReader);
 
+    /// <summary>Decodes immutable Integration observations from this retained image.</summary>
+    public EcosystemIntegrationObservationContext EcosystemIntegrationObservations()
+    {
+        _image.EnsureAlive();
+        return _image.HasMetadata
+            ? EcosystemIntegrationObservationReader.Read(_image.GetMetadataReader())
+            : new EcosystemIntegrationObservationContext([], []);
+    }
+
+    /// <summary>Runs one selected scanner without computing full-library presence.</summary>
+    public List<EcosystemIntegrationSignalInfo> EcosystemIntegrations(
+        EcosystemIntegrationScannerBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(binding);
+        return EcosystemIntegrationScanner.Scan(
+            EcosystemIntegrationObservations(),
+            binding);
+    }
+
     /// <summary>Presence flags summarized from grouped integration evidence.</summary>
     public EcosystemIntegrationPresence EcosystemIntegrationPresence(
         IEnumerable<EcosystemIntegrationSignalInfo> ecosystemSignals)

--- a/src/ILInspector.Metadata/EcosystemIntegrationClassifier.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationClassifier.cs
@@ -1,13 +1,114 @@
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
 
 /// <summary>
 /// Pure ecosystem policy over metadata type names and decoded extension-method
-/// signatures. It owns no traversal, accumulation, or output ordering.
+/// signatures. It owns no traversal, evidence projection, or output ordering.
 /// </summary>
 internal static class EcosystemIntegrationClassifier
 {
+    internal static ImmutableArray<EcosystemIntegrationClassification> ClassifyAspire(
+        EcosystemIntegrationObservationContext context)
+    {
+        var classifications =
+            ImmutableArray.CreateBuilder<EcosystemIntegrationClassification>();
+        foreach (EcosystemIntegrationTypeObservation type in context.Types)
+        {
+            if (TryGetAspireKind(type.MetadataName, out string kind))
+                classifications.Add(type.Classify(IntegrationConceptCatalog.Aspire, kind));
+        }
+        foreach (EcosystemIntegrationMethodObservation method in context.StarterMethods)
+        {
+            if (TryClassifyAspireStarterMethod(
+                    method.DeclaringType.MetadataName,
+                    method.Name,
+                    method.Signature,
+                    out string kind))
+            {
+                classifications.Add(method.Classify(IntegrationConceptCatalog.Aspire, kind));
+            }
+        }
+        return classifications.ToImmutable();
+    }
+
+    internal static ImmutableArray<EcosystemIntegrationClassification> Classify(
+        EcosystemIntegrationObservationContext context)
+    {
+        var classifications =
+            ImmutableArray.CreateBuilder<EcosystemIntegrationClassification>();
+        foreach (EcosystemIntegrationTypeObservation type in context.Types)
+            ClassifyType(type, classifications);
+        foreach (EcosystemIntegrationMethodObservation method in context.StarterMethods)
+            ClassifyStarterMethod(method, classifications);
+        return classifications.ToImmutable();
+    }
+
+    static void ClassifyType(
+        EcosystemIntegrationTypeObservation type,
+        ImmutableArray<EcosystemIntegrationClassification>.Builder classifications)
+    {
+        string typeName = type.MetadataName;
+        if (TryGetAspNetCoreKind(typeName, out var aspNetCoreKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.AspNetCore, aspNetCoreKind));
+        if (TryGetAspireKind(typeName, out var aspireKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Aspire, aspireKind));
+        if (TryGetAIKind(typeName, out var aiKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.AI, aiKind));
+        if (TryGetAuthenticationKind(typeName, out var authenticationKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Authentication, authenticationKind));
+        if (TryGetConfigurationKind(typeName, out var configurationKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Configuration, configurationKind));
+        if (TryGetOpenApiKind(typeName, out var openApiKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.OpenAPI, openApiKind));
+        if (TryGetDependencyInjectionKind(typeName, out var dependencyInjectionKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.DependencyInjection, dependencyInjectionKind));
+        if (IsLoggingType(typeName))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Logging, "Logging"));
+        if (IsOptionsType(typeName))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Options, "Options"));
+        if (IsHostingType(typeName))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.Hosting, "Hosting"));
+        if (IsHealthChecksType(typeName))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.HealthChecks, "Health Check"));
+        if (TryGetHttpClientKind(typeName, out var httpClientKind))
+            classifications.Add(type.Classify(IntegrationConceptCatalog.HttpClient, httpClientKind));
+    }
+
+    static void ClassifyStarterMethod(
+        EcosystemIntegrationMethodObservation method,
+        ImmutableArray<EcosystemIntegrationClassification>.Builder classifications)
+    {
+        string typeName = method.DeclaringType.MetadataName;
+        string methodName = method.Name;
+        MethodSignature<string> signature = method.Signature;
+        if (TryClassifyAspireStarterMethod(typeName, methodName, signature, out var aspireKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Aspire, aspireKind));
+        if (TryClassifyAIStarterMethod(typeName, methodName, signature, out var aiKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.AI, aiKind));
+        if (TryClassifyAuthenticationStarterMethod(methodName, signature, out var authenticationKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Authentication, authenticationKind));
+        if (TryClassifyConfigurationStarterMethod(methodName, signature, out var configurationKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Configuration, configurationKind));
+        if (TryClassifyDependencyInjectionStarterMethod(typeName, methodName, signature, out var dependencyInjectionKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.DependencyInjection, dependencyInjectionKind));
+        if (TryClassifyLoggingStarterMethod(typeName, methodName, signature, out var loggingKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Logging, loggingKind));
+        if (TryClassifyOpenApiStarterMethod(typeName, methodName, signature, out var openApiKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.OpenAPI, openApiKind));
+        if (TryClassifyOptionsStarterMethod(methodName, signature, out var optionsKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Options, optionsKind));
+        if (TryClassifyAspNetCoreStarterMethod(methodName, signature, out var aspNetCoreKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.AspNetCore, aspNetCoreKind));
+        if (TryClassifyHealthChecksStarterMethod(methodName, signature, out var healthChecksKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.HealthChecks, healthChecksKind));
+        if (TryClassifyHostingStarterMethod(typeName, methodName, signature, out var hostingKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.Hosting, hostingKind));
+        if (TryClassifyHttpClientStarterMethod(typeName, methodName, signature, out var httpClientKind))
+            classifications.Add(method.Classify(IntegrationConceptCatalog.HttpClient, httpClientKind));
+    }
+
     internal static bool IsDependencyInjectionType(string typeName)
         => typeName.StartsWith("Microsoft.Extensions.DependencyInjection.", StringComparison.Ordinal);
 

--- a/src/ILInspector.Metadata/EcosystemIntegrationObservationContext.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationObservationContext.cs
@@ -1,0 +1,95 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+/// <summary>Decoded, reader-independent observations from one participant.</summary>
+public sealed class EcosystemIntegrationObservationContext
+{
+    internal EcosystemIntegrationObservationContext(
+        ImmutableArray<EcosystemIntegrationTypeObservation> types,
+        ImmutableArray<EcosystemIntegrationMethodObservation> starterMethods)
+    {
+        Types = types;
+        StarterMethods = starterMethods;
+    }
+
+    public ImmutableArray<EcosystemIntegrationTypeObservation> Types { get; }
+    public ImmutableArray<EcosystemIntegrationMethodObservation> StarterMethods { get; }
+}
+
+/// <summary>An owner-produced observation with its original evidence association.</summary>
+public abstract class EcosystemIntegrationObservation
+{
+    internal EcosystemIntegrationObservation() { }
+
+    public EcosystemIntegrationClassification Classify(
+        IntegrationConceptDescriptor concept,
+        string kind) => new(this, concept, kind);
+}
+
+public sealed class EcosystemIntegrationTypeObservation : EcosystemIntegrationObservation
+{
+    internal EcosystemIntegrationTypeObservation(
+        string metadataName,
+        MetadataTypeDefinitionName? definition)
+    {
+        MetadataName = metadataName;
+        Definition = definition;
+    }
+
+    public string MetadataName { get; }
+    public MetadataTypeDefinitionName? Definition { get; }
+}
+
+public sealed class EcosystemIntegrationMethodObservation : EcosystemIntegrationObservation
+{
+    internal EcosystemIntegrationMethodObservation(
+        EcosystemIntegrationTypeObservation declaringType,
+        string name,
+        MethodSignature<string> signature,
+        EcosystemIntegrationApiEvidence? evidence)
+    {
+        DeclaringType = declaringType;
+        Name = name;
+        Signature = signature;
+        Evidence = evidence;
+    }
+
+    public EcosystemIntegrationTypeObservation DeclaringType { get; }
+    public string Name { get; }
+    public ImmutableArray<string> ParameterTypes => Signature.ParameterTypes;
+    public string ReturnType => Signature.ReturnType;
+    public EcosystemIntegrationApiEvidence? Evidence { get; }
+
+    internal MethodSignature<string> Signature { get; }
+}
+
+/// <summary>Interpretation paired with the observation that supplies its evidence.</summary>
+public sealed class EcosystemIntegrationClassification
+{
+    internal EcosystemIntegrationClassification(
+        EcosystemIntegrationObservation observation,
+        IntegrationConceptDescriptor concept,
+        string kind)
+    {
+        ArgumentNullException.ThrowIfNull(concept);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (!IntegrationConceptCatalog.EcosystemObserved.Concepts.Contains(
+                concept,
+                ReferenceEqualityComparer.Instance))
+        {
+            throw new ArgumentException(
+                "The concept does not belong to the ecosystem observation policy.",
+                nameof(concept));
+        }
+
+        Observation = observation;
+        Concept = concept;
+        Kind = kind;
+    }
+
+    public EcosystemIntegrationObservation Observation { get; }
+    public IntegrationConceptDescriptor Concept { get; }
+    public string Kind { get; }
+}

--- a/src/ILInspector.Metadata/EcosystemIntegrationObservationReader.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationObservationReader.cs
@@ -1,0 +1,109 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Metadata;
+
+internal static class EcosystemIntegrationObservationReader
+{
+    internal static EcosystemIntegrationObservationContext Read(MetadataReader reader)
+    {
+        var types = ImmutableArray.CreateBuilder<EcosystemIntegrationTypeObservation>();
+        var methods = ImmutableArray.CreateBuilder<EcosystemIntegrationMethodObservation>();
+        foreach (TypeDefinitionHandle handle in reader.TypeDefinitions)
+        {
+            TypeDefinition definition = reader.GetTypeDefinition(handle);
+            if (!definition.IsPublic)
+                continue;
+
+            string typeName = reader.GetFullTypeName(definition);
+            MetadataTypeDefinitionName? definitionName =
+                MetadataTypeDefinitionNameReader.Read(reader, handle)
+                    is MetadataTypeDefinitionNameReadResult.Read read
+                        ? read.Name
+                        : null;
+            var type = new EcosystemIntegrationTypeObservation(
+                typeName,
+                definitionName);
+            types.Add(type);
+            AddStarterMethods(methods, reader, handle, definition, type);
+        }
+
+        return new EcosystemIntegrationObservationContext(
+            types.ToImmutable(),
+            methods.ToImmutable());
+    }
+
+    static void AddStarterMethods(
+        ImmutableArray<EcosystemIntegrationMethodObservation>.Builder methods,
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        TypeDefinition typeDefinition,
+        EcosystemIntegrationTypeObservation declaringType)
+    {
+        TypeAttributes attributes = typeDefinition.Attributes;
+        bool isStatic = (attributes & TypeAttributes.Sealed) != 0
+                        && (attributes & TypeAttributes.Abstract) != 0;
+        if (!isStatic
+            || !AttributeReader.HasExtensionAttribute(
+                reader,
+                typeDefinition.GetCustomAttributes()))
+        {
+            return;
+        }
+
+        foreach (MethodDefinitionHandle handle in typeDefinition.GetMethods())
+        {
+            MethodDefinition method = reader.GetMethodDefinition(handle);
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+                || (method.Attributes & MethodAttributes.Static) == 0
+                || !AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes()))
+            {
+                continue;
+            }
+
+            string name = reader.GetString(method.Name);
+            GenericContext context = GenericContext.ForMethod(reader, typeDefinition, method);
+            MethodSignature<string> signature;
+            try
+            {
+                signature = GuardedSignatureText.MethodText(reader, method, context)
+                    .GetValueOrThrow();
+            }
+            catch (BadImageFormatException)
+            {
+                continue;
+            }
+            if (signature.ParameterTypes.Length == 0)
+                continue;
+
+            EcosystemIntegrationApiEvidence? evidence = null;
+            if (declaringType.Definition is { } definitionName)
+            {
+                try
+                {
+                    ExtensionMemberAnchorInfo anchor =
+                        ApiMemberIdentity.CreateExtensionMethodAnchorInfo(
+                            reader,
+                            typeHandle,
+                            method);
+                    evidence = new EcosystemIntegrationApiEvidence(
+                        anchor.Anchor,
+                        definitionName,
+                        anchor.ExtendedTypeReference,
+                        anchor.ReturnTypeReference);
+                }
+                catch (BadImageFormatException)
+                {
+                    evidence = null;
+                }
+            }
+
+            methods.Add(new EcosystemIntegrationMethodObservation(
+                declaringType,
+                name,
+                signature,
+                evidence));
+        }
+    }
+}

--- a/src/ILInspector.Metadata/EcosystemIntegrationProjection.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationProjection.cs
@@ -1,42 +1,45 @@
-using System.Reflection;
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
 
 /// <summary>
-/// Performs the single SRM traversal and projects classified integration evidence
-/// into the ordered signal rows consumed by queries and Findings.
+/// Projects classifications with their original evidence into the ordered signal
+/// rows consumed by queries and Findings.
 /// </summary>
 internal static class EcosystemIntegrationProjection
 {
     internal static List<EcosystemIntegrationSignalInfo> Scan(MetadataReader reader)
+        => Project(EcosystemIntegrationClassifier.Classify(
+            EcosystemIntegrationObservationReader.Read(reader)));
+
+    internal static List<EcosystemIntegrationSignalInfo> Project(
+        ImmutableArray<EcosystemIntegrationClassification> classifications)
     {
         var buckets = IntegrationBuckets.Create();
-
-        foreach (var handle in reader.TypeDefinitions)
+        foreach (EcosystemIntegrationClassification classification in classifications)
         {
-            var typeDefinition = reader.GetTypeDefinition(handle);
-            if (!typeDefinition.IsPublic)
-                continue;
-
-            var typeName = reader.GetFullTypeName(typeDefinition);
-            MetadataTypeDefinitionName? definitionName =
-                MetadataTypeDefinitionNameReader.Read(reader, handle)
-                    is MetadataTypeDefinitionNameReadResult.Read read
-                        ? read.Name
-                        : null;
-            AddType(
-                buckets,
-                typeName,
-                "TypeDef",
-                definitionName);
-            AddStarterMethods(
-                buckets,
-                reader,
-                handle,
-                typeDefinition,
-                typeName,
-                definitionName);
+            IntegrationBucket bucket = GetBucket(buckets, classification);
+            switch (classification.Observation)
+            {
+                case EcosystemIntegrationTypeObservation type:
+                    AddType(
+                        bucket,
+                        type.MetadataName,
+                        "TypeDef",
+                        classification.Kind,
+                        type.Definition);
+                    break;
+                case EcosystemIntegrationMethodObservation method:
+                    AddApi(
+                        bucket,
+                        $"{TypeResolver.FormatDisplayName(method.DeclaringType.MetadataName)}.{method.Name}(...)",
+                        classification.Kind,
+                        method.Evidence);
+                    break;
+                default:
+                    throw new InvalidOperationException("Unknown Integration observation.");
+            }
         }
 
         List<EcosystemIntegrationSignalInfo> results = [];
@@ -45,36 +48,36 @@ internal static class EcosystemIntegrationProjection
         return results;
     }
 
-    private static void AddType(
+    private static IntegrationBucket GetBucket(
         IntegrationBuckets buckets,
-        string typeName,
-        string source,
-        MetadataTypeDefinitionName? definitionName)
+        EcosystemIntegrationClassification classification)
     {
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetAspNetCoreKind(typeName, out var aspNetCoreKind))
-            AddType(buckets.AspNetCore, typeName, source, aspNetCoreKind, definitionName);
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetAspireKind(typeName, out var aspireKind))
-            AddType(buckets.Aspire, typeName, source, aspireKind, definitionName);
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetAIKind(typeName, out var aiKind))
-            AddType(GetAIBucket(buckets, aiKind), typeName, source, definitionName);
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetAuthenticationKind(typeName, out var authenticationKind))
-            AddType(buckets.Authentication, typeName, source, authenticationKind, definitionName);
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetConfigurationKind(typeName, out var configurationKind))
-            AddType(buckets.Configuration, typeName, source, configurationKind, definitionName);
-        if (source == "TypeDef" && EcosystemIntegrationClassifier.TryGetOpenApiKind(typeName, out var openApiKind))
-            AddType(buckets.OpenApi, typeName, source, openApiKind, definitionName);
-        if (EcosystemIntegrationClassifier.TryGetDependencyInjectionKind(typeName, out var dependencyInjectionKind))
-            AddType(buckets.DependencyInjection, typeName, source, dependencyInjectionKind, definitionName);
-        if (EcosystemIntegrationClassifier.IsLoggingType(typeName))
-            AddType(buckets.Logging, typeName, source, definitionName);
-        if (EcosystemIntegrationClassifier.IsOptionsType(typeName))
-            AddType(buckets.Options, typeName, source, definitionName);
-        if (EcosystemIntegrationClassifier.IsHostingType(typeName))
-            AddType(buckets.Hosting, typeName, source, definitionName);
-        if (EcosystemIntegrationClassifier.IsHealthChecksType(typeName))
-            AddType(buckets.HealthChecks, typeName, source, definitionName);
-        if (EcosystemIntegrationClassifier.TryGetHttpClientKind(typeName, out var httpClientKind))
-            AddType(buckets.HttpClient, typeName, source, httpClientKind, definitionName);
+        IntegrationConceptDescriptor concept = classification.Concept;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.AI))
+            return GetAIBucket(buckets, classification.Kind);
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.AspNetCore))
+            return buckets.AspNetCore;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Aspire))
+            return buckets.Aspire;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Authentication))
+            return buckets.Authentication;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Configuration))
+            return buckets.Configuration;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.OpenAPI))
+            return buckets.OpenApi;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.DependencyInjection))
+            return buckets.DependencyInjection;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Logging))
+            return buckets.Logging;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Options))
+            return buckets.Options;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.Hosting))
+            return buckets.Hosting;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.HealthChecks))
+            return buckets.HealthChecks;
+        if (ReferenceEquals(concept, IntegrationConceptCatalog.HttpClient))
+            return buckets.HttpClient;
+        throw new InvalidOperationException("Unknown ecosystem Integration concept.");
     }
 
     private static IntegrationBucket GetAIBucket(IntegrationBuckets buckets, string kind) => kind switch
@@ -97,18 +100,6 @@ internal static class EcosystemIntegrationProjection
         IntegrationBucket bucket,
         string typeName,
         string source,
-        MetadataTypeDefinitionName? definitionName)
-        => AddType(
-            bucket,
-            typeName,
-            source,
-            bucket.ApiKind,
-            definitionName);
-
-    private static void AddType(
-        IntegrationBucket bucket,
-        string typeName,
-        string source,
         string kind,
         MetadataTypeDefinitionName? definitionName)
     {
@@ -125,92 +116,6 @@ internal static class EcosystemIntegrationProjection
         bucket.Kinds[typeName] = kind;
         if (definitionName is not null)
             bucket.TypeDefinitions.Add(typeName, definitionName);
-    }
-
-    private static void AddStarterMethods(
-        IntegrationBuckets buckets,
-        MetadataReader reader,
-        TypeDefinitionHandle typeDefinitionHandle,
-        TypeDefinition typeDefinition,
-        string typeName,
-        MetadataTypeDefinitionName? definitionName)
-    {
-        var attributes = typeDefinition.Attributes;
-        var isStatic = (attributes & TypeAttributes.Sealed) != 0
-                       && (attributes & TypeAttributes.Abstract) != 0;
-        if (!isStatic || !AttributeReader.HasExtensionAttribute(reader, typeDefinition.GetCustomAttributes()))
-            return;
-
-        foreach (var methodHandle in typeDefinition.GetMethods())
-        {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
-                || (method.Attributes & MethodAttributes.Static) == 0
-                || !AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes()))
-                continue;
-
-            var methodName = reader.GetString(method.Name);
-            var context = GenericContext.ForMethod(reader, typeDefinition, method);
-            MethodSignature<string> signature;
-            try
-            {
-                signature = GuardedSignatureText.MethodText(reader, method, context)
-                    .GetValueOrThrow();
-            }
-            catch (BadImageFormatException)
-            {
-                continue;
-            }
-            if (signature.ParameterTypes.Length == 0)
-                continue;
-
-            var api = $"{TypeResolver.FormatDisplayName(typeName)}.{methodName}(...)";
-            EcosystemIntegrationApiEvidence? evidence = null;
-            if (definitionName is not null)
-            {
-                try
-                {
-                    ExtensionMemberAnchorInfo anchor =
-                        ApiMemberIdentity.CreateExtensionMethodAnchorInfo(
-                            reader,
-                            typeDefinitionHandle,
-                            method);
-                    evidence = new EcosystemIntegrationApiEvidence(
-                        anchor.Anchor,
-                        definitionName,
-                        anchor.ExtendedTypeReference,
-                        anchor.ReturnTypeReference);
-                }
-                catch (BadImageFormatException)
-                {
-                    evidence = null;
-                }
-            }
-            if (EcosystemIntegrationClassifier.TryClassifyAspireStarterMethod(typeName, methodName, signature, out var aspireKind))
-                AddApi(buckets.Aspire, api, aspireKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyAIStarterMethod(typeName, methodName, signature, out var aiKind))
-                AddApi(GetAIBucket(buckets, aiKind), api, aiKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyAuthenticationStarterMethod(methodName, signature, out var authenticationKind))
-                AddApi(buckets.Authentication, api, authenticationKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyConfigurationStarterMethod(methodName, signature, out var configurationKind))
-                AddApi(buckets.Configuration, api, configurationKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyDependencyInjectionStarterMethod(typeName, methodName, signature, out var dependencyInjectionKind))
-                AddApi(buckets.DependencyInjection, api, dependencyInjectionKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyLoggingStarterMethod(typeName, methodName, signature, out var loggingKind))
-                AddApi(buckets.Logging, api, loggingKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyOpenApiStarterMethod(typeName, methodName, signature, out var openApiKind))
-                AddApi(buckets.OpenApi, api, openApiKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyOptionsStarterMethod(methodName, signature, out var optionsKind))
-                AddApi(buckets.Options, api, optionsKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyAspNetCoreStarterMethod(methodName, signature, out var aspNetCoreKind))
-                AddApi(buckets.AspNetCore, api, aspNetCoreKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyHealthChecksStarterMethod(methodName, signature, out var healthChecksKind))
-                AddApi(buckets.HealthChecks, api, healthChecksKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyHostingStarterMethod(typeName, methodName, signature, out var hostingKind))
-                AddApi(buckets.Hosting, api, hostingKind, evidence);
-            if (EcosystemIntegrationClassifier.TryClassifyHttpClientStarterMethod(typeName, methodName, signature, out var httpClientKind))
-                AddApi(buckets.HttpClient, api, httpClientKind, evidence);
-        }
     }
 
     static void AddApi(

--- a/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationScanner.cs
@@ -155,6 +155,23 @@ public record EcosystemIntegrationPresence
 /// </summary>
 public static class EcosystemIntegrationScanner
 {
+    /// <summary>Existing Aspire interpretation for staged application-catalog adoption.</summary>
+    public static EcosystemIntegrationScannerBinding AspireBinding { get; } =
+        EcosystemIntegrationScannerBinding.Create(EcosystemIntegrationClassifier.ClassifyAspire);
+
+    /// <summary>
+    /// Runs one selected interpretation over owner-produced observations.
+    /// The returned rows do not constitute full-library presence or a Census.
+    /// </summary>
+    public static List<EcosystemIntegrationSignalInfo> Scan(
+        EcosystemIntegrationObservationContext context,
+        EcosystemIntegrationScannerBinding binding)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(binding);
+        return EcosystemIntegrationProjection.Project(binding.Scan(context));
+    }
+
     public static List<EcosystemIntegrationSignalInfo> Scan(PEReader peReader)
     {
         if (!peReader.HasMetadata)

--- a/src/ILInspector.Metadata/EcosystemIntegrationScannerBinding.cs
+++ b/src/ILInspector.Metadata/EcosystemIntegrationScannerBinding.cs
@@ -1,0 +1,45 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>An opaque static interpretation, invoked only by Integration operations.</summary>
+public sealed class EcosystemIntegrationScannerBinding
+{
+    readonly Func<
+        EcosystemIntegrationObservationContext,
+        ImmutableArray<EcosystemIntegrationClassification>> _scan;
+
+    EcosystemIntegrationScannerBinding(
+        Func<EcosystemIntegrationObservationContext,
+            ImmutableArray<EcosystemIntegrationClassification>> scan)
+        => _scan = scan;
+
+    public static EcosystemIntegrationScannerBinding Create(
+        Func<EcosystemIntegrationObservationContext,
+            ImmutableArray<EcosystemIntegrationClassification>> scan)
+    {
+        ArgumentNullException.ThrowIfNull(scan);
+        if (scan.Target is not null || scan.GetInvocationList().Length != 1)
+        {
+            throw new ArgumentException(
+                "An Integration scanner must be exactly one target-free static method group.",
+                nameof(scan));
+        }
+
+        return new EcosystemIntegrationScannerBinding(scan);
+    }
+
+    internal ImmutableArray<EcosystemIntegrationClassification> Scan(
+        EcosystemIntegrationObservationContext context)
+    {
+        ImmutableArray<EcosystemIntegrationClassification> classifications =
+            _scan(context);
+        if (classifications.IsDefault)
+        {
+            throw new InvalidOperationException(
+                "The Integration scanner returned an uninitialized classification sequence.");
+        }
+
+        return classifications;
+    }
+}

--- a/src/dotnet-inspect.Tests/EcosystemIntegrationScannerTests.cs
+++ b/src/dotnet-inspect.Tests/EcosystemIntegrationScannerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
@@ -10,6 +11,234 @@ namespace DotnetInspector.Tests;
 
 public class EcosystemIntegrationScannerTests
 {
+    static int s_invocations;
+
+    [Fact]
+    public void AspireBinding_PreservesExistingCurrencyWithoutIncludingNeighboringConcepts()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly(includeAspire: true);
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+
+        List<EcosystemIntegrationSignalInfo> selected =
+            session.EcosystemIntegrations(EcosystemIntegrationScanner.AspireBinding);
+        List<EcosystemIntegrationSignalInfo> full = session.EcosystemIntegrations();
+
+        Assert.Equal(
+            [
+                new EcosystemIntegrationSignalInfo(
+                    EcosystemIntegrationNames.Aspire,
+                    "Resource Builder",
+                    "Aspire.Hosting.TestResourceBuilderExtensions.AddSample(...)",
+                    IntegrationSignalShape.Api),
+                new EcosystemIntegrationSignalInfo(
+                    EcosystemIntegrationNames.Aspire,
+                    "Resource",
+                    "Aspire.Hosting.ApplicationModel.SampleResource"),
+            ],
+            selected);
+        Assert.Equal(
+            full.Where(signal => signal.GetConcept() == IntegrationConceptCatalog.Aspire),
+            selected);
+        Assert.Contains(full, signal =>
+            signal.GetConcept() == IntegrationConceptCatalog.DependencyInjection);
+        Assert.Equal("AddSample", selected[0].GetApiEvidence()?.Member.MemberName);
+        Assert.Equal(
+            "Aspire.Hosting.IDistributedApplicationBuilder",
+            selected[0].GetApiEvidence()?.ReceiverType?.Type.ToMetadataFullName());
+        Assert.Equal(
+            "Aspire.Hosting.ApplicationModel.IResourceBuilder`1",
+            selected[0].GetApiEvidence()?.ReturnType?.Type.ToMetadataFullName());
+    }
+
+    [Fact]
+    public void AspireBinding_DoesNotClassifyNonAspireDependencyInjection()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly();
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+        Assert.Empty(session.EcosystemIntegrations(EcosystemIntegrationScanner.AspireBinding));
+        Assert.Equal(2, session.EcosystemIntegrations().Count);
+    }
+
+    [Fact]
+    public void Binding_ConstructionIsInertAndRejectsInstanceOrCombinedCallbacks()
+    {
+        s_invocations = 0;
+        EcosystemIntegrationScannerBinding binding =
+            EcosystemIntegrationScannerBinding.Create(CountAndClassify);
+        Assert.NotNull(binding);
+        Assert.Equal(0, s_invocations);
+
+        int captured = 0;
+        Assert.Throws<ArgumentException>(() =>
+            EcosystemIntegrationScannerBinding.Create(context =>
+            {
+                captured++;
+                return [];
+            }));
+        Func<EcosystemIntegrationObservationContext,
+            ImmutableArray<EcosystemIntegrationClassification>> combined = CountAndClassify;
+        combined += CountAndClassify;
+        Assert.Throws<ArgumentException>(() =>
+            EcosystemIntegrationScannerBinding.Create(combined));
+        Assert.Equal(0, captured);
+        Assert.Equal(0, s_invocations);
+    }
+
+    [Fact]
+    public void SelectedScan_PreservesOrderedRowsAndPresence()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly();
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+        s_invocations = 0;
+        var binding = EcosystemIntegrationScannerBinding.Create(CountAndClassify);
+
+        List<EcosystemIntegrationSignalInfo> full = session.EcosystemIntegrations();
+        List<EcosystemIntegrationSignalInfo> selected = session.EcosystemIntegrations(binding);
+
+        Assert.Equal(1, s_invocations);
+        Assert.Equal(full, selected);
+        Assert.Equal(
+            session.EcosystemIntegrationPresence(full),
+            session.EcosystemIntegrationPresence(selected));
+        Assert.Equal(full[0].GetApiEvidenceSet(), selected[0].GetApiEvidenceSet());
+        Assert.Equal(full[1].GetTypeDefinition(), selected[1].GetTypeDefinition());
+        Assert.Same(full[0].GetConcept(), selected[0].GetConcept());
+        Assert.Same(full[0].GetProducerPolicy(), selected[0].GetProducerPolicy());
+    }
+
+    [Fact]
+    public void Observations_PreserveParametersAndOutliveTheReader()
+    {
+        EcosystemIntegrationObservationContext context;
+        using (var stream = BuildDependencyInjectionExtensionAssembly(
+                   includeConfigurationParameter: true))
+        using (var session = AssemblyInspectionSession.OpenPrefetched(stream))
+        {
+            context = session.EcosystemIntegrationObservations();
+        }
+
+        EcosystemIntegrationMethodObservation configure = Assert.Single(
+            context.StarterMethods,
+            method => method.Name == "Configure");
+        Assert.Equal(
+            [
+                "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+                "Microsoft.Extensions.Configuration.IConfiguration",
+            ],
+            configure.ParameterTypes);
+        Assert.Equal("void", configure.ReturnType);
+        Assert.Contains(configure.DeclaringType, context.Types);
+        Assert.Equal(
+            configure.DeclaringType.Definition,
+            configure.Evidence?.DeclaringType);
+        var binding = EcosystemIntegrationScannerBinding.Create(ClassifyConfiguration);
+
+        EcosystemIntegrationSignalInfo signal = Assert.Single(
+            EcosystemIntegrationScanner.Scan(context, binding));
+
+        Assert.Same(IntegrationConceptCatalog.Configuration, signal.GetConcept());
+        Assert.Equal("Options Binding", signal.Kind);
+        Assert.Same(configure.Evidence, signal.GetApiEvidence());
+    }
+
+    [Fact]
+    public void SelectedScan_CoalescesRowsWithoutLosingOverloadEvidence()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly(
+            includeAdditionalOverload: true);
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+        EcosystemIntegrationObservationContext context =
+            session.EcosystemIntegrationObservations();
+        var binding = EcosystemIntegrationScannerBinding.Create(CountAndClassify);
+
+        List<EcosystemIntegrationSignalInfo> signals =
+            EcosystemIntegrationScanner.Scan(context, binding);
+
+        Assert.Equal(2, signals.Count);
+        EcosystemIntegrationSignalInfo api = signals[0];
+        Assert.Equal(IntegrationSignalShape.Api, api.Shape);
+        Assert.Equal(2, context.StarterMethods.Length);
+        ImmutableArray<EcosystemIntegrationApiEvidence> evidence = api.GetApiEvidenceSet();
+        Assert.Equal(2, evidence.Length);
+        Assert.NotEqual(evidence[0].Member, evidence[1].Member);
+        Assert.Same(context.StarterMethods[0].Evidence, evidence[0]);
+        Assert.Same(context.StarterMethods[1].Evidence, evidence[1]);
+        Assert.False(api.IsApiEvidenceIncomplete());
+    }
+
+    [Fact]
+    public void Observations_ExcludeReceiverlessAndUndecodableMethods()
+    {
+        using (var stream = BuildDependencyInjectionExtensionAssembly(
+                   includeMalformedExtension: true))
+        using (var session = AssemblyInspectionSession.OpenPrefetched(stream))
+        {
+            Assert.Equal(
+                "AddPublicThing",
+                Assert.Single(session.EcosystemIntegrationObservations().StarterMethods).Name);
+        }
+
+        using var invalidStream = new MemoryStream(
+            BuildAnchorOverBudgetExtensionAssembly(invalidSignature: true),
+            writable: false);
+        using var invalidSession = AssemblyInspectionSession.OpenPrefetched(invalidStream);
+        Assert.Empty(invalidSession.EcosystemIntegrationObservations().StarterMethods);
+        Assert.Empty(invalidSession.EcosystemIntegrations());
+    }
+
+    [Fact]
+    public void SelectedScan_PreservesClassifiedApiWithoutStructuredAnchor()
+    {
+        using var stream = new MemoryStream(
+            BuildAnchorOverBudgetExtensionAssembly(),
+            writable: false);
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+        EcosystemIntegrationObservationContext context =
+            session.EcosystemIntegrationObservations();
+        Assert.Null(Assert.Single(context.StarterMethods).Evidence);
+        var binding = EcosystemIntegrationScannerBinding.Create(CountAndClassify);
+
+        EcosystemIntegrationSignalInfo signal = Assert.Single(
+            EcosystemIntegrationScanner.Scan(context, binding));
+
+        Assert.Equal(IntegrationSignalShape.Api, signal.Shape);
+        Assert.Same(IntegrationConceptCatalog.DependencyInjection, signal.GetConcept());
+        Assert.Null(signal.GetApiEvidence());
+        Assert.True(signal.IsApiEvidenceIncomplete());
+    }
+
+    [Fact]
+    public void SelectedScan_DoesNotTreatDefaultClassificationsAsEmptySuccess()
+    {
+        using var stream = BuildDependencyInjectionExtensionAssembly();
+        using var session = AssemblyInspectionSession.OpenPrefetched(stream);
+        var binding = EcosystemIntegrationScannerBinding.Create(UninitializedClassifications);
+
+        Assert.Throws<InvalidOperationException>(() => session.EcosystemIntegrations(binding));
+    }
+
+    static ImmutableArray<EcosystemIntegrationClassification> CountAndClassify(
+        EcosystemIntegrationObservationContext context)
+    {
+        s_invocations++;
+        return EcosystemIntegrationClassifier.Classify(context);
+    }
+
+    static ImmutableArray<EcosystemIntegrationClassification> ClassifyConfiguration(
+        EcosystemIntegrationObservationContext context) =>
+        [
+            .. context.StarterMethods
+                .Where(method => method.Name == "Configure"
+                    && method.ParameterTypes.Contains(
+                        "Microsoft.Extensions.Configuration.IConfiguration"))
+                .Select(method => method.Classify(
+                    IntegrationConceptCatalog.Configuration,
+                    "Options Binding")),
+        ];
+
+    static ImmutableArray<EcosystemIntegrationClassification> UninitializedClassifications(
+        EcosystemIntegrationObservationContext context) => default;
+
     [Fact]
     public void Scan_ProjectsExactOrderedPublicCurrencyAndPresence()
     {
@@ -259,7 +488,10 @@ public class EcosystemIntegrationScannerTests
     }
 
     private static MemoryStream BuildDependencyInjectionExtensionAssembly(
-        bool includeMalformedExtension = false)
+        bool includeMalformedExtension = false,
+        bool includeAdditionalOverload = false,
+        bool includeConfigurationParameter = false,
+        bool includeAspire = false)
     {
         var assemblyBuilder = new PersistedAssemblyBuilder(
             new AssemblyName("IntegrationVisibilityFixture"),
@@ -281,6 +513,29 @@ public class EcosystemIntegrationScannerTests
 
         DefineExtensionMethod(extensions, "AddPublicThing", MethodAttributes.Public);
         DefineExtensionMethod(extensions, "AddInternalThing", MethodAttributes.Assembly);
+        if (includeAdditionalOverload)
+        {
+            var overload = extensions.DefineMethod(
+                "AddPublicThing",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(void),
+                [serviceCollectionType, typeof(string)]);
+            overload.SetCustomAttribute(extensionAttribute);
+            overload.GetILGenerator().Emit(OpCodes.Ret);
+        }
+        if (includeConfigurationParameter)
+        {
+            var configuration = module.DefineType(
+                "Microsoft.Extensions.Configuration.IConfiguration",
+                TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+            var configure = extensions.DefineMethod(
+                "Configure",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(void),
+                [serviceCollectionType, configuration.CreateType()]);
+            configure.SetCustomAttribute(extensionAttribute);
+            configure.GetILGenerator().Emit(OpCodes.Ret);
+        }
         if (includeMalformedExtension)
         {
             var malformed = extensions.DefineMethod(
@@ -293,6 +548,36 @@ public class EcosystemIntegrationScannerTests
         }
 
         extensions.CreateType();
+
+        if (includeAspire)
+        {
+            Type applicationBuilder = module.DefineType(
+                "Aspire.Hosting.IDistributedApplicationBuilder",
+                TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract)
+                .CreateType();
+            Type resource = module.DefineType(
+                "Aspire.Hosting.ApplicationModel.SampleResource",
+                TypeAttributes.Public | TypeAttributes.Class)
+                .CreateType();
+            TypeBuilder resourceBuilder = module.DefineType(
+                "Aspire.Hosting.ApplicationModel.IResourceBuilder`1",
+                TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract);
+            resourceBuilder.DefineGenericParameters("T");
+            Type builder = resourceBuilder.CreateType().MakeGenericType(resource);
+            TypeBuilder aspireExtensions = module.DefineType(
+                "Aspire.Hosting.TestResourceBuilderExtensions",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+            aspireExtensions.SetCustomAttribute(extensionAttribute);
+            MethodBuilder add = aspireExtensions.DefineMethod(
+                "AddSample",
+                MethodAttributes.Public | MethodAttributes.Static,
+                builder,
+                [applicationBuilder]);
+            add.SetCustomAttribute(extensionAttribute);
+            add.GetILGenerator().Emit(OpCodes.Ldnull);
+            add.GetILGenerator().Emit(OpCodes.Ret);
+            aspireExtensions.CreateType();
+        }
 
         var stream = new MemoryStream();
         assemblyBuilder.Save(stream);
@@ -341,7 +626,8 @@ public class EcosystemIntegrationScannerTests
         public int GetHashCode(IntegrationConceptDescriptor obj) => 0;
     }
 
-    private static byte[] BuildAnchorOverBudgetExtensionAssembly()
+    private static byte[] BuildAnchorOverBudgetExtensionAssembly(
+        bool invalidSignature = false)
     {
         const int ParameterCount = 400;
         const int GenericArity = 2030;
@@ -450,6 +736,8 @@ public class EcosystemIntegrationScannerTests
                 typeSpecificationIndex);
             methodSignature.WriteByte(0x08);
         }
+        if (invalidSignature)
+            methodSignature.Clear();
 
         metadata.AddTypeDefinition(
             TypeAttributes.NotPublic,


### PR DESCRIPTION
Enable ecosystem interpretation without creating a second metadata engine:
Integration-owned observations in, evidence-preserving Integration rows out.
This implements the focused scanner substrate while keeping existing library
inspection behavior and leaving catalog/host selection to their own slices.

Closes #5902. Implements step 2 of the six-step scanner track in #5728,
following the locked design in #5886.

## Demo

The new public API can select the existing Aspire interpretation without a
reader or acquisition service crossing into the semantic callback:

```csharp
using var session = AssemblyInspectionSession.Open(path);
var rows = session.EcosystemIntegrations(
    EcosystemIntegrationScanner.AspireBinding);
```

Captured with the Release implementation against
`Aspire.Hosting.PostgreSQL@13.5.3`, `lib/net8.0/Aspire.Hosting.PostgreSQL.dll`:

```text
Aspire.Hosting.PostgreSQL.dll
Observations: 6 public types, 15 starter methods
Selected Aspire: 6 rows; full scan: 6 rows
Resource Builder | Aspire.Hosting.PostgresBuilderExtensions.AddPostgres(...) | overload evidence: 1
Resource | Aspire.Hosting.ApplicationModel.PostgresDatabaseResource | overload evidence: 0
Resource | Aspire.Hosting.ApplicationModel.PostgresServerResource | overload evidence: 0
Resource | Aspire.Hosting.Postgres.PgAdminContainerResource | overload evidence: 0
Resource | Aspire.Hosting.Postgres.PgWebContainerResource | overload evidence: 0
```

Five of the six rows are shown. The selected rows equal the full scan's Aspire
subset. A neighboring `ILInspector.Metadata.dll` input returns zero selected
Aspire rows. The compiled DI fixture likewise returns no Aspire rows while
remaining DI currency in the full scan.

Boundary case: two `AddPublicThing` overloads still produce one compact API row,
with two distinct original member anchors. A classified method whose anchor is
unavailable keeps its row and incomplete-evidence marker.

## Design basis

One owner: Integrations,
`docs/design/integrations.md#authority` and
`docs/design/integration-scanner-binding.md`.

The binding retains one target-free static method group. Integration decodes
public types and admitted extension methods into immutable observations,
invokes one selected scanner, and projects classifications using the original
evidence. Concept/policy identity, kind ranking, ordering, deduplication, and
failure semantics remain with the owner.

Existing static capability and product-demo bindings provide the comparative
pattern; scanner invocation deliberately stays internal to the binding rather
than exposing a public delegate or `Invoke`.

## Meaningful changes

- Separate observation construction from interpretation and row projection;
  the current full scanner is the production consumer of the extraction.
- Preserve all decoded parameter types and structured evidence associations,
  including overload coalescing and reader-independent observation lifetime.
- Add an uncached group/role/participant selected operation. Its distinct
  result retains the selected binding, has no full-presence fields, and reuses
  existing rejected/failed participant outcomes.
- Keep callback/projection faults outside metadata-error mapping.
- Expose the existing Aspire predicates through an owner-side compatibility
  binding, so catalog adoption need not duplicate semantic policy.
- Update the owner docs and indexes to distinguish implemented substrate from
  pending catalog/CLI/browser adoption.

## Scope and compatibility

No new project, dependency, production friendship, catalog registration, CLI
flag, browser selection, acquisition path, Census policy, renderer, scanner
instance graph, retry, or cache. Kind remains the existing string/ranking
currency; no new kind registry is introduced.

Scanners are cooperating application code, not sandboxed plugins. The approved
evidence posture is public-outcome/parity testing and ordinary design review,
not source policing or a recursive reachable-API audit.

Remaining steps are Aspire catalog adoption, CLI adoption, browser
CatalogExports adoption, and owner-side Aspire compatibility-policy retirement.
Both hosts keep their existing typed results/lowering boundaries; CLI uses
Markout, browser uses its existing interactive DTO/UI path. Host-selection
parity and the first catalog/host binding publish-size measurement remain
explicit later gates.

## Validation

After integrating effective base
`30c22b09e67be4e98b1234eafab6480da67efdf2`:

```sh
dotnet run --project src/dotnet-inspect.Tests -c Release -- \
  --filter-class DotnetInspector.Tests.EcosystemIntegrationScannerTests \
    DotnetInspector.Tests.PackageIntegrationsWorkspaceTests --no-progress
# 49 passed

dotnet run --project src/DotnetInspector.Queries.Tests -c Release -- \
  -class DotnetInspector.Queries.Tests.AssemblyContextIntegrationsQueryTests \
  -class DotnetInspector.Queries.Tests.PackageAssemblyContextCompletionTests
# 39 passed

npx markdownlint-cli docs/design/integration-scanner-binding.md \
  docs/design/integrations.md docs/design/ecosystem-packs.md \
  docs/README.md docs/overview.md
git diff --check
```

The CLI test executable uses MTP; the Queries test executable still uses the
native xUnit runner, hence the different supported filter syntax. The public
query consumer tests are not friends of `ILInspector.Metadata`.
