### PR TITLE
Design policy-issued resolver-lineage continuations

### DIFF
--- a/docs/design/models/resolver-lineage/.gitignore
+++ b/docs/design/models/resolver-lineage/.gitignore
@@ -1,0 +1,4 @@
+states/
+*.out
+*.bin
+*_TTrace*

--- a/docs/design/models/resolver-lineage/AssemblyBindingLineage.tla
+++ b/docs/design/models/resolver-lineage/AssemblyBindingLineage.tla
@@ -1,0 +1,173 @@
+------------------------- MODULE AssemblyBindingLineage -------------------------
+EXTENDS Integers, FiniteSets, TLC
+
+\* The binding owner supplies a selected descriptor and its continuation as a
+\* pair. Each flow is an independent resolution of the same forwarding image.
+CONSTANTS VersionOne, VersionTwo, Mode, AllowPolicyChange
+
+Flows == {"Left", "Right"}
+Destinations == {"Transitive", "CanonicalRight"}
+Modes == {"Explicit", "RegistrationMap", "CandidateCache",
+          "AlwaysInherit", "RouteChurn"}
+Candidates == {"Shared", "RightRoot", "LeftBase", "RightBase"}
+NoValue == "None"
+
+ASSUME /\ VersionOne # VersionTwo
+       /\ Mode \in Modes
+       /\ AllowPolicyChange \in BOOLEAN
+
+VARIABLES version, advanced, externalChange, destination, phase,
+          occurrences, routes, cache, answers, status, committedVersion
+
+BindingVersion ==
+    INSTANCE AssemblyBindingPolicyVersionLifecycle WITH
+        InitialVersion <- VersionOne,
+        ReplacementVersion <- VersionTwo,
+        version <- version,
+        advanced <- advanced
+
+vars == <<version, advanced, externalChange, destination, phase,
+          occurrences, routes, cache, answers, status, committedVersion>>
+
+SelectedCandidate ==
+    IF destination = "Transitive" THEN "Shared" ELSE "RightRoot"
+
+ExpectedResolver(flow) ==
+    IF destination = "CanonicalRight" THEN "Right" ELSE flow
+
+Terminal(resolver) ==
+    IF resolver = "Left" THEN "LeftBase" ELSE "RightBase"
+
+Lineage(resolver) ==
+    [issuer |-> "Group", policyVersion |-> VersionOne, resolver |-> resolver]
+
+Occurrence(flow) ==
+    [candidate |-> SelectedCandidate,
+     lineage |-> Lineage(
+         IF Mode = "AlwaysInherit" THEN flow ELSE ExpectedResolver(flow))]
+
+CacheKey(occurrence) ==
+    IF Mode = "CandidateCache"
+    THEN <<VersionOne, occurrence.candidate, "BaseReference", "Any">>
+    ELSE <<VersionOne, occurrence.candidate, occurrence.lineage,
+           "BaseReference", "Any">>
+
+Init ==
+    /\ BindingVersion!Init
+    /\ externalChange = FALSE
+    /\ destination \in Destinations
+    /\ phase = [f \in Flows |-> "Seed"]
+    /\ occurrences = [f \in Flows |-> NoValue]
+    /\ routes = [candidate \in {"RightRoot"} |-> "Right"]
+    /\ cache = [key \in {} |-> NoValue]
+    /\ answers = [f \in Flows |-> NoValue]
+    /\ status = "Running"
+    /\ committedVersion = NoValue
+
+SelectOccurrence(flow) ==
+    /\ status = "Running"
+    /\ version = VersionOne
+    /\ phase[flow] = "Seed"
+    /\ phase' = [phase EXCEPT ![flow] = "Selected"]
+    /\ occurrences' = [occurrences EXCEPT ![flow] = Occurrence(flow)]
+    /\ routes' =
+        IF Mode = "RegistrationMap" /\ SelectedCandidate \notin DOMAIN routes
+        THEN routes @@ (SelectedCandidate :> ExpectedResolver(flow))
+        ELSE routes
+    /\ IF Mode = "RouteChurn"
+       THEN BindingVersion!Advance
+       ELSE UNCHANGED <<version, advanced>>
+    /\ UNCHANGED <<externalChange, destination, cache, answers, status,
+                   committedVersion>>
+
+ResolveReference(flow) ==
+    /\ status = "Running"
+    /\ version = VersionOne
+    /\ phase[flow] = "Selected"
+    /\ LET occurrence == occurrences[flow]
+           key == CacheKey(occurrence)
+           resolver ==
+               IF Mode = "RegistrationMap"
+               THEN routes[occurrence.candidate]
+               ELSE occurrence.lineage.resolver
+           answer ==
+               IF key \in DOMAIN cache THEN cache[key] ELSE Terminal(resolver)
+       IN /\ answers' = [answers EXCEPT ![flow] = answer]
+          /\ cache' = IF key \in DOMAIN cache
+                      THEN cache
+                      ELSE cache @@ (key :> answer)
+    /\ phase' = [phase EXCEPT ![flow] = "Prepared"]
+    /\ UNCHANGED <<version, advanced, externalChange, destination,
+                   occurrences, routes, status, committedVersion>>
+
+ChangePolicy ==
+    /\ AllowPolicyChange
+    /\ status = "Running"
+    /\ BindingVersion!Advance
+    /\ externalChange' = TRUE
+    /\ UNCHANGED <<destination, phase, occurrences, routes, cache, answers,
+                   status, committedVersion>>
+
+Settle ==
+    /\ status = "Running"
+    /\ IF version # VersionOne
+       THEN /\ status' = "Superseded"
+            /\ UNCHANGED committedVersion
+       ELSE /\ \A f \in Flows : phase[f] = "Prepared"
+            /\ status' = "Published"
+            /\ committedVersion' = version
+    /\ UNCHANGED <<version, advanced, externalChange, destination, phase,
+                   occurrences, routes, cache, answers>>
+
+Next ==
+    (\E f \in Flows : SelectOccurrence(f) \/ ResolveReference(f))
+    \/ ChangePolicy
+    \/ Settle
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ \A f \in Flows : WF_vars(SelectOccurrence(f))
+    /\ \A f \in Flows : WF_vars(ResolveReference(f))
+    /\ WF_vars(Settle)
+
+TypeOK ==
+    /\ BindingVersion!TypeOK
+    /\ externalChange \in BOOLEAN
+    /\ destination \in Destinations
+    /\ phase \in [Flows -> {"Seed", "Selected", "Prepared"}]
+    /\ \A f \in Flows :
+        IF phase[f] = "Seed"
+        THEN occurrences[f] = NoValue
+        ELSE occurrences[f] \in
+            [candidate : Candidates,
+             lineage : [issuer : {"Group"},
+                        policyVersion : {VersionOne},
+                        resolver : Flows]]
+    /\ answers \in [Flows -> Candidates \union {NoValue}]
+    /\ status \in {"Running", "Published", "Superseded"}
+    /\ committedVersion \in {NoValue, VersionOne}
+
+SelectionRetainsResolver ==
+    \A f \in Flows :
+        phase[f] \in {"Selected", "Prepared"}
+        => occurrences[f].lineage = Lineage(ExpectedResolver(f))
+
+ReferenceUsesSelectingContext ==
+    \A f \in Flows :
+        answers[f] # NoValue => answers[f] = Terminal(ExpectedResolver(f))
+
+ContinuationDoesNotChangePolicy == advanced => externalChange
+
+PublishedAssociation ==
+    status = "Published"
+    => /\ committedVersion = VersionOne
+       /\ \A f \in Flows : answers[f] = Terminal(ExpectedResolver(f))
+
+BindingVersionAdvanceIsFresh == BindingVersion!AdvancedVersionIsFresh
+BindingVersionBehaviorRefinesOwner == BindingVersion!SafetySpec
+AttemptSettles == <>(status # "Running")
+StableAttemptPublishes == <>(status = "Published")
+NeverSuperseded == status # "Superseded"
+
+=============================================================================

--- a/docs/design/models/resolver-lineage/BrokenAlwaysInherit.cfg
+++ b/docs/design/models/resolver-lineage/BrokenAlwaysInherit.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "AlwaysInherit"
+    AllowPolicyChange = FALSE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANT SelectionRetainsResolver

--- a/docs/design/models/resolver-lineage/BrokenCandidateCache.cfg
+++ b/docs/design/models/resolver-lineage/BrokenCandidateCache.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "CandidateCache"
+    AllowPolicyChange = FALSE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANT ReferenceUsesSelectingContext

--- a/docs/design/models/resolver-lineage/BrokenRegistrationMap.cfg
+++ b/docs/design/models/resolver-lineage/BrokenRegistrationMap.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "RegistrationMap"
+    AllowPolicyChange = FALSE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANT ReferenceUsesSelectingContext

--- a/docs/design/models/resolver-lineage/BrokenRouteChurn.cfg
+++ b/docs/design/models/resolver-lineage/BrokenRouteChurn.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "RouteChurn"
+    AllowPolicyChange = FALSE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANT ContinuationDoesNotChangePolicy

--- a/docs/design/models/resolver-lineage/README.md
+++ b/docs/design/models/resolver-lineage/README.md
@@ -1,0 +1,90 @@
+# Resolver-lineage continuation model
+
+Owner:
+[Type-forwarding resolution: resolver-lineage continuations](../../type-forwarding-resolution.md#resolver-lineage-continuations).
+Focused issue: #5666. End-to-end adoption: #5274.
+
+## Question and boundary
+
+Can two independent requests reach the same selected assembly and retain
+different resolver contexts without mutating a registration-to-resolver map?
+Can an already configured canonical participant instead supply its own context?
+
+`AssemblyBindingLineage.tla` represents the product join currency directly.
+An occurrence pairs a candidate with a lineage containing the issuing group,
+captured policy version, and resolver discriminator. Both the request and its
+cache key retain that lineage. The issuer is one fixed group; this model does
+not claim cross-issuer rejection coverage.
+
+The finite model has two flows, two resolver contexts, one shared intermediate
+candidate, two terminal dependencies, and one possible real policy replacement.
+Both the transitive and canonical-right-root scenarios are explored.
+`VersionOne` is the captured generation version. Selecting an occurrence
+under the stable routing function leaves it unchanged.
+
+## Imported boundary
+
+`BindingVersion` is a named instance of the existing
+`AssemblyBindingPolicyVersionLifecycle` module, with its two versions bound to
+`VersionOne` and `VersionTwo` and its state bound to `version` and `advanced`.
+`ChangePolicy` invokes the owner's `Advance` action. The positive configuration
+rechecks freshness and projected refinement of the imported safety
+specification. `BrokenRouteChurn` uses that same valid advance at the wrong
+semantic event; it demonstrates that lifecycle freshness alone does not justify
+superseding a generation for an ordinary selection.
+
+The generation either publishes its two prepared results or is superseded.
+Weak fairness covers each flow and settlement. External policy change is
+optional, not fair or inevitable. No retry action exists. This is an
+association model, not a replacement for the existing atomic-snapshot or
+workspace-realization models.
+
+## Exact configurations
+
+| Configuration | Required TLC result | Property |
+| --- | --- | --- |
+| `Safety.cfg` | 0 | Occurrence, cache, and publication association; imported version lifecycle; eventual settlement |
+| `StableProgress.cfg` | 0 | Both flows publish under the unchanged token |
+| `BrokenRegistrationMap.cfg` | 12 | The second context cannot use the first writer's registration route |
+| `BrokenCandidateCache.cfg` | 12 | Candidate-only cache identity mixes different resolver answers |
+| `BrokenAlwaysInherit.cfg` | 12 | Selecting a canonical root must use its configured context |
+| `BrokenRouteChurn.cfg` | 12 | Selecting a continuation is not external policy change |
+| `ReachabilitySupersession.cfg` | 12 | Witness that a genuine policy change can supersede the attempt |
+
+The negative controls describe plausible association regressions, not hostile
+internal callers. The reachability configuration intentionally asserts the
+negation of its witness. Exact outcomes are registered in
+`eng/tla-expected-exit-codes.txt`.
+
+## Running and interpretation
+
+Use the repository-pinned TLC build `2026.08.11.125311`, SHA-256
+`ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f`.
+From the repository root:
+
+```bash
+TLA_TOOLS_JAR=/path/to/tla2tools.jar \
+  ./eng/run-tla-checks.sh docs/design/models/resolver-lineage
+```
+
+The 2026-09-04 run completed all seven exact outcomes with the pinned build.
+`Safety.cfg` explored 64 generated / 56 distinct states; `StableProgress.cfg`
+explored 28 generated / 20 distinct states. Both exhausted their state spaces.
+
+Single-worker trace inspection confirmed the intended negative controls:
+the registration map sent Right to `LeftBase`; the candidate-only cache reused
+Left's answer for Right; always-inherit gave a canonical Right root Left's
+context; and route churn advanced the version with no external policy change.
+The supersession witness was `ChangePolicy -> Settle`, with no published
+result. Counterexample state counts are scheduling-dependent and are not gates.
+
+TLC results establish only this bounded model's behavior. The model abstracts
+PE contents, identity matching, candidate-domain finalization, ambiguity,
+intrinsic metadata reads, acquisition and budget enforcement, multiple nested
+composites, historical recipe carry-forward, and real host execution.
+Those are not implicitly proven by a successful model run.
+
+The #5801 compiled fixture is the existing product oracle for the minimal
+Services forwarding case. The new representation's Metadata, Services/CLI, and
+Queries/Browser adoption gates remain unverified until the four-step plan in
+the owning design lands. No inspected assembly is executed by this model.

--- a/docs/design/models/resolver-lineage/ReachabilitySupersession.cfg
+++ b/docs/design/models/resolver-lineage/ReachabilitySupersession.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "Explicit"
+    AllowPolicyChange = TRUE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANT NeverSuperseded

--- a/docs/design/models/resolver-lineage/Safety.cfg
+++ b/docs/design/models/resolver-lineage/Safety.cfg
@@ -1,0 +1,17 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "Explicit"
+    AllowPolicyChange = TRUE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANTS
+    TypeOK
+    SelectionRetainsResolver
+    ReferenceUsesSelectingContext
+    ContinuationDoesNotChangePolicy
+    PublishedAssociation
+    BindingVersionAdvanceIsFresh
+PROPERTIES
+    BindingVersionBehaviorRefinesOwner
+    AttemptSettles

--- a/docs/design/models/resolver-lineage/StableProgress.cfg
+++ b/docs/design/models/resolver-lineage/StableProgress.cfg
@@ -1,0 +1,16 @@
+CONSTANTS
+    VersionOne = versionOne
+    VersionTwo = versionTwo
+    Mode = "Explicit"
+    AllowPolicyChange = FALSE
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+INVARIANTS
+    TypeOK
+    SelectionRetainsResolver
+    ReferenceUsesSelectingContext
+    ContinuationDoesNotChangePolicy
+    PublishedAssociation
+PROPERTIES
+    BindingVersionBehaviorRefinesOwner
+    StableAttemptPublishes

--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -505,6 +505,11 @@ its Metadata provenance representation does not.
 
 There are four legitimate starts and they stay explicit:
 
+The following sketches show the implemented seed-origin surface. The
+[resolver-lineage continuation contract](#resolver-lineage-continuations)
+adds a selected-occurrence start and origin; an acquisition descriptor alone
+remains a seed, not a way to resume a context-sensitive selection.
+
 ```csharp
 public abstract class AssemblyBindingOrigin
 {
@@ -648,7 +653,8 @@ context's frozen catalog, probe it, then follow any forwarder." An unregistered
 handle is a typed `UnregisteredAssembly` rejection; resolution never mutates a
 frozen catalog. `Reference` means "first ask the binding policy to resolve this
 exact `AssemblyRef` from this binding origin, then probe the result." Forwarder
-hops always use the current candidate as `RequestingAssembly`; a global origin
+hops always use the current candidate as `RequestingAssembly`, retaining its
+selected occurrence's continuation when present; a global origin
 is explicit and a policy may reject it for a source-relative scope. The builder
 registers a reference start's requesting registration as a plan root before
 freeze, then policy receives only that opaque registration. A frozen context
@@ -1268,12 +1274,14 @@ return the delegate token as the governing token for composite behavior. It
 never relabels a mismatched delegated payload with its own version.
 
 One atomically published composite state contains its token, captured delegate
-versions, and immutable routing inputs. A learned source-relative route is
-staged into a fresh composite state and token; it cannot mutate answers under
-the current token. #5216 may instead provide a complete route map during
-workspace realization. This contract defines the policy-local state
-transition, not construction, publication, termination, or replacement of the
-workspace generation that consumes it.
+versions, and immutable routing inputs. Changing that routing function requires
+a fresh composite state and token; it cannot mutate answers under the current
+token. Selecting another occurrence under that unchanged function is not a
+policy change. The resolver-lineage contract below replaces discovery-time
+route insertion for source-relative groups with an explicit continuation.
+Issue #5216 may instead provide a complete route map during workspace realization.
+This contract defines the policy-local state transition, not construction,
+publication, termination, or replacement of the consuming workspace generation.
 
 `AssemblyReferenceBindingPolicy` has two disjoint modes. A structured-policy
 delegate is fully transparent for every target: the adapter exposes the
@@ -1302,6 +1310,182 @@ mutations, commit-point validation, pre-commit policy-publication exclusion,
 and eventual publication. Its companion composite model checks matching success,
 foreign-snapshot propagation, state refresh, route replacement, and retry
 progress.
+
+#### Resolver-lineage continuations
+
+> **Status: design-only; product adoption is unverified.** #5801 supplies
+> compiled evidence for the existing behavior, not this representation.
+> #5666 owns this focused decision; #5274 tracks adoption and retirement.
+> Existing policies retain their transitional behavior until their adoption
+> slices land.
+
+**Claim:** a selected assembly occurrence retains the policy-issued binding
+context required for its subsequent references, without changing the answers
+to other requests under the same policy version.
+
+The production consumer is `AssemblySetSurfaceBuilder`, through
+`AssemblySetResolutionSession`. CLI `DiffCommand` and `TimelineCommand`
+already invoke it through `ApiSurfaceEndpointResolver`. The #5801 fixture
+demonstrates `Consumer -> Middle forwarder -> Base`: a constraint classifies as
+`ReferenceType` through Consumer's resolver and as `Undetermined` when the
+learned association is removed. This establishes the need for resolver lineage,
+not the need for a shared mutable route map. It is Services-level evidence;
+it does not claim an end-to-end command or call-graph demonstration.
+
+##### Decision and alternatives
+
+| Representation | Decision and reason |
+| --- | --- |
+| Policy-issued continuation on the selected occurrence | Chosen: retains the source of the next binding decision without publishing a new answer for an existing origin. |
+| Complete immutable participant routes | Retained for sealed workspaces. Open-ended assembly-set inspection cannot assume that all selected forwarding participants were initial roots. |
+| Registration-to-resolver map with fresh tokens | Not the default: every newly discovered route could supersede discovery, requiring a retry/convergence owner that this path does not have. |
+| Add-only map under one token | Rejected: an unrouted origin already receives the fallback answer, so insertion can change an equal request. Sharing one registration also makes first-writer ownership insufficient. |
+| Separate catalog per initial root | Insufficient by itself: selecting a canonical peer root can switch the governing resolver. That context still has to survive the next hop; duplicating catalogs does not define the missing association. |
+
+The two-context boundary is deliberately distinct from the minimal #5801
+fixture: two supported policy delegates can return the same acquisition
+descriptor while prescribing different dependencies. The model explores this
+boundary; a compiled product gate for it remains part of adoption.
+
+##### Currency and authority
+
+An `AssemblyBindingOccurrence` pairs a selected `ResolvedAssemblyReference`
+with its `AssemblyBindingLineage`. The descriptor continues to own acquisition
+identity; the lineage owns the binding context in which references from that
+occurrence are interpreted. Neither field is inferred from a path, display
+name, MVID, or the order in which a candidate was discovered.
+
+A lineage is opaque outside its issuing policy. It is scoped to the exact
+issuing policy state/version and denotes an immutable continuation of that
+state's routing function. Its equality must preserve the issuer, policy
+version, and every delegated-context distinction that can change a subsequent
+answer. Equal continuation meanings within one state have stable equality;
+traversing another hop does not create a new meaning merely because it is
+another call. This is a bounded routing context, not an accumulated path.
+
+A seed origin explicitly names an initial assembly or the existing global
+arm. It uses the policy's fixed seed/default rules. A continuation origin
+names the selected occurrence. Reconstructing a seed from that occurrence's
+registration is not an equivalent operation. Existing context-free policies
+may return an explicit seed continuation; they do not claim to retain a
+source-relative context.
+
+Only the selection issuer pairs an assembly with its continuation. Metadata
+retains that pair, projects the descriptor through the acquisition catalog,
+and passes the occurrence as the requesting origin for forwarding, intrinsic
+core-library binding, and other context-sensitive resolution dependencies.
+The issuer has the requesting descriptor as well as the opaque lineage when
+its binding rule needs image facts; it need not recover a descriptor from an
+otherwise uninformative registration.
+
+For a source-relative group, selecting a configured canonical participant
+uses that participant's configured resolver context. Selecting a transitive
+non-participant retains the selecting delegate's context. Thus the rule is
+not "always copy the parent's context": existing canonical-root and
+designated/platform selection semantics still determine the selected result.
+A terminal missing, unavailable, rejected, or ambiguous result creates no
+active selected occurrence and installs no route. Shadowed descriptors are
+evidence, not active continuations.
+
+A transparent wrapper preserves the occurrence unchanged. A transforming
+composite issues its own continuation and retains the delegated continuation
+inside it; it does not pass an outer context to a delegate that did not issue
+it. The existing delegated-snapshot version check precedes payload use and
+therefore precedes occurrence issuance. This section does not change
+candidate-domain eligibility or finalization: when composition returns a
+terminal selection, that selection's issuer also supplies its continuation.
+
+##### Association, reuse, and failure
+
+The atomic selection snapshot governs the assembly and continuation together.
+An occurrence from another issuing state cannot be silently rebound under a
+new token or treated as a seed. A stale or foreign continuation is an explicit
+binding-origin rejection, not an identity miss or a reason to use the default
+resolver. Ordinary in-flight version drift keeps the existing
+`PolicyVersionChanged` control and commit rules. A later generation must obtain
+fresh occurrences from its seeds; this design adds no automatic retry.
+
+The Metadata binding-domain projection includes the candidate and the full
+lineage distinction. Type-request keys, intrinsic-binding keys, deferred
+kind-resolution dependencies, frozen manifests, and policy-dependent recipes
+retain the same distinction. The same candidate reached through two lineages
+may share acquisition, inventory, and image-local declaration facts, but not a
+binding answer or context-dependent type-kind result merely because its
+physical definition is the same.
+
+A selected binding outcome, a terminal resolution result, and a retained
+recipe preserve the occurrence needed to start a later context-sensitive
+request. A physical definition key, token, or address remains physical
+correspondence currency; it does not become a resolver-context lookup key.
+The continuation supplies no new acquisition authority and does not extend
+the lifetime of a catalog or an owning workspace.
+
+Across a policy-version change, context-sensitive recipes are re-derived
+from seeds rather than relabeling old lineages. Image-local reuse remains
+available. Selective cross-version equivalence of lineage-bearing recipes
+is not a claim of this slice.
+
+Stable lineage equality makes repeated semantic requests idempotent.
+Occurrences count as relationship/discovery work under the existing bounds,
+even when they share one candidate; the candidate count is not a substitute
+for that work bound. Existing physical-candidate forwarder-cycle detection
+and hop budgets remain unchanged. This effort does not widen support for
+revisiting a candidate through a different context on one forwarding path.
+
+##### Both production hosts and retirement
+
+The counted adoption path in #5274 has **four steps**, including this design.
+The table is a composition plan, not authority over another owner's internals.
+
+| Step | Owning slice and completion |
+| --- | --- |
+| 1 | Binding owner: lock this currency and the companion model in #5666. Product behavior is unchanged. |
+| 2 | Metadata: carry selected occurrences through requests, results, deferred dependencies, and policy-dependent caches. Existing seed-only producers remain behavior-compatible; context-aware gates demonstrate distinct answers for a shared registration. |
+| 3 | Services: adopt the currency in `SourceRelativeAssemblyGroupBindingPolicy` and remove learned-route insertion, its CAS publication, and registration-only intrinsic caching. Preserve the #5801 result and demonstrate it through the existing CLI `diff` endpoint; `timeline` uses the same endpoint construction. |
+| 4 | Queries/Browser: adopt through `AssemblyContextTypeResolutionQuery` and `MemberCallGraphSession`, exercised by `PlatformCallGraphExports`. Confirm terminal member navigation and call-graph endpoints while retaining sealed participant provisioning and one attempt per authorized demand. |
+
+The CLI production path is reached at step 3; the Browser path at step 4.
+Browser is an actual caller of both named query services. It is not evidence
+for discovery-time route learning: the workspace-owned complete-plan and
+one-attempt contract remains unchanged. No Browser filesystem resolver or
+host-specific continuation algorithm is introduced.
+
+The replacement is incomplete until step 3 retires the Services learned-route
+representation and step 4 closes both-host adoption. Other transforming
+policies remain the separately scoped work in #5667, #5668, and #5669.
+Delegated-version refresh is still required when a delegate actually changes;
+it is not made unnecessary by replacing route learning.
+
+##### Evidence and limits
+
+The [resolver-lineage model](models/resolver-lineage/README.md) checks the
+selected-occurrence association, lineage-sensitive cache reuse, canonical-root
+context selection, and stable-token progress. It imports the binding owner's
+version lifecycle and checks that genuine policy change can supersede the
+attempt without an automatic retry. Negative controls erase the occurrence
+context, omit it from cache identity, always inherit a parent context, or
+advance the token merely for selecting a continuation.
+
+The model abstracts two resolver contexts, one shared selected candidate, and
+two terminal dependencies; it is not a PE decoder, a workspace realization
+model, or proof of product adoption. Exact TLC outcomes are enforced by
+`eng/tla-expected-exit-codes.txt`. Product enforcement remains unverified until
+steps 2-4 provide Release gates at the Metadata, Services/CLI, and
+Queries/Browser boundaries. No feature-specific rendering domain is added:
+the existing API and call-graph models and their lowering owners remain.
+
+The comparative baseline is explicit context association, not a new loading
+mechanism. [AssemblyLoadContext][lineage-alc] associates assemblies with loading
+contexts and requires repeatable answers; shared assemblies retain their
+owning context, rather than copying every referring context.
+[MetadataLoadContext][lineage-mlc] keeps binding answers, including failures,
+inside one context and rejects resolver results belonging to another context.
+Those constraints inform association and cache scope. Their loading APIs,
+one-name-per-context rules, and fallback policies are not this tool's binding
+authority; no implementation code or runtime-loading mechanism is imported.
+
+[lineage-alc]: https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext
+[lineage-mlc]: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.Resolving.cs
 
 #### Complete identity-eligible binding composition
 
@@ -1536,7 +1720,9 @@ the requesting origin in the request and cache key; different origins may reuse
 the same selected registration without sharing a cached policy decision.
 
 The internal structurally equatable `AssemblyBindingDomainKey` is a closed
-value with `Global` and `RequestingCandidate(AssemblyCandidateId)` arms. It is
+origin projection. Its implemented arms are `Global` and
+`RequestingCandidate(AssemblyCandidateId)`; the continuation target contract
+adds the lineage distinction to a requesting occurrence. It is
 generation-scoped and is the only origin projection permitted in binding and
 resolution cache keys. `AssemblyBindingCacheKey` is the structural tuple of
 that domain key, closed binding target, and scope; the containing cache supplies
@@ -2152,9 +2338,11 @@ It stores:
 - the exact `AssemblyBindingCacheKey` dependencies and their closed,
   structurally comparable `AssemblyBindingSnapshot` values.
 
-`AssemblyBindingSnapshot` contains only the binding arm, missing disposition,
-selected candidate ids, and typed failure payload; it never compares public
-outcome objects or descriptors. Freeze stores recipes by
+`AssemblyBindingSnapshot` contains the binding arm, missing disposition,
+selected candidate ids, their lineage distinctions when present, and typed
+failure payload; it never compares public outcome objects or descriptors.
+Lineage-bearing recipes follow the seed re-derivation rule above on policy
+replacement. Freeze stores recipes by
 `(AssemblyCatalogGenerationId, TypeResolutionCacheKey)` and materializes the
 public outcome and definition keys for that generation. A later epoch carries
 each dependency forward without a policy call while its owning policy version
@@ -2223,9 +2411,10 @@ catalog, and caches:
 
 `TypeResolutionCacheKey` is an internal projection; it does not use the public
 request object's reference equality. Its start arm contains either the internal
-candidate id plus scope or the closed binding target plus binding-domain key
-plus scope, or the source candidate plus module name, followed by the
-structurally equatable `MetadataTypeDefinitionName`.
+candidate id and any selected-occurrence lineage plus scope or the closed
+binding target plus binding-domain key plus scope, or the source occurrence
+plus module name, followed by the structurally equatable
+`MetadataTypeDefinitionName`.
 
 The cache retains typed failures as well as successes. Re-running a rejected
 probe must not turn it into a success-shaped miss.

--- a/eng/tla-expected-exit-codes.txt
+++ b/eng/tla-expected-exit-codes.txt
@@ -36,6 +36,13 @@ docs/design/models/binding-selection-version/AssemblyBindingPolicyVersionLifecyc
 docs/design/models/binding-selection-version/CompositeBindingVersionBrokenLifecycle.cfg=13
 docs/design/models/binding-selection-version/CompositeBindingVersionLiveness.cfg=0
 docs/design/models/binding-selection-version/CompositeBindingVersionSafety.cfg=0
+docs/design/models/resolver-lineage/BrokenAlwaysInherit.cfg=12
+docs/design/models/resolver-lineage/BrokenCandidateCache.cfg=12
+docs/design/models/resolver-lineage/BrokenRegistrationMap.cfg=12
+docs/design/models/resolver-lineage/BrokenRouteChurn.cfg=12
+docs/design/models/resolver-lineage/ReachabilitySupersession.cfg=12
+docs/design/models/resolver-lineage/Safety.cfg=0
+docs/design/models/resolver-lineage/StableProgress.cfg=0
 docs/design/models/research-workspace-target-composition/BlockedTerminalCensusUnavailable.cfg=0
 docs/design/models/research-workspace-target-composition/BroaderResearchPopulationRejected.cfg=0
 docs/design/models/research-workspace-target-composition/BrokenBindingDrift.cfg=12


### PR DESCRIPTION
## Claim

Make dependable inspection results simpler: preserve the resolver context of
a selected assembly explicitly instead of mutating shared routes during
discovery.

This is a binding-owner **design and model**, not product adoption.
The normative owner is
`docs/design/type-forwarding-resolution.md#resolver-lineage-continuations`.
An occurrence pairs an acquisition descriptor with its policy-issued
continuation; requests and policy-dependent reuse preserve that association.

Relates to #5666. End-to-end adoption and retirement: #5274.
This PR completes only step 1 of the four-step replacement plan when merged;
neither issue should close with this PR.

## Demo

The existing production caller is:

```text
CLI diff / timeline
  -> ApiSurfaceEndpointResolver
  -> AssemblySetSurfaceBuilder
  -> AssemblySetResolutionSession
  -> SourceRelativeAssemblyGroupBindingPolicy
```

The compiled evidence already landed in #5801:

```text
Roots: [Unrelated, Consumer]
Consumer -> Middle forwarder -> Base

Preserve Consumer's resolver: constraint kind = ReferenceType
Remove the learned association: constraint kind = Undetermined
```

That Services result establishes a need for resolver lineage, not a requirement
for shared mutable route state. It is not an end-to-end CLI demonstration.

The new bounded model illustrates the replacement:

```text
Left  -> (Shared candidate, Left context)  -> LeftBase
Right -> (Shared candidate, Right context) -> RightBase

Same physical candidate; different binding occurrences.
The policy version stays unchanged during ordinary selection.
```

Neighboring case: if Left selects a configured canonical Right root, the
selected occurrence uses Right's context, not Left's. Merely inheriting the
parent context is therefore insufficient.

Four negative controls expose registration-map first-writer ownership,
candidate-only cache reuse, always-inherited context, and unnecessary version
churn. A separate witness reaches supersession on genuine policy change.

## Decision and compatibility

- Prefer immutable policy-issued continuations to route-learning token churn.
  Keep complete participant routes for sealed workspaces.
- Keep physical acquisition identity distinct from resolver context; do not
  clone registrations to encode lineage.
- Preserve descriptor/context association through forwarding, intrinsic and
  deferred dependencies, results, recipes, and policy-dependent caches.
- Preserve canonical-root context choice, atomic snapshot validation, real
  delegated-version refresh, and one attempt per authorized workspace demand.
- Keep existing physical-candidate cycle detection and hop bounds.

AssemblyLoadContext and MetadataLoadContext provide comparative evidence for
explicit context association and cache scope, not loading APIs or normative
binding rules. No inspected-assembly loading is introduced.

## Production-host adoption and retirement

The four counted steps are:

1. **This PR:** lock the binding-owner contract and model.
2. **Metadata:** propagate occurrences through requests, results, deferred
   dependencies, and caches; demonstrate distinct contexts for a shared
   registration.
3. **Services/CLI:** adopt in the existing source-relative group policy,
   retire learned-route insertion/CAS and registration-only intrinsic caching,
   preserve #5801, and exercise the actual `diff` endpoint. `timeline` shares it.
4. **Queries/Browser:** adopt through `AssemblyContextTypeResolutionQuery` and
   `MemberCallGraphSession`, exercised by `PlatformCallGraphExports`, preserving
   sealed provisioning and terminal navigation/call-graph endpoints.

Both hosts already have production callers. The new representation remains
unimplemented until those slices land. Other transforming policies remain
separate work in #5667, #5668, and #5669. No new rendering domain is added;
existing API/call-graph models and lowering owners remain.

## Evidence

The model directly represents the occurrence's candidate, issuer, captured
version, and resolver distinction. It imports
`AssemblyBindingPolicyVersionLifecycle` by named instance and rechecks its
safety refinement and freshness. Weak fairness covers local progress, not an
inevitable external change.

The model does not cover PE parsing, identity eligibility/finalization,
ambiguity handling, nested composites, acquisition/budget enforcement,
historical recipe reuse, or real host execution. Product enforcement is
explicitly unverified until the planned Release gates land.

## Validation

- `TLA_TOOLS_JAR="$PWD/artifacts/tlaplus/tla2tools.jar" ./eng/run-tla-checks.sh docs/design/models/resolver-lineage`
  completed all seven registered exact outcomes with pinned TLC
  `2026.08.11.125311`.
- Safety: 64 generated / 56 distinct states. Stable progress: 28 generated /
  20 distinct states. Both state spaces exhausted.
- Inspected all four negative-control traces and the supersession witness;
  each failed its intended invariant.
- `npx --no-install markdownlint-cli docs/design/type-forwarding-resolution.md docs/design/models/resolver-lineage/README.md`
- `git diff --check`

No product code changes; no new .NET build claim.
