### PR TITLE
Refine Member Facts header and analysis summary

### DIFF
--- a/docs/design/inspect-web-surface-composition.md
+++ b/docs/design/inspect-web-surface-composition.md
@@ -322,6 +322,20 @@ section.
 Call graph and Facts retain their owned result semantics and use the same
 full-area scroller.
 
+Member Facts begins with a compact `Analysis summary` that separates static
+analysis values and supporting IL offsets from subject identity. The subject
+path and quiet member header retain declaring type, member kind, and overload
+ordinal; the summary does not repeat them. The metadata token follows the
+summary as compact identity, before the unchanged detail sections.
+
+Summary rows preserve every existing signal, including explicit zero and
+`no` values. IL offsets remain non-interactive evidence, not Finding-navigation
+links or runtime measurements. The summary retains a readable measure; when
+the detail pane narrows, supporting offsets move below their value. Long
+values and evidence wrap within their row without widening the member
+scroller. Loading and failure retain the member header and remain visibly
+distinct from a successful zero-valued summary.
+
 #### Graph Explore
 
 Member Call graph retains its inline default and exposes `Explore` in the

--- a/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar-harness.ts
@@ -41,6 +41,8 @@ import {
   renderSourceResult,
 } from "../src/type-panel.ts";
 import { renderMemberContractSections } from "../src/member-overview.ts";
+import { renderMemberFacts } from "../src/member-facts.ts";
+import { memberFactsFixture } from "../test/member-facts-fixture.ts";
 import {
   bindWorkspaceSubject,
   focusWorkspace,
@@ -101,6 +103,7 @@ const packageMetadataMode = params.has("package-metadata");
 const packageMode =
   params.has("package") || packageDependenciesMode || packageMetadataMode;
 const memberMode = params.has("member");
+const memberFactsMode = params.get("member-facts");
 const memberDocumentationMode = params.get("member-docs") ?? "missing";
 const longSignatureMode = params.has("long-signature");
 const emptyMode = params.has("empty");
@@ -223,7 +226,9 @@ let activeTypeLens: TypeLens = sourceMode
   : metadataMode
     ? "metadata"
     : "api";
-let activeMemberSection: MemberSection = sourceMode ? "source" : "overview";
+let activeMemberSection: MemberSection = sourceMode
+  ? "source"
+  : memberFactsMode ? "facts" : "overview";
 let contentFramePane: ContentFramePane = "detail";
 let contentFrameFocusOwner: ContentFrameFocusOwner = null;
 let contentFrameReplacementFocusOwner: ContentFrameFocusOwner = null;
@@ -386,6 +391,24 @@ function detailHtml() {
     </section>`;
   }
   if (memberMode) {
+    if (activeMemberSection === "facts") {
+      const mode = memberFactsMode === "zero" || memberFactsMode === "long"
+        ? memberFactsMode
+        : "populated";
+      return `<section class="member-surface" aria-labelledby="member-surface-title">
+        <header class="api-surface-head member-surface-head">
+          <h1 id="member-surface-title">DeserializeSync</h1>
+          <p>method <span>· 1 of 1</span></p>
+        </header>
+        <div class="member-surface-scroll">${renderMemberFacts({
+          memberFacts: memberFactsMode === "error" ? null : memberFactsFixture(mode),
+          memberFactsLoading: memberFactsMode === "loading",
+          memberFactsError: memberFactsMode === "error"
+            ? "The selected method could not be decoded."
+            : "",
+        })}</div>
+      </section>`;
+    }
     const returnType = longSignatureMode
       ? "System.Collections.Generic.IReadOnlyDictionary<string, TValue?>"
       : "TValue?";

--- a/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
+++ b/prototypes/inspect-web/browser/workspace-titlebar.spec.ts
@@ -407,6 +407,85 @@ test("the narrow return control integrates with Metadata and Source frames", asy
   await expect(page.locator("#inspector-panel > h1")).toHaveCount(0);
 });
 
+test("Member Facts presents a compact summary separate from member identity", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/browser/workspace-titlebar.html?member=1&member-facts=populated");
+  await expect(page.locator(".facts-summary-heading h2"))
+    .toHaveText("Analysis summary");
+  await expect(page.locator(".facts-summary-list dt")).toHaveText([
+    "Allocations", "Calls", "Copies", "Reflection calls",
+    "Throws / catches / finally", "Unsafe", "Allocates in loop",
+  ]);
+  await expect(page.locator(".facts-summary-value"))
+    .toHaveText(["1", "3", "0", "0", "1 / 0 / 0", "no", "no"]);
+  await expect(page.locator(".facts-summary a, .facts-summary button"))
+    .toHaveCount(0);
+  await expect(page.locator(".facts-metadata-identity"))
+    .toHaveText("Metadata token0x06000125");
+  await expect(page.locator(".member-surface-head p"))
+    .toHaveText("method · 1 of 1");
+  await expect(page.locator(".fact-group").first().locator("h2"))
+    .toHaveText("Allocation facts");
+  const header = await box(page, ".member-surface-head");
+  const summary = await box(page, ".facts-summary");
+  expect(summary.y - (header.y + header.height)).toBeCloseTo(12, 0);
+  expect(summary.height).toBeLessThanOrEqual(310);
+  const value = await box(page, ".facts-summary-list > div:first-child .facts-summary-value");
+  const evidence = await box(page, ".facts-summary-list > div:first-child .fact-evidence");
+  expect(Math.abs(value.y - evidence.y)).toBeLessThan(3);
+  expect(evidence.x).toBeGreaterThan(value.x + value.width);
+});
+
+test("Member Facts keeps zero, loading, and failure states distinct", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 600, height: 900 });
+  for (const mode of ["zero", "loading", "error"]) {
+    await page.goto(
+      `/browser/workspace-titlebar.html?member=1&member-facts=${mode}`);
+    await expect(page.locator(".member-surface-head")).toBeVisible();
+    if (mode === "zero") {
+      await expect(page.locator(".facts-summary-value"))
+        .toHaveText(["0", "0", "0", "0", "0 / 0 / 0", "no", "no"]);
+      await expect(page.locator(".fact-evidence")).toHaveCount(0);
+    } else {
+      await expect(page.locator(".facts-summary")).toHaveCount(0);
+      await expect(page.locator(".member-surface-scroll h2"))
+        .toHaveText(mode === "loading" ? "Analyzing method…" : "Facts query failed");
+      if (mode === "error") {
+        await expect(page.locator(".member-surface-scroll p"))
+          .toHaveText("The selected method could not be decoded.");
+      }
+    }
+  }
+});
+
+test("Member Facts reflows values and evidence within the detail pane", async ({
+  page,
+}) => {
+  for (const width of [900, 480, 360]) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto(
+      "/browser/workspace-titlebar.html?member=1&member-facts=long");
+    const value = await box(page, ".facts-summary-list > div:first-child .facts-summary-value");
+    const evidence = await box(page, ".facts-summary-list > div:first-child .fact-evidence");
+    expect(evidence.y).toBeGreaterThanOrEqual(value.y + value.height);
+    expect(evidence.x).toBeCloseTo(value.x, 0);
+    for (const selector of [
+      ".facts-summary", ".facts-summary-list > div",
+      ".facts-summary-value", ".fact-evidence", ".member-surface-scroll",
+    ]) {
+      const contained = await page.locator(selector).evaluateAll(elements =>
+        elements.every(element => element.scrollWidth <= element.clientWidth));
+      expect(contained, `${selector} at ${width}px`).toBe(true);
+    }
+    expect(await page.evaluate(() =>
+      document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+  }
+});
+
 test("Member Overview anchors its declaration below the quiet header", async ({
   page,
 }) => {

--- a/prototypes/inspect-web/src/dotnet-inspect.ts
+++ b/prototypes/inspect-web/src/dotnet-inspect.ts
@@ -176,6 +176,7 @@ import {
   type GraphSourceRequest,
 } from "./source-inspection.ts";
 import { renderMemberContractSections } from "./member-overview.ts";
+import { renderMemberFacts } from "./member-facts.ts";
 import { createOperationAuthorityPage } from "./operation-authority.ts";
 import {
   createMetadataInspectionCoordinator,
@@ -5292,7 +5293,7 @@ function renderMember(type: AppTypeSurface, member: AppMemberGroup) {
         : `<section class="document-section empty-member-section"><h2>Call graph query failed</h2><p>${escapeHtml(callGraphError || "No call graph result was returned.")}</p></section>`;
     content = `<div data-call-graph-surface>${content}</div>`;
   } else if (state.memberSection === "facts") {
-    content = renderMemberFacts(type, member, overload, overloadIndex);
+    content = renderMemberFacts(state);
   } else if (state.memberSection === "annotated") {
     const destinationError = state.annotatedDestinationError
       ? `<div id="annotated-destination-error" class="graph-drill-error" role="alert">${escapeHtml(state.annotatedDestinationError)}</div>`
@@ -5386,121 +5387,11 @@ function renderAnnotatedSourceRejection(error: TypeError) {
   </section>`;
 }
 
-function renderMemberFacts(
-  type: AppTypeSurface,
-  member: AppMemberGroup,
-  overload: InspectedMemberSurface,
-  overloadIndex: number,
-) {
-  if (state.memberFactsLoading) {
-    return `<section class="document-section source-progress"><span class="loader"></span><h2>Analyzing method…</h2><p>Decoding the selected overload and deriving method evidence and performance opportunities.</p></section>`;
-  }
-  if (!state.memberFacts) {
-    return `<section class="document-section empty-member-section"><h2>Facts query failed</h2><p>${escapeHtml(state.memberFactsError || "No facts result was returned.")}</p></section>`;
-  }
-
-  const facts = state.memberFacts;
-  const signals = facts.signals;
-  const heapAllocations = facts.allocations.filter(a => a.countedAsHeap);
-  const allocOffsets = heapAllocations.map(a => a.offset);
-  const callOffsets = facts.calls.map(c => c.offset);
-  const safetyOffsets = facts.safety
-    .map(s => s.offset)
-    .filter((offset): offset is string => offset != null);
-  const loopAllocOffsets = heapAllocations.filter(a => a.inLoop).map(a => a.offset);
-  return `
-    <section class="document-section facts-section">
-      <div class="section-title"><h2>Method facts</h2><span>selected overload</span></div>
-      ${factRows([
-        ["Overload", `${overloadIndex + 1} of ${member.overloads.length}`],
-        ["Kind", overload.kind],
-        ["Metadata token", `0x${facts.metadataToken.toString(16).padStart(8, "0")}`],
-        ["Declaring type", type.id],
-        ["Allocations", String(signals.allocations), allocOffsets],
-        ["Calls", String(facts.calls.length), callOffsets],
-        ["Copies", String(signals.copies)],
-        ["Reflection calls", String(signals.reflection)],
-        ["Throws / catches / finally", `${signals.throws} / ${signals.catches} / ${signals.finallys}`],
-        ["Unsafe", signals.unsafe ? "yes" : "no", signals.unsafe ? safetyOffsets : []],
-        ["Allocates in loop", signals.allocatesInLoop ? "yes" : "no", signals.allocatesInLoop ? loopAllocOffsets : []]
-      ])}
-    </section>
-    ${renderFactTable("Allocation facts", facts.allocations, [
-      ["IL", "offset"], ["Kind", "kind"], ["Type", "type"],
-      ["Heap", row => row.countedAsHeap ? "yes" : "no"], ["Multiplicity", "multiplicity"],
-      ["Path", "path"], ["Escape", "escape"], ["Loop", row => row.inLoop ? "yes" : ""],
-      ["Size", row => typeof row.estimatedSizeBytes === "number"
-        ? `${row.estimatedSizeBytes} B`
-        : ""]
-    ], "No allocation occurrences were found in this method.")}
-    ${renderFactTable("Calls", facts.calls, [
-      ["IL", "offset"], ["Opcode", "opcode"], ["Callee", "callee"],
-      ["Multiplicity", "multiplicity"], ["Loop", row => row.inLoop ? "yes" : ""]
-    ], "No direct call sites were found in this method.")}
-    ${renderFactTable("Safety facts", facts.safety, [
-      ["IL", row => row.offset || ""], ["Kind", "kind"], ["Operation", "operation"],
-      ["Requirement", "requirement"], ["Evidence", "evidence"]
-    ], "No unsafe operations or declaration evidence were found.")}
-    ${renderFactTable("Exception regions", facts.exceptionRegions, [
-      ["Region", "region"], ["Clause", "clause"], ["Try", "tryRange"],
-      ["Handler", "handlerRange"], ["Filter", row => row.filterRange || ""],
-      ["Caught type", row => row.caughtType || ""]
-    ], "No exception regions were found in this method.")}
-    <section class="document-section performance-facts">
-      <div class="section-title"><h2>Performance opportunities</h2><span>ranked judgments · ${facts.performanceOpportunities.length}</span></div>
-      ${facts.performanceOpportunities.length
-        ? facts.performanceOpportunities.map(opportunity => `
-          <article class="performance-opportunity">
-            <div><strong>${escapeHtml(opportunity.shape)}</strong><span class="confidence ${escapeHtml(opportunity.confidence)}">${escapeHtml(opportunity.confidence)}</span>${opportunity.offset ? `<code>${escapeHtml(opportunity.offset)}</code>` : ""}</div>
-            <p>${escapeHtml(opportunity.evidence)}</p>
-            <dl><dt>Possible direction</dt><dd>${escapeHtml(opportunity.fix)}</dd>${opportunity.caveat ? `<dt>Caveat</dt><dd>${escapeHtml(opportunity.caveat)}</dd>` : ""}<dt>Provenance</dt><dd>${escapeHtml([opportunity.provenance, opportunity.finding].filter(Boolean).join(" · "))}</dd></dl>
-          </article>`).join("")
-        : '<div class="empty-fact-group">No curated performance opportunities were found for this method.</div>'}
-    </section>
-    ${facts.diagnostics.length
-      ? `<section class="document-section fact-group"><div class="section-title"><h2>Analysis diagnostics</h2><span>${facts.diagnostics.length}</span></div><ul>${facts.diagnostics.map(diagnostic => `<li>${escapeHtml(diagnostic)}</li>`).join("")}</ul></section>`
-      : ""}`;
-}
-
-type FactTableColumn<T> =
-  readonly [label: string, field: keyof T | ((row: T) => unknown)];
-
-function renderFactTable<T extends object>(
-  title: string,
-  rows: readonly T[],
-  columns: readonly FactTableColumn<T>[],
-  emptyText: string,
-) {
-  return `<section class="document-section fact-group">
-    <div class="section-title"><h2>${escapeHtml(title)}</h2><span>${rows.length}</span></div>
-    ${rows.length
-      ? `<div class="fact-table" style="--fact-columns:${columns.length}">${columns.map(([label]) => `<strong>${escapeHtml(label)}</strong>`).join("")}${rows.map(row => columns.map(([, field]) => {
-          const value = typeof field === "function" ? field(row) : row[field];
-          return `<code>${escapeHtml(value ?? "")}</code>`;
-        }).join("")).join("")}</div>`
-      : `<div class="empty-fact-group">${escapeHtml(emptyText)}</div>`}
-  </section>`;
-}
-
 type FactSummaryRow =
-  readonly [key: string, value: string, evidence?: readonly string[]];
+  readonly [key: string, value: string];
 
 function factRows(rows: readonly FactSummaryRow[]) {
-  return `<dl class="fact-rows">${rows.map(([key, value, evidence]) => `<div><dt>${escapeHtml(key)}</dt><dd><code>${escapeHtml(value)}</code>${factEvidence(evidence)}</dd></div>`).join("")}</dl>`;
-}
-
-// Inline, muted IL-offset evidence riding along a fact's value (e.g. "1  IL_000C").
-// Deduplicated and capped so a hot method never restores the long-line problem; the
-// overflow count carries the full list in a tooltip and the detail table below holds
-// every occurrence. Sourced from the detail collections so the summary and the tables agree.
-function factEvidence(offsets?: readonly string[]) {
-  const unique = [...new Set((offsets ?? []).filter(Boolean))];
-  if (!unique.length) return "";
-  const CAP = 2;
-  const shown = unique.slice(0, CAP);
-  const extra = unique.length - shown.length;
-  const label = shown.join(", ") + (extra > 0 ? ` +${extra}` : "");
-  return `<span class="fact-evidence" title="${escapeHtml(unique.join(", "))}">${escapeHtml(label)}</span>`;
+  return `<dl class="fact-rows">${rows.map(([key, value]) => `<div><dt>${escapeHtml(key)}</dt><dd><code>${escapeHtml(value)}</code></dd></div>`).join("")}</dl>`;
 }
 
 function shortTypeName(fullName: string) {

--- a/prototypes/inspect-web/src/member-facts.ts
+++ b/prototypes/inspect-web/src/member-facts.ts
@@ -1,0 +1,121 @@
+import type { MemberDetailInspectionState } from "./member-detail-inspection.ts";
+
+function escapeHtml(value: unknown) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+export function renderMemberFacts(
+  state: Pick<
+    MemberDetailInspectionState,
+    "memberFacts" | "memberFactsLoading" | "memberFactsError"
+  >,
+) {
+  if (state.memberFactsLoading) {
+    return `<section class="document-section source-progress"><span class="loader"></span><h2>Analyzing method…</h2><p>Decoding the selected overload and deriving method evidence and performance opportunities.</p></section>`;
+  }
+  if (!state.memberFacts) {
+    return `<section class="document-section empty-member-section"><h2>Facts query failed</h2><p>${escapeHtml(state.memberFactsError || "No facts result was returned.")}</p></section>`;
+  }
+
+  const facts = state.memberFacts;
+  const signals = facts.signals;
+  const heapAllocations = facts.allocations.filter(a => a.countedAsHeap);
+  const allocOffsets = heapAllocations.map(a => a.offset);
+  const callOffsets = facts.calls.map(c => c.offset);
+  const safetyOffsets = facts.safety
+    .map(s => s.offset)
+    .filter((offset): offset is string => offset != null);
+  const loopAllocOffsets = heapAllocations.filter(a => a.inLoop).map(a => a.offset);
+  const rows: readonly (readonly [
+    label: string,
+    value: string,
+    evidence?: readonly string[],
+  ])[] = [
+    ["Allocations", String(signals.allocations), allocOffsets],
+    ["Calls", String(facts.calls.length), callOffsets],
+    ["Copies", String(signals.copies)],
+    ["Reflection calls", String(signals.reflection)],
+    ["Throws / catches / finally", `${signals.throws} / ${signals.catches} / ${signals.finallys}`],
+    ["Unsafe", signals.unsafe ? "yes" : "no", signals.unsafe ? safetyOffsets : []],
+    ["Allocates in loop", signals.allocatesInLoop ? "yes" : "no", signals.allocatesInLoop ? loopAllocOffsets : []],
+  ];
+  return `
+    <section class="facts-summary" aria-labelledby="facts-summary-title">
+      <header class="facts-summary-heading"><h2 id="facts-summary-title">Analysis summary</h2><span>Static analysis</span></header>
+      <dl class="facts-summary-list">${rows.map(([label, value, evidence]) => `
+        <div><dt>${escapeHtml(label)}</dt><dd><code class="facts-summary-value">${escapeHtml(value)}</code>${factEvidence(evidence)}</dd></div>`).join("")}
+      </dl>
+      <p class="facts-metadata-identity"><span>Metadata token</span><code>${escapeHtml(`0x${facts.metadataToken.toString(16).padStart(8, "0")}`)}</code></p>
+    </section>
+    ${renderFactTable("Allocation facts", facts.allocations, [
+      ["IL", "offset"], ["Kind", "kind"], ["Type", "type"],
+      ["Heap", row => row.countedAsHeap ? "yes" : "no"], ["Multiplicity", "multiplicity"],
+      ["Path", "path"], ["Escape", "escape"], ["Loop", row => row.inLoop ? "yes" : ""],
+      ["Size", row => typeof row.estimatedSizeBytes === "number"
+        ? `${row.estimatedSizeBytes} B`
+        : ""]
+    ], "No allocation occurrences were found in this method.")}
+    ${renderFactTable("Calls", facts.calls, [
+      ["IL", "offset"], ["Opcode", "opcode"], ["Callee", "callee"],
+      ["Multiplicity", "multiplicity"], ["Loop", row => row.inLoop ? "yes" : ""]
+    ], "No direct call sites were found in this method.")}
+    ${renderFactTable("Safety facts", facts.safety, [
+      ["IL", row => row.offset || ""], ["Kind", "kind"], ["Operation", "operation"],
+      ["Requirement", "requirement"], ["Evidence", "evidence"]
+    ], "No unsafe operations or declaration evidence were found.")}
+    ${renderFactTable("Exception regions", facts.exceptionRegions, [
+      ["Region", "region"], ["Clause", "clause"], ["Try", "tryRange"],
+      ["Handler", "handlerRange"], ["Filter", row => row.filterRange || ""],
+      ["Caught type", row => row.caughtType || ""]
+    ], "No exception regions were found in this method.")}
+    <section class="document-section performance-facts">
+      <div class="section-title"><h2>Performance opportunities</h2><span>ranked judgments · ${facts.performanceOpportunities.length}</span></div>
+      ${facts.performanceOpportunities.length
+        ? facts.performanceOpportunities.map(opportunity => `
+          <article class="performance-opportunity">
+            <div><strong>${escapeHtml(opportunity.shape)}</strong><span class="confidence ${escapeHtml(opportunity.confidence)}">${escapeHtml(opportunity.confidence)}</span>${opportunity.offset ? `<code>${escapeHtml(opportunity.offset)}</code>` : ""}</div>
+            <p>${escapeHtml(opportunity.evidence)}</p>
+            <dl><dt>Possible direction</dt><dd>${escapeHtml(opportunity.fix)}</dd>${opportunity.caveat ? `<dt>Caveat</dt><dd>${escapeHtml(opportunity.caveat)}</dd>` : ""}<dt>Provenance</dt><dd>${escapeHtml([opportunity.provenance, opportunity.finding].filter(Boolean).join(" · "))}</dd></dl>
+          </article>`).join("")
+        : '<div class="empty-fact-group">No curated performance opportunities were found for this method.</div>'}
+    </section>
+    ${facts.diagnostics.length
+      ? `<section class="document-section fact-group"><div class="section-title"><h2>Analysis diagnostics</h2><span>${facts.diagnostics.length}</span></div><ul>${facts.diagnostics.map(diagnostic => `<li>${escapeHtml(diagnostic)}</li>`).join("")}</ul></section>`
+      : ""}`;
+}
+
+type FactTableColumn<T> =
+  readonly [label: string, field: keyof T | ((row: T) => unknown)];
+
+function renderFactTable<T extends object>(
+  title: string,
+  rows: readonly T[],
+  columns: readonly FactTableColumn<T>[],
+  emptyText: string,
+) {
+  return `<section class="document-section fact-group">
+    <div class="section-title"><h2>${escapeHtml(title)}</h2><span>${rows.length}</span></div>
+    ${rows.length
+      ? `<div class="fact-table" style="--fact-columns:${columns.length}">${columns.map(([label]) => `<strong>${escapeHtml(label)}</strong>`).join("")}${rows.map(row => columns.map(([, field]) => {
+          const value = typeof field === "function" ? field(row) : row[field];
+          return `<code>${escapeHtml(value ?? "")}</code>`;
+        }).join("")).join("")}</div>`
+      : `<div class="empty-fact-group">${escapeHtml(emptyText)}</div>`}
+  </section>`;
+}
+
+// The summary shows two distinct offsets; the tooltip and detail tables retain the rest.
+function factEvidence(offsets?: readonly string[]) {
+  const unique = [...new Set((offsets ?? []).filter(Boolean))];
+  if (!unique.length) return "";
+  const CAP = 2;
+  const shown = unique.slice(0, CAP);
+  const extra = unique.length - shown.length;
+  const label = shown.join(", ") + (extra > 0 ? ` +${extra}` : "");
+  return `<span class="fact-evidence" title="${escapeHtml(unique.join(", "))}">${escapeHtml(label)}</span>`;
+}

--- a/prototypes/inspect-web/src/styles.css
+++ b/prototypes/inspect-web/src/styles.css
@@ -1360,6 +1360,24 @@ kbd {
 .fact-rows div { display: grid; grid-template-columns: 180px 1fr; padding: 12px 10px; border-bottom: 1px solid var(--line); }
 .fact-rows dt { color: var(--dim); font-size: 13px; }
 .fact-rows dd { margin: 0; color: var(--text); font: 13px var(--mono); }
+.facts-summary { max-width: 900px; }
+.facts-summary-heading { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.facts-summary-heading h2 { margin: 0; font-size: 16px; font-weight: 600; }
+.facts-summary-heading > span { color: var(--muted); font-size: 12px; }
+.facts-summary-list { margin: 0; border-top: 1px solid var(--line); }
+.facts-summary-list > div { display: grid; grid-template-columns: minmax(195px, 32%) minmax(0, 1fr); align-items: baseline; gap: 16px; padding: 8px 0; border-bottom: 1px solid var(--line); }
+.facts-summary-list dt { min-width: 0; color: var(--muted); font-size: 13px; overflow-wrap: anywhere; }
+.facts-summary-list dd { display: flex; align-items: baseline; gap: 24px; min-width: 0; margin: 0; }
+.facts-summary-value { flex: 0 0 76px; min-width: 0; font: 13px var(--mono); overflow-wrap: anywhere; }
+.facts-summary-list .fact-evidence { min-width: 0; color: var(--muted); font: 12px var(--mono); overflow-wrap: anywhere; }
+.facts-metadata-identity { display: flex; flex-wrap: wrap; gap: 6px 12px; margin: 10px 0 0; font-size: 12px; }
+.facts-metadata-identity > span { color: var(--muted); }
+.facts-metadata-identity code { min-width: 0; color: var(--text); font: 12px var(--mono); overflow-wrap: anywhere; }
+@container member-surface (max-width: 575px) {
+  .facts-summary-list > div { grid-template-columns: minmax(0, 48%) minmax(0, 1fr); gap: 12px; }
+  .facts-summary-list dd { flex-direction: column; gap: 4px; }
+  .facts-summary-value { flex-basis: auto; max-width: 100%; }
+}
 .assembly-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 .assembly-grid .assembly-cell { display: flex; flex-direction: column; gap: 6px; padding: 14px 12px; background: var(--panel); min-width: 0; }
 .assembly-grid .assembly-name { font: 13px var(--mono); color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -1399,7 +1417,6 @@ kbd {
 .dep-version { flex: 0 0 auto; font: 13px var(--mono); color: var(--dim); white-space: nowrap; }
 .graph-empty { color: var(--muted); font-size: 12px; padding: 24px 12px; text-align: center; }
 .fact-rows .dim { color: var(--muted); }
-.fact-rows dd .fact-evidence { margin-left: 10px; color: var(--muted); font-size: 12px; }
 .perf-list { display: flex; flex-direction: column; gap: 6px; }
 .perf-row { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; padding: 8px 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); color: var(--fg); cursor: pointer; }
 .perf-row:hover { border-color: var(--accent); background: var(--panel-active); }

--- a/prototypes/inspect-web/src/type-panel.ts
+++ b/prototypes/inspect-web/src/type-panel.ts
@@ -9,7 +9,7 @@ import { WORKBENCH_KEYBINDING_PRIORITY } from "./workbench-keybindings.ts";
 // renders; `dotnet-inspect.ts` owns the type index, filters, member grouping, and navigation
 // state transitions behind explicit callbacks. Shared text helpers
 // (kindIcon, shortKind, typeDisplayName, highlight, highlightCSharp, factRows,
-// factEvidence, relatedTypeChip) stay in `dotnet-inspect.ts`, since they are used well beyond the
+// relatedTypeChip) stay in `dotnet-inspect.ts`, since they are used well beyond the
 // type panel, and are passed in rather than duplicated here.
 
 export interface TypeSummary {

--- a/prototypes/inspect-web/test/member-facts-fixture.ts
+++ b/prototypes/inspect-web/test/member-facts-fixture.ts
@@ -1,0 +1,66 @@
+import type { MemberFacts } from "../src/member-detail-inspection.ts";
+
+export function memberFactsFixture(
+  mode: "populated" | "zero" | "long" = "populated",
+): MemberFacts {
+  const zero = mode === "zero";
+  const long = mode === "long";
+  return {
+    metadataToken: 0x06000125,
+    signals: {
+      allocations: zero ? 0 : 1,
+      copies: long ? 2147483647 : 0,
+      reflection: 0,
+      throws: zero ? 0 : long ? 2147483647 : 1,
+      catches: long ? 2147483647 : 0,
+      finallys: long ? 2147483647 : 0,
+      unsafe: false,
+      allocatesInLoop: false,
+      evidenceOffsets: [],
+      exceptionTypes: [],
+    },
+    allocations: zero ? [] : [{
+      kind: "newobj",
+      type: "System.Text.Json.JsonException",
+      offset: "IL_0020",
+      countedAsHeap: true,
+      frequency: "conditional",
+      multiplicity: "once",
+      path: "conditional",
+      escape: "escapes",
+      inLoop: false,
+      estimatedSizeBytes: null,
+      detail: null,
+    }],
+    calls: zero ? [] : [
+      {
+        callee: "JsonTypeInfo.EnsureConfigured()",
+        offset: long ? "IL_12345678" : "IL_0008",
+        opcode: "call",
+        kind: "direct",
+        multiplicity: "once",
+        inLoop: false,
+      },
+      {
+        callee: "JsonConverter.ReadCore()",
+        offset: long ? "IL_23456789" : "IL_0014",
+        opcode: "callvirt",
+        kind: "virtual",
+        multiplicity: "once",
+        inLoop: false,
+      },
+      {
+        callee: "JsonException..ctor()",
+        offset: "IL_0020",
+        opcode: "newobj",
+        kind: "constructor",
+        multiplicity: "once",
+        inLoop: false,
+      },
+    ],
+    safety: [],
+    exceptionRegions: [],
+    performanceOpportunities: [],
+    diagnostics: [],
+  };
+}

--- a/prototypes/inspect-web/test/member-facts.test.ts
+++ b/prototypes/inspect-web/test/member-facts.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { renderMemberFacts } from "../src/member-facts.ts";
+import type { MemberFacts } from "../src/member-detail-inspection.ts";
+import { memberFactsFixture } from "./member-facts-fixture.ts";
+
+function render(facts: MemberFacts = memberFactsFixture()) {
+  return renderMemberFacts({
+    memberFacts: facts,
+    memberFactsLoading: false,
+    memberFactsError: "",
+  });
+}
+
+function summaryRow(html: string, label: string) {
+  const row = html.split(`<dt>${label}</dt>`)[1]?.split("</dd>")[0];
+  assert.ok(row, `Summary row ${label} is missing.`);
+  return row;
+}
+
+test("member Facts summary preserves all signals without repeating subject identity", () => {
+  const html = render();
+  assert.match(html, /<h2 id="facts-summary-title">Analysis summary<\/h2>/);
+  for (const [label, value] of [
+    ["Allocations", "1"], ["Calls", "3"], ["Copies", "0"],
+    ["Reflection calls", "0"], ["Throws / catches / finally", "1 / 0 / 0"],
+    ["Unsafe", "no"], ["Allocates in loop", "no"],
+  ] as const) {
+    assert.ok(summaryRow(html, label).includes(`>${value}</code>`));
+  }
+  assert.doesNotMatch(html, /<dt>Overload|<dt>Kind|<dt>Declaring type/);
+  assert.match(html, /<\/dl>\s*<p class="facts-metadata-identity"><span>Metadata token<\/span><code>0x06000125<\/code>/);
+});
+
+test("member Facts evidence retains heap filtering, deduplication, and the full tooltip", () => {
+  const facts = memberFactsFixture();
+  const allocation = facts.allocations[0]!;
+  const html = render({
+    ...facts,
+    signals: { ...facts.signals, unsafe: true, allocatesInLoop: true },
+    allocations: [
+      { ...allocation, inLoop: true },
+      { ...allocation, offset: "IL_0030", countedAsHeap: false, inLoop: true },
+    ],
+    calls: [...facts.calls, facts.calls[0]!],
+    safety: [
+      { kind: "declaration", offset: null, operation: "unsafe", requirement: "", evidence: "" },
+      { kind: "instruction", offset: "IL_0040", operation: "localloc", requirement: "", evidence: "" },
+    ],
+  });
+  assert.match(summaryRow(html, "Allocations"), /IL_0020/);
+  assert.doesNotMatch(summaryRow(html, "Allocations"), /IL_0030/);
+  assert.match(summaryRow(html, "Calls"), />4<\/code>/);
+  assert.match(summaryRow(html, "Calls"), /title="IL_0008, IL_0014, IL_0020">IL_0008, IL_0014 \+1<\/span>/);
+  assert.match(summaryRow(html, "Unsafe"), />yes<\/code>.*IL_0040/);
+  assert.match(summaryRow(html, "Allocates in loop"), />yes<\/code>.*IL_0020/);
+  assert.doesNotMatch(summaryRow(html, "Allocates in loop"), /IL_0030/);
+  assert.match(html, /<code>IL_0030<\/code>/);
+});
+
+test("member Facts keeps explicit zero results distinct from loading and failure", () => {
+  const html = render(memberFactsFixture("zero"));
+  for (const label of ["Allocations", "Calls", "Copies", "Reflection calls"]) {
+    assert.match(summaryRow(html, label), />0<\/code>/);
+  }
+  assert.match(summaryRow(html, "Throws / catches / finally"), />0 \/ 0 \/ 0<\/code>/);
+  assert.match(summaryRow(html, "Unsafe"), />no<\/code>/);
+  assert.doesNotMatch(html, /class="fact-evidence"/);
+  assert.match(html, /No direct call sites were found/);
+
+  const loading = renderMemberFacts({
+    memberFacts: memberFactsFixture(),
+    memberFactsLoading: true,
+    memberFactsError: "",
+  });
+  assert.match(loading, /Analyzing method/);
+  assert.doesNotMatch(loading, /facts-summary|Metadata token/);
+
+  const failure = renderMemberFacts({
+    memberFacts: null,
+    memberFactsLoading: false,
+    memberFactsError: "Could not decode <method>.",
+  });
+  assert.match(failure, /Facts query failed/);
+  assert.match(failure, /Could not decode &lt;method&gt;\./);
+  assert.doesNotMatch(failure, /facts-summary|No direct call sites/);
+  assert.match(renderMemberFacts({
+    memberFacts: null,
+    memberFactsLoading: false,
+    memberFactsError: "",
+  }), /No facts result was returned/);
+});
+
+test("member Facts escapes summary evidence and all relocated detail sections", () => {
+  const facts = memberFactsFixture();
+  const html = render({
+    ...facts,
+    calls: [{ ...facts.calls[0]!, offset: "<offset>\"", callee: "<callee>" }],
+    allocations: [{ ...facts.allocations[0]!, type: "<type>" }],
+    safety: [{ kind: "<kind>", offset: null, operation: "<operation>", requirement: "<requirement>", evidence: "<evidence>" }],
+    exceptionRegions: [{ region: 1, clause: "<clause>", tryRange: "<try>", handlerRange: "<handler>", filterRange: "<filter>", caughtType: "<caught>" }],
+    performanceOpportunities: [{ shape: "<shape>", evidence: "<evidence>", fix: "<fix>", confidence: "<confidence>", offset: "<offset>", inLoop: false, caveat: "<caveat>", finding: "<finding>", provenance: "<provenance>" }],
+    diagnostics: ["<diagnostic>"],
+  });
+  for (const value of [
+    "offset", "callee", "type", "kind", "operation", "requirement", "evidence",
+    "clause", "try", "handler", "filter", "caught", "shape", "fix",
+    "confidence", "caveat", "finding", "provenance", "diagnostic",
+  ]) {
+    assert.ok(html.includes(`&lt;${value}&gt;`));
+    assert.ok(!html.includes(`<${value}>`));
+  }
+  assert.match(html, /title="&lt;offset&gt;&quot;"/);
+  assert.match(html, /Analysis diagnostics/);
+});

--- a/prototypes/inspect-web/test/spotlight-identity.test.ts
+++ b/prototypes/inspect-web/test/spotlight-identity.test.ts
@@ -3827,10 +3827,9 @@ test("member detail adapters preserve exact engine coordinates", () => {
     appSource.match(
       /async function loadSelectedMemberFacts\(\)[\s\S]*?\n}\n\ninterface LoadPackageOptions/)?.[0]
     ?? "";
-  const factsRenderer =
-    appSource.match(
-      /function renderMemberFacts\([\s\S]*?\n}\n\ntype FactTableColumn/)?.[0]
-    ?? "";
+  const factsRenderer = readFileSync(
+    new URL("../src/member-facts.ts", import.meta.url), "utf8");
+  assert.match(appSource, /content = renderMemberFacts\(state\)/);
 
   assert.match(
     coordinator,


### PR DESCRIPTION
Make static analysis easier to scan while preserving its evidence: the approved
Member Facts summary is compact, separates subject identity from analysis, and
responds to the detail pane rather than behaving like a second document header.

Closes #5905. This implements the visual proposal approved with
"Looks good. continue" and continues the top-down Inspect Web theme.

## Demo

Open a concrete member's **Facts** view. The persistent subject path and quiet
member header already identify the declaring type, kind, and selected overload.

| Before | After |
| --- | --- |
| `Method facts` plus `selected overload`, then four identity rows mixed with analysis | `Analysis summary`, seven preserved signal rows, then a compact metadata-token line |
| Summary occupies 506 px in the populated fixture | Summary occupies 306 px with the same values |
| Supporting IL offsets follow each value inline | Offsets align on wide panes and move below the value when the pane narrows |

Screenshots use the shipping renderer and stylesheet with a typed, illustrative
`MemberFacts` fixture in the current browser shell. They demonstrate rendering,
not measured results for the displayed member. The before capture executes the
unchanged production renderer from `f143600dc` against the same fixture.

Neighboring cases retain explicit zero/`no` results and contain large counts
and longer offsets at a 360 px viewport. Loading and query failure remain
visibly distinct from a successful result.

### Before

![Original production renderer with the populated fixture](https://github.com/user-attachments/assets/9d336746-a17e-4e63-b318-693ad636abc8)

### After

![Implemented compact Member Facts summary at wide width](https://github.com/user-attachments/assets/30439482-a3bd-47cd-a0df-0dd174e8a2a8)

### Constrained detail pane

![Implemented Member Facts with IL evidence below values in a constrained pane](https://github.com/user-attachments/assets/f0472cfd-0255-44d9-bc21-5a36fc225fa1)

### Narrow boundary case

![Large counts and longer offsets remain contained at 360 px](https://github.com/user-attachments/assets/117d3e40-1da6-4814-b3da-56babaccbb24)

### Successful zero-result neighbor

![Explicit zero and no values remain visible in the Member Facts summary](https://github.com/user-attachments/assets/aecebf60-f436-4522-884f-f1476356590c)

## Design and boundaries

**Normative owner:** `docs/design/inspect-web-surface-composition.md`,
**Working surfaces > Type and Member API**. Its claim is compact,
pane-responsive Facts summary composition that separates existing subject
identity while preserving every analysis value and supporting offset.

Chrome DevTools' request-detail property rows provide a limited comparison for
label/value alignment; the landed Member Overview provides local hierarchy and
spacing. Neither is adopted as a new overall application model.

**Consumer and complexity basis:** the existing Member Facts browser view
consumes the existing `MemberFacts` result. The renderer is extracted from the
application coordinator so the browser fixture exercises the shipping DOM
construction, including loading/failure and the unchanged lower sections.
No new query, analysis substrate, dependency, or host path is introduced.

**Production adoption:** one step, tracked end-to-end by #5905: replace the
current Member Facts summary in place. This PR completes that step. There is no
parallel architecture or retirement phase.

**Rendering:** browser-specific DOM/CSS at the existing interactive boundary,
intentionally outside Markout. Typed `MemberFacts` data is retained until
escaped HTML rendering; CSS controls layout. CLI behavior is unchanged. The
user approved this browser presentation scope, not a new single-host substrate.

The lower allocation, call, safety, exception, performance, and diagnostic
sections retain their existing content and behavior. Graph Explore (#5867) and
Finding-identity navigation (#5517) remain separate. IL offsets remain
non-interactive text with the existing deduplicated two-offset preview and
full-list tooltip.

## Validation

- `npm run typecheck`.
- `node --test --test-reporter=dot test/member-facts.test.ts test/member-detail-inspection.test.ts test/type-panel.test.ts test/spotlight-identity.test.ts`.
- `npm run analyze`.
- `npm run build`.
- `npx markdownlint-cli docs/design/inspect-web-surface-composition.md`.
- All 60 `workspace-titlebar.spec.ts` Firefox tests passed with one worker.
  Port 4175 was already occupied, so a session-only configuration imported the
  existing Playwright configuration and changed only its absolute test
  directory/server working directory and server/base URL to port 4188.
- The ordinary browser gate covers compact populated layout, zero/loading/error
  states, and row plus member-scroller containment at 900, 480, and 360 px.

The final base integration adds #5858's package-payload capacity work. It does
not change frontend rendering, fixture inputs, CSS, or these focused gates.

## Candidate

- Head: `20d432729c665a8af491b87acb5b8c52c1f8e9cf`.
- Effective base: `7b02b2764811eb88db08a93073cf28aa66e66ec9` (`main`).
- Round 1: **2/2 CLEAN**, GPT-6 Astra and Claude Opus 5, at this unchanged head.
- Carry-forward through `191e8dacc2fc1fec7faa887253cf5c7005d1a633`:
  **no interaction**. #5885 moves JSExport fixtures and their references/routing,
  without changing Member Facts rendering, input contracts, CSS, or its gates.
- Current-head `ci-required` succeeded; live GitHub state was
  `MERGEABLE` / `CLEAN` at round completion.
- No merge authorization has been given.
