### PR TITLE
Design NuGet Gallery discovery, facets, and row delegation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
 | [Member Body Substrate](design/member-body-substrate.md) | One base for skeleton/full/merged/diff body rendering: `ApiType` shape, `MemberAnchor` address, one scope, and `MemberBody`'s scalar (whole-body) and vector (offset-keyed) shapes. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
+| [NuGet Gallery Discovery](design/nuget-gallery-discovery.md) | Proposed NuGetFetch termless/type-filtered Gallery search, source orders, search-facet discovery, and bounded row-source delegation, with CLI/browser adoption tracked separately. |
 | [NuGet Feed Authentication](design/nuget-authentication.md) | How feeds are authenticated: `nuget.config` credentials, credential provider discovery and the 401-driven plugin protocol, source-scoped plugin credential isolation, supported credential forms, and hermetic/live test tiers. See [Private NuGet Feeds](private-feeds.md) for setup instructions. |
 | [Local Package Source Identity](design/local-package-source-identity.md) | Canonical config- and command-relative path identity shared by local source consumers. |
 | [Local Folder Package Source](design/local-folder-package-source.md) | General V2/V3 folder-feed recognition, independent capabilities, bounded filesystem and archive observation, typed failures, and payload lifetime. |

--- a/docs/design/nuget-gallery-discovery.md
+++ b/docs/design/nuget-gallery-discovery.md
@@ -34,9 +34,9 @@ This owner defines:
 The exact claim is:
 
 > One host-neutral Gallery discovery operation binds an authorized source and
-> typed search intent to ordered package metadata and honest completion
-> evidence. Its supported delegated selection has the same meaning as the
-> caller's reference computation; it is not a provider page-size shortcut.
+> typed search intent to an explicitly bounded, ordered package-metadata input
+> and honest scope/completion evidence. Row selection preserves that named
+> input; a provider page-size shortcut cannot replace semantic selection.
 
 This does not own generic feed behavior, source authorization or identity,
 row-schema binding, row predicates, selection-stage meaning, Count, CLI
@@ -65,8 +65,9 @@ tracker, not this document, assigns their implementation work.
 ## Gallery input and discovery domain
 
 A request names one authorized Gallery source, optional search text, zero or
-one package-type selector, a source order, and prerelease policy. The caller's
-semantic selection and the operation's resource ceilings are separate inputs.
+one package-type selector, a source order, prerelease policy, and bounded
+response capacity K. The caller's semantic selection and the operation's other
+resource ceilings are separate inputs.
 
 Missing or whitespace-only text means **browse**, not invalid input and not a
 request for a fabricated wildcard. Nonempty text uses Gallery search semantics;
@@ -74,26 +75,40 @@ it is encoded as one provider parameter, not interpreted as CLI text, a row
 predicate, or a literal package-ID prefix. Existing literal-prefix inspection
 remains a separate supported operation.
 
-The discovery domain is the Gallery's searchable listed package IDs under that
-text, type, and version policy, including the provider's browse eligibility
+The discovery population is the Gallery's searchable listed package IDs under
+that text, type, and version policy, including the provider's browse eligibility
 rules. It is not every package ever uploaded or every version of each package.
 One result identifies one package ID and its provider-selected eligible
 version. Stable-only is the default; SemVer 2 packages remain eligible.
 Package-type selection applies to the provider-selected version under the same
 prerelease policy, not to an arbitrary historical version.
 
+The initial **row input is one bounded Gallery response**, not the whole
+discovery population. Its capacity K is part of the declared source input,
+chosen before row planning and preserved with the result. It requests offset
+zero and up to K rows, with positive K within the adapter's advertised maximum
+of 1,000.
+Changing only a semantic selection such as `Head(10)` must not silently change
+K. The source cannot shrink K to ten as an optimization.
+
+This restriction matters because Gallery selects page membership using indexed
+download counts, then re-sorts that page using auxiliary lifetime counts.
+The first ten of a 200-candidate response need not equal a ten-candidate
+response. Each is useful Gallery discovery; neither certifies the globally
+most-downloaded ten packages.
+
 The initial source orders are:
 
 | Order | Meaning |
 | --- | --- |
-| Most downloaded | Descending package-level lifetime downloads, retaining the provider's tie order. Not recent activity or unique users. |
+| Most downloaded | Gallery's download-ranked candidate selection, then descending package-level lifetime downloads within that response, retaining provider tie order. Not global top-N, recent activity, or unique users. |
 | Relevance | The Gallery's relevance order for this query, including its provider ranking policy. Not a locally reproducible numeric score. |
 
 An omitted source order resolves to Most downloaded for browse and Relevance
 for nonempty text. An explicit order wins in either case. Selection never
 changes that resolved source order.
 
-These are source-input orders: they define the incoming logical sequence.
+These are source-input orders: they define the incoming bounded sequence.
 They are not aliases for L2 `--order-by` or semantic `Top`. A caller that
 retains this incoming order can select its head; an additional row-order
 operation still occupies its normal place in the caller's plan.
@@ -160,11 +175,13 @@ Selected package type can be reported as evidence of the provider-applied
 selector. It is not a claim that the response included an exhaustive list of
 that package's types, or that its archive has been inspected.
 
-The typed result retains the request association and completion evidence with
-its ordered rows. It reuses the existing source-result identity and containment
-contracts rather than introducing caller-policing tokens. Source-reported
-`totalHits` belongs to this response's discovery domain; it is not an L2 Count
-and does not authorize a count after residual predicates or semantic stages.
+The typed result retains the full source-input association, including K, and
+completion evidence with its ordered rows. It reuses the existing source-result
+identity and containment contracts rather than introducing caller-policing
+tokens. Source-reported `totalHits` is an **estimate** of the discovery
+population, not an L2 Count. It cannot prove population exhaustion, including
+when it equals the returned row count or is zero. A missing or unusable
+estimate remains unavailable without making otherwise valid rows unavailable.
 This Gallery response has its own wire shape, including
 `PackageRegistration.Id`, `Version`, and `NormalizedVersion`. It is not the
 V3 search DTO; its count interpretation does not change generic feed parsing,
@@ -177,73 +194,63 @@ unverified until that gate runs against the product adapter.
 
 ## Source delegation and semantic limits
 
-The first optimized adoption supports a single declared package-row sequence
-and a source-closed `Head(N)` over the incoming Gallery order, with no preceding
-membership-changing projection, row predicate, or local ordering operation.
-It consumes an owner-formed candidate rather than parsing `-n` or inventing a
-row plan. The RowSelection owner's source-closed declaration and the Source
-Delegation implementation are prerequisites, not claims made by this design.
+The initial adoption supports **acquisition-only row handoff** for one declared
+bounded Gallery response input. The delegated operation prefix is empty;
+semantic `Head`, predicates, ordering, and other stages stay in the caller's
+exact residual. NuGetFetch consumes the owner-formed candidate and does not
+parse `-n`, invent a row plan, or imply that using the row language authorizes
+selection pushdown.
 
 Acceptance, failure, and publication follow
 [Source Delegation's effect protocol](source-delegation.md#effect-protocol).
-This owner contributes only the supported input/operation combination and the
-provider evidence below. Accepted execution never silently retries a different
-plan or substitutes another source.
+The Source Delegation implementation and L2's declared finite-input binding are
+prerequisites. This source design does not implement or alter their contracts.
+Nonempty delegated prefixes, whole-population completion requirements, and
+upstream exact Count decline before source work. A caller may use another
+separately supported strategy after decline or report unsupported; it must not
+quietly reinterpret the input.
 
-The initial exact optimization is deliberately **one provider response from
-offset zero**, for `N` within the adapter's advertised response capacity
-(at most the provider's 1,000-row `take` ceiling). Publication is atomic.
-Larger selections, strict windows, Tail, reordered or callback-bearing
-operations, and exact upstream Count are not advertised by this initial
-delegation capability. They decline before source work. A caller may use a
-separately supported reference strategy after decline, or report unsupported;
-it must not quietly clamp the request.
+Publication is atomic after one complete successful provider response. The
+adapter admits its full ordered row sequence, without silently dropping
+malformed rows or repeated package IDs, and preserves the accepted source
+input. The named finite input is precisely the rows in that response, whose
+membership and order belong to Gallery; K is its maximum requested capacity,
+not a promise that K rows exist or will be returned.
 
-For that response, the adapter establishes:
+The matching evidence proves that this **finite response input** was fully
+acquired and admitted. It can establish logical exhaustion only of that named
+input when the caller's completion requirement accepts that scope. Neither
+transport EOF nor a response containing K rows establishes exhaustion or a
+Head witness over the discovery population. The candidate must name the finite
+input before execution; the source cannot relabel an incomplete population
+request after receiving a short response.
 
-- the response answers the accepted text/type/version/order input at offset
-  zero, under the adopted provider filtering and ordering contract;
-- the admitted rows are the response's complete ordered package-ID prefix,
-  without silently dropping malformed rows or repeated package IDs; and
-- either N applicable rows reached the caller's clamp, or the response's
-  source-reported population is exhausted by the admitted rows.
+A valid short or empty response can therefore be a complete finite input,
+while remaining inconclusive about the wider population. Malformed/truncated
+transport, decode failure, byte/time limits, or cancellation do not become
+complete empty inputs. Accepted failures retain the existing source/delegation
+failure outcomes and never silently switch plan or source.
 
-The first case supplies the caller's required Head witness. The second requires
-a well-formed nonnegative integral `totalHits` for that same response equal to
-the admitted row count and smaller than N. A short/empty page alone is not
-exhaustion. A contradictory count, malformed response, unknown provider cap,
-byte/time limit, or cancellation cannot construct either proof.
-
-Returning N rows is not sufficient in isolation: an operational candidate cap,
-a page from an unfiltered domain, or a relevance page later sorted locally
-does not establish the accepted ordered-prefix claim. Equivalence fixtures
-must distinguish these cases. Trust in the Gallery's declared computation is
-the explicit provider-contract assumption permitted by Source Delegation; this
-does not claim to detect a provider that lies consistently about its results.
-
-The one-response restriction avoids treating successive requests against a
-changing index as one stable snapshot. There is no immutable corpus or
-repeatability claim across refreshes, and no cross-page exactness claim.
-Later paging adoption must establish its own completion basis rather than
-promoting provider offsets or a repeated `totalHits` into snapshot identity.
+There is no immutable-corpus, cross-page, or refresh-repeatability claim.
+Future selection delegation needs both the operation owner's source-closed
+declaration and a provider basis that proves equivalence over the same input.
+The one-response restriction alone does not make download ranking
+prefix-stable, and approximate `totalHits` cannot supply the missing proof.
 
 ### Residual predicates are a real boundary
 
-Consider Most downloaded tools followed by a manifest predicate and `Head(10)`.
-The first ten tools need not contain ten predicate matches. The source cannot
-push `Head(10)` ahead of that predicate, fetch ten, filter locally, and claim
-the requested result.
+Consider a 200-candidate tools input followed by a manifest predicate and
+`Head(10)`. The caller evaluates that exact residual over the acquired input.
+It may produce fewer than ten matches because this finite input contains fewer,
+not because the Gallery has no further matching tools. Product adoption must
+make the bounded scope visible; it cannot describe those rows as an exhausted
+global top ten.
 
-Such a plan keeps the operation under its existing owner and uses an
-acquisition-only handoff or another separately supported strategy. Its retained
-residual and source-result usability remain caller-owned. If bounded
-acquisition cannot satisfy the complete semantic request, report that
-limitation; do not describe fewer matches as an exhausted top ten.
-
-Likewise, `Head(100) -> Top(10, downloads)` is not equivalent to changing the
-source order and requesting its first ten. Registry discovery grants no
-permission to reorder either plan. General predicate/order pushdown requires
-separate source-closed declarations by the relevant operation owners.
+Fetching only ten candidates before evaluating the predicate changes both the
+input and the plan. Likewise, `Head(100) -> Top(10, downloads)` does not
+authorize changing the source order or capacity. Registry discovery grants no
+permission to reorder either plan. These barriers leave useful local selection
+available without promising unsupported global search semantics.
 
 ## Failures, resources, and platform
 
@@ -254,9 +261,11 @@ remote strings and failures retain the existing contained source-result form.
 There is no new local-actor or inspected-code-execution threat model.
 
 Provider page and response limits are operational ceilings, distinct from the
-semantic row count. Expected source failure and insufficient completion evidence
-remain visible through the existing source/delegation outcomes. Failed
-execution does not become unsupported planning or success-shaped empty rows.
+semantic row count. The declared response capacity makes the initial source
+scope explicit; additional operational limits cannot truncate it into success.
+Expected source failure and insufficient completion evidence remain visible
+through the existing source/delegation outcomes. Failed execution does not
+become unsupported planning or success-shaped empty rows.
 
 The new endpoint must remain usable through the existing injected HTTP
 capability on CLI and Browser/Wasm. CORS is a concrete browser-adoption
@@ -280,6 +289,9 @@ CLI gestures / browser controls
 
 The CLI should consume its existing semantic `-n` lowering, not forward the
 token to HTTP. The browser should express the equivalent typed selection.
+Both should disclose the bounded Gallery input independently of the selected
+row count. The shared product binding owns its default capacity; the example
+below uses 200, not a new CLI flag or a mandatory source default.
 CLI text/Markdown/JSON lowering uses the existing Markout/Sections path.
 Browser interactive controls and cards remain host-specific rendering over
 typed rows; browser adoption must name that lowering boundary rather than
@@ -289,6 +301,7 @@ Mockup, not shipped syntax or a new CLI grammar:
 
 ```text
 Gallery browse: .NET Tool, Most downloaded
+Source input:  up to 200 Gallery candidates
 CLI selection: -n 10
 Browser:       Search [ optional text ] Type [ .NET tools ]
                Sort [ Most downloads ]  [ Search ]
@@ -298,12 +311,15 @@ Cake.Tool                            170,466,408
 dotnet-ef                            123,908,981
 GitVersion.Tool                      122,595,411
 ...                                  ...
-10 packages shown; Gallery reports 8,868 matching package IDs
+10 packages shown from a bounded Gallery input
+Gallery estimates about 8,868 matching package IDs
 ```
 
-The neighboring case uses nonempty text and Relevance without changing the
-row pipeline. A generic V3 feed lacking Gallery browse/order capability remains
-a feed, not an automatic substitute. A content-enriched query still exposes
+The package values illustrate the observed ten-candidate request, not a claim
+that every capacity returns the same prefix. The neighboring case uses
+nonempty text and Relevance without changing the row pipeline. A generic V3
+feed lacking Gallery browse/order capability remains a feed, not an automatic
+substitute. A content-enriched query still exposes
 its acquisition cost and semantic-selection boundary.
 
 [#5919](https://github.com/richlander/dotnet-inspect/issues/5919) owns the
@@ -327,10 +343,22 @@ download counts. The Gallery implementation at
 [`bc5a59e3cf5d4d357e40615639b78615f97b2cc0`][gallery-controller] separately
 accepts sorting on `/search/query`, not `/query`.
 [Its parameter mapping][gallery-parameters] recognizes
-`totalDownloads-desc`; [its search builder][gallery-order] orders by lifetime
-download count and provider creation-time tie order. That same builder limits
-`take` to 1,000; out-of-range values fall back to the provider's default rather
-than honoring a larger semantic request.
+`totalDownloads-desc`; [its search builder][gallery-order] selects candidates
+using indexed download counts and creation-time tie order.
+[Its response builder][gallery-response] then re-sorts only the selected page
+using auxiliary lifetime counts. That is why capacity is part of input meaning.
+The search builder limits `take` to 1,000; out-of-range values fall back to the
+provider's default rather than honoring a larger request.
+
+A fixed-state counterexample preserves this boundary as reproducible design
+evidence: A has indexed/auxiliary counts 200/200; B has 100/300. `take=1`
+selects A, while the response for `take=2` orders B before A. Thus changing K
+to implement `Head(1)` changes the answer without any concurrent index update.
+
+[The Gallery wrapper][gallery-wrapper] reads only the first Azure result page
+and forwards its `TotalCount`. Azure's [IncludeTotalCount contract][azure-count]
+explicitly describes that value as approximate. A short page whose approximate
+total happens to equal its length cannot prove population exhaustion.
 
 This is the deliberate provider-specific extension of the existing Gallery
 source, not an extension silently imposed on generic V3. Gallery browse is the
@@ -367,12 +395,12 @@ They are not present or passing merely because this design names them.
 | `GalleryDiscoveryRequestAndCatalog` | Termless/type-filtered requests, explicit/default orders, stable/prerelease selection, custom valid package types, invalid/unknown selections, and inert shared descriptor discovery retain their declared meaning. |
 | `GalleryDiscoveryUsesSearchMetadataOnly` | The product adapter returns basic browse rows with only search transport; no per-package enrichment is requested. |
 | `GalleryDiscoveryProviderProjection` | Lifetime versus version downloads, optional missing fields, required-field failures, source association, provider ordering, and selector evidence are preserved. |
-| `GalleryDiscoveryHeadMatchesReference` | Product delegation matches `RowSelectionExecutor` over independently authored complete finite source sequences, including ties, zero/fewer/exactly/more-than-N rows, and the full emitted order. |
-| `GalleryDiscoveryCompletionEvidence` | A matching offset-zero prefix and same-response total establish the accepted witness/exhaustion cases; short pages, operational caps, contradictory totals, malformed/duplicate rows, cancellation, and resource failures do not become exact success. |
-| `GalleryDiscoveryDelegationBoundaries` | Plans with prior predicates/order, unsupported stages, larger response requirements, or upstream Count decline before source work; accepted failures do not fall back. The acquired-prefix/local-filter counterexample cannot claim ten matches. |
+| `GalleryDiscoveryFiniteInputSelection` | Product acquisition preserves K and the whole provider response; the shared adopter's residual matches `RowSelectionExecutor` over that exact finite input, including ties and zero/fewer/exactly/more-than-N rows. The fixed index/auxiliary divergence detects replacing K with N. |
+| `GalleryDiscoveryCompletionEvidence` | Evidence binds complete acquisition to the predeclared finite input, never to population exhaustion. Short/empty responses and approximate totals retain that distinction; malformed/duplicate rows, truncated transport, cancellation, and resource failures do not become complete inputs. |
+| `GalleryDiscoveryDelegationBoundaries` | Nonempty delegated prefixes, whole-population completion, out-of-range capacity, and upstream Count decline before source work; accepted failures do not fall back. Local predicate/Head composition retains the declared candidate scope. |
 
 The adoption consumes the Source Delegation and RowSelection owners' own gates;
-these tests do not replace their source-closed or effect-protocol evidence.
+these tests do not replace their effect-protocol or reference-semantics evidence.
 The L2 and host milestones separately gate binding and CLI/browser equivalence.
 A live provider probe detects observed provider drift but does not prove future
 provider honesty; deterministic fixtures enforce adapter behavior in CI.
@@ -385,3 +413,6 @@ publication would require separate owner work and corresponding model evidence.
 [gallery-controller]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
 [gallery-parameters]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
 [gallery-order]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs
+[gallery-response]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/SearchService/SearchResponseBuilder.cs#L330-L353
+[gallery-wrapper]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/Wrappers/SearchClientWrapper.cs#L40-L61
+[azure-count]: https://learn.microsoft.com/en-us/dotnet/api/azure.search.documents.searchoptions.includetotalcount?view=azure-dotnet

--- a/docs/design/nuget-gallery-discovery.md
+++ b/docs/design/nuget-gallery-discovery.md
@@ -1,0 +1,387 @@
+# NuGet Gallery discovery
+
+## Status and purpose
+
+Focused design for [#5920](https://github.com/richlander/dotnet-inspect/issues/5920).
+NuGet Gallery discovery in `NuGetFetch` is the sole normative owner.
+[Delivery tracker #5919](https://github.com/richlander/dotnet-inspect/issues/5919)
+records eight milestones from this design through both CLI and browser adoption.
+
+**Design only; implementation and delegation claims below are unverified.**
+Existing Gallery keyword/prefix search, typed source results, deadlines, and
+the semantic row-selection language already exist. Gallery browse requests,
+this catalog, the general Source Delegation protocol, and their product-row
+adoption do not. Closed design issues are not implementation evidence.
+
+The user goal is inexpensive discovery: find popular packages, tools, or
+templates without already knowing a package name. Gallery capabilities should
+serve that goal directly, rather than being limited to the portable feed API.
+The added machinery is limited to typed source intent, a small discoverable
+selector catalog, and completion evidence needed to preserve semantic limits.
+
+## Authority and scope
+
+This owner defines:
+
+- Gallery-specific text and termless discovery, package-type selection, and
+  source order;
+- discovery and admission of Gallery search selectors and available orders;
+- provider request/response interpretation, bounded acquisition, and typed
+  package discovery observations; and
+- Gallery-specific capability and evidence construction when adopting the
+  existing Source Delegation protocol.
+
+The exact claim is:
+
+> One host-neutral Gallery discovery operation binds an authorized source and
+> typed search intent to ordered package metadata and honest completion
+> evidence. Its supported delegated selection has the same meaning as the
+> caller's reference computation; it is not a provider page-size shortcut.
+
+This does not own generic feed behavior, source authorization or identity,
+row-schema binding, row predicates, selection-stage meaning, Count, CLI
+grammar, browser interaction, archive inspection, or product-demo registration.
+It introduces one source capability, not a universal query language or a new
+source-delegation protocol.
+
+### Consumed contracts and layering
+
+| Owner | Boundary consumed here |
+| --- | --- |
+| [NuGetFetch source identity](browser-package-sources.md#nugetfetch-typed-source-result-identity) and [operation deadlines](browser-package-sources.md#timeout-ownership) | Existing source association, factory-bound provenance, contained failures, cancellation, and operation ceiling. |
+| [Package source model](package-source-model.md) | Host-authorized source eligibility and package-level result adoption; producer equality does not grant authority. |
+| [Semantic row selection](semantic-row-selection.md) | Typed declaration language and complete-sequence reference meaning, without importing Sections or CLI concepts into NuGetFetch. |
+| [Source delegation](source-delegation.md) | Caller-formed candidate, pure support decision, acceptance, closed result algebra, completion requirements, and residual boundary. |
+| [Row query and ordering](row-query-order.md) | Resolved field/order meaning and source-closed declarations; this source cannot declare another owner's operation source-closed. |
+| [Section-row shaping](section-row-shaping.md) | Declared package-row binding, plan partition, residual execution, and terminal Rows/Count meaning. |
+| [CLI row selection](cli-row-selection.md) and [Package Query experience](package-query-experience.md) | Production consumers of shared typed intent/results, not owners of Gallery HTTP or search interpretation. |
+
+NuGetFetch owns provider functionality. The row language is an orthogonal leaf,
+as established by [Inspection layers](inspection-layers.md#the-layers).
+Product row adapters retain schema/projection concerns above NuGetFetch; the
+CLI and browser lower gestures into that shared composition. The adoption
+tracker, not this document, assigns their implementation work.
+
+## Gallery input and discovery domain
+
+A request names one authorized Gallery source, optional search text, zero or
+one package-type selector, a source order, and prerelease policy. The caller's
+semantic selection and the operation's resource ceilings are separate inputs.
+
+Missing or whitespace-only text means **browse**, not invalid input and not a
+request for a fabricated wildcard. Nonempty text uses Gallery search semantics;
+it is encoded as one provider parameter, not interpreted as CLI text, a row
+predicate, or a literal package-ID prefix. Existing literal-prefix inspection
+remains a separate supported operation.
+
+The discovery domain is the Gallery's searchable listed package IDs under that
+text, type, and version policy, including the provider's browse eligibility
+rules. It is not every package ever uploaded or every version of each package.
+One result identifies one package ID and its provider-selected eligible
+version. Stable-only is the default; SemVer 2 packages remain eligible.
+Package-type selection applies to the provider-selected version under the same
+prerelease policy, not to an arbitrary historical version.
+
+The initial source orders are:
+
+| Order | Meaning |
+| --- | --- |
+| Most downloaded | Descending package-level lifetime downloads, retaining the provider's tie order. Not recent activity or unique users. |
+| Relevance | The Gallery's relevance order for this query, including its provider ranking policy. Not a locally reproducible numeric score. |
+
+An omitted source order resolves to Most downloaded for browse and Relevance
+for nonempty text. An explicit order wins in either case. Selection never
+changes that resolved source order.
+
+These are source-input orders: they define the incoming logical sequence.
+They are not aliases for L2 `--order-by` or semantic `Top`. A caller that
+retains this incoming order can select its head; an additional row-order
+operation still occupies its normal place in the caller's plan.
+
+## Search-facet registry
+
+Use one small, immutable, source-owned catalog in NuGetFetch. A search facet is
+a typed selector over the Gallery discovery domain, not an arbitrary callback
+and not a predicate over downloaded package contents.
+
+A descriptor exposes a stable identity, display label and explanation, typed
+value domain, cardinality, and availability. Lookup uses identity rather than
+display text. Discovery is inert and does not perform source work. Selection
+returns validated typed intent or a visible unsupported/invalid selection;
+unknown selectors and invalid values are never dropped.
+
+The initial facet is **package type**, with zero-or-one cardinality.
+`DotnetTool`, `Template`, and `Dependency` are initial discoverable suggestions.
+Other valid NuGet package-type names can be supplied as typed values.
+All types means no selector, not a provider type named `all`. Dependency
+packages are not labelled as guaranteed libraries: they may be metapackages.
+Multiple package types do not implicitly become an OR query.
+
+The same owner exposes the two source-order descriptors, separately from
+filter facets. Text and prerelease policy retain their request roles. This
+does not create a generalized registry for every search widget or operator.
+
+The existing `PackageQuery.Facets` remains authoritative for manifest/content
+evaluation. Its any-tool facet, for example, currently evaluates manifest
+evidence; the Gallery package-type selector instead consumes index evidence.
+Matching labels do not make those contracts or their evidence interchangeable.
+A future composition may explicitly relate owner-issued descriptors, but it
+must not move a residual manifest/content predicate into source input to evade
+the delegation barrier.
+
+Both hosts discover the same catalog. CLI aliases and UI labels may project it,
+but neither host maintains a second provider-parameter or predicate inventory.
+Additional facets earn admission individually with a provider contract and
+gate; framework, verified-owner, dependency, and archive-content predicates are
+not implied by this initial registry.
+
+## Provider contract and typed results
+
+The existing built-in Gallery transport is the authority for its endpoints.
+It does not turn an arbitrary feed into a Gallery or infer authority from a
+matching hostname.
+
+The initial adapter adopts the Gallery `/search/query` service with
+`packageType` and `sortBy=totalDownloads-desc` or `sortBy=relevance`.
+The public V3 `/query` service supports package-type filtering, but does not
+accept a sort parameter. A request for Most downloaded cannot silently switch
+to relevance, to V3 search, or to a locally sorted relevance-limited subset.
+
+Source observations preserve the selected package ID/version, description,
+available display metadata, package-level lifetime downloads, producer
+provenance, actual source order, and the applicable source selector evidence.
+The Gallery response's `PackageRegistration.DownloadCount` is the lifetime
+count; the row's outer `DownloadCount` is version-specific and must not replace
+it. Optional fields remain unavailable when absent. A missing or malformed
+field required to support a selected order or completion claim is a visible
+source-contract failure, not zero, an omitted row, or an empty success.
+
+Selected package type can be reported as evidence of the provider-applied
+selector. It is not a claim that the response included an exhaustive list of
+that package's types, or that its archive has been inspected.
+
+The typed result retains the request association and completion evidence with
+its ordered rows. It reuses the existing source-result identity and containment
+contracts rather than introducing caller-policing tokens. Source-reported
+`totalHits` belongs to this response's discovery domain; it is not an L2 Count
+and does not authorize a count after residual predicates or semantic stages.
+This Gallery response has its own wire shape, including
+`PackageRegistration.Id`, `Version`, and `NormalizedVersion`. It is not the
+V3 search DTO; its count interpretation does not change generic feed parsing,
+which deliberately tolerates sources without useful `totalHits`.
+
+Basic discovery acquires search metadata only. Manifest, registration, archive,
+and assembly enrichment are separate capability-bearing work. The enforcing
+future gate is `GalleryDiscoveryUsesSearchMetadataOnly`; the property is
+unverified until that gate runs against the product adapter.
+
+## Source delegation and semantic limits
+
+The first optimized adoption supports a single declared package-row sequence
+and a source-closed `Head(N)` over the incoming Gallery order, with no preceding
+membership-changing projection, row predicate, or local ordering operation.
+It consumes an owner-formed candidate rather than parsing `-n` or inventing a
+row plan. The RowSelection owner's source-closed declaration and the Source
+Delegation implementation are prerequisites, not claims made by this design.
+
+Acceptance, failure, and publication follow
+[Source Delegation's effect protocol](source-delegation.md#effect-protocol).
+This owner contributes only the supported input/operation combination and the
+provider evidence below. Accepted execution never silently retries a different
+plan or substitutes another source.
+
+The initial exact optimization is deliberately **one provider response from
+offset zero**, for `N` within the adapter's advertised response capacity
+(at most the provider's 1,000-row `take` ceiling). Publication is atomic.
+Larger selections, strict windows, Tail, reordered or callback-bearing
+operations, and exact upstream Count are not advertised by this initial
+delegation capability. They decline before source work. A caller may use a
+separately supported reference strategy after decline, or report unsupported;
+it must not quietly clamp the request.
+
+For that response, the adapter establishes:
+
+- the response answers the accepted text/type/version/order input at offset
+  zero, under the adopted provider filtering and ordering contract;
+- the admitted rows are the response's complete ordered package-ID prefix,
+  without silently dropping malformed rows or repeated package IDs; and
+- either N applicable rows reached the caller's clamp, or the response's
+  source-reported population is exhausted by the admitted rows.
+
+The first case supplies the caller's required Head witness. The second requires
+a well-formed nonnegative integral `totalHits` for that same response equal to
+the admitted row count and smaller than N. A short/empty page alone is not
+exhaustion. A contradictory count, malformed response, unknown provider cap,
+byte/time limit, or cancellation cannot construct either proof.
+
+Returning N rows is not sufficient in isolation: an operational candidate cap,
+a page from an unfiltered domain, or a relevance page later sorted locally
+does not establish the accepted ordered-prefix claim. Equivalence fixtures
+must distinguish these cases. Trust in the Gallery's declared computation is
+the explicit provider-contract assumption permitted by Source Delegation; this
+does not claim to detect a provider that lies consistently about its results.
+
+The one-response restriction avoids treating successive requests against a
+changing index as one stable snapshot. There is no immutable corpus or
+repeatability claim across refreshes, and no cross-page exactness claim.
+Later paging adoption must establish its own completion basis rather than
+promoting provider offsets or a repeated `totalHits` into snapshot identity.
+
+### Residual predicates are a real boundary
+
+Consider Most downloaded tools followed by a manifest predicate and `Head(10)`.
+The first ten tools need not contain ten predicate matches. The source cannot
+push `Head(10)` ahead of that predicate, fetch ten, filter locally, and claim
+the requested result.
+
+Such a plan keeps the operation under its existing owner and uses an
+acquisition-only handoff or another separately supported strategy. Its retained
+residual and source-result usability remain caller-owned. If bounded
+acquisition cannot satisfy the complete semantic request, report that
+limitation; do not describe fewer matches as an exhausted top ten.
+
+Likewise, `Head(100) -> Top(10, downloads)` is not equivalent to changing the
+source order and requesting its first ten. Registry discovery grants no
+permission to reorder either plan. General predicate/order pushdown requires
+separate source-closed declarations by the relevant operation owners.
+
+## Failures, resources, and platform
+
+Inherited NuGetFetch source association, HTTP policy, bounded metadata decoding,
+retry, cancellation, and shared operation deadlines apply. The external input
+is Gallery response content entering that established construction boundary;
+remote strings and failures retain the existing contained source-result form.
+There is no new local-actor or inspected-code-execution threat model.
+
+Provider page and response limits are operational ceilings, distinct from the
+semantic row count. Expected source failure and insufficient completion evidence
+remain visible through the existing source/delegation outcomes. Failed
+execution does not become unsupported planning or success-shaped empty rows.
+
+The new endpoint must remain usable through the existing injected HTTP
+capability on CLI and Browser/Wasm. CORS is a concrete browser-adoption
+requirement, not a reason to add a browser-only search implementation. Current
+provider observations support that path; they are not a permanent availability
+guarantee or a platform exception.
+
+## Consumer composition and demo
+
+This section is a non-normative adoption map, not host or row-owner design.
+
+```text
+CLI gestures / browser controls
+  -> shared product row intent and source selection
+  -> L2 binding, order resolution, and delegation candidate + residual
+  -> NuGetFetch Gallery operation using the row language
+  -> typed rows + source completion evidence
+  -> L2 residual / selected package rows
+  -> CLI Markout output / browser query interaction
+```
+
+The CLI should consume its existing semantic `-n` lowering, not forward the
+token to HTTP. The browser should express the equivalent typed selection.
+CLI text/Markdown/JSON lowering uses the existing Markout/Sections path.
+Browser interactive controls and cards remain host-specific rendering over
+typed rows; browser adoption must name that lowering boundary rather than
+copying Gallery behavior into TypeScript.
+
+Mockup, not shipped syntax or a new CLI grammar:
+
+```text
+Gallery browse: .NET Tool, Most downloaded
+CLI selection: -n 10
+Browser:       Search [ optional text ] Type [ .NET tools ]
+               Sort [ Most downloads ]  [ Search ]
+
+Package                              Lifetime downloads
+Cake.Tool                            170,466,408
+dotnet-ef                            123,908,981
+GitVersion.Tool                      122,595,411
+...                                  ...
+10 packages shown; Gallery reports 8,868 matching package IDs
+```
+
+The neighboring case uses nonempty text and Relevance without changing the
+row pipeline. A generic V3 feed lacking Gallery browse/order capability remains
+a feed, not an automatic substitute. A content-enriched query still exposes
+its acquisition cost and semantic-selection boundary.
+
+[#5919](https://github.com/richlander/dotnet-inspect/issues/5919) owns the
+eight-milestone sequence and retirement of the Gallery page's required-prefix
+assumption. Exact package lookup, literal prefix profiling, generic feeds, and
+existing content facets stay supported. No host behavior changes in this PR.
+
+Demand-windowed streaming is separately tracked by
+[#5816](https://github.com/richlander/dotnet-inspect/issues/5816).
+This design neither changes its backpressure/worker contracts nor treats the
+current Source Delegation protocol as permitting incremental success
+publication. Query-demo registration and URL sharing remain focused follow-ons.
+
+## Evidence and required gates
+
+### Provider and convention evidence
+
+The [public NuGet search contract][v3-search] documents termless search,
+package-type filtering, package-ID grouping, prerelease policy, and response
+download counts. The Gallery implementation at
+[`bc5a59e3cf5d4d357e40615639b78615f97b2cc0`][gallery-controller] separately
+accepts sorting on `/search/query`, not `/query`.
+[Its parameter mapping][gallery-parameters] recognizes
+`totalDownloads-desc`; [its search builder][gallery-order] orders by lifetime
+download count and provider creation-time tie order. That same builder limits
+`take` to 1,000; out-of-range values fall back to the provider's default rather
+than honoring a larger semantic request.
+
+This is the deliberate provider-specific extension of the existing Gallery
+source, not an extension silently imposed on generic V3. Gallery browse is the
+behavioral analogue; the row reference evaluator, not Gallery implementation
+details, remains the selection-equivalence oracle. No provider code is copied.
+
+On 2026-09-04 a macOS HTTP observation of ten stable tools used 6,742 compressed
+response bytes in 0.355 seconds; V3 relevance search used 17,047 bytes in 0.367
+seconds. These are single observations, not latency thresholds or a speedup
+claim. The sorted response produced the first three package counts shown in
+the mockup. Reproduce the sorted request with:
+
+```sh
+curl --compressed --get \
+  'https://azuresearch-usnc.nuget.org/search/query' \
+  --data-urlencode 'packageType=DotnetTool' \
+  --data-urlencode 'sortBy=totalDownloads-desc' \
+  --data-urlencode 'prerelease=false' \
+  --data-urlencode 'semVerLevel=2.0.0' \
+  --data-urlencode 'take=10'
+```
+
+A subsequent GET with `Origin: https://dotnet-inspect.net` returned
+`Access-Control-Allow-Origin: *` on 2026-09-05 UTC. Browser adoption still
+requires a real browser run against the product path.
+
+### Future Release gates
+
+These gates are required before their respective implementation claims ship.
+They are not present or passing merely because this design names them.
+
+| Gate | Outcome established |
+| --- | --- |
+| `GalleryDiscoveryRequestAndCatalog` | Termless/type-filtered requests, explicit/default orders, stable/prerelease selection, custom valid package types, invalid/unknown selections, and inert shared descriptor discovery retain their declared meaning. |
+| `GalleryDiscoveryUsesSearchMetadataOnly` | The product adapter returns basic browse rows with only search transport; no per-package enrichment is requested. |
+| `GalleryDiscoveryProviderProjection` | Lifetime versus version downloads, optional missing fields, required-field failures, source association, provider ordering, and selector evidence are preserved. |
+| `GalleryDiscoveryHeadMatchesReference` | Product delegation matches `RowSelectionExecutor` over independently authored complete finite source sequences, including ties, zero/fewer/exactly/more-than-N rows, and the full emitted order. |
+| `GalleryDiscoveryCompletionEvidence` | A matching offset-zero prefix and same-response total establish the accepted witness/exhaustion cases; short pages, operational caps, contradictory totals, malformed/duplicate rows, cancellation, and resource failures do not become exact success. |
+| `GalleryDiscoveryDelegationBoundaries` | Plans with prior predicates/order, unsupported stages, larger response requirements, or upstream Count decline before source work; accepted failures do not fall back. The acquired-prefix/local-filter counterexample cannot claim ten matches. |
+
+The adoption consumes the Source Delegation and RowSelection owners' own gates;
+these tests do not replace their source-closed or effect-protocol evidence.
+The L2 and host milestones separately gate binding and CLI/browser equivalence.
+A live provider probe detects observed provider drift but does not prove future
+provider honesty; deterministic fixtures enforce adapter behavior in CI.
+
+No new scheduling protocol is defined here. Atomic one-response adoption uses
+the existing delegation contract; concurrent execution or incremental
+publication would require separate owner work and corresponding model evidence.
+
+[v3-search]: https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource
+[gallery-controller]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.SearchService.Core/Controllers/SearchController.cs
+[gallery-parameters]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/SearchService/Models/ParameterUtilities.cs
+[gallery-order]: https://github.com/NuGet/NuGetGallery/blob/bc5a59e3cf5d4d357e40615639b78615f97b2cc0/src/NuGet.Services.AzureSearch/SearchService/SearchParametersBuilder.cs

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -418,6 +418,11 @@ use the task map in `AGENTS.md` to find the focused guidance for a change.
   timeout identity, and source-safe post-return stream failures. It consumes
   source-result identity; source eligibility, failover policy, cache behavior,
   and presentation remain with their focused owners.
+- [NuGet Gallery discovery](design/nuget-gallery-discovery.md): proposed
+  NuGetFetch-owned termless/type-filtered discovery, source ordering,
+  search-selector catalog, typed metadata observations, and Gallery-specific
+  row-delegation evidence. Row meaning, generic source contracts, and host
+  adoption remain with their focused owners.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Cache concurrency and publication](design/cache-concurrency.md): process-local single-flight, atomic publication, dependency overlap, and filesystem guarantees.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.


### PR DESCRIPTION
Make package discovery a capable, inexpensive shared product experience:
popular packages, tools, and templates without requiring a search term.
This PR establishes the focused NuGetFetch design, not a shipped feature.

Closes #5920. Milestone 1 of 8 in #5919.

## Demo

Design mockup; not new CLI command syntax:

```text
Gallery browse: .NET Tool, Most downloaded
Source input:  up to 200 Gallery candidates
CLI selection: -n 10
Browser:       Search [ optional text ] Type [ .NET tools ]
               Sort [ Most downloads ]  [ Search ]

Package                              Lifetime downloads
Cake.Tool                            170,466,408
dotnet-ef                            123,908,981
GitVersion.Tool                      122,595,411
...                                  ...
10 packages shown from a bounded Gallery input
Gallery estimates about 8,868 matching package IDs
```

Before: the browser Gallery query requires a package-ID prefix.
After adoption: empty text can browse all packages or a package type, with
Gallery ranking over an explicitly bounded input and semantic row selection.
Neighboring case: nonempty text defaults to relevance, while manifest/content
predicates remain explicit and cannot receive an incorrectly pushed-down limit.
The displayed values illustrate the observed ten-candidate request, not a
guarantee that different candidate capacities return identical prefixes.

## Design basis and scope

**Normative owner:** `docs/design/nuget-gallery-discovery.md#authority-and-scope`.
NuGetFetch binds authorized Gallery search intent to an explicitly bounded,
ordered metadata input and honest scope/completion evidence; provider `take`
does not replace semantic `-n` over that input.

The conventional baseline is server-side search/filter/order before paging.
The deliberate provider-specific choice is the Gallery `/search/query`
endpoint for download ordering, rather than pretending generic V3 `/query`
supports it. Pinned provider source and a reproducible metadata-only request
support that choice; no provider code is copied. Review established that the
provider additionally re-sorts only the selected page using auxiliary download
counts, and that its total is approximate. The source contract follows that
actual behavior rather than assuming global prefix stability.

The added complexity serves one correctness requirement: a source page or
candidate cap must not masquerade as completed row selection. A small catalog
serves shared host discovery without a universal predicate framework.

Adjacent row-selection, source-delegation, row-query, section-shaping, source
identity, and host contracts remain with their owners. The initial optimization
is atomic, one-response acquisition-only handoff. All semantic selection stays
in the caller's residual over the declared finite input. Global top-N, global
exhaustion, upstream exact Count, selection pushdown, paging snapshot claims,
and streaming extensions are not promised.

## Production-host adoption

#5919 records eight owner-sized milestones, not a promise of eight PRs:

1. This focused design.
2. NuGetFetch typed discovery intent, bounded input, and facet/order catalog.
3. Existing Source Delegation protocol implementation.
4. NuGetFetch request/catalog/transport/result/delegation adoption.
5. Row Query/Ordering fields and source-order bindings.
6. Section-row Shaping binding, residuals, and completion requirements.
7. CLI adoption, semantic `-n`, ordinary formats, and guidance.
8. Inspect Web adoption and retirement of its required-prefix-only Gallery entry.

Both CLI and Browser/Wasm are planned consumers. Shared typed rows reach the
CLI's Markout/Sections lowering and the browser's interactive query rendering;
Gallery behavior does not move into TypeScript. Generic feeds, exact lookup,
literal-prefix profiling, and archive-derived facets remain supported.

Demand-windowed query responsiveness remains separately tracked by #5816.
Product query-demo registration remains follow-on work.

## Validation and evidence

- `npx --no-install markdownlint-cli docs/design/nuget-gallery-discovery.md docs/README.md docs/overview.md`
- `git diff --check`
- Pinned NuGetGallery controller, parameter mapping, and search-builder review;
  point-in-time live ordering, response-field, cost, and CORS observations.
- Six named future outcome-level Release gates; implementation claims are
  explicitly **unverified**, not passed by a design-only PR.

Markdown-only review uses the documented fast path. No product behavior,
dependencies, platform exceptions, or executable test infrastructure changes.
Two-seat fixed-head review will use GPT-6 Astra and Claude Opus 5, following
AGENTS.md's binding different-family tier rather than the conflicting initial
second-seat preference in the orchestration roster.
