### PR TITLE
Fix browser facade inventory after Type Source cancellation export

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -181,7 +181,7 @@ capability they adapt, not ownership of the underlying product facts.
 
 ## Production surface inventory
 
-The seven rooted export assemblies contain 49 `[JSExport]` methods.
+The seven rooted export assemblies contain 50 `[JSExport]` methods.
 The generated `initializeRuntime()` and `runEntryPoint()` functions are
 generator-owned infrastructure and are not part of that count.
 
@@ -265,16 +265,17 @@ so absence remains a visible capability result rather than a missing binding.
 The module does not combine Analysis with call-graph topology; graph traversal
 has its own facade and product owner.
 
-### Source facade: 5 exports
+### Source facade: 6 exports
 
 - `CancelSourceQuery`
+- `CancelTypeSourceQuery`
 - `QueryMemberAnnotatedSource`
 - `QueryMemberSource`
 - `QueryTypeMemberSource`
 - `QueryTypeSource`
 
 The source cancellation coordinator remains shared consumer infrastructure, but
-its public cancellation operation belongs beside the work it cancels.
+its public cancellation operations belong beside the work they cancel.
 Annotated source stays with source because the returned document and its
 viewer contract are the capability being requested; Analysis facts embedded in
 that product document do not transfer ownership to this adapter.
@@ -636,7 +637,7 @@ The partition is implemented when all of the following hold:
 1. `ProductionFacadeContext_DeclaresExactAssemblySet` reads the compiled
    `InspectWebJsExportContext` and proves its root identities equal the seven
    expected managed assemblies.
-2. `ProductionFacadePartition_AssignsEveryJsExportExactlyOnce` derives 49
+2. `ProductionFacadePartition_AssignsEveryJsExportExactlyOnce` derives 50
    current exports across the seven expected assemblies with no omission or
    duplicate.
 3. `ProductionFacadeProjects_HaveAcyclicOwnerReferences` proves the host,

--- a/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
+++ b/prototypes/inspect-web/engine.Tests/ProductionFacadeContextTests.cs
@@ -158,10 +158,10 @@ public sealed class ProductionFacadeContextTests
                 actual[assembly]);
         }
 
-        // 49 operations, and no operation name in two modules: a move that forgot to delete its
+        // 50 operations, and no operation name in two modules: a move that forgot to delete its
         // origin, or a name published twice, fails here rather than in the browser.
         string[] everyExport = [.. actual.Values.SelectMany(names => names)];
-        Assert.Equal(49, everyExport.Length);
+        Assert.Equal(50, everyExport.Length);
         Assert.Equal(
             everyExport.Length,
             everyExport.Distinct(StringComparer.Ordinal).Count());


### PR DESCRIPTION
# Restore the precise browser facade inventory

Reconcile the browser engine's existing 50-export inventory so its merge gate
can validate the partition instead of rejecting the supported Type Source
cancellation operation.

Fixes #5958.

## Demo

After #5910 introduced `CancelTypeSourceQuery`, the per-assembly inventory
already matched all compiled exports, but its total assertion still expected
49. The failure reproduced in several PRs, including
[PR #5911's browser job](https://github.com/richlander/dotnet-inspect/actions/runs/33944769827/job/101249038750):

```text
ProductionFacadePartition_AssignsEveryJsExportExactlyOnce
Expected: 49
Actual:   50
```

After this correction, the same Release facade-context class reports:

```text
Total: 4, Errors: 0, Failed: 0, Skipped: 0
```

The Source facade contains six exports, including `CancelTypeSourceQuery`.
Neighboring facade memberships remain unchanged; exact per-assembly
membership, unique operation names, assembly ownership, and wire-context
checks remain intact.

## Scope and design

The owner is `docs/design/inspect-web-jsexport-partitioning.md`, specifically
**Production surface inventory** and **Acceptance**. This correction aligns
the total assertion, comment, and exhaustive documentation with the already
adopted Source cancellation export. It does not change Source operation
semantics, runtime exports, generated bindings, or product behavior.

The total changes from 49 to 50; the documented Source count changes from
five to six and includes the missing operation. This is a separate repair
from the Library hierarchy in #5911, whose locked head remains unchanged.

Review tier: **trivial**. Only an expected numeric literal, its comment, and
matching inventory documentation change. There is no control-flow, API, or
runtime change, so the repository's trivial-change tier requires no review
round.

## Validation

- `dotnet run --project prototypes/inspect-web/engine.Tests -c Release -- -class
  InspectWeb.Engine.Tests.ProductionFacadeContextTests`: 4 passed.
- `npm run build` in `prototypes/inspect-web`: passed, including TypeScript
  checks and frontend artifact construction required by the engine build.
- `npx --no-install markdownlint-cli
  docs/design/inspect-web-jsexport-partitioning.md`: passed.
- Both pre-push base integrations are complete; the second fetch found the
  same base and required no additional integration.

Head: `adb7f8c962a0bd4f634b54f13badc3a8f0b4adcd`.
Effective base: `35bc49ec10b07f5b7a1b3f3a1ebf752e5a1b0b3d` (`main`).
Current-head CI is separate from the local evidence above. No merge has been
authorized.
