### PR TITLE
Replace mutable route learning with resolver-lineage continuations

### DIFF
--- a/docs/design/type-forwarding-resolution.md
+++ b/docs/design/type-forwarding-resolution.md
@@ -1313,11 +1313,11 @@ progress.
 
 #### Resolver-lineage continuations
 
-> **Status: Metadata support implemented; production adoption pending.**
-> #5953 carries occurrences through Metadata; Services/CLI and Queries/Browser
-> adoption remain separate steps. #5801 supplies compiled evidence for the
-> prior behavior, not the replacement. #5666 owns this focused decision;
-> #5274 tracks adoption and retirement.
+> **Status: Metadata and Services/CLI implemented; Browser adoption pending.**
+> #5953 carries occurrences through Metadata; #5666 adopts them in the
+> source-relative Services producer and the existing CLI API-surface path.
+> #5801 supplies the original compiled behavioral evidence.
+> #5274 tracks the remaining Queries/Browser endpoint adoption.
 
 **Claim:** a selected assembly occurrence retains the policy-issued binding
 context required for its subsequent references, without changing the answers
@@ -1329,8 +1329,12 @@ already invoke it through `ApiSurfaceEndpointResolver`. The #5801 fixture
 demonstrates `Consumer -> Middle forwarder -> Base`: a constraint classifies as
 `ReferenceType` through Consumer's resolver and as `Undetermined` when the
 learned association is removed. This establishes the need for resolver lineage,
-not the need for a shared mutable route map. It is Services-level evidence;
-it does not claim an end-to-end command or call-graph demonstration.
+not the need for a shared mutable route map. That original fixture is
+Services-level evidence. The Services adoption also exercises the same
+forwarding chain through the real CLI `diff` parser: a complete dependency set
+returns a complete comparison, while an absent Base produces explicit
+inspection failures and a nonzero exit. This single-root command case does
+not claim to reproduce the two-resolver boundary or a Browser call graph.
 
 ##### Decision and alternatives
 
@@ -1345,7 +1349,10 @@ it does not claim an end-to-end command or call-graph demonstration.
 The two-context boundary is deliberately distinct from the minimal #5801
 fixture: two supported policy delegates can return the same acquisition
 descriptor while prescribing different dependencies. The model explores this
-boundary; a compiled product gate for it remains part of adoption.
+boundary; `ExtractApiSurface_SharedForwarderRetainsBothResolverContexts`
+enforces it with compiled class and interface implementations of Base.
+Both discovery orders and repeated extraction retain `ReferenceType` versus
+`NeitherReferenceNorValue` under one policy version.
 
 ##### Currency and authority
 
@@ -1443,9 +1450,9 @@ alone is not host adoption; this sequencing follows #5865.
 
 | Step | Owning slice and completion |
 | --- | --- |
-| 1 | Binding owner: lock this currency and the companion model in #5666. Product behavior is unchanged. |
-| 2 | Metadata (#5953): carry selected occurrences through requests, results, deferred dependencies, and policy-dependent caches. Existing seed-only producers remain behavior-compatible; context-aware gates demonstrate distinct answers for a shared registration. |
-| 3 | Services: adopt the currency in `SourceRelativeAssemblyGroupBindingPolicy` and remove learned-route insertion, its CAS publication, and registration-only intrinsic caching. Preserve the #5801 result and demonstrate it through the existing CLI `diff` endpoint; `timeline` uses the same endpoint construction. |
+| 1 | Binding owner: currency and companion model locked in #5912 under #5666. Product behavior was unchanged. |
+| 2 | Metadata (#5953): implemented selected occurrences across requests, results, deferred dependencies, and policy-dependent caches. Existing seed-only producers remain behavior-compatible; context-aware gates demonstrate distinct answers for a shared registration. |
+| 3 | Services (#5666): implemented `SourceRelativeAssemblyGroupBindingPolicy` continuation issuance, retiring learned-route insertion and registration-only intrinsic caching. The #5801 result and real CLI `diff` endpoint are exercised; `timeline` uses the same endpoint construction. |
 | 4 | Queries/Browser: adopt through `AssemblyContextTypeResolutionQuery` and `MemberCallGraphSession`, exercised by `PlatformCallGraphExports`. Confirm terminal member navigation and call-graph endpoints while retaining sealed participant provisioning and one attempt per authorized demand. |
 
 The CLI production path is reached at step 3; the Browser path at step 4.
@@ -1454,8 +1461,8 @@ for discovery-time route learning: the workspace-owned complete-plan and
 one-attempt contract remains unchanged. No Browser filesystem resolver or
 host-specific continuation algorithm is introduced.
 
-The replacement is incomplete until step 3 retires the Services learned-route
-representation and step 4 closes both-host adoption. Other transforming
+Step 3 retires the Services learned-route representation; the replacement is
+incomplete until step 4 closes both-host adoption. Other transforming
 policies remain the separately scoped work in #5667, #5668, and #5669.
 Retirement requires the affected existing consumers to have safely cut over;
 the presence of the new currency alone does not justify deletion. If that
@@ -1479,10 +1486,17 @@ model, or proof of product adoption. Exact TLC outcomes are enforced by
 `eng/tla-expected-exit-codes.txt`. Metadata's `TypeResolutionContextTests`
 enforce occurrence separation, forwarding and deferred-dependency propagation,
 intrinsic answers, same-version recipe reuse, stale-origin rejection, and
-contextual discovery bounds in Release. Services/CLI and Queries/Browser
-enforcement remains unverified until their adoption steps supply their own
-Release gates. No feature-specific rendering domain is added: the existing
-API and call-graph models and their lowering owners remain.
+contextual discovery bounds in Release. Services'
+`SourceRelativeAssemblyGroupBindingPolicyTests` enforce canonical-root and
+nested-delegate continuation, stable seed behavior, separate intrinsic answers,
+delegate-version refresh, and the compiled two-context case.
+`AssemblySetResolutionSessionTests` retain the original forwarded-constraint
+oracle; CLI `CommandLine_ForwardedConstraint_ReportsDependencyCompleteness`
+exercises the real command and its missing-dependency neighbor.
+Existing `MemberCallGraphSessionTests` provide query-level regression coverage,
+not Browser endpoint adoption. That endpoint enforcement remains unverified
+until step 4. No feature-specific rendering domain is added: the existing API
+and call-graph models and their lowering owners remain.
 
 The comparative baseline is explicit context association, not a new loading
 mechanism. [AssemblyLoadContext][lineage-alc] associates assemblies with loading

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -83,6 +83,7 @@
     <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.Base/DotnetInspector.Services.RouteLearning.Base.csproj" />
     <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.Consumer/DotnetInspector.Services.RouteLearning.Consumer.csproj" />
     <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.Contract/DotnetInspector.Services.RouteLearning.Contract.csproj" />
+    <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase/DotnetInspector.Services.RouteLearning.InterfaceBase.csproj" />
     <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.Middle/DotnetInspector.Services.RouteLearning.Middle.csproj" />
     <Project Path="fixtures/services/DotnetInspector.Services.RouteLearning.Unrelated/DotnetInspector.Services.RouteLearning.Unrelated.csproj" />
     <Project Path="fixtures/shared/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj" />

--- a/fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase/DotnetInspector.Services.RouteLearning.InterfaceBase.csproj
+++ b/fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase/DotnetInspector.Services.RouteLearning.InterfaceBase.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DotnetInspector.Services.RouteLearning.Base</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase/Middle.cs
+++ b/fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase/Middle.cs
@@ -1,0 +1,5 @@
+namespace DotnetInspector.Services.RouteLearning;
+
+public interface Middle
+{
+}

--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -613,7 +613,7 @@ public class AssemblyDependencyResolverTests
     }
 
     [Fact]
-    public async Task AssemblyGroup_ConcurrentLearnedRoutesAreBothRetained()
+    public async Task AssemblyGroup_ConcurrentSelectionsRetainBothOccurrences()
     {
         ResolvedAssemblyReference defaultOwner = Descriptor(
             new AssemblyReferenceIdentity(
@@ -687,14 +687,12 @@ public class AssemblyDependencyResolverTests
         AssemblyBindingSelectionSnapshot[] snapshots =
             await Task.WhenAll(firstSelection, secondSelection);
 
-        Assert.Same(
-            firstCandidate,
-            Assert.IsType<AssemblyBindingSelection.Selected>(
-                snapshots[0].Selection).Assembly);
-        Assert.Same(
-            secondCandidate,
-            Assert.IsType<AssemblyBindingSelection.Selected>(
-                snapshots[1].Selection).Assembly);
+        var firstSelected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            snapshots[0].Selection);
+        var secondSelected = Assert.IsType<AssemblyBindingSelection.Selected>(
+            snapshots[1].Selection);
+        Assert.Same(firstCandidate, firstSelected.Assembly);
+        Assert.Same(secondCandidate, secondSelected.Assembly);
         Assert.All(
             snapshots,
             snapshot => Assert.Same(version, snapshot.Version));
@@ -709,14 +707,14 @@ public class AssemblyDependencyResolverTests
                 group.Select(
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(probe),
-                        AssemblyBindingOrigin.FromAssembly(firstCandidate),
+                        AssemblyBindingOrigin.FromOccurrence(firstSelected.Occurrence),
                         AssemblyResolutionScope.Any)).Selection);
         var secondProbe = Assert.IsType<
             AssemblyBindingSelection.Selected>(
                 group.Select(
                     new AssemblyBindingRequest(
                         AssemblyBindingTarget.Reference(probe),
-                        AssemblyBindingOrigin.FromAssembly(secondCandidate),
+                        AssemblyBindingOrigin.FromOccurrence(secondSelected.Occurrence),
                         AssemblyResolutionScope.Any)).Selection);
 
         Assert.Same(firstCandidate, firstProbe.Assembly);

--- a/src/DotnetInspector.Services.Tests/SourceRelativeAssemblyGroupBindingPolicyTests.cs
+++ b/src/DotnetInspector.Services.Tests/SourceRelativeAssemblyGroupBindingPolicyTests.cs
@@ -1,0 +1,91 @@
+using DotnetInspector.Fixtures;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Services.Tests;
+
+public class SourceRelativeAssemblyGroupBindingPolicyTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExtractApiSurface_SharedForwarderRetainsBothResolverContexts(
+        bool interfaceFirst)
+    {
+        string consumerPath = FixtureCatalog.ServicesRouteLearningConsumer.AssemblyPath();
+        ResolvedAssemblyReference classConsumer = Descriptor(consumerPath);
+        ResolvedAssemblyReference interfaceConsumer = Descriptor(consumerPath);
+        ResolvedAssemblyReference middle = Descriptor(
+            FixtureCatalog.ServicesRouteLearningConsumer.AssetPath("middle"));
+        ResolvedAssemblyReference classBase = Descriptor(
+            FixtureCatalog.ServicesRouteLearningConsumer.AssetPath("base"));
+        ResolvedAssemblyReference interfaceBase = Descriptor(
+            FixtureCatalog.ServicesRouteLearningInterfaceBase.AssemblyPath());
+        var classPolicy = new AssemblyReferenceBindingPolicy(
+            new FixtureResolver(consumerPath, middle, classBase));
+        var interfacePolicy = new AssemblyReferenceBindingPolicy(
+            new FixtureResolver(consumerPath, middle, interfaceBase));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [
+                (classConsumer, (IAssemblyBindingPolicy)classPolicy),
+                (interfaceConsumer, (IAssemblyBindingPolicy)interfacePolicy),
+            ]);
+        AssemblyBindingPolicyVersion version = group.Version;
+        using var catalog = new TypeResolutionCatalog();
+        (ResolvedAssemblyReference Assembly, TypeParameterTypeKind Kind)[] requests =
+            [
+                (classConsumer, TypeParameterTypeKind.ReferenceType),
+                (interfaceConsumer, TypeParameterTypeKind.NeitherReferenceNorValue),
+            ];
+        if (interfaceFirst)
+            Array.Reverse(requests);
+
+        for (int repeat = 0; repeat < 2; repeat++)
+        {
+            foreach (var request in requests)
+            {
+                ApiSurface surface = Assert.IsType<
+                    ResolutionAwareApiSurfaceOutcome.Read>(
+                        catalog.ExtractApiSurface(request.Assembly, group)).Surface;
+                ApiType consumer = Assert.Single(
+                    surface.Types,
+                    static type => type.FullName
+                        == "DotnetInspector.Services.RouteLearning.Consumer`1");
+
+                Assert.Equal(
+                    request.Kind,
+                    Assert.Single(consumer.TypeParameters).TypeKind);
+                Assert.Empty(surface.InspectionFailures);
+                Assert.Same(version, group.Version);
+            }
+        }
+    }
+
+    static ResolvedAssemblyReference Descriptor(string path) =>
+        ResolvedAssemblyReference.CreateFromPath(
+            path,
+            AssemblyResolutionProvenance.Local("resolver-lineage fixture"));
+
+    sealed class FixtureResolver(
+        string consumerPath,
+        ResolvedAssemblyReference middle,
+        ResolvedAssemblyReference implementation) : IAssemblyReferenceResolver
+    {
+        readonly AssemblyDependencyResolver _fallback = new(
+            new AssemblyDependencyResolutionOptions(consumerPath)
+            {
+                PreferImplementationAssemblies = true,
+                AllowPlatformAssemblyVersionRollForward = true,
+            });
+
+        public ResolvedAssemblyReference? Resolve(
+            AssemblyReferenceIdentity identity,
+            AssemblyResolutionScope scope)
+        {
+            if (identity.Name == middle.Identity.Name)
+                return middle;
+            if (identity.Name == implementation.Identity.Name)
+                return implementation;
+            return _fallback.Resolve(identity, scope);
+        }
+    }
+}

--- a/src/DotnetInspector.Services.Tests/SourceRelativeAssemblyGroupBindingPolicyTests.cs
+++ b/src/DotnetInspector.Services.Tests/SourceRelativeAssemblyGroupBindingPolicyTests.cs
@@ -5,6 +5,226 @@ namespace DotnetInspector.Services.Tests;
 
 public class SourceRelativeAssemblyGroupBindingPolicyTests
 {
+    [Fact]
+    public void Select_ContinuationDoesNotChangeSeedFallback()
+    {
+        var fallback = NamedDescriptor("Fallback");
+        var owner = NamedDescriptor("Owner");
+        var shared = NamedDescriptor("Shared");
+        var dependency = NamedDescriptor("Dependency");
+        var missing = new SelectionPolicy(_ => AssemblyBindingSelection.NameNotOwned());
+        var selecting = new SelectionPolicy(request =>
+            AssemblyBindingSelection.Found(
+                request.Target is AssemblyBindingTarget.AssemblyReference
+                    { Identity.Name: "Shared" } ? shared : dependency));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(fallback, (IAssemblyBindingPolicy)missing), (owner, selecting)]);
+        AssemblyBindingRequest seedProbe = Request(dependency, shared);
+        Assert.IsType<AssemblyBindingSelection.Missing>(group.Select(seedProbe).Selection);
+        AssemblyBindingPolicyVersion version = group.Version;
+
+        var selected = Selected(group, Request(shared, owner));
+        var repeated = Selected(group, Request(shared, owner));
+        var continued = Selected(group, Request(dependency, selected.Occurrence));
+
+        Assert.Same(dependency, continued.Assembly);
+        Assert.Equal(selected.Occurrence.Lineage, repeated.Occurrence.Lineage);
+        Assert.NotEqual(AssemblyBindingLineage.Seed, selected.Occurrence.Lineage);
+        Assert.Same(version, selected.Occurrence.Lineage.Version);
+        Assert.Same(version, group.Version);
+        Assert.IsType<AssemblyBindingSelection.Missing>(group.Select(seedProbe).Selection);
+    }
+
+    [Fact]
+    public void Select_CanonicalRootUsesItsConfiguredResolver()
+    {
+        var first = NamedDescriptor("First");
+        var peer = NamedDescriptor("Peer");
+        var firstDependency = NamedDescriptor("FirstDependency");
+        var peerDependency = NamedDescriptor("PeerDependency");
+        var firstPolicy = new SelectionPolicy(_ => AssemblyBindingSelection.Found(firstDependency));
+        var peerPolicy = new SelectionPolicy(_ => AssemblyBindingSelection.Found(peerDependency));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(first, (IAssemblyBindingPolicy)firstPolicy), (peer, peerPolicy)]);
+
+        var selectedPeer = Selected(group, Request(peer, first));
+        var continued = Selected(group, Request(peerDependency, selectedPeer.Occurrence));
+
+        Assert.Same(peer, selectedPeer.Assembly);
+        Assert.Same(peerDependency, continued.Assembly);
+        Assert.Equal(0, firstPolicy.SelectionCount);
+        Assert.Equal(1, peerPolicy.SelectionCount);
+    }
+
+    [Fact]
+    public void Select_NestedGroupPreservesDelegatedContinuation()
+    {
+        var fallback = NamedDescriptor("Fallback");
+        var owner = NamedDescriptor("Owner");
+        var shared = NamedDescriptor("Shared");
+        var dependency = NamedDescriptor("Dependency");
+        var missing = new SelectionPolicy(_ => AssemblyBindingSelection.NameNotOwned());
+        var selecting = new SelectionPolicy(request =>
+            AssemblyBindingSelection.Found(
+                request.Target is AssemblyBindingTarget.AssemblyReference
+                    { Identity.Name: "Shared" } ? shared : dependency));
+        var inner = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(fallback, (IAssemblyBindingPolicy)missing), (owner, selecting)]);
+        var outer = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(fallback, (IAssemblyBindingPolicy)missing), (owner, inner)]);
+
+        var selected = Selected(outer, Request(shared, owner));
+        var repeated = Selected(outer, Request(shared, owner));
+        var continued = Selected(outer, Request(dependency, selected.Occurrence));
+
+        Assert.Same(dependency, continued.Assembly);
+        Assert.Equal(selected.Occurrence.Lineage, repeated.Occurrence.Lineage);
+        Assert.Same(outer.Version, continued.Occurrence.Lineage.Version);
+        Assert.IsType<AssemblyBindingSelection.Missing>(
+            outer.Select(Request(dependency, shared)).Selection);
+    }
+
+    [Fact]
+    public void Select_AmbiguityAndShadowsDoNotEstablishRoutes()
+    {
+        var fallback = NamedDescriptor("Fallback");
+        var owner = NamedDescriptor("Owner");
+        var first = NamedDescriptor("FirstCandidate");
+        var second = NamedDescriptor("SecondCandidate");
+        var active = NamedDescriptor("Active");
+        var probe = NamedDescriptor("Probe");
+        var missing = new SelectionPolicy(_ => AssemblyBindingSelection.NameNotOwned());
+        var selecting = new SelectionPolicy(request =>
+            request.Target is AssemblyBindingTarget.AssemblyReference
+                { Identity.Name: "Active" }
+                ? AssemblyBindingSelection.Found(active, [first])
+                : AssemblyBindingSelection.Multiple([first, second]));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(fallback, (IAssemblyBindingPolicy)missing), (owner, selecting)]);
+
+        Assert.IsType<AssemblyBindingSelection.Ambiguous>(
+            group.Select(Request(probe, owner)).Selection);
+        var selected = Selected(group, Request(active, owner));
+        Assert.Same(first, Assert.Single(selected.ShadowedAssemblies));
+        foreach (var inactive in new[] { first, second })
+        {
+            Assert.IsType<AssemblyBindingSelection.Missing>(
+                group.Select(Request(probe, inactive)).Selection);
+        }
+    }
+
+    [Fact]
+    public void Select_RejectsForeignAndStaleContinuations()
+    {
+        var owner = NamedDescriptor("Owner");
+        var candidate = NamedDescriptor("Candidate");
+        var policy = new SelectionPolicy(_ => AssemblyBindingSelection.Found(candidate));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(owner, (IAssemblyBindingPolicy)policy)]);
+        var foreignGroup = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(owner, (IAssemblyBindingPolicy)policy)]);
+        var selected = Selected(group, Request(candidate, owner));
+        AssemblyBindingRequest continuation = Request(candidate, selected.Occurrence);
+        var foreign = Assert.IsType<AssemblyBindingSelection.Rejected>(
+            foreignGroup.Select(continuation).Selection);
+        Assert.Equal(AssemblyBindingFailureKind.InvalidBindingOrigin, foreign.Failure.Kind);
+
+        AssemblyBindingPolicyVersion version = group.Version;
+        policy.Replace(_ => AssemblyBindingSelection.Found(candidate));
+
+        Assert.NotSame(version, group.Version);
+        var stale = Assert.IsType<AssemblyBindingSelection.Rejected>(
+            group.Select(continuation).Selection);
+        Assert.Equal(AssemblyBindingFailureKind.InvalidBindingOrigin, stale.Failure.Kind);
+        var fresh = Selected(group, Request(candidate, owner));
+        Assert.NotEqual(selected.Occurrence.Lineage, fresh.Occurrence.Lineage);
+        Assert.Same(group.Version, fresh.Occurrence.Lineage.Version);
+    }
+
+    [Fact]
+    public void Select_IntrinsicCacheSeparatesSharedDescriptorLineages()
+    {
+        var first = NamedDescriptor("First");
+        var second = NamedDescriptor("Second");
+        var shared = Descriptor(typeof(SourceRelativeAssemblyGroupBindingPolicyTests).Assembly.Location);
+        var firstCore = Descriptor(typeof(object).Assembly.Location);
+        var secondCore = Descriptor(typeof(object).Assembly.Location);
+        var firstPolicy = new SelectionPolicy(request =>
+            AssemblyBindingSelection.Found(
+                request.Target is AssemblyBindingTarget.AssemblyReference reference
+                    && reference.Identity.Name == shared.Identity.Name ? shared : firstCore));
+        var secondPolicy = new SelectionPolicy(request =>
+            AssemblyBindingSelection.Found(
+                request.Target is AssemblyBindingTarget.AssemblyReference reference
+                    && reference.Identity.Name == shared.Identity.Name ? shared : secondCore));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(first, (IAssemblyBindingPolicy)firstPolicy), (second, secondPolicy)]);
+        var firstShared = Selected(group, Request(shared, first)).Occurrence;
+        var secondShared = Selected(group, Request(shared, second)).Occurrence;
+
+        for (int repeat = 0; repeat < 2; repeat++)
+        {
+            Assert.Same(firstCore, SelectCore(firstShared).Assembly);
+            Assert.Same(secondCore, SelectCore(secondShared).Assembly);
+        }
+        Assert.Equal(2, firstPolicy.SelectionCount);
+        Assert.Equal(2, secondPolicy.SelectionCount);
+
+        AssemblyBindingSelection.Selected SelectCore(AssemblyBindingOccurrence occurrence) =>
+            Selected(group, new AssemblyBindingRequest(
+                AssemblyBindingTarget.CoreLibrary(),
+                AssemblyBindingOrigin.FromOccurrence(occurrence),
+                AssemblyResolutionScope.Any));
+    }
+
+    [Fact]
+    public void Select_WarmIntrinsicCacheObservesDelegateVersionChange()
+    {
+        var owner = Descriptor(typeof(SourceRelativeAssemblyGroupBindingPolicyTests).Assembly.Location);
+        var firstCore = Descriptor(typeof(object).Assembly.Location);
+        var secondCore = Descriptor(typeof(object).Assembly.Location);
+        var policy = new SelectionPolicy(_ => AssemblyBindingSelection.Found(firstCore));
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(owner, (IAssemblyBindingPolicy)policy)]);
+        var request = new AssemblyBindingRequest(
+            AssemblyBindingTarget.CoreLibrary(),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+        Assert.Same(firstCore, Selected(group, request).Assembly);
+        Assert.Same(firstCore, Selected(group, request).Assembly);
+        Assert.Equal(1, policy.SelectionCount);
+        AssemblyBindingPolicyVersion version = group.Version;
+
+        policy.Replace(_ => AssemblyBindingSelection.Found(secondCore));
+
+        Assert.NotSame(version, group.Version);
+        Assert.Same(secondCore, Selected(group, request).Assembly);
+        Assert.Equal(2, policy.SelectionCount);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Select_ForeignSnapshotEscapesBeforePayloadComposition(bool intrinsic)
+    {
+        var owner = Descriptor(typeof(SourceRelativeAssemblyGroupBindingPolicyTests).Assembly.Location);
+        var candidate = NamedDescriptor("Candidate");
+        var foreign = new AssemblyBindingSelectionSnapshot(
+            new AssemblyBindingPolicyVersion(),
+            AssemblyBindingSelection.Found(candidate));
+        var policy = new ForeignSnapshotPolicy(foreign);
+        var group = new SourceRelativeAssemblyGroupBindingPolicy(
+            [(owner, (IAssemblyBindingPolicy)policy)]);
+        var request = new AssemblyBindingRequest(
+            intrinsic ? AssemblyBindingTarget.CoreLibrary()
+                : AssemblyBindingTarget.Reference(candidate.Identity),
+            AssemblyBindingOrigin.FromAssembly(owner),
+            AssemblyResolutionScope.Any);
+
+        Assert.Same(foreign, group.Select(request));
+        Assert.Equal(1, policy.SelectionCount);
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
@@ -64,6 +284,68 @@ public class SourceRelativeAssemblyGroupBindingPolicyTests
         ResolvedAssemblyReference.CreateFromPath(
             path,
             AssemblyResolutionProvenance.Local("resolver-lineage fixture"));
+
+    static ResolvedAssemblyReference NamedDescriptor(string name) =>
+        ResolvedAssemblyReference.Create(
+            new AssemblyReferenceIdentity(name, new Version(1, 0, 0, 0), null, null),
+            name + ".dll",
+            static () => throw new InvalidOperationException(
+                "Descriptor-only selection must not open an assembly."),
+            AssemblyResolutionProvenance.Local("resolver-lineage selection"));
+
+    static AssemblyBindingRequest Request(
+        ResolvedAssemblyReference target,
+        ResolvedAssemblyReference origin) =>
+        new(
+            AssemblyBindingTarget.Reference(target.Identity),
+            AssemblyBindingOrigin.FromAssembly(origin),
+            AssemblyResolutionScope.Any);
+
+    static AssemblyBindingRequest Request(
+        ResolvedAssemblyReference target,
+        AssemblyBindingOccurrence origin) =>
+        new(
+            AssemblyBindingTarget.Reference(target.Identity),
+            AssemblyBindingOrigin.FromOccurrence(origin),
+            AssemblyResolutionScope.Any);
+
+    static AssemblyBindingSelection.Selected Selected(
+        IAssemblyBindingPolicy policy,
+        AssemblyBindingRequest request) =>
+        Assert.IsType<AssemblyBindingSelection.Selected>(policy.Select(request).Selection);
+
+    sealed class SelectionPolicy(
+        Func<AssemblyBindingRequest, AssemblyBindingSelection> select) : IAssemblyBindingPolicy
+    {
+        Func<AssemblyBindingRequest, AssemblyBindingSelection> _select = select;
+        public AssemblyBindingPolicyVersion Version { get; private set; } = new();
+        internal int SelectionCount { get; private set; }
+
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            SelectionCount++;
+            return new(Version, _select(request));
+        }
+
+        internal void Replace(Func<AssemblyBindingRequest, AssemblyBindingSelection> replacement)
+        {
+            _select = replacement;
+            Version = new();
+        }
+    }
+
+    sealed class ForeignSnapshotPolicy(
+        AssemblyBindingSelectionSnapshot snapshot) : IAssemblyBindingPolicy
+    {
+        public AssemblyBindingPolicyVersion Version { get; } = new();
+        internal int SelectionCount { get; private set; }
+
+        public AssemblyBindingSelectionSnapshot Select(AssemblyBindingRequest request)
+        {
+            SelectionCount++;
+            return snapshot;
+        }
+    }
 
     sealed class FixtureResolver(
         string consumerPath,

--- a/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
+++ b/src/DotnetInspector.Services/SourceRelativeAssemblyGroupBindingPolicy.cs
@@ -12,6 +12,10 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
     IAssemblyBindingPolicy
 {
     readonly ImmutableArray<ResolvedAssemblyReference> _roots;
+    readonly ImmutableDictionary<
+        AssemblyAcquisitionRegistration,
+        AssemblyRoute> _routes;
+    readonly ImmutableArray<IAssemblyBindingPolicy> _delegates;
     BindingPolicyState _state;
 
     public SourceRelativeAssemblyGroupBindingPolicy(
@@ -26,6 +30,10 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             AssemblyAcquisitionRegistration,
             AssemblyRoute>(
                 ReferenceEqualityComparer.Instance);
+        var delegates = ImmutableArray.CreateBuilder<
+            IAssemblyBindingPolicy>();
+        var seenDelegates = new HashSet<IAssemblyBindingPolicy>(
+            ReferenceEqualityComparer.Instance);
         foreach ((ResolvedAssemblyReference assembly,
             IAssemblyBindingPolicy policy) in participants)
         {
@@ -35,6 +43,8 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             routes.Add(
                 assembly.Registration,
                 new AssemblyRoute(assembly, policy));
+            if (seenDelegates.Add(policy))
+                delegates.Add(policy);
         }
 
         if (roots.Count == 0)
@@ -45,42 +55,50 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
         }
 
         _roots = roots.ToImmutable();
-        ImmutableDictionary<
-            AssemblyAcquisitionRegistration,
-            AssemblyRoute> initialRoutes = routes.ToImmutable();
-        _state = new BindingPolicyState(
-            new AssemblyBindingPolicyVersion(),
-            initialRoutes[_roots[0].Registration].Policy,
-            initialRoutes,
-            new IntrinsicSelectionCache());
+        _routes = routes.ToImmutable();
+        _delegates = delegates.ToImmutable();
+        _state = CreateState();
     }
 
     public AssemblyBindingPolicyVersion Version =>
-        Volatile.Read(ref _state).Version;
+        CurrentState().Version;
 
     public AssemblyBindingSelectionSnapshot Select(
         AssemblyBindingRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        BindingPolicyState state = Volatile.Read(ref _state);
-        return new AssemblyBindingSelectionSnapshot(
-            state.Version,
-            Select(state, request));
+        BindingPolicyState state = CurrentState();
+        try
+        {
+            return new AssemblyBindingSelectionSnapshot(
+                state.Version,
+                Select(state, request));
+        }
+        catch (ForeignSnapshotException foreign)
+        {
+            return foreign.Snapshot;
+        }
     }
 
     AssemblyBindingSelection Select(
         BindingPolicyState state,
         AssemblyBindingRequest request)
     {
-        IAssemblyBindingPolicy policy =
-            PolicyFor(state, request.Origin);
+        if (RouteRequest(state, request) is not { } route)
+        {
+            return AssemblyBindingSelection.Invalid(
+                new AssemblyBindingFailure(
+                    AssemblyBindingFailureKind.InvalidBindingOrigin));
+        }
+
         if (request.Target is AssemblyBindingTarget.IntrinsicCoreLibrary
             && request.Origin
-                is AssemblyBindingOrigin.RequestingAssembly requesting
-            && AssemblyFor(state, requesting.Registration)
-                is { } requestingAssembly)
+                is AssemblyBindingOrigin.RequestingAssembly requesting)
         {
-            var key = (requesting.Registration, request.Scope);
+            var key = new IntrinsicSelectionKey(
+                requesting.Assembly,
+                requesting.Lineage,
+                request.Scope);
             if (!state.IntrinsicSelections.TryGet(
                     key,
                     out Lazy<AssemblyBindingSelection>?
@@ -91,7 +109,8 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                         key,
                         () => SelectIntrinsicCoreLibrary(
                             state,
-                            requestingAssembly,
+                            route,
+                            requesting,
                             request.Origin,
                             request.Scope));
             }
@@ -136,14 +155,28 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                             reference.Identity)),
                 ];
                 if (matches.Length == 1)
-                    return AssemblyBindingSelection.Found(matches[0]);
+                {
+                    return IssueSelection(
+                        state,
+                        route,
+                        AssemblyBindingSelection.Found(matches[0]));
+                }
                 if (matches.Length > 1)
                     return AssemblyBindingSelection.Multiple(matches);
             }
         }
 
         AssemblyBindingSelectionSnapshot? snapshot =
-            policy.Select(request);
+            route.Delegate.Policy.Select(route.DelegatedRequest);
+        if (snapshot is not null
+            && !ReferenceEquals(
+                route.Delegate.Version,
+                snapshot.Version))
+        {
+            _ = CurrentState();
+            throw new ForeignSnapshotException(snapshot);
+        }
+
         AssemblyBindingSelection selection =
             AssemblyBindingSelection.ValidateForRequest(
                 request,
@@ -174,17 +207,7 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             selection = mismatch;
         }
 
-        switch (selection)
-        {
-            case AssemblyBindingSelection.Selected selected:
-                Register([selected.Assembly], policy);
-                break;
-            case AssemblyBindingSelection.Ambiguous ambiguous:
-                Register(ambiguous.Assemblies, policy);
-                break;
-        }
-
-        return selection;
+        return IssueSelection(state, route, selection);
     }
 
     static AssemblyBindingSelection ComposePendingDesignated(
@@ -257,9 +280,18 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
                         requested,
                         candidate,
                         ignoreVersion: true)));
-        return AssemblyBindingSelection.Found(
-            designatedCandidates[0],
-            platforms);
+        ResolvedAssemblyReference chosen = designatedCandidates[0];
+        return policySelection
+                is AssemblyBindingSelection.Selected delegated
+            && ReferenceEquals(
+                chosen.Registration,
+                delegated.Assembly.Registration)
+                ? AssemblyBindingSelection.FoundOccurrence(
+                    delegated.Occurrence,
+                    platforms)
+                : AssemblyBindingSelection.Found(
+                    chosen,
+                    platforms);
     }
 
     static ImmutableArray<ResolvedAssemblyReference> DesignatedCandidates(
@@ -379,110 +411,202 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
 
     AssemblyBindingSelection SelectIntrinsicCoreLibrary(
         BindingPolicyState state,
-        ResolvedAssemblyReference requestingAssembly,
+        RoutedRequest route,
+        AssemblyBindingOrigin.RequestingAssembly requesting,
         AssemblyBindingOrigin origin,
         AssemblyResolutionScope scope)
-        => IntrinsicCoreLibraryBinding.Select(
-            requestingAssembly,
-            facade => Select(
-                state,
-                new AssemblyBindingRequest(
-                    AssemblyBindingTarget.Reference(facade),
-                    origin,
-                    scope)));
-
-    static IAssemblyBindingPolicy PolicyFor(
-        BindingPolicyState state,
-        AssemblyBindingOrigin origin)
     {
-        if (origin is not AssemblyBindingOrigin.RequestingAssembly requesting)
-            return state.Default;
+        AssemblyBindingSelection selection =
+            IntrinsicCoreLibraryBinding.Select(
+                requesting.Assembly,
+                facade => Select(
+                    state,
+                    new AssemblyBindingRequest(
+                        AssemblyBindingTarget.Reference(facade),
+                        origin,
+                        scope)));
+        selection = AssemblyBindingSelection.ValidateForRequest(
+            new AssemblyBindingRequest(
+                AssemblyBindingTarget.CoreLibrary(),
+                origin,
+                scope),
+            selection);
+        AssemblyBindingOccurrence? requestingOccurrence =
+            route.RequestingOccurrence;
+        if (selection
+                is AssemblyBindingSelection.Selected selected
+            && selected.Occurrence.Lineage
+                == AssemblyBindingLineage.Seed
+            && requestingOccurrence is not null
+            && ReferenceEquals(
+                selected.Assembly.Registration,
+                requesting.Assembly.Registration))
+        {
+            return IssueSelection(
+                state,
+                route,
+                AssemblyBindingSelection.FoundOccurrence(
+                    requestingOccurrence,
+                    selected.ShadowedAssemblies));
+        }
 
-        return state.Routes.TryGetValue(
-            requesting.Registration,
-            out AssemblyRoute? route)
-                ? route.Policy
-                : state.Default;
+        return IssueSelection(state, route, selection);
     }
 
-    static ResolvedAssemblyReference? AssemblyFor(
+    RoutedRequest? RouteRequest(
         BindingPolicyState state,
-        AssemblyAcquisitionRegistration registration)
-        => state.Routes.GetValueOrDefault(registration)?.Assembly;
+        AssemblyBindingRequest request)
+    {
+        if (request.Origin
+            is not AssemblyBindingOrigin.RequestingAssembly requesting)
+        {
+            return new RoutedRequest(
+                state.DelegateFor(DefaultRoute.Policy),
+                request,
+                null);
+        }
 
-    void Register(
-        IEnumerable<ResolvedAssemblyReference> assemblies,
-        IAssemblyBindingPolicy policy)
+        if (requesting.Lineage is null
+            || requesting.Lineage == AssemblyBindingLineage.Seed)
+        {
+            AssemblyRoute route = _routes.GetValueOrDefault(
+                    requesting.Registration)
+                ?? DefaultRoute;
+            return new RoutedRequest(
+                state.DelegateFor(route.Policy),
+                request,
+                requesting.Occurrence
+                    ?? AssemblyBindingOccurrence.Seed(
+                        requesting.Assembly));
+        }
+
+        if (requesting.Lineage
+                is not SourceRelativeBindingLineage lineage
+            || !ReferenceEquals(lineage.Issuer, this)
+            || !ReferenceEquals(lineage.State, state))
+        {
+            return null;
+        }
+
+        return new RoutedRequest(
+            lineage.Delegate,
+            new AssemblyBindingRequest(
+                request.Target,
+                AssemblyBindingOrigin.FromOccurrence(
+                    lineage.DelegatedOccurrence),
+                request.Scope),
+            lineage.DelegatedOccurrence);
+    }
+
+    AssemblyBindingSelection IssueSelection(
+        BindingPolicyState state,
+        RoutedRequest route,
+        AssemblyBindingSelection selection)
+    {
+        if (selection
+            is not AssemblyBindingSelection.Selected selected)
+        {
+            return selection;
+        }
+
+        if (selected.Occurrence.Lineage
+                is SourceRelativeBindingLineage issued
+            && ReferenceEquals(issued.Issuer, this)
+            && ReferenceEquals(issued.State, state))
+        {
+            return selection;
+        }
+
+        DelegateCapture bindingDelegate = route.Delegate;
+        AssemblyBindingOccurrence delegatedOccurrence =
+            selected.Occurrence;
+        if (_routes.TryGetValue(
+                selected.Assembly.Registration,
+                out AssemblyRoute? canonicalRoute))
+        {
+            bindingDelegate = state.DelegateFor(
+                canonicalRoute.Policy);
+            delegatedOccurrence = AssemblyBindingOccurrence.Seed(
+                canonicalRoute.Assembly);
+        }
+
+        var lineage = new SourceRelativeBindingLineage(
+            this,
+            state,
+            bindingDelegate,
+            delegatedOccurrence);
+        return AssemblyBindingSelection.FoundOccurrence(
+            lineage.Issue(selected.Assembly),
+            selected.ShadowedAssemblies);
+    }
+
+    BindingPolicyState CurrentState()
     {
         while (true)
         {
             BindingPolicyState current = Volatile.Read(ref _state);
-            ImmutableDictionary<
-                AssemblyAcquisitionRegistration,
-                AssemblyRoute> routes = current.Routes;
+            if (IsCurrent(current))
+                return current;
 
-            bool changed = false;
-            foreach (ResolvedAssemblyReference assembly in assemblies)
-            {
-                if (routes.ContainsKey(assembly.Registration))
-                    continue;
-
-                routes = routes.Add(
-                    assembly.Registration,
-                    new AssemblyRoute(assembly, policy));
-                changed = true;
-            }
-
-            if (!changed)
-                return;
-
-            BindingPolicyState replacement =
-                current.WithLearnedRoutes(routes);
-            if (ReferenceEquals(
-                    Interlocked.CompareExchange(
-                        ref _state,
-                        replacement,
-                        current),
-                    current))
-            {
-                return;
-            }
+            BindingPolicyState replacement = CreateState();
+            Interlocked.CompareExchange(
+                ref _state,
+                replacement,
+                current);
         }
     }
 
+    bool IsCurrent(BindingPolicyState state)
+    {
+        foreach (IAssemblyBindingPolicy policy in _delegates)
+        {
+            if (!ReferenceEquals(
+                    state.DelegateFor(policy).Version,
+                    policy.Version))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    BindingPolicyState CreateState()
+    {
+        var delegates = ImmutableDictionary.CreateBuilder<
+            IAssemblyBindingPolicy,
+            DelegateCapture>(
+                ReferenceEqualityComparer.Instance);
+        foreach (IAssemblyBindingPolicy policy in _delegates)
+        {
+            delegates.Add(
+                policy,
+                new DelegateCapture(policy, policy.Version));
+        }
+
+        return new BindingPolicyState(
+            new AssemblyBindingPolicyVersion(),
+            delegates.ToImmutable(),
+            new IntrinsicSelectionCache());
+    }
+
+    AssemblyRoute DefaultRoute => _routes[_roots[0].Registration];
+
     sealed class BindingPolicyState(
         AssemblyBindingPolicyVersion version,
-        IAssemblyBindingPolicy defaultPolicy,
         ImmutableDictionary<
-            AssemblyAcquisitionRegistration,
-            AssemblyRoute> routes,
+            IAssemblyBindingPolicy,
+            DelegateCapture> delegates,
         IntrinsicSelectionCache intrinsicSelections)
     {
         internal AssemblyBindingPolicyVersion Version { get; } =
             version;
-        internal IAssemblyBindingPolicy Default { get; } =
-            defaultPolicy;
-        internal ImmutableDictionary<
-            AssemblyAcquisitionRegistration,
-            AssemblyRoute> Routes
-        { get; } =
-                routes;
         internal IntrinsicSelectionCache IntrinsicSelections { get; } =
             intrinsicSelections;
 
-        internal BindingPolicyState WithLearnedRoutes(
-            ImmutableDictionary<
-                AssemblyAcquisitionRegistration,
-                AssemblyRoute> learnedRoutes)
-        {
-            // Learning only fills previously unknown registrations, so cached
-            // intrinsic answers for already-known origins remain valid.
-            return new BindingPolicyState(
-                Version,
-                Default,
-                learnedRoutes,
-                IntrinsicSelections);
-        }
+        internal DelegateCapture DelegateFor(
+            IAssemblyBindingPolicy policy) =>
+            delegates[policy];
     }
 
     sealed class AssemblyRoute(
@@ -495,17 +619,73 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
             policy;
     }
 
+    sealed class DelegateCapture(
+        IAssemblyBindingPolicy policy,
+        AssemblyBindingPolicyVersion version)
+    {
+        internal IAssemblyBindingPolicy Policy { get; } = policy;
+        internal AssemblyBindingPolicyVersion Version { get; } =
+            version;
+    }
+
+    sealed record SourceRelativeBindingLineage :
+        AssemblyBindingLineage
+    {
+        internal SourceRelativeBindingLineage(
+            SourceRelativeAssemblyGroupBindingPolicy issuer,
+            BindingPolicyState state,
+            DelegateCapture bindingDelegate,
+            AssemblyBindingOccurrence delegatedOccurrence)
+            : base(state.Version)
+        {
+            Issuer = issuer;
+            State = state;
+            Delegate = bindingDelegate;
+            DelegatedOccurrence = delegatedOccurrence;
+        }
+
+        internal SourceRelativeAssemblyGroupBindingPolicy Issuer
+        {
+            get;
+        }
+        internal BindingPolicyState State { get; }
+        internal DelegateCapture Delegate { get; }
+        internal AssemblyBindingOccurrence DelegatedOccurrence
+        {
+            get;
+        }
+
+        internal AssemblyBindingOccurrence Issue(
+            ResolvedAssemblyReference assembly) =>
+            CreateOccurrence(assembly);
+    }
+
+    sealed class ForeignSnapshotException(
+        AssemblyBindingSelectionSnapshot snapshot) : Exception
+    {
+        internal AssemblyBindingSelectionSnapshot Snapshot { get; } =
+            snapshot;
+    }
+
+    readonly record struct RoutedRequest(
+        DelegateCapture Delegate,
+        AssemblyBindingRequest DelegatedRequest,
+        AssemblyBindingOccurrence? RequestingOccurrence);
+
+    readonly record struct IntrinsicSelectionKey(
+        ResolvedAssemblyReference RequestingAssembly,
+        AssemblyBindingLineage? Lineage,
+        AssemblyResolutionScope Scope);
+
     sealed class IntrinsicSelectionCache
     {
         readonly object _gate = new();
         readonly Dictionary<
-            (AssemblyAcquisitionRegistration Origin,
-                AssemblyResolutionScope Scope),
+            IntrinsicSelectionKey,
             Lazy<AssemblyBindingSelection>> _selections = [];
 
         internal bool TryGet(
-            (AssemblyAcquisitionRegistration Origin,
-                AssemblyResolutionScope Scope) key,
+            IntrinsicSelectionKey key,
             out Lazy<AssemblyBindingSelection>? selection)
         {
             lock (_gate)
@@ -513,8 +693,7 @@ public sealed class SourceRelativeAssemblyGroupBindingPolicy :
         }
 
         internal Lazy<AssemblyBindingSelection> GetOrAdd(
-            (AssemblyAcquisitionRegistration Origin,
-                AssemblyResolutionScope Scope) key,
+            IntrinsicSelectionKey key,
             Func<AssemblyBindingSelection> select)
         {
             lock (_gate)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -2540,6 +2540,61 @@ public class DiffCommandTests
         Assert.Contains("## Implementation Diff", output, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task CommandLine_ForwardedConstraint_ReportsDependencyCompleteness(
+        bool includeBase)
+    {
+        string directory = Directory.CreateTempSubdirectory(
+            "diff-resolver-lineage-").FullName;
+        string consumer = FixtureCatalog.ServicesRouteLearningConsumer.AssemblyPath();
+        string middle = FixtureCatalog.ServicesRouteLearningConsumer.AssetPath("middle");
+        string implementation = FixtureCatalog.ServicesRouteLearningConsumer.AssetPath("base");
+        string target = Path.Combine(directory, Path.GetFileName(consumer));
+        try
+        {
+            File.Copy(consumer, target);
+            File.Copy(middle, Path.Combine(directory, Path.GetFileName(middle)));
+            if (includeBase)
+            {
+                File.Copy(
+                    implementation,
+                    Path.Combine(directory, Path.GetFileName(implementation)));
+            }
+
+            string[] args = CommandLineBuilder.PreprocessArgs(
+                ["diff", "--library", $"{target}..{target}", "--json"]);
+            var (exitCode, output, error) = await ConsoleCapture.RunAsync(
+                async () => await CommandLineBuilder.CreateRootCommand()
+                    .Parse(args).InvokeAsync());
+
+            Assert.Equal(includeBase ? 0 : 1, exitCode);
+            Assert.Empty(error);
+            using var document = JsonDocument.Parse(output);
+            Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+            if (includeBase)
+            {
+                Assert.DoesNotContain("incomplete", output, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Assert.Contains(
+                    ApiSurfaceInspectionFailure.GenericParameterConstraintResolutionOperation,
+                    output,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "DotnetInspector.Services.RouteLearning.Base",
+                    output,
+                    StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task ExecuteAsync_AllSections_ReportsFocusedFindingTransitionsException()
     {

--- a/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
+++ b/tests/DotnetInspector.FixtureInfrastructure/FixtureCatalog.cs
@@ -127,6 +127,8 @@ public static class FixtureIds
 
     public const string ServicesRouteLearningBase =
         "services.route-learning.base";
+    public const string ServicesRouteLearningInterfaceBase =
+        "services.route-learning.interface-base";
     public const string ServicesRouteLearningContract =
         "services.route-learning.contract";
     public const string ServicesRouteLearningMiddle =
@@ -620,6 +622,16 @@ public static class FixtureCatalog
                 FixtureBoundary.CrossAssemblyBoundary),
             "services", "binding", "route-learning", "compile-contract");
 
+    public static readonly FixtureDefinition ServicesRouteLearningInterfaceBase =
+        Fixture(
+            FixtureIds.ServicesRouteLearningInterfaceBase,
+            "DotnetInspector.Services.RouteLearning.InterfaceBase",
+            "DotnetInspector.Services.RouteLearning.Base.dll",
+            Boundaries(
+                FixtureBoundary.AssemblyName,
+                FixtureBoundary.CrossAssemblyBoundary),
+            "services", "binding", "resolver-lineage", "interface-base");
+
     public static readonly FixtureDefinition ServicesRouteLearningMiddle =
         Fixture(
             FixtureIds.ServicesRouteLearningMiddle,
@@ -717,6 +729,7 @@ public static class FixtureCatalog
         RestoredProjectDependencyFacts,
         ServicesRouteLearningBase,
         ServicesRouteLearningContract,
+        ServicesRouteLearningInterfaceBase,
         ServicesRouteLearningMiddle,
         ServicesRouteLearningConsumer,
         ServicesRouteLearningUnrelated,
@@ -1024,6 +1037,7 @@ public static class FixtureCatalog
             "DotnetInspector.Services.RouteLearning.Base" => "fixtures/services/DotnetInspector.Services.RouteLearning.Base",
             "DotnetInspector.Services.RouteLearning.Consumer" => "fixtures/services/DotnetInspector.Services.RouteLearning.Consumer",
             "DotnetInspector.Services.RouteLearning.Contract" => "fixtures/services/DotnetInspector.Services.RouteLearning.Contract",
+            "DotnetInspector.Services.RouteLearning.InterfaceBase" => "fixtures/services/DotnetInspector.Services.RouteLearning.InterfaceBase",
             "DotnetInspector.Services.RouteLearning.Middle" => "fixtures/services/DotnetInspector.Services.RouteLearning.Middle",
             "DotnetInspector.Services.RouteLearning.Unrelated" => "fixtures/services/DotnetInspector.Services.RouteLearning.Unrelated",
             "ILInspector.Analysis.AsyncSiblingFriendFixtures" => "fixtures/analysis/ILInspector.Analysis.AsyncSiblingFriendFixtures",


### PR DESCRIPTION
Makes resolver-relative API inspection repeatable: selecting an assembly now
retains its resolver context instead of teaching a shared registration-to-policy
map. This is the immediate production Services/CLI consumer of Metadata
PR #5978, not another substrate-only slice.

## Demo

The same compiled Middle forwarder can be selected by two resolvers. One
provides a class implementation of Base; the other provides an interface
implementation with the same assembly identity.

```text
Consumer A -> shared Middle [resolver A] -> Base containing class Middle
Consumer B -> shared Middle [resolver B] -> Base containing interface Middle
```

| Discovery order | Before: A / B constraint kinds | After: A / B constraint kinds |
| --- | --- | --- |
| A first | ReferenceType / ReferenceType | ReferenceType / NeitherReferenceNorValue |
| B first | NeitherReferenceNorValue / NeitherReferenceNorValue | ReferenceType / NeitherReferenceNorValue |

Repeated extraction preserves both answers under one policy version while
sharing the forwarding assembly's physical acquisition descriptor.
The original #5801 `AssemblySetSurfaceBuilder` case also retains its
`ReferenceType` answer when an unrelated fallback root precedes Consumer.

The existing production path is exercised without a new command or flag:

```text
CLI diff / timeline
  -> ApiSurfaceEndpointResolver
  -> AssemblySetSurfaceBuilder / AssemblySetResolutionSession
  -> SourceRelativeAssemblyGroupBindingPolicy
```

After the normal Release build, run the actual command on the compiled chain:

```sh
consumer="$PWD/artifacts/bin/DotnetInspector.Services.RouteLearning.Consumer/release/DotnetInspector.Services.RouteLearning.Consumer.dll"
dotnet run --project src/dotnet-inspect -c Release --no-build -- \
  diff --library "$consumer..$consumer" --json
```

Output, exit 0:

```json
{
  "title": "Diff: DotnetInspector.Services.RouteLearning.Consumer",
  "versions": "DotnetInspector.Services.RouteLearning.Consumer.dll -\u003E DotnetInspector.Services.RouteLearning.Consumer.dll",
  "changes_summary": "no changes"
}
```

Neighboring case: copying Consumer and Middle to a fresh directory without
Base returns exit 1 and reports:

```text
API comparison is incomplete because metadata inspection reported 2 failure(s).
operation: resolve generic parameter constraints
dependency: DotnetInspector.Services.RouteLearning.Base
```

The executable `CommandLine_ForwardedConstraint_ReportsDependencyCompleteness`
cases reproduce both command outcomes. This single-root command demo is not
presented as a CLI reproduction of the separate two-resolver boundary.

## Design basis and implementation

The sole normative owner is
[Resolver-lineage continuations](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/type-forwarding-resolution.md#resolver-lineage-continuations):
a selected occurrence retains the binding context needed for subsequent
references without changing other requests under the same policy version.
The landed TLA+ model supplies the contract model; Metadata PR #5978 supplies
the consumed occurrence currency.

Configured roots remain immutable and use their configured resolver.
Nonparticipant selections retain the selecting delegate's occurrence; nested
groups unwrap only their own continuation. Ambiguity and shadow evidence do
not establish routes. Seed fallback stays stable after selections.

Intrinsic caching includes lineage. Genuine delegated-version changes produce
a fresh outer state/version and cache; selecting an occurrence does not.
Delegated snapshots are checked before payload composition, including intrinsic
callbacks. A foreign snapshot propagates unchanged and is not retried.
Stale or foreign origins are explicit binding-origin rejections.

This retires learned-route insertion and its publication path in Services.
The remaining CAS loop publishes actual delegate-version changes, not learned
routes. Existing API models and their output lowering remain in place; this
slice changes resolution rather than rendering.

## Stack and remaining adoption

Slice 2 of 2, now targeting `main` after parent PR #5978 merged.
The recovered head is `3fcd830794f57984d92bf1c121de65e78689c6b3`, based on
`7313ea4f21210d15f7e001a3e72d3622268b7059`.
It implements the Services/CLI milestone in #5666 and #5274, following #5865's
immediate-consumer and safe-retirement discipline.

The four-step overall path remains: design/model, Metadata, Services/CLI, then
Queries/Browser endpoint adoption. Existing `MemberCallGraphSessionTests`
provide regression coverage for the shared query consumer; they do not complete
Browser endpoint adoption. `PlatformCallGraphExports` terminal navigation and
call-graph endpoints remain step 4, with sealed participant provisioning and
one attempt per authorized demand unchanged.

Other transforming policies remain separately scoped under #5667, #5668, and
#5669. This PR does not claim to complete #5865 routes A-E or the entire
both-host migration.

## Validation

The following evidence predates the post-merge restack. It ran in this child
worktree with the repository-selected .NET 11 preview SDK and Release
configuration; it is not presented as new-head evidence:

- Normal solution build succeeded.
- 89 Services cases passed across `SourceRelativeAssemblyGroupBindingPolicyTests`,
  `AssemblySetResolutionSessionTests`, and `AssemblyDependencyResolverTests`.
- 2 real CLI parser cases passed, with complete and missing-Base dependencies.
- 43 `MemberCallGraphSessionTests` passed.
- 19 `FixtureCatalogTests` passed.
- Both actual CLI invocations above produced their stated output and exit code.
- The changed owner document passes `markdownlint`.

The new InterfaceBase input is independently compiled under `fixtures/services`,
registered in `FixtureCatalog`, and built by the normal solution graph.

Fresh evidence at recovered head
`3fcd830794f57984d92bf1c121de65e78689c6b3`:

- Normal Release solution build passed with zero warnings and errors.
- All 89 focused Services cases passed.
- Both real CLI parser cases passed.
- The changed owner document passes `markdownlint`.

Current-head `ci-required` succeeded in
[run 33999080421](https://github.com/richlander/dotnet-inspect/actions/runs/33999080421).
Round 1 is clean: GPT-5.6 Sol and Claude Opus 5 both reviewed exact head
`3fcd830794f57984d92bf1c121de65e78689c6b3` with no qualifying findings.
The PR remains unmerged; no merge authorization is recorded.

The range-diff keeps the Services implementation commit identical; the fixture commit drops
only an obsolete empty `runfaster` solution folder after main moved that fixture
and test project. No Metadata prerequisite changes remain in this PR's diff.
