### PR TITLE
Adopt keyed managed operations for Type Source

### DIFF
--- a/docs/design/inspect-web-managed-operation-bridge.md
+++ b/docs/design/inspect-web-managed-operation-bridge.md
@@ -675,6 +675,48 @@ Implementation proceeds in independently coherent slices:
 The migration must not thread browser operation IDs into host-neutral
 inspection models. IDs terminate at the browser host adapter.
 
+### Source-host adoption and retirement
+
+The first production consumer is the existing Type Source view, tracked by
+[#5419](https://github.com/richlander/dotnet-inspect/issues/5419). Its
+operation-authority adapter passes the page-owned ID and normalized cancellation
+reason through the generated source facade. The managed wrapper participates
+in the existing aggregate source-acquisition budget; keyed admission does not
+authorize concurrent source acquisition. Its scope and budget leases are
+released before the managed terminal result settles.
+
+Type Source has no nonterminal payload in this slice. It uses the bridge's
+existing admission-without-callback contract rather than manufacturing progress
+events. Its concrete result and cancellation-status DTOs use supported
+source-generated JSON contracts; native C# JSON union projection is not a
+prerequisite. Source rendering, provenance, and acquisition policy remain
+feature-owned.
+
+`BrowserTypeSourceOperationTests` gates keyed cancellation, shared-budget
+accounting, result classification, and lease release in the Release engine
+suite. `test/type-source-managed-operation.test.ts` gates browser-adapter
+publication, late-failure diagnostics, cancellation, and quiescence;
+`scripts/verify-engine-facade-runtime.ts` gates the generated DTO projection
+and argument forwarding.
+
+Source singleton retirement has **two ordered adoption slices**:
+
+1. migrate the Type Source export and its production caller together to keyed
+   admission, cancellation, and terminal results;
+2. migrate the remaining member-source and graph-source callers and their
+   exports to the same operation-keyed boundary, then remove parameterless
+   source cancellation and the singleton cancellation slot in that slice,
+   retaining the feature's aggregate acquisition-budget enforcement.
+
+Only the first slice is included here. The legacy source coordinator remains
+necessary for the other callers. Shared-producer subscriptions and epoch-work
+leases remain separate bridge work, not a replacement for this source budget.
+The end-to-end Worker adoption scenario is
+[#5420](https://github.com/richlander/dotnet-inspect/issues/5420), composed through
+[#5095](https://github.com/richlander/dotnet-inspect/issues/5095). This direct
+facade adoption does not move work off the DOM thread or establish a
+responsiveness or prompt physical-cancellation claim.
+
 ## Checked abstract model
 
 The companion TLA+ model covers two managed operations and one shared producer.

--- a/prototypes/inspect-web/engine.Core/BrowserSourceOperationCoordinator.cs
+++ b/prototypes/inspect-web/engine.Core/BrowserSourceOperationCoordinator.cs
@@ -13,16 +13,24 @@ internal static class BrowserSourceOperationCoordinator
     static readonly SemaphoreSlim Gate = new(1, 1);
     static SourceOperation? _current;
 
-    internal static async ValueTask<BrowserSourceOperationLease> BeginAsync()
+    internal static ValueTask<BrowserSourceOperationLease> BeginAsync() =>
+        BeginAsync(new SourceOperation());
+
+    internal static ValueTask<BrowserSourceOperationLease> BeginAsync(
+        CancellationToken cancellationToken,
+        Action<BrowserManagedOperationCancelReason> requestCancellation) =>
+        BeginAsync(new SourceOperation(cancellationToken, requestCancellation));
+
+    static async ValueTask<BrowserSourceOperationLease> BeginAsync(
+        SourceOperation operation)
     {
-        var operation = new SourceOperation();
         SourceOperation? superseded =
             Interlocked.Exchange(ref _current, operation);
-        superseded?.Cancel();
 
         bool entered = false;
         try
         {
+            superseded?.Cancel(BrowserManagedOperationCancelReason.Superseded);
             await Gate.WaitAsync(operation.Token);
             entered = true;
             operation.Token.ThrowIfCancellationRequested();
@@ -41,7 +49,7 @@ internal static class BrowserSourceOperationCoordinator
     }
 
     internal static void CancelCurrent() =>
-        Volatile.Read(ref _current)?.Cancel();
+        Volatile.Read(ref _current)?.Cancel(BrowserManagedOperationCancelReason.User);
 
     static void Complete(SourceOperation operation)
     {
@@ -53,17 +61,38 @@ internal static class BrowserSourceOperationCoordinator
     sealed class SourceOperation : IDisposable
     {
         readonly object _sync = new();
-        readonly CancellationTokenSource _cancellation = new();
+        readonly CancellationTokenSource? _cancellation;
+        readonly Action<BrowserManagedOperationCancelReason>? _requestCancellation;
         bool _disposed;
 
-        internal CancellationToken Token => _cancellation.Token;
+        internal SourceOperation()
+        {
+            _cancellation = new();
+            Token = _cancellation.Token;
+        }
 
-        internal void Cancel()
+        internal SourceOperation(
+            CancellationToken token,
+            Action<BrowserManagedOperationCancelReason> requestCancellation)
+        {
+            ArgumentNullException.ThrowIfNull(requestCancellation);
+            Token = token;
+            _requestCancellation = requestCancellation;
+        }
+
+        internal CancellationToken Token { get; }
+
+        internal void Cancel(BrowserManagedOperationCancelReason reason)
         {
             lock (_sync)
             {
                 if (!_disposed)
-                    _cancellation.Cancel();
+                {
+                    if (_requestCancellation is { } requestCancellation)
+                        requestCancellation(reason);
+                    else
+                        _cancellation!.Cancel();
+                }
             }
         }
 
@@ -74,7 +103,7 @@ internal static class BrowserSourceOperationCoordinator
                 if (_disposed)
                     return;
                 _disposed = true;
-                _cancellation.Dispose();
+                _cancellation?.Dispose();
             }
         }
     }

--- a/prototypes/inspect-web/engine.SourceExports/BrowserSourceContracts.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserSourceContracts.cs
@@ -191,6 +191,8 @@ public sealed record BrowserAnnotatedSource
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(BrowserSource))]
+[JsonSerializable(typeof(BrowserTypeSourceResult))]
+[JsonSerializable(typeof(BrowserTypeSourceCancellation))]
 [JsonSerializable(typeof(BrowserAnnotatedSource))]
 [JsonSerializable(typeof(string[]))]
 internal sealed partial class BrowserSourceJsonContext : JsonSerializerContext;

--- a/prototypes/inspect-web/engine.SourceExports/BrowserTypeSourceOperation.cs
+++ b/prototypes/inspect-web/engine.SourceExports/BrowserTypeSourceOperation.cs
@@ -1,0 +1,99 @@
+using System.Text.Json.Serialization;
+
+namespace InspectWeb.Engine.SourceFacade;
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserTypeSourceResultKind>))]
+public enum BrowserTypeSourceResultKind
+{
+    Succeeded,
+    Failed,
+    Canceled,
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserTypeSourceFailureKind>))]
+public enum BrowserTypeSourceFailureKind
+{
+    Expected,
+    Unexpected,
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<BrowserTypeSourceCancellationKind>))]
+public enum BrowserTypeSourceCancellationKind
+{
+    Requested,
+    AlreadyRequested,
+    NotActive,
+}
+
+public sealed record BrowserTypeSourceResult(
+    int Version,
+    BrowserTypeSourceResultKind Kind,
+    BrowserSource? Value,
+    BrowserTypeSourceFailureKind? FailureKind,
+    string? Error,
+    string? Diagnostic,
+    string? Reason)
+{
+    internal static BrowserTypeSourceResult From(
+        BrowserManagedOperationResult<BrowserSource, string, string> result) =>
+        result switch
+        {
+            BrowserManagedOperationResult<BrowserSource, string, string>.Succeeded succeeded =>
+                new(1, BrowserTypeSourceResultKind.Succeeded, succeeded.Value, null, null, null, null),
+            BrowserManagedOperationResult<BrowserSource, string, string>.Failed failed =>
+                new(1, BrowserTypeSourceResultKind.Failed, null,
+                    failed.FailureKind switch
+                    {
+                        BrowserManagedOperationFailureKind.Expected => BrowserTypeSourceFailureKind.Expected,
+                        BrowserManagedOperationFailureKind.Unexpected => BrowserTypeSourceFailureKind.Unexpected,
+                        _ => throw new ArgumentOutOfRangeException(nameof(result)),
+                    },
+                    failed.Error, failed.Diagnostic, null),
+            BrowserManagedOperationResult<BrowserSource, string, string>.Canceled canceled =>
+                new(1, BrowserTypeSourceResultKind.Canceled, null, null, null, null,
+                    BrowserTypeSourceCancellation.FormatReason(canceled.Reason)),
+            _ => throw new ArgumentOutOfRangeException(nameof(result)),
+        };
+}
+
+public sealed record BrowserTypeSourceCancellation(
+    BrowserTypeSourceCancellationKind Kind,
+    string? Reason)
+{
+    internal static BrowserTypeSourceCancellation From(
+        BrowserManagedCancellationRequestResult result) =>
+        result switch
+        {
+            BrowserManagedCancellationRequestResult.Requested requested =>
+                new(BrowserTypeSourceCancellationKind.Requested, FormatReason(requested.Reason)),
+            BrowserManagedCancellationRequestResult.AlreadyRequested requested =>
+                new(BrowserTypeSourceCancellationKind.AlreadyRequested, FormatReason(requested.Reason)),
+            BrowserManagedCancellationRequestResult.NotActive =>
+                new(BrowserTypeSourceCancellationKind.NotActive, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(result)),
+        };
+
+    internal static string FormatReason(BrowserManagedOperationCancelReason reason) =>
+        reason switch
+        {
+            BrowserManagedOperationCancelReason.User => "user",
+            BrowserManagedOperationCancelReason.Superseded => "superseded",
+            BrowserManagedOperationCancelReason.Disposed => "disposed",
+            BrowserManagedOperationCancelReason.FeatureObserverFailed => "feature-observer-failed",
+            BrowserManagedOperationCancelReason.Timeout => "timeout",
+            BrowserManagedOperationCancelReason.WorkerRestarted => "worker-restarted",
+            _ => throw new ArgumentOutOfRangeException(nameof(reason)),
+        };
+
+    internal static BrowserManagedOperationCancelReason ParseReason(string reason) =>
+        reason switch
+        {
+            "user" => BrowserManagedOperationCancelReason.User,
+            "superseded" => BrowserManagedOperationCancelReason.Superseded,
+            "disposed" => BrowserManagedOperationCancelReason.Disposed,
+            "feature-observer-failed" => BrowserManagedOperationCancelReason.FeatureObserverFailed,
+            "timeout" => BrowserManagedOperationCancelReason.Timeout,
+            "worker-restarted" => BrowserManagedOperationCancelReason.WorkerRestarted,
+            _ => throw new ArgumentException("Unknown type-source cancellation reason.", nameof(reason)),
+        };
+}

--- a/prototypes/inspect-web/engine.SourceExports/SourceExports.cs
+++ b/prototypes/inspect-web/engine.SourceExports/SourceExports.cs
@@ -15,6 +15,7 @@ using InspectWeb.Engine.SourceFacade;
 [SupportedOSPlatform("browser")]
 public static partial class SourceExports
 {
+    static readonly BrowserManagedOperationBridge TypeSourceOperations = new();
     const long MiB = 1024L * 1024;
     static readonly SymbolAcquisitionLimits SourceSymbolLimits =
         new(
@@ -26,6 +27,18 @@ public static partial class SourceExports
     [JSExport]
     public static void CancelSourceQuery() =>
         BrowserSourceOperationCoordinator.CancelCurrent();
+
+    [JSExport]
+    public static string CancelTypeSourceQuery(string operationId, string reason)
+    {
+        BrowserTypeSourceCancellation result = BrowserTypeSourceCancellation.From(
+            TypeSourceOperations.RequestCancellation(
+                BrowserManagedOperationId.From(operationId),
+                BrowserTypeSourceCancellation.ParseReason(reason)));
+        return JsonSerializer.Serialize(
+            result,
+            BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation);
+    }
 
     [JSExport]
     public static async Task<string> QueryMemberSource(
@@ -56,6 +69,7 @@ public static partial class SourceExports
 
     [JSExport]
     public static async Task<string> QueryTypeSource(
+        string operationId,
         string packageId,
         string version,
         string targetFramework,
@@ -63,8 +77,45 @@ public static partial class SourceExports
         string typeIdentity,
         string styleOptionsJson)
     {
-        using BrowserSourceOperationLease operation =
-            await BrowserSourceOperationCoordinator.BeginAsync();
+        BrowserManagedOperationId id = BrowserManagedOperationId.From(operationId);
+        BrowserManagedOperationResult<BrowserSource, string, string> result =
+            await TypeSourceOperations.RunAsync<BrowserSource, string, string, object>(
+                id,
+                eventCallback: null,
+                async (token, _) =>
+                {
+                    using BrowserSourceOperationLease operation =
+                        await BrowserSourceOperationCoordinator.BeginAsync(
+                            token,
+                            reason => TypeSourceOperations.RequestCancellation(id, reason));
+                    try
+                    {
+                        return new BrowserManagedOperationBodyResult<BrowserSource, string, string>.Succeeded(
+                            await QueryTypeSourceCore(
+                                packageId, version, targetFramework, assemblyName,
+                                typeIdentity, styleOptionsJson, token));
+                    }
+                    catch (TypeSourceUnavailableException error)
+                    {
+                        return new BrowserManagedOperationBodyResult<BrowserSource, string, string>.Failed(
+                            error.Message, error.ToString());
+                    }
+                },
+                error => new(error.Message, error.ToString()));
+        return JsonSerializer.Serialize(
+            BrowserTypeSourceResult.From(result),
+            BrowserSourceJsonContext.Default.BrowserTypeSourceResult);
+    }
+
+    static async Task<BrowserSource> QueryTypeSourceCore(
+        string packageId,
+        string version,
+        string targetFramework,
+        string assemblyName,
+        string typeIdentity,
+        string styleOptionsJson,
+        CancellationToken cancellationToken)
+    {
         (
             BrowserScopeLease<BrowserInspectionScope> scopeLease,
             BrowserWorkspaceParticipant participant,
@@ -75,7 +126,7 @@ public static partial class SourceExports
             targetFramework,
             assemblyName,
             typeIdentity,
-            operation.CancellationToken);
+            cancellationToken);
         using (scopeLease)
         {
             BrowserInspectionScope scope = scopeLease.Scope;
@@ -89,11 +140,9 @@ public static partial class SourceExports
                     member,
                     request,
                     CreateSourceContext(),
-                    operation.CancellationToken));
+                    cancellationToken));
 
-            return JsonSerializer.Serialize(
-                Adapt(result, participant),
-                BrowserSourceJsonContext.Default.BrowserSource);
+            return Adapt(result, participant);
         }
     }
 
@@ -218,7 +267,7 @@ public static partial class SourceExports
             cancellationToken.ThrowIfCancellationRequested();
             if (projected.Truncation is { } truncation)
             {
-                throw new InvalidOperationException(
+                throw new TypeSourceUnavailableException(
                     $"The source surface for '{typeIdentity}' exceeds the browser projection "
                     + "bounds. "
                     + BrowserApiSurfacePolicy.TruncationNotice(truncation));
@@ -237,7 +286,7 @@ public static partial class SourceExports
             ];
             if (matches.Length != 1)
             {
-                throw new InvalidOperationException(
+                throw new TypeSourceUnavailableException(
                     $"The selected participant does not contain one exact type '{typeIdentity}'.");
             }
 
@@ -294,17 +343,20 @@ public static partial class SourceExports
             AssemblyTypeSourceEntry.Available available =>
                 Adapt(available.Source, participant),
             AssemblyTypeSourceEntry.Rejected rejected =>
-                throw new InvalidOperationException(
+                throw new TypeSourceUnavailableException(
                     $"{rejected.Failure.Kind}: {rejected.Failure.Detail}"),
             AssemblyTypeSourceEntry.Unavailable unavailable =>
-                throw SourceUnavailable(
+                throw new TypeSourceUnavailableException(SourceUnavailable(
                     unavailable.Failure,
                     unavailable.PdbAttempt is { } pdb
                         ? PdbSourceLimitation(pdb.Lines)
-                        : null),
+                        : null).Message, unavailable.Failure.Error),
             _ => throw new InvalidOperationException(
                 "Unknown assembly type source result."),
         };
+
+    sealed class TypeSourceUnavailableException(string message, Exception? inner = null)
+        : InvalidOperationException(message, inner);
 
     static BrowserSource Adapt(
         AssemblyMemberSource source,

--- a/prototypes/inspect-web/engine.Tests/BrowserTypeSourceOperationTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserTypeSourceOperationTests.cs
@@ -1,0 +1,277 @@
+using System.IO.Compression;
+using System.Runtime.Versioning;
+using System.Text.Json;
+using InspectWeb.Engine.SourceFacade;
+using TsJsExport;
+
+namespace InspectWeb.Engine.Tests;
+
+[CollectionDefinition("Type source operations", DisableParallelization = true)]
+public sealed class TypeSourceOperationCollection;
+
+[Collection("Type source operations")]
+[SupportedOSPlatform("browser")]
+public sealed class BrowserTypeSourceOperationTests(ITestOutputHelper output)
+{
+    [Fact]
+    public async Task RunningManagedSource_RetainsBudgetUntilReleaseAndKeepsUserReasonAcrossLegacySupersession()
+    {
+        var bridge = new BrowserManagedOperationBridge();
+        BrowserManagedOperationId id = BrowserManagedOperationId.From(Guid.NewGuid().ToString());
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<BrowserManagedOperationResult<int, string, string>> running =
+            bridge.RunAsync<int, string, string, object>(
+                id, null,
+                async (token, _) =>
+                {
+                    using BrowserSourceOperationLease lease =
+                        await BrowserSourceOperationCoordinator.BeginAsync(
+                            token, reason => bridge.RequestCancellation(id, reason));
+                    await release.Task;
+                    token.ThrowIfCancellationRequested();
+                    return new BrowserManagedOperationBodyResult<int, string, string>.Succeeded(1);
+                },
+                error => new(error.Message, error.ToString()));
+
+        Assert.IsType<BrowserManagedCancellationRequestResult.Requested>(
+            bridge.RequestCancellation(id, BrowserManagedOperationCancelReason.User));
+        Task<BrowserSourceOperationLease> legacy =
+            BrowserSourceOperationCoordinator.BeginAsync().AsTask();
+        var repeated = Assert.IsType<BrowserManagedCancellationRequestResult.AlreadyRequested>(
+            bridge.RequestCancellation(id, BrowserManagedOperationCancelReason.Timeout));
+        Assert.Equal(BrowserManagedOperationCancelReason.User, repeated.Reason);
+        Assert.False(running.IsCompleted);
+        Assert.False(legacy.IsCompleted);
+        Assert.Equal(1, bridge.ActiveCount);
+        release.SetResult();
+
+        var canceled = Assert.IsType<BrowserManagedOperationResult<int, string, string>.Canceled>(
+            await running);
+        Assert.Equal(BrowserManagedOperationCancelReason.User, canceled.Reason);
+        Assert.Equal(0, bridge.ActiveCount);
+        using BrowserSourceOperationLease successor = await legacy;
+        Assert.False(successor.CancellationToken.IsCancellationRequested);
+    }
+
+    [Theory]
+    [InlineData("user")]
+    [InlineData("superseded")]
+    [InlineData("disposed")]
+    [InlineData("feature-observer-failed")]
+    [InlineData("timeout")]
+    [InlineData("worker-restarted")]
+    public async Task CanceledGateWaiter_PreservesFirstReasonAndReleasesOnlyItsOwnResources(
+        string reason)
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> waiting = Query(id);
+        Assert.False(waiting.IsCompleted);
+
+        BrowserTypeSourceCancellation first = Cancel(id, reason);
+        Assert.Equal(BrowserTypeSourceCancellationKind.Requested, first.Kind);
+        Assert.Equal(reason, first.Reason);
+        BrowserTypeSourceCancellation repeated = Cancel(id, "user");
+        if (repeated.Kind == BrowserTypeSourceCancellationKind.AlreadyRequested)
+            Assert.Equal(reason, repeated.Reason);
+        else
+            Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, repeated.Kind);
+
+        BrowserTypeSourceResult result = Read(await waiting);
+        Assert.Equal(BrowserTypeSourceResultKind.Canceled, result.Kind);
+        Assert.Equal(reason, result.Reason);
+        Assert.Null(result.Value);
+        Assert.Null(result.Error);
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, Cancel(id).Kind);
+
+        Task<BrowserSourceOperationLease> next =
+            BrowserSourceOperationCoordinator.BeginAsync().AsTask();
+        Assert.False(next.IsCompleted);
+        holder.Dispose();
+        using BrowserSourceOperationLease successor = await next;
+        Assert.False(successor.CancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task LegacySupersession_RecordsReasonBeforeCancelingManagedWaiter()
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> typeSource = Query(id);
+        Task<BrowserSourceOperationLease> memberSource =
+            BrowserSourceOperationCoordinator.BeginAsync().AsTask();
+
+        Assert.Equal("superseded", Read(await typeSource).Reason);
+        Assert.False(memberSource.IsCompleted);
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, Cancel(id).Kind);
+        holder.Dispose();
+        using BrowserSourceOperationLease member = await memberSource;
+        Assert.False(member.CancellationToken.IsCancellationRequested);
+        SourceExports.CancelSourceQuery();
+        Assert.True(member.CancellationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task KeyedCancellationOfOldOperation_DoesNotCancelReplacement()
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string firstId = Guid.NewGuid().ToString();
+        string secondId = Guid.NewGuid().ToString();
+        Task<string> first = Query(firstId);
+        Task<string> second = Query(secondId);
+        string firstJson = await first;
+        output.WriteLine($"A terminal: {firstJson}");
+        Assert.Equal("superseded", Read(firstJson).Reason);
+        string oldCancellation = SourceExports.CancelTypeSourceQuery(firstId, "user");
+        output.WriteLine($"Cancel A after B starts: {oldCancellation}");
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive,
+            JsonSerializer.Deserialize(oldCancellation,
+                BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!.Kind);
+        Assert.False(second.IsCompleted);
+        output.WriteLine($"B remains pending: {!second.IsCompleted}");
+        Assert.Equal(BrowserTypeSourceCancellationKind.Requested, Cancel(secondId).Kind);
+        string secondJson = await second;
+        output.WriteLine($"B terminal: {secondJson}");
+        Assert.Equal("user", Read(secondJson).Reason);
+        string settledCancellation = SourceExports.CancelTypeSourceQuery(secondId, "user");
+        output.WriteLine($"Cancel B after settlement: {settledCancellation}");
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive,
+            JsonSerializer.Deserialize(settledCancellation,
+                BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!.Kind);
+    }
+
+    [Fact]
+    public async Task LegacyCancellation_UsesUserReasonForManagedWaiter()
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> waiting = Query(id);
+        SourceExports.CancelSourceQuery();
+        Assert.Equal("user", Read(await waiting).Reason);
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, Cancel(id).Kind);
+    }
+
+    [Fact]
+    public async Task DuplicateActiveId_RejectsWithoutReplacingOriginal()
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> original = Query(id);
+        var error = await Assert.ThrowsAsync<BrowserManagedOperationBoundaryException>(
+            () => Query(id));
+        Assert.Equal("duplicate-active-operation", error.FailureKind);
+        Assert.False(original.IsCompleted);
+        Assert.Equal(BrowserTypeSourceCancellationKind.Requested, Cancel(id).Kind);
+        Assert.Equal("user", Read(await original).Reason);
+    }
+
+    [Fact]
+    public async Task InvalidReason_RejectsWithoutCancelingActiveOperation()
+    {
+        using BrowserSourceOperationLease holder =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        string id = Guid.NewGuid().ToString();
+        Task<string> waiting = Query(id);
+        Assert.Throws<ArgumentException>(() => SourceExports.CancelTypeSourceQuery(id, "other"));
+        Assert.False(waiting.IsCompleted);
+        Cancel(id, "disposed");
+        Assert.Equal("disposed", Read(await waiting).Reason);
+        await Assert.ThrowsAsync<ArgumentException>(() => Query(""));
+    }
+
+    [Fact]
+    public async Task ExportSuccess_PreservesSourceAndProvenanceAndReleasesScope()
+    {
+        const string packageId = "Type.Source.Bridge.Success";
+        RegisterSourcePackage(packageId);
+        string id = Guid.NewGuid().ToString();
+        BrowserTypeSourceResult result = Read(await SourceExports.QueryTypeSource(
+            id, packageId, "1.0.0", "net11.0", "TsJsExport.Contracts.dll",
+            "TsJsExport.JsExportRootAttribute", "[]"));
+
+        Assert.Equal(1, result.Version);
+        Assert.Equal(BrowserTypeSourceResultKind.Succeeded, result.Kind);
+        Assert.NotNull(result.Value);
+        Assert.Equal("decompiled", result.Value.Provider);
+        Assert.Contains("JsExportRootAttribute", result.Value.Text);
+        Assert.Contains(packageId, result.Value.Provenance);
+        Assert.Null(result.Value.Url);
+        Assert.NotNull(result.Value.PdbSourceLimitation);
+        await AssertReleased(id, packageId);
+    }
+
+    [Fact]
+    public async Task MissingType_IsExpectedFailureAndReleasesScope()
+    {
+        const string packageId = "Type.Source.Bridge.Missing";
+        RegisterSourcePackage(packageId);
+        string id = Guid.NewGuid().ToString();
+        BrowserTypeSourceResult result = Read(await SourceExports.QueryTypeSource(
+            id, packageId, "1.0.0", "net11.0", "TsJsExport.Contracts.dll",
+            "Missing.Type", "[]"));
+
+        Assert.Equal(BrowserTypeSourceResultKind.Failed, result.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Expected, result.FailureKind);
+        Assert.Contains("does not contain one exact type", result.Error);
+        Assert.Contains("Missing.Type", result.Diagnostic);
+        Assert.Null(result.Value);
+        await AssertReleased(id, packageId);
+    }
+
+    [Fact]
+    public async Task ProducerException_IsUnexpectedFailureAndReleasesScope()
+    {
+        const string packageId = "Type.Source.Bridge.Unexpected";
+        RegisterSourcePackage(packageId);
+        string id = Guid.NewGuid().ToString();
+        BrowserTypeSourceResult result = Read(await SourceExports.QueryTypeSource(
+            id, packageId, "1.0.0", "net11.0", "TsJsExport.Contracts.dll",
+            "TsJsExport.JsExportRootAttribute", "{"));
+
+        Assert.Equal(BrowserTypeSourceResultKind.Failed, result.Kind);
+        Assert.Equal(BrowserTypeSourceFailureKind.Unexpected, result.FailureKind);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+        Assert.Contains("JsonException", result.Diagnostic);
+        await AssertReleased(id, packageId);
+    }
+
+    static async Task AssertReleased(string id, string packageId)
+    {
+        Assert.Equal(BrowserTypeSourceCancellationKind.NotActive, Cancel(id).Kind);
+        using BrowserSourceOperationLease next =
+            await BrowserSourceOperationCoordinator.BeginAsync();
+        BrowserInspectionScope scope = await BrowserPackageWorkspace.OpenScopeAsync(
+            packageId, "1.0.0", "net11.0");
+        BrowserPackageWorkspace.RemoveScope(scope);
+        Assert.False(BrowserPackageWorkspace.IsScopeRetained(scope));
+    }
+
+    static Task<string> Query(string id) => SourceExports.QueryTypeSource(
+        id, "", "1.0.0", "net11.0", "Example.dll", "Example.Type", "[]");
+
+    static BrowserTypeSourceCancellation Cancel(string id, string reason = "user") =>
+        JsonSerializer.Deserialize(
+            SourceExports.CancelTypeSourceQuery(id, reason),
+            BrowserSourceJsonContext.Default.BrowserTypeSourceCancellation)!;
+
+    static BrowserTypeSourceResult Read(string json) =>
+        JsonSerializer.Deserialize(
+            json, BrowserSourceJsonContext.Default.BrowserTypeSourceResult)!;
+
+    static void RegisterSourcePackage(string packageId)
+    {
+        using var bytes = new MemoryStream();
+        using (var archive = new ZipArchive(bytes, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using Stream entry = archive.CreateEntry("lib/net11.0/TsJsExport.Contracts.dll").Open();
+            entry.Write(File.ReadAllBytes(typeof(JsExportRootAttribute).Assembly.Location));
+        }
+        BrowserPackageWorkspace.RegisterAcquiredPackage(
+            new BrowserPackage(packageId, "1.0.0", bytes.ToArray(), fromCache: false));
+    }
+}

--- a/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
+++ b/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
@@ -94,6 +94,7 @@ public sealed class ProductionFacadeContextTests
         [SourceAssembly] =
         [
             "CancelSourceQuery",
+            "CancelTypeSourceQuery",
             "QueryMemberAnnotatedSource",
             "QueryMemberSource",
             "QueryTypeMemberSource",
@@ -156,10 +157,10 @@ public sealed class ProductionFacadeContextTests
                 actual[assembly]);
         }
 
-        // 48 operations, and no operation name in two modules: a move that forgot to delete its
+        // 49 operations, and no operation name in two modules: a move that forgot to delete its
         // origin, or a name published twice, fails here rather than in the browser.
         string[] everyExport = [.. actual.Values.SelectMany(names => names)];
-        Assert.Equal(48, everyExport.Length);
+        Assert.Equal(49, everyExport.Length);
         Assert.Equal(
             everyExport.Length,
             everyExport.Distinct(StringComparer.Ordinal).Count());

--- a/prototypes/inspect-web/engine/facades/inspect-web-source.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-source.ts
@@ -4,6 +4,12 @@ export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" |
 
 export type BrowserAnnotatedSourceMedium = "CSharp" | "Il" | number;
 
+export type BrowserTypeSourceCancellationKind = "Requested" | "AlreadyRequested" | "NotActive" | number;
+
+export type BrowserTypeSourceFailureKind = "Expected" | "Unexpected" | number;
+
+export type BrowserTypeSourceResultKind = "Succeeded" | "Failed" | "Canceled" | number;
+
 export interface BrowserAnnotatedSource {
   readonly document: unknown;
   readonly viewerCatalog: BrowserAnnotatedSourceViewerCatalog;
@@ -58,13 +64,29 @@ export interface BrowserSource {
   readonly text: string;
 }
 
+export interface BrowserTypeSourceCancellation {
+  readonly kind: BrowserTypeSourceCancellationKind;
+  readonly reason: string | null;
+}
+
+export interface BrowserTypeSourceResult {
+  readonly version: number;
+  readonly kind: BrowserTypeSourceResultKind;
+  readonly value: BrowserSource | null;
+  readonly failureKind: BrowserTypeSourceFailureKind | null;
+  readonly error: string | null;
+  readonly diagnostic: string | null;
+  readonly reason: string | null;
+}
+
 type $ManagedExports = {
   readonly "SourceExports": {
     readonly "CancelSourceQuery.19325221": () => void;
+    readonly "CancelTypeSourceQuery.271973316": (operationId: string, reason: string) => string;
     readonly "QueryMemberAnnotatedSource.1135530322": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
     readonly "QueryMemberSource.641907440": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
     readonly "QueryTypeMemberSource.641907440": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string) => Promise<string>;
-    readonly "QueryTypeSource.649160465": (packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string) => Promise<string>;
+    readonly "QueryTypeSource.1160082336": (operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string) => Promise<string>;
   };
 };
 
@@ -121,6 +143,14 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "SourceExports");
+    value = $ownDataProperty(value, "CancelTypeSourceQuery.271973316");
+    if (typeof value !== "function") {
+      throw new Error("Managed export \u0027SourceExports.CancelTypeSourceQuery.271973316\u0027 is not callable.");
+    }
+  }
+  {
+    let value: unknown = exports;
+    value = $ownDataProperty(value, "SourceExports");
     value = $ownDataProperty(value, "QueryMemberAnnotatedSource.1135530322");
     if (typeof value !== "function") {
       throw new Error("Managed export \u0027SourceExports.QueryMemberAnnotatedSource.1135530322\u0027 is not callable.");
@@ -145,9 +175,9 @@ function $validateManagedExports(exports: unknown): asserts exports is $ManagedE
   {
     let value: unknown = exports;
     value = $ownDataProperty(value, "SourceExports");
-    value = $ownDataProperty(value, "QueryTypeSource.649160465");
+    value = $ownDataProperty(value, "QueryTypeSource.1160082336");
     if (typeof value !== "function") {
-      throw new Error("Managed export \u0027SourceExports.QueryTypeSource.649160465\u0027 is not callable.");
+      throw new Error("Managed export \u0027SourceExports.QueryTypeSource.1160082336\u0027 is not callable.");
     }
   }
 }
@@ -191,6 +221,12 @@ export function cancelSourceQuery(): void {
   return $requireManagedExports()["SourceExports"]["CancelSourceQuery.19325221"]();
 }
 
+export function cancelTypeSourceQuery(operationId: string, reason: string): BrowserTypeSourceCancellation {
+  const $result = $requireManagedExports()["SourceExports"]["CancelTypeSourceQuery.271973316"](operationId, reason);
+  const $parsed: unknown = JSON.parse($result);
+  return $parsed as BrowserTypeSourceCancellation;
+}
+
 export async function queryMemberAnnotatedSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserAnnotatedSource> {
   const $result = await $requireManagedExports()["SourceExports"]["QueryMemberAnnotatedSource.1135530322"](packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
   const $parsed: unknown = JSON.parse($result);
@@ -209,9 +245,9 @@ export async function queryTypeMemberSource(packageId: string, version: string, 
   return $parsed as BrowserSource;
 }
 
-export async function queryTypeSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserSource> {
-  const $result = await $requireManagedExports()["SourceExports"]["QueryTypeSource.649160465"](packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+export async function queryTypeSource(operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserTypeSourceResult> {
+  const $result = await $requireManagedExports()["SourceExports"]["QueryTypeSource.1160082336"](operationId, packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
   const $parsed: unknown = JSON.parse($result);
-  return $parsed as BrowserSource;
+  return $parsed as BrowserTypeSourceResult;
 }
 

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
@@ -42,6 +42,14 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "SourceExports");
+        value = $ownDataProperty(value, "CancelTypeSourceQuery.271973316");
+        if (typeof value !== "function") {
+            throw new Error("Managed export \u0027SourceExports.CancelTypeSourceQuery.271973316\u0027 is not callable.");
+        }
+    }
+    {
+        let value = exports;
+        value = $ownDataProperty(value, "SourceExports");
         value = $ownDataProperty(value, "QueryMemberAnnotatedSource.1135530322");
         if (typeof value !== "function") {
             throw new Error("Managed export \u0027SourceExports.QueryMemberAnnotatedSource.1135530322\u0027 is not callable.");
@@ -66,9 +74,9 @@ function $validateManagedExports(exports) {
     {
         let value = exports;
         value = $ownDataProperty(value, "SourceExports");
-        value = $ownDataProperty(value, "QueryTypeSource.649160465");
+        value = $ownDataProperty(value, "QueryTypeSource.1160082336");
         if (typeof value !== "function") {
-            throw new Error("Managed export \u0027SourceExports.QueryTypeSource.649160465\u0027 is not callable.");
+            throw new Error("Managed export \u0027SourceExports.QueryTypeSource.1160082336\u0027 is not callable.");
         }
     }
 }
@@ -99,6 +107,11 @@ export function runEntryPoint(mainAssemblyName, args) {
 export function cancelSourceQuery() {
     return $requireManagedExports()["SourceExports"]["CancelSourceQuery.19325221"]();
 }
+export function cancelTypeSourceQuery(operationId, reason) {
+    const $result = $requireManagedExports()["SourceExports"]["CancelTypeSourceQuery.271973316"](operationId, reason);
+    const $parsed = JSON.parse($result);
+    return $parsed;
+}
 export async function queryMemberAnnotatedSource(packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson) {
     const $result = await $requireManagedExports()["SourceExports"]["QueryMemberAnnotatedSource.1135530322"](packageId, version, targetFramework, assemblyName, typeIdentity, typeQueryId, memberName, memberSignature, selectorKey, metadataToken, styleOptionsJson);
     const $parsed = JSON.parse($result);
@@ -114,8 +127,8 @@ export async function queryTypeMemberSource(packageId, version, targetFramework,
     const $parsed = JSON.parse($result);
     return $parsed;
 }
-export async function queryTypeSource(packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
-    const $result = await $requireManagedExports()["SourceExports"]["QueryTypeSource.649160465"](packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
+export async function queryTypeSource(operationId, packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson) {
+    const $result = await $requireManagedExports()["SourceExports"]["QueryTypeSource.1160082336"](operationId, packageId, version, targetFramework, assemblyName, typeIdentity, styleOptionsJson);
     const $parsed = JSON.parse($result);
     return $parsed;
 }

--- a/prototypes/inspect-web/scripts/verify-engine-facade-runtime.ts
+++ b/prototypes/inspect-web/scripts/verify-engine-facade-runtime.ts
@@ -7,6 +7,23 @@ import assert from "node:assert/strict";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import type { BrowserTypeSourceResult } from "../src/facades/inspect-web-source.d.ts";
+
+const typeSourceResult: BrowserTypeSourceResult = {
+  version: 1,
+  kind: "Succeeded",
+  value: {
+    provider: "decompiled",
+    provenance: "facade transport probe",
+    url: null,
+    pdbSourceLimitation: null,
+    text: "class Example {}",
+  },
+  failureKind: null,
+  error: null,
+  diagnostic: null,
+  reason: null,
+};
 
 interface FacadeIdentity {
   readonly module: string;
@@ -242,6 +259,12 @@ const assemblies = new Map(managedAssemblies.map(entry => [entry.assembly, {
       if (operation.key.startsWith("AsyncLoweringCanary.")) {
         return Promise.resolve("inspect-web-async-lowering-ok");
       }
+      if (operation.key.startsWith("QueryTypeSource.")) {
+        return Promise.resolve(${JSON.stringify(JSON.stringify(typeSourceResult))});
+      }
+      if (operation.key.startsWith("CancelTypeSourceQuery.")) {
+        return JSON.stringify({ kind: "Requested", reason: args[1] });
+      }
       return operation.asynchronous ? Promise.resolve("null") : "null";
     },
   ])),
@@ -334,6 +357,25 @@ for (const facade of facades) {
       representative.key}\\.-?\\d+:`),
     `${facade.module}.${representative.name}() must dispatch into its own assembly`);
 }
+
+const source = facadeModule("inspect-web-source");
+const sourceArguments = [
+  "page-owned-source-id", "Example.Package", "1.0.0", "net11.0",
+  "Example.dll", "Example.Type", "[]",
+];
+assert.deepEqual(
+  await callableOperation(source, "queryTypeSource")(...sourceArguments),
+  typeSourceResult,
+  "type source must decode the generated concrete terminal DTO");
+assert.ok(
+  importedState.calls.at(-1)?.endsWith(`:${JSON.stringify(sourceArguments)}`),
+  "type source must forward the page-owned operation ID and all query arguments");
+assert.deepEqual(
+  callableOperation(source, "cancelTypeSourceQuery")(
+    "page-owned-source-id", "superseded"),
+  { kind: "Requested", reason: "superseded" });
+assert.ok(importedState.calls.at(-1)?.endsWith(
+  ':["page-owned-source-id","superseded"]'));
 
 assert.equal(await host.runEntryPoint(), 0);
 assert.equal(importedState.calls.at(-1), "runMain:<default>:0");

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -466,6 +466,7 @@ let inspectPlatformIntegrations: AnalysisFacade["queryPlatformIntegrations"];
 let inspectPlatformOpportunities: AnalysisFacade["queryPlatformOpportunities"];
 let inspectPlatformPerformance: AnalysisFacade["queryPlatformPerformance"];
 let cancelSourceInspection: SourceFacade["cancelSourceQuery"];
+let cancelTypeSourceInspection: SourceFacade["cancelTypeSourceQuery"];
 let inspectMemberAnnotatedSource: SourceFacade["queryMemberAnnotatedSource"];
 let inspectMemberSource: SourceFacade["queryMemberSource"];
 let inspectTypeMemberSource: SourceFacade["queryTypeMemberSource"];
@@ -548,6 +549,7 @@ async function loadEngineModule() {
   } = analysisFacade);
   ({
     cancelSourceQuery: cancelSourceInspection,
+    cancelTypeSourceQuery: cancelTypeSourceInspection,
     queryMemberAnnotatedSource: inspectMemberAnnotatedSource,
     queryMemberSource: inspectMemberSource,
     queryTypeMemberSource: inspectTypeMemberSource,
@@ -1065,7 +1067,8 @@ const sourceInspection = createSourceInspectionCoordinator({
     request.selectorKey,
     request.metadataToken,
     request.taste),
-  queryTypeSource: request => inspectTypeSource(
+  queryTypeSource: (operationId, request) => inspectTypeSource(
+    operationId,
     request.packageId,
     request.version,
     request.framework,
@@ -1084,6 +1087,9 @@ const sourceInspection = createSourceInspectionCoordinator({
     taste),
   memberSourceHasConcreteOverload,
   cancelEngineSourceRequest: () => cancelSourceInspection?.(),
+  cancelTypeSourceRequest: (operationId, reason) => {
+    cancelTypeSourceInspection(operationId, reason);
+  },
   reportOperationDiagnostic: diagnostic => {
     console.error("Source operation authority failure.", diagnostic);
     return undefined;

--- a/prototypes/inspect-web/src/facades/inspect-web-source.d.ts
+++ b/prototypes/inspect-web/src/facades/inspect-web-source.d.ts
@@ -1,5 +1,8 @@
 export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" | "ContextUnavailable" | number;
 export type BrowserAnnotatedSourceMedium = "CSharp" | "Il" | number;
+export type BrowserTypeSourceCancellationKind = "Requested" | "AlreadyRequested" | "NotActive" | number;
+export type BrowserTypeSourceFailureKind = "Expected" | "Unexpected" | number;
+export type BrowserTypeSourceResultKind = "Succeeded" | "Failed" | "Canceled" | number;
 export interface BrowserAnnotatedSource {
     readonly document: unknown;
     readonly viewerCatalog: BrowserAnnotatedSourceViewerCatalog;
@@ -48,6 +51,19 @@ export interface BrowserSource {
     readonly pdbSourceLimitation: string | null;
     readonly text: string;
 }
+export interface BrowserTypeSourceCancellation {
+    readonly kind: BrowserTypeSourceCancellationKind;
+    readonly reason: string | null;
+}
+export interface BrowserTypeSourceResult {
+    readonly version: number;
+    readonly kind: BrowserTypeSourceResultKind;
+    readonly value: BrowserSource | null;
+    readonly failureKind: BrowserTypeSourceFailureKind | null;
+    readonly error: string | null;
+    readonly diagnostic: string | null;
+    readonly reason: string | null;
+}
 export interface JsExportRuntime {
     readonly getAssemblyExports: (assemblyName: string) => Promise<unknown>;
     readonly runMain: (mainAssemblyName?: string, args?: string[]) => Promise<number>;
@@ -56,7 +72,8 @@ export declare function createRuntime(): Promise<JsExportRuntime>;
 export declare function initializeRuntime(runtime?: JsExportRuntime | PromiseLike<JsExportRuntime>): Promise<void>;
 export declare function runEntryPoint(mainAssemblyName?: string, args?: string[]): Promise<number>;
 export declare function cancelSourceQuery(): void;
+export declare function cancelTypeSourceQuery(operationId: string, reason: string): BrowserTypeSourceCancellation;
 export declare function queryMemberAnnotatedSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, typeQueryId: string, memberName: string, memberSignature: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserAnnotatedSource>;
 export declare function queryMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
 export declare function queryTypeMemberSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, memberName: string, selectorKey: string, metadataToken: number, styleOptionsJson: string): Promise<BrowserSource>;
-export declare function queryTypeSource(packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserSource>;
+export declare function queryTypeSource(operationId: string, packageId: string, version: string, targetFramework: string, assemblyName: string, typeIdentity: string, styleOptionsJson: string): Promise<BrowserTypeSourceResult>;

--- a/prototypes/inspect-web/src/source-inspection.ts
+++ b/prototypes/inspect-web/src/source-inspection.ts
@@ -6,10 +6,14 @@ import {
   type SourceRequestState,
   type SourceWorkbenchState,
 } from "./data.ts";
-import type { BrowserSource } from "./facades/inspect-web-source.d.ts";
+import type {
+  BrowserSource,
+  BrowserTypeSourceResult,
+} from "./facades/inspect-web-source.d.ts";
 import type { MemberFocusSnapshot } from "./member-focus.ts";
 import type {
   OperationAuthorityPage,
+  OperationCancelReason,
   OperationDiagnostic,
   OperationFeatureEvent,
   OperationId,
@@ -80,13 +84,20 @@ export interface SourceInspectionDependencies {
   state: SourceInspectionState;
   operationAuthority: OperationAuthorityPage;
   queryMemberSource(request: MemberSourceQuery): Promise<BrowserSource>;
-  queryTypeSource(request: TypeSourceQuery): Promise<BrowserSource>;
+  queryTypeSource(
+    operationId: OperationId,
+    request: TypeSourceQuery,
+  ): Promise<BrowserTypeSourceResult>;
   queryGraphSource(
     request: GraphSourceRequest,
     taste: string,
   ): Promise<BrowserSource>;
   memberSourceHasConcreteOverload(): boolean;
   cancelEngineSourceRequest(): void;
+  cancelTypeSourceRequest(
+    operationId: OperationId,
+    reason: OperationCancelReason,
+  ): void;
   readonly reportOperationDiagnostic: (
     diagnostic: OperationDiagnostic,
   ) => undefined;
@@ -130,7 +141,6 @@ export function createSourceInspectionCoordinator(
 
   const typeSourceOperations =
     new Map<OperationId, TypeSourceOperationContext>();
-  let activeEngineTypeOperation: OperationId | null = null;
   const typeSourceContext = (
     operationId: OperationId,
   ): TypeSourceOperationContext => {
@@ -204,51 +214,79 @@ export function createSourceInspectionCoordinator(
         preservedFocus: null,
       });
       let engineCancellationRequested = false;
-      const cancelEngineIfOwned = (): undefined => {
-        if (engineCancellationRequested
-          || activeEngineTypeOperation !== identity.id) {
+      const cancelEngine = (reason: OperationCancelReason): undefined => {
+        if (engineCancellationRequested) {
           return undefined;
         }
         engineCancellationRequested = true;
-        dependencies.cancelEngineSourceRequest();
+        dependencies.cancelTypeSourceRequest(identity.id, reason);
         return undefined;
       };
-      const finish = (
-        outcome:
-          | { readonly kind: "succeeded"; readonly value: BrowserSource }
-          | { readonly kind: "failed"; readonly error: unknown },
-      ): undefined => {
-        sink.reportTerminal(outcome);
-        if (activeEngineTypeOperation === identity.id)
-          activeEngineTypeOperation = null;
+      const quiesce = (): undefined => {
         typeSourceOperations.delete(identity.id);
         sink.reportQuiesced();
         return undefined;
       };
+      const boundaryFailure = (error: unknown): undefined => {
+        sink.reportUnexpectedTerminal(error, error);
+        return quiesce();
+      };
+      const finish = (result: BrowserTypeSourceResult): undefined => {
+        try {
+          if (result.version !== 1)
+            throw new Error("Unsupported type-source result version.");
+          switch (result.kind) {
+            case "Succeeded":
+              if (result.value === null || typeof result.value !== "object")
+                throw new Error("Type-source success has no source.");
+              sink.reportTerminal({ kind: "succeeded", value: result.value });
+              break;
+            case "Failed": {
+              if (typeof result.error !== "string" || typeof result.diagnostic !== "string")
+                throw new Error("Type-source failure has no error or diagnostic.");
+              const error = new Error(result.error);
+              if (result.failureKind === "Expected")
+                sink.reportTerminal({ kind: "failed", error });
+              else if (result.failureKind === "Unexpected")
+                sink.reportUnexpectedTerminal(error, result.diagnostic);
+              else
+                throw new Error("Unknown type-source failure kind.");
+              break;
+            }
+            case "Canceled":
+              switch (result.reason) {
+                case "user":
+                case "superseded":
+                case "disposed":
+                case "feature-observer-failed":
+                case "timeout":
+                case "worker-restarted":
+                  sink.reportTerminal({ kind: "canceled", reason: result.reason });
+                  break;
+                default:
+                  throw new Error("Unknown type-source cancellation reason.");
+              }
+              break;
+            default:
+              throw new Error("Unknown type-source result kind.");
+          }
+        } catch (error: unknown) {
+          sink.reportUnexpectedTerminal(error, error);
+        }
+        return quiesce();
+      };
       return {
         kind: "prepared",
         binding: {
-          requestCancellation: () => {
-            return cancelEngineIfOwned();
-          },
+          requestCancellation: cancelEngine,
           activate: () => {
-            activeEngineTypeOperation = identity.id;
-            let query: Promise<BrowserSource>;
+            let query: Promise<BrowserTypeSourceResult>;
             try {
-              query = dependencies.queryTypeSource(request);
+              query = dependencies.queryTypeSource(identity.id, request);
             } catch (error: unknown) {
-              try {
-                cancelEngineIfOwned();
-              } catch (cancellationError: unknown) {
-                sink.reportUnexpectedFailure(cancellationError);
-              }
-              finish({ kind: "failed", error });
-              return undefined;
+              return boundaryFailure(error);
             }
-            void query.then(
-              value => finish({ kind: "succeeded", value }),
-              (error: unknown) => finish({ kind: "failed", error }),
-            );
+            void query.then(finish, boundaryFailure);
             return undefined;
           },
           abandon: () => {

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -7,7 +7,10 @@ import {
   type SourceInspectionDependencies,
   type SourceInspectionState,
 } from "../src/source-inspection.ts";
-import type { BrowserSource } from "../src/facades/inspect-web-source.d.ts";
+import type {
+  BrowserSource,
+  BrowserTypeSourceResult,
+} from "../src/facades/inspect-web-source.d.ts";
 import type { MemberFocusSnapshot } from "../src/member-focus.ts";
 import { createOperationAuthorityPage } from "../src/operation-authority.ts";
 
@@ -18,6 +21,18 @@ function source(text: string): BrowserSource {
     url: "https://example.test/source.cs",
     pdbSourceLimitation: null,
     text,
+  };
+}
+
+function typeSource(text: string): BrowserTypeSourceResult {
+  return {
+    version: 1,
+    kind: "Succeeded",
+    value: source(text),
+    failureKind: null,
+    error: null,
+    diagnostic: null,
+    reason: null,
   };
 }
 
@@ -85,10 +100,11 @@ function inspectionDependencies(
       },
     }),
     queryMemberSource: async () => source("member"),
-    queryTypeSource: async () => source("type"),
+    queryTypeSource: async () => typeSource("type"),
     queryGraphSource: async () => source("graph"),
     memberSourceHasConcreteOverload: () => true,
     cancelEngineSourceRequest: () => {},
+    cancelTypeSourceRequest: () => {},
     reportOperationDiagnostic: () => undefined,
     describeError: error =>
       error instanceof Error ? error.message : String(error),
@@ -338,7 +354,7 @@ test("type source caches an owned result without repainting a hidden surface", a
     inspectionDependencies(state, {
       queryTypeSource: async () => {
         queries++;
-        return source("type");
+        return typeSource("type");
       },
       renderPreservingMemberFocus: fallback => {
         renders++;
@@ -367,8 +383,8 @@ test("type source caches an owned result without repainting a hidden surface", a
 });
 
 test("type source replacement suppresses stale publication without cancelling the replacement", async () => {
-  const firstQuery = deferred<BrowserSource>();
-  const secondQuery = deferred<BrowserSource>();
+  const firstQuery = deferred<BrowserTypeSourceResult>();
+  const secondQuery = deferred<BrowserTypeSourceResult>();
   let cancellations = 0;
   const state = inspectionState({
     lens: "source",
@@ -377,11 +393,11 @@ test("type source replacement suppresses stale publication without cancelling th
   });
   const coordinator = createSourceInspectionCoordinator(
     inspectionDependencies(state, {
-      queryTypeSource: request =>
+      queryTypeSource: (_operationId, request) =>
         request.type === "Example.First"
           ? firstQuery.promise
           : secondQuery.promise,
-      cancelEngineSourceRequest: () => cancellations++,
+      cancelTypeSourceRequest: () => cancellations++,
     }));
   const request = {
     packageId: "Example.Package",
@@ -403,21 +419,21 @@ test("type source replacement suppresses stale publication without cancelling th
     type: "Example.Second",
   });
 
-  assert.equal(cancellations, 0);
+  assert.equal(cancellations, 1);
   assert.equal(state.typeSourceKey, "second");
-  firstQuery.resolve(source("stale"));
+  firstQuery.resolve(typeSource("stale"));
   await firstLoad;
   assert.equal(state.typeSource, null);
   assert.equal(state.typeSourceLoading, true);
 
-  secondQuery.resolve(source("current"));
+  secondQuery.resolve(typeSource("current"));
   await secondLoad;
   assert.equal(sourceText(state.typeSource), "current");
   assert.equal(state.typeSourceLoading, false);
 });
 
 test("synchronous type source failure cannot cancel a reentrant replacement", async () => {
-  const replacementQuery = deferred<BrowserSource>();
+  const replacementQuery = deferred<BrowserTypeSourceResult>();
   let cancellations = 0;
   let replacementLoad: Promise<void> | undefined;
   const state = inspectionState({
@@ -428,7 +444,7 @@ test("synchronous type source failure cannot cancel a reentrant replacement", as
   let coordinator!: ReturnType<typeof createSourceInspectionCoordinator>;
   coordinator = createSourceInspectionCoordinator(
     inspectionDependencies(state, {
-      queryTypeSource: request => {
+      queryTypeSource: (_operationId, request) => {
         if (request.type === "Example.First") {
           replacementLoad = coordinator.loadTypeSource({
             signature: "second",
@@ -444,7 +460,7 @@ test("synchronous type source failure cannot cancel a reentrant replacement", as
         }
         return replacementQuery.promise;
       },
-      cancelEngineSourceRequest: () => cancellations++,
+      cancelTypeSourceRequest: () => cancellations++,
     }));
 
   await coordinator.loadTypeSource({
@@ -458,10 +474,10 @@ test("synchronous type source failure cannot cancel a reentrant replacement", as
     isVisible: () => true,
   });
 
-  assert.equal(cancellations, 0);
+  assert.equal(cancellations, 1);
   assert.equal(state.typeSourceKey, "second");
   assert.equal(state.typeSourceLoading, true);
-  replacementQuery.resolve(source("replacement"));
+  replacementQuery.resolve(typeSource("replacement"));
   assert.ok(replacementLoad);
   await replacementLoad;
   assert.equal(sourceText(state.typeSource), "replacement");
@@ -482,7 +498,7 @@ test("synchronous type source failure does not repeat reentrant cancellation", a
         assert.equal(coordinator.cancelCurrentRequest(), true);
         throw new Error("activation failed after cancellation");
       },
-      cancelEngineSourceRequest: () => cancellations++,
+      cancelTypeSourceRequest: () => cancellations++,
     }));
 
   await coordinator.loadTypeSource({
@@ -503,7 +519,7 @@ test("synchronous type source failure does not repeat reentrant cancellation", a
 });
 
 test("legacy member source takeover cancels the authoritative type operation first", async () => {
-  const typeQuery = deferred<BrowserSource>();
+  const typeQuery = deferred<BrowserTypeSourceResult>();
   let cancellations = 0;
   const state = inspectionState({
     lens: "source",
@@ -513,7 +529,7 @@ test("legacy member source takeover cancels the authoritative type operation fir
   const coordinator = createSourceInspectionCoordinator(
     inspectionDependencies(state, {
       queryTypeSource: async () => typeQuery.promise,
-      cancelEngineSourceRequest: () => cancellations++,
+      cancelTypeSourceRequest: () => cancellations++,
     }));
   const typeLoad = coordinator.loadTypeSource({
     signature: "type",
@@ -543,7 +559,7 @@ test("legacy member source takeover cancels the authoritative type operation fir
   assert.equal(cancellations, 1);
   assert.equal(state.memberSource?.text, "member");
   assert.equal(state.typeSource, null);
-  typeQuery.resolve(source("stale type"));
+  typeQuery.resolve(typeSource("stale type"));
   await typeLoad;
   assert.equal(state.typeSource, null);
 });
@@ -583,7 +599,7 @@ test("current type source failures remain visible and restore focus", async () =
 });
 
 test("type cancellation completes logically before the query quiesces", async () => {
-  const query = deferred<BrowserSource>();
+  const query = deferred<BrowserTypeSourceResult>();
   let cancellations = 0;
   const state = inspectionState({
     lens: "source",
@@ -593,7 +609,7 @@ test("type cancellation completes logically before the query quiesces", async ()
   const coordinator = createSourceInspectionCoordinator(
     inspectionDependencies(state, {
       queryTypeSource: async () => query.promise,
-      cancelEngineSourceRequest: () => cancellations++,
+      cancelTypeSourceRequest: () => cancellations++,
     }));
   const load = coordinator.loadTypeSource({
     signature: "type",
@@ -612,7 +628,7 @@ test("type cancellation completes logically before the query quiesces", async ()
   assert.equal(state.typeSourceKey, "");
   assert.equal(await promiseSettled(load), false);
 
-  query.resolve(source("late"));
+  query.resolve(typeSource("late"));
   await load;
   assert.equal(state.typeSource, null);
   assert.equal(coordinator.cancelCurrentRequest(), false);

--- a/prototypes/inspect-web/test/type-source-managed-operation.test.ts
+++ b/prototypes/inspect-web/test/type-source-managed-operation.test.ts
@@ -1,0 +1,229 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createSourceInspectionCoordinator,
+  type SourceInspectionState,
+  type TypeSourceLoadRequest,
+} from "../src/source-inspection.ts";
+import {
+  createOperationAuthorityPage,
+  type OperationCancelReason,
+  type OperationDiagnostic,
+  type OperationId,
+} from "../src/operation-authority.ts";
+import type { BrowserTypeSourceResult } from "../src/facades/inspect-web-source.d.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((accept, fail) => {
+    resolve = accept;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function fixture() {
+  const state: SourceInspectionState = {
+    settings: false, explorer: null, loading: false, error: "", home: false,
+    package: {}, atPackageRoot: false, lens: "source", selectedMemberKey: "",
+    memberSection: "overview", sourceRequestGeneration: 0,
+    memberSource: null, memberSourceLoading: false, memberSourceError: "",
+    memberSourceKey: "", typeSource: null, typeSourceLoading: false,
+    typeSourceError: "", typeSourceKey: "", graphSourceOpen: false,
+    graphSource: null, graphSourceLoading: false, graphSourceError: "",
+    graphSourceTitle: "", graphSourceRequest: null, graphSourceSeq: 0, taste: [],
+  };
+  const queries = new Map<OperationId, ReturnType<typeof deferred<BrowserTypeSourceResult>>>();
+  const cancellations: Array<readonly [OperationId, OperationCancelReason]> = [];
+  const diagnostics: OperationDiagnostic[] = [];
+  let nextId = 1;
+  let legacyCancellations = 0;
+  const coordinator = createSourceInspectionCoordinator({
+    state,
+    operationAuthority: createOperationAuthorityPage({
+      allocation: { createId: () => `managed-source-${nextId++}` },
+    }),
+    queryTypeSource: (id, request) => {
+      assert.equal(request.packageId, "Example");
+      const query = deferred<BrowserTypeSourceResult>();
+      queries.set(id, query);
+      return query.promise;
+    },
+    cancelTypeSourceRequest: (id, reason) => { cancellations.push([id, reason]); },
+    queryMemberSource: async () => { throw new Error("unused member query"); },
+    queryGraphSource: async () => ({
+      provider: "pdb", provenance: "verified", url: null,
+      pdbSourceLimitation: null, text: "graph",
+    }),
+    memberSourceHasConcreteOverload: () => false,
+    cancelEngineSourceRequest: () => { legacyCancellations++; },
+    reportOperationDiagnostic: diagnostic => {
+      diagnostics.push(diagnostic);
+      return undefined;
+    },
+    describeError: error => error instanceof Error ? error.message : String(error),
+    render: () => {},
+    renderPreservingMemberFocus: () => ({
+      selector: "#type-list", dataTarget: null, selection: null,
+      navigationScope: null, navigationSelection: null, navigationScrollTop: null,
+      focusLost: false,
+    }),
+  });
+  function start(signature: string) {
+    const request: TypeSourceLoadRequest = {
+      signature, packageId: "Example", version: "1.0.0", framework: "net11.0",
+      assembly: "Example.dll", type: signature, taste: "[]", isVisible: () => true,
+    };
+    const load = coordinator.loadTypeSource(request);
+    const entry = [...queries.entries()].at(-1);
+    assert.ok(entry);
+    return { load, id: entry[0], query: entry[1] };
+  }
+  return { state, start, coordinator, cancellations, diagnostics,
+    legacyCancellations: () => legacyCancellations };
+}
+
+function succeeded(text: string): BrowserTypeSourceResult {
+  return {
+    version: 1, kind: "Succeeded",
+    value: { provider: "pdb", provenance: "verified", url: null,
+      pdbSourceLimitation: null, text },
+    failureKind: null, error: null, diagnostic: null, reason: null,
+  };
+}
+
+function failed(kind: "Expected" | "Unexpected"): BrowserTypeSourceResult {
+  return {
+    version: 1, kind: "Failed", value: null, failureKind: kind,
+    error: "source unavailable", diagnostic: "producer detail", reason: null,
+  };
+}
+
+test("type requests forward page identity and exact reason without legacy cancellation", async () => {
+  const f = fixture();
+  const a = f.start("A");
+  const b = f.start("B");
+  assert.notEqual(a.id, b.id);
+  assert.deepEqual(f.cancellations, [[a.id, "superseded"]]);
+  a.query.resolve(succeeded("stale"));
+  await a.load;
+  assert.equal(f.state.typeSource, null);
+  assert.equal(f.state.typeSourceLoading, true);
+  assert.equal(f.coordinator.cancelCurrentRequest(), true);
+  assert.equal(f.coordinator.cancelCurrentRequest(), false);
+  assert.deepEqual(f.cancellations, [[a.id, "superseded"], [b.id, "user"]]);
+  assert.equal(f.legacyCancellations(), 0);
+  let quiesced = false;
+  void b.load.then(() => {
+    quiesced = true;
+    return undefined;
+  });
+  await Promise.resolve();
+  assert.equal(quiesced, false);
+  b.query.resolve({ version: 1, kind: "Canceled", reason: "user",
+    value: null, failureKind: null, error: null, diagnostic: null });
+  await b.load;
+  assert.equal(quiesced, true);
+  assert.equal(f.state.typeSource, null);
+  assert.equal(f.state.typeSourceError, "");
+});
+
+for (const kind of ["Expected", "Unexpected"] as const) {
+  test(`${kind} managed failure remains visible when current`, async () => {
+    const f = fixture();
+    const operation = f.start("A");
+    operation.query.resolve(failed(kind));
+    await operation.load;
+    assert.equal(f.state.typeSourceError, "source unavailable");
+    assert.equal(f.state.typeSourceLoading, false);
+    assert.equal(f.diagnostics.length, kind === "Unexpected" ? 1 : 0);
+    if (kind === "Unexpected")
+      assert.equal(f.diagnostics[0]?.error, "producer detail");
+  });
+
+  test(`${kind} stale failure cannot overwrite replacement or hide unexpected diagnostics`, async () => {
+    const f = fixture();
+    const a = f.start("A");
+    const b = f.start("B");
+    a.query.resolve(failed(kind));
+    await a.load;
+    assert.equal(f.state.typeSourceError, "");
+    assert.equal(f.state.typeSourceKey, "B");
+    assert.equal(f.diagnostics.length, kind === "Unexpected" ? 1 : 0);
+    b.query.resolve(succeeded("current"));
+    await b.load;
+    assert.equal(f.state.typeSource?.text, "current");
+  });
+}
+
+for (const canceled of [false, true]) {
+  test(`Promise rejection is a visible boundary diagnostic even after cancellation=${canceled}`, async () => {
+    const f = fixture();
+    const operation = f.start("A");
+    if (canceled) f.coordinator.cancelCurrentRequest();
+    const error = new Error("OperationCanceledException: canceled");
+    operation.query.reject(error);
+    await operation.load;
+    assert.equal(f.diagnostics.length, 1);
+    assert.equal(f.diagnostics[0]?.operationId, operation.id);
+    assert.equal(f.diagnostics[0]?.error, error);
+    assert.equal(f.state.typeSourceError, canceled ? "" : error.message);
+    assert.equal(f.state.typeSourceLoading, false);
+  });
+}
+
+test("late Promise rejection cannot affect a successful replacement", async () => {
+  const f = fixture();
+  const a = f.start("A");
+  const b = f.start("B");
+  b.query.resolve(succeeded("B"));
+  await b.load;
+  a.query.reject(new Error("interop failed"));
+  await a.load;
+  assert.equal(f.state.typeSource?.text, "B");
+  assert.equal(f.state.typeSourceError, "");
+  assert.equal(f.diagnostics.length, 1);
+  assert.equal(f.diagnostics[0]?.operationId, a.id);
+});
+
+test("managed cancellation reaches the logical authority without an error", async () => {
+  const f = fixture();
+  const operation = f.start("A");
+  operation.query.resolve({ version: 1, kind: "Canceled", reason: "superseded",
+    value: null, failureKind: null, error: null, diagnostic: null });
+  await operation.load;
+  assert.equal(f.state.typeSourceError, "");
+  assert.equal(f.state.typeSourceKey, "");
+  assert.equal(f.state.typeSourceLoading, false);
+  assert.equal(f.diagnostics.length, 0);
+});
+
+test("legacy graph takeover preserves graph output and keyed type cancellation", async () => {
+  const f = fixture();
+  const type = f.start("A");
+  await f.coordinator.openGraphSource({
+    packageId: "Example", version: "1.0.0", framework: "net11.0",
+    assembly: "Example.dll", type: "Example.Type", member: "Build",
+    selectorKey: "method", metadataToken: 42,
+  }, "Example.Type.Build");
+  assert.deepEqual(f.cancellations, [[type.id, "superseded"]]);
+  assert.equal(f.state.graphSource?.text, "graph");
+  type.query.reject(new Error("late type boundary failure"));
+  await type.load;
+  assert.equal(f.state.graphSource?.text, "graph");
+  assert.equal(f.state.graphSourceError, "");
+  assert.equal(f.state.typeSource, null);
+  assert.equal(f.diagnostics.length, 1);
+  assert.equal(f.legacyCancellations(), 0);
+});
+
+test("malformed terminal payload is a boundary failure, not an empty success", async () => {
+  const f = fixture();
+  const operation = f.start("A");
+  operation.query.resolve({ ...succeeded("A"), value: null });
+  await operation.load;
+  assert.equal(f.state.typeSource, null);
+  assert.match(f.state.typeSourceError, /has no source/);
+  assert.equal(f.diagnostics.length, 1);
+});


### PR DESCRIPTION
Type Source now addresses the exact managed operation it started, making
cancellation and source-view replacement reliable without changing the source
acquisition budget or adding a new orchestration layer.

Continues #5419; prerequisite for the first Worker-hosted source scenario in
#5420, composed by #5095. This does not close those broader trackers.

## Demo

Before, the source export exposed only `CancelSourceQuery()`: cancellation
addressed the current singleton, and the Type Source adapter needed an
active-operation guard to avoid canceling a replacement.

After, the production exports accept a page-owned ID. This deterministic
in-process demo holds the real source-acquisition gate, starts operations A
and B through `SourceExports.QueryTypeSource`, and calls the real cancellation
export. It does not fabricate terminal DTOs.

```sh
export DOTNET_ROOT="$PWD/artifacts/dotnet/11.0.100-preview.7.26381.103"
"$DOTNET_ROOT/dotnet" run --project prototypes/inspect-web/engine.Tests \
  -c Release --no-build -- \
  -method '*KeyedCancellationOfOldOperation_DoesNotCancelReplacement' \
  -showliveoutput
```

```text
A terminal: {"version":1,"kind":"Canceled","value":null,"failureKind":null,"error":null,"diagnostic":null,"reason":"superseded"}
Cancel A after B starts: {"kind":"NotActive","reason":null}
B remains pending: True
B terminal: {"version":1,"kind":"Canceled","value":null,"failureKind":null,"error":null,"diagnostic":null,"reason":"user"}
Cancel B after settlement: {"kind":"NotActive","reason":null}
```

Notice that canceling A cannot cancel B, the supersession/user reasons remain
distinct, and settled operations are no longer addressable.

Neighbor: `ExportSuccess_PreservesSourceAndProvenanceAndReleasesScope` invokes
the same production query over a cached package containing the compiled
`TsJsExport.Contracts` assembly. It returns decompiled
`TsJsExport.JsExportRootAttribute` source with package provenance and its PDB
limitation, then permits scope release. Member/graph takeover retains its
existing source behavior.

This is managed-export and generated-facade evidence, not a live browser,
network-acquisition, Worker-placement, or responsiveness demo.

## Design basis and scope

One normative owner:
`docs/design/inspect-web-managed-operation-bridge.md`, specifically Admission,
Cancellation, Release and quiescence, and Source-host adoption and retirement.
The claim is page-ID-keyed managed admission/cancellation with immutable first
reason and resource release before typed terminal settlement.

Supporting owners: operation authority controls logical cancellation and
publication; `ts-jsexport` authenticates and generates the existing JSON DTO
contract; Source retains query semantics, rendering, focus, provenance, and
acquisition policy. The existing bridge lifecycle and its TLA+ model are the
baseline, not a new state machine. The newly landed #5830 canary remains a
separate boundary gate.

The shared source coordinator still enforces its single acquisition budget.
Migrated operations borrow the bridge token and route legacy supersession
through keyed cancellation, so the bridge records the reason before signaling.
Legacy member/graph callers retain their parameterless API for now.

Source-owned missing/truncated/unavailable conditions become expected terminal
failures without changing their messages. Other producer exceptions remain
unexpected; even stale or logically canceled operations report unexpected
diagnostics. Runtime/interop/serialization rejection follows the boundary
failure path, never exception-text cancellation detection.

The production caller consumes generated concrete result and cancellation
DTOs. There is no new progress payload, handwritten wire union, native-union
generator dependency (#5892), Worker protocol, broker, epoch lease, rendering
strategy, or platform exception. The existing browser-specific scope was
explicitly approved; reusable inspection/query models remain unchanged.

The source cancellation adoption/retirement plan totals **two slices**:

1. Type Source export, generated facade, and actual browser caller together
   (this PR).
2. Remaining member/graph source callers and exports, retiring parameterless
   cancellation and the singleton cancellation slot in that same slice while
   preserving aggregate budget enforcement.

The old #4600 stack is closed. This candidate integrates the landed #5830
canary and #5834 annotated-scroll changes without conflict. #5897 is CLI-only;
the separate Worker and Package Query work is not modified.

## Validation

Candidate `959f6fa11e28e722d9805aad9a0c25a05d2397ad` against effective base
`29362f0d1bd8599d0af8172950c12fa28022af39`.

- Release managed source, bridge, facade inventory, and source boundary:
  **44 passed** after base integration.
- TypeScript source, operation authority, graph source, and production
  composition: **286 passed** after base integration.
- All three TypeScript projects and the official `npm run analyze`: passed
  after base integration.
- All seven facades regenerated with the product `ts-jsexport`: direct,
  production-context, and checked-in TypeScript are byte-identical, as are the
  seven compiled JavaScript modules and declaration files. The real facade
  runtime gate covers ID/reason forwarding and DTO decoding.
- Frontend production and Browser/Wasm engine builds passed on the pushed
  candidate after the final base integration.
- Changed Markdown and `git diff --check`: passed.

The focused gates cover canceled waiters not releasing another operation's
budget, legacy supersession, exact reasons, successful scope release, expected
and unexpected failure, stale fulfillment/rejection, and physical quiescence.
