### PR TITLE
Record conversion return-type shape correspondence

### DIFF
--- a/docs/design/type-member-api-representation.md
+++ b/docs/design/type-member-api-representation.md
@@ -579,6 +579,15 @@ source sibling prevents uniqueness. Rank-one non-SZ metadata has no ordinary
 C# declaration counterpart. These are correspondence gates, not member-identity
 or source-ownership proofs.
 
+`ConversionSignatureShapeFlowTests` records conversion return shapes and
+canonical transport against compiler-produced methods and independently located
+MethodDef tokens. Same-name conversion candidates remain distinct by return
+type; ordinary-method return types are erased, so their shape cannot establish
+return-type identity. The caller supplies the operator-name group: the shape
+itself does not distinguish implicit from explicit or checked operators. Checked
+explicit operators retain Metadata return evidence, while the current source
+adapter refuses their headers visibly rather than manufacturing correspondence.
+
 Metadata projection fails closed when a generic signature header is
 noncanonical, when a MethodDef header and its owned contiguous GenericParam rows
 disagree, or when a declaring TypeDef chain's canonical name arities and

--- a/tests/ILInspector.Metadata.Tests/ConversionFlowSamples.cs
+++ b/tests/ILInspector.Metadata.Tests/ConversionFlowSamples.cs
@@ -1,0 +1,14 @@
+namespace ILInspector.Metadata.Tests;
+
+public readonly struct ConversionFlowSample
+{
+    public static implicit operator int(ConversionFlowSample value) => 0;
+    public static implicit operator long(ConversionFlowSample value) => 0;
+    public static explicit operator short(ConversionFlowSample value) => 0;
+    public static explicit operator byte(ConversionFlowSample value) => 0;
+    public static explicit operator checked short(ConversionFlowSample value) => 0;
+    public static explicit operator checked byte(ConversionFlowSample value) => 0;
+
+    public static int ReadInt32(ConversionFlowSample value) => 0;
+    public static long ReadInt64(ConversionFlowSample value) => 0;
+}

--- a/tests/ILInspector.Metadata.Tests/ConversionSignatureShapeFlowTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ConversionSignatureShapeFlowTests.cs
@@ -1,0 +1,251 @@
+using CSharpText;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class ConversionSignatureShapeFlowTests
+{
+    const string ParameterDeclaration = "global::ILInspector.Metadata.Tests.ConversionFlowSample value";
+    const string ParameterTransport =
+        "mss1:0(1:vn26:ILInspector.Metadata.Tests1:20:ConversionFlowSample0:0:)";
+
+    static readonly Specimen[] Conversions =
+    [
+        new(
+            "ImplicitInt32", "op_Implicit", typeof(int), "System.Int32",
+            $"public static implicit operator int({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp12:System.Int32"),
+        new(
+            "ImplicitInt64", "op_Implicit", typeof(long), "System.Int64",
+            $"public static implicit operator long({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp12:System.Int64"),
+        new(
+            "ExplicitInt16", "op_Explicit", typeof(short), "System.Int16",
+            $"public static explicit operator short({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp12:System.Int16"),
+        new(
+            "ExplicitByte", "op_Explicit", typeof(byte), "System.Byte",
+            $"public static explicit operator byte({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp11:System.Byte"),
+        new(
+            "CheckedInt16", "op_CheckedExplicit", typeof(short), "System.Int16",
+            $"public static explicit operator checked short({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp12:System.Int16",
+            SourceAvailable: false),
+        new(
+            "CheckedByte", "op_CheckedExplicit", typeof(byte), "System.Byte",
+            $"public static explicit operator checked byte({ParameterDeclaration}) => 0;",
+            ParameterTransport + "yp11:System.Byte",
+            SourceAvailable: false),
+    ];
+
+    public static TheoryData<string> ConversionNames =>
+        new(Conversions.Select(specimen => specimen.Name));
+
+    [Theory]
+    [MemberData(nameof(ConversionNames))]
+    public void ConversionFlow_PreservesRecordedReturnShapeAndCandidate(string specimenName)
+    {
+        Specimen specimen = Conversions.Single(candidate => candidate.Name == specimenName);
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        MethodDefinitionHandle expected = ExpectedHandle(specimen.MetadataName, specimen.RuntimeReturnType);
+        var candidates = MetadataCandidates(reader, specimen.MetadataName);
+        Assert.Equal(2, candidates.Length);
+        MemberSignatureShapeResult metadata = Assert.Single(
+            candidates, candidate => candidate.Candidate == expected).Shape;
+        MemberSignatureShapeResult restoredMetadata =
+            AssertStages(metadata, specimen.ReturnType, specimen.Transport);
+        var restoredCandidates = candidates
+            .Select(candidate => (candidate.Candidate, Shape: Transport(candidate.Shape)))
+            .ToArray();
+
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredMetadata, restoredCandidates), expected);
+
+        MemberSignatureShapeResult source = SourceMemberSignatureShape.Create(
+            specimen.Declaration, SourceMemberSignatureKind.ConversionOperator);
+        if (!specimen.SourceAvailable)
+        {
+            Assert.False(source.IsAvailable);
+            Assert.Null(source.Shape);
+            Assert.False(string.IsNullOrWhiteSpace(source.UnavailableReason));
+            AssertUnavailable(MemberSignatureShapeMatcher.Match(
+                restoredMetadata, [(specimen.Name, source)]));
+            return;
+        }
+
+        MemberSignatureShapeResult restoredSource =
+            AssertStages(source, specimen.ReturnType, specimen.Transport);
+        AssertUnique(MemberSignatureShapeMatcher.Match(source, candidates), expected);
+        AssertUnique(MemberSignatureShapeMatcher.Match(restoredSource, restoredCandidates), expected);
+
+        var sourceCandidates = Conversions
+            .Where(candidate => candidate.MetadataName == specimen.MetadataName)
+            .Select(candidate => (
+                Candidate: candidate.Name,
+                Shape: AssertStages(
+                    SourceMemberSignatureShape.Create(
+                        candidate.Declaration, SourceMemberSignatureKind.ConversionOperator),
+                    candidate.ReturnType,
+                    candidate.Transport)))
+            .ToArray();
+        AssertUnique(
+            MemberSignatureShapeMatcher.Match(restoredMetadata, sourceCandidates),
+            specimen.Name);
+    }
+
+    [Fact]
+    public void ConversionReturnWithoutSameNameCandidate_RemainsUnavailableAfterTransport()
+    {
+        using var peReader = OpenFixture();
+        MetadataReader reader = peReader.GetMetadataReader();
+        MemberSignatureShapeResult source = AssertStages(
+            SourceMemberSignatureShape.Create(
+                $"public static implicit operator byte({ParameterDeclaration}) => 0;",
+                SourceMemberSignatureKind.ConversionOperator),
+            "System.Byte",
+            ParameterTransport + "yp11:System.Byte");
+        var implicitCandidates = MetadataCandidates(reader, "op_Implicit")
+            .Select(candidate => (candidate.Candidate, Shape: Transport(candidate.Shape)))
+            .ToArray();
+        Assert.Equal(2, implicitCandidates.Length);
+        MemberSignatureCorrespondence<MethodDefinitionHandle> result =
+            MemberSignatureShapeMatcher.Match(source, implicitCandidates);
+
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unavailable, result.Kind);
+        Assert.True(result.Match.IsNil);
+        Assert.Empty(result.Candidates);
+        Assert.False(string.IsNullOrWhiteSpace(result.UnavailableReason));
+
+        // The return type exists in a different operator-name group.
+        var explicitCandidates = MetadataCandidates(reader, "op_Explicit")
+            .Select(candidate => (candidate.Candidate, Shape: Transport(candidate.Shape)))
+            .ToArray();
+        AssertUnique(
+            MemberSignatureShapeMatcher.Match(source, explicitCandidates),
+            ExpectedHandle("op_Explicit", typeof(byte)));
+    }
+
+    [Theory]
+    [InlineData(nameof(ConversionFlowSample.ReadInt32), typeof(int), "int", "long")]
+    [InlineData(nameof(ConversionFlowSample.ReadInt64), typeof(long), "long", "int")]
+    public void OrdinaryReturnTypes_AreErasedRatherThanUsedAsIdentity(
+        string methodName,
+        Type runtimeReturnType,
+        string sourceReturnType,
+        string otherReturnType)
+    {
+        using var peReader = OpenFixture();
+        MethodDefinitionHandle expected = ExpectedHandle(methodName, runtimeReturnType);
+        MemberSignatureShapeResult metadata = AssertStages(
+            MetadataMemberSignatureShape.Create(peReader.GetMetadataReader(), expected),
+            returnType: null,
+            ParameterTransport + "n");
+        MemberSignatureShapeResult original = AssertStages(
+            SourceMemberSignatureShape.Create(
+                $"public static {sourceReturnType} {methodName}({ParameterDeclaration}) => 0;",
+                SourceMemberSignatureKind.Method),
+            returnType: null,
+            ParameterTransport + "n");
+        MemberSignatureShapeResult differentReturn = AssertStages(
+            SourceMemberSignatureShape.Create(
+                $"public static {otherReturnType} {methodName}({ParameterDeclaration}) => 0;",
+                SourceMemberSignatureKind.Method),
+            returnType: null,
+            ParameterTransport + "n");
+
+        AssertUnique(
+            MemberSignatureShapeMatcher.Match(metadata, [("different-return", differentReturn)]),
+            "different-return");
+        MemberSignatureCorrespondence<string> ambiguous = MemberSignatureShapeMatcher.Match(
+            metadata, [("original", original), ("different-return", differentReturn)]);
+        Assert.Equal(MemberSignatureCorrespondenceKind.Ambiguous, ambiguous.Kind);
+        Assert.Equal(["original", "different-return"], ambiguous.Candidates);
+        Assert.Null(ambiguous.Match);
+        Assert.Null(ambiguous.UnavailableReason);
+    }
+
+    static (MethodDefinitionHandle Candidate, MemberSignatureShapeResult Shape)[] MetadataCandidates(
+        MetadataReader reader, string name)
+    {
+        var typeHandle = (TypeDefinitionHandle)MetadataTokens.EntityHandle(typeof(ConversionFlowSample).MetadataToken);
+        return reader.GetTypeDefinition(typeHandle).GetMethods()
+            .Where(handle => reader.StringComparer.Equals(reader.GetMethodDefinition(handle).Name, name))
+            .Select(handle => (
+                Candidate: handle,
+                Shape: MetadataMemberSignatureShape.Create(reader, handle)))
+            .ToArray();
+    }
+
+    static MethodDefinitionHandle ExpectedHandle(string name, Type returnType)
+    {
+        // Reflection supplies an oracle independent of the SRM shape adapter.
+        MethodInfo method = typeof(ConversionFlowSample)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method => method.Name == name && method.ReturnType == returnType);
+        return (MethodDefinitionHandle)MetadataTokens.EntityHandle(method.MetadataToken);
+    }
+
+    static MemberSignatureShapeResult AssertStages(
+        MemberSignatureShapeResult result, string? returnType, string expectedTransport)
+    {
+        var parameterType = new NamedTypeSignatureShape(
+            "ILInspector.Metadata.Tests",
+            new([new NamedTypeSegment("ConversionFlowSample", 0, SignatureShapeList<TypeSignatureShape>.Empty)]));
+        var expected = new MemberSignatureShape(
+            0,
+            new([new MemberParameterSignatureShape(ParameterPassingKind.Value, parameterType)]),
+            returnType is null ? null : new PrimitiveTypeSignatureShape(returnType));
+
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        Assert.Null(result.UnavailableReason);
+        Assert.Equal(expected, result.Shape);
+        string text = MemberSignatureShapeCodec.Encode(result.Shape!);
+        Assert.Equal(expectedTransport, text);
+        MemberSignatureShapeResult restored = MemberSignatureShapeCodec.Decode(text);
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        Assert.Null(restored.UnavailableReason);
+        Assert.Equal(expected, restored.Shape);
+        return restored;
+    }
+
+    static MemberSignatureShapeResult Transport(MemberSignatureShapeResult result)
+    {
+        Assert.True(result.IsAvailable, result.UnavailableReason);
+        MemberSignatureShapeResult restored =
+            MemberSignatureShapeCodec.Decode(MemberSignatureShapeCodec.Encode(result.Shape!));
+        Assert.True(restored.IsAvailable, restored.UnavailableReason);
+        return restored;
+    }
+
+    static void AssertUnique<T>(MemberSignatureCorrespondence<T> result, T expected)
+    {
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unique, result.Kind);
+        Assert.Equal(expected, result.Match);
+        Assert.Empty(result.Candidates);
+        Assert.Null(result.UnavailableReason);
+    }
+
+    static void AssertUnavailable(MemberSignatureCorrespondence<string> result)
+    {
+        Assert.Equal(MemberSignatureCorrespondenceKind.Unavailable, result.Kind);
+        Assert.Null(result.Match);
+        Assert.Empty(result.Candidates);
+        Assert.False(string.IsNullOrWhiteSpace(result.UnavailableReason));
+    }
+
+    static PEReader OpenFixture() =>
+        new(File.OpenRead(typeof(ConversionFlowSample).Assembly.Location));
+
+    sealed record Specimen(
+        string Name,
+        string MetadataName,
+        Type RuntimeReturnType,
+        string ReturnType,
+        string Declaration,
+        string Transport,
+        bool SourceAvailable = true);
+}


### PR DESCRIPTION
## Summary

Strengthens signature correspondence evidence where the return type matters:
conversion candidates with the same parameter must remain distinguishable,
while ordinary-method return types are deliberately absent from this currency.

Adds compiler-produced conversion samples and literal stage expectations for
source/Metadata shapes, canonical `mss1:` transport, and candidate outcomes.
Expected MethodDef tokens come independently from reflection over the already
loaded sample type, not from the product shape adapter.

Closes #5907. This is the return-type slice following #5871. It changes no
product behavior or public API and does not claim authoritative member identity
or source ownership.

## Demo

```text
$ dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build -- \
    -class ILInspector.Metadata.Tests.ConversionSignatureShapeFlowTests

ILInspector.Metadata.Tests  Total: 9, Errors: 0, Failed: 0, Skipped: 0
```

All samples take the same `ConversionFlowSample` parameter. Only the return
evidence varies:

| Scenario | Recorded return shape / transport suffix | Candidate result |
| --- | --- | --- |
| Implicit conversion to `int` | `System.Int32` / `yp12:System.Int32` | Select the `int` MethodDef, not the same-name `long` conversion |
| Implicit conversion to `long` | `System.Int64` / `yp12:System.Int64` | Select the `long` MethodDef, not `int` |
| Explicit conversion to `short` / `byte` | `System.Int16` / `System.Byte` | Preserve both return distinctions |
| Requested implicit conversion to `byte` | `System.Byte` / `yp11:System.Byte` | Unavailable in the implicit group, even though an explicit conversion exists |
| Checked explicit conversions | Metadata retains the same typed return evidence | Current source adapter refuses the checked header; no source correspondence is manufactured |
| Ordinary `int` / `long` return | `null` / `n` | Return changes alone cannot distinguish source candidates; two remain ambiguous |

The shared literal parameter transport is:

```text
mss1:0(1:vn26:ILInspector.Metadata.Tests1:20:ConversionFlowSample0:0:)
```

The operator-name group remains caller-supplied context, not part of the shape.
The missing-implicit-`byte` case also demonstrates that the shape can match an
explicit candidate if supplied that different group; callers must not interpret
shape equality as operator identity.

## Design and scope

Sole normative owner:
`docs/design/type-member-api-representation.md#conversion-ownership`.
The claim is return-type-sensitive conversion correspondence versus deliberate
ordinary-return erasure. Existing CSharpText and Metadata adapters, codec, and
matcher supply product evidence; the previous shape flow and
`ApiMemberIdentityTests` supply comparative evidence.

The samples compile normally inside the Metadata test assembly in a focused
`*Samples.cs` file, per fixture governance. Reflection accesses only that
already loaded test type to locate the expected rows. The product adapters
consume SRM readers; the compiler produces input fixtures, not reconstructed
product output.

Issue #5907 is the one-step adoption tracker: the existing Metadata Release
harness consumes these cases immediately. There is no new product architecture,
dependency, rendering path, CLI/browser adoption, or retirement plan.

The existing source refusal for checked explicit headers is recorded as a
limitation, not a new regression or supported syntax. Adding that support and
metadata-only checked implicit flow cases is outside this slice; the existing
four-name conversion-identity gate remains in place.

## Validation

- Conversion flow: 9 passed.
  `dotnet run --project tests/ILInspector.Metadata.Tests -c Release --no-build -- -class ILInspector.Metadata.Tests.ConversionSignatureShapeFlowTests`
- Signature-shape and member-identity coverage: 109 passed.
  `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class '*SignatureShape*' -class ILInspector.Metadata.Tests.ApiMemberIdentityTests`
- `npx --no-install markdownlint-cli docs/design/type-member-api-representation.md`
