### PR TITLE
Bind inspect-web generated runtime to a browser Worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,10 @@ jobs:
         working-directory: prototypes/inspect-web
         run: npm run test:browser
 
+      - name: Test published Worker browser binding
+        working-directory: prototypes/inspect-web
+        run: npm run inspect-web-worker-browser-binding
+
       - name: Test inspect-web promotion validation
         run: dotnet run eng/validate-inspect-web-promotion.cs -- --self-test
 

--- a/docs/design/inspect-web-worker-runtime.md
+++ b/docs/design/inspect-web-worker-runtime.md
@@ -7,11 +7,15 @@ This document defines the target worker-runtime host and protocol for
 The user approved its inspect-web-only host scope on 2026-09-02. Implementation
 under [issue #5418](https://github.com/richlander/dotnet-inspect/issues/5418)
 is dependency-ordered and partial. The descriptor-safe two-stage wire codec,
-fake-worker runtime core, host authority, and complete base TypeScript protocol
+shared runtime core, host authority, and complete base TypeScript protocol
 gate are implemented under `inspect-web-worker-envelope-validation` and
-`inspect-web-worker-protocol`. Real browser `Worker` and .NET binding, browser
-lifecycle integration, responsiveness evidence, and the remaining browser
-gates named below are still required.
+`inspect-web-worker-protocol`. The browser binding additionally connects a real
+module `Worker`, the current generated facade set, and native lifecycle inputs
+under `inspect-web-worker-browser-binding`. Its explicit diagnostic consumer
+uses the existing managed async-lowering canary. It does not route current UI
+features through the Worker. Feature adoption, managed epoch-work reporter
+registration, full lifecycle coverage, responsiveness evidence, and the
+remaining browser gates named below are still required.
 
 Its finite state models establish only the abstract properties recorded with
 those models. The engine-to-browser event-stream contract is now defined by
@@ -356,6 +360,35 @@ elapsed time; they preserve the remaining budget rather than grant a fresh one.
 Startup rejection or budget exhaustion closes admission, terminates the
 partial realm, reports unexpected startup failure for every activated held
 producer, quiesces those producers after termination, and closes the epoch.
+
+### Browser binding
+
+The native binding uses a module Worker and retains one exact source binding
+for its message, error, and messageerror listeners. Detachment removes those
+listeners before native termination. A browser `error` event does not prove
+physical destruction: it reports a worker-message failure, and ordinary
+termination remains the destruction barrier.
+
+Both the page and Worker use the same seven generated facade modules and
+consumer-owned bootstrap coordinator. A Worker does not inherit the page's
+import map. The consumer's published runtime loader therefore resolves the
+SDK-selected fingerprinted runtime module directly; it must neither depend on
+document import-map state nor publish an unhashed framework alias. This is
+consumer artifact addressing, not a second facade-generation mechanism or
+runtime initialization policy.
+
+Native active time pauses while any visibility, page-hide, or freeze
+suspension remains in effect. Resume clears only its corresponding suspension.
+A clock read or timer notification that detects a scheduling gap reports
+recovery before the host judges deadlines. That gap preserves the remaining
+startup, command-response, and drain budgets and gives the existing
+post-readiness watchdog its recovery interval.
+
+The initial binding's diagnostic operation invokes the existing generated
+`asyncLoweringCanary` export and declares unbounded managed execution. Its
+registry admits no shared managed producers or epoch-work classes.
+Registering the managed epoch-work reporter and adopting feature operations
+remain later handoffs; the diagnostic operation does not depend on them.
 
 ## Operation adapter
 
@@ -1235,7 +1268,16 @@ deterministic scheduling rather than a real browser worker. It includes:
 - a neighboring browser-native producer proving operation authority does not
   depend on the worker adapter.
 
-`inspect-web-worker-lifecycle` is a Release browser gate and must include:
+`inspect-web-worker-browser-binding` is the first Release browser sub-gate. It
+uses the product-published client, module Worker, seven generated facades, and
+actual .NET runtime. It covers cold and warm managed calls, idle heartbeats,
+explicit replacement with a new epoch, native termination, failed bootstrap,
+and a stalled Wasm initialization while page input remains available. Its
+focused TypeScript cases cover overlapping lifecycle suspensions, initial
+hidden state, scheduling-gap recovery before deadline reads, and subscription
+cleanup. It is not the complete lifecycle or managed CPU responsiveness gate.
+
+`inspect-web-worker-lifecycle` is the complete Release browser gate and must include:
 
 - cold and warm bootstrap through the consumer-owned barrier;
 - responsive JavaScript with permanently stalled .NET initialization;
@@ -1316,10 +1358,10 @@ into the runtime host:
 
 1. introduce the descriptor-safe wire codec under
    `inspect-web-worker-envelope-validation` (**implemented**);
-2. add the fake-worker runtime core, host authority, and complete
+2. add the shared runtime core, host authority, and complete
    `inspect-web-worker-protocol` gate (**implemented**);
 3. adapt the current generated facade bootstrap behind the consumer-owned
-   bootstrap operation;
+   bootstrap operation (**implemented** with the browser-binding sub-gate);
 4. move one long-running source or package inspection through a typed worker
    operation adapter;
 5. connect keyed cancellation, progress, managed settlement, and epoch-work
@@ -1329,6 +1371,15 @@ into the runtime host:
    payload and liveness policy; and
 8. add durable event batches only after #5570 and the relevant #5419 handoff
    supply their remaining prerequisite contracts; #5566 is merged.
+
+These eight production-host adoption steps are tracked by #5418 under #4937
+and #4571, with composition handoffs mapped by #5095. The first feature
+consumer is the existing source operation in
+issue #5420, not a duplicate feature. Step 7 retires each remaining direct
+main-thread feature invocation as its adapter is adopted. The approved
+inspect-web-only scope does not imply a CLI runtime migration. Typed feature
+results continue to reach their existing rendering owners; this binding adds
+no rendering or format-lowering domain.
 
 The implementation starts from the official .NET 11 Web Worker hosting pattern
 but replaces stringly method invocation with the generated inspect-web facade

--- a/eng/generate-inspect-web-engine-facade.sh
+++ b/eng/generate-inspect-web-engine-facade.sh
@@ -137,7 +137,7 @@ fi
   "$source_assembly" \
   --context "$context_type" \
   --assembly-search-path "$source_assembly_directory" \
-  --runtime-module ./_framework/dotnet.js \
+  --runtime-module ./runtime-loader.js \
   --output "$context_output"
 
 expected_artifacts="$(printf '%s\n' "${context_artifacts[@]}" | sort)"
@@ -170,7 +170,7 @@ for index in "${!context_artifacts[@]}"; do
     "${generator_build_properties[@]}" \
     -- \
     "$root_assembly" \
-    --runtime-module ./_framework/dotnet.js \
+    --runtime-module ./runtime-loader.js \
     --output "$scratch/direct/$artifact"
   if ! cmp "$context_output/$artifact" "$scratch/direct/$artifact"; then
     echo "The JsExportRoot recipe differs from direct generation for $artifact." >&2
@@ -183,10 +183,13 @@ done
 
 mkdir -p "$scratch/sources/_framework"
 cp "$dotnet_dts" "$scratch/sources/_framework/dotnet.d.ts"
+cp "$js_output_directory/runtime-loader.js" "$scratch/sources/runtime-loader.js"
 {
   cat <<'JSON'
 {
   "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
     "declaration": true,
     "exactOptionalPropertyTypes": true,
     "lib": ["DOM", "ES2022"],
@@ -207,7 +210,7 @@ JSON
     [[ "$index" == 0 ]] || printf ', '
     printf '"%s.ts"' "${facade_modules[$index]}"
   done
-  printf ']\n}\n'
+  printf ', "runtime-loader.js"]\n}\n'
 } > "$scratch/sources/tsconfig.json"
 "$tsc" -p "$scratch/sources/tsconfig.json"
 
@@ -215,6 +218,10 @@ compiled="$scratch/sources/out"
 expected_declarations="$(
   printf '%s.d.ts\n' "${facade_modules[@]}" | sort)"
 expected_modules="$(printf '%s.js\n' "${facade_modules[@]}" | sort)"
+expected_compiled_declarations="$(
+  printf '%s.d.ts\n' "${facade_modules[@]}" runtime-loader | sort)"
+expected_compiled_modules="$(
+  printf '%s.js\n' "${facade_modules[@]}" runtime-loader | sort)"
 shopt -s nullglob
 compiled_declaration_paths=("$compiled"/*.d.ts)
 compiled_module_paths=("$compiled"/*.js)
@@ -222,9 +229,9 @@ shopt -u nullglob
 compiled_declarations="$(
   printf '%s\n' "${compiled_declaration_paths[@]##*/}" | sort)"
 compiled_modules="$(printf '%s\n' "${compiled_module_paths[@]##*/}" | sort)"
-if [[ "$compiled_declarations" != "$expected_declarations" \
-    || "$compiled_modules" != "$expected_modules" ]]; then
-  echo "Compiling the facade set produced a different artifact set than the consumer map." >&2
+if [[ "$compiled_declarations" != "$expected_compiled_declarations" \
+    || "$compiled_modules" != "$expected_compiled_modules" ]]; then
+  echo "Compiling the facades and runtime loader produced an unexpected artifact set." >&2
   exit 1
 fi
 
@@ -288,7 +295,7 @@ elif [[ "$mode" == check ]]; then
   assert_directory_inventory \
     "$dts_output_directory" '*.d.ts' "$expected_declarations" || drifted=1
   assert_directory_inventory \
-    "$js_output_directory" '*.js' "$expected_modules" || drifted=1
+    "$js_output_directory" 'inspect-web-*.js' "$expected_modules" || drifted=1
   if [[ "$drifted" != 0 ]]; then
     exit 1
   fi
@@ -333,5 +340,5 @@ else
   done
   assert_directory_inventory "$ts_output_directory" '*.ts' "$expected_sources"
   assert_directory_inventory "$dts_output_directory" '*.d.ts' "$expected_declarations"
-  assert_directory_inventory "$js_output_directory" '*.js' "$expected_modules"
+  assert_directory_inventory "$js_output_directory" 'inspect-web-*.js' "$expected_modules"
 fi

--- a/eng/verify-inspect-web-async-deployment.sh
+++ b/eng/verify-inspect-web-async-deployment.sh
@@ -181,7 +181,7 @@ TMPDIR="$repo_root/artifacts" \
   "$assembly" \
   --context InspectWeb.Engine.InspectWebJsExportContext \
   --assembly-search-path "$assembly_directory" \
-  --runtime-module ./_framework/dotnet.js \
+  --runtime-module ./runtime-loader.js \
   --output "$context_output"
 
 runtime_pack_directory=$(
@@ -210,6 +210,8 @@ fi
 
 mkdir -p "$compiled_sources/_framework"
 cp "$dotnet_dts" "$compiled_sources/_framework/dotnet.d.ts"
+cp "$repo_root/prototypes/inspect-web/engine/wwwroot/runtime-loader.js" \
+  "$compiled_sources/runtime-loader.js"
 "$node" --input-type=module - \
   "$domain" \
   "$context_output" \
@@ -249,6 +251,8 @@ const [domainPath, configPath] = process.argv.slice(2);
 const domain = JSON.parse(readFileSync(domainPath, "utf8"));
 writeFileSync(configPath, `${JSON.stringify({
   compilerOptions: {
+    allowJs: true,
+    checkJs: true,
     declaration: true,
     exactOptionalPropertyTypes: true,
     lib: ["DOM", "ES2022"],
@@ -263,7 +267,7 @@ writeFileSync(configPath, `${JSON.stringify({
     types: [],
     verbatimModuleSyntax: true,
   },
-  include: domain.map(entry => `${entry.module}.ts`),
+  include: [...domain.map(entry => `${entry.module}.ts`), "runtime-loader.js"],
 }, null, 2)}\n`);
 JS
 
@@ -295,11 +299,11 @@ assert.deepEqual(
   "contract generation did not emit the context-issued declaration set");
 assert.deepEqual(
   readdirSync(compiled).filter(name => name.endsWith(".d.ts")).sort(),
-  expectedDeclarations,
+  [...expectedDeclarations, "runtime-loader.d.ts"].sort(),
   "pinned TypeScript compilation emitted an unexpected declaration set");
 assert.deepEqual(
   readdirSync(compiled).filter(name => name.endsWith(".js")).sort(),
-  expectedModules,
+  [...expectedModules, "runtime-loader.js"].sort(),
   "pinned TypeScript compilation emitted an unexpected JavaScript set");
 for (const entry of domain) {
   const declaration = `${entry.module}.d.ts`;

--- a/prototypes/inspect-web/README.md
+++ b/prototypes/inspect-web/README.md
@@ -823,6 +823,31 @@ own assembly, and exercises build identity plus `asyncLoweringCanary()`, a
 genuinely awaited operation with a fixed typed result and no network,
 package-cache, server-API, or user-data dependency.
 
+The same generated facade set also bootstraps in a dedicated module Worker.
+The publish step binds `runtime-loader.js` to the SDK's fingerprinted runtime
+module, so Worker startup does not depend on the document's import map.
+`src/engine-worker-client.ts` is a separately published entry: its explicit
+diagnostic probe drives the existing managed async-lowering canary through the
+Worker core and operation authority. It does not move current UI features off
+the main thread.
+
+After a Release publish, run the native binding gate:
+
+```bash
+dotnet publish prototypes/inspect-web/engine/InspectWeb.Engine.csproj \
+  -c Release --output artifacts/inspect-web-publish
+cd prototypes/inspect-web
+npm run inspect-web-worker-browser-binding
+```
+
+The existing frontend build must precede the publish. Set
+`INSPECT_WEB_WORKER_SITE` to use another published `wwwroot` directory.
+The gate uses Firefox and the complete published artifact, covering cold and
+warm managed calls, restart, bootstrap rejection, and input during stalled
+Wasm initialization. It does not yet prove responsiveness during managed CPU
+work or complete the Worker lifecycle gate; those and source-feature adoption
+remain focused follow-on slices under #5418 and #5420.
+
 The purpose-built `multi-facade-canary` proves that this lifecycle composes
 across independently generated modules. Its Alpha and Beta assemblies
 deliberately use the same namespace, declaring-type names, method names,

--- a/prototypes/inspect-web/browser/worker-runtime.spec.ts
+++ b/prototypes/inspect-web/browser/worker-runtime.spec.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { expect, test, type Page, type Worker } from "@playwright/test";
+import type { createEngineWorkerProbe } from "../src/engine-worker-client.ts";
+
+type WorkerProbe = ReturnType<typeof createEngineWorkerProbe>;
+type WorkerClient = typeof import("../src/engine-worker-client.ts");
+
+declare global {
+  interface Window {
+    engineWorkerProbe: WorkerProbe;
+    engineWorkerEvents: string[];
+    engineWorkerPending: ReturnType<WorkerProbe["probe"]> | null;
+  }
+}
+
+const site = resolve(
+  process.env.INSPECT_WEB_WORKER_SITE ?? "../../artifacts/inspect-web-publish/wwwroot",
+);
+const manifest: unknown = JSON.parse(readFileSync(resolve(site, "manifest.json"), "utf8"));
+if (typeof manifest !== "object" || manifest === null
+    || !("src/engine-worker-client.ts" in manifest)) {
+  throw new Error("Published site is missing the Worker client entry.");
+}
+const entry = manifest["src/engine-worker-client.ts"];
+if (typeof entry !== "object" || entry === null
+    || !("file" in entry) || typeof entry.file !== "string") {
+  throw new Error("Published Worker client entry has no asset.");
+}
+const clientUrl = `/${entry.file}`;
+
+async function start(page: Page, startupBudgetMilliseconds = 60_000) {
+  await page.goto("/worker-runtime-gate.html");
+  return page.evaluate(async ({ url, budget }) => {
+    const imported: unknown = await import(url);
+    function isClient(value: unknown): value is WorkerClient {
+      return typeof value === "object" && value !== null
+        && "createEngineWorkerProbe" in value
+        && typeof value.createEngineWorkerProbe === "function";
+    }
+    if (!isClient(imported)) throw new Error("Published Worker client exports are missing.");
+    window.engineWorkerEvents = [];
+    window.engineWorkerProbe = imported.createEngineWorkerProbe({
+      startupBudgetMilliseconds: budget,
+      callbacks: {
+        failure: failure => {
+          window.engineWorkerEvents.push(`failure:${failure.kind}`);
+          return undefined;
+        },
+        diagnostic: diagnostic => {
+          window.engineWorkerEvents.push(`diagnostic:${diagnostic.kind}`);
+          return undefined;
+        },
+        realmReleased: epoch => {
+          window.engineWorkerEvents.push(`released:${epoch}`);
+          return undefined;
+        },
+      },
+      operationDiagnostic: diagnostic => {
+        window.engineWorkerEvents.push(`operation:${diagnostic.kind}`);
+        return undefined;
+      },
+    });
+    const started = window.engineWorkerProbe.host.start(location.origin);
+    window.engineWorkerPending = window.engineWorkerProbe.probe();
+    return started;
+  }, { url: clientUrl, budget: startupBudgetMilliseconds });
+}
+
+async function canary(page: Page) {
+  return page.evaluate(async () => {
+    const result = window.engineWorkerPending ?? window.engineWorkerProbe.probe();
+    window.engineWorkerPending = null;
+    if (result.kind !== "started") throw new Error(`Canary refused: ${result.reason.kind}`);
+    const outcome = await result.handle.outcome;
+    await result.handle.quiesced;
+    return outcome;
+  });
+}
+
+test("published generated facades boot in a real Worker and serve cold and warm managed calls", async ({ page }) => {
+  const workers: Worker[] = [];
+  page.on("worker", worker => workers.push(worker));
+  expect((await start(page)).kind).toBe("started");
+  expect(await canary(page)).toEqual({
+    kind: "succeeded", value: "inspect-web-async-lowering-ok",
+  });
+  expect(await canary(page)).toEqual({
+    kind: "succeeded", value: "inspect-web-async-lowering-ok",
+  });
+  expect(workers).toHaveLength(1);
+  const worker = workers[0];
+  if (worker === undefined) throw new Error("The runtime did not create a Worker.");
+  expect(await worker.evaluate(() => globalThis.constructor.name)).toBe("DedicatedWorkerGlobalScope");
+  const origin = await page.evaluate(() => window.engineWorkerProbe.host.snapshot().lastTaskEvidenceOrigin);
+  await expect.poll(() => page.evaluate(
+    () => window.engineWorkerProbe.host.snapshot().lastTaskEvidenceOrigin,
+  )).toBeGreaterThan(origin ?? 0);
+  await page.evaluate(() => window.engineWorkerProbe.dispose());
+  expect(await page.evaluate(() => window.engineWorkerEvents)).toEqual(["released:1"]);
+  await expect(worker.evaluate(() => 1)).rejects.toThrow();
+});
+
+test("restart destroys the old realm and explicitly boots a new epoch", async ({ page }) => {
+  expect((await start(page)).kind).toBe("started");
+  expect((await canary(page)).kind).toBe("succeeded");
+  const restarted = await page.evaluate(() => {
+    window.engineWorkerProbe.host.restart();
+    return window.engineWorkerProbe.host.start(location.origin);
+  });
+  expect(restarted.kind).toBe("started");
+  if (restarted.kind === "started") expect(restarted.epochToken).toBe(2);
+  expect((await canary(page)).kind).toBe("succeeded");
+  await page.evaluate(() => window.engineWorkerProbe.dispose());
+  expect(await page.evaluate(() => window.engineWorkerEvents)).toEqual(["released:1", "released:2"]);
+});
+
+test("a generated-facade bootstrap rejection fails held work and releases the partial realm", async ({ page, context }) => {
+  await context.addCookies([{
+    name: "worker-runtime-gate",
+    value: "reject-bootstrap",
+    url: "http://127.0.0.1:4186",
+  }]);
+  expect((await start(page)).kind).toBe("started");
+  expect(await canary(page)).toEqual({ kind: "failed", error: "Worker startup failed." });
+  expect(await page.evaluate(() => window.engineWorkerEvents)).toEqual(["failure:startup", "released:1"]);
+  await page.evaluate(() => window.engineWorkerProbe.dispose());
+});
+
+test("stalled Wasm initialization leaves page input available and exhausts startup", async ({ page, context }) => {
+  let blocked = 0;
+  await context.route("**/_framework/*.wasm", () => { blocked++; });
+  expect((await start(page, 5_000)).kind).toBe("started");
+  await expect.poll(() => blocked).toBeGreaterThan(0);
+  await page.evaluate(() => {
+    document.querySelector("#input")!.addEventListener("click", () => {
+      document.querySelector("#count")!.textContent = "1";
+    });
+  });
+  await page.getByRole("button", { name: "Input" }).click();
+  await expect(page.locator("#count")).toHaveText("1");
+  await expect.poll(() => page.evaluate(
+    () => window.engineWorkerProbe.host.snapshot().phase,
+  ), { timeout: 15_000 }).toBe("closed");
+  expect(await page.evaluate(() => window.engineWorkerEvents)).toEqual(["failure:startup", "released:1"]);
+  await page.evaluate(() => window.engineWorkerProbe.dispose());
+});

--- a/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
+++ b/prototypes/inspect-web/engine.Tests/BrowserStaticWebAppConfigTests.cs
@@ -53,13 +53,30 @@ public class BrowserStaticWebAppConfigTests
             "PreserveNewest",
             (string?)content.Attribute("CopyToPublishDirectory"));
 
+        XElement runtimeLoaderTarget = Assert.Single(
+            project.Descendants("Target"),
+            element =>
+                (string?)element.Attribute("Name") ==
+                "PublishInspectWebRuntimeLoader");
+        Assert.Equal(
+            "PublishInspectWebFrontendIndex",
+            (string?)runtimeLoaderTarget.Attribute("AfterTargets"));
+        XElement runtimeLoaderCommand = Assert.Single(
+            runtimeLoaderTarget.Elements("Exec"));
+        Assert.Contains(
+            "publish-runtime-loader.ts",
+            (string?)runtimeLoaderCommand.Attribute("Command"));
+        Assert.Contains(
+            "$(PublishDir)wwwroot",
+            (string?)runtimeLoaderCommand.Attribute("Command"));
+
         XElement verificationTarget = Assert.Single(
             project.Descendants("Target"),
             element =>
                 (string?)element.Attribute("Name") ==
                 "VerifyPublishedInspectWebSite");
         Assert.Equal(
-            "PublishInspectWebFrontendIndex",
+            "PublishInspectWebRuntimeLoader",
             (string?)verificationTarget.Attribute("AfterTargets"));
         XElement verificationCommand = Assert.Single(
             verificationTarget.Elements("Exec"));

--- a/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
+++ b/prototypes/inspect-web/engine/InspectWeb.Engine.csproj
@@ -61,7 +61,11 @@
     <Copy SourceFiles="@(_HtmlPublishCandidates)" DestinationFiles="@(_HtmlPublishCandidates->'$(PublishDir)wwwroot/index.html')" />
   </Target>
 
-  <Target Name="VerifyPublishedInspectWebSite" AfterTargets="PublishInspectWebFrontendIndex">
+  <Target Name="PublishInspectWebRuntimeLoader" AfterTargets="PublishInspectWebFrontendIndex">
+    <Exec Command="node &quot;../scripts/publish-runtime-loader.ts&quot; &quot;$(PublishDir)wwwroot&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+  <Target Name="VerifyPublishedInspectWebSite" AfterTargets="PublishInspectWebRuntimeLoader">
     <Exec Command="node &quot;../scripts/verify-site-artifact.ts&quot; &quot;$(PublishDir)wwwroot&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 

--- a/prototypes/inspect-web/engine/facades/inspect-web-analysis.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-analysis.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 

--- a/prototypes/inspect-web/engine/facades/inspect-web-call-graph.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-call-graph.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export interface BrowserCallGraph {
   readonly mermaid: string;

--- a/prototypes/inspect-web/engine/facades/inspect-web-catalog.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-catalog.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 

--- a/prototypes/inspect-web/engine/facades/inspect-web-host.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-host.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export interface BrowserBuildIdentity {
   readonly version: string;

--- a/prototypes/inspect-web/engine/facades/inspect-web-metadata.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-metadata.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 

--- a/prototypes/inspect-web/engine/facades/inspect-web-package.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-package.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export type BrowserCompileLibraryStatus = "Selected" | "NoCompileAssets" | "NoMatchingTargetFramework" | "EmptyCompileGroup" | "InvalidImplementationAssets" | number;
 

--- a/prototypes/inspect-web/engine/facades/inspect-web-source.ts
+++ b/prototypes/inspect-web/engine/facades/inspect-web-source.ts
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 
 export type BrowserAnnotatedSourceCapabilityUnavailableReason = "NotProjected" | "ContextUnavailable" | number;
 

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-analysis.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-analysis.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-call-graph.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-call-graph.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-catalog.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-catalog.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-host.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-host.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-metadata.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-metadata.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-package.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-package.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
+++ b/prototypes/inspect-web/engine/wwwroot/inspect-web-source.js
@@ -1,4 +1,4 @@
-import { dotnet } from "./_framework/dotnet.js";
+import { dotnet } from "./runtime-loader.js";
 const $notInitializedError = new Error("The .NET runtime facade is not initialized.");
 let $runtime;
 let $managedExports;

--- a/prototypes/inspect-web/engine/wwwroot/runtime-loader.js
+++ b/prototypes/inspect-web/engine/wwwroot/runtime-loader.js
@@ -1,0 +1,1 @@
+export { dotnet } from "./_framework/dotnet.js";

--- a/prototypes/inspect-web/package.json
+++ b/prototypes/inspect-web/package.json
@@ -14,9 +14,10 @@
     "test:browser": "playwright test --project=firefox",
     "inspect-web-worker-envelope-validation": "node --test test/worker-runtime-protocol.test.ts",
     "inspect-web-worker-protocol": "node --test test/worker-runtime-protocol.test.ts test/worker-runtime-core.test.ts",
+    "inspect-web-worker-browser-binding": "node --test test/worker-runtime-browser.test.ts && playwright test --config playwright.worker.config.ts",
     "inspect-web-typescript-semantic-facts": "node --test test/typescript-semantic-facts.test.ts test/typescript-semantic-facts-artifact.test.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json && tsc --noEmit -p tsconfig.node.json",
-    "lint": "node scripts/verify-analysis-host.ts && oxlint --no-ignore --disable-nested-config src test browser scripts multi-facade-canary/coordinator.ts multi-facade-canary/exercise.ts multi-facade-canary/facades managed-operation-bridge-canary/initialize.ts managed-operation-bridge-canary/exercise.ts managed-operation-bridge-canary/facades engine/facades engine/wwwroot/inspect-web-host.js engine/wwwroot/inspect-web-package.js engine/wwwroot/inspect-web-metadata.js engine/wwwroot/inspect-web-analysis.js engine/wwwroot/inspect-web-source.js engine/wwwroot/inspect-web-call-graph.js engine/wwwroot/inspect-web-catalog.js vite.config.ts playwright.config.ts && html-validate --config .htmlvalidate.json \"**/*.{html,htm,xhtml}\"",
+    "lint": "node scripts/verify-analysis-host.ts && oxlint --no-ignore --disable-nested-config src test browser scripts multi-facade-canary/coordinator.ts multi-facade-canary/exercise.ts multi-facade-canary/facades managed-operation-bridge-canary/initialize.ts managed-operation-bridge-canary/exercise.ts managed-operation-bridge-canary/facades engine/facades engine/wwwroot/inspect-web-host.js engine/wwwroot/inspect-web-package.js engine/wwwroot/inspect-web-metadata.js engine/wwwroot/inspect-web-analysis.js engine/wwwroot/inspect-web-source.js engine/wwwroot/inspect-web-call-graph.js engine/wwwroot/inspect-web-catalog.js engine/wwwroot/runtime-loader.js vite.config.ts playwright.config.ts playwright.worker.config.ts && html-validate --config .htmlvalidate.json \"**/*.{html,htm,xhtml}\"",
     "analyze": "npm run lint && knip"
   },
   "devDependencies": {

--- a/prototypes/inspect-web/playwright.config.ts
+++ b/prototypes/inspect-web/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./browser",
   testMatch: "*.spec.ts",
+  testIgnore: "worker-runtime.spec.ts",
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,

--- a/prototypes/inspect-web/playwright.worker.config.ts
+++ b/prototypes/inspect-web/playwright.worker.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./browser",
+  testMatch: "worker-runtime.spec.ts",
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  timeout: 120_000,
+  reporter: "line",
+  use: {
+    baseURL: "http://127.0.0.1:4186",
+    trace: "retain-on-failure",
+  },
+  projects: [{
+    name: "firefox",
+    use: { ...devices["Desktop Firefox"] },
+  }],
+  webServer: {
+    command: "node scripts/serve-worker-runtime-gate.ts",
+    url: "http://127.0.0.1:4186/worker-runtime-gate.html",
+    reuseExistingServer: false,
+  },
+});

--- a/prototypes/inspect-web/scripts/publish-runtime-loader.ts
+++ b/prototypes/inspect-web/scripts/publish-runtime-loader.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export function publishedRuntimeTarget(siteArgument: string): string {
+  const site = resolve(siteArgument);
+  const index = readFileSync(resolve(site, "index.html"), "utf8");
+  const target = /"\.\/_framework\/dotnet\.js"\s*:\s*"(\.\/_framework\/dotnet\.[^"/]+\.js)"/
+    .exec(index)?.[1];
+  if (!target) {
+    throw new Error(
+      "Published import map has no valid fingerprinted dotnet.js mapping.");
+  }
+  if (!existsSync(resolve(site, target))) {
+    throw new Error(`Published runtime module '${target}' is missing.`);
+  }
+  return target;
+}
+
+export function publishRuntimeLoader(siteArgument: string): void {
+  const target = publishedRuntimeTarget(siteArgument);
+  writeFileSync(
+    resolve(siteArgument, "runtime-loader.js"),
+    `export { dotnet } from ${JSON.stringify(target)};\n`,
+  );
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined
+  && import.meta.url === pathToFileURL(resolve(invokedPath)).href) {
+  const siteArgument = process.argv[2];
+  if (!siteArgument) {
+    throw new Error("Usage: node scripts/publish-runtime-loader.ts <published-wwwroot>");
+  }
+  publishRuntimeLoader(siteArgument);
+}

--- a/prototypes/inspect-web/scripts/serve-worker-runtime-gate.ts
+++ b/prototypes/inspect-web/scripts/serve-worker-runtime-gate.ts
@@ -1,0 +1,59 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, resolve, sep } from "node:path";
+
+const site = resolve(
+  process.env.INSPECT_WEB_WORKER_SITE ?? "../../artifacts/inspect-web-publish/wwwroot",
+);
+await readFile(resolve(site, "manifest.json"));
+const contentTypes: Readonly<Record<string, string>> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+  ".css": "text/css",
+};
+
+createServer((request, response) => {
+  const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+  if (pathname === "/worker-runtime-gate.html") {
+    response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    response.end("<!doctype html><html lang=\"en\"><title>Worker runtime gate</title>"
+      + "<body><button id=\"input\" type=\"button\">Input</button><output id=\"count\">0</output></body></html>");
+    return;
+  }
+  if (pathname === "/inspect-web-host.js"
+    && request.headers.cookie?.split("; ")
+      .includes("worker-runtime-gate=reject-bootstrap")) {
+    response.writeHead(503);
+    response.end("Worker bootstrap rejection fixture.");
+    return;
+  }
+  const file = resolve(site, `.${pathname}`);
+  if (!file.startsWith(`${site}${sep}`)) {
+    response.writeHead(404);
+    response.end();
+    return;
+  }
+  void readFile(file).then(
+    contents => {
+      response.writeHead(200, {
+        "Content-Type": contentTypes[extname(file)] ?? "application/octet-stream",
+        "Cache-Control": "no-store",
+      });
+      response.end(contents);
+      return undefined;
+    },
+    (error: unknown) => {
+      const missing = error instanceof Error
+        && "code" in error
+        && (error.code === "ENOENT" || error.code === "ENOTDIR");
+      if (!missing) console.error(error);
+      response.writeHead(missing ? 404 : 500);
+      response.end();
+      return undefined;
+    },
+  );
+}).listen(4186, "127.0.0.1", () => {
+  console.log(`Worker runtime gate: http://127.0.0.1:4186 (${site})`);
+});

--- a/prototypes/inspect-web/scripts/verify-engine-facade-runtime.ts
+++ b/prototypes/inspect-web/scripts/verify-engine-facade-runtime.ts
@@ -4,7 +4,7 @@
 // importing a module performs no managed work, and that only the host module's
 // `runEntryPoint()` reaches the runtime.
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -197,8 +197,8 @@ for (const facade of facades) {
 
   const imports = [...source.matchAll(/^import\s[^;]*?from\s+"([^"]+)";$/gm)]
     .map(match => match[1]);
-  assert.deepEqual(imports, ["./_framework/dotnet.js"],
-    `${facade.module}.js must acquire the runtime through the one shared SDK module`);
+  assert.deepEqual(imports, ["./runtime-loader.js"],
+    `${facade.module}.js must acquire the runtime through the one shared loader module`);
 
   const acquired = [...source.matchAll(/getAssemblyExports\("([^"]+)"\)/g)]
     .map(match => match[1]);
@@ -222,17 +222,15 @@ for (const facade of facades) {
   });
 }
 
-const frameworkDirectory = resolve(resolvedDirectory, "_framework");
 const statePath = resolve(resolvedDirectory, "probe-state.js");
-const runtimePath = resolve(frameworkDirectory, "dotnet.js");
-mkdirSync(frameworkDirectory, { recursive: true });
+const runtimePath = resolve(resolvedDirectory, "runtime-loader.js");
 writeFileSync(statePath, "export const calls = [];\n");
 
 // One runtime for the whole set, the way the SDK behaves: a repeated `create()` call
 // returns the completed runtime instead of building a second one.
 writeFileSync(
   runtimePath,
-  `import { calls } from "../probe-state.js";
+  `import { calls } from "./probe-state.js";
 const managedAssemblies = ${JSON.stringify(managedAssemblies)};
 const assemblies = new Map(managedAssemblies.map(entry => [entry.assembly, {
   [entry.root]: Object.fromEntries(entry.operations.map(operation => [

--- a/prototypes/inspect-web/scripts/verify-published-engine-facades.ts
+++ b/prototypes/inspect-web/scripts/verify-published-engine-facades.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import {
   existsSync,
   readFileSync,
-  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { publishedRuntimeTarget } from "./publish-runtime-loader.ts";
 
 interface FacadeIdentity {
   readonly assembly: string;
@@ -198,20 +198,22 @@ assert.deepEqual(
   "published facade domain does not match the production facade set");
 
 const site = resolve(siteArgument);
-const index = readFileSync(resolve(site, "index.html"), "utf8");
-const dotnetModule = /"\.\/_framework\/dotnet\.js": "\.\/_framework\/([^"]+\.js)"/
-  .exec(index)?.[1];
-assert.ok(dotnetModule, "published import map has no dotnet.js mapping");
-
-const frameworkDirectory = resolve(site, "_framework");
-const dotnetAlias = resolve(frameworkDirectory, "dotnet.js");
+const dotnetModule = publishedRuntimeTarget(site);
+const runtimeLoader = resolve(site, "runtime-loader.js");
+const originalLoader = readFileSync(runtimeLoader);
 assert.equal(
-  existsSync(dotnetAlias),
+  originalLoader.toString("utf8"),
+  `export { dotnet } from ${JSON.stringify(dotnetModule)};\n`,
+  "published runtime loader does not address the SDK import-map target");
+assert.equal(
+  existsSync(resolve(site, "_framework/dotnet.js")),
   false,
   "published framework unexpectedly contains an unhashed dotnet.js");
-writeFileSync(
-  dotnetAlias,
-  `import { dotnet as sdkDotnet } from "./${dotnetModule}";
+
+try {
+  writeFileSync(
+    runtimeLoader,
+    `import { dotnet as sdkDotnet } from ${JSON.stringify(dotnetModule)};
 const runtimes = new Set();
 let createCalls = 0;
 let runMainCount = 0;
@@ -246,7 +248,6 @@ export function inspectWebRuntimeObservation() {
 }
 `);
 
-try {
   assert.equal(
     Reflect.has(globalThis, "window"),
     false,
@@ -284,7 +285,7 @@ try {
     Promise.all([initializeFacades(), initializeFacades()]).then(() => undefined),
     "facade initialization");
 
-  const sdkModule: unknown = await import(pathToFileURL(dotnetAlias).href);
+  const sdkModule: unknown = await import(pathToFileURL(runtimeLoader).href);
   assert.ok(
     isRecord(sdkModule)
       && typeof sdkModule.inspectWebRuntimeObservation === "function",
@@ -429,5 +430,5 @@ try {
     `inspect-web published ${modeArgument} facade smoke passed `
       + `(${version}; ${facades.length} facades; one SDK runtime).`);
 } finally {
-  unlinkSync(dotnetAlias);
+  writeFileSync(runtimeLoader, originalLoader);
 }

--- a/prototypes/inspect-web/src/engine-facades.ts
+++ b/prototypes/inspect-web/src/engine-facades.ts
@@ -1,7 +1,7 @@
 // The application's one runtime composition point for the production facade set.
 //
 // Seven independently generated modules attach to one Browser/Wasm runtime through the one
-// shared `./_framework/dotnet.js` module. Startup is eager, ordered and serial: every facade
+// shared `./runtime-loader.js` module. Startup is eager, ordered and serial: every facade
 // acquires its own managed export assembly before any application operation is published as
 // ready. Concurrent callers share one attempt, and the first failure is the failure every
 // later caller observes, so a stale module or a missing export root fails the application

--- a/prototypes/inspect-web/src/engine-worker-client.ts
+++ b/prototypes/inspect-web/src/engine-worker-client.ts
@@ -1,0 +1,82 @@
+import {
+  createOperationAuthorityPage,
+  type OperationDiagnostic,
+} from "./operation-authority.ts";
+import { createBrowserWorkerRuntimeHost } from "./worker-runtime-browser.ts";
+import {
+  engineWorkerCanaryKind,
+  engineWorkerDiagnostic,
+  engineWorkerPolicy,
+  engineWorkerText,
+} from "./engine-worker-contract.ts";
+import {
+  WorkerProducerClassRegistry,
+  type WorkerRuntimeHostOptions,
+  type WorkerRuntimePreparationError,
+} from "./worker-runtime-core.ts";
+
+function createEngineWorker(): Worker {
+  return new Worker(new URL("./engine-worker-entry.ts", import.meta.url), {
+    type: "module",
+    name: "dotnet-inspect",
+  });
+}
+
+export interface EngineWorkerProbeOptions {
+  readonly callbacks: WorkerRuntimeHostOptions<string, string>["callbacks"];
+  readonly operationDiagnostic: (diagnostic: OperationDiagnostic) => undefined;
+  readonly startupBudgetMilliseconds?: number;
+}
+
+// The existing managed canary is an explicit diagnostic consumer, not a feature
+// migration or a claim that application operations already run in this Worker.
+export function createEngineWorkerProbe(options: EngineWorkerProbeOptions) {
+  const host = createBrowserWorkerRuntimeHost(createEngineWorker, {
+    ...engineWorkerPolicy,
+    startupBudgetMilliseconds:
+      options.startupBudgetMilliseconds ?? engineWorkerPolicy.startupBudgetMilliseconds,
+    producerClasses: new WorkerProducerClassRegistry(
+      engineWorkerPolicy.idleHeartbeatIntervalMilliseconds
+        + engineWorkerPolicy.schedulingToleranceMilliseconds,
+    ),
+    bootstrap: { encode: engineWorkerText.decode, diagnostic: engineWorkerText },
+    diagnostic: engineWorkerText,
+    createDiagnostic: (kind, detail) => `${kind}: ${engineWorkerDiagnostic(detail)}`.slice(0, 4_096),
+    callbacks: options.callbacks,
+  });
+  const adapter = host.registerOperation({
+    kind: engineWorkerCanaryKind,
+    allowance: { kind: "unbounded" },
+    encodeInput: (input: string) => engineWorkerText.decode(input),
+    value: engineWorkerText,
+    error: engineWorkerText,
+    diagnostic: engineWorkerText,
+    progress: engineWorkerText,
+    mapPreparationError: error => error,
+    boundaryErrors: {
+      startup: "Worker startup failed.",
+      "worker-crash": "Worker realm was lost.",
+      protocol: "Worker protocol failed.",
+      watchdog: "Worker event loop stopped responding.",
+      "control-response": "Worker control response was missing.",
+      "probe-exhaustion": "Worker probe identity was exhausted.",
+      "worker-declared": "Worker reported a runtime failure.",
+      "worker-message": "Worker message delivery failed.",
+    },
+  });
+  const page = createOperationAuthorityPage();
+  const session = page.createSession<
+    string, string, string, string, WorkerRuntimePreparationError
+  >({
+    feature: { publish: () => undefined },
+    diagnostic: { report: options.operationDiagnostic },
+  });
+  return {
+    host,
+    probe: () => session.start("", adapter),
+    dispose: () => {
+      session.dispose();
+      host.dispose();
+    },
+  };
+}

--- a/prototypes/inspect-web/src/engine-worker-contract.ts
+++ b/prototypes/inspect-web/src/engine-worker-contract.ts
@@ -1,0 +1,32 @@
+import type { BoundedPayloadDecoder } from "./worker-runtime-protocol.ts";
+
+export const engineWorkerPolicy = {
+  idleHeartbeatIntervalMilliseconds: 500,
+  schedulingToleranceMilliseconds: 1_000,
+  startupBudgetMilliseconds: 60_000,
+  controlResponseGraceMilliseconds: 5_000,
+  drainBudgetMilliseconds: 2_000,
+} as const;
+
+export const engineWorkerText: BoundedPayloadDecoder<string> = {
+  decode(value) {
+    if (typeof value !== "string") {
+      return { kind: "rejected", reason: "invalid", message: "Expected Worker text." };
+    }
+    if (value.length > 4_096) {
+      return { kind: "rejected", reason: "oversized", message: "Worker text exceeds 4096 characters." };
+    }
+    return { kind: "decoded", value };
+  },
+};
+
+export function engineWorkerDiagnostic(detail: unknown): string {
+  const message = detail instanceof Error
+    ? detail.message
+    : typeof detail === "string"
+      ? detail
+      : "Worker runtime boundary failure.";
+  return message.slice(0, 4_096);
+}
+
+export const engineWorkerCanaryKind = "runtime-async-lowering-canary";

--- a/prototypes/inspect-web/src/engine-worker-entry.ts
+++ b/prototypes/inspect-web/src/engine-worker-entry.ts
@@ -1,0 +1,58 @@
+import { startEngine } from "./engine-facades.ts";
+import {
+  engineWorkerCanaryKind,
+  engineWorkerDiagnostic,
+  engineWorkerPolicy,
+  engineWorkerText,
+} from "./engine-worker-contract.ts";
+import { WorkerProducerClassRegistry } from "./worker-runtime-core.ts";
+import { WorkerOperationCatalog, WorkerRuntimeRealm } from "./worker-runtime-realm.ts";
+
+const operations = new WorkerOperationCatalog();
+operations.register({
+  kind: engineWorkerCanaryKind,
+  allowance: { kind: "unbounded" },
+  input: engineWorkerText,
+  rejectInvalidPayload: failure => ({
+    error: failure.message,
+    diagnostic: failure.message,
+  }),
+  invoke: async () => {
+    const host = await import("/inspect-web-host.js");
+    return { kind: "succeeded", value: await host.asyncLoweringCanary() };
+  },
+});
+
+let heartbeat: ReturnType<typeof setInterval> | undefined;
+const realm = new WorkerRuntimeRealm({
+  bootstrap: { decoder: engineWorkerText, bootstrap: startEngine },
+  diagnostic: engineWorkerDiagnostic,
+  unknownOperationRejection: kind => ({
+    error: `Unknown Worker operation: ${kind}`,
+    diagnostic: `Unknown Worker operation: ${kind}`,
+  }),
+  operations,
+  producerClasses: new WorkerProducerClassRegistry(
+    engineWorkerPolicy.idleHeartbeatIntervalMilliseconds
+      + engineWorkerPolicy.schedulingToleranceMilliseconds,
+  ),
+  post(message) {
+    globalThis.postMessage(message, { transfer: [] });
+    if (message.kind === "ready") {
+      heartbeat = setInterval(
+        () => realm.emitHeartbeat(),
+        message.idleHeartbeatIntervalMilliseconds,
+      );
+    }
+    if (message.kind === "startup-failed" || message.kind === "epoch-failed") {
+      clearInterval(heartbeat);
+    }
+  },
+});
+
+globalThis.addEventListener("message", (event: MessageEvent<unknown>) => {
+  realm.receive(event.data);
+});
+globalThis.addEventListener("messageerror", () => {
+  realm.fail(new Error("Main-thread message could not be deserialized."));
+});

--- a/prototypes/inspect-web/src/worker-runtime-browser.ts
+++ b/prototypes/inspect-web/src/worker-runtime-browser.ts
@@ -1,0 +1,243 @@
+import {
+  WorkerRuntimeHost,
+  type WorkerRuntimeHostOptions,
+  type WorkerRuntimeLifecycleListeners,
+  type WorkerRuntimeSource,
+  type WorkerRuntimeTransportBinding,
+  type WorkerRuntimeTransportHandlers,
+} from "./worker-runtime-core.ts";
+
+interface BrowserRuntimeDocument extends EventTarget {
+  readonly hidden: boolean;
+}
+
+export interface BrowserWorkerRuntimeEnvironmentOptions {
+  readonly document: BrowserRuntimeDocument;
+  readonly window: EventTarget;
+  readonly pollIntervalMilliseconds?: number;
+  readonly schedulingToleranceMilliseconds?: number;
+  readonly now?: () => number;
+  readonly schedule?: (
+    callback: () => void,
+    milliseconds: number,
+  ) => () => void;
+}
+
+function positiveMilliseconds(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive safe integer.`);
+  }
+  return value;
+}
+
+function scheduleInterval(callback: () => void, milliseconds: number): () => void {
+  const timer = globalThis.setInterval(callback, milliseconds);
+  return () => globalThis.clearInterval(timer);
+}
+
+export class BrowserWorkerRuntimeEnvironment {
+  readonly #options: BrowserWorkerRuntimeEnvironmentOptions;
+  readonly #now: () => number;
+  readonly #interval: number;
+  readonly #tolerance: number;
+  readonly #clockListeners = new Set<() => void>();
+  readonly #lifecycleListeners = new Set<WorkerRuntimeLifecycleListeners>();
+  #stopTimer: (() => void) | null = null;
+  #wallTime = 0;
+  #activeTime = 0;
+  #hidden = false;
+  #pageHidden = false;
+  #frozen = false;
+
+  readonly clock = {
+    now: (): number => this.#sample(),
+    subscribe: (listener: () => void): (() => void) => {
+      this.#connect();
+      this.#clockListeners.add(listener);
+      return () => {
+        this.#clockListeners.delete(listener);
+        this.#disconnectIfUnused();
+      };
+    },
+  };
+
+  readonly lifecycle = {
+    subscribe: (listener: WorkerRuntimeLifecycleListeners): (() => void) => {
+      this.#connect();
+      this.#lifecycleListeners.add(listener);
+      return () => {
+        this.#lifecycleListeners.delete(listener);
+        this.#disconnectIfUnused();
+      };
+    },
+  };
+
+  constructor(options: BrowserWorkerRuntimeEnvironmentOptions) {
+    this.#options = options;
+    this.#now = options.now ?? (() => performance.now());
+    this.#interval = positiveMilliseconds(
+      options.pollIntervalMilliseconds ?? 100,
+      "pollIntervalMilliseconds",
+    );
+    this.#tolerance = options.schedulingToleranceMilliseconds ?? 1_000;
+    if (!Number.isSafeInteger(this.#tolerance) || this.#tolerance < 0) {
+      throw new RangeError("schedulingToleranceMilliseconds must be a non-negative safe integer.");
+    }
+  }
+
+  #suspended(): boolean {
+    return this.#hidden || this.#pageHidden || this.#frozen;
+  }
+
+  #sample(): number {
+    const wallTime = this.#now();
+    const elapsed = Math.max(0, wallTime - this.#wallTime);
+    this.#wallTime = wallTime;
+    if (this.#stopTimer === null || this.#suspended()) {
+      return Math.floor(this.#activeTime);
+    }
+    const previous = Math.floor(this.#activeTime);
+    this.#activeTime += elapsed;
+    const activeTime = Math.floor(this.#activeTime);
+    if (elapsed > this.#interval + this.#tolerance) {
+      // Publish recovery before a message handler can judge an overdue deadline.
+      // Advancing the anchor first also makes a recovery callback's now() safe.
+      for (const listener of this.#lifecycleListeners) {
+        listener.mainLoopRecovered(activeTime - previous);
+      }
+    }
+    return Math.floor(this.#activeTime);
+  }
+
+  #transition(change: () => void): void {
+    this.#sample();
+    const wasSuspended = this.#suspended();
+    change();
+    const suspended = this.#suspended();
+    if (wasSuspended === suspended) return;
+    for (const listener of this.#lifecycleListeners) {
+      if (suspended) listener.suspended();
+      else listener.resumed();
+    }
+    for (const listener of this.#clockListeners) listener();
+  }
+
+  readonly #visibilityChanged = (): void => {
+    this.#transition(() => {
+      this.#hidden = this.#options.document.hidden;
+    });
+  };
+
+  readonly #pageHide = (): void => {
+    this.#transition(() => { this.#pageHidden = true; });
+  };
+
+  readonly #pageShow = (): void => {
+    this.#transition(() => {
+      this.#pageHidden = false;
+      this.#hidden = this.#options.document.hidden;
+    });
+  };
+
+  readonly #freeze = (): void => {
+    this.#transition(() => { this.#frozen = true; });
+  };
+
+  readonly #resume = (): void => {
+    this.#transition(() => { this.#frozen = false; });
+  };
+
+  #connect(): void {
+    if (this.#stopTimer !== null) return;
+    this.#wallTime = this.#now();
+    this.#hidden = this.#options.document.hidden;
+    this.#pageHidden = false;
+    this.#frozen = false;
+    const document = this.#options.document;
+    const window = this.#options.window;
+    document.addEventListener("visibilitychange", this.#visibilityChanged);
+    document.addEventListener("freeze", this.#freeze);
+    document.addEventListener("resume", this.#resume);
+    window.addEventListener("pagehide", this.#pageHide);
+    window.addEventListener("pageshow", this.#pageShow);
+    this.#stopTimer = (this.#options.schedule ?? scheduleInterval)(() => {
+      this.#sample();
+      for (const listener of this.#clockListeners) listener();
+    }, this.#interval);
+  }
+
+  #disconnectIfUnused(): void {
+    if (this.#clockListeners.size !== 0 || this.#lifecycleListeners.size !== 0) {
+      return;
+    }
+    this.#sample();
+    this.#stopTimer?.();
+    this.#stopTimer = null;
+    const document = this.#options.document;
+    const window = this.#options.window;
+    document.removeEventListener("visibilitychange", this.#visibilityChanged);
+    document.removeEventListener("freeze", this.#freeze);
+    document.removeEventListener("resume", this.#resume);
+    window.removeEventListener("pagehide", this.#pageHide);
+    window.removeEventListener("pageshow", this.#pageShow);
+  }
+}
+
+class BrowserWorkerRuntimeTransport {
+  readonly #createWorker: () => Worker;
+
+  constructor(createWorker: () => Worker) {
+    this.#createWorker = createWorker;
+  }
+
+  create(): WorkerRuntimeTransportBinding {
+    const worker = this.#createWorker();
+    const source: WorkerRuntimeSource = {
+      send: message => worker.postMessage(message, { transfer: [] }),
+      terminate: () => worker.terminate(),
+    };
+    return {
+      source,
+      bind(handlers: WorkerRuntimeTransportHandlers): () => void {
+        const message = (event: MessageEvent<unknown>): void => {
+          handlers.message(source, event.data);
+        };
+        const error = (event: ErrorEvent): void => {
+          handlers.error(source, new Error(event.message));
+        };
+        const messageError = (): void => {
+          handlers.messageError(source, new Error("Worker message could not be deserialized."));
+        };
+        worker.addEventListener("message", message);
+        worker.addEventListener("error", error);
+        worker.addEventListener("messageerror", messageError);
+        return () => {
+          worker.removeEventListener("message", message);
+          worker.removeEventListener("error", error);
+          worker.removeEventListener("messageerror", messageError);
+        };
+      },
+    };
+  }
+}
+
+export function createBrowserWorkerRuntimeHost<TBootstrap, TDiagnostic>(
+  createWorker: () => Worker,
+  options: Omit<
+    WorkerRuntimeHostOptions<TBootstrap, TDiagnostic>,
+    "clock" | "lifecycle" | "transport"
+  >,
+): WorkerRuntimeHost<TBootstrap, TDiagnostic> {
+  const environment = new BrowserWorkerRuntimeEnvironment({
+    document,
+    window,
+    schedulingToleranceMilliseconds:
+      options.schedulingToleranceMilliseconds ?? 0,
+  });
+  return new WorkerRuntimeHost({
+    ...options,
+    clock: environment.clock,
+    lifecycle: environment.lifecycle,
+    transport: new BrowserWorkerRuntimeTransport(createWorker),
+  });
+}

--- a/prototypes/inspect-web/src/worker-runtime-core.ts
+++ b/prototypes/inspect-web/src/worker-runtime-core.ts
@@ -8,18 +8,14 @@ import type {
   PreparedOperationProducer,
 } from "./operation-authority.ts";
 import {
-  decodeBoundMainToWorkerEnvelope,
   decodeEpochFailedPayload,
   decodeProgressPayload,
   decodeRejectedPayload,
   decodeSettledPayload,
-  decodeStartPayload,
   decodeStartupFailedPayload,
-  decodeUnboundInitializationEnvelope,
   decodeWorkerToMainEnvelope,
   type BoundedPayloadDecodeResult,
   type BoundedPayloadDecoder,
-  type ManagedOperationSettlement,
   type RawMainToWorkerEnvelope,
   type RawWorkerToMainEnvelope,
   type WorkerEnvelopeDecodeFailure,
@@ -27,6 +23,13 @@ import {
   type WorkerWireOperationReference,
   WORKER_RUNTIME_PROTOCOL_VERSION,
 } from "./worker-runtime-protocol.ts";
+import {
+  sameAllowance,
+  WorkerRuntimeRealm,
+  type WorkerEpochCache as FakeWorkerEpochCache,
+  type WorkerRuntimeRealmOptions,
+  type WorkerRuntimeTaskScheduler,
+} from "./worker-runtime-realm.ts";
 
 declare const workerEpochTokenBrand: unique symbol;
 const workerIdleCompatibleBrand: unique symbol
@@ -105,10 +108,6 @@ export interface WorkerRuntimeLifecycleListeners {
   readonly suspended: () => void;
   readonly resumed: () => void;
   readonly mainLoopRecovered: (gapActiveMilliseconds: number) => void;
-}
-
-interface WorkerRuntimeTaskScheduler {
-  enqueue(task: () => void): void;
 }
 
 interface WorkerRuntimeBootstrapCodec<TBootstrap, TDiagnostic> {
@@ -402,17 +401,6 @@ function validateNonNegativeSafeInteger(value: number, name: string): number {
   if (!Number.isSafeInteger(value) || value < 0)
     throw new RangeError(`${name} must be a non-negative safe integer.`);
   return value;
-}
-
-function sameAllowance(
-  left: WorkerLivenessAllowance,
-  right: WorkerLivenessAllowance,
-): boolean {
-  return left.kind === "unbounded"
-    ? right.kind === "unbounded"
-    : right.kind === "bounded"
-      && left.maxSilentActiveMilliseconds
-        === right.maxSilentActiveMilliseconds;
 }
 
 function operationKey(reference: WorkerWireOperationReference): string {
@@ -2650,266 +2638,43 @@ export class WorkerRuntimeHost<TBootstrap, TDiagnostic> {
   }
 }
 
-interface FakeWorkerBootstrapAdapter<TBootstrap> {
-  readonly decoder: BoundedPayloadDecoder<TBootstrap>;
-  readonly bootstrap: (
-    bootstrap: TBootstrap,
-  ) => void | Promise<void>;
-}
+export {
+  WorkerOperationCatalog as FakeWorkerOperationCatalog,
+  type WorkerOperationContext as FakeWorkerOperationContext,
+  type WorkerOperationRegistration as FakeWorkerOperationRegistration,
+  type WorkerEpochCache as FakeWorkerEpochCache,
+} from "./worker-runtime-realm.ts";
 
-export interface FakeWorkerOperationContext {
-  readonly operation: WorkerWireOperationReference;
-  readonly cache: FakeWorkerEpochCache;
-  startEpochWork(
-    producerClass: string,
-    sequence: number,
-    advertisedAllowance?: WorkerLivenessAllowance,
-  ): boolean;
-  finishEpochWork(sequence: number): boolean;
-}
-
-export interface FakeWorkerEpochCache {
-  readonly size: number;
-  get(key: string): unknown;
-  set(key: string, value: unknown): boolean;
-  has(key: string): boolean;
-  delete(key: string): boolean;
-}
-
-class RevocableFakeWorkerEpochCache implements FakeWorkerEpochCache {
-  readonly #entries = new Map<string, unknown>();
-  #active = true;
-
-  get size(): number {
-    return this.#entries.size;
-  }
-
-  get(key: string): unknown {
-    return this.#active ? this.#entries.get(key) : undefined;
-  }
-
-  set(key: string, value: unknown): boolean {
-    if (!this.#active) return false;
-    this.#entries.set(key, value);
-    return true;
-  }
-
-  has(key: string): boolean {
-    return this.#active && this.#entries.has(key);
-  }
-
-  delete(key: string): boolean {
-    return this.#active && this.#entries.delete(key);
-  }
-
-  revoke(): void {
-    this.#active = false;
-    this.#entries.clear();
-  }
-}
-
-export interface FakeWorkerOperationRegistration<
-  TInput,
-  TValue,
-  TError,
-  TOperationDiagnostic,
-> {
-  readonly kind: string;
-  readonly allowance: WorkerLivenessAllowance;
-  readonly input: BoundedPayloadDecoder<TInput>;
-  readonly rejectInvalidPayload: (
-    failure: WorkerEnvelopeDecodeFailure,
-  ) => {
-    readonly error: TError;
-    readonly diagnostic: TOperationDiagnostic;
-  };
-  readonly invoke: (
-    input: TInput,
-    context: FakeWorkerOperationContext,
-  ) => ManagedOperationSettlement<TValue, TError, TOperationDiagnostic>
-    | Promise<
-      ManagedOperationSettlement<TValue, TError, TOperationDiagnostic>
-    >;
-  readonly cancel?: (
-    operation: WorkerWireOperationReference,
-    reason: OperationCancelReason,
-  ) => boolean | Promise<boolean>;
-}
-
-type FakeWorkerCancel = (
-  operation: WorkerWireOperationReference,
-  reason: OperationCancelReason,
-) => boolean | Promise<boolean>;
-
-interface FakeWorkerOperationDispatchHandlers {
-  readonly accepted: (
-    allowance: WorkerLivenessAllowance,
-    cancel: FakeWorkerCancel | null,
-  ) => boolean;
-  readonly rejected: (error: unknown, diagnostic: unknown) => void;
-  readonly settled: (
-    settlement: ManagedOperationSettlement<unknown, unknown, unknown>,
-  ) => void;
-  readonly failed: (error: unknown) => void;
-}
-
-interface ErasedFakeWorkerOperationRegistration {
-  readonly kind: string;
-  readonly dispatch: (
-    envelope: Extract<
-      RawMainToWorkerEnvelope,
-      { readonly kind: "start" }
-    >,
-    context: FakeWorkerOperationContext,
-    handlers: FakeWorkerOperationDispatchHandlers,
-  ) => void;
-}
-
-function eraseSettlement<TValue, TError, TDiagnostic>(
-  settlement: ManagedOperationSettlement<TValue, TError, TDiagnostic>,
-): ManagedOperationSettlement<unknown, unknown, unknown> {
-  if (settlement.kind === "succeeded")
-    return { kind: "succeeded", value: settlement.value };
-  if (settlement.kind === "failed") {
-    return {
-      kind: "failed",
-      failureKind: settlement.failureKind,
-      error: settlement.error,
-      diagnostic: settlement.diagnostic,
-    };
-  }
-  return { kind: "canceled", reason: settlement.reason };
-}
-
-export class FakeWorkerOperationCatalog {
-  readonly #registrations =
-    new Map<string, ErasedFakeWorkerOperationRegistration>();
-
-  register<TInput, TValue, TError, TOperationDiagnostic>(
-    registration: FakeWorkerOperationRegistration<
-      TInput,
-      TValue,
-      TError,
-      TOperationDiagnostic
-    >,
-  ): void {
-    if (this.#registrations.has(registration.kind))
-      throw new Error(`Fake operation ${registration.kind} is duplicated.`);
-    const erased: ErasedFakeWorkerOperationRegistration = {
-      kind: registration.kind,
-      dispatch: (envelope, context, handlers) => {
-        const decoded = decodeStartPayload(envelope, registration.input);
-        if (decoded.kind === "failure") {
-          const rejection = registration.rejectInvalidPayload(
-            decoded.failure,
-          );
-          handlers.rejected(rejection.error, rejection.diagnostic);
-          return;
-        }
-        const cancel = registration.cancel;
-        const accepted = handlers.accepted(
-          registration.allowance,
-          cancel === undefined
-            ? null
-            : (operation, reason) => cancel(operation, reason),
-        );
-        if (!accepted) return;
-        let result:
-          | ManagedOperationSettlement<
-            TValue,
-            TError,
-            TOperationDiagnostic
-          >
-          | Promise<
-            ManagedOperationSettlement<
-              TValue,
-              TError,
-              TOperationDiagnostic
-            >
-          >;
-        try {
-          result = registration.invoke(decoded.value.payload, context);
-        } catch (error: unknown) {
-          handlers.failed(error);
-          return;
-        }
-        Promise.resolve(result).then(
-          settlement => {
-            handlers.settled(eraseSettlement(settlement));
-            return undefined;
-          },
-          (error: unknown) => {
-            handlers.failed(error);
-            return undefined;
-          },
-        );
-      },
-    };
-    this.#registrations.set(registration.kind, erased);
-  }
-
-  dispatch(
-    envelope: Extract<
-      RawMainToWorkerEnvelope,
-      { readonly kind: "start" }
-    >,
-    context: FakeWorkerOperationContext,
-    handlers: FakeWorkerOperationDispatchHandlers,
-  ): boolean {
-    const registration = this.#registrations.get(envelope.operationKind);
-    if (registration === undefined) return false;
-    registration.dispatch(envelope, context, handlers);
-    return true;
-  }
-}
-
-export interface FakeWorkerRuntimeOptions<TBootstrap, TDiagnostic> {
+export interface FakeWorkerRuntimeOptions<TBootstrap, TDiagnostic>
+extends Omit<WorkerRuntimeRealmOptions<TBootstrap, TDiagnostic>, "post"> {
   readonly scheduler: WorkerRuntimeTaskScheduler;
-  readonly bootstrap: FakeWorkerBootstrapAdapter<TBootstrap>;
-  readonly diagnostic: (detail: unknown) => TDiagnostic;
-  readonly unknownOperationRejection: (kind: string) => {
-    readonly error: unknown;
-    readonly diagnostic: unknown;
-  };
-  readonly operations: FakeWorkerOperationCatalog;
-  readonly producerClasses: WorkerProducerClassRegistry;
   readonly omitResponse?: (
     kind: "accepted" | "rejected" | "cancel-acknowledged" | "probe-acknowledged",
     correlation: string,
   ) => boolean;
 }
 
-interface FakeActiveOperation {
-  readonly operation: WorkerWireOperationReference;
-  readonly cancel: FakeWorkerCancel | null;
-  settling: boolean;
-}
-
 export class FakeWorkerRuntime<TBootstrap, TDiagnostic>
 implements WorkerRuntimeTransportBinding, WorkerRuntimeSource {
   readonly source: WorkerRuntimeSource = this;
-  readonly #cache = new RevocableFakeWorkerEpochCache();
   readonly receivedMessages: unknown[] = [];
   readonly emittedMessages: RawWorkerToMainEnvelope[] = [];
   readonly #options: FakeWorkerRuntimeOptions<TBootstrap, TDiagnostic>;
-  readonly #active = new Map<string, FakeActiveOperation>();
-  readonly #epochWork = new Map<number, WorkerLivenessAllowance>();
+  readonly #realm: WorkerRuntimeRealm<TBootstrap, TDiagnostic>;
   #handlers: WorkerRuntimeTransportHandlers | null = null;
-  #epochToken: number | null = null;
-  #idleHeartbeatIntervalMilliseconds: number | null = null;
-  #operationHighWater = 0;
-  #workHighWater = 0;
-  #lane: Promise<void> = Promise.resolve();
-  #initialized = false;
-  #ready = false;
-  #failed = false;
-  #terminated = false;
   #terminateCount = 0;
 
-  constructor(
-    options: FakeWorkerRuntimeOptions<TBootstrap, TDiagnostic>,
-  ) {
+  constructor(options: FakeWorkerRuntimeOptions<TBootstrap, TDiagnostic>) {
     this.#options = options;
+    this.#realm = new WorkerRuntimeRealm({
+      scheduler: options.scheduler,
+      bootstrap: options.bootstrap,
+      diagnostic: options.diagnostic,
+      unknownOperationRejection: options.unknownOperationRejection,
+      operations: options.operations,
+      producerClasses: options.producerClasses,
+      post: message => this.#post(message),
+    });
   }
 
   get terminateCount(): number {
@@ -2917,19 +2682,19 @@ implements WorkerRuntimeTransportBinding, WorkerRuntimeSource {
   }
 
   get cache(): FakeWorkerEpochCache {
-    return this.#cache;
+    return this.#realm.cache;
   }
 
   get activeOperationCount(): number {
-    return this.#active.size;
+    return this.#realm.activeOperationCount;
   }
 
   get activeEpochWorkCount(): number {
-    return this.#epochWork.size;
+    return this.#realm.activeEpochWorkCount;
   }
 
   get terminated(): boolean {
-    return this.#terminated;
+    return this.#realm.disposed;
   }
 
   bind(handlers: WorkerRuntimeTransportHandlers): () => void {
@@ -2940,38 +2705,20 @@ implements WorkerRuntimeTransportBinding, WorkerRuntimeSource {
   }
 
   send(message: unknown): void {
-    if (this.#terminated) throw new Error("Fake worker is terminated.");
+    if (this.terminated) throw new Error("Fake worker is terminated.");
     this.receivedMessages.push(message);
-    if (!this.#initialized) {
-      this.#initialized = true;
-      this.#options.scheduler.enqueue(() => {
-        this.#initialize(message);
-      });
-      return;
-    }
-    this.#lane = this.#lane.then(() => this.#processCommand(message));
-    this.#lane.catch((error: unknown) => {
-      this.#declareFailure(error);
-    });
+    this.#realm.receive(message);
   }
 
   terminate(): void {
-    if (this.#terminated) return;
-    this.#terminated = true;
+    if (this.terminated) return;
     this.#terminateCount++;
     this.#handlers = null;
-    this.#active.clear();
-    this.#epochWork.clear();
-    this.#cache.revoke();
+    this.#realm.dispose();
   }
 
   emitHeartbeat(): void {
-    if (!this.#ready || this.#epochToken === null) return;
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#epochToken,
-      kind: "heartbeat",
-    });
+    this.#realm.emitHeartbeat();
   }
 
   emitRaw(data: unknown, source: WorkerRuntimeSource = this): void {
@@ -2994,330 +2741,27 @@ implements WorkerRuntimeTransportBinding, WorkerRuntimeSource {
     sequence: number,
     advertisedAllowance?: WorkerLivenessAllowance,
   ): boolean {
-    if (this.#terminated
-      || !this.#ready
-      || this.#failed
-      || this.#epochToken === null) return false;
-    const registered = this.#options.producerClasses.allowance(producerClass);
-    if (!Number.isSafeInteger(sequence)
-      || sequence <= 0
-      || sequence <= this.#workHighWater
-      || registered === null) {
-      this.#declareFailure({
-        kind: "invalid-epoch-work-start",
-        producerClass,
-        sequence,
-      });
-      return false;
-    }
-    this.#workHighWater = sequence;
-    const advertised = advertisedAllowance ?? registered;
-    if (!sameAllowance(registered, advertised)) {
-      this.#declareFailure({
-        kind: "epoch-work-allowance-mismatch",
-        producerClass,
-        sequence,
-      });
-      return false;
-    }
-    this.#epochWork.set(sequence, registered);
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#epochToken,
-      kind: "epoch-work-started",
-      workSequence: sequence,
-      allowance: registered,
-    });
-    return true;
+    return this.#realm.startEpochWork(
+      producerClass,
+      sequence,
+      advertisedAllowance,
+    );
   }
 
   finishEpochWork(sequence: number): boolean {
-    if (this.#terminated
-      || !this.#ready
-      || this.#epochToken === null) return false;
-    if (!this.#epochWork.delete(sequence)) {
-      if (!this.#failed) {
-        this.#declareFailure({
-          kind: "invalid-epoch-work-finish",
-          sequence,
-        });
-      }
-      return false;
-    }
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#epochToken,
-      kind: "epoch-work-finished",
-      workSequence: sequence,
-    });
-    return true;
+    return this.#realm.finishEpochWork(sequence);
   }
 
-  #initialize(message: unknown): void {
-    if (this.#terminated) return;
-    const decoded = decodeUnboundInitializationEnvelope(
-      message,
-      this.#options.bootstrap.decoder,
-    );
-    if (decoded.kind === "failure") {
-      this.#failed = true;
-      return;
+  #post(data: RawWorkerToMainEnvelope): void {
+    if (data.kind === "accepted"
+      || data.kind === "rejected"
+      || data.kind === "cancel-acknowledged"
+      || data.kind === "probe-acknowledged") {
+      const correlation = data.kind === "probe-acknowledged"
+        ? String(data.probeSequence)
+        : operationKey(data.operation);
+      if (this.#options.omitResponse?.(data.kind, correlation) === true) return;
     }
-    this.#epochToken = decoded.value.epochToken;
-    this.#idleHeartbeatIntervalMilliseconds
-      = decoded.value.idleHeartbeatIntervalMilliseconds;
-    if (decoded.value.idleAllowanceMilliseconds
-      !== this.#options.producerClasses.idleAllowanceMilliseconds) {
-      this.#startupFailed({
-        kind: "producer-class-idle-allowance-mismatch",
-        expected: decoded.value.idleAllowanceMilliseconds,
-        actual: this.#options.producerClasses.idleAllowanceMilliseconds,
-      });
-      return;
-    }
-    let bootstrap: void | Promise<void>;
-    try {
-      bootstrap = this.#options.bootstrap.bootstrap(decoded.value.bootstrap);
-    } catch (error: unknown) {
-      this.#startupFailed(error);
-      return;
-    }
-    Promise.resolve(bootstrap).then(
-      () => {
-        if (this.#terminated || this.#failed || this.#epochToken === null)
-          return undefined;
-        this.#ready = true;
-        this.#emit({
-          protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-          epochToken: this.#epochToken,
-          kind: "ready",
-          idleHeartbeatIntervalMilliseconds:
-            this.#idleHeartbeatIntervalMilliseconds
-            ?? decoded.value.idleHeartbeatIntervalMilliseconds,
-        });
-        return undefined;
-      },
-      (error: unknown) => {
-        this.#startupFailed(error);
-        return undefined;
-      },
-    );
-  }
-
-  async #processCommand(message: unknown): Promise<void> {
-    if (this.#terminated || this.#failed || this.#epochToken === null) return;
-    const decoded = decodeBoundMainToWorkerEnvelope(
-      message,
-      this.#epochToken,
-    );
-    if (decoded.kind === "failure") {
-      this.#declareFailure(decoded.failure);
-      return;
-    }
-    if (!this.#ready || decoded.value.kind === "initialize") {
-      this.#declareFailure({
-        kind: "illegal-command-state",
-        command: decoded.value.kind,
-      });
-      return;
-    }
-    if (decoded.value.kind === "start") {
-      this.#processStart(decoded.value);
-      return;
-    }
-    if (decoded.value.kind === "cancel") {
-      await this.#processCancel(decoded.value);
-      return;
-    }
-    this.#processProbe(decoded.value.probeSequence);
-  }
-
-  #processStart(
-    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "start" }>,
-  ): void {
-    if (envelope.operation.operationSequence <= this.#operationHighWater) {
-      this.#declareFailure({
-        kind: "operation-sequence-replay",
-        operation: envelope.operation,
-      });
-      return;
-    }
-    this.#operationHighWater = envelope.operation.operationSequence;
-    if (this.#active.has(envelope.operation.operationId)) {
-      this.#declareFailure({
-        kind: "active-operation-id-duplicate",
-        operation: envelope.operation,
-      });
-      return;
-    }
-    const context: FakeWorkerOperationContext = {
-      operation: envelope.operation,
-      cache: this.cache,
-      startEpochWork: (producerClass, sequence, advertisedAllowance) =>
-        this.startEpochWork(producerClass, sequence, advertisedAllowance),
-      finishEpochWork: sequence => this.finishEpochWork(sequence),
-    };
-    const dispatched = this.#options.operations.dispatch(
-      envelope,
-      context,
-      {
-        accepted: (allowance, cancel) => {
-          if (this.#terminated || this.#failed) return false;
-          this.#active.set(envelope.operation.operationId, {
-            operation: envelope.operation,
-            cancel,
-            settling: false,
-          });
-          if (!this.#omit("accepted", operationKey(envelope.operation))) {
-            this.#emit({
-              protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-              epochToken: this.#requiredEpochToken(),
-              kind: "accepted",
-              operation: envelope.operation,
-              allowance,
-            });
-          }
-          return !this.#terminated && !this.#failed;
-        },
-        rejected: (error, diagnostic) => {
-          this.#rejectStart(envelope, error, diagnostic);
-        },
-        settled: settlement => {
-          this.#settle(envelope.operation, settlement);
-        },
-        failed: error => {
-          this.#declareFailure(error);
-        },
-      },
-    );
-    if (dispatched) return;
-    const rejection = this.#options.unknownOperationRejection(
-      envelope.operationKind,
-    );
-    this.#rejectStart(envelope, rejection.error, rejection.diagnostic);
-  }
-
-  async #processCancel(
-    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "cancel" }>,
-  ): Promise<void> {
-    if (envelope.operation.operationSequence > this.#operationHighWater) {
-      this.#declareFailure({
-        kind: "future-cancellation",
-        operation: envelope.operation,
-      });
-      return;
-    }
-    const active = this.#active.get(envelope.operation.operationId);
-    let running = false;
-    if (active !== undefined
-      && active.operation.operationSequence
-        === envelope.operation.operationSequence
-      && !active.settling) {
-      running = active.cancel === null
-        ? false
-        : await active.cancel(envelope.operation, envelope.reason);
-    }
-    if (!this.#omit("cancel-acknowledged", operationKey(envelope.operation))) {
-      this.#emit({
-        protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-        epochToken: this.#requiredEpochToken(),
-        kind: "cancel-acknowledged",
-        operation: envelope.operation,
-        status: running ? "running" : "not-active",
-      });
-    }
-  }
-
-  #processProbe(sequence: number): void {
-    if (this.#omit("probe-acknowledged", String(sequence))) return;
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#requiredEpochToken(),
-      kind: "probe-acknowledged",
-      probeSequence: sequence,
-    });
-  }
-
-  #rejectStart(
-    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "start" }>,
-    error: unknown,
-    diagnostic: unknown,
-  ): void {
-    if (this.#omit("rejected", operationKey(envelope.operation))) return;
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#requiredEpochToken(),
-      kind: "rejected",
-      operation: envelope.operation,
-      error,
-      diagnostic,
-    });
-  }
-
-  #settle(
-    operation: WorkerWireOperationReference,
-    settlement: ManagedOperationSettlement<unknown, unknown, unknown>,
-  ): void {
-    if (this.#terminated) return;
-    const active = this.#active.get(operation.operationId);
-    if (active === undefined
-      || active.operation.operationSequence !== operation.operationSequence) {
-      if (!this.#failed) {
-        this.#declareFailure({
-          kind: "settlement-without-active-operation",
-          operation,
-        });
-      }
-      return;
-    }
-    active.settling = true;
-    this.#active.delete(operation.operationId);
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#requiredEpochToken(),
-      kind: "settled",
-      operation,
-      settlement,
-    });
-  }
-
-  #startupFailed(error: unknown): void {
-    if (this.#terminated || this.#failed || this.#epochToken === null) return;
-    this.#failed = true;
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#epochToken,
-      kind: "startup-failed",
-      diagnostic: this.#options.diagnostic(error),
-    });
-  }
-
-  #declareFailure(detail: unknown): void {
-    if (this.#terminated || this.#failed || this.#epochToken === null) return;
-    this.#failed = true;
-    this.#emit({
-      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
-      epochToken: this.#epochToken,
-      kind: "epoch-failed",
-      diagnostic: this.#options.diagnostic(detail),
-    });
-  }
-
-  #requiredEpochToken(): number {
-    if (this.#epochToken === null)
-      throw new Error("Fake worker has no epoch token.");
-    return this.#epochToken;
-  }
-
-  #omit(
-    kind: "accepted" | "rejected" | "cancel-acknowledged" | "probe-acknowledged",
-    correlation: string,
-  ): boolean {
-    return this.#options.omitResponse?.(kind, correlation) ?? false;
-  }
-
-  #emit(data: RawWorkerToMainEnvelope): void {
-    if (this.#terminated) return;
     this.emittedMessages.push(data);
     this.#handlers?.message(this, data);
   }

--- a/prototypes/inspect-web/src/worker-runtime-realm.ts
+++ b/prototypes/inspect-web/src/worker-runtime-realm.ts
@@ -1,0 +1,701 @@
+import type { OperationCancelReason } from "./operation-authority.ts";
+import type { WorkerProducerClassRegistry } from "./worker-runtime-core.ts";
+import {
+  decodeBoundMainToWorkerEnvelope,
+  decodeStartPayload,
+  decodeUnboundInitializationEnvelope,
+  type BoundedPayloadDecoder,
+  type ManagedOperationSettlement,
+  type RawMainToWorkerEnvelope,
+  type RawWorkerToMainEnvelope,
+  type WorkerEnvelopeDecodeFailure,
+  type WorkerLivenessAllowance,
+  type WorkerWireOperationReference,
+  WORKER_RUNTIME_PROTOCOL_VERSION,
+} from "./worker-runtime-protocol.ts";
+
+export function sameAllowance(
+  left: WorkerLivenessAllowance,
+  right: WorkerLivenessAllowance,
+): boolean {
+  return left.kind === "unbounded"
+    ? right.kind === "unbounded"
+    : right.kind === "bounded"
+      && left.maxSilentActiveMilliseconds
+        === right.maxSilentActiveMilliseconds;
+}
+
+export interface WorkerRuntimeTaskScheduler {
+  enqueue(task: () => void): void;
+}
+
+interface WorkerRuntimeBootstrapAdapter<TBootstrap> {
+  readonly decoder: BoundedPayloadDecoder<TBootstrap>;
+  readonly bootstrap: (
+    bootstrap: TBootstrap,
+  ) => void | Promise<void>;
+}
+
+export interface WorkerOperationContext {
+  readonly operation: WorkerWireOperationReference;
+  readonly cache: WorkerEpochCache;
+  /** Returns false after settlement, realm failure, or disposal. */
+  reportProgress(payload: unknown): boolean;
+  startEpochWork(
+    producerClass: string,
+    sequence: number,
+    advertisedAllowance?: WorkerLivenessAllowance,
+  ): boolean;
+  finishEpochWork(sequence: number): boolean;
+}
+
+export interface WorkerEpochCache {
+  readonly size: number;
+  get(key: string): unknown;
+  set(key: string, value: unknown): boolean;
+  has(key: string): boolean;
+  delete(key: string): boolean;
+}
+
+class RevocableWorkerEpochCache implements WorkerEpochCache {
+  readonly #entries = new Map<string, unknown>();
+  #active = true;
+
+  get size(): number {
+    return this.#entries.size;
+  }
+
+  get(key: string): unknown {
+    return this.#active ? this.#entries.get(key) : undefined;
+  }
+
+  set(key: string, value: unknown): boolean {
+    if (!this.#active) return false;
+    this.#entries.set(key, value);
+    return true;
+  }
+
+  has(key: string): boolean {
+    return this.#active && this.#entries.has(key);
+  }
+
+  delete(key: string): boolean {
+    return this.#active && this.#entries.delete(key);
+  }
+
+  revoke(): void {
+    this.#active = false;
+    this.#entries.clear();
+  }
+}
+
+export interface WorkerOperationRegistration<
+  TInput,
+  TValue,
+  TError,
+  TOperationDiagnostic,
+> {
+  readonly kind: string;
+  readonly allowance: WorkerLivenessAllowance;
+  readonly input: BoundedPayloadDecoder<TInput>;
+  readonly rejectInvalidPayload: (
+    failure: WorkerEnvelopeDecodeFailure,
+  ) => {
+    readonly error: TError;
+    readonly diagnostic: TOperationDiagnostic;
+  };
+  readonly invoke: (
+    input: TInput,
+    context: WorkerOperationContext,
+  ) => ManagedOperationSettlement<TValue, TError, TOperationDiagnostic>
+    | Promise<
+      ManagedOperationSettlement<TValue, TError, TOperationDiagnostic>
+    >;
+  readonly cancel?: (
+    operation: WorkerWireOperationReference,
+    reason: OperationCancelReason,
+  ) => boolean | Promise<boolean>;
+}
+
+type WorkerCancel = (
+  operation: WorkerWireOperationReference,
+  reason: OperationCancelReason,
+) => boolean | Promise<boolean>;
+
+interface WorkerOperationDispatchHandlers {
+  readonly accepted: (
+    allowance: WorkerLivenessAllowance,
+    cancel: WorkerCancel | null,
+  ) => boolean;
+  readonly rejected: (error: unknown, diagnostic: unknown) => void;
+  readonly settled: (
+    settlement: ManagedOperationSettlement<unknown, unknown, unknown>,
+  ) => void;
+  readonly failed: (error: unknown) => void;
+}
+
+interface ErasedWorkerOperationRegistration {
+  readonly kind: string;
+  readonly dispatch: (
+    envelope: Extract<
+      RawMainToWorkerEnvelope,
+      { readonly kind: "start" }
+    >,
+    context: WorkerOperationContext,
+    handlers: WorkerOperationDispatchHandlers,
+  ) => void;
+}
+
+function eraseSettlement<TValue, TError, TDiagnostic>(
+  settlement: ManagedOperationSettlement<TValue, TError, TDiagnostic>,
+): ManagedOperationSettlement<unknown, unknown, unknown> {
+  if (settlement.kind === "succeeded")
+    return { kind: "succeeded", value: settlement.value };
+  if (settlement.kind === "failed") {
+    return {
+      kind: "failed",
+      failureKind: settlement.failureKind,
+      error: settlement.error,
+      diagnostic: settlement.diagnostic,
+    };
+  }
+  return { kind: "canceled", reason: settlement.reason };
+}
+
+export class WorkerOperationCatalog {
+  readonly #registrations =
+    new Map<string, ErasedWorkerOperationRegistration>();
+
+  register<TInput, TValue, TError, TOperationDiagnostic>(
+    registration: WorkerOperationRegistration<
+      TInput,
+      TValue,
+      TError,
+      TOperationDiagnostic
+    >,
+  ): void {
+    if (this.#registrations.has(registration.kind))
+      throw new Error(`Worker operation ${registration.kind} is duplicated.`);
+    const erased: ErasedWorkerOperationRegistration = {
+      kind: registration.kind,
+      dispatch: (envelope, context, handlers) => {
+        const decoded = decodeStartPayload(envelope, registration.input);
+        if (decoded.kind === "failure") {
+          const rejection = registration.rejectInvalidPayload(
+            decoded.failure,
+          );
+          handlers.rejected(rejection.error, rejection.diagnostic);
+          return;
+        }
+        const cancel = registration.cancel;
+        const accepted = handlers.accepted(
+          registration.allowance,
+          cancel === undefined
+            ? null
+            : (operation, reason) => cancel(operation, reason),
+        );
+        if (!accepted) return;
+        let result:
+          | ManagedOperationSettlement<
+            TValue,
+            TError,
+            TOperationDiagnostic
+          >
+          | Promise<
+            ManagedOperationSettlement<
+              TValue,
+              TError,
+              TOperationDiagnostic
+            >
+          >;
+        try {
+          result = registration.invoke(decoded.value.payload, context);
+        } catch (error: unknown) {
+          handlers.failed(error);
+          return;
+        }
+        Promise.resolve(result).then(
+          settlement => {
+            handlers.settled(eraseSettlement(settlement));
+            return undefined;
+          },
+          (error: unknown) => {
+            handlers.failed(error);
+            return undefined;
+          },
+        );
+      },
+    };
+    this.#registrations.set(registration.kind, erased);
+  }
+
+  dispatch(
+    envelope: Extract<
+      RawMainToWorkerEnvelope,
+      { readonly kind: "start" }
+    >,
+    context: WorkerOperationContext,
+    handlers: WorkerOperationDispatchHandlers,
+  ): boolean {
+    const registration = this.#registrations.get(envelope.operationKind);
+    if (registration === undefined) return false;
+    registration.dispatch(envelope, context, handlers);
+    return true;
+  }
+}
+
+export interface WorkerRuntimeRealmOptions<TBootstrap, TDiagnostic> {
+  /** Optional initialization task dispatch; omit for synchronous decoding. */
+  readonly scheduler?: WorkerRuntimeTaskScheduler;
+  readonly bootstrap: WorkerRuntimeBootstrapAdapter<TBootstrap>;
+  readonly diagnostic: (detail: unknown) => TDiagnostic;
+  readonly unknownOperationRejection: (kind: string) => {
+    readonly error: unknown;
+    readonly diagnostic: unknown;
+  };
+  readonly operations: WorkerOperationCatalog;
+  readonly producerClasses: WorkerProducerClassRegistry;
+  /** One ordered output channel, normally the Worker's global postMessage. */
+  readonly post: (message: RawWorkerToMainEnvelope) => void;
+}
+
+interface WorkerActiveOperation {
+  readonly operation: WorkerWireOperationReference;
+  readonly cancel: WorkerCancel | null;
+  settling: boolean;
+}
+
+export class WorkerRuntimeRealm<TBootstrap, TDiagnostic> {
+  readonly #cache = new RevocableWorkerEpochCache();
+  readonly #options: WorkerRuntimeRealmOptions<TBootstrap, TDiagnostic>;
+  readonly #active = new Map<string, WorkerActiveOperation>();
+  readonly #epochWork = new Map<number, WorkerLivenessAllowance>();
+  #epochToken: number | null = null;
+  #idleHeartbeatIntervalMilliseconds: number | null = null;
+  #operationHighWater = 0;
+  #workHighWater = 0;
+  #lane: Promise<void> = Promise.resolve();
+  #initialized = false;
+  #ready = false;
+  #failed = false;
+  #terminated = false;
+
+  constructor(
+    options: WorkerRuntimeRealmOptions<TBootstrap, TDiagnostic>,
+  ) {
+    this.#options = options;
+  }
+
+  get cache(): WorkerEpochCache {
+    return this.#cache;
+  }
+
+  get activeOperationCount(): number {
+    return this.#active.size;
+  }
+
+  get activeEpochWorkCount(): number {
+    return this.#epochWork.size;
+  }
+
+  get disposed(): boolean {
+    return this.#terminated;
+  }
+
+  /**
+   * Invalid initialization throws with the decode failure as its cause, since
+   * no validated epoch token exists for a response. An optional scheduler
+   * receives that throw in its initialization task instead of this call.
+   */
+  receive(message: unknown): void {
+    if (this.#terminated) return;
+    if (!this.#initialized) {
+      this.#initialized = true;
+      if (this.#options.scheduler === undefined) {
+        this.#initialize(message);
+      } else {
+        this.#options.scheduler.enqueue(() => {
+          this.#initialize(message);
+        });
+      }
+      return;
+    }
+    this.#lane = this.#lane.then(() => this.#processCommand(message));
+    this.#lane.catch((error: unknown) => {
+      this.#declareFailure(error);
+    });
+  }
+
+  /** Revokes local callback authority; the transport owns Worker destruction. */
+  dispose(): void {
+    if (this.#terminated) return;
+    this.#terminated = true;
+    this.#active.clear();
+    this.#epochWork.clear();
+    this.#cache.revoke();
+  }
+
+  emitHeartbeat(): void {
+    if (!this.#ready || this.#epochToken === null) return;
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#epochToken,
+      kind: "heartbeat",
+    });
+  }
+
+  /**
+   * Reports StartupFailed before readiness or EpochFailed afterwards, allowing
+   * admitted physical release until disposal. Before binding, throws instead.
+   */
+  fail(detail: unknown): void {
+    if (this.#terminated) return;
+    if (this.#epochToken === null) {
+      this.#failed = true;
+      throw new Error("Worker realm failed before initialization.", {
+        cause: detail,
+      });
+    }
+    if (!this.#ready) this.#startupFailed(detail);
+    else this.#declareFailure(detail);
+  }
+
+  startEpochWork(
+    producerClass: string,
+    sequence: number,
+    advertisedAllowance?: WorkerLivenessAllowance,
+  ): boolean {
+    if (this.#terminated
+      || !this.#ready
+      || this.#failed
+      || this.#epochToken === null) return false;
+    const registered = this.#options.producerClasses.allowance(producerClass);
+    if (!Number.isSafeInteger(sequence)
+      || sequence <= 0
+      || sequence <= this.#workHighWater
+      || registered === null) {
+      this.#declareFailure({
+        kind: "invalid-epoch-work-start",
+        producerClass,
+        sequence,
+      });
+      return false;
+    }
+    this.#workHighWater = sequence;
+    const advertised = advertisedAllowance ?? registered;
+    if (!sameAllowance(registered, advertised)) {
+      this.#declareFailure({
+        kind: "epoch-work-allowance-mismatch",
+        producerClass,
+        sequence,
+      });
+      return false;
+    }
+    this.#epochWork.set(sequence, registered);
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#epochToken,
+      kind: "epoch-work-started",
+      workSequence: sequence,
+      allowance: registered,
+    });
+    return true;
+  }
+
+  finishEpochWork(sequence: number): boolean {
+    if (this.#terminated
+      || !this.#ready
+      || this.#epochToken === null) return false;
+    if (!this.#epochWork.delete(sequence)) {
+      if (!this.#failed) {
+        this.#declareFailure({
+          kind: "invalid-epoch-work-finish",
+          sequence,
+        });
+      }
+      return false;
+    }
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#epochToken,
+      kind: "epoch-work-finished",
+      workSequence: sequence,
+    });
+    return true;
+  }
+
+  #initialize(message: unknown): void {
+    if (this.#terminated) return;
+    const decoded = decodeUnboundInitializationEnvelope(
+      message,
+      this.#options.bootstrap.decoder,
+    );
+    if (decoded.kind === "failure") {
+      this.#failed = true;
+      throw new Error("Worker initialization envelope was rejected.", {
+        cause: decoded.failure,
+      });
+    }
+    this.#epochToken = decoded.value.epochToken;
+    this.#idleHeartbeatIntervalMilliseconds
+      = decoded.value.idleHeartbeatIntervalMilliseconds;
+    if (decoded.value.idleAllowanceMilliseconds
+      !== this.#options.producerClasses.idleAllowanceMilliseconds) {
+      this.#startupFailed({
+        kind: "producer-class-idle-allowance-mismatch",
+        expected: decoded.value.idleAllowanceMilliseconds,
+        actual: this.#options.producerClasses.idleAllowanceMilliseconds,
+      });
+      return;
+    }
+    let bootstrap: void | Promise<void>;
+    try {
+      bootstrap = this.#options.bootstrap.bootstrap(decoded.value.bootstrap);
+    } catch (error: unknown) {
+      this.#startupFailed(error);
+      return;
+    }
+    Promise.resolve(bootstrap).then(
+      () => {
+        if (this.#terminated || this.#failed || this.#epochToken === null)
+          return undefined;
+        this.#ready = true;
+        this.#emit({
+          protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+          epochToken: this.#epochToken,
+          kind: "ready",
+          idleHeartbeatIntervalMilliseconds:
+            this.#idleHeartbeatIntervalMilliseconds
+            ?? decoded.value.idleHeartbeatIntervalMilliseconds,
+        });
+        return undefined;
+      },
+      (error: unknown) => {
+        this.#startupFailed(error);
+        return undefined;
+      },
+    );
+  }
+
+  async #processCommand(message: unknown): Promise<void> {
+    if (this.#terminated || this.#failed || this.#epochToken === null) return;
+    const decoded = decodeBoundMainToWorkerEnvelope(
+      message,
+      this.#epochToken,
+    );
+    if (decoded.kind === "failure") {
+      this.#declareFailure(decoded.failure);
+      return;
+    }
+    if (!this.#ready || decoded.value.kind === "initialize") {
+      this.#declareFailure({
+        kind: "illegal-command-state",
+        command: decoded.value.kind,
+      });
+      return;
+    }
+    if (decoded.value.kind === "start") {
+      this.#processStart(decoded.value);
+      return;
+    }
+    if (decoded.value.kind === "cancel") {
+      await this.#processCancel(decoded.value);
+      return;
+    }
+    this.#processProbe(decoded.value.probeSequence);
+  }
+
+  #processStart(
+    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "start" }>,
+  ): void {
+    if (envelope.operation.operationSequence <= this.#operationHighWater) {
+      this.#declareFailure({
+        kind: "operation-sequence-replay",
+        operation: envelope.operation,
+      });
+      return;
+    }
+    this.#operationHighWater = envelope.operation.operationSequence;
+    if (this.#active.has(envelope.operation.operationId)) {
+      this.#declareFailure({
+        kind: "active-operation-id-duplicate",
+        operation: envelope.operation,
+      });
+      return;
+    }
+    let admitted: WorkerActiveOperation | null = null;
+    const context: WorkerOperationContext = {
+      operation: envelope.operation,
+      cache: this.cache,
+      reportProgress: payload => {
+        if (this.#terminated
+          || this.#failed
+          || admitted === null
+          || admitted.settling
+          || this.#active.get(envelope.operation.operationId) !== admitted)
+          return false;
+        this.#emit({
+          protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+          epochToken: this.#requiredEpochToken(),
+          kind: "progress",
+          operation: envelope.operation,
+          payload,
+        });
+        return true;
+      },
+      startEpochWork: (producerClass, sequence, advertisedAllowance) =>
+        this.startEpochWork(producerClass, sequence, advertisedAllowance),
+      finishEpochWork: sequence => this.finishEpochWork(sequence),
+    };
+    const dispatched = this.#options.operations.dispatch(
+      envelope,
+      context,
+      {
+        accepted: (allowance, cancel) => {
+          if (this.#terminated || this.#failed) return false;
+          admitted = {
+            operation: envelope.operation,
+            cancel,
+            settling: false,
+          };
+          this.#active.set(envelope.operation.operationId, admitted);
+          this.#emit({
+            protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+            epochToken: this.#requiredEpochToken(),
+            kind: "accepted",
+            operation: envelope.operation,
+            allowance,
+          });
+          return !this.#terminated && !this.#failed;
+        },
+        rejected: (error, diagnostic) => {
+          this.#rejectStart(envelope, error, diagnostic);
+        },
+        settled: settlement => {
+          this.#settle(envelope.operation, settlement);
+        },
+        failed: error => {
+          this.#declareFailure(error);
+        },
+      },
+    );
+    if (dispatched) return;
+    const rejection = this.#options.unknownOperationRejection(
+      envelope.operationKind,
+    );
+    this.#rejectStart(envelope, rejection.error, rejection.diagnostic);
+  }
+
+  async #processCancel(
+    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "cancel" }>,
+  ): Promise<void> {
+    if (envelope.operation.operationSequence > this.#operationHighWater) {
+      this.#declareFailure({
+        kind: "future-cancellation",
+        operation: envelope.operation,
+      });
+      return;
+    }
+    const active = this.#active.get(envelope.operation.operationId);
+    let running = false;
+    if (active !== undefined
+      && active.operation.operationSequence
+        === envelope.operation.operationSequence
+      && !active.settling) {
+      running = active.cancel === null
+        ? false
+        : await active.cancel(envelope.operation, envelope.reason);
+    }
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#requiredEpochToken(),
+      kind: "cancel-acknowledged",
+      operation: envelope.operation,
+      status: running ? "running" : "not-active",
+    });
+  }
+
+  #processProbe(sequence: number): void {
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#requiredEpochToken(),
+      kind: "probe-acknowledged",
+      probeSequence: sequence,
+    });
+  }
+
+  #rejectStart(
+    envelope: Extract<RawMainToWorkerEnvelope, { readonly kind: "start" }>,
+    error: unknown,
+    diagnostic: unknown,
+  ): void {
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#requiredEpochToken(),
+      kind: "rejected",
+      operation: envelope.operation,
+      error,
+      diagnostic,
+    });
+  }
+
+  #settle(
+    operation: WorkerWireOperationReference,
+    settlement: ManagedOperationSettlement<unknown, unknown, unknown>,
+  ): void {
+    if (this.#terminated) return;
+    const active = this.#active.get(operation.operationId);
+    if (active === undefined
+      || active.operation.operationSequence !== operation.operationSequence) {
+      if (!this.#failed) {
+        this.#declareFailure({
+          kind: "settlement-without-active-operation",
+          operation,
+        });
+      }
+      return;
+    }
+    active.settling = true;
+    this.#active.delete(operation.operationId);
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#requiredEpochToken(),
+      kind: "settled",
+      operation,
+      settlement,
+    });
+  }
+
+  #startupFailed(error: unknown): void {
+    if (this.#terminated || this.#failed || this.#epochToken === null) return;
+    this.#failed = true;
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#epochToken,
+      kind: "startup-failed",
+      diagnostic: this.#options.diagnostic(error),
+    });
+  }
+
+  #declareFailure(detail: unknown): void {
+    if (this.#terminated || this.#failed || this.#epochToken === null) return;
+    this.#failed = true;
+    this.#emit({
+      protocolVersion: WORKER_RUNTIME_PROTOCOL_VERSION,
+      epochToken: this.#epochToken,
+      kind: "epoch-failed",
+      diagnostic: this.#options.diagnostic(detail),
+    });
+  }
+
+  #requiredEpochToken(): number {
+    if (this.#epochToken === null)
+      throw new Error("Worker realm has no epoch token.");
+    return this.#epochToken;
+  }
+
+  #emit(data: RawWorkerToMainEnvelope): void {
+    if (this.#terminated) return;
+    this.#options.post(data);
+  }
+}

--- a/prototypes/inspect-web/test/runtime-loader.test.ts
+++ b/prototypes/inspect-web/test/runtime-loader.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import type { TestContext } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { publishRuntimeLoader } from "../scripts/publish-runtime-loader.ts";
+
+const publishScript = fileURLToPath(
+  new URL("../scripts/publish-runtime-loader.ts", import.meta.url),
+);
+const smokeScript = fileURLToPath(
+  new URL("../scripts/verify-published-engine-facades.ts", import.meta.url),
+);
+const sourceRoot = fileURLToPath(new URL("../engine/wwwroot/", import.meta.url));
+const target = "./_framework/dotnet.fingerprint.js";
+const sdkSource = 'export const dotnet = { identity: "SDK runtime" };\n';
+
+function createSite(context: TestContext): string {
+  const site = mkdtempSync(join(tmpdir(), "inspect-web-runtime-loader-"));
+  context.after(() => rmSync(site, { recursive: true, force: true }));
+  mkdirSync(join(site, "_framework"));
+  writeFileSync(join(site, "package.json"), '{"type":"module"}\n');
+  writeFileSync(join(site, target), sdkSource);
+  writeFileSync(
+    join(site, "index.html"),
+    `<script type="importmap">${JSON.stringify({
+      imports: { "./_framework/dotnet.js": target },
+    }, null, 2)}</script>`,
+  );
+  return site;
+}
+
+test("publication emits the exact SDK runtime target without an import map", async (context) => {
+  const site = createSite(context);
+  const result = spawnSync(process.execPath, [publishScript, site], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    readFileSync(join(site, "runtime-loader.js"), "utf8"),
+    `export { dotnet } from "${target}";\n`,
+  );
+  const loader: unknown = await import(
+    pathToFileURL(join(site, "runtime-loader.js")).href,
+  );
+  const sdk: unknown = await import(pathToFileURL(join(site, target)).href);
+  assert.deepEqual(loader, sdk);
+  assert.equal(readFileSync(join(site, target), "utf8"), sdkSource);
+  assert.equal(existsSync(join(site, "_framework/dotnet.js")), false);
+});
+
+test("publication replaces the loader with a newly selected fingerprint", (context) => {
+  const site = createSite(context);
+  publishRuntimeLoader(site);
+  const nextTarget = "./_framework/dotnet.next-fingerprint.js";
+  writeFileSync(join(site, nextTarget), sdkSource);
+  writeFileSync(
+    join(site, "index.html"),
+    `<script type="importmap">${JSON.stringify({
+      imports: { "./_framework/dotnet.js": nextTarget },
+    })}</script>`,
+  );
+
+  publishRuntimeLoader(site);
+
+  assert.equal(
+    readFileSync(join(site, "runtime-loader.js"), "utf8"),
+    `export { dotnet } from "${nextTarget}";\n`,
+  );
+});
+
+for (const [label, imports] of [
+  ["missing", {}],
+  ["non-string", { "./_framework/dotnet.js": 42 }],
+  ["unfingerprinted", { "./_framework/dotnet.js": "./_framework/dotnet.js" }],
+  ["non-JavaScript", { "./_framework/dotnet.js": "./_framework/dotnet.hash.wasm" }],
+] as const) {
+  test(`publication fails visibly for a ${label} mapping`, (context) => {
+    const site = createSite(context);
+    writeFileSync(
+      join(site, "index.html"),
+      `<script type="importmap">${JSON.stringify({ imports })}</script>`,
+    );
+    const result = spawnSync(process.execPath, [publishScript, site], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no valid fingerprinted dotnet\.js mapping/);
+    assert.equal(existsSync(join(site, "runtime-loader.js")), false);
+  });
+}
+
+test("publication fails visibly when the mapped runtime is missing", (context) => {
+  const site = createSite(context);
+  rmSync(join(site, target));
+
+  const result = spawnSync(process.execPath, [publishScript, site], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Published runtime module .* is missing/);
+  assert.equal(existsSync(join(site, "runtime-loader.js")), false);
+});
+
+test("the source loader re-exports the SDK build runtime", async (context) => {
+  const site = createSite(context);
+  copyFileSync(join(sourceRoot, "runtime-loader.js"), join(site, "runtime-loader.js"));
+  writeFileSync(join(site, "_framework/dotnet.js"), sdkSource);
+
+  const loader: unknown = await import(
+    pathToFileURL(join(site, "runtime-loader.js")).href,
+  );
+  const sdk: unknown = await import(
+    pathToFileURL(join(site, "_framework/dotnet.js")).href,
+  );
+
+  assert.deepEqual(loader, sdk);
+});
+
+test("published facade smoke restores the exact loader after runtime failure", (context) => {
+  const site = createSite(context);
+  for (const facade of readdirSync(sourceRoot).filter(
+    name => name.startsWith("inspect-web-") && name.endsWith(".js"),
+  )) {
+    copyFileSync(join(sourceRoot, facade), join(site, facade));
+  }
+  writeFileSync(
+    join(site, target),
+    'export const dotnet = { create() { throw new Error("runtime fixture failed"); } };\n',
+  );
+  publishRuntimeLoader(site);
+  const original = readFileSync(join(site, "runtime-loader.js"));
+
+  const result = spawnSync(process.execPath, [smokeScript, site, "deployment"], {
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /runtime fixture failed/);
+  assert.deepEqual(readFileSync(join(site, "runtime-loader.js")), original);
+  assert.equal(existsSync(join(site, "_framework/dotnet.js")), false);
+});

--- a/prototypes/inspect-web/test/toolchain.test.ts
+++ b/prototypes/inspect-web/test/toolchain.test.ts
@@ -179,7 +179,7 @@ test("TypeScript compiler contexts keep Node globals out of browser source", () 
   assert.deepEqual(testTsconfig.compilerOptions.types, ["node"]);
   assert.deepEqual(
     testTsconfig.include,
-    ["./**/*.ts", "../browser/**/*.ts", "../playwright.config.ts"],
+    ["./**/*.ts", "../browser/**/*.ts", "../playwright.config.ts", "../playwright.worker.config.ts"],
   );
   // The toolchain scripts and the Vite config are Node programs rather than browser
   // source, so they get Node globals from their own project instead of widening the
@@ -390,6 +390,7 @@ const generatedFacadeSources =
   facadeModules.map(module => `engine/facades/${module}.ts`);
 const publishedFacadeModules =
   facadeModules.map(module => `engine/wwwroot/${module}.js`);
+const runtimeLoaderSource = "engine/wwwroot/runtime-loader.js";
 
 const typeScriptExtensions = typeScriptSourceExtensions;
 const javaScriptExtensions = javaScriptSourceExtensions;
@@ -400,9 +401,12 @@ test("no source file suppresses type checking", () => {
   // Round 3 (Sol) hid a suppression directive in `scripts/probe.mts`: the scan asked only
   // for `.ts` while the compiler happily reads all four TypeScript extensions, so a file
   // the program did type-check could turn that checking off and say nothing.
-  const files = projectFiles(typeScriptExtensions);
+  const files = [
+    ...projectFiles(typeScriptExtensions),
+    resolve(root, runtimeLoaderSource),
+  ];
 
-  assert.ok(files.length > 50, `expected the TypeScript sources, found ${files.length}`);
+  assert.ok(files.length > 50, `expected the checked sources, found ${files.length}`);
   const suppressionPattern = new RegExp(
     ["nocheck", "ignore"].map(directive => `@ts-${directive}`).join("|"),
   );
@@ -425,11 +429,9 @@ test("no source file suppresses type checking", () => {
 // exemption for free. Those files are TypeScript now, and the one remaining exemption is
 // the compiler-derived engine facade, which is Wasm build output rather than authored source.
 //
-// Rather than restate that file name twice, the two sets are asserted against each other:
-// the JavaScript actually present must be exactly the JavaScript actually exempted. A new
-// authored file fails, a widened exemption fails, and an exemption left behind by a
-// deleted file fails too.
-test("the only JavaScript is the file the lint exemption names", () => {
+// The authored runtime loader is checked against the SDK declaration in the facade
+// compiler program. Only the compiler-derived facades receive lint exemptions.
+test("JavaScript is either compiler-derived or the SDK-checked runtime loader", () => {
   const root = fileURLToPath(new URL("../", import.meta.url));
   const present = projectFiles(javaScriptExtensions)
     .map(file => projectRelative(root, file))
@@ -440,11 +442,11 @@ test("the only JavaScript is the file the lint exemption names", () => {
     .filter(file => javaScriptExtensions.some(extension => file.endsWith(extension)))
     .sort();
 
-  assert.deepEqual(present, [...publishedFacadeModules].sort(),
+  assert.deepEqual(present, [...publishedFacadeModules, runtimeLoaderSource].sort(),
     "authored JavaScript here would be checked by neither the compiler nor the "
       + "type-aware lint rules the rest of the project is held to");
-  assert.deepEqual(exempted, present,
-    "the lint exemption and the JavaScript it covers must name the same files");
+  assert.deepEqual(exempted, [...publishedFacadeModules].sort(),
+    "only compiler-derived facades may receive the JavaScript lint exemption");
 });
 
 // Every gate in this file accounts for *files*: the compiler builds a program out of
@@ -1118,6 +1120,14 @@ test("the generated facade TypeScript uses its SDK-owned compiler gates", () => 
   assert.match(
     engineGenerationScript,
     /"\$tsc" -p "\$scratch\/sources\/tsconfig\.json"/);
+  assert.match(engineGenerationScript, /"allowJs": true/);
+  assert.match(engineGenerationScript, /"checkJs": true/);
+  assert.match(
+    engineGenerationScript,
+    /cp "\$js_output_directory\/runtime-loader\.js" "\$scratch\/sources\/runtime-loader\.js"/);
+  assert.match(
+    engineGenerationScript,
+    /printf ', "runtime-loader\.js"\]/);
   // The whole set is compiled by one program built from an exact file inventory, not from a
   // directory glob that would admit an unowned source.
   assert.match(
@@ -1515,6 +1525,7 @@ test("the lint covers every file the bundler reads", async () => {
   // `src/styles.css` is style content. It sits under a lint target, but oxlint reads
   // script and the compiler has no account of a stylesheet at all, so it cannot clear
   // either half of the test below. A browser will not execute it either.
+  // The module Worker build also reads `tsconfig.json` as configuration, not source.
   //
   // Pinning the exact list is what makes this fail closed. Anything else the build reads
   // changes it and fails -- including a second stylesheet, which is a small cost for a
@@ -1525,6 +1536,7 @@ test("the lint covers every file the bundler reads", async () => {
     "../annotated-source-viewer/src/document-model.js",
     "index.html",
     "src/styles.css",
+    "tsconfig.json",
   ];
 
   const targets = lintTargets;
@@ -2842,8 +2854,8 @@ test("the analysis host check matches locked native packages and lint wiring", (
       + "managed-operation-bridge-canary/initialize.ts "
       + "managed-operation-bridge-canary/exercise.ts "
       + "managed-operation-bridge-canary/facades engine/facades "
-      + `${publishedFacadeModules.join(" ")} vite.config.ts `
-      + "playwright.config.ts && "
+      + `${publishedFacadeModules.join(" ")} ${runtimeLoaderSource} vite.config.ts `
+      + "playwright.config.ts playwright.worker.config.ts && "
       + "html-validate --config .htmlvalidate.json \"**/*.{html,htm,xhtml}\"",
   );
 });

--- a/prototypes/inspect-web/test/tsconfig.json
+++ b/prototypes/inspect-web/test/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["./**/*.ts", "../browser/**/*.ts", "../playwright.config.ts"]
+  "include": ["./**/*.ts", "../browser/**/*.ts", "../playwright.config.ts", "../playwright.worker.config.ts"]
 }

--- a/prototypes/inspect-web/test/worker-runtime-browser.test.ts
+++ b/prototypes/inspect-web/test/worker-runtime-browser.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BrowserWorkerRuntimeEnvironment } from "../src/worker-runtime-browser.ts";
+import {
+  FakeWorkerOperationCatalog,
+  FakeWorkerRuntime,
+  ManualWorkerRuntimeEnvironment,
+  QueueWorkerRuntimeTransportFactory,
+  WorkerProducerClassRegistry,
+  WorkerRuntimeHost,
+} from "../src/worker-runtime-core.ts";
+import { engineWorkerText } from "../src/engine-worker-contract.ts";
+
+class LifecycleDocument extends EventTarget {
+  hidden = false;
+}
+
+function environment(initiallyHidden = false) {
+  const document = new LifecycleDocument();
+  document.hidden = initiallyHidden;
+  const window = new EventTarget();
+  let time = 0;
+  let tick: (() => void) | undefined;
+  const events: string[] = [];
+  const runtime = new BrowserWorkerRuntimeEnvironment({
+    document,
+    window,
+    now: () => time,
+    pollIntervalMilliseconds: 10,
+    schedulingToleranceMilliseconds: 20,
+    schedule: callback => {
+      tick = callback;
+      return () => { tick = undefined; };
+    },
+  });
+  const stopClock = runtime.clock.subscribe(() => {
+    events.push(`clock:${runtime.clock.now()}`);
+  });
+  const stopLifecycle = runtime.lifecycle.subscribe({
+    suspended: () => events.push("suspended"),
+    resumed: () => events.push("resumed"),
+    mainLoopRecovered: gap => {
+      events.push(`gap:${gap}:now:${runtime.clock.now()}`);
+    },
+  });
+  return {
+    document,
+    window,
+    runtime,
+    events,
+    advance(milliseconds: number, notify = true) {
+      time += milliseconds;
+      if (notify) tick?.();
+    },
+    hasTimer: () => tick !== undefined,
+    stopClock,
+    stopLifecycle,
+  };
+}
+
+test("browser active time pauses until every lifecycle suspension clears", () => {
+  const state = environment();
+  state.advance(10);
+  state.document.hidden = true;
+  state.document.dispatchEvent(new Event("visibilitychange"));
+  state.window.dispatchEvent(new Event("pagehide"));
+  state.document.dispatchEvent(new Event("freeze"));
+  state.advance(500);
+  assert.equal(state.runtime.clock.now(), 10);
+  state.document.hidden = false;
+  state.document.dispatchEvent(new Event("visibilitychange"));
+  state.window.dispatchEvent(new Event("pageshow"));
+  state.advance(500);
+  assert.equal(state.runtime.clock.now(), 10);
+  state.document.dispatchEvent(new Event("resume"));
+  state.advance(10);
+  assert.equal(state.runtime.clock.now(), 20);
+  assert.deepEqual(
+    state.events.filter(event => !event.startsWith("clock:")),
+    ["suspended", "resumed"],
+  );
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("an initially hidden document has no active startup elapsed time", () => {
+  const state = environment(true);
+  state.advance(10_000);
+  assert.equal(state.runtime.clock.now(), 0);
+  state.document.hidden = false;
+  state.document.dispatchEvent(new Event("visibilitychange"));
+  state.advance(10);
+  assert.equal(state.runtime.clock.now(), 10);
+  assert.equal(state.events.some(event => event.startsWith("gap:")), false);
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("a delayed timer reports one gap before deadline evaluation", () => {
+  const state = environment();
+  state.advance(10);
+  state.events.length = 0;
+  state.advance(1_000);
+  assert.deepEqual(state.events, ["gap:1000:now:1010", "clock:1010"]);
+  state.advance(10);
+  assert.equal(state.events.filter(event => event.startsWith("gap:")).length, 1);
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("a message-time clock read notices a gap before the timer runs", () => {
+  const state = environment();
+  state.advance(2_000, false);
+  assert.equal(state.runtime.clock.now(), 2_000);
+  assert.deepEqual(state.events, ["gap:2000:now:2000"]);
+  state.advance(0);
+  assert.deepEqual(state.events, ["gap:2000:now:2000", "clock:2000"]);
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("ordinary scheduling tolerance remains active time", () => {
+  const state = environment();
+  state.advance(30);
+  assert.equal(state.runtime.clock.now(), 30);
+  assert.deepEqual(state.events, ["clock:30"]);
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("the last subscription releases the timer and browser event listeners", () => {
+  const state = environment();
+  state.stopClock();
+  assert.equal(state.hasTimer(), true);
+  state.stopLifecycle();
+  assert.equal(state.hasTimer(), false);
+  const before = [...state.events];
+  state.document.dispatchEvent(new Event("freeze"));
+  state.window.dispatchEvent(new Event("pagehide"));
+  state.advance(1_000);
+  assert.deepEqual(state.events, before);
+  assert.equal(state.runtime.clock.now(), 0);
+});
+
+function nativeClockHost(state: ReturnType<typeof environment>) {
+  const scheduler = new ManualWorkerRuntimeEnvironment();
+  const worker = new FakeWorkerRuntime({
+    scheduler,
+    bootstrap: { decoder: engineWorkerText, bootstrap: () => undefined },
+    diagnostic: () => "Worker failure.",
+    unknownOperationRejection: () => ({ error: "Unknown operation.", diagnostic: "Unknown operation." }),
+    operations: new FakeWorkerOperationCatalog(),
+    producerClasses: new WorkerProducerClassRegistry(30),
+  });
+  const failures: string[] = [];
+  const released: number[] = [];
+  const host = new WorkerRuntimeHost({
+    transport: new QueueWorkerRuntimeTransportFactory([worker]),
+    clock: state.runtime.clock,
+    lifecycle: state.runtime.lifecycle,
+    bootstrap: { encode: engineWorkerText.decode, diagnostic: engineWorkerText },
+    diagnostic: engineWorkerText,
+    createDiagnostic: kind => kind,
+    callbacks: {
+      failure: failure => { failures.push(failure.kind); return undefined; },
+      diagnostic: diagnostic => { assert.fail(diagnostic.kind); },
+      realmReleased: epoch => { released.push(epoch); return undefined; },
+    },
+    producerClasses: new WorkerProducerClassRegistry(30),
+    idleHeartbeatIntervalMilliseconds: 10,
+    schedulingToleranceMilliseconds: 20,
+    startupBudgetMilliseconds: 100,
+    controlResponseGraceMilliseconds: 50,
+    drainBudgetMilliseconds: 20,
+  });
+  assert.equal(host.start("").kind, "started");
+  return { host, scheduler, worker, failures, released };
+}
+
+test("native visibility preserves the real host startup budget", async () => {
+  const state = environment(true);
+  const { host, scheduler, failures } = nativeClockHost(state);
+  state.advance(10_000);
+  assert.equal(host.snapshot().phase, "starting");
+  state.document.hidden = false;
+  state.document.dispatchEvent(new Event("visibilitychange"));
+  state.advance(20);
+  await scheduler.flushAsync();
+  assert.equal(host.snapshot().phase, "ready");
+  assert.deepEqual(failures, []);
+  host.dispose();
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("native scheduling recovery preserves remaining startup time without renewing the budget", () => {
+  const state = environment();
+  const { host, failures, released } = nativeClockHost(state);
+  state.advance(20);
+  state.advance(1_000);
+  assert.equal(host.snapshot().phase, "starting");
+  for (let elapsed = 0; elapsed < 70; elapsed += 10) state.advance(10);
+  assert.equal(host.snapshot().phase, "starting");
+  state.advance(10);
+  assert.equal(host.snapshot().phase, "closed");
+  assert.deepEqual(failures, ["startup"]);
+  assert.deepEqual(released, [1]);
+  host.dispose();
+  state.stopClock();
+  state.stopLifecycle();
+});
+
+test("native message-time recovery lets a heartbeat renew the real host watchdog", async () => {
+  const state = environment();
+  const { host, scheduler, worker, failures } = nativeClockHost(state);
+  await scheduler.flushAsync();
+  state.advance(10_000, false);
+  worker.emitHeartbeat();
+  assert.equal(host.snapshot().phase, "ready");
+  assert.deepEqual(failures, []);
+  state.advance(30);
+  assert.equal(host.snapshot().phase, "suspect");
+  host.dispose();
+  state.stopClock();
+  state.stopLifecycle();
+});

--- a/prototypes/inspect-web/test/worker-runtime-core.test.ts
+++ b/prototypes/inspect-web/test/worker-runtime-core.test.ts
@@ -37,9 +37,17 @@ import {
   type WorkerRuntimeTransportHandlers,
 } from "../src/worker-runtime-core.ts";
 import {
+  WorkerOperationCatalog,
+  WorkerRuntimeRealm,
+  type WorkerOperationContext,
+  type WorkerOperationRegistration,
+  type WorkerRuntimeRealmOptions,
+} from "../src/worker-runtime-realm.ts";
+import {
   type BoundedPayloadDecodeResult,
   type BoundedPayloadDecoder,
   type ManagedOperationSettlement,
+  type RawWorkerToMainEnvelope,
   type WorkerLivenessAllowance,
   WORKER_RUNTIME_PROTOCOL_VERSION,
 } from "../src/worker-runtime-protocol.ts";
@@ -685,6 +693,421 @@ function ownDataProperty(value: object, property: string): unknown {
 function postWorker(worker: TestWorker, message: unknown): void {
   worker.send(message);
 }
+
+function createRealmHarness(options: {
+  readonly bootstrap?: WorkerRuntimeRealmOptions<
+    string,
+    TestDiagnostic
+  >["bootstrap"];
+  readonly invoke?: WorkerOperationRegistration<
+    string,
+    string,
+    string,
+    TestDiagnostic
+  >["invoke"];
+  readonly cancel?: WorkerOperationRegistration<
+    string,
+    string,
+    string,
+    TestDiagnostic
+  >["cancel"];
+} = {}) {
+  const messages: RawWorkerToMainEnvelope[] = [];
+  const operations = new WorkerOperationCatalog();
+  operations.register({
+    kind: "echo",
+    allowance: { kind: "bounded", maxSilentActiveMilliseconds: 20 },
+    input: stringDecoder(),
+    rejectInvalidPayload: detail => ({
+      error: "invalid-payload",
+      diagnostic: { code: "invalid-payload", detail },
+    }),
+    invoke: options.invoke ?? (input => ({ kind: "succeeded", value: input })),
+    ...(options.cancel === undefined ? {} : { cancel: options.cancel }),
+  });
+  const realm = new WorkerRuntimeRealm({
+    bootstrap: options.bootstrap ?? {
+      decoder: stringDecoder(),
+      bootstrap: () => undefined,
+    },
+    diagnostic: detail => ({ code: "worker", detail }),
+    unknownOperationRejection: kind => ({
+      error: "unknown-operation-kind",
+      diagnostic: { code: "unknown-operation-kind", detail: kind },
+    }),
+    operations,
+    producerClasses: createProducerClasses([{
+      name: "speculative",
+      allowance: { kind: "bounded", maxSilentActiveMilliseconds: 30 },
+      structuralBoundMilliseconds: 30,
+    }]),
+    post: message => messages.push(message),
+  });
+  return { realm, messages };
+}
+
+function realmInitialization(bootstrap: unknown = "bootstrap"): unknown {
+  return workerEnvelope(1, {
+    kind: "initialize",
+    bootstrap,
+    idleHeartbeatIntervalMilliseconds: 10,
+    idleAllowanceMilliseconds: 10,
+  });
+}
+
+async function flushRealm(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+test("production realm waits for bootstrap fulfillment and echoes readiness without a scheduler", async () => {
+  const bootstrap = deferred<void>();
+  const inputs: string[] = [];
+  const { realm, messages } = createRealmHarness({
+    bootstrap: {
+      decoder: stringDecoder(),
+      bootstrap: input => {
+        inputs.push(input);
+        return bootstrap.promise;
+      },
+    },
+  });
+  realm.emitHeartbeat();
+  realm.receive(realmInitialization());
+  realm.emitHeartbeat();
+  await flushRealm();
+  assert.deepEqual(inputs, ["bootstrap"]);
+  assert.deepEqual(messages, []);
+  bootstrap.resolve(undefined);
+  await flushRealm();
+  assert.deepEqual(messages, [workerEnvelope(1, {
+    kind: "ready",
+    idleHeartbeatIntervalMilliseconds: 10,
+  })]);
+  realm.emitHeartbeat();
+  assert.deepEqual(messages.at(-1), workerEnvelope(1, { kind: "heartbeat" }));
+  realm.dispose();
+});
+
+for (const invalid of [
+  { name: "malformed envelope", message: null, code: "not-record" },
+  {
+    name: "invalid bootstrap payload",
+    message: realmInitialization(42),
+    code: "payload-rejected",
+  },
+]) {
+  test(`production realm surfaces ${invalid.name} before epoch binding`, async () => {
+    let bootstrapCalls = 0;
+    const { realm, messages } = createRealmHarness({
+      bootstrap: {
+        decoder: stringDecoder(),
+        bootstrap: () => { bootstrapCalls++; },
+      },
+    });
+    assert.throws(() => realm.receive(invalid.message), (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.message, "Worker initialization envelope was rejected.");
+      assert.ok(typeof error.cause === "object" && error.cause !== null);
+      assert.ok("code" in error.cause);
+      assert.equal(error.cause.code, invalid.code);
+      assert.throws(
+        () => realm.fail(error),
+        { message: "Worker realm failed before initialization.", cause: error },
+      );
+      return true;
+    });
+    realm.emitHeartbeat();
+    await flushRealm();
+    assert.equal(bootstrapCalls, 0);
+    assert.deepEqual(messages, []);
+    realm.dispose();
+  });
+}
+
+for (const mode of ["throw", "reject"] as const) {
+  test(`production realm reports bootstrap ${mode} as StartupFailed`, async () => {
+    const error = new Error("bootstrap boundary failed");
+    const { realm, messages } = createRealmHarness({
+      bootstrap: {
+        decoder: stringDecoder(),
+        bootstrap: () => {
+          if (mode === "throw") throw error;
+          return Promise.reject(error);
+        },
+      },
+    });
+    realm.receive(realmInitialization());
+    await flushRealm();
+    assert.deepEqual(messages, [workerEnvelope(1, {
+      kind: "startup-failed",
+      diagnostic: { code: "worker", detail: error },
+    })]);
+    realm.dispose();
+  });
+}
+
+test("production realm accepts before synchronous progress and revokes progress at settlement", async () => {
+  const settlement = deferred<TestSettlement>();
+  const contexts: WorkerOperationContext[] = [];
+  const { realm, messages } = createRealmHarness({
+    invoke: (_input, context) => {
+      contexts.push(context);
+      assert.equal(messages.at(-1)?.kind, "accepted");
+      assert.equal(context.reportProgress("synchronous prefix"), true);
+      return settlement.promise;
+    },
+  });
+  realm.receive(realmInitialization());
+  await flushRealm();
+  const operation = { operationId: "progress", operationSequence: 1 };
+  realm.receive(workerEnvelope(1, {
+    kind: "start",
+    operation,
+    operationKind: "echo",
+    payload: "input",
+  }));
+  await flushRealm();
+  assert.deepEqual(messages.map(message => message.kind), [
+    "ready", "accepted", "progress",
+  ]);
+  assert.deepEqual(messages.at(-1), workerEnvelope(1, {
+    kind: "progress",
+    operation,
+    payload: "synchronous prefix",
+  }));
+  assert.equal(contexts[0]!.reportProgress({ completed: 1 }), true);
+  settlement.resolve({ kind: "succeeded", value: "complete" });
+  await flushRealm();
+  assert.equal(contexts[0]!.reportProgress("late"), false);
+  assert.equal(messages.at(-1)?.kind, "settled");
+  assert.equal(realm.activeOperationCount, 0);
+  realm.dispose();
+});
+
+for (const running of [true, false]) {
+  test(`production realm serializes synchronous cancellation returning ${running}`, async () => {
+    const settlement = deferred<TestSettlement>();
+    const operation = { operationId: "cancel", operationSequence: 1 };
+    const { realm, messages } = createRealmHarness({
+      invoke: () => settlement.promise,
+      cancel: (reference, reason) => {
+        assert.deepEqual(reference, operation);
+        assert.equal(reason, "user");
+        assert.equal(messages.at(-1)?.kind, "accepted");
+        return running;
+      },
+    });
+    realm.receive(realmInitialization());
+    await flushRealm();
+    realm.receive(workerEnvelope(1, {
+      kind: "start", operation, operationKind: "echo", payload: "input",
+    }));
+    realm.receive(workerEnvelope(1, {
+      kind: "cancel", operation, reason: "user",
+    }));
+    realm.receive(workerEnvelope(1, { kind: "probe", probeSequence: 1 }));
+    await flushRealm();
+    assert.deepEqual(messages.slice(1), [
+      workerEnvelope(1, {
+        kind: "accepted",
+        operation,
+        allowance: { kind: "bounded", maxSilentActiveMilliseconds: 20 },
+      }),
+      workerEnvelope(1, {
+        kind: "cancel-acknowledged",
+        operation,
+        status: running ? "running" : "not-active",
+      }),
+      workerEnvelope(1, { kind: "probe-acknowledged", probeSequence: 1 }),
+    ]);
+    settlement.resolve({ kind: "canceled", reason: "user" });
+    await flushRealm();
+    assert.equal(messages.at(-1)?.kind, "settled");
+    realm.dispose();
+  });
+}
+
+test("production realm awaits cancellation before later commands but not physical settlement", async () => {
+  const first = deferred<TestSettlement>();
+  const second = deferred<TestSettlement>();
+  const cancellation = deferred<boolean>();
+  const contexts: WorkerOperationContext[] = [];
+  const { realm, messages } = createRealmHarness({
+    invoke: (input, context) => {
+      contexts.push(context);
+      return input === "first" ? first.promise : second.promise;
+    },
+    cancel: () => cancellation.promise,
+  });
+  realm.receive(realmInitialization());
+  await flushRealm();
+  const operation = { operationId: "first", operationSequence: 1 };
+  realm.receive(workerEnvelope(1, {
+    kind: "start", operation, operationKind: "echo", payload: "first",
+  }));
+  realm.receive(workerEnvelope(1, {
+    kind: "cancel", operation, reason: "user",
+  }));
+  realm.receive(workerEnvelope(1, { kind: "probe", probeSequence: 1 }));
+  realm.receive(workerEnvelope(1, {
+    kind: "start",
+    operation: { operationId: "second", operationSequence: 2 },
+    operationKind: "echo",
+    payload: "second",
+  }));
+  await flushRealm();
+  assert.deepEqual(messages.map(message => message.kind), ["ready", "accepted"]);
+  assert.equal(contexts.length, 1);
+  first.resolve({ kind: "canceled", reason: "user" });
+  await flushRealm();
+  assert.equal(messages.at(-1)?.kind, "settled");
+  assert.equal(contexts[0]!.reportProgress("late"), false);
+  cancellation.resolve(false);
+  await flushRealm();
+  assert.deepEqual(messages.slice(-3).map(message => message.kind), [
+    "cancel-acknowledged", "probe-acknowledged", "accepted",
+  ]);
+  assert.equal(contexts.length, 2);
+  assert.equal(contexts[0]!.reportProgress("still late"), false);
+  assert.equal(contexts[1]!.reportProgress("current"), true);
+  second.resolve({ kind: "succeeded", value: "second" });
+  await flushRealm();
+  realm.dispose();
+});
+
+test("production realm failure suppresses progress and new commands but preserves admitted release", async () => {
+  const settlement = deferred<TestSettlement>();
+  const contexts: WorkerOperationContext[] = [];
+  const { realm, messages } = createRealmHarness({
+    invoke: (_input, context) => {
+      contexts.push(context);
+      return settlement.promise;
+    },
+  });
+  realm.receive(realmInitialization());
+  await flushRealm();
+  const operation = { operationId: "drain", operationSequence: 1 };
+  realm.receive(workerEnvelope(1, {
+    kind: "start", operation, operationKind: "echo", payload: "input",
+  }));
+  await flushRealm();
+  assert.equal(contexts[0]!.startEpochWork("speculative", 1), true);
+  const detail = new Error("worker boundary failed");
+  realm.fail(detail);
+  realm.fail(new Error("later failure"));
+  assert.deepEqual(messages.at(-1), workerEnvelope(1, {
+    kind: "epoch-failed",
+    diagnostic: { code: "worker", detail },
+  }));
+  assert.equal(contexts[0]!.reportProgress("late"), false);
+  assert.equal(realm.startEpochWork("speculative", 2), false);
+  realm.receive(workerEnvelope(1, {
+    kind: "start",
+    operation: { operationId: "refused", operationSequence: 2 },
+    operationKind: "echo",
+    payload: "input",
+  }));
+  realm.receive(workerEnvelope(1, { kind: "cancel", operation, reason: "user" }));
+  realm.receive(workerEnvelope(1, { kind: "probe", probeSequence: 1 }));
+  await flushRealm();
+  assert.equal(messages.at(-1)?.kind, "epoch-failed");
+  settlement.resolve({ kind: "succeeded", value: "physical release" });
+  await flushRealm();
+  assert.equal(contexts[0]!.finishEpochWork(1), true);
+  assert.equal(realm.finishEpochWork(1), false);
+  assert.deepEqual(messages.slice(-3).map(message => message.kind), [
+    "epoch-failed", "settled", "epoch-work-finished",
+  ]);
+  assert.equal(realm.activeOperationCount, 0);
+  assert.equal(realm.activeEpochWorkCount, 0);
+  realm.dispose();
+});
+
+test("production realm disposal revokes pending callbacks, work, and cache authority", async () => {
+  const settlement = deferred<TestSettlement>();
+  const cancellation = deferred<boolean>();
+  const contexts: WorkerOperationContext[] = [];
+  const { realm, messages } = createRealmHarness({
+    invoke: (_input, context) => {
+      contexts.push(context);
+      return settlement.promise;
+    },
+    cancel: () => cancellation.promise,
+  });
+  realm.receive(realmInitialization());
+  await flushRealm();
+  const operation = { operationId: "dispose", operationSequence: 1 };
+  realm.receive(workerEnvelope(1, {
+    kind: "start", operation, operationKind: "echo", payload: "input",
+  }));
+  realm.receive(workerEnvelope(1, { kind: "cancel", operation, reason: "user" }));
+  await flushRealm();
+  const context = contexts[0]!;
+  assert.equal(context.cache.set("prepared", "value"), true);
+  assert.equal(context.startEpochWork("speculative", 1), true);
+  const beforeDisposal = [...messages];
+  realm.dispose();
+  realm.dispose();
+  assert.equal(realm.disposed, true);
+  assert.equal(realm.activeOperationCount, 0);
+  assert.equal(realm.activeEpochWorkCount, 0);
+  assert.equal(context.cache.size, 0);
+  assert.equal(context.cache.set("late", "value"), false);
+  assert.equal(context.reportProgress("late"), false);
+  assert.equal(context.finishEpochWork(1), false);
+  assert.equal(context.startEpochWork("speculative", 2), false);
+  realm.emitHeartbeat();
+  realm.receive(workerEnvelope(1, { kind: "probe", probeSequence: 1 }));
+  realm.fail(new Error("late error"));
+  settlement.resolve({ kind: "succeeded", value: "late" });
+  cancellation.resolve(true);
+  await flushRealm();
+  assert.deepEqual(messages, beforeDisposal);
+});
+
+test("production realm failure or disposal during bootstrap prevents later readiness", async () => {
+  for (const close of ["fail", "dispose"] as const) {
+    const bootstrap = deferred<void>();
+    const { realm, messages } = createRealmHarness({
+      bootstrap: {
+        decoder: stringDecoder(),
+        bootstrap: () => bootstrap.promise,
+      },
+    });
+    realm.receive(realmInitialization());
+    if (close === "fail") realm.fail("startup boundary");
+    else realm.dispose();
+    bootstrap.resolve(undefined);
+    await flushRealm();
+    assert.deepEqual(messages.map(message => message.kind),
+      close === "fail" ? ["startup-failed"] : []);
+    realm.dispose();
+  }
+});
+
+test("fake transport publishes shared realm progress and revokes it on hard termination", async () => {
+  const settlement = deferred<TestSettlement>();
+  const contexts: WorkerOperationContext[] = [];
+  const harness = createHarness({
+    invoke: (_input, context) => {
+      contexts.push(context);
+      return settlement.promise;
+    },
+  });
+  await startReady(harness);
+  const operationSession = session(harness.adapter);
+  const handle = started(operationSession.session.start("input", harness.adapter));
+  await harness.environment.flushAsync();
+  assert.equal(contexts[0]!.reportProgress("live"), true);
+  assert.equal(harness.workers[0]!.emittedMessages.at(-1)?.kind, "progress");
+  assert.equal(operationSession.events.at(-1)?.kind, "progress");
+  harness.host.restart();
+  assert.equal(contexts[0]!.reportProgress("late"), false);
+  assert.equal(harness.workers[0]!.terminateCount, 1);
+  settlement.resolve({ kind: "succeeded", value: "late" });
+  await harness.environment.flushAsync();
+  await handle.quiesced;
+});
 
 test("epoch tokens are positive, monotonic, non-reused, and exhaust visibly", () => {
   const allocator = new WorkerEpochTokenAllocator(2);

--- a/prototypes/inspect-web/vite.config.ts
+++ b/prototypes/inspect-web/vite.config.ts
@@ -1,22 +1,30 @@
 import { defineConfig } from "vite";
 
+const facadeModules = [
+  "/inspect-web-host.js",
+  "/inspect-web-package.js",
+  "/inspect-web-metadata.js",
+  "/inspect-web-analysis.js",
+  "/inspect-web-source.js",
+  "/inspect-web-call-graph.js",
+  "/inspect-web-catalog.js",
+];
+
 export default defineConfig({
   // Anything under `publicDir` is copied into the build output verbatim, without the
   // bundler, the compiler or the lint ever reading it. This project ships no such assets,
   // so the path stays closed; `test/toolchain.test.ts` fails if it reopens.
   publicDir: false,
+  worker: {
+    format: "es",
+    rollupOptions: { external: facadeModules },
+  },
   build: {
     manifest: "manifest.json",
     rollupOptions: {
-      external: [
-        "/inspect-web-host.js",
-        "/inspect-web-package.js",
-        "/inspect-web-metadata.js",
-        "/inspect-web-analysis.js",
-        "/inspect-web-source.js",
-        "/inspect-web-call-graph.js",
-        "/inspect-web-catalog.js",
-      ],
+      input: ["index.html", "src/engine-worker-client.ts"],
+      preserveEntrySignatures: "strict",
+      external: facadeModules,
     },
   },
 });


### PR DESCRIPTION
Build a reliable foundation for responsive inspect-web: bind the existing Worker runtime protocol to a real browser Worker and the existing generated .NET facade composition.

This is adoption step **3 of 8** under #5418, following the runtime core in #5636. It supports an explicit managed diagnostic consumer; existing UI features still use their current main-thread paths. It advances, but does not close, #5418.

## Demo

Build the frontend, publish the actual application in Release, then run:

```bash
cd prototypes/inspect-web
INSPECT_WEB_WORKER_SITE=/path/to/published/wwwroot \
  npm run inspect-web-worker-browser-binding
```

The published client creates one `DedicatedWorkerGlobalScope`, boots the same seven generated facades, and calls the existing managed `asyncLoweringCanary()` export. Both cold and warm calls return:

```json
{"kind":"succeeded","value":"inspect-web-async-lowering-ok"}
```

An explicit restart releases epoch 1, boots epoch 2, and serves another managed call. Disposal releases the realm and makes the old Worker unavailable.

The neighboring failure case serves a failed host-facade import. Held work receives:

```json
{"kind":"failed","error":"Worker startup failed."}
```

The runtime reports `failure:startup` and `released:1`. A separate stalled-Wasm scenario keeps page input usable and then exhausts the five-second startup budget. These scenarios run against the product-published artifact, not a replacement bootstrap or simulated managed engine.

## Design basis

**Normative owner:** `docs/design/inspect-web-worker-runtime.md`, Runtime construction and readiness / Browser binding. The claim is an exact native Worker source and epoch binding, consumer-owned generated-facade readiness, native active-time lifecycle inputs, and physical realm release.

Supporting contracts retain their ownership: operation authority supplies IDs, logical outcomes and quiescence; the existing facade coordinator owns one-runtime initialization; generated facades supply typed managed calls. The prior protocol model and deterministic gate remain evidence for the shared protocol rather than substitutes for browser execution.

The .NET SDK fingerprints `dotnet.js`, but a Worker does not inherit the document's import map. A consumer-owned `runtime-loader.js` directly re-exports the SDK-selected published module. Both hosts retain one canonical seven-facade graph. The authored loader receives SDK-backed `allowJs`/`checkJs` compilation and normal lint, without generated-code exemptions.

## Meaningful changes

- Extract the reusable Worker realm from the fake wrapper; retain one protocol implementation and add live-operation progress reporting.
- Bind native message/error channels and visibility, page-hide, freeze and scheduling-gap signals to the existing host.
- Publish an explicit diagnostic client and module Worker, using the existing async-lowering canary without adding managed fixture exports.
- Add the narrow published-artifact Firefox gate to the existing inspect-web CI job, reusing its Release publish and browser installation.

## Compatibility and remaining adoption

This retains the approved inspect-web-only scope. It does not change CLI behavior, generated declaration contracts, feature rendering, feature result policy, or the current UI's runtime location.

The eight-step adoption path is recorded in the Worker owner and tracked by #5418: wire codec; shared core; browser bootstrap; first source adapter (#5420); managed cancellation/progress/settlement and epoch-work handoffs (#5419); complete lifecycle and CPU-responsiveness gates; remaining adapters with retirement of direct main-thread feature calls; durable event batches after their prerequisites.

The diagnostic registry admits no shared managed producers. Managed epoch-work reporter registration, source-feature adoption, full lifecycle/BFCache coverage, representative managed CPU responsiveness, and durable batches remain separate work. The new binding gate does not claim those are complete.

## Validation

- Focused Worker, operation-authority, facade and loader cases: 263 passed.
- Toolchain and loader cases: 56 passed.
- Native lifecycle/host cases: 9 passed.
- Published Firefox binding scenarios: 4 passed; measured at 42.5 seconds while the generator check ran concurrently.
- Typecheck, source analysis, frontend build, Release publication, and changed Markdown checks passed.
- Final generated-facade parity and the seven-facade published production smoke passed.
- Full inspect-web Node suite: 1,199 passed.
- Publication/configuration Release cases: 3 passed after updating the existing assertion to cover index -> runtime loader -> site verification.
