### PR TITLE
Define the single-runtime Inspect Web engine client

### DIFF
--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -4,7 +4,8 @@ Status: **implemented** for issue
 [#4497](https://github.com/richlander/dotnet-inspect/issues/4497).
 The [page-facing engine client](#page-facing-engine-client) is **design-only,
 not implemented**, preparing the single-runtime Worker cutover for
-[#5420](https://github.com/richlander/dotnet-inspect/issues/5420).
+[#5987](https://github.com/richlander/dotnet-inspect/issues/5987) and its Source
+consumer [#5420](https://github.com/richlander/dotnet-inspect/issues/5420).
 
 This is the owning document for the inspect-web production facade partition:
 which existing browser-host exports belong together, how independently
@@ -550,6 +551,9 @@ updates credit only after a synchronous successful grant.
 requires synchronous share encode/decode today. These consumers need focused
 adoption before the production switch, not type assertions that pretend their
 existing synchronous contracts already support a Worker.
+In particular, share/copy must not assume that transient user activation
+survives an awaited engine call; its navigation owner retains that interaction
+constraint.
 
 ### Adoption and evidence
 

--- a/docs/design/inspect-web-jsexport-partitioning.md
+++ b/docs/design/inspect-web-jsexport-partitioning.md
@@ -2,6 +2,9 @@
 
 Status: **implemented** for issue
 [#4497](https://github.com/richlander/dotnet-inspect/issues/4497).
+The [page-facing engine client](#page-facing-engine-client) is **design-only,
+not implemented**, preparing the single-runtime Worker cutover for
+[#5420](https://github.com/richlander/dotnet-inspect/issues/5420).
 
 This is the owning document for the inspect-web production facade partition:
 which existing browser-host exports belong together, how independently
@@ -115,7 +118,7 @@ source set into a fresh scratch directory:
 ts-jsexport InspectWeb.Engine.dll
   --context InspectWeb.Engine.InspectWebJsExportContext
   --assembly-search-path <browser-output>
-  --runtime-module ./_framework/dotnet.js
+  --runtime-module ./runtime-loader.js
   --output <fresh-scratch>/facades
 
 <fresh-scratch>/facades/
@@ -170,8 +173,9 @@ This partition does not:
 - change any managed operation's parameters, JSON wire shape, failure
   semantics, query behavior, or progressive-disclosure policy;
 - expose raw `ILInspector` or `DotnetInspector` objects to TypeScript;
-- introduce lazy module loading, multiple runtimes, workers, or a network
-  protocol;
+- introduce lazy module loading, multiple runtimes, or a network protocol;
+- define Worker hosting or lifecycle; the proposed client consumes the
+  [Worker runtime](inspect-web-worker-runtime.md);
 - make module names into product-layer authorities; or
 - claim that managed project boundaries and product architecture layers are
   identical.
@@ -361,8 +365,13 @@ the facade that publishes it.
 All generated facades use the exact same runtime module specifier:
 
 ```text
-./_framework/dotnet.js
+./runtime-loader.js
 ```
+
+The published loader resolves the SDK's fingerprinted runtime module without
+requiring a document import map. The coordinator is shared by the implemented
+page host and the separate Worker diagnostic host; sharing its source does not
+share a runtime between realms.
 
 The consumer owns one coordinator:
 
@@ -442,6 +451,171 @@ The production gate adds all seven real assemblies and their actual operations;
 the fixture canary remains because its intentionally colliding identities are a
 stronger close negative than the production names.
 
+## Page-facing engine client
+
+This proposed extension owns **consumer binding to the generated facade set
+through one asynchronous client**. The production consumer is Inspect Web,
+with Type Source as the first fully composed Worker feature in
+[#5420](https://github.com/richlander/dotnet-inspect/issues/5420). It retains the
+one-runtime and shared-core contracts above; it does not change the generated
+facade ABI or create a new logical-operation or Worker-protocol owner.
+
+### Composition contract
+
+After cutover, the application's managed runtime resides in its dedicated
+Worker. Every capability uses that runtime, including calls that have not yet
+adopted the managed-operation bridge. Moving only Source while keeping a page
+runtime for its neighbors would split the shared workspace and source budget
+and is not a supported intermediate production state.
+
+The page-facing client exposes consumer-required capabilities grouped by their
+owning facade, not arbitrary managed member lookup or a new generated monolith.
+Its bindings consume the generated parameter and result types; generated
+functions still own managed names, overload selection, serialization, and
+runtime dispatch. Bootstrap retains host configuration and entry-point
+execution. The existing canary remains a diagnostic, not a UI capability.
+
+Managed results and acknowledgments cross the client asynchronously, including
+results currently returned synchronously by generated functions. A fulfilled
+ordinary query preserves its generated result; managed rejection or Worker
+boundary failure remains visible through the caller's error path. Posting a
+command is not an acknowledgment of its effect. The client must allow controls
+to be dispatched while a query awaits them rather than queueing every call
+behind that query's completion.
+
+The consumer retains one complete readiness barrier: all facades initialize
+before managed dispatch is ready. Concurrent readiness callers share the
+attempt and its failure. A failed Worker bootstrap remains failure; it does not
+start a replacement runtime on the page. Static catalog results may be
+materialized as page data after readiness. Mutable lookups and actions remain
+asynchronous operations, not synchronous reads of an implicitly stale cache.
+
+An operation already governed by
+[operation authority](inspect-web-operation-authority.md) consumes a
+Worker producer adapter with the same authority-issued identity. It is not
+wrapped in another logical operation just to obtain a Promise-shaped facade.
+Logical cancellation and the separate terminal/quiescence handoffs retain
+their existing owner contracts. Ordinary Promise results do not acquire a new
+claim of managed quiescence merely by crossing this client.
+
+Callback-bearing calls need an explicit feature adapter, not a structured clone
+of a page callback or `JSObject`. The adapter consumes the Worker owner's
+validated event path and the feature's generated payloads. Package Query's
+durable matches and failures require
+[#5418's durable-event residual](https://github.com/richlander/dotnet-inspect/issues/5418)
+before cutover; sending them as advisory progress would change their contract.
+Its existing credit acknowledgment remains a real asynchronous result.
+
+Worker-issued epoch identity and operation-authority identity keep their
+separate meanings. A client bound to a closed epoch cannot silently send old
+actions to a replacement epoch. The initial consumer recovery policy is a
+visible page reload, not automatic in-place restoration of managed state.
+The Worker owner's restart mechanism remains available to its own callers and
+gates; adopting in-place application recovery needs a later consumer contract.
+This avoids inventing a cache rehydration or action-rebinding protocol here.
+
+UI owners decide how to await results while preserving navigation, user
+activation, focus, and current-view publication. The client does not reproduce
+managed codecs or ranking in JavaScript. Typed results still reach their
+existing rendering owners; this extension adds no rendering or format-lowering
+domain.
+
+### Call-site migration inventory
+
+This is migration evidence at `48d5436a2`, not a second export specification.
+The [production inventory](#production-surface-inventory) and generated
+declarations remain authoritative. Of its 50 managed exports, 48 are bound by
+`loadEngineModule` in
+[`dotnet-inspect.ts`](../../prototypes/inspect-web/src/dotnet-inspect.ts).
+Generated lifecycle functions are not included in these counts.
+
+| Current call class | Count | Generated operations | Consumer handoff to prepare |
+| --- | ---: | --- | --- |
+| Bootstrap/diagnostic only | 2 | `configureHost`, `asyncLoweringCanary` | Retain bootstrap/diagnostic ownership; do not expose a blanket facade proxy. |
+| Synchronous startup data | 4 | `buildIdentity`, `listVocabulary`, `listHomeDemos`, `listPackageQueryFacets` | Await acquisition; supply typed catalog data to existing readers. |
+| Synchronous computed results | 5 | `decodeWorkspaceShareState`, `encodeWorkspaceShareState`, `resolveHomeDemo`, `matchPackageDependencyCoordinate`, `searchTypes` | Await the real result in navigation/share, demo resolution, dependency matching, and Spotlight owners. |
+| Synchronous stateful operations | 3 | `activateWorkspacePackageOccurrence`, `clearWorkspacePackageOccurrences`, `packageCacheStats` | Await activation/clear completion or a current stats result; retain the UI owner's ordering and invalidation. |
+| Synchronous controls | 4 | `cancelPackageQuery`, `cancelSourceQuery`, `cancelTypeSourceQuery`, `requestPackageQueryMatches` | Preserve existing targeting and real acknowledgment; logical cancellation stays with its existing feature/operation authority. |
+| Callback stream | 1 | `runPackageQuery` | Worker-local callback adapter, durable delivery, terminal ordering, and existing match-credit behavior. |
+| Authority-governed Source | 1 | `queryTypeSource` | Direct Worker producer adapter; consume the existing keyed managed bridge and generated terminal DTO. |
+| Other Promise-returning calls | 30 | Package: 9; Metadata: 8; Analysis: 7; Source: 3; Call graph: 2; Catalog: `runHomeDemo` | Preserve generated inputs, results, and failures through typed bindings; placement alone does not complete lifecycle adoption. |
+
+The nonterminal, control, and query paths are one migration obligation, not
+optional methods to omit from an initial client. In particular,
+[`package-query-source.ts`](../../prototypes/inspect-web/src/package-query-source.ts)
+constructs a property-setter callback, and
+[`package-query.ts`](../../prototypes/inspect-web/src/package-query.ts) currently
+updates credit only after a synchronous successful grant.
+[`workspace-navigation.ts`](../../prototypes/inspect-web/src/workspace-navigation.ts)
+requires synchronous share encode/decode today. These consumers need focused
+adoption before the production switch, not type assertions that pretend their
+existing synchronous contracts already support a Worker.
+
+### Adoption and evidence
+
+The user-approved
+[five-milestone plan](https://github.com/richlander/dotnet-inspect/issues/5420#issuecomment-5549528380)
+is the production-host adoption and retirement path under #5418 and #5420:
+
+1. Lock this consumer contract and migration inventory.
+2. Prepare asynchronous consumer calls in focused slices, retaining the
+   existing single page runtime.
+3. Consume the separately owned durable Worker event prerequisite in #5418.
+4. Prepare typed Worker bindings and the Source producer adapter in a
+   Worker-only host, without activating them alongside the production runtime.
+5. Switch production bootstrap and all required bindings together, retire the
+   temporary page client/direct managed calls, and complete the Source demo.
+
+Steps 2 and 3 may proceed independently under their owners. Step 5 waits for
+all required paths; it includes the production demonstration rather than
+deferring correctness to a later slice. This uses the approved inspect-web-only
+Worker scope; it is not a CLI runtime migration. Feature-specific lifecycle
+adoption may continue after placement, but direct page managed dispatch does
+not.
+
+All new runtime claims are **unverified** until implementation. Extend the
+existing published facade-composition gate to exercise the actual client
+bootstrap, one SDK creation across the page/Worker composition, all required
+bindings, and visible startup failure. Its neighboring case uses package and
+metadata through the same runtime. This is behavioral evidence for that
+consumer path, not a repository-wide source absence audit.
+
+Worker protocol/lifecycle and durable ordering remain covered by their owner's
+gates; managed lifetime remains covered by #5419. Consumer adoption gates must
+exercise pending-query controls and preserve existing feature outcomes across
+the new asynchronous boundary. The #5420 browser scenario must show paint/input
+during representative managed Source work and distinguish logical cancellation
+from physical release, with a browser-native neighboring producer. Existing
+models remain evidence for their owned components, not proof of these new
+consumer bindings.
+
+### Comparative basis and mock demo
+
+[Comlink](https://github.com/GoogleChromeLabs/comlink#api) demonstrates the
+conventional asynchronous Worker-call boundary: even a synchronous remote
+function produces a Promise, and callbacks need special handling rather than
+ordinary cloning. Inspect Web deliberately uses its existing closed Worker
+catalog and explicit feature adapters instead of adopting a general proxy
+system. The [official .NET Worker evidence](inspect-web-worker-runtime.md#runtime-evidence)
+supports runtime placement, not inspect-web's publication or lifetime policy.
+
+Before, calling an asynchronous Source export still runs its managed work on
+the page's runtime. The proposed composition is:
+
+```text
+page: existing Source view and operation authority
+  -> typed Worker producer adapter, same operation identity
+  -> owning generated Source facade
+  -> one Worker runtime and shared managed workspace/source budget
+
+neighbor: package and metadata queries -> that same Worker runtime
+neighbor: browser-native fetch -> operation authority, without managed dispatch
+failure: Worker bootstrap rejects -> visible failure, not a page runtime
+```
+
+This is a design mockup, not a responsiveness result. Source rendering and
+focus remain with the existing view.
+
 ## TypeScript ownership
 
 Each checked-in TypeScript source is a byte-identical copy of one canonical
@@ -478,7 +652,9 @@ Application files import DTOs from their owning facade declaration. Runtime
 composition imports JavaScript modules only in the coordinator. A small
 authored bindings module may adapt generated names to existing application
 callback interfaces, but it does not re-export all generated functions as a
-new monolithic facade.
+new monolithic facade. The proposed page-facing client adapts invocation
+placement through the existing Worker boundary; it does not reconstruct the
+managed dispatch wrappers that generation owns.
 
 Generated sources, declarations, JavaScript outputs, compiler programs, lint
 targets, and generated-file relaxations remain exact inventories. The

--- a/docs/design/inspect-web-worker-runtime.md
+++ b/docs/design/inspect-web-worker-runtime.md
@@ -20,10 +20,10 @@ remaining browser gates named below are still required.
 Its finite state models establish only the abstract properties recorded with
 those models. The engine-to-browser event-stream contract is now defined by
 [the async event-stream owner](engine-browser-async-event-stream.md). Durable
-worker event batches remain a later residual blocked on
-[#5570](https://github.com/richlander/dotnet-inspect/issues/5570) and the
-relevant [#5419](https://github.com/richlander/dotnet-inspect/issues/5419)
-managed handoff.
+worker event batches remain an implementation residual under #5418. They must
+consume the implemented publication path from
+[#5570](https://github.com/richlander/dotnet-inspect/issues/5570) and the relevant
+[#5419](https://github.com/richlander/dotnet-inspect/issues/5419) managed handoff.
 
 ## Decision
 
@@ -1365,8 +1365,8 @@ into the runtime host:
 4. add durable event batches after #5570 and the relevant #5419 handoff supply
    their prerequisite contracts, before moving the existing Package Query
    stream; #5566 and #5570 are merged;
-5. consume the [single-runtime client cutover](inspect-web-jsexport-partitioning.md#page-facing-engine-client)
-   and move the existing source operation through a typed worker adapter;
+5. prepare the existing source operation's typed worker adapter for the
+   [single-runtime client cutover](inspect-web-jsexport-partitioning.md#page-facing-engine-client);
 6. connect keyed cancellation, progress, managed settlement, and epoch-work
    reporting through their existing owners;
 7. prove real-browser responsiveness and hard realm release; and
@@ -1376,9 +1376,12 @@ into the runtime host:
 These eight production-host adoption steps are tracked by #5418 under #4937
 and #4571, with composition handoffs mapped by #5095. The first feature
 consumer is the existing source operation in
-issue #5420, not a duplicate feature. The client owner retires direct
-main-thread managed dispatch in one production cutover; step 8 is subsequent
-feature lifecycle adoption, not permission to retain a second runtime. The approved
+issue #5420, not a duplicate feature. Steps 4-7 must be satisfied before the
+client's production cutover lands: adapter preparation, lifecycle connection,
+and browser evidence are prerequisites, not work deferred until after
+activation. The client owner activates the required bindings and retires direct
+main-thread managed dispatch together. Step 8 is subsequent feature lifecycle
+adoption, not permission to retain a second runtime. The approved
 inspect-web-only scope does not imply a CLI runtime migration. Typed feature
 results continue to reach their existing rendering owners; this binding adds
 no rendering or format-lowering domain.

--- a/docs/design/inspect-web-worker-runtime.md
+++ b/docs/design/inspect-web-worker-runtime.md
@@ -1362,21 +1362,23 @@ into the runtime host:
    `inspect-web-worker-protocol` gate (**implemented**);
 3. adapt the current generated facade bootstrap behind the consumer-owned
    bootstrap operation (**implemented** with the browser-binding sub-gate);
-4. move one long-running source or package inspection through a typed worker
-   operation adapter;
-5. connect keyed cancellation, progress, managed settlement, and epoch-work
+4. add durable event batches after #5570 and the relevant #5419 handoff supply
+   their prerequisite contracts, before moving the existing Package Query
+   stream; #5566 and #5570 are merged;
+5. consume the [single-runtime client cutover](inspect-web-jsexport-partitioning.md#page-facing-engine-client)
+   and move the existing source operation through a typed worker adapter;
+6. connect keyed cancellation, progress, managed settlement, and epoch-work
    reporting through their existing owners;
-6. prove real-browser responsiveness and hard realm release;
-7. migrate additional feature adapters only after each declares its own
-   payload and liveness policy; and
-8. add durable event batches only after #5570 and the relevant #5419 handoff
-   supply their remaining prerequisite contracts; #5566 is merged.
+7. prove real-browser responsiveness and hard realm release; and
+8. migrate additional feature lifecycle adapters only after each declares its
+   own payload and liveness policy.
 
 These eight production-host adoption steps are tracked by #5418 under #4937
 and #4571, with composition handoffs mapped by #5095. The first feature
 consumer is the existing source operation in
-issue #5420, not a duplicate feature. Step 7 retires each remaining direct
-main-thread feature invocation as its adapter is adopted. The approved
+issue #5420, not a duplicate feature. The client owner retires direct
+main-thread managed dispatch in one production cutover; step 8 is subsequent
+feature lifecycle adoption, not permission to retain a second runtime. The approved
 inspect-web-only scope does not imply a CLI runtime migration. Typed feature
 results continue to reach their existing rendering owners; this binding adds
 no rendering or format-lowering domain.


### PR DESCRIPTION
## Summary

**Make Inspect Web responsive while preserving one managed workspace and source budget.** This design-only slice defines the page-facing engine client needed before the production Type Source Worker adoption.

The sole normative owner is `docs/design/inspect-web-jsexport-partitioning.md#page-facing-engine-client`: bind the existing generated facade set through one asynchronous consumer client and one runtime. The Worker document changes only its migration ordering and ownership references.

The design inventories all 50 managed exports and 48 UI bindings, including synchronous lookups, stateful actions, controls, callbacks, and the 30 remaining Promise calls. It preserves the generated ABI, existing authority/bridge identities, real command acknowledgments, and visible failures. Initial application recovery requires a visible reload instead of inventing in-place rehydration of epoch-local state.

Focused consumer tracker: #5987. Related: #5420 (first production Source consumer and the approved five-milestone plan), #5418 (Worker owner and overall adoption), #5419 (managed lifetime), #5095 (composition). This PR does not complete or close those implementation issues.

## Demo

Design mockup, not a measured responsiveness result:

```text
Before:
  Source Promise -> .NET runtime on the page -> managed work can block the DOM

After the planned cutover:
  Source view + operation authority
    -> typed Worker adapter, same operation identity
    -> generated Source facade
    -> one Worker runtime, shared workspace and source budget

Neighbor:
  Package and Metadata -> that same Worker runtime
  browser-native fetch -> operation authority, without managed dispatch

Boundary:
  Worker bootstrap failure -> visible error, not another runtime on the page
  Package Query waiting for credit -> controls remain dispatchable
```

The key sequencing correction: Package Query is already a stream consumer, so durable Worker events must precede the runtime switch. They cannot be hidden inside advisory progress or deferred until after a source-only, two-runtime migration.

## Adoption and scope

Five milestones: (1) this consumer contract/inventory, (2) asynchronous-ready caller slices on the existing runtime, (3) separately owned durable Worker transport, (4) typed Worker bindings and the Source adapter in a Worker-only host, (5) atomic production activation and retirement of direct page managed dispatch, with the real Source demo.

The user approved the single-runtime planning direction and then proceeding with this focused design. The existing inspect-web-only Worker scope applies; there is no CLI runtime migration. Worker protocol/lifetime policy, feature semantics, and rendering/format lowering remain with their existing owners. No `ts-jsexport` or native JSON-union feature is required.

The baseline is conventional asynchronous Worker invocation; Comlink provides comparative evidence for Promise-valued remote calls and non-cloneable callbacks. The deliberate choice is to consume the existing closed Worker catalog rather than introduce a general proxy system. No new implementation or model is claimed: participating owner models do not prove the future client.

## Coordination

#5911 remains the owner of four library-scoped facade signature changes and its surrounding UI changes. This PR edits neither those bindings nor the composition root. Future bindings will consume its settled signatures. #5933/#5951 are merged baseline behavior; #5418/#5419 residuals remain separate work.

## Validation

- `npx --no-install markdownlint-cli docs/design/inspect-web-jsexport-partitioning.md docs/design/inspect-web-worker-runtime.md`
- Inventory comparison against all seven current generated declaration files and the application bindings: 50 managed exports, 48 distinct UI bindings, and 30 other Promise-returning calls.
- `git diff --check`

Runtime and responsiveness acceptance targets are explicitly **unverified** until implementation. This PR changes only two Markdown files and uses the repository's Markdown-only review path.
