### PR TITLE
Adopt Aspire scanner selection in the ecosystem catalog

### DIFF
--- a/docs/design/ecosystem-packs.md
+++ b/docs/design/ecosystem-packs.md
@@ -19,9 +19,11 @@ manifest, ten-demo contribution, Workspace-owned lazy source binding, CLI
 handoff, inspect-web facade handoff, and the corresponding active Release gates
 named below are implemented. The assembly-friend tests, solution
 dependency-policy rule, and strengthened inspect-web facade boundary gate are
-active. Prefix and scanner slots and their future gates remain absent until
-their owners issue the required currencies; existing search and Integration
-behavior is unchanged.
+active. The optional scanner slot and Aspire binding selection are implemented
+under [#5935](https://github.com/richlander/dotnet-inspect/issues/5935), using
+the Integration-owned compatibility binding. CLI/browser scanner selection
+remains staged. Prefix slots remain absent until their owner issues the
+required currency; existing search and full Integration behavior is unchanged.
 
 Participating normative owner:
 
@@ -198,6 +200,12 @@ ecosystem.
 
 The public discovery boundary exposes immutable pack, prefix-action, and demo
 descriptor metadata, package-set identity, and whether a scanner is available.
+`EcosystemPackDescriptor.HasScanner` reports scanner availability without
+exposing the binding. `EcosystemPackCatalog.SelectScanner` accepts the exact
+typed pack ID and returns `EcosystemScannerSelectionResult`: `Known` carries
+only the selected owner-issued binding, `Unavailable` identifies a registered
+pack without that capability, and `Unknown` preserves an unregistered ID.
+Neither missing case selects a neighboring scanner or a default.
 Exact demo selection returns one `EcosystemDemoSelection`, retaining the
 catalog descriptor beside the Workspace-Definitions-owned resolved scenario.
 Hosts use descriptor title and summary for product discovery and display;
@@ -563,19 +571,21 @@ classification passes, its scanner composes them behind the single
 Integration-owned binding rather than exposing a runtime scanner collection or
 execution graph.
 
-The current broad `EcosystemIntegrationScanner` remains the behavior oracle
-until the Integration owner adopts this pattern. Extracting Aspire or another
-ecosystem-specific semantic scanner requires first separating common guarded
-traversal from the decoded observation context in a focused Integration change;
-it does not join the pack-contract PR.
+The [Integration-owned contract](integration-scanner-binding.md), locked under
+issue #5719 and implemented under #5902, separates common guarded traversal from
+decoded observations. The broad scanner remains the behavior oracle.
+The Aspire registration uses `EcosystemIntegrationScanner.AspireBinding`
+directly during migration, retaining one owner-side semantic policy rather
+than copying its predicates into application source. Other packs have no
+scanner contribution yet.
 
-The executable pack registration cannot land the scanner slot before that
-focused owner issues the binding currency under
-[#5719](https://github.com/richlander/dotnet-inspect/issues/5719), whose
-[Integration-owned contract](integration-scanner-binding.md) now has its
-substrate implementation under #5902. Catalog adoption remains a separate step.
-The pack design does not introduce a generic delegate or parallel scan result as a
-placeholder.
+Catalog adoption under #5935 is step 3 of the
+[six-step scanner path](integration-scanner-binding.md#adoption-and-retirement)
+in #5728. Explicit CLI and browser selection follow separately. Moving Aspire
+interpretation fully into application source and retiring owner-side
+compatibility remain the final step, after existing full-scan/presence
+consumers retain their behavior. The catalog introduces neither a generic
+delegate nor a parallel scan result.
 
 ## Discovery and selection
 
@@ -663,9 +673,9 @@ currencies and content:
 | Pack identity | Package-set identity | Product demos | Residual capabilities |
 | --- | --- | --- | --- |
 | `ecosystem.platform` | absent | `stj-serializer`, `stj-serialize-callgraph`, `stj-getdecimal-callgraph` | no prefix or scanner planned by this slice |
-| `ecosystem.microsoft-extensions` | `package-set.microsoft-extensions` | `extensions-callgraph`, `config-bind-callgraph`, `options-add-callgraph`, `di-tryadd-callgraph`, `http-addhttpclient-callgraph` | prefix waits for #5602; scanner waits for #5719 |
-| `ecosystem.aspnetcore` | `package-set.aspnetcore` | none initially | prefix waits for #5602; scanner waits for #5719 |
-| `ecosystem.aspire` | `package-set.aspire` | `aspire-postgres-callgraph`, `aspire-redis-callgraph` | prefixes wait for #5602; scanner waits for #5719 |
+| `ecosystem.microsoft-extensions` | `package-set.microsoft-extensions` | `extensions-callgraph`, `config-bind-callgraph`, `options-add-callgraph`, `di-tryadd-callgraph`, `http-addhttpclient-callgraph` | prefix waits for #5602; no scanner contributed yet |
+| `ecosystem.aspnetcore` | `package-set.aspnetcore` | none initially | prefix waits for #5602; no scanner contributed yet |
+| `ecosystem.aspire` | `package-set.aspire` | `aspire-postgres-callgraph`, `aspire-redis-callgraph` | scanner selectable through the catalog; host selection remains staged; prefixes wait for #5602 |
 
 The eight existing demo IDs, metadata, global order, records, pins, and run
 plans remain unchanged. Their global orders are assigned in their current
@@ -733,6 +743,26 @@ candidate packs, not registrations authorized by this design.
 
 ## Demo
 
+Scanner selection is a shared application-catalog API, not a new CLI or
+browser action:
+
+```csharp
+var selection = EcosystemPackCatalog.SelectScanner(EcosystemPackIds.Aspire);
+if (selection is not EcosystemScannerSelectionResult.Known scanner)
+    throw new InvalidOperationException("The shipped Aspire scanner is unavailable.");
+
+using var session = AssemblyInspectionSession.Open(path);
+var rows = session.EcosystemIntegrations(scanner.Binding);
+```
+
+On the pinned `Aspire.Hosting.PostgreSQL@13.5.3` and
+`Aspire.Hosting.Redis@13.5.3` `net8.0` assemblies this yields six and four
+Aspire rows respectively, retaining the same ordered rows and evidence as the
+full scanner's Aspire subset. `ILInspector.Metadata.dll` is a neighboring
+input with zero Aspire rows. Selecting `ecosystem.microsoft-extensions`
+instead returns typed `Unavailable`; discovering or selecting any pack does
+not itself run a scanner.
+
 The flat product-demo projection preserves current order and appends Aspire:
 
 ```text
@@ -791,6 +821,9 @@ ordinary non-friend consumer.
 | `ProductDemoSourceBindingTests.ResolveRequiresExactlyOneMatchingScenario` | A selected source must return exactly one scenario with the binding's exact ID; absent, duplicate, and mismatched scenario records fail visibly. |
 | `ProductDemoSourceBindingTests.ResolvePreservesDefinitionAndSectionFailures` | Invalid peer records and unsupported demo sections remain visible Workspace-Definitions-owned failures. |
 | `EcosystemPackRegistryTests.ScannerSelectionReturnsOnlyTheSelectedBinding` | Selecting one synthetic pack returns only its scanner binding and leaves every neighboring binding unreturned and uninvoked. |
+| `EcosystemPackRegistryTests.ScannerOnlyPackIsValidAndMissingCapabilityIsDistinctFromUnknownPack` | A scanner-only contribution is valid; exact selection distinguishes a known pack without a scanner from an unknown pack. |
+| `ProductEcosystemPackTests.AspireIsTheOnlyShippedScannerAndRetainsTheOwnerBinding` | Literal shipped availability identifies only Aspire and selection preserves the Integration-owned compatibility binding by identity. |
+| `PackageSetRegistryConsumerTests.PublicSurfaceHandsSelectedScannerToIntegrationOwner` | A non-friend consumer discovers and selects Aspire, passes only the binding to the public Integration operation, and retains typed missing-capability/unknown results. |
 | `EcosystemPackRegistryTests.PrefixSelectionPreservesExactValidatedIntent` | After the prefix owner issues its currency, selecting a prefix returns that typed request unchanged and does not expand, combine, count, or execute it. |
 | `EcosystemPackRegistryTests.PackageSetSelectionPreservesExactTypedIdentity` | Selecting a curated set returns only its `PackageSetId` and does not copy membership or activate another pack capability. |
 | `PackageSetRegistryConsumerTests.PublicSurfaceSupportsEcosystemDiscoveryAndDemoSelection` | An ordinary non-friend front-end consumer discovers and selects available actions through only the public surface, without registration construction, manifest publication, demo factories, scanner implementation, CLI types, package clients, or workspaces. |

--- a/docs/design/integration-scanner-binding.md
+++ b/docs/design/integration-scanner-binding.md
@@ -7,8 +7,10 @@ owned by [Integrations](integrations.md). The observation, binding, and selected
 operation substrate is implemented under
 [#5902](https://github.com/richlander/dotnet-inspect/issues/5902).
 Existing full-library inspection and Census behavior is unchanged.
-Application-catalog registration and CLI/browser selection remain later
-adoption steps; their gates remain planned and unverified.
+Application-catalog registration is implemented under
+[#5935](https://github.com/richlander/dotnet-inspect/issues/5935), reusing the
+Aspire compatibility binding. CLI/browser selection remains later adoption;
+its gates remain planned and unverified.
 
 **Claim:** Integration orchestration supplies an immutable, decoded observation
 context to one selected static semantic scanner and projects its classifications
@@ -286,7 +288,7 @@ non-normative end-to-end tracker. This scanner track has **six steps**:
    scanner facade, add the opaque binding and selected operation, and prove
    parity with the current classifier/projection/presence paths. Existing
    library inspection is the production consumer of the extraction.
-3. **Application catalog adoption:** expose the Aspire scanner binding under
+3. **Application catalog adoption (#5935):** expose the Aspire scanner binding under
    the pack owner's existing static selection contract. During migration,
    reuse the owner-side Aspire interpretation through a compatibility adapter
    rather than maintain two independently edited semantic policies.
@@ -318,7 +320,9 @@ var rows = session.EcosystemIntegrations(
     EcosystemIntegrationScanner.AspireBinding);
 ```
 
-Catalog selection remains a later adoption step. The scenario is:
+Catalog consumers obtain the same binding through the
+[pack selection surface](ecosystem-packs.md#integration-scanner-binding).
+CLI/browser selection remains staged. The scenario is:
 
 ```text
 Select: ecosystem.aspire / Integration

--- a/src/DotnetInspector.Ecosystems.Tests/EcosystemPackAssemblyBoundaryTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/EcosystemPackAssemblyBoundaryTests.cs
@@ -30,6 +30,9 @@ public sealed class EcosystemPackAssemblyBoundaryTests
                 .Where(reference =>
                     reference.Name?.StartsWith(
                         "DotnetInspector.",
+                        StringComparison.Ordinal) == true
+                    || reference.Name?.StartsWith(
+                        "ILInspector.",
                         StringComparison.Ordinal) == true)
                 .Select(Assembly.Load),
         ];

--- a/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/EcosystemPackRegistryTests.cs
@@ -1,4 +1,6 @@
+using System.Collections.Immutable;
 using DotnetInspector.Queries.Definitions;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems.Tests;
 
@@ -188,8 +190,91 @@ public sealed class EcosystemPackRegistryTests
             registry.SelectDemo("first"));
     }
 
+    [Fact]
+    public void ScannerSelectionReturnsOnlyTheSelectedBinding()
+    {
+        s_firstInvocations = 0;
+        s_secondInvocations = 0;
+        s_firstScannerInvocations = 0;
+        s_secondScannerInvocations = 0;
+        var first = EcosystemIntegrationScannerBinding.Create(ScanFirst);
+        var second = EcosystemIntegrationScannerBinding.Create(ScanSecond);
+        EcosystemPackRegistry registry = Registry(
+            Pack("ecosystem.first", 100, "package-set.first", Demo("first", 100, CreateFirstRecords))
+                with { Scanner = first },
+            Pack("ecosystem.second", 200, null, Demo("second", 200, CreateSecondRecords))
+                with { Scanner = second });
+
+        Assert.All(registry.Packs, pack => Assert.True(pack.HasScanner));
+        Assert.Equal(2, registry.Demos.Length);
+        var lookup = Assert.IsType<EcosystemPackLookupResult.Known>(
+            registry.Lookup(registry.Packs[0].Id));
+        Assert.Equal("package-set.first", lookup.Descriptor.PackageSet!.Value);
+        var selected = Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            registry.SelectScanner(registry.Packs[1].Id));
+        Assert.Same(second, selected.Binding);
+        Assert.Same(second, Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            registry.SelectScanner(registry.Packs[1].Id)).Binding);
+        Assert.Equal(0, s_firstInvocations);
+        Assert.Equal(0, s_secondInvocations);
+        Assert.Equal(0, s_firstScannerInvocations);
+        Assert.Equal(0, s_secondScannerInvocations);
+
+        _ = registry.SelectDemo("first");
+        Assert.Equal(1, s_firstInvocations);
+        Assert.Equal(0, s_secondInvocations);
+        Assert.Equal(0, s_firstScannerInvocations);
+        Assert.Equal(0, s_secondScannerInvocations);
+
+        using var session = AssemblyInspectionSession.Open(
+            typeof(EcosystemIntegrationScannerBinding).Assembly.Location);
+        Assert.Empty(session.EcosystemIntegrations(selected.Binding));
+        Assert.Equal(0, s_firstScannerInvocations);
+        Assert.Equal(1, s_secondScannerInvocations);
+    }
+
+    [Fact]
+    public void ScannerOnlyPackIsValidAndMissingCapabilityIsDistinctFromUnknownPack()
+    {
+        var binding = EcosystemIntegrationScannerBinding.Create(ScanFirst);
+        EcosystemPackRegistry registry = Registry(
+            Pack("ecosystem.first", 100, null) with { Scanner = binding },
+            Pack("ecosystem.second", 200, "package-set.second"));
+
+        Assert.True(registry.Packs[0].HasScanner);
+        Assert.Empty(registry.Packs[0].Demos);
+        Assert.Null(registry.Packs[0].PackageSet);
+        Assert.Same(binding, Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            registry.SelectScanner(registry.Packs[0].Id)).Binding);
+        Assert.False(registry.Packs[1].HasScanner);
+        Assert.Same(registry.Packs[1].Id,
+            Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
+                registry.SelectScanner(registry.Packs[1].Id)).Id);
+
+        EcosystemPackId unknown = EcosystemPackId.Create("ecosystem.first-other");
+        Assert.Same(unknown, Assert.IsType<EcosystemScannerSelectionResult.Unknown>(
+            registry.SelectScanner(unknown)).Id);
+        Assert.Throws<ArgumentNullException>(() => registry.SelectScanner(null!));
+    }
+
     private static int s_firstInvocations;
     private static int s_secondInvocations;
+    private static int s_firstScannerInvocations;
+    private static int s_secondScannerInvocations;
+
+    private static ImmutableArray<EcosystemIntegrationClassification> ScanFirst(
+        EcosystemIntegrationObservationContext context)
+    {
+        s_firstScannerInvocations++;
+        return [];
+    }
+
+    private static ImmutableArray<EcosystemIntegrationClassification> ScanSecond(
+        EcosystemIntegrationObservationContext context)
+    {
+        s_secondScannerInvocations++;
+        return [];
+    }
 
     private static EcosystemPackRegistry Registry(
         params EcosystemPackRegistration[] registrations) =>

--- a/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
+++ b/src/DotnetInspector.Ecosystems.Tests/ProductEcosystemPackTests.cs
@@ -1,11 +1,32 @@
 using DotnetInspector.Packages;
 using DotnetInspector.Queries;
 using DotnetInspector.Queries.Definitions;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems.Tests;
 
 public sealed class ProductEcosystemPackTests
 {
+    [Fact]
+    public void AspireIsTheOnlyShippedScannerAndRetainsTheOwnerBinding()
+    {
+        Assert.Equal(
+            [false, false, false, true],
+            EcosystemPackCatalog.Discover().Select(pack => pack.HasScanner));
+        var selected = Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            EcosystemPackCatalog.SelectScanner(EcosystemPackIds.Aspire));
+        Assert.Same(EcosystemIntegrationScanner.AspireBinding, selected.Binding);
+        Assert.All(
+            new[]
+            {
+                EcosystemPackIds.Platform,
+                EcosystemPackIds.MicrosoftExtensions,
+                EcosystemPackIds.AspNetCore,
+            },
+            id => Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
+                EcosystemPackCatalog.SelectScanner(id)));
+    }
+
     [Fact]
     public void ShippedManifestMatchesLiteralPolicy()
     {

--- a/src/DotnetInspector.Ecosystems/DotnetInspector.Ecosystems.csproj
+++ b/src/DotnetInspector.Ecosystems/DotnetInspector.Ecosystems.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Packages\DotnetInspector.Packages.csproj" />
     <ProjectReference Include="..\DotnetInspector.Queries\DotnetInspector.Queries.csproj" />
+    <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <InternalsVisibleTo Include="DotnetInspector.Ecosystems.Tests" />
   </ItemGroup>
 

--- a/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackDescriptor.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using DotnetInspector.Queries.Definitions;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems;
 
@@ -12,7 +13,8 @@ public sealed class EcosystemPackDescriptor
         string summary,
         int order,
         PackageSetId? packageSet,
-        IEnumerable<EcosystemDemoDescriptor> demos)
+        IEnumerable<EcosystemDemoDescriptor> demos,
+        bool hasScanner)
     {
         Id = id;
         Title = title;
@@ -20,6 +22,7 @@ public sealed class EcosystemPackDescriptor
         Order = order;
         PackageSet = packageSet;
         Demos = [.. demos];
+        HasScanner = hasScanner;
     }
 
     public EcosystemPackId Id { get; }
@@ -33,6 +36,8 @@ public sealed class EcosystemPackDescriptor
     public PackageSetId? PackageSet { get; }
 
     public ImmutableArray<EcosystemDemoDescriptor> Demos { get; }
+
+    public bool HasScanner { get; }
 }
 
 /// <summary>Immutable product metadata for one ecosystem demo.</summary>
@@ -111,5 +116,36 @@ public abstract record EcosystemDemoSelectionResult
         internal Unknown(string scenarioId) => ScenarioId = scenarioId;
 
         public string ScenarioId { get; }
+    }
+}
+
+/// <summary>The result of exact scanner selection, without invoking a scanner.</summary>
+public abstract record EcosystemScannerSelectionResult
+{
+    private protected EcosystemScannerSelectionResult()
+    {
+    }
+
+    public sealed record Known : EcosystemScannerSelectionResult
+    {
+        internal Known(EcosystemIntegrationScannerBinding binding) =>
+            Binding = binding;
+
+        public EcosystemIntegrationScannerBinding Binding { get; }
+    }
+
+    /// <summary>The pack is registered but does not contribute a scanner.</summary>
+    public sealed record Unavailable : EcosystemScannerSelectionResult
+    {
+        internal Unavailable(EcosystemPackId id) => Id = id;
+
+        public EcosystemPackId Id { get; }
+    }
+
+    public sealed record Unknown : EcosystemScannerSelectionResult
+    {
+        internal Unknown(EcosystemPackId id) => Id = id;
+
+        public EcosystemPackId Id { get; }
     }
 }

--- a/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
+++ b/src/DotnetInspector.Ecosystems/EcosystemPackRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using DotnetInspector.Queries.Definitions;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems;
 
@@ -15,15 +16,20 @@ internal sealed record EcosystemPackRegistration(
     string Summary,
     int Order,
     PackageSetId? PackageSet,
-    IReadOnlyList<EcosystemDemoRegistration> Demos);
+    IReadOnlyList<EcosystemDemoRegistration> Demos,
+    EcosystemIntegrationScannerBinding? Scanner = null);
 
 internal sealed class EcosystemPackRegistry
 {
+    private sealed record PackEntry(
+        EcosystemPackDescriptor Descriptor,
+        EcosystemIntegrationScannerBinding? Scanner);
+
     private sealed record DemoEntry(
         EcosystemDemoDescriptor Descriptor,
         ProductDemoSourceBinding Source);
 
-    private readonly Dictionary<EcosystemPackId, EcosystemPackDescriptor> _packsById;
+    private readonly Dictionary<EcosystemPackId, PackEntry> _packsById;
     private readonly Dictionary<string, DemoEntry> _demosById;
 
     internal EcosystemPackRegistry(IEnumerable<EcosystemPackRegistration> registrations)
@@ -40,7 +46,7 @@ internal sealed class EcosystemPackRegistry
         var packDescriptors =
             ImmutableArray.CreateBuilder<EcosystemPackDescriptor>(manifest.Length);
         var demoEntries = new List<DemoEntry>();
-        _packsById = new Dictionary<EcosystemPackId, EcosystemPackDescriptor>();
+        _packsById = new Dictionary<EcosystemPackId, PackEntry>();
         _demosById = new Dictionary<string, DemoEntry>(StringComparer.Ordinal);
         var demoOrders = new HashSet<int>();
         int previousPackOrder = default;
@@ -81,7 +87,8 @@ internal sealed class EcosystemPackRegistry
                         $"Ecosystem pack '{registration.Id}' has no demo sequence.",
                         nameof(registrations)),
             ];
-            if (registration.PackageSet is null && demos.Length == 0)
+            if (registration.PackageSet is null && demos.Length == 0
+                && registration.Scanner is null)
             {
                 throw new ArgumentException(
                     $"Ecosystem pack '{registration.Id}' must expose at least one capability.",
@@ -147,8 +154,11 @@ internal sealed class EcosystemPackRegistry
                 registration.Summary,
                 registration.Order,
                 registration.PackageSet,
-                descriptors.MoveToImmutable());
-            _packsById.Add(packDescriptor.Id, packDescriptor);
+                descriptors.MoveToImmutable(),
+                registration.Scanner is not null);
+            _packsById.Add(
+                packDescriptor.Id,
+                new PackEntry(packDescriptor, registration.Scanner));
             packDescriptors.Add(packDescriptor);
             previousPackOrder = registration.Order;
             hasPreviousPackOrder = true;
@@ -170,9 +180,20 @@ internal sealed class EcosystemPackRegistry
     internal EcosystemPackLookupResult Lookup(EcosystemPackId id)
     {
         ArgumentNullException.ThrowIfNull(id);
-        return _packsById.TryGetValue(id, out EcosystemPackDescriptor? descriptor)
-            ? new EcosystemPackLookupResult.Known(descriptor)
+        return _packsById.TryGetValue(id, out PackEntry? entry)
+            ? new EcosystemPackLookupResult.Known(entry.Descriptor)
             : new EcosystemPackLookupResult.Unknown(id);
+    }
+
+    internal EcosystemScannerSelectionResult SelectScanner(EcosystemPackId id)
+    {
+        ArgumentNullException.ThrowIfNull(id);
+        if (!_packsById.TryGetValue(id, out PackEntry? entry))
+            return new EcosystemScannerSelectionResult.Unknown(id);
+
+        return entry.Scanner is { } binding
+            ? new EcosystemScannerSelectionResult.Known(binding)
+            : new EcosystemScannerSelectionResult.Unavailable(id);
     }
 
     internal EcosystemDemoSelectionResult SelectDemo(string scenarioId)
@@ -214,6 +235,9 @@ public static class EcosystemPackCatalog
 
     public static EcosystemPackLookupResult Lookup(EcosystemPackId id) =>
         ProductEcosystemPacks.Registry.Lookup(id);
+
+    public static EcosystemScannerSelectionResult SelectScanner(EcosystemPackId id) =>
+        ProductEcosystemPacks.Registry.SelectScanner(id);
 
     public static EcosystemDemoSelectionResult SelectDemo(string scenarioId) =>
         ProductEcosystemPacks.Registry.SelectDemo(scenarioId);

--- a/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
+++ b/src/DotnetInspector.Ecosystems/ProductEcosystemPacks.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Queries.Definitions;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems;
 
@@ -46,7 +47,8 @@ internal static class ProductEcosystemPacks
             [
                 Demo(ProductDemoIds.AspirePostgresCallGraph, "Aspire AddPostgres", "PostgreSQL resource registration graph", 900, CreateAspirePostgresCallGraphRecords),
                 Demo(ProductDemoIds.AspireRedisCallGraph, "Aspire AddRedis", "Redis resource registration graph", 1000, CreateAspireRedisCallGraphRecords),
-            ]),
+            ],
+            Scanner: EcosystemIntegrationScanner.AspireBinding),
     ]);
 
     private static EcosystemDemoRegistration Demo(

--- a/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
+++ b/tests/DotnetInspector.Ecosystems.Consumer.Tests/PackageSetRegistryConsumerTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Ecosystems;
+using ILInspector.Metadata;
 
 namespace DotnetInspector.Ecosystems.Consumer.Tests;
 
@@ -41,5 +42,25 @@ public sealed class PackageSetRegistryConsumerTests
         Assert.Equal(
             ProductDemoIds.StjSerializer,
             selected.Selection.Scenario.ScenarioId);
+    }
+
+    [Fact]
+    public void PublicSurfaceHandsSelectedScannerToIntegrationOwner()
+    {
+        EcosystemPackDescriptor aspire = Assert.Single(
+            EcosystemPackCatalog.Discover().Where(pack => pack.HasScanner));
+        Assert.Equal(EcosystemPackIds.Aspire, aspire.Id);
+        var selected = Assert.IsType<EcosystemScannerSelectionResult.Known>(
+            EcosystemPackCatalog.SelectScanner(aspire.Id));
+
+        using var session = AssemblyInspectionSession.Open(
+            typeof(EcosystemPackCatalog).Assembly.Location);
+        Assert.Empty(session.EcosystemIntegrations(selected.Binding));
+        Assert.IsType<EcosystemScannerSelectionResult.Unavailable>(
+            EcosystemPackCatalog.SelectScanner(EcosystemPackIds.MicrosoftExtensions));
+        Assert.True(EcosystemPackId.TryCreate(
+            "ecosystem.not-shipped", out EcosystemPackId? unknownId));
+        Assert.IsType<EcosystemScannerSelectionResult.Unknown>(
+            EcosystemPackCatalog.SelectScanner(unknownId));
     }
 }


### PR DESCRIPTION
Delivers the next sound, behavior-preserving ecosystem capability: discover
Aspire scanner availability and select its Integration-owned binding without
invoking it or activating neighboring capabilities.

Closes #5935. Step 3 of the six-stage scanner path in #5728, following #5909.

## Claim and scope

Normative owner: `docs/design/ecosystem-packs.md#integration-scanner-binding`,
with its discovery and materialization contract. The internal registration
gains one optional owner-issued binding; immutable descriptors expose only
`HasScanner`; exact `SelectScanner(EcosystemPackId)` returns `Known`,
`Unavailable` for a registered pack without a scanner, or `Unknown`.

Aspire alone registers a scanner and retains
`EcosystemIntegrationScanner.AspireBinding` by identity. There is no copied
Aspire policy, new scanner instance, registry graph, cache, delegate surface,
or catalog-owned execution. One private pack entry associates its descriptor
with its binding; existing static lookup mechanics remain sufficient.

Integrations is a supporting owner: it supplies decoded observations, binding,
execution, evidence, projection, and outcomes through its existing public API.
Workspace Definitions continues to own demo resolution. Both hosts retain
their existing presentation and defaults. The added Metadata project reference
uses public currency and keeps the existing dependency/friendship gates.

## Demo

Catalog discovery and explicit owner-side execution through the selected
binding, using pinned Aspire 13.5.3 `net8.0` assemblies:

```text
ecosystem.platform | scanner: False
ecosystem.microsoft-extensions | scanner: False
ecosystem.aspnetcore | scanner: False
ecosystem.aspire | scanner: True
Microsoft.Extensions: Unavailable
Aspire.Hosting.PostgreSQL.dll: 6 Aspire rows; owner parity
  Resource Builder | Aspire.Hosting.PostgresBuilderExtensions.AddPostgres(...) | anchors: 1
  Resource | Aspire.Hosting.ApplicationModel.PostgresDatabaseResource | anchors: 0
Aspire.Hosting.Redis.dll: 4 Aspire rows; owner parity
  Resource Builder | Aspire.Hosting.RedisBuilderExtensions.AddRedis(...) | anchors: 2
  Resource | Aspire.Hosting.ApplicationModel.RedisResource | anchors: 0
ILInspector.Metadata.dll: 0 Aspire rows; owner parity
```

The demo compares row order, overload evidence sets, structured type
definitions, and incomplete-evidence markers against the full scanner's Aspire
subset. The focused owner documentation includes the public-API usage.

Before this slice the catalog has no scanner-availability or selection API.
After it, ordinary non-friend consumers discover and select the same binding
without invoking it. Existing package-set and ten-demo content is unchanged.

## Validation

- Release `DotnetInspector.Ecosystems.Tests`: 49 passed.
- Release `DotnetInspector.Ecosystems.Consumer.Tests`: 3 passed.
- Both changed design documents pass markdownlint; diff whitespace is clean.
- Synthetic registry gates cover inert discovery/selection, scanner-only
  registrations, unknown versus unavailable, unchanged selected binding,
  neighboring demo/scanner isolation, and explicit owner-side execution.
- Literal product policy and the non-friend consumer cover the shipped Aspire
  binding and public Metadata handoff.
- Pinned PostgreSQL/Redis demo and the neighboring Metadata assembly preserve
  the owner oracle as shown above.
- Browser frontend build, fresh baseline/candidate Browser/Wasm publishes, and
  the existing `EcosystemCatalogIsFacadeOnly` browser boundary test pass.
- Exact-head `ci-required` succeeded for
  `114849a47fb6fef7e92ee14b7998d6c3657ab142`; fixed-head review follows.

### First-adoption Browser/Wasm size evidence

Release baseline `1075a49fdad669a5eb17b403f58dd6d9a4f1553e` versus candidate
`114849a47fb6fef7e92ee14b7998d6c3657ab142`, using SDK
`11.0.100-preview.7.26381.103` and the same official Emscripten tools:

| Published `_framework` bytes | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Raw | 18,538,656 | 18,541,216 | +2,560 |
| Brotli | 5,472,849 | 5,475,075 | +2,226 |
| gzip | 7,193,588 | 7,194,497 | +909 |

Both outputs have the same 77 logical assets and 77 files per encoding.
Ecosystems WebCIL grows by 1,536 raw bytes (400 Brotli); Metadata WebCIL grows
by 1,024 raw bytes (914 Brotli). These are the only raw-size changes.
Compressed totals describe the whole publication, including other binary and
fingerprint changes, rather than an isolated method-level cost.

**Sensor decision:** retain this first-adoption measurement, but do not add a
new recurring sensor for a 2.5 KiB raw / approximately 2.2 KiB Brotli increase
(0.041% of baseline Brotli). This is a measured small cost, not a zero-cost
claim or a general guarantee for future scanner registrations.

### Toolchain recovery and evidence correction

The earlier statement that no SDK files had been modified was incorrect.
A helper changed the shared SDK's `clang` and `clang++` launchers without
approval. Work was stopped, that measurement was invalidated, and the user
approved restoring the official launchers before an isolated resumption.
Both launchers now match the official package byte-for-byte, including after
the fresh builds; their SHA-256 is
`7a68cc98466801c5575ffa6bc998be7ca4ce178a69c95615c4b63b583446fc74`.

The fresh evidence above uses an extracted, unmodified official tools copy
under ignored `artifacts/emscripten-isolated/tools/`, with executable modes
restored only in that copy. The supported MSBuild
`EmscriptenSdkToolsPath` property selects its space-free path; no PATH wrapper
or further shared-SDK edit is used. Both sides were rebuilt, including native
compilation and linking, and published to new `artifacts/inspect-web-isolated`
directories. The original helper baseline is not used.

## Adoption and non-action boundary

The six steps are (1) Integration contract, (2) Integration substrate,
(3) this catalog adoption, (4) CLI explicit selection, (5) browser
CatalogExports selection, and (6) owner-side Aspire compatibility retirement
after both hosts and existing full-scan/presence callers retain behavior.
The ordinary non-friend catalog harness exercises this slice; both production
hosts remain in the enumerated plan.

No host action is presented as enabled by this PR. Existing section/Markout
and browser typed presentation lowerings are unchanged. Prefix/source intent
remains with #5602. No package membership changes, AI-kind vocabulary, new
concept, decoder, scanner sandbox, or source-policing gate is included.
