### PR TITLE
Add full-area Explore for package dependency graphs

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -353,21 +353,45 @@ Leaving the originating member, overload, package, framework, or inspector
 closes the viewer. Opening another dialog also closes it, without reopening it
 when that dialog is dismissed.
 
+Package Dependencies uses the same viewer and action-row placement. Explore is
+available once dependency groups have been read, including a selected group with
+no connected packages. The viewer contains the manifest-group selector, exact-group
+notice, graph, and workspace/diagram diagnostics. Package coordinate controls,
+dependency lists, assembly references, and the coordinate footer remain on the
+underlying page. The viewer identifies the inspected package; group buttons
+identify the selected manifest framework independently of the active coordinate.
+Selecting a group stays in Explore and updates the existing list and graph.
+Closing retains that selection. Pending graph rendering can complete in either
+placement; opening or closing does not restart it.
+
+Dependency nodes use the same keyboard activation and drag suppression as Call
+graph nodes. Selecting a loaded or unloaded package closes Explore and uses the
+existing dependency-navigation path. Success focuses the destination heading;
+failure exposes the existing inline notice and restores Explore focus. A package,
+version, active framework, assembly, or inspector change closes the viewer rather
+than moving an unrelated graph into it. Empty, query-failed, render-failed,
+partial-workspace, and truncated results remain visible; graph controls do not
+cover truncation diagnostics.
+
 The browser-only presentation scope was explicitly approved for
 [the two-step adoption tracker](https://github.com/richlander/dotnet-inspect/issues/5867).
 Step 1 is [Member Call graph](https://github.com/richlander/dotnet-inspect/issues/5868);
-step 2 is Package Dependencies using the same placement component. Dependencies
-does not advertise Explore until that separate slice lands. Inline presentation
-is not retired. Existing typed `BrowserCallGraph`/`InspectedCallGraph` results,
-target bindings, and Mermaid lowering continue to supply graph data and node
-identity. This host-only placement change bypasses Markout for the interactive
-browser canvas, adds no graph-analysis substrate, and does not change CLI output,
-query scope, traversal, acquisition, or layout algorithms.
+step 2 is [Package Dependencies](https://github.com/richlander/dotnet-inspect/issues/5904)
+using the same placement component. Inline presentation is not retired.
+Existing typed `BrowserCallGraph`/`InspectedCallGraph` and
+`DependencyGraphModel`/`DependencyGraphResult` results, target bindings, and
+Mermaid lowering continue to supply graph data and node identity. This host-only
+placement change bypasses Markout for the interactive browser canvas, adds no
+graph-analysis substrate, and does not change CLI output, query scope, traversal,
+acquisition, or layout algorithms.
 
 The browser gate covers live DOM and interaction retention across placement
 changes, result replacement, pending completion, no-body/failure visibility,
 dialog focus and dismissal, and narrow geometry. Published Wasm evidence covers
-the production action row, platform drill/back, and member navigation.
+the production action row and destination navigation. Dependency coverage also
+exercises group changes, empty groups, pending completion, truncation geometry,
+and package navigation/failure. Live platform drill/back evidence is reported
+separately from component coverage when acquisition is unavailable.
 
 Member Source and Annotated Source remain the heading-free full-area exceptions
 defined below. Loading and failure states stay visible and do not become
@@ -435,6 +459,10 @@ target-framework selector, dependency graph, package dependency list, assembly
 references, and partial workspace warning. Selecting another manifest group
 patches its list and graph in place without changing the surface frame or
 resetting the package coordinate.
+
+The action row also exposes [Graph Explore](#graph-explore), retaining inline
+presentation as the default and the same dependency-group selection in both
+placements.
 
 The fixed bottom context row preserves the exact package coordinate and active
 framework. Loading, query failure, no-dependency, no-exact-group, graph

--- a/prototypes/inspect-web/browser/dependency-graph-explorer-harness.ts
+++ b/prototypes/inspect-web/browser/dependency-graph-explorer-harness.ts
@@ -1,0 +1,203 @@
+import mermaid from "mermaid";
+import { bindGraphExplore, createGraphExplorer } from "../src/graph-explorer.ts";
+import { bindGraphPanZoom } from "../src/graph-interactions.ts";
+import { buildDependencyGraphMermaid, resolveMermaidCssVariables } from "../src/graph-mermaid.ts";
+import { bindPackageView } from "../src/package-view.ts";
+import { createWorkbenchKeybindings } from "../src/workbench-keybindings.ts";
+
+const app = document.querySelector<HTMLElement>("#app")!;
+const explorer = createGraphExplorer(document);
+const keybindings = createWorkbenchKeybindings();
+keybindings.attach(document);
+const pkg = { id: "Example.Package", version: "1.0.0", activeFramework: "net10.0" };
+const loaded = { ...pkg, id: "Loaded.Dependency" };
+const groups = [
+  {
+    index: 0, framework: "net10.0", isActive: true,
+    dependencies: ["Loaded.Dependency", "New.Dependency", "Failed.Dependency"]
+      .map(id => ({ id, versionRange: "1.0.0" })),
+  },
+  { index: 1, framework: "net11.0", dependencies: [] },
+  {
+    index: 2, framework: "netstandard2.0",
+    dependencies: Array.from({ length: 85 }, (_, index) => ({
+      id: `Dependency.${index}`, versionRange: "1.0.0",
+    })),
+  },
+];
+let groupIndex = 0;
+let state: "ready" | "query-error" | "render-error" | "no-groups" = "ready";
+let notices = false;
+let notice = "";
+let mounts = 0;
+let navigations = 0;
+let retainedSvg: SVGSVGElement | null = null;
+let hold: Promise<void> | null = null;
+let releasePending: (() => void) | null = null;
+let pendingRender = Promise.resolve();
+
+declare global {
+  interface Window {
+    dependencyExploreProbe: {
+      update: (next: typeof state) => Promise<void>;
+      startPending: () => void;
+      finishPending: () => Promise<void>;
+      showNotices: () => Promise<void>;
+      changeOwner: () => Promise<void>;
+      rememberSvg: () => void;
+      sameSvg: () => boolean;
+      counts: () => { mounts: number; navigations: number };
+    };
+  }
+}
+
+function key() {
+  return `dependencies:${pkg.id}@${pkg.version}/${pkg.activeFramework}`;
+}
+
+function target() {
+  return {
+    key: key(),
+    title: "Dependency graph",
+    context: `${pkg.id}@${pkg.version} · ${pkg.activeFramework}`,
+    content: document.querySelector<HTMLElement>("[data-dependency-graph-surface]")!,
+    invoker: document.querySelector<HTMLElement>("#explore")!,
+  };
+}
+
+async function mountGraph() {
+  const diagram = document.querySelector<HTMLElement>("#dependency-graph-diagram");
+  if (!diagram) return;
+  if (state === "render-error") {
+    diagram.innerHTML = '<div class="graph-render-error"><strong>Diagram rendering failed</strong><p>Fixture diagram failure</p></div>';
+    return;
+  }
+  const graph = buildDependencyGraphMermaid({
+    package: pkg,
+    packages: [pkg, loaded],
+    packageDependencies: { dependencyGroups: groups },
+    dependenciesGroupIndex: groupIndex,
+    workspaceDependencies: {},
+  }, (packages, id) => packages.find(candidate => candidate.id === id) ?? null);
+  if (!graph) {
+    diagram.innerHTML = "<p>No connected packages for this framework.</p>";
+    return;
+  }
+  const pending = hold;
+  mermaid.initialize({
+    startOnLoad: false, securityLevel: "strict", flowchart: { htmlLabels: false },
+  });
+  const style = getComputedStyle(document.documentElement);
+  const definition = resolveMermaidCssVariables(graph.definition, name => style.getPropertyValue(name));
+  const { svg } = await mermaid.render(`dependency-browser-${++mounts}`, definition);
+  await pending;
+  if (document.querySelector("#dependency-graph-diagram") !== diagram) return;
+  diagram.innerHTML = `
+    <div class="dependency-graph-stage">
+      <div class="graph-viewport">${svg}</div>
+      <div class="graph-controls">
+        <button type="button" data-zoom="in" aria-label="Zoom in">+</button>
+        <button type="button" data-zoom="out" aria-label="Zoom out">-</button>
+        <button type="button" data-zoom="reset" aria-label="Fit">fit</button>
+      </div>
+    </div>
+    ${graph.truncated ? `<div class="graph-drill-error graph-diagnostics" role="status">Dependency graph truncated at ${graph.nodeLimit} nodes.</div>` : ""}`;
+  bindGraphPanZoom(diagram, diagram.querySelector<HTMLElement>(".graph-viewport")!, {
+    keybindings,
+    resolveDependencyGraphNode: nodeId => {
+      const info = graph.nodeInfoById.get(nodeId);
+      if (!info?.id || info.kind === "self") return null;
+      const id = info.id;
+      return {
+        label: `${info.kind === "open" ? "Open" : "Load"} ${id}`,
+        onSelect: () => { void navigate(id); },
+      };
+    },
+  });
+}
+
+async function navigate(id: string) {
+  explorer.close(false);
+  navigations++;
+  if (id === "Failed.Dependency") {
+    notice = "Could not load Failed.Dependency: fixture acquisition failure.";
+    await render();
+    document.querySelector<HTMLElement>("#explore")!.focus();
+  } else {
+    pkg.id = id;
+    await render();
+    document.querySelector<HTMLElement>("h1")!.focus();
+  }
+}
+
+function patchGroup() {
+  const selected = groups[groupIndex];
+  if (!selected) throw new Error(`Unknown fixture dependency group: ${groupIndex}`);
+  document.querySelectorAll<HTMLElement>("[data-dep-group]").forEach(button => {
+    const active = Number(button.dataset.depGroup) === groupIndex;
+    button.classList.toggle("active", active);
+    button.setAttribute("aria-pressed", String(active));
+  });
+  document.querySelector<HTMLElement>("#dep-list-section")!.textContent =
+    `${selected.framework}: ${selected.dependencies.length} packages`;
+  return mountGraph();
+}
+
+async function render() {
+  explorer.beforeRender(key());
+  app.innerHTML = `
+    <main>
+      <h1 tabindex="-1">Dependencies: ${pkg.id}</h1>
+      <div class="working-surface-actions"><button type="button" id="explore" data-graph-explore${state === "query-error" || state === "no-groups" ? " disabled" : ""}>Explore</button></div>
+      <button type="button" id="coordinates">Package coordinate controls</button>
+      ${notice ? `<p role="status">${notice}</p>` : ""}
+      <div class="package-dependencies-scroll">
+        <div data-dependency-graph-surface>
+          ${state === "query-error" || state === "no-groups"
+            ? `<section class="document-section empty-document"><h2>${state === "query-error" ? "Dependency query failed" : "No package dependencies"}</h2><p>${state === "query-error" ? "Fixture query failure" : "Self-contained package"}</p></section>`
+            : `
+              ${notices ? '<section class="document-section empty-document"><h2>No exact dependency group</h2><p>The package has no manifest group matching the active coordinate.</p></section>' : ""}
+              <section class="document-section dependency-group-selector">
+                <div class="section-title"><h2>Target frameworks</h2><span>one framework at a time</span></div>
+                <div class="type-chip-list" id="dep-tfm-chips">${groups.map(group => `<button type="button" class="type-chip" data-dep-group="${group.index}">${group.framework}</button>`).join("")}</div>
+              </section>
+              <section class="document-section dependency-graph-section">
+                <div class="section-title"><h2>Dependency graph</h2><span>callers above · dependencies below · click a package to open</span></div>
+                ${notices ? '<div class="graph-drill-error" role="status">Some workspace manifests could not be read.</div>' : ""}
+                <div id="dependency-graph-diagram" class="call-graph-diagram"><p>Rendering graph...</p></div>
+              </section>`}
+        </div>
+        <section class="document-section" id="dep-list-section"></section>
+        <section class="document-section" id="assembly-references">Assembly references</section>
+      </div>
+    </main>`;
+  bindGraphExplore(document, () => explorer.open(target()));
+  bindPackageView(document, {
+    onDependencyGroupSelect: index => { groupIndex = index; void patchGroup(); },
+    onDependencyOpen: id => { void navigate(id); },
+    onDependencyLoad: id => { void navigate(id); },
+    onGraphTypeSelect() {},
+    onKindJump() {},
+    onLibraryScopeSelect() {},
+    onNamespaceJump() {},
+    onPerformanceMemberSelect() {},
+  });
+  explorer.afterRender(target());
+  await patchGroup();
+}
+
+window.dependencyExploreProbe = {
+  update: async next => { state = next; await render(); },
+  startPending: () => {
+    hold = new Promise<void>(resolve => { releasePending = resolve; });
+    pendingRender = render();
+  },
+  finishPending: async () => { releasePending?.(); hold = null; await pendingRender; },
+  showNotices: async () => { notices = true; await render(); },
+  changeOwner: async () => { pkg.activeFramework = "net11.0"; await render(); },
+  rememberSvg: () => { retainedSvg = document.querySelector("#dependency-graph-diagram svg"); },
+  sameSvg: () => retainedSvg === document.querySelector("#dependency-graph-diagram svg"),
+  counts: () => ({ mounts, navigations }),
+};
+
+await render();

--- a/prototypes/inspect-web/browser/dependency-graph-explorer.html
+++ b/prototypes/inspect-web/browser/dependency-graph-explorer.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dependency Graph Explore browser gate</title>
+    <link rel="stylesheet" href="../src/styles.css">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./dependency-graph-explorer-harness.ts"></script>
+  </body>
+</html>

--- a/prototypes/inspect-web/browser/dependency-graph-explorer.spec.ts
+++ b/prototypes/inspect-web/browser/dependency-graph-explorer.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/browser/dependency-graph-explorer.html");
+  await expect(page.locator("#dependency-graph-diagram svg")).toBeVisible();
+});
+
+test("Dependencies relocates the live graph and group controls, not the lists", async ({ page }) => {
+  await page.getByRole("button", { name: "Zoom in", exact: true }).click();
+  const style = await page.locator("#dependency-graph-diagram svg").getAttribute("style");
+  await page.evaluate(() => window.dependencyExploreProbe.rememberSvg());
+  const before = await page.evaluate(() => ({
+    ...window.dependencyExploreProbe.counts(), url: location.href, history: history.length,
+  }));
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Dependency graph" });
+  await expect(dialog.locator("#dep-tfm-chips")).toBeVisible();
+  await expect(dialog.locator("#dep-list-section, #assembly-references, #coordinates")).toHaveCount(0);
+  await expect(page.locator("#graph-explorer-title")).toBeFocused();
+  expect(await page.evaluate(() => window.dependencyExploreProbe.sameSvg())).toBe(true);
+  expect(await page.locator("#dependency-graph-diagram svg").getAttribute("style")).toBe(style);
+  await page.keyboard.press("Shift+Tab");
+  await expect(page.getByRole("button", { name: "Fit", exact: true })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Close", exact: true })).toBeFocused();
+  await page.evaluate(() => document.querySelector<HTMLElement>("#coordinates")!.focus());
+  await expect(page.getByRole("button", { name: "Close", exact: true })).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("button", { name: "Explore", exact: true })).toBeFocused();
+  expect(await page.evaluate(() => window.dependencyExploreProbe.sameSvg())).toBe(true);
+  expect(await page.locator("#dependency-graph-diagram svg").getAttribute("style")).toBe(style);
+  expect(await page.evaluate(() => ({
+    ...window.dependencyExploreProbe.counts(), url: location.href, history: history.length,
+  }))).toEqual(before);
+});
+
+test("group changes stay expanded and preserve an empty selection on Close", async ({ page }) => {
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.getByRole("button", { name: "net11.0", exact: true }).click();
+  await expect(page.getByRole("dialog")).toContainText("No connected packages");
+  await expect(page.getByRole("button", { name: "net11.0", exact: true })).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator("#dep-list-section")).toHaveText("net11.0: 0 packages");
+  await page.getByRole("button", { name: "net10.0", exact: true }).click();
+  await expect(page.getByRole("dialog").locator("svg")).toBeVisible();
+  await page.getByRole("button", { name: "net11.0", exact: true }).click();
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Explore", exact: true })).toBeFocused();
+  await expect(page.getByRole("button", { name: "net11.0", exact: true })).toHaveAttribute("aria-pressed", "true");
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await expect(page.getByRole("dialog")).toContainText("No connected packages");
+});
+
+test("a pending diagram completes in the viewer without another mount", async ({ page }) => {
+  await page.evaluate(() => window.dependencyExploreProbe.startPending());
+  await expect(page.getByText("Rendering graph...", { exact: true })).toBeVisible();
+  const before = await page.evaluate(() => window.dependencyExploreProbe.counts());
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.evaluate(() => window.dependencyExploreProbe.finishPending());
+  await expect(page.getByRole("dialog").locator("svg")).toBeVisible();
+  expect(await page.evaluate(() => window.dependencyExploreProbe.counts())).toEqual(before);
+});
+
+test("dependency nodes are keyboard navigable and dragging does not activate them", async ({ page }) => {
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  const node = page.getByRole("button", { name: "Open Loaded.Dependency", exact: true });
+  const box = await node.boundingBox();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + box!.width / 2 + 55, box!.y + box!.height / 2 + 40, { steps: 5 });
+  await page.mouse.up();
+  expect((await page.evaluate(() => window.dependencyExploreProbe.counts())).navigations).toBe(0);
+  await node.focus();
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Dependencies: Loaded.Dependency");
+  await expect(page.getByRole("heading", { level: 1 })).toBeFocused();
+});
+
+test("unloaded package navigation dismisses the viewer; failure remains inline", async ({ page }) => {
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.getByRole("button", { name: "Load Failed.Dependency", exact: true }).click();
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("status")).toContainText("fixture acquisition failure");
+  await expect(page.getByRole("button", { name: "Explore", exact: true })).toBeFocused();
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.getByRole("button", { name: "Load New.Dependency", exact: true }).focus();
+  await page.keyboard.press("Space");
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Dependencies: New.Dependency");
+  await expect(page.getByRole("heading", { level: 1 })).toBeFocused();
+});
+
+test("query, diagram, and empty results remain distinct in an already-open viewer", async ({ page }) => {
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.evaluate(() => window.dependencyExploreProbe.update("render-error"));
+  await expect(page.getByRole("dialog")).toContainText("Diagram rendering failed");
+  await page.evaluate(() => window.dependencyExploreProbe.update("query-error"));
+  await expect(page.getByRole("dialog")).toContainText("Dependency query failed");
+  await page.evaluate(() => window.dependencyExploreProbe.update("no-groups"));
+  await expect(page.getByRole("dialog")).toContainText("No package dependencies");
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("heading", { name: "No package dependencies" })).toBeFocused();
+  await expect(page.getByRole("button", { name: "Explore", exact: true })).toBeDisabled();
+});
+
+test("coordinate replacement closes the viewer and notices travel with the graph", async ({ page }) => {
+  await page.getByRole("button", { name: "Explore", exact: true }).click();
+  await page.evaluate(() => window.dependencyExploreProbe.showNotices());
+  await expect(page.getByRole("dialog")).toContainText("No exact dependency group");
+  await expect(page.getByRole("dialog")).toContainText("Some workspace manifests could not be read");
+  await expect(page.getByRole("dialog").locator("svg")).toBeVisible();
+  await page.evaluate(() => window.dependencyExploreProbe.changeOwner());
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.locator("#dependency-graph-diagram svg")).toBeVisible();
+});
+
+for (const size of [{ width: 1440, height: 1000 }, { width: 390, height: 844 }]) {
+  test(`Dependencies uses the viewport and keeps truncated diagnostics clear at ${size.width}px`, async ({ page }) => {
+    await page.setViewportSize(size);
+    const inline = await page.locator(".graph-viewport").boundingBox();
+    expect(inline!.height).toBeCloseTo(540, 2);
+    await page.getByRole("button", { name: "Explore", exact: true }).click();
+    const viewport = await page.locator(".graph-viewport").boundingBox();
+    expect(viewport!.width).toBeGreaterThan(size.width - 30);
+    expect(viewport!.height).toBeGreaterThan(size.height * 0.7);
+    await page.getByRole("button", { name: "netstandard2.0", exact: true }).click();
+    await expect(page.getByRole("status")).toHaveText("Dependency graph truncated at 80 nodes.");
+    await expect(page.getByRole("status")).toBeInViewport();
+    const warning = await page.getByRole("status").boundingBox();
+    const controls = await page.locator(".graph-controls").boundingBox();
+    expect(controls!.y + controls!.height).toBeLessThanOrEqual(warning!.y);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(size.width);
+    await page.getByRole("button", { name: "Fit", exact: true }).click();
+    await expect(page.getByRole("button", { name: "Close", exact: true })).toBeInViewport();
+    await page.getByRole("button", { name: "Close", exact: true }).click();
+    expect((await page.locator(".graph-viewport").boundingBox())!.height).toBeCloseTo(540, 2);
+  });
+}

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -202,14 +202,14 @@ import {
 } from "./member-focus.ts";
 import {
   buildDependencyGraphMermaid,
-  buildTypeGraphMermaid
+  buildTypeGraphMermaid,
+  resolveMermaidCssVariables,
 } from "./graph-mermaid.ts";
 import {
-  bindDependencyGraphNodes,
   bindGraphBack,
   bindGraphPanZoom,
   bindTypeGraphNodes,
-  type CallGraphNodeBinding,
+  type GraphNodeBinding,
   type GraphBackBindingActions,
 } from "./graph-interactions.ts";
 import { bindGraphExplore, createGraphExplorer } from "./graph-explorer.ts";
@@ -3084,7 +3084,7 @@ function typeDisplayName(
 function render(options: { synchronizeUrl?: boolean } = {}) {
   sourceInspection.cancelHiddenRequest();
   const graphExplorerWasOpen = graphExplorer.isOpen;
-  graphExplorer.beforeRender(callGraphExplorerKey());
+  graphExplorer.beforeRender(graphExplorerKey());
   if (graphExplorerWasOpen && !graphExplorer.isOpen) {
     graphExplorerNavigationFocusPending = !state.settings && !state.keyboardHelp
       && !state.explorer?.open && !workbenchModalOwnsFocus();
@@ -3307,8 +3307,11 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
           activeScope === "workspace" ? "workspace" : null,
           true,
           escapeHtml),
-        contextualActionsHtml: annotatedPageContext || sourcePageKind || callGraphPageContext
-          ? `<div class="working-surface-actions" role="group" aria-label="${callGraphPageContext ? "Call graph actions" : annotatedPageContext ? "Annotated Source actions" : "Source actions"}">
+        contextualActionsHtml: annotatedPageContext || sourcePageKind || callGraphPageContext || packageDependenciesWorkingSurface
+          ? `<div class="working-surface-actions" role="group" aria-label="${packageDependenciesWorkingSurface ? "Dependency graph actions" : callGraphPageContext ? "Call graph actions" : annotatedPageContext ? "Annotated Source actions" : "Source actions"}">
+              ${packageDependenciesWorkingSurface
+                ? `<button type="button" id="dependency-graph-explore" data-graph-explore${dependencyGraphAvailable() ? "" : " disabled"}>Explore</button>`
+                : ""}
               ${callGraphPageContext
                 ? `<button type="button" id="call-graph-explore" data-graph-explore${currentCallGraph() && !currentCallGraph()?.noBody ? "" : " disabled"}>Explore</button>`
                 : ""}
@@ -3427,7 +3430,7 @@ function render(options: { synchronizeUrl?: boolean } = {}) {
   }
   restorePackageQueryReturnFocus();
   restorePackageQueryWorkspaceFocus();
-  graphExplorer.afterRender(callGraphExplorerTarget());
+  graphExplorer.afterRender(graphExplorerTarget());
   recordNav();
   const productDemosRouteVisible =
     scope() === "workspace"
@@ -3961,18 +3964,18 @@ function renderPackageDependencies() {
   const fresh = state.packageDependenciesKey === current;
   if (state.packageDependenciesLoading && fresh) {
     return renderPackageDependenciesSurface(
-      `<section class="document-section package-dependencies-state source-progress"><span class="loader"></span><h2>Reading dependencies…</h2><p>Parsing the package manifest and assembly references.</p></section>`,
+      `<section data-dependency-graph-surface class="document-section package-dependencies-state source-progress"><span class="loader"></span><h2>Reading dependencies…</h2><p>Parsing the package manifest and assembly references.</p></section>`,
       "reading");
   }
   if (fresh && state.packageDependenciesError) {
     return renderPackageDependenciesSurface(
-      `<section class="document-section package-dependencies-state empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(state.packageDependenciesError)}</p></section>`,
+      `<section data-dependency-graph-surface class="document-section package-dependencies-state empty-document"><span class="large-glyph">⌘</span><h2>Dependency query failed</h2><p>${escapeHtml(state.packageDependenciesError)}</p></section>`,
       "query failed");
   }
   const data = fresh ? state.packageDependencies : null;
   if (!data) {
     return renderPackageDependenciesSurface(
-      `<section class="document-section package-dependencies-state empty-document"><span class="loader"></span><h2>Loading…</h2></section>`,
+      `<section data-dependency-graph-surface class="document-section package-dependencies-state empty-document"><span class="loader"></span><h2>Loading…</h2></section>`,
       "loading");
   }
 
@@ -3984,17 +3987,17 @@ function renderPackageDependencies() {
     : "";
   if (!groups.length) {
     return renderPackageDependenciesSurface(
-      `${dependencyGroupNotice}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No package dependencies</h2><p>The manifest declares no NuGet dependencies — a self-contained package.</p></section>${assemblyReferences}`,
+      `<div data-dependency-graph-surface>${dependencyGroupNotice}<section class="document-section empty-document"><span class="large-glyph">◇</span><h2>No package dependencies</h2><p>The manifest declares no NuGet dependencies — a self-contained package.</p></section></div>${assemblyReferences}`,
       packageDependenciesStatus(data, null));
   }
 
   const selectedGroupIndex = resolveDependenciesGroupIndex(groups);
   const orderedGroups = groups;
   const selectorChips = orderedGroups
-    .map(group => `<button class="type-chip ${group.index === selectedGroupIndex ? "active" : ""}" data-dep-group="${group.index}">${escapeHtml(group.framework)}</button>`)
+    .map(group => `<button class="type-chip ${group.index === selectedGroupIndex ? "active" : ""}" data-dep-group="${group.index}" aria-pressed="${group.index === selectedGroupIndex}">${escapeHtml(group.framework)}</button>`)
     .join("");
   const selector = `
-    <section class="document-section">
+    <section class="document-section dependency-group-selector">
       <div class="section-title"><h2>Target frameworks</h2><span>one framework at a time</span></div>
       <div class="type-chip-list" id="dep-tfm-chips">${selectorChips}</div>
     </section>`;
@@ -4002,14 +4005,14 @@ function renderPackageDependencies() {
   const depList = dependencyListSectionHtml(groups, selectedGroupIndex);
 
   const graphSection = `
-    <section class="document-section">
+    <section class="document-section dependency-graph-section">
       <div class="section-title"><h2>Dependency graph</h2><span>callers above · dependencies below · click a package to open</span></div>
       ${workspaceDependencyErrorHtml()}
       <div id="dependency-graph-diagram" class="call-graph-diagram"><span class="loader"></span><p>Rendering graph…</p></div>
     </section>`;
 
   return renderPackageDependenciesSurface(
-    `${dependencyGroupNotice}${selector}${graphSection}${depList}${assemblyReferences}`,
+    `<div data-dependency-graph-surface>${dependencyGroupNotice}${selector}${graphSection}</div>${depList}${assemblyReferences}`,
     packageDependenciesStatus(data, selectedGroupIndex));
 }
 
@@ -4087,10 +4090,11 @@ function patchDependenciesGroup() {
     document.querySelector<HTMLElement>("[data-package-dependencies-status]");
   if (!data || !groups.length || !listSection || !status) { render(); return; }
   const selectedGroupIndex = resolveDependenciesGroupIndex(groups);
-  document.querySelectorAll<HTMLElement>("#dep-tfm-chips [data-dep-group]").forEach(button =>
-    button.classList.toggle(
-      "active",
-      Number(button.dataset.depGroup) === selectedGroupIndex));
+  document.querySelectorAll<HTMLElement>("#dep-tfm-chips [data-dep-group]").forEach(button => {
+    const selected = Number(button.dataset.depGroup) === selectedGroupIndex;
+    button.classList.toggle("active", selected);
+    button.setAttribute("aria-pressed", String(selected));
+  });
   status.textContent = packageDependenciesStatus(data, selectedGroupIndex);
   listSection.outerHTML = dependencyListSectionHtml(groups, selectedGroupIndex);
   bindPackageDependencyListEvents();
@@ -6333,7 +6337,7 @@ function bindEvents() {
   workbenchShellBinding =
     bindWorkbenchShell(document, workbenchShellActions);
   bindGraphBack(document, graphBackActions);
-  bindGraphExplore(document, openCallGraphExplorer);
+  bindGraphExplore(document, openGraphExplorer);
   bindContentFrameEvents();
   observeAsync(ensurePackageVersions(state.package), "Loading package versions");
   if (state.package?.isRuntimePack)
@@ -9262,11 +9266,8 @@ async function renderTypeGraph() {
     });
     const id = `type-graph-${Date.now().toString(36)}`;
     const rootStyle = getComputedStyle(document.documentElement);
-    const resolved = definition.replace(
-      /var\((--[\w-]+)\)/g,
-      (whole: string, name: string) =>
-        rootStyle.getPropertyValue(name).trim() || whole
-    );
+    const resolved = resolveMermaidCssVariables(
+      definition, name => rootStyle.getPropertyValue(name));
     const { svg } = await mermaid.render(id, resolved);
     if (document.querySelector("#type-graph-diagram") !== container) return;
     container.innerHTML =
@@ -9401,22 +9402,19 @@ async function renderDependencyGraph() {
     });
     const id = `dep-graph-${seq.toString(36)}-${Date.now().toString(36)}`;
     const rootStyle = getComputedStyle(document.documentElement);
-    const resolved = built.definition.replace(
-      /var\((--[\w-]+)\)/g,
-      (whole: string, name: string) =>
-        rootStyle.getPropertyValue(name).trim() || whole
-    );
+    const resolved = resolveMermaidCssVariables(
+      built.definition, name => rootStyle.getPropertyValue(name));
     const { svg } = await mermaid.render(id, resolved);
     // A newer render superseded this one, or the container was swapped out — bail without touching the DOM.
     if (!depGraphRenderSequence.isCurrent(seq)) return;
     if (document.querySelector("#dependency-graph-diagram") !== container) return;
     container.innerHTML =
-      '<div class="graph-viewport"></div>'
+      '<div class="dependency-graph-stage"><div class="graph-viewport"></div>'
       + '<div class="graph-controls">'
       + '<button type="button" data-zoom="in" title="Zoom in" aria-label="Zoom in">+</button>'
       + '<button type="button" data-zoom="out" title="Zoom out" aria-label="Zoom out">\u2212</button>'
       + '<button type="button" class="reset" data-zoom="reset" title="Reset view" aria-label="Reset view">fit</button>'
-      + '</div>'
+      + '</div></div>'
       + (built.truncated
         ? `<div class="graph-drill-error graph-diagnostics" role="status">Dependency graph truncated at ${built.nodeLimit} nodes.</div>`
         : "");
@@ -9425,20 +9423,27 @@ async function renderDependencyGraph() {
     if (!viewport) return;
     viewport.innerHTML = svg;
     container.dataset.graphDef = signature;
-    bindGraphPanZoom(container, viewport, { keybindings });
-    bindDependencyGraphNodes(viewport, nodeId => {
-      const info = nodeId ? built.nodeInfoById.get(nodeId) : null;
-      if (!info || info.kind === "self") return null;
-      return {
-        onSelect: () => {
-          if (info.kind === "open" && info.packageKey)
-            switchToPackageForDependencies(info.packageKey);
-          else if (info.id)
-            observeAsync(
-              openDependencyPackage(info.id, info.versionRange),
-              "Opening a dependency package");
-        },
-      };
+    bindGraphPanZoom(container, viewport, {
+      keybindings,
+      resolveDependencyGraphNode: nodeId => {
+        const info = nodeId ? built.nodeInfoById.get(nodeId) : null;
+        if (!info || info.kind === "self") return null;
+        const loaded = state.packages.find(candidate =>
+          packageIdentityKey(candidate) === info.packageKey);
+        return {
+          label: loaded
+            ? `Open ${packageDisplayName(loaded)}@${loaded.version} · ${loaded.activeFramework}`
+            : `Load ${info.id} ${info.versionRange || "latest stable"}`,
+          onSelect: () => {
+            if (info.kind === "open" && info.packageKey)
+              switchToPackageForDependencies(info.packageKey);
+            else if (info.id)
+              observeAsync(
+                openDependencyPackage(info.id, info.versionRange),
+                "Opening a dependency package");
+          },
+        };
+      },
     });
   } catch (error) {
     // Only surface the error if this is still the latest render and nothing else has drawn a graph.
@@ -9458,6 +9463,7 @@ function switchToPackageForDependencies(packageKey: string) {
   const target = state.packages.find(item =>
     packageIdentityKey(item) === packageKey);
   if (!target) return;
+  closeGraphExplorerForNavigation();
   state.loading = false;
   activatePackage(target, { resetAccessibility: true });
   state.atPackageRoot = true;
@@ -9486,6 +9492,7 @@ async function openDependencyPackage(
     switchToPackageForDependencies(packageIdentityKey(existing));
     return;
   }
+  closeGraphExplorerForNavigation();
   const navigationSeq = navigationSequence.begin();
   state.loading = true;
   state.error = "";
@@ -9674,11 +9681,8 @@ function renderMermaidCallGraph(): Promise<CallGraphRenderResult> {
       });
       const id = `call-graph-${Date.now().toString(36)}-${seq}`;
       const rootStyle = getComputedStyle(document.documentElement);
-      const renderDefinition = definition.replace(
-        /var\((--[\w-]+)\)/g,
-        (whole: string, name: string) =>
-          rootStyle.getPropertyValue(name).trim() || whole
-      );
+      const renderDefinition = resolveMermaidCssVariables(
+        definition, name => rootStyle.getPropertyValue(name));
       const { svg } = await mermaid.render(id, renderDefinition);
       if (seq !== callGraphRenderSeq) {
         return { status: "superseded" };
@@ -9740,7 +9744,7 @@ function renderMermaidCallGraph(): Promise<CallGraphRenderResult> {
 function callGraphNodeBinding(
   callGraph: InspectedCallGraph,
   nodeId: string,
-): CallGraphNodeBinding | null {
+): GraphNodeBinding | null {
   const target =
     callGraph.targets?.find(candidate => candidate.id === nodeId) ?? null;
   if (!target) return null;
@@ -9754,7 +9758,7 @@ function callGraphTargetBinding(
   target: InspectedCallGraphTarget,
   destination: CallGraphTargetDestination = "default",
   failureSurface: GraphNavigationFailureSurface = "call-graph",
-): CallGraphNodeBinding | null {
+): GraphNodeBinding | null {
   const typeId = callGraphTargetTypeId(target);
 
   // Inside a platform descent the whole graph lives in the runtime pack, not
@@ -9961,7 +9965,7 @@ function blockedCallGraphNodeBinding(
   target: InspectedCallGraphTarget,
   reason: string,
   failureSurface: GraphNavigationFailureSurface = "call-graph",
-): CallGraphNodeBinding {
+): GraphNodeBinding {
   return {
     label: `Cannot open ${target.typeFullName}.${target.memberName}: ${reason}`,
     blocked: true,
@@ -10004,12 +10008,22 @@ function currentCallGraph() {
   return top ? top.graph : state.memberCallGraph;
 }
 
-function callGraphExplorerKey(): string | null {
+function dependencyGraphAvailable() {
+  return state.packageDependenciesKey === packageDependenciesSignature()
+    && !state.packageDependenciesLoading
+    && !state.packageDependenciesError
+    && Boolean(state.packageDependencies?.dependencyGroups?.length);
+}
+
+function graphExplorerKey(): string | null {
   if (state.home || state.loading || state.error || state.packageQueryOpen
     || state.credits || state.settings || state.keyboardHelp || state.explorer?.open
     || state.spotlightOpen || state.docViewerOpen || state.graphSourceOpen
-    || state.memberAnnotatedModal || scope() !== "member"
-    || state.memberSection !== "call-graph") return null;
+    || state.memberAnnotatedModal) return null;
+  if (scope() === "package" && state.packageLens === "dependencies") {
+    return JSON.stringify(["dependencies", packageDependenciesSignature()]);
+  }
+  if (scope() !== "member" || state.memberSection !== "call-graph") return null;
   const type = selectedType();
   const member = selectedMember(type);
   const overload = member
@@ -10023,23 +10037,27 @@ function callGraphExplorerKey(): string | null {
     : null;
 }
 
-function callGraphExplorerTarget() {
-  const key = callGraphExplorerKey();
-  const content = document.querySelector<HTMLElement>("[data-call-graph-surface]");
-  const invoker = document.querySelector<HTMLElement>("#call-graph-explore");
+function graphExplorerTarget() {
+  const key = graphExplorerKey();
+  const dependencies = scope() === "package";
+  const content = document.querySelector<HTMLElement>(
+    dependencies ? "[data-dependency-graph-surface]" : "[data-call-graph-surface]");
+  const invoker = document.querySelector<HTMLElement>("[data-graph-explore]");
   return key && content && invoker
     ? {
         key,
-        title: "Call graph",
-        context: currentInspectedSubjectPath().map(segment => segment.label).join(" > "),
+        title: dependencies ? "Dependency graph" : "Call graph",
+        context: dependencies
+          ? `${currentPackage().id}@${currentPackage().version} · ${currentPackage().activeFramework}`
+          : currentInspectedSubjectPath().map(segment => segment.label).join(" > "),
         content,
         invoker,
       }
     : null;
 }
 
-function openCallGraphExplorer() {
-  const target = callGraphExplorerTarget();
+function openGraphExplorer() {
+  const target = graphExplorerTarget();
   if (!target) return;
   graphExplorerOriginKey = target.key;
   graphExplorer.open(target);
@@ -10054,8 +10072,8 @@ function restoreGraphExplorerNavigationFocus() {
   }
   if (state.loading || state.graphMemberNavigationTitle || state.platformDrillLoading) return;
   graphExplorerNavigationFocusPending = false;
-  const explore = document.querySelector<HTMLButtonElement>("#call-graph-explore");
-  if (callGraphExplorerKey() === graphExplorerOriginKey && explore && !explore.disabled) {
+  const explore = document.querySelector<HTMLButtonElement>("[data-graph-explore]");
+  if (graphExplorerKey() === graphExplorerOriginKey && explore && !explore.disabled) {
     explore.focus({ preventScroll: true });
   } else {
     focusLevelOneHeading();

--- a/prototypes/inspect-web/src/graph-interactions.ts
+++ b/prototypes/inspect-web/src/graph-interactions.ts
@@ -5,7 +5,7 @@ export interface GraphBackBindingActions {
   onBack: () => void;
 }
 
-export interface CallGraphNodeBinding {
+export interface GraphNodeBinding {
   onSelect: () => void;
   label: string;
   platform?: boolean;
@@ -16,16 +16,15 @@ export interface GraphPanZoomBindingOptions {
   keybindings: KeybindingRegistry;
   resolveCallGraphNode?: (
     nodeId: string,
-  ) => CallGraphNodeBinding | null;
+  ) => GraphNodeBinding | null;
+  resolveDependencyGraphNode?: (
+    nodeId: string,
+  ) => GraphNodeBinding | null;
 }
 
 export interface TypeGraphNodeBinding {
   onSelect?: () => void;
   unavailableLabel?: string;
-}
-
-export interface DependencyGraphNodeBinding {
-  onSelect: () => void;
 }
 
 export function bindGraphBack(
@@ -63,21 +62,6 @@ export function bindTypeGraphNodes(
       node.ownerDocument.createElementNS("http://www.w3.org/2000/svg", "title");
     title.textContent = binding.unavailableLabel;
     node.insertBefore(title, node.firstChild);
-  });
-}
-
-export function bindDependencyGraphNodes(
-  root: ParentNode,
-  resolveNode: (
-    nodeId: string,
-  ) => DependencyGraphNodeBinding | null,
-) {
-  root.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-    const binding = resolveNode(mermaidNodeId(node, "d"));
-    if (!binding) return;
-    node.classList.add("nav-node");
-    node.style.cursor = "pointer";
-    node.addEventListener("click", binding.onSelect);
   });
 }
 
@@ -246,10 +230,11 @@ export function bindGraphPanZoom(
     run: handlePanZoomKey,
   }, viewport);
 
-  if (options.resolveCallGraphNode) {
+  const resolveNode = options.resolveCallGraphNode ?? options.resolveDependencyGraphNode;
+  if (resolveNode) {
     svg.querySelectorAll<SVGGElement>("g.node").forEach(node => {
-      const binding =
-        options.resolveCallGraphNode?.(mermaidNodeId(node, "n"));
+      const binding = resolveNode(
+        mermaidNodeId(node, options.resolveCallGraphNode ? "n" : "d"));
       if (!binding) return;
       node.classList.add("nav-node");
       if (binding.platform) node.classList.add("platform-node");
@@ -261,7 +246,9 @@ export function bindGraphPanZoom(
         if (!moved) binding.onSelect();
       });
       options.keybindings.register({
-        id: "call-graph-node.activate",
+        id: options.resolveCallGraphNode
+          ? "call-graph-node.activate"
+          : "dependency-graph-node.activate",
         key: ["Enter", " "],
         allowExtraModifiers: true,
         priority: WORKBENCH_KEYBINDING_PRIORITY.element,

--- a/prototypes/inspect-web/src/graph-mermaid.ts
+++ b/prototypes/inspect-web/src/graph-mermaid.ts
@@ -13,6 +13,15 @@ import {
   type PackageIdentity,
 } from "./data.ts";
 
+export function resolveMermaidCssVariables(
+  definition: string,
+  readProperty: (name: string) => string,
+): string {
+  return definition.replace(
+    /var\((--[\w-]+)\)/g,
+    (whole: string, name: string) => readProperty(name).trim() || whole);
+}
+
 function shortTypeName(fullName: string): string {
   const generic = fullName.indexOf("<");
   const head = generic < 0 ? fullName : fullName.slice(0, generic);

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1110,6 +1110,7 @@ kbd {
 .package-dependencies-scroll,
 .package-metadata-scroll { min-width: 0; min-height: 0; overflow: auto; padding-bottom: 24px; }
 .package-dependencies-scroll > .document-section,
+.package-dependencies-scroll > [data-dependency-graph-surface] > .document-section,
 .package-metadata-scroll > .document-section { padding: 24px 16px 0; }
 .package-metadata-scroll > .metadata-warning { padding: 14px 16px; }
 .package-metadata-scroll > .meta-assembly + .meta-assembly { margin-top: 24px; border-top: 1px solid var(--line); }
@@ -1234,6 +1235,7 @@ kbd {
 .member-applicability span { color: var(--dim); font: 10px var(--mono); letter-spacing: .08em; text-transform: uppercase; }
 .member-applicability code { padding: 4px 8px; border: 1px solid var(--line-strong); border-radius: 2px; color: var(--blue); font: 11px var(--mono); }
 .call-graph-section { max-width: 1100px; padding-top: 8px; }
+.dependency-graph-stage { position: relative; width: 100%; }
 .graph-expanding { display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-top: 1px solid var(--line); color: var(--muted); font: 11px var(--mono); }
 .graph-expanding .loader { width: 13px; height: 13px; border-width: 2px; }
 .graph-scope { display: grid; grid-template-columns: max-content 1fr max-content 1fr; gap: 8px 14px; align-items: center; padding: 10px; border-top: 1px solid var(--line); color: var(--dim); font: 11px var(--mono); }
@@ -1288,10 +1290,20 @@ kbd {
 .graph-explorer-head button { flex: none; padding: 5px 10px; border: 1px solid var(--line-strong); border-radius: 3px; background: var(--panel-raised); color: var(--text); cursor: pointer; }
 .graph-explorer-head button:focus-visible { outline: 2px solid var(--blue); outline-offset: 2px; }
 .graph-explorer-content,
-.graph-explorer [data-call-graph-surface] { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; overflow: auto; }
-.graph-explorer .call-graph-section { display: flex; flex: 1; min-width: 0; min-height: min(320px, 70dvh); max-width: none; flex-direction: column; padding: 0; margin: 0; }
+.graph-explorer [data-call-graph-surface],
+.graph-explorer [data-dependency-graph-surface] { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; overflow: auto; }
+.graph-explorer .call-graph-section,
+.graph-explorer .dependency-graph-section { display: flex; flex: 1; min-width: 0; min-height: min(320px, 70dvh); max-width: none; flex-direction: column; padding: 0; margin: 0; }
+.graph-explorer [data-dependency-graph-surface] > .document-section:not(.dependency-graph-section) { flex: none; margin: 0; padding: 8px 14px; max-width: none; }
 .graph-explorer .section-title { flex: none; padding: 5px 14px; }
 .graph-explorer .section-title h2 { display: none; }
+.graph-explorer .dependency-group-selector .section-title { padding: 0; }
+.graph-explorer .dependency-group-selector .section-title h2 { display: block; }
+.graph-explorer #dep-tfm-chips .type-chip { max-width: 100%; white-space: normal; overflow-wrap: anywhere; }
+.graph-explorer .dependency-graph-section .call-graph-diagram { display: flex; flex-direction: column; justify-content: center; }
+.graph-explorer .dependency-graph-stage { display: flex; flex: 1; min-height: 180px; }
+.graph-explorer .dependency-graph-stage .graph-viewport { flex: 1; height: auto; }
+.graph-explorer .dependency-graph-section .graph-diagnostics { align-self: stretch; overflow-wrap: anywhere; }
 .graph-explorer .graph-breadcrumb,
 .graph-explorer .graph-expanding,
 .graph-explorer .graph-drill-error { flex: none; }
@@ -1849,6 +1861,7 @@ kbd {
   .package-dependencies-controls,
   .package-metadata-controls { padding-inline: 10px; }
   .package-dependencies-scroll > .document-section,
+  .package-dependencies-scroll > [data-dependency-graph-surface] > .document-section,
   .package-metadata-scroll > .document-section { padding-inline: 12px; }
   .member-surface-scroll { padding: 12px 12px 52px; }
   .member-overload-surface .member-surface-scroll { padding: 0 0 20px; }

--- a/prototypes/inspect-web/test/annotated-source.test.ts
+++ b/prototypes/inspect-web/test/annotated-source.test.ts
@@ -748,10 +748,10 @@ test("Annotated Source composition requires a concrete overload and validated se
     /class="contextual-actions annotated-contextual-actions"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"/);
   assert.match(
     appSource,
     /detail-scroll\$\{annotatedWorkingSurface \? " annotated-working-surface" : ""\}/);

--- a/prototypes/inspect-web/test/graph-interactions.test.ts
+++ b/prototypes/inspect-web/test/graph-interactions.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  bindDependencyGraphNodes,
   bindGraphBack,
   bindGraphPanZoom,
   bindTypeGraphNodes,
@@ -220,7 +219,7 @@ test("graph back binding dispatches only from the rendered control", () => {
   assert.equal(calls, 1);
 });
 
-test("type and dependency nodes decode stable Mermaid identities", () => {
+test("type nodes decode stable Mermaid identities", () => {
   const type = new FakeElement({ dataId: "t1" });
   const unavailable = new FakeElement({ id: "flowchart-t2-4" });
   const unknown = new FakeElement({ id: "flowchart-x3-4" });
@@ -247,23 +246,51 @@ test("type and dependency nodes decode stable Mermaid identities", () => {
   assert.equal(unavailable.classList.contains("nav-node"), false);
   assert.equal(unavailable.inserted[0]?.textContent, "Hidden.Type — unavailable");
   assert.equal(unknown.classList.contains("nav-node"), false);
+});
 
+test("dependency nodes share keyboard activation and suppress clicks after dragging", () => {
   const dependency = new FakeElement({ id: "flowchart-d7-2" });
   const self = new FakeElement({ dataId: "d0" });
+  const direct = new FakeElement({ dataId: "d8" });
+  const viewport = new FakeViewport(new FakeSvg([dependency, self, direct]));
+  const keybindings = new KeybindingRegistry();
   const dependencyCalls: string[] = [];
-  bindDependencyGraphNodes(
-    fakeDom.parentNode(new FakeNodeRoot([dependency, self])),
-    nodeId => nodeId === "d7"
-      ? { onSelect: () => dependencyCalls.push(nodeId) }
-      : null);
+  bindGraphPanZoom(
+    fakeDom.parentNode(new FakeContainer([])),
+    fakeDom.htmlElement(viewport),
+    {
+      keybindings,
+      resolveDependencyGraphNode: nodeId => nodeId === "d0"
+        ? null
+        : {
+            label: `Open ${nodeId}`,
+            onSelect: () => dependencyCalls.push(nodeId),
+          },
+    });
 
   assert.deepEqual(dependencyCalls, []);
   assert.equal(dependency.classList.contains("nav-node"), true);
   assert.equal(dependency.style.cursor, "pointer");
+  assert.equal(dependency.attributes.get("aria-label"), "Open d7");
+  assert.equal(dependency.attributes.get("tabindex"), "0");
+  assert.equal(dependency.attributes.get("role"), "button");
   assert.equal(self.classList.contains("nav-node"), false);
   dependency.dispatch("click");
   self.dispatch("click");
   assert.deepEqual(dependencyCalls, ["d7"]);
+  for (const key of ["Enter", " "]) {
+    assert.equal(dispatchKey(keybindings, direct, { key }).prevented, true);
+  }
+  assert.deepEqual(dependencyCalls, ["d7", "d8", "d8"]);
+  viewport.dispatch("pointerdown", {
+    button: 0, clientX: 10, clientY: 10, pointerId: 1,
+  });
+  viewport.dispatch("pointermove", {
+    clientX: 30, clientY: 10, pointerId: 1,
+  });
+  viewport.dispatch("pointerup", { pointerId: 1 });
+  dependency.dispatch("click");
+  assert.deepEqual(dependencyCalls, ["d7", "d8", "d8"]);
 });
 
 test("graph pan, zoom, keyboard, controls, and call-node clicks stay coordinated", () => {
@@ -454,7 +481,6 @@ test("graph bindings tolerate missing rendered surfaces", () => {
   const keybindings = new KeybindingRegistry();
   const root = fakeDom.parentNode(new FakeNodeRoot([]));
   assert.doesNotThrow(() => bindTypeGraphNodes(root, () => null));
-  assert.doesNotThrow(() => bindDependencyGraphNodes(root, () => null));
   assert.doesNotThrow(() => bindGraphBack(
     fakeDom.parentNode({ querySelector: () => null }),
     { onBack() {} }));

--- a/prototypes/inspect-web/test/source-inspection.test.ts
+++ b/prototypes/inspect-web/test/source-inspection.test.ts
@@ -118,7 +118,7 @@ test("Source composition uses shell actions and a full-area loaded surface", () 
     /const sourcePageKind =[\s\S]*activeScope === "type" && state\.lens === "source"[\s\S]*activeScope === "member"[\s\S]*state\.memberSection === "source"/);
   assert.match(
     appSource,
-    /class="working-surface-actions" role="group" aria-label="\$\{callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"[\s\S]*renderSourcePageActions\(\{[\s\S]*copyButtonId: sourcePageKind === "member"[\s\S]*"copy-source"[\s\S]*"copy-type-source"/);
+    /class="working-surface-actions" role="group" aria-label="\$\{packageDependenciesWorkingSurface \? "Dependency graph actions" : callGraphPageContext \? "Call graph actions" : annotatedPageContext \? "Annotated Source actions" : "Source actions"\}"[\s\S]*renderSourcePageActions\(\{[\s\S]*copyButtonId: sourcePageKind === "member"[\s\S]*"copy-source"[\s\S]*"copy-type-source"/);
   assert.match(
     appSource,
     /contextualActionsHtml: annotatedPageContext \|\| sourcePageKind[\s\S]*class="working-surface-actions"/);

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -108,7 +108,8 @@ import type {
 } from "../src/data.ts";
 import {
   buildDependencyGraphMermaid,
-  buildTypeGraphMermaid
+  buildTypeGraphMermaid,
+  resolveMermaidCssVariables,
 } from "../src/graph-mermaid.ts";
 
 const packageAt = (version: string, framework: string, types = 1) => ({
@@ -1393,9 +1394,6 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
   const callGraphBinding =
     appSource.match(/function callGraphNodeBinding\([\s\S]*?\n}(?=\n\nfunction currentCallGraph)/)?.[0]
     ?? "";
-  const dependencyNodeBinding =
-    graphInteractionsSource.match(/export function bindDependencyGraphNodes\([\s\S]*?\n}(?=\n\nexport function bindGraphPanZoom)/)?.[0]
-    ?? "";
   assert.match(
     graphInteractionsSource,
     /export function bindGraphBack\([\s\S]*\[data-graph-back\]/);
@@ -1409,8 +1407,8 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     graphInteractionsSource,
     /export function bindTypeGraphNodes\([\s\S]*"t"[\s\S]*nav-node[\s\S]*non-nav[\s\S]*createElementNS/);
   assert.match(
-    dependencyNodeBinding,
-    /mermaidNodeId\(node, "d"\)[\s\S]*classList\.add\("nav-node"\)[\s\S]*style\.cursor = "pointer"[\s\S]*addEventListener\("click", binding\.onSelect\)/);
+    graphInteractionsSource,
+    /const resolveNode = options\.resolveCallGraphNode \?\? options\.resolveDependencyGraphNode;[\s\S]*mermaidNodeId\(node, options\.resolveCallGraphNode \? "n" : "d"\)[\s\S]*if \(!moved\) binding\.onSelect\(\)/);
   assert.match(
     appSource,
     /const graphBackActions: GraphBackBindingActions = \{\s*onBack: popPlatformDrill,\s*};/);
@@ -1425,7 +1423,7 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /const target = graphNode\.role === "self"\s*\? selectedType\(\)\s*: uniqueTypeByQueryId\(pkg\.types, fullName\)/);
   assert.match(
     dependencyGraph,
-    /bindGraphPanZoom\(container, viewport, \{ keybindings \}\);[\s\S]*bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
+    /bindGraphPanZoom\(container, viewport, \{[\s\S]*resolveDependencyGraphNode: nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)[\s\S]*switchToPackageForDependencies\(info\.packageKey\)[\s\S]*openDependencyPackage\(info\.id, info\.versionRange\)/);
   assert.match(
     dependencyGraph,
     /const info = nodeId \? built\.nodeInfoById\.get\(nodeId\) : null;\s*if \(!info \|\| info\.kind === "self"\) return null/);
@@ -1455,11 +1453,10 @@ test("typed graph interactions own graph controls and Mermaid node bindings", ()
     /if \(loaded\) \{[\s\S]*navigateToGraphMember\([\s\S]*loaded,[\s\S]*target,[\s\S]*loadedSection,[\s\S]*failureSurface\)[\s\S]*\} else if \(disposition === "resident"\) \{[\s\S]*startPlatformDrill\(target\)[\s\S]*\} else if \(platform\) \{[\s\S]*navigateOrDrillPlatform\([\s\S]*target,[\s\S]*runtimeSection,[\s\S]*failureSurface\)/);
   assert.match(
     graphInteractionsSource,
-    /resolveCallGraphNode[\s\S]*setAttribute\("tabindex", "0"\)[\s\S]*setAttribute\("role", "button"\)[\s\S]*setAttribute\("aria-label", binding\.label\)[\s\S]*addEventListener\("click"[\s\S]*id: "call-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
+    /resolveCallGraphNode[\s\S]*setAttribute\("tabindex", "0"\)[\s\S]*setAttribute\("role", "button"\)[\s\S]*setAttribute\("aria-label", binding\.label\)[\s\S]*addEventListener\("click"[\s\S]*"call-graph-node\.activate"[\s\S]*"dependency-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
   assert.equal(appSource.match(/\bbindGraphBack\(/g)?.length, 1);
   assert.equal(appSource.match(/\bbindGraphPanZoom\(/g)?.length, 3);
   assert.equal(appSource.match(/\bbindTypeGraphNodes\(/g)?.length, 1);
-  assert.equal(appSource.match(/\bbindDependencyGraphNodes\(/g)?.length, 1);
   assert.equal(appSource.match(/\bcallGraphNodeBinding\(/g)?.length, 2);
   assert.doesNotMatch(
     `${typeGraph}\n${dependencyGraph}\n${callGraph}`,
@@ -3677,7 +3674,7 @@ test("dependency graph binds navigation to generated node identities", () => {
     /const dataId = node\.getAttribute\("data-id"\);[\s\S]*return dataId \|\| idMatch\?\.\[1\] \|\| ""/);
   assert.match(
     appSource,
-    /bindDependencyGraphNodes\(viewport, nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)/);
+    /resolveDependencyGraphNode: nodeId => \{[\s\S]*built\.nodeInfoById\.get\(nodeId\)/);
   assert.doesNotMatch(appSource, /nodeInfoByLabel/);
   assert.match(
     appSource,
@@ -5355,6 +5352,33 @@ test("package dependencies use compact coordinates in a full-area working surfac
     /\.package-dependencies-scroll,[\s\S]*?overflow: auto;/s);
 });
 
+test("Dependencies adopts the shared graph viewer without moving the package lists", () => {
+  assert.match(
+    appSource,
+    /id="dependency-graph-explore" data-graph-explore\$\{dependencyGraphAvailable\(\)/);
+  assert.match(
+    appSource,
+    /<div data-dependency-graph-surface>\$\{dependencyGroupNotice\}\$\{selector\}\$\{graphSection\}<\/div>\$\{depList\}\$\{assemblyReferences\}/);
+  assert.match(
+    appSource,
+    /graphExplorer\.beforeRender\(graphExplorerKey\(\)\)/);
+  assert.match(
+    appSource,
+    /graphExplorer\.afterRender\(graphExplorerTarget\(\)\)/);
+  const key = appSource.match(/function graphExplorerKey\(\)[\s\S]*?\n}/)?.[0] ?? "";
+  assert.match(key, /JSON\.stringify\(\["dependencies", packageDependenciesSignature\(\)\]\)/);
+  assert.doesNotMatch(key, /dependenciesGroupIndex/);
+  assert.match(
+    appSource,
+    /function switchToPackageForDependencies[\s\S]*?closeGraphExplorerForNavigation\(\);[\s\S]*?activatePackage\(target/);
+  assert.match(
+    appSource,
+    /async function openDependencyPackage[\s\S]*?closeGraphExplorerForNavigation\(\);[\s\S]*?navigationSequence\.begin\(\)/);
+  assert.match(
+    appSource,
+    /function restoreGraphExplorerNavigationFocus[\s\S]*?querySelector<HTMLButtonElement>\("\[data-graph-explore\]"\)/);
+});
+
 test("graph member projections stay transport- and package-bounded", () => {
   assert.match(
     browserGraphMemberSource,
@@ -5488,7 +5512,7 @@ test("ambiguous call graph targets expose a visible refusal", () => {
     /invalidateGraphMemberNavigation\(\);\s*state\.memberCallGraphSeq\+\+;[\s\S]*?state\.graphMemberNavigationError\s*=\s*`Could not open \$\{target\.typeFullName\}\.\$\{target\.memberName\}: \$\{reason\}\.`;[\s\S]*?render\(\)/);
   assert.match(
     graphInteractionsSource,
-    /node\.setAttribute\("tabindex", "0"\);[\s\S]*node\.setAttribute\("role", "button"\)[\s\S]*node\.addEventListener\("click"[\s\S]*id: "call-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
+    /node\.setAttribute\("tabindex", "0"\);[\s\S]*node\.setAttribute\("role", "button"\)[\s\S]*node\.addEventListener\("click"[\s\S]*"call-graph-node\.activate"[\s\S]*key: \["Enter", " "\]/);
 });
 
 test("navigable call graph targets share mouse and keyboard activation", () => {
@@ -6504,6 +6528,14 @@ test("type graph rendering contains artifact labels", () => {
     /t0\["A&#92;u202E&#92;uD800-Café😀"\]:::self/);
   assert.equal(definition.includes("\u202E"), false);
   assert.equal(definition.includes("\uD800"), false);
+});
+
+test("Mermaid resolves the current theme without inventing missing colors", () => {
+  assert.equal(
+    resolveMermaidCssVariables(
+      "classDef self fill:var(--accent-soft),stroke:var(--accent);",
+      name => name === "--accent-soft" ? " #abcdef " : ""),
+    "classDef self fill:#abcdef,stroke:var(--accent);");
 });
 
 test("dependency graph rendering contains artifact labels", () => {


### PR DESCRIPTION
Make package dependency exploration a full-area working experience while keeping
the familiar inline view. This completes the two-consumer adoption of the shared
Graph Explorer rather than adding another graph implementation.

Closes #5904. Production adoption step 2 of 2 in #5867, following #5879.

## Demo

Package > Dependencies now offers **Explore** in the working-surface action row.
It expands the existing graph and target-framework group selector into the
viewport. Close and Escape restore the same inline graph and selected group;
package coordinate controls, lists, references, and footer stay on the
underlying page.

The component browser scenario exercises a real dependency model and Mermaid
canvas: open Explore, change groups, return to an empty group, and close.
It retains the live SVG and pan/zoom across placement changes, completes pending
rendering inside Explore, and supports keyboard package activation without
turning a drag into navigation. At 1440px and 390px widths, the canvas fills the
available area and truncation diagnostics remain below the graph controls.
The neighboring Member Call graph viewer retains its existing behavior.

The real published Wasm scenario uses `System.Text.Json` 10.0.0 / `net10.0`.
Its `net10.0` manifest group is empty; selecting `.NETStandard2.0` produces an
eight-node graph. Explore retains the same SVG, zoom, and URL. The canvas measures
1440 x 810 at the wide size and 390 x 627 at the narrow size. Selecting the empty
group and returning to `.NETStandard2.0` stays expanded and survives Close.
Keyboard activation of `System.Text.Encodings.Web` works both before and after
that package is loaded, closing the viewer and focusing the destination heading.

Inline:

![Inline package Dependencies](https://github.com/user-attachments/assets/88133e7c-3218-45cd-abf5-28defe091374)

Explore:

![Full-area Dependency graph](https://github.com/user-attachments/assets/42c22840-fba7-449a-a5df-01e4f596c077)

Narrow:

![Narrow Dependency graph viewer](https://github.com/user-attachments/assets/79726551-32cc-459f-a017-fb50fa37c7db)

## Design and scope

**Normative owner:** `docs/design/inspect-web-surface-composition.md#graph-explore`
owns placement and consumer adoption. The existing shell modal contract supplies
focus, background containment, dismissal, replacement, and history.

**Reuse:** one placement component, one live graph, existing manifest-group
patching and package navigation. Both graph consumers use the same node
activation/pan handling. Existing CSS-variable lowering is shared by the
production graph renderers and the browser scenario.

**Compatibility boundary:** this is user-approved browser-only UI work.
`DependencyGraphModel` / `DependencyGraphResult`, typed node identities,
coordinate matching, acquisition, traversal limits, and Mermaid layout keep
their existing semantics. Interactive browser rendering bypasses Markout as
before; CLI output is unchanged. Inline remains the default.

## Validation

- Frontend TypeScript, static analysis, and production bundle.
- Focused graph-interaction, package-binding, composition, Source, and
  Annotated Source tests.
- 89 Firefox surface scenarios, including both Graph Explore consumers, empty groups,
  pending completion, focus, errors, package destinations, drag suppression,
  and wide/narrow geometry.
- Markdown lint.
- Complete Release Wasm publication and the real package scenario above.
- Exact-head `ci-required` succeeded in run 33932518081.
- Fixed-head GPT-6 Astra and Claude Opus 5 reviews: both CLEAN, no author changes.

Acquisition-failure presentation is covered by the component browser gate.
A live network-abort probe still loaded the requested package, so it does not
establish a production acquisition failure and is not claimed as such.

Candidate: `8daf1fa78a378227ad13f2526f7d7a27344cfb6a`.
Effective base: `f143600dc52bedc3bc1fc25332807d6181b25266` on `main`.
